### PR TITLE
Fix empty array creation

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -523,19 +523,20 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
 - (NSArray*) allReports
 {
+    NSMutableArray* reports = [NSMutableArray array];
     int reportCount = sentrycrash_getReportCount();
-    int64_t reportIDs[reportCount];
-    reportCount = sentrycrash_getReportIDs(reportIDs, reportCount);
-    NSMutableArray* reports = [NSMutableArray arrayWithCapacity:(NSUInteger)reportCount];
-    for(int i = 0; i < reportCount; i++)
-    {
-        NSDictionary* report = [self reportWithIntID:reportIDs[i]];
-        if(report != nil)
+    if (reportCount > 0) {
+        int64_t reportIDs[reportCount];
+        reportCount = sentrycrash_getReportIDs(reportIDs, reportCount);
+        for(int i = 0; i < reportCount; i++)
         {
-            [reports addObject:report];
+            NSDictionary* report = [self reportWithIntID:reportIDs[i]];
+            if(report != nil)
+            {
+                [reports addObject:report];
+            }
         }
     }
-
     return reports;
 }
 


### PR DESCRIPTION
An array of length 0 is not ideal and Xcode is stopping there if sanitizer flags are on while running in debug mode.