### PR TITLE
Add more error checking to crash recording and reporting

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -129,6 +129,12 @@ static bool installSignalHandler()
         SentryCrashLOG_DEBUG("Allocating signal stack area.");
         g_signalStack.ss_size = SIGSTKSZ;
         g_signalStack.ss_sp = malloc(g_signalStack.ss_size);
+
+        if (g_signalStack.ss_sp == NULL)
+        {
+            SentryCrashLOG_ERROR("Failed to allocate signal stack area of size %ul", g_signalStack.ss_size);
+            goto failed;
+        }
     }
 
     SentryCrashLOG_DEBUG("Setting signal stack area.");

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -130,7 +130,7 @@ static bool installSignalHandler()
         g_signalStack.ss_size = SIGSTKSZ;
         g_signalStack.ss_sp = malloc(g_signalStack.ss_size);
 
-        if (g_signalStack.ss_sp == NULL)
+        if(g_signalStack.ss_sp == NULL)
         {
             SentryCrashLOG_ERROR("Failed to allocate signal stack area of size %ul", g_signalStack.ss_size);
             goto failed;

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -128,6 +128,11 @@ static const char* stringSysctl(const char* name)
     }
 
     char* value = malloc((size_t)size);
+    if(value == NULL)
+    {
+        return NULL;
+    }
+
     if(sentrycrashsysctl_stringForName(name, value, size) <= 0)
     {
         free(value);
@@ -140,7 +145,10 @@ static const char* stringSysctl(const char* name)
 static const char* dateString(time_t date)
 {
     char* buffer = malloc(21);
-    sentrycrashdate_utcStringFromTimestamp(date, buffer);
+    if(buffer != NULL)
+    {
+        sentrycrashdate_utcStringFromTimestamp(date, buffer);
+    }
     return buffer;
 }
 

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1843,7 +1843,10 @@ void sentrycrashreport_setDoNotIntrospectClasses(const char** doNotIntrospectCla
     {
         for(int i = 0; i < oldClassesLength; i++)
         {
-            free((void*)oldClasses[i]);
+            if (oldClasses[i] != NULL)
+            {
+                free((void*)oldClasses[i]);
+            }
         }
         free(oldClasses);
     }

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -649,7 +649,8 @@ static bool isRestrictedClass(const char* name)
     {
         for(int i = 0; i < g_introspectionRules.restrictedClassesCount; i++)
         {
-            if(strcmp(name, g_introspectionRules.restrictedClasses[i]) == 0)
+            const char* className = g_introspectionRules.restrictedClasses[i];
+            if(className != NULL && strcmp(name, className) == 0)
             {
                 return true;
             }

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1843,7 +1843,7 @@ void sentrycrashreport_setDoNotIntrospectClasses(const char** doNotIntrospectCla
     {
         for(int i = 0; i < oldClassesLength; i++)
         {
-            if (oldClasses[i] != NULL)
+            if(oldClasses[i] != NULL)
             {
                 free((void*)oldClasses[i]);
             }

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
@@ -249,9 +249,20 @@ char* sentrycrashcrf_fixupCrashReport(const char* crashReport)
     };
     int stringBufferLength = 10000;
     char* stringBuffer = malloc((unsigned)stringBufferLength);
+    if(stringBuffer == NULL)
+    {
+        SentryCrashLOG_ERROR("Failed to allocate string buffer of size %ul", stringBufferLength);
+        return NULL;
+    }
     int crashReportLength = (int)strlen(crashReport);
     int fixedReportLength = (int)(crashReportLength * 1.5);
     char* fixedReport = malloc((unsigned)fixedReportLength);
+    if (fixedReport == NULL)
+    {
+        free(stringBuffer);
+        SentryCrashLOG_ERROR("Failed to allocate fixed report buffer of size %ld", fixedReportLength);
+        return NULL;
+    }
     SentryCrashJSONEncodeContext encodeContext;
     FixupContext fixupContext =
     {

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
@@ -257,7 +257,7 @@ char* sentrycrashcrf_fixupCrashReport(const char* crashReport)
     int crashReportLength = (int)strlen(crashReport);
     int fixedReportLength = (int)(crashReportLength * 1.5);
     char* fixedReport = malloc((unsigned)fixedReportLength);
-    if (fixedReport == NULL)
+    if(fixedReport == NULL)
     {
         free(stringBuffer);
         SentryCrashLOG_ERROR("Failed to allocate fixed report buffer of size %ld", fixedReportLength);

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -111,17 +111,20 @@ static void dirContents(const char* path, char*** entries, int* count)
     }
 
     entryList = calloc((unsigned)entryCount, sizeof(char*));
-    struct dirent* ent;
-    int index = 0;
-    while((ent = readdir(dir)))
+    if(entryList != NULL)
     {
-        if(index >= entryCount)
+        struct dirent* ent;
+        int index = 0;
+        while((ent = readdir(dir)))
         {
-            SentryCrashLOG_ERROR("Contents of %s have been mutated", path);
-            goto done;
+            if(index >= entryCount)
+            {
+                SentryCrashLOG_ERROR("Contents of %s have been mutated", path);
+                goto done;
+            }
+            entryList[index] = strdup(ent->d_name);
+            index++;
         }
-        entryList[index] = strdup(ent->d_name);
-        index++;
     }
 
 done:

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
@@ -315,7 +315,10 @@ void i_sentrycrashlog_logObjCBasic(CFStringRef fmt, ...)
     }
     writeToLog("\n");
 
-    free(stringBuffer);
+    if(stringBuffer != NULL)
+    {
+        free(stringBuffer);
+    }
     CFRelease(entry);
 }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
@@ -305,7 +305,7 @@ void i_sentrycrashlog_logObjCBasic(CFStringRef fmt, ...)
 
     int bufferLength = (int)CFStringGetLength(entry) * 4 + 1;
     char* stringBuffer = malloc((unsigned)bufferLength);
-    if(CFStringGetCString(entry, stringBuffer, (CFIndex)bufferLength, kCFStringEncodingUTF8))
+    if(stringBuffer != NULL && CFStringGetCString(entry, stringBuffer, (CFIndex)bufferLength, kCFStringEncodingUTF8))
     {
         writeToLog(stringBuffer);
     }

--- a/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.m
+++ b/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.m
@@ -61,7 +61,10 @@
     if((self = [super init]))
     {
         _bytes = strdup(string);
-        _length = strlen(_bytes);
+        if(_bytes != NULL)
+        {
+            _length = strlen(_bytes);
+        }
     }
     return self;
 }

--- a/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.m
+++ b/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.m
@@ -80,9 +80,16 @@
     {
         _length = length;
         char* bytes = malloc((unsigned)_length+1);
-        memcpy(bytes, data, _length);
-        bytes[_length] = 0;
-        _bytes = bytes;
+        if(bytes != NULL)
+        {
+            memcpy(bytes, data, _length);
+            bytes[_length] = 0;
+            _bytes = bytes;
+        }
+        else
+        {
+            _length = 0;
+        }
     }
     return self;
 }


### PR DESCRIPTION
We ran version 4.4.3 of the Sentry SDK through a code scanner, and it identified several unchecked error conditions, mostly related to memory allocation. This branch has my patches to address those items.