### PR TITLE
fix: Return breadcrumbs in order in which they where created

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -112,12 +112,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<NSString *> *)allFilesInFolder:(NSString *)path {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *error = nil;
-    NSArray < NSString * > *storedEvents = [fileManager contentsOfDirectoryAtPath:path error:&error];
+    NSArray <NSString *> *storedFiles = [fileManager contentsOfDirectoryAtPath:path error:&error];
     if (nil != error) {
         [SentryLog logWithMessage:[NSString stringWithFormat:@"Couldn't load files in folder %@: %@", path, error] andLevel:kSentryLogLevelError];
         return [NSArray new];
     }
-    return storedEvents;
+    return [storedFiles sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
 }
 
 - (BOOL)removeFileAtPath:(NSString *)path {

--- a/Tests/SentryTests/SentryBreadcrumbTests.m
+++ b/Tests/SentryTests/SentryBreadcrumbTests.m
@@ -95,6 +95,38 @@
     XCTAssertEqualObjects([client.breadcrumbs serialize], serialized);
 }
 
+- (void)testSerializeSorted {
+    NSError *error = nil;
+    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/12345" didFailWithError:&error];
+    XCTAssertNil(error);
+    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:10];
+    crumb.timestamp = date;
+    [client.breadcrumbs addBreadcrumb:crumb];
+    
+    SentryBreadcrumb *crumb2 = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+    NSDate *date2 = [NSDate dateWithTimeIntervalSince1970:899990];
+    crumb2.timestamp = date2;
+    [client.breadcrumbs addBreadcrumb:crumb2];
+    
+    SentryBreadcrumb *crumb3 = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+    NSDate *date3 = [NSDate dateWithTimeIntervalSince1970:5];
+    crumb3.timestamp = date3;
+    [client.breadcrumbs addBreadcrumb:crumb3];
+    
+    SentryBreadcrumb *crumb4 = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+    NSDate *date4 = [NSDate dateWithTimeIntervalSince1970:11];
+    crumb4.timestamp = date4;
+    [client.breadcrumbs addBreadcrumb:crumb4];
+    
+    NSDictionary *serialized = [client.breadcrumbs serialize];
+    NSArray *dates = [serialized valueForKeyPath:@"breadcrumbs.timestamp"];
+    XCTAssertTrue([[dates objectAtIndex:0] isEqualToString:[date sentry_toIso8601String]]);
+    XCTAssertTrue([[dates objectAtIndex:1] isEqualToString:[date2 sentry_toIso8601String]]);
+    XCTAssertTrue([[dates objectAtIndex:2] isEqualToString:[date3 sentry_toIso8601String]]);
+    XCTAssertTrue([[dates objectAtIndex:3] isEqualToString:[date4 sentry_toIso8601String]]);
+}
+
 - (SentryBreadcrumb *)getBreadcrumb {
     return [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
 }


### PR DESCRIPTION
Send breadcrumbs in the order in which they got created.

See files:
```
    "1508754960.460319-0-4DAA9212-4FF6-4064-8A7D-7FF7ABE37807.json",
    "1508754960.461277-1-4A0ACA73-207F-4D16-BB79-E9E8C89BAC0D.json",
    "1508754960.462301-2-12BC2A42-D67E-4C2D-ADE5-5439AEFB039C.json",
    "1508754960.463050-3-B17304D1-45D8-4C2F-B47D-DD6817450874.json",
    "1508754969.272279-0-EEF0BCEE-1E1D-4435-A54A-50700F10B181.json",
    "1508754969.278541-1-69F4BAB7-8BB2-4664-B617-3D6A8E47FF5A.json",
    "1508754969.281323-2-46566918-0A3A-44A6-AE86-BC8F39AA1FD3.json",
    "1508754969.282348-3-797B166F-C983-4794-8095-DAC01D9D37C5.json"
```

So that's how filename get generated:
https://github.com/getsentry/sentry-cocoa/blob/master/Sources/Sentry/SentryFileManager.m#L70-L75

`Timestamp-counter-UUID` so it should be sortable.