### PR TITLE
added more tests for `SentrySDK` and `SentryHub`

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -68,10 +68,7 @@
 }
 
 - (void)reset {
-    _client = nil;
-
-    // TODO(fetzig): remove this as soon as SentryHub is fully capable of managing multiple `SentryClient`s
-    [SentryClient setSharedClient:nil];
+    [self unbindClient];
 }
 
 @end


### PR DESCRIPTION
code coverage of SentryCrashReportSink.m is still low.

@HazAT Looks like there are 2 tests covering this, but the constraint `nil != SentryClient.sharedClient` is always false. Maybe the related tests aren't properly setup or the cleanup of another test is sloppy? Anyways, should I fix or ignore this?