### PR TITLE
feat: Improve rate limiting and local file cache

### DIFF
--- a/Sources/Sentry/SentryBreadcrumbStore.m
+++ b/Sources/Sentry/SentryBreadcrumbStore.m
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)addBreadcrumb:(SentryBreadcrumb *)crumb {
     [SentryLog logWithMessage:[NSString stringWithFormat:@"Add breadcrumb: %@", crumb] andLevel:kSentryLogLevelDebug];
-    [self.fileManager storeBreadcrumb:crumb];
+    [self.fileManager storeBreadcrumb:crumb maxCount:self.maxBreadcrumbs];
 }
 
 - (NSUInteger)count {
@@ -52,22 +52,10 @@ NS_ASSUME_NONNULL_BEGIN
     [self.fileManager deleteAllStoredBreadcrumbs];
 }
 
-- (void)removeOverflowBreadcrumbs:(NSArray<NSDictionary<NSString *, id> *>*)breadCrumbs {
-    NSInteger numberOfBreadcrumbsToRemove = ((NSInteger)breadCrumbs.count) - ((NSInteger)self.maxBreadcrumbs);
-    if (numberOfBreadcrumbsToRemove > 0) {
-        for (NSUInteger i = 0; i < numberOfBreadcrumbsToRemove; i++) {
-            [self.fileManager removeFileAtPath:[breadCrumbs objectAtIndex:i][@"path"]];
-        }
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"Dropped %ld breadcrumb(s) due limit", (long)numberOfBreadcrumbsToRemove]
-                         andLevel:kSentryLogLevelDebug];
-    }
-}
-
 - (NSDictionary<NSString *, id> *)serialize {
     NSMutableDictionary *serializedData = [NSMutableDictionary new];
     
     NSArray<NSDictionary<NSString *, id> *> *breadCrumbs = [self.fileManager getAllStoredBreadcrumbs];
-    [self removeOverflowBreadcrumbs:breadCrumbs];
     
     NSMutableArray *crumbs = [NSMutableArray new];
     for (NSDictionary<NSString *, id> *crumb in breadCrumbs) {

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -109,7 +109,7 @@ requestManager:(id <SentryRequestManager>)requestManager
 
 - (void)setupQueueing {
     self.shouldQueueEvent = ^BOOL(SentryEvent *_Nonnull event, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
-        // Take from Apple Docs
+        // Taken from Apple Docs:
         // If a response from the server is received, regardless of whether the request completes successfully or fails,
         // the response parameter contains that information.
         if (response == nil) {

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -147,7 +147,7 @@ NSInteger const maxBreadcrumbs = 200;
 
 - (NSString *)storeEvent:(SentryEvent *)event maxCount:(NSUInteger)maxCount {
     NSString *result = [self storeDictionary:[event serialize] toPath:self.eventsPath];
-    [self hardLimitFileStore:self.eventsPath maxCount:MIN(maxCount, maxEvents)];
+    [self handleFileManagerLimit:self.eventsPath maxCount:MIN(maxCount, maxEvents)];
     return result;
 }
 
@@ -157,7 +157,7 @@ NSInteger const maxBreadcrumbs = 200;
 
 - (NSString *)storeBreadcrumb:(SentryBreadcrumb *)crumb maxCount:(NSUInteger)maxCount {
     NSString *result = [self storeDictionary:[crumb serialize] toPath:self.breadcrumbsPath];
-    [self hardLimitFileStore:self.breadcrumbsPath maxCount:MIN(maxCount, maxBreadcrumbs)];
+    [self handleFileManagerLimit:self.breadcrumbsPath maxCount:MIN(maxCount, maxBreadcrumbs)];
     return result;
 }
 
@@ -174,14 +174,14 @@ NSInteger const maxBreadcrumbs = 200;
     }
 }
 
-- (void)hardLimitFileStore:(NSString *)path maxCount:(NSUInteger)maxCount {
+- (void)handleFileManagerLimit:(NSString *)path maxCount:(NSUInteger)maxCount {
     NSArray<NSString *> *files = [self allFilesInFolder:path];
     NSInteger numbersOfFilesToRemove = ((NSInteger)files.count) - maxCount;
     if (numbersOfFilesToRemove > 0) {
         for (NSUInteger i = 0; i < numbersOfFilesToRemove; i++) {
             [self removeFileAtPath:[path stringByAppendingPathComponent:[files objectAtIndex:i]]];
         }
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"Removed %ld file(s) from local cache due hard limit", (long)numbersOfFilesToRemove]
+        [SentryLog logWithMessage:[NSString stringWithFormat:@"Removed %ld file(s) from <%@>", (long)numbersOfFilesToRemove, [path lastPathComponent]]
                          andLevel:kSentryLogLevelDebug];
     }
 }

--- a/Sources/Sentry/SentryQueueableRequestManager.m
+++ b/Sources/Sentry/SentryQueueableRequestManager.m
@@ -48,10 +48,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler {
     SentryRequestOperation *operation = [[SentryRequestOperation alloc] initWithSession:self.session
                                                                                 request:request
-                                                                      completionHandler:^(NSError *_Nullable error, BOOL shouldDiscardEvent) {
+                                                                      completionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
                                                                           [SentryLog logWithMessage:[NSString stringWithFormat:@"Queued requests: %@", @(self.queue.operationCount - 1)] andLevel:kSentryLogLevelDebug];
                                                                           if (completionHandler) {
-                                                                              completionHandler(error, shouldDiscardEvent);
+                                                                              completionHandler(response, error);
                                                                           }
                                                                       }];
     [self.queue addOperation:operation];

--- a/Sources/Sentry/SentryQueueableRequestManager.m
+++ b/Sources/Sentry/SentryQueueableRequestManager.m
@@ -45,13 +45,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self.queue.operationCount <= 1;
 }
 
-- (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestFinished)completionHandler {
+- (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler {
     SentryRequestOperation *operation = [[SentryRequestOperation alloc] initWithSession:self.session
                                                                                 request:request
-                                                                      completionHandler:^(NSError *_Nullable error) {
+                                                                      completionHandler:^(NSError *_Nullable error, BOOL shouldDiscardEvent) {
                                                                           [SentryLog logWithMessage:[NSString stringWithFormat:@"Queued requests: %@", @(self.queue.operationCount - 1)] andLevel:kSentryLogLevelDebug];
                                                                           if (completionHandler) {
-                                                                              completionHandler(error);
+                                                                              completionHandler(error, shouldDiscardEvent);
                                                                           }
                                                                       }];
     [self.queue addOperation:operation];

--- a/Sources/Sentry/SentryRequestOperation.m
+++ b/Sources/Sentry/SentryRequestOperation.m
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SentryRequestOperation
 
 - (instancetype)initWithSession:(NSURLSession *)session request:(NSURLRequest *)request
-              completionHandler:(_Nullable SentryRequestFinished)completionHandler {
+              completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler {
     self = [super init];
     if (self) {
         self.request = request;
@@ -40,7 +40,9 @@ NS_ASSUME_NONNULL_BEGIN
 
             [SentryLog logWithMessage:[NSString stringWithFormat:@"Request status: %ld", (long) statusCode] andLevel:kSentryLogLevelDebug];
             [SentryLog logWithMessage:[NSString stringWithFormat:@"Request response: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]] andLevel:kSentryLogLevelVerbose];
-
+            
+            BOOL shouldDiscardEvent = YES;
+            
             if (nil != error) {
                 [SentryLog logWithMessage:[NSString stringWithFormat:@"Request failed: %@", error] andLevel:kSentryLogLevelError];
             }
@@ -51,11 +53,10 @@ NS_ASSUME_NONNULL_BEGIN
                 if (statusCode == 429) {
                     [SentryLog logWithMessage:@"Rate limit reached, event will be stored and sent later" andLevel:kSentryLogLevelError];
                 }
-                [SentryLog logWithMessage:[NSString stringWithFormat:@"Request failed: %@", requestError] andLevel:kSentryLogLevelError];
             }
 
             if (completionHandler) {
-                completionHandler(error ? error : requestError);
+                completionHandler(error ? error : requestError, shouldDiscardEvent);
             }
 
             [self completeOperation];

--- a/Sources/Sentry/include/SentryClient.h
+++ b/Sources/Sentry/include/SentryClient.h
@@ -102,10 +102,10 @@ NS_SWIFT_NAME(Client)
 @property(nonatomic) float sampleRate;
 
 /**
- * This block can be used to prevent the event from being stored after a failed send attempt.
- * Default is it will not be stored, except there was no internet connection.
+ * This block can be used to prevent the event from being deleted after a failed send attempt.
+ * Default is it will only be stored once after you hit a rate limit or there is no internet connect/cannot connect.
  * Also note that if an event fails to be sent again after it was queued, it will be discarded regardless.
- * @return BOOL
+ * @return BOOL YES = store and try again later, NO = delete
  */
 @property(nonatomic, copy) SentryShouldQueueEvent _Nullable shouldQueueEvent;
 

--- a/Sources/Sentry/include/SentryClient.h
+++ b/Sources/Sentry/include/SentryClient.h
@@ -102,6 +102,14 @@ NS_SWIFT_NAME(Client)
 @property(nonatomic) float sampleRate;
 
 /**
+ * This block can be used to prevent the event from being stored after a failed send attempt.
+ * Default is it will not be stored, except there was no internet connection.
+ * Also note that if an event fails to be sent again after it was queued, it will be discarded regardless.
+ * @return BOOL
+ */
+@property(nonatomic, copy) SentryShouldQueueEvent _Nullable shouldQueueEvent;
+
+/**
  * Initializes a SentryClient. Pass your private DSN string.
  *
  * @param dsn DSN string of sentry

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -39,6 +39,13 @@
  * Block used for returning after a request finished
  */
 typedef void (^SentryRequestFinished)(NSError *_Nullable error);
+
+/**
+ * Block used for request operation finished, shouldDiscardEvent is YES if event should be deleted
+ * regardless if an error occured or not
+ */
+typedef void (^SentryRequestOperationFinished)(NSError *_Nullable error, BOOL shouldDiscardEvent);
+
 /**
  * Block can be used to mutate event before its send
  */

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -44,7 +44,7 @@ typedef void (^SentryRequestFinished)(NSError *_Nullable error);
  * Block used for request operation finished, shouldDiscardEvent is YES if event should be deleted
  * regardless if an error occured or not
  */
-typedef void (^SentryRequestOperationFinished)(NSError *_Nullable error, BOOL shouldDiscardEvent);
+typedef void (^SentryRequestOperationFinished)(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error);
 
 /**
  * Block can be used to mutate event before its send
@@ -55,9 +55,16 @@ typedef void (^SentryBeforeSerializeEvent)(SentryEvent *_Nonnull event);
  */
 typedef void (^SentryBeforeSendRequest)(SentryNSURLRequest *_Nonnull request);
 /**
- * Block can to prevent the event from being sent
+ * Block can be used to prevent the event from being sent
  */
 typedef BOOL (^SentryShouldSendEvent)(SentryEvent *_Nonnull event);
+/**
+ * Block can be used to determine if an event should be queued and stored locally.
+ * It will be tried to send again after next successful send.
+ * Note that this will only be called once the event is created and send manully.
+ * Once it has been queued once it will be discarded if it fails again.
+ */
+typedef BOOL (^SentryShouldQueueEvent)(NSDictionary<NSString *, id> *_Nonnull serializedEvent, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error);
 /**
  * Loglevel
  */

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -64,7 +64,7 @@ typedef BOOL (^SentryShouldSendEvent)(SentryEvent *_Nonnull event);
  * Note that this will only be called once the event is created and send manully.
  * Once it has been queued once it will be discarded if it fails again.
  */
-typedef BOOL (^SentryShouldQueueEvent)(NSDictionary<NSString *, id> *_Nonnull serializedEvent, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error);
+typedef BOOL (^SentryShouldQueueEvent)(SentryEvent *_Nonnull event, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error);
 /**
  * Loglevel
  */

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -24,8 +24,10 @@ SENTRY_NO_INIT
 - (_Nullable instancetype)initWithDsn:(SentryDsn *)dsn didFailWithError:(NSError **)error;
 
 - (NSString *)storeEvent:(SentryEvent *)event;
+- (NSString *)storeEvent:(SentryEvent *)event maxCount:(NSUInteger)maxCount;
 
 - (NSString *)storeBreadcrumb:(SentryBreadcrumb *)crumb;
+- (NSString *)storeBreadcrumb:(SentryBreadcrumb *)crumb maxCount:(NSUInteger)maxCount;
 
 + (BOOL)createDirectoryAtPath:(NSString *)path withError:(NSError **)error;
 

--- a/Sources/Sentry/include/SentryQueueableRequestManager.h
+++ b/Sources/Sentry/include/SentryQueueableRequestManager.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithSession:(NSURLSession *)session;
 
-- (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestFinished)completionHandler;
+- (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler;
 
 - (void)cancelAllOperations;
 

--- a/Sources/Sentry/include/SentryRequestOperation.h
+++ b/Sources/Sentry/include/SentryRequestOperation.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryRequestOperation : SentryAsynchronousOperation
 
 - (instancetype)initWithSession:(NSURLSession *)session request:(NSURLRequest *)request
-              completionHandler:(_Nullable SentryRequestFinished)completionHandler;
+              completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler;
 
 @end
 

--- a/Tests/SentryTests/SentryBreadcrumbTests.m
+++ b/Tests/SentryTests/SentryBreadcrumbTests.m
@@ -59,8 +59,6 @@
     for (NSInteger i = 0; i <= 100; i++) {
         [client.breadcrumbs addBreadcrumb:[self getBreadcrumb]];
     }
-    XCTAssertEqual(client.breadcrumbs.count, (unsigned long)101);
-    [client.breadcrumbs serialize];
     XCTAssertEqual(client.breadcrumbs.count, (unsigned long)50);
     
     [client.breadcrumbs clear];
@@ -75,8 +73,6 @@
     for (NSInteger i = 0; i < 51; i++) {
         [client.breadcrumbs addBreadcrumb:[self getBreadcrumb]];
     }
-    XCTAssertEqual(client.breadcrumbs.count, (unsigned long)51);
-    [client.breadcrumbs serialize];
     XCTAssertEqual(client.breadcrumbs.count, (unsigned long)50);
 }
 

--- a/Tests/SentryTests/SentryFileManagerTests.m
+++ b/Tests/SentryTests/SentryFileManagerTests.m
@@ -90,4 +90,22 @@
     XCTAssertNil([self.fileManager storeDictionary:@{@"date": [NSDate date]} toPath:@""]);
 }
 
+- (void)testEventStoringHardLimit {
+    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+    for (NSInteger i = 0; i <= 20; i++) {
+        [self.fileManager storeEvent:event];
+    }
+    NSArray<NSDictionary<NSString *, NSData *>*> *events = [self.fileManager getAllStoredEvents];
+    XCTAssertEqual(events.count, (unsigned long)10);
+}
+
+- (void)testBreadcrumbStoringHardLimit {
+    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"category"];
+    for (NSInteger i = 0; i <= 210; i++) {
+        [self.fileManager storeBreadcrumb:crumb];
+    }
+    NSArray<NSDictionary<NSString *, NSData *>*> *crumbs = [self.fileManager getAllStoredBreadcrumbs];
+    XCTAssertEqual(crumbs.count, (unsigned long)200);
+}
+
 @end

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -275,6 +275,7 @@
 
 - (void)testBreadcrumbStore {
     SentryBreadcrumbStore *store = [[SentryBreadcrumbStore alloc] initWithFileManager:[[SentryFileManager alloc] initWithDsn:[[SentryDsn alloc] initWithString:@"https://username:password@app.getsentry.com/12345" didFailWithError:nil] didFailWithError:nil]];
+    [store clear];
     SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"http"];
     [store addBreadcrumb:crumb];
     NSDate *date = [NSDate date];

--- a/Tests/SentryTests/SentryRequestTests.m
+++ b/Tests/SentryTests/SentryRequestTests.m
@@ -111,21 +111,21 @@ NSInteger requestsWithErrors = 0;
     return self.queue.operationCount <= 1;
 }
 
-- (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestFinished)completionHandler {
+- (void)addRequest:(NSURLRequest *)request completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler {
 
     if (request.allHTTPHeaderFields[@"X-TEST"]) {
         if (completionHandler) {
-            completionHandler([NSError errorWithDomain:@"" code:9898 userInfo:nil]);
+            completionHandler([NSError errorWithDomain:@"" code:9898 userInfo:nil], YES);
             return;
         }
     }
 
     self.lastOperation = [[SentryRequestOperation alloc] initWithSession:self.session
                                                                                 request:request
-                                                                      completionHandler:^(NSError * _Nullable error) {
+                                                                      completionHandler:^(NSError * _Nullable error, BOOL shouldDiscardEvent) {
                                                                           [SentryLog logWithMessage:[NSString stringWithFormat:@"Queued requests: %lu", (unsigned long)(self.queue.operationCount - 1)] andLevel:kSentryLogLevelDebug];
                                                                           if (completionHandler) {
-                                                                              completionHandler(error);
+                                                                              completionHandler(error, shouldDiscardEvent);
                                                                           }
                                                                       }];
     [self.queue addOperation:self.lastOperation];

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,7 +4,7 @@ before_all do
 end
 
 lane :localcoverage do
-    test_swift
+    test
     sh('cd ..; slather coverage --input-format profdata Sentry.xcodeproj')
 end
 


### PR DESCRIPTION
This PR should greatly improve the handling we do when hitting rate limits and general "extreme" situations when dealing with many events.

- Introduced a max local queue for events of 10
- Introduced a max local queue for breadcrumbs of 200
- By default events will be stored locally and send again later if:
  - There is no internet connection
  - Or they hit a 429 in which case it will be only retired once, ever.
- Provide a callback block for people to implement their own logic of local caching

(The hard cap of local 10 events applies to all of it)

Example of the the block: see default implementation in the PRs code
```objc
self.client.shouldQueueEvent = ^BOOL(SentryEvent * _Nonnull event, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
    return NO; // Always discard the event
};

self.client.shouldQueueEvent = ^BOOL(SentryEvent * _Nonnull event, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
    if (event.level == kSentrySeverityFatal) {
        return YES; // Will only be stored if it fatal
    }
    return NO;
};

self.client.shouldQueueEvent = ^BOOL(SentryEvent * _Nonnull event, NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
    if (event.timestamp.is.not.older.than.3.days) { // pseudo code
        return YES; // Will only not older than 3 days
    }
    return NO;
};
```