### PR TITLE
For atomic logging to work, only a single write call should be issued…

### DIFF
--- a/Sources/Sentry/NSString+SentryNSUIntegerValue.m
+++ b/Sources/Sentry/NSString+SentryNSUIntegerValue.m
@@ -19,7 +19,7 @@
 @implementation NSString (SentryNSUIntegerValue)
 
 - (NSUInteger)unsignedLongLongValue {
-    return strtoull([self UTF8String], NULL, 0);
+    return (NSUInteger)strtoull([self UTF8String], NULL, 0);
 }
 
 @end

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -106,9 +106,18 @@ static inline NSString *hexAddress(NSNumber *value) {
     if (nil == event.dist && event.context.appContext[@"app_build"]) {
         event.dist = event.context.appContext[@"app_build"];
     }
-    event.extra = [self convertExtra];
     event.tags = [self convertTags];
     event.user = [self convertUser];
+
+	// Apperently console_log is disabled in multiple ways, so add the console text line by line to the
+	// event.extra until we get this figured out. This appears on the server, sorted perfectly by key.
+	NSMutableDictionary *extra = [NSMutableDictionary dictionaryWithDictionary:[self convertExtra]];
+	int count = 0;
+	for (NSString *line in self.report[@"debug"][@"console_log"]) {
+		NSString *key = [NSString stringWithFormat:@"log:%05d", count++];
+		extra[key] = line;
+	}
+	event.extra = extra.copy;
     return event;
 }
 

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -79,6 +79,7 @@ static void printPreviousLog(const char* filePath)
         printf("%s\n", data);
         printf("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n\n");
         fflush(stdout);
+		free(data);
     }
 }
 


### PR DESCRIPTION
… per log line. To accomplish this, the partial logging functions instead write to a line buffer, and then are flushed out to the streams at the end. 'flushLog' was repurposed for this. Buffer size is controlled by the existing macro 'SentryCrashLOGGER_CBufferSize', which now has its default size increased to account for emoji streams and ligatures for colorized console fonts. setLogFD no longer allows setting the g_fd or g_file to stdout, etc., because stdout was always written anyway, so this part was cleaned up.