### PR TITLE
Fix NSInvalidArgumentException in SentryBreadcrumbStore

### DIFF
--- a/Sources/Sentry/SentryBreadcrumbStore.m
+++ b/Sources/Sentry/SentryBreadcrumbStore.m
@@ -59,7 +59,10 @@ NS_ASSUME_NONNULL_BEGIN
     
     NSMutableArray *crumbs = [NSMutableArray new];
     for (NSDictionary<NSString *, id> *crumb in breadCrumbs) {
-        [crumbs addObject:[NSJSONSerialization JSONObjectWithData:crumb[@"data"] options:0 error:nil]];
+        id serializedCrumb = [NSJSONSerialization JSONObjectWithData:crumb[@"data"] options:0 error:nil];
+        if (serializedCrumb != nil) {
+            [crumbs addObject:serializedCrumb];
+        }
     }
     if (crumbs.count > 0) {
         [serializedData setValue:crumbs forKey:@"breadcrumbs"];


### PR DESCRIPTION
This fixes https://github.com/getsentry/react-native-sentry/issues/515.