### PR TITLE
fix: SentryFilemanager will create folder depending on dsn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode8.3
+osx_image: xcode9.2
 
 cache:
   - bundler

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -92,7 +92,7 @@ static SentryKSCrashInstallation *installation = nil;
         self.dsn = [[SentryDsn alloc] initWithString:dsn didFailWithError:error];
         self.requestManager = requestManager;
         NSLog(@"Sentry Started -- Version: %@", self.class.versionString);
-        self.fileManager = [[SentryFileManager alloc] initWithError:error];
+        self.fileManager = [[SentryFileManager alloc] initWithDsn:self.dsn didFailWithError:error];
         self.breadcrumbs = [[SentryBreadcrumbStore alloc] initWithFileManager:self.fileManager];
         if (nil != error && nil != *error) {
             [SentryLog logWithMessage:(*error).localizedDescription andLevel:kSentryLogLevelError];

--- a/Sources/Sentry/SentryDsn.m
+++ b/Sources/Sentry/SentryDsn.m
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)getHash {
     NSData *data = [[self.url absoluteString] dataUsingEncoding:NSUTF8StringEncoding];
     uint8_t digest[CC_SHA1_DIGEST_LENGTH];
-    CC_SHA1(data.bytes, data.length, digest);
+    CC_SHA1(data.bytes, (CC_LONG)data.length, digest);
     NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
     for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
         [output appendFormat:@"%02x", digest[i]];

--- a/Sources/Sentry/SentryDsn.m
+++ b/Sources/Sentry/SentryDsn.m
@@ -6,6 +6,8 @@
 //  Copyright © 2017 Sentry. All rights reserved.
 //
 
+#import <CommonCrypto/CommonDigest.h>
+
 #if __has_include(<Sentry/Sentry.h>)
 
 #import <Sentry/SentryDsn.h>
@@ -35,6 +37,17 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
     return self;
+}
+
+- (NSString *)getHash {
+    NSData *data = [[self.url absoluteString] dataUsingEncoding:NSUTF8StringEncoding];
+    uint8_t digest[CC_SHA1_DIGEST_LENGTH];
+    CC_SHA1(data.bytes, data.length, digest);
+    NSMutableString *output = [NSMutableString stringWithCapacity:CC_SHA1_DIGEST_LENGTH * 2];
+    for (int i = 0; i < CC_SHA1_DIGEST_LENGTH; i++) {
+        [output appendFormat:@"%02x", digest[i]];
+    }
+    return output;
 }
 
 - (NSURL *_Nullable)convertDsnString:(NSString *)dsnString didFailWithError:(NSError *_Nullable *_Nullable)error {

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -65,10 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (void)checkForSandbox {
-    
-}
-
 - (void)deleteAllFolders {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     [fileManager removeItemAtPath:self.breadcrumbsPath error:nil];

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -13,6 +13,7 @@
 #import <Sentry/SentryLog.h>
 #import <Sentry/SentryEvent.h>
 #import <Sentry/SentryBreadcrumb.h>
+#import <Sentry/SentryDsn.h>
 
 #else
 #import "SentryFileManager.h"
@@ -20,6 +21,7 @@
 #import "SentryLog.h"
 #import "SentryEvent.h"
 #import "SentryBreadcrumb.h"
+#import "SentryDsn.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,12 +37,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryFileManager
 
-- (_Nullable instancetype)initWithError:(NSError **)error {
+- (_Nullable instancetype)initWithDsn:(SentryDsn *)dsn didFailWithError:(NSError **)error {
     self = [super init];
     if (self) {
         NSFileManager *fileManager = [NSFileManager defaultManager];
         NSString *cachePath = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES).firstObject;
+        
         self.sentryPath = [cachePath stringByAppendingPathComponent:@"io.sentry"];
+        self.sentryPath = [self.sentryPath stringByAppendingPathComponent:[dsn getHash]];
+        
         if (![fileManager fileExistsAtPath:self.sentryPath]) {
             [self.class createDirectoryAtPath:self.sentryPath withError:error];
         }
@@ -58,6 +63,10 @@ NS_ASSUME_NONNULL_BEGIN
         self.currentFileCounter = 0;
     }
     return self;
+}
+
+- (void)checkForSandbox {
+    
 }
 
 - (void)deleteAllFolders {

--- a/Sources/Sentry/include/SentryDsn.h
+++ b/Sources/Sentry/include/SentryDsn.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (_Nullable instancetype)initWithString:(NSString *)dsnString didFailWithError:(NSError *_Nullable *_Nullable)error;
 
+- (NSString *)getHash;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -16,12 +16,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryEvent, SentryBreadcrumb;
+@class SentryEvent, SentryBreadcrumb, SentryDsn;
 
 @interface SentryFileManager : NSObject
 SENTRY_NO_INIT
 
-- (_Nullable instancetype)initWithError:(NSError **)error;
+- (_Nullable instancetype)initWithDsn:(SentryDsn *)dsn didFailWithError:(NSError **)error;
 
 - (NSString *)storeEvent:(SentryEvent *)event;
 

--- a/Tests/SentryTests/SentryBreadcrumbTests.m
+++ b/Tests/SentryTests/SentryBreadcrumbTests.m
@@ -11,6 +11,7 @@
 #import "SentryBreadcrumbStore.h"
 #import "SentryFileManager.h"
 #import "NSDate+Extras.h"
+#import "SentryDsn.h"
 
 @interface SentryBreadcrumbTests : XCTestCase
 
@@ -23,7 +24,7 @@
 - (void)setUp {
     [super setUp];
     NSError *error = nil;
-    self.fileManager = [[SentryFileManager alloc] initWithError:&error];
+    self.fileManager = [[SentryFileManager alloc] initWithDsn:[[SentryDsn alloc] initWithString:@"https://username:password@app.getsentry.com/12345" didFailWithError:nil] didFailWithError:&error];
     XCTAssertNil(error);
 }
 

--- a/Tests/SentryTests/SentryFileManagerTests.m
+++ b/Tests/SentryTests/SentryFileManagerTests.m
@@ -9,6 +9,7 @@
 #import <XCTest/XCTest.h>
 #import <Sentry/Sentry.h>
 #import "SentryFileManager.h"
+#import "SentryDsn.h"
 
 @interface SentryFileManagerTests : XCTestCase
 
@@ -22,7 +23,7 @@
     [super setUp];
     SentryClient.logLevel = kSentryLogLevelDebug;
     NSError *error = nil;
-    self.fileManager = [[SentryFileManager alloc] initWithError:&error];
+    self.fileManager = [[SentryFileManager alloc] initWithDsn:[[SentryDsn alloc] initWithString:@"https://username:password@app.getsentry.com/12345" didFailWithError:nil] didFailWithError:&error];
     XCTAssertNil(error);
 }
 

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -274,7 +274,7 @@
 }
 
 - (void)testBreadcrumbStore {
-    SentryBreadcrumbStore *store = [[SentryBreadcrumbStore alloc] initWithFileManager:[[SentryFileManager alloc] initWithError:nil]];
+    SentryBreadcrumbStore *store = [[SentryBreadcrumbStore alloc] initWithFileManager:[[SentryFileManager alloc] initWithDsn:[[SentryDsn alloc] initWithString:@"https://username:password@app.getsentry.com/12345" didFailWithError:nil] didFailWithError:nil]];
     SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"http"];
     [store addBreadcrumb:crumb];
     NSDate *date = [NSDate date];

--- a/Tests/SentryTests/SentryRequestTests.m
+++ b/Tests/SentryTests/SentryRequestTests.m
@@ -156,7 +156,7 @@ NSInteger requestsWithErrors = 0;
 
 - (void)clearAllFiles {
     NSError *error = nil;
-    SentryFileManager *fileManager = [[SentryFileManager alloc] initWithError:&error];
+    SentryFileManager *fileManager = [[SentryFileManager alloc] initWithDsn:[[SentryDsn alloc] initWithString:@"https://username:password@app.getsentry.com/12345" didFailWithError:nil] didFailWithError:&error];
     [fileManager deleteAllStoredEvents];
     [fileManager deleteAllStoredBreadcrumbs];
     [fileManager deleteAllFolders];

--- a/Tests/SentryTests/SentrySwiftTests.swift
+++ b/Tests/SentryTests/SentrySwiftTests.swift
@@ -13,7 +13,7 @@ class SentrySwiftTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        let fileManager = try! SentryFileManager(error: ())
+        let fileManager = try! SentryFileManager(dsn: SentryDsn(string: "https://username:password@app.getsentry.com/12345"))
         fileManager.deleteAllStoredEvents()
         fileManager.deleteAllStoredBreadcrumbs()
         fileManager.deleteAllFolders()

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -54,13 +54,15 @@
 
 - (void)testBreadCrumbTracking {
     NSError *error = nil;
-    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/12345" didFailWithError:&error];
+    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/123456" didFailWithError:&error];
+    [client.breadcrumbs clear];
     [client enableAutomaticBreadcrumbTracking];
     XCTAssertEqual(client.breadcrumbs.count, (unsigned long)0);
     [SentryClient setSharedClient:client];
     [SentryClient.sharedClient enableAutomaticBreadcrumbTracking];
     XCTAssertEqual(SentryClient.sharedClient.breadcrumbs.count, (unsigned long)1);
     [SentryClient setSharedClient:nil];
+    [client.breadcrumbs clear];
 }
 
 - (void)testInstallation {


### PR DESCRIPTION
Fixes #216 

This will create a subfolder for each instance of SentryClient so multiple clients do not interfere. 