### PR TITLE
added fingerprint option on createSentryEventFromJavaScriptEvent

### DIFF
--- a/Sources/Sentry/SentryJavaScriptBridgeHelper.m
+++ b/Sources/Sentry/SentryJavaScriptBridgeHelper.m
@@ -126,6 +126,9 @@ NS_ASSUME_NONNULL_BEGIN
     if (jsonEvent[@"logger"]) {
         event.logger = jsonEvent[@"logger"];
     }
+    if (jsonEvent[@"fingerprint"]) {
+        event.logger = jsonEvent[@"fingerprint"];
+    }
     event.tags = [self.class sanitizeDictionary:jsonEvent[@"tags"]];
     if (jsonEvent[@"extra"]) {
         event.extra = jsonEvent[@"extra"];


### PR DESCRIPTION
We needed to set a custom fingerprint on captureException in react-native-sentry. The fingerprint was not part of the event sent to Sentry. We added the ability to set a custom fingerprint for iOS (and Android within the react-native-sentry package). The feature was requested over a year ago, so we thought it would be nice to share our implementation.

If there are questions or problems please contact me, so I can resolve them. 