### PR TITLE
feat: Add support for event type and custom contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache:
   - bundler
 
 rvm:
-  - 2.3
+  - 2.4
 
 script: travis_retry .travis/run.sh
 

--- a/Sources/Sentry/SentryContext.m
+++ b/Sources/Sentry/SentryContext.m
@@ -50,6 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
         self.deviceContext = [self generatedDeviceContext];
     }
     [serializedData setValue:self.deviceContext forKey:@"device"];
+    
+    [serializedData addEntriesFromDictionary:self.otherContexts];
 
     return serializedData;
 }

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -165,7 +165,13 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.serverName forKey:@"server_name"];
     [serializedData setValue:self.type forKey:@"type"];
     if (nil != self.type && [self.type isEqualToString:@"transaction"]) {
-        [serializedData setValue:[self.timestamp sentry_toIso8601String] forKey:@"start_timestamp"];
+        if (nil != self.startTimestamp) {
+            [serializedData setValue:[self.startTimestamp sentry_toIso8601String] forKey:@"start_timestamp"];
+        } else {
+            // start timestamp should never be empty
+            [serializedData setValue:[self.timestamp sentry_toIso8601String] forKey:@"start_timestamp"];
+        }
+        
     }
 }
 

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -163,6 +163,10 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.message forKey:@"message"];
     [serializedData setValue:self.logger forKey:@"logger"];
     [serializedData setValue:self.serverName forKey:@"server_name"];
+    [serializedData setValue:self.type forKey:@"type"];
+    if (nil != self.type && [self.type isEqualToString:@"transaction"]) {
+        [serializedData setValue:[self.timestamp sentry_toIso8601String] forKey:@"start_timestamp"];
+    }
 }
 
 @end

--- a/Sources/Sentry/include/SentryContext.h
+++ b/Sources/Sentry/include/SentryContext.h
@@ -36,6 +36,12 @@ NS_SWIFT_NAME(Context)
  */
 @property(nonatomic, strong) NSDictionary<NSString *, id> *_Nullable appContext;
 
+/**
+ * User set contexts should go here
+ */
+@property(nonatomic, strong) NSDictionary<NSString *, id> *_Nullable otherContexts;
+
+
 - (instancetype)init;
 + (instancetype)new NS_UNAVAILABLE;
 

--- a/Sources/Sentry/include/SentryEvent.h
+++ b/Sources/Sentry/include/SentryEvent.h
@@ -40,6 +40,11 @@ SENTRY_NO_INIT
 @property(nonatomic, strong) NSDate *timestamp;
 
 /**
+ * NSDate of when the event started, mostly useful if event type transaction
+ */
+@property(nonatomic, strong) NSDate *_Nullable startTimestamp;
+
+/**
  * SentrySeverity of the event
  */
 @property(nonatomic) enum SentrySeverity level;

--- a/Sources/Sentry/include/SentryEvent.h
+++ b/Sources/Sentry/include/SentryEvent.h
@@ -79,6 +79,12 @@ SENTRY_NO_INIT
  */
 @property(nonatomic, copy) NSString *_Nullable transaction;
 
+
+/**
+ * The type of the event, null, default or transaction
+ */
+@property(nonatomic, copy) NSString *_Nullable type;
+
 /**
  * Arbitrary key:value (string:string ) data that will be shown with the event
  */


### PR DESCRIPTION
A lot of code, but with this, you can send transactions to Sentry.
```swift
        let event = Event(level: .info)
        event.transaction = "test.transaction.1"
        event.type = "transaction"
        let context = Context()
        context.otherContexts = ["trace": [
            "trace_id": NSUUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased(),
            "span_id": NSUUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased().prefix(16),
            "op": "manual",
            "description": "Test operation"
            ]
        ]
        event.context = context
        Client.shared?.send(event: event) { (error) in
            // Optional callback after event has been send
        }
```