### PR TITLE
Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,127 @@
+// swift-tools-version:5.1
+import PackageDescription
+
+let package = Package(
+    name: "Sentry",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v8),
+        .tvOS(.v9),
+        .watchOS(.v2),
+    ],
+    products: [
+        .library(
+            name: "Sentry",
+            targets: ["Sentry"]
+        ),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Sentry",
+            dependencies: [
+                "SentryCrash/Installations",
+                "SentryCrash/Recording",
+                "SentryCrash/Recording/Monitors",
+                "SentryCrash/Recording/Tools",
+                "SentryCrash/Reporting/Filters",
+                "SentryCrash/Reporting/Filters/Tools",
+                "SentryCrash/Reporting/Tools",
+            ],
+            path: "Sources/Sentry",
+            publicHeadersPath: "include",
+            cxxSettings: [
+                .headerSearchPath("../SentryCrash/Installations"),
+                .headerSearchPath("../SentryCrash/Recording"),
+                .headerSearchPath("../SentryCrash/Recording/Monitors"),
+                .headerSearchPath("../SentryCrash/Recording/Tools"),
+                .headerSearchPath("../SentryCrash/Reporting/Filters"),
+            ],
+            linkerSettings: [
+                .linkedLibrary("z"),
+                .linkedLibrary("c++"),
+            ]
+        ),
+
+        .target(
+            name: "SentryCrash/Installations",
+            path: "Sources/SentryCrash/Installations",
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .headerSearchPath("../Recording"),
+                .headerSearchPath("../Recording/Monitors"),
+                .headerSearchPath("../Recording/Tools"),
+                .headerSearchPath("../Reporting/Filters"),
+                .headerSearchPath("../Reporting/Tools"),
+            ]
+        ),
+
+        .target(
+            name: "SentryCrash/Recording",
+            path: "Sources/SentryCrash/Recording",
+            exclude: [
+                "Monitors",
+                "Tools",
+            ],
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .headerSearchPath("Tools"),
+                .headerSearchPath("Monitors"),
+                .headerSearchPath("../Reporting/Filters"),
+            ]
+        ),
+
+        .target(
+            name: "SentryCrash/Recording/Monitors",
+            path: "Sources/SentryCrash/Recording/Monitors",
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .define("GCC_ENABLE_CPP_EXCEPTIONS", to: "YES"),
+                .headerSearchPath(".."),
+                .headerSearchPath("../Tools"),
+                .headerSearchPath("../../Reporting/Filters"),
+            ]
+        ),
+
+        .target(
+            name: "SentryCrash/Recording/Tools",
+            path: "Sources/SentryCrash/Recording/Tools",
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .headerSearchPath(".."),
+            ]
+        ),
+
+        .target(
+            name: "SentryCrash/Reporting/Filters",
+            path: "Sources/SentryCrash/Reporting/Filters",
+            exclude: [
+                "Tools",
+            ],
+            publicHeadersPath: ".",
+            cxxSettings: [
+                .headerSearchPath("Tools"),
+                .headerSearchPath("../../Recording/Tools"),
+            ]
+        ),
+
+        .target(
+            name: "SentryCrash/Reporting/Filters/Tools",
+            path: "Sources/SentryCrash/Reporting/Filters/Tools",
+            publicHeadersPath: "."
+        ),
+
+        .target(
+            name: "SentryCrash/Reporting/Tools",
+            path: "Sources/SentryCrash/Reporting/Tools",
+            publicHeadersPath: "."
+        ),
+
+        // TODO: make tests work.
+        // "contains mixed language source files; feature not supported"
+        // .testTarget(
+        //     name: "SentryTests",
+        //     dependencies: ["Sentry"]
+        // ),
+    ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,6 @@ let package = Package(
                 "SentryCrash/Reporting/Tools",
             ],
             path: "Sources/Sentry",
-            publicHeadersPath: "include",
             cxxSettings: [
                 .headerSearchPath("../SentryCrash/Installations"),
                 .headerSearchPath("../SentryCrash/Recording"),
@@ -117,11 +116,26 @@ let package = Package(
             publicHeadersPath: "."
         ),
 
-        // TODO: make tests work.
-        // "contains mixed language source files; feature not supported"
+        .testTarget(
+            name: "SentrySwiftTests",
+            dependencies: [
+                "Sentry",
+            ],
+            path: "Tests/SentryTests",
+            sources: [
+                "SentrySwiftTests.swift",
+            ]
+        ),
+
+        // TODO: make Objective-C tests work.
         // .testTarget(
         //     name: "SentryTests",
-        //     dependencies: ["Sentry"]
+        //     dependencies: [
+        //         "Sentry",
+        //     ],
+        //     exclude: [
+        //         "SentrySwiftTests.swift",
+        //     ]
         // ),
     ]
 )

--- a/Sources/Sentry/include/module.modulemap
+++ b/Sources/Sentry/include/module.modulemap
@@ -1,0 +1,4 @@
+module Sentry {
+    umbrella "."
+    export *
+}


### PR DESCRIPTION
This PR implements [Swift Package Manager](https://swift.org/package-manager/) support with the existing `SentryCrash` directory structure. I’ve tested this lightly within an existing iOS app, and it seems to operate in line with the CocoaPods build.

It builds on the command line via `swift build` on macOS Catalina, and I haven’t tested it on tvOS, watchOS, or iOS earlier than 13.3.

This fixes #312 and was inspired by #321.