### PR TITLE
Remove SKIP_INSTALL settings from Sentry-KSCrash project settings.

### DIFF
--- a/KSCrash/Sentry-KSCrash.xcodeproj/project.pbxproj
+++ b/KSCrash/Sentry-KSCrash.xcodeproj/project.pbxproj
@@ -1311,7 +1311,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
-				SKIP_INSTALL = NO;
 				USE_HEADERMAP = YES;
 			};
 			name = Debug;
@@ -1347,7 +1346,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
-				SKIP_INSTALL = NO;
 				USE_HEADERMAP = YES;
 			};
 			name = Release;


### PR DESCRIPTION
The SKIP_INSTALL setting for frameworks is normally set to YES.

This PR removes the KSCrash project level NO setting, allowing the Sentry.xcconfig setting of YES to be used.

With the setting set to NO the resulting framework is copied to any generated archive, creating a Generic Archive which cannot be uploaded to the app store.
This breaks automated builds managed with Carthage/Fastlane without hacks to toggle the setting to NO.

See: https://developer.apple.com/library/archive/technotes/tn2215/_index.html#//apple_ref/doc/uid/DTS40011221-CH1-PROJ
(Under the image ... "You must set "Skip Install" to YES to prevent your
static libraries or framework from being added to your archive.")

Also in the bordered note: "Note: If your archive contains unexpected items such as header files, static libraries, or frameworks, then it is a generic Xcode archive."