### PR TITLE
fix(react-native): Correctly label fingerprints for JS bridge.

### DIFF
--- a/Sources/Sentry/SentryJavaScriptBridgeHelper.m
+++ b/Sources/Sentry/SentryJavaScriptBridgeHelper.m
@@ -127,7 +127,7 @@ NS_ASSUME_NONNULL_BEGIN
         event.logger = jsonEvent[@"logger"];
     }
     if (jsonEvent[@"fingerprint"]) {
-        event.logger = jsonEvent[@"fingerprint"];
+        event.fingerprint = jsonEvent[@"fingerprint"];
     }
     event.tags = [self.class sanitizeDictionary:jsonEvent[@"tags"]];
     if (jsonEvent[@"extra"]) {


### PR DESCRIPTION
### What does this PR do?
Hey all!
I believe I've discovered the fix to an issue that turned up over in [getsentry/react-native-sentry](https://github.com/getsentry/react-native-sentry/) regarding fingerprints not being set (issue https://github.com/getsentry/react-native-sentry/issues/407). Looks like it was a simple copy-paste mistake from PR #269 — all `fingerprint` event data was being assigned to the `logger` field. I've tested this fork myself against @edenhealth's on-prem Sentry instance, and verified that fingerprints are now passed through properly. 👌

### Steps to reproduce / verify
Running via the JS bridge in a react-native application, something like:

```typescript
Sentry.config(SENTRY_DSN, {
  // ...
  dataCallback: (data: any) => {
    data.fingerprint = ['Custom', 'Fingerprint']
    return data
  },
}).install()

Sentry.captureException(new Error('Uh oh.'))
```

...then observe in the Sentry console for that event (accessible by clicking on the link shown [here](https://jstu.art/8aa12945be4a)) that `fingerprint` is still set to `["{{ default }}"]`. Apply this patch, rebuild the app, repeat, and you get the expected `["Custom", "Fingerprint"]`.

-------

If this looks good to you @HazAT, we can tag a patch release here — then I'd be happy to PR a fix in `react-native-sentry` bumping the `Podspec` dependency so we can get the fix in there as well.