### PR TITLE
removes `logLevel` from `SentryClient` ...

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -109,15 +109,6 @@ NSString *const SentryClientSdkName = @"sentry-cocoa";
     return SentryClientSdkName;
 }
 
-//+ (void)setLogLevel:(SentryLogLevel)level {
-//    NSParameterAssert(level);
-//    logLevel = level;
-//}
-//
-//+ (SentryLogLevel)logLevel {
-//    return logLevel;
-//}
-
 #pragma mark prepareEvent
 
 - (SentryEvent *_Nullable)prepareEvent:(SentryEvent *)event

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -50,7 +50,6 @@ NS_ASSUME_NONNULL_BEGIN
 NSString *const SentryClientVersionString = @"5.0.0";
 NSString *const SentryClientSdkName = @"sentry-cocoa";
 
-static SentryLogLevel logLevel = kSentryLogLevelError;
 
 @interface SentryClient ()
 
@@ -62,7 +61,6 @@ static SentryLogLevel logLevel = kSentryLogLevelError;
 
 @synthesize options = _options;
 @synthesize transport = _transport;
-@dynamic logLevel;
 
 #pragma mark Initializer
 
@@ -111,14 +109,14 @@ static SentryLogLevel logLevel = kSentryLogLevelError;
     return SentryClientSdkName;
 }
 
-+ (void)setLogLevel:(SentryLogLevel)level {
-    NSParameterAssert(level);
-    logLevel = level;
-}
-
-+ (SentryLogLevel)logLevel {
-    return logLevel;
-}
+//+ (void)setLogLevel:(SentryLogLevel)level {
+//    NSParameterAssert(level);
+//    logLevel = level;
+//}
+//
+//+ (SentryLogLevel)logLevel {
+//    return logLevel;
+//}
 
 #pragma mark prepareEvent
 

--- a/Sources/Sentry/SentryLog.m
+++ b/Sources/Sentry/SentryLog.m
@@ -10,10 +10,12 @@
 
 #import <Sentry/SentryClient.h>
 #import <Sentry/SentryLog.h>
+#import <Sentry/SentrySDK.h>
 
 #else
 #import "SentryClient.h"
 #import "SentryLog.h"
+#import "SentrySDK.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -22,8 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)logWithMessage:(NSString *)message andLevel:(SentryLogLevel)level {
     SentryLogLevel defaultLevel = kSentryLogLevelError;
-    if (SentryClient.logLevel > 0) {
-        defaultLevel = SentryClient.logLevel;
+    if ([SentrySDK.currentHub getClient].options.logLevel > 0) {
+        defaultLevel = [SentrySDK.currentHub getClient].options.logLevel;
     }
     if (level <= defaultLevel && level != kSentryLogLevelNone) {
         NSLog(@"Sentry - %@:: %@", [self.class logLevelToString:level], message);

--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -15,6 +15,7 @@
 #import <Sentry/SentryError.h>
 #import <Sentry/SentryLog.h>
 #import <Sentry/NSData+SentryCompression.h>
+#import <Sentry/SentrySDK.h>
 
 #else
 #import "SentryDsn.h"
@@ -24,6 +25,7 @@
 #import "SentryError.h"
 #import "SentryLog.h"
 #import "NSData+SentryCompression.h"
+#import "SentrySDK.h"
 
 #endif
 
@@ -58,11 +60,11 @@ NSTimeInterval const SentryRequestTimeout = 15;
         }
         
         jsonData = [NSJSONSerialization dataWithJSONObject:serialized
-                                                           options:SentryClient.logLevel == kSentryLogLevelVerbose ? NSJSONWritingPrettyPrinted : 0
-                                                             error:error];
+                                                   options:[SentrySDK.currentHub getClient].options.logLevel == kSentryLogLevelVerbose ? NSJSONWritingPrettyPrinted : 0
+                                                     error:error];
     }
     
-    if (SentryClient.logLevel == kSentryLogLevelVerbose) {
+    if ([SentrySDK.currentHub getClient].options.logLevel == kSentryLogLevelVerbose) {
         [SentryLog logWithMessage:@"Sending JSON -------------------------------" andLevel:kSentryLogLevelVerbose];
         [SentryLog logWithMessage:[NSString stringWithFormat:@"%@", [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]] andLevel:kSentryLogLevelVerbose];
         [SentryLog logWithMessage:@"--------------------------------------------" andLevel:kSentryLogLevelVerbose];

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -42,6 +42,9 @@
     return self;
 }
 
+/**
+ populates all `SentryOptions` values from `options` dict using fallbacks/defaults if needed.
+ */
 - (void)validateOptions:(NSDictionary<NSString *, id> *)options
        didFailWithError:(NSError *_Nullable *_Nullable)error {
     if (nil == [options valueForKey:@"dsn"] || ![[options valueForKey:@"dsn"] isKindOfClass:[NSString class]]) {

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -51,6 +51,18 @@
     }
     
     self.dsn = [[SentryDsn alloc] initWithString:[options valueForKey:@"dsn"] didFailWithError:error];
+
+    if (nil != [options objectForKey:@"debug"]) {
+        self.debug = [NSNumber numberWithBool:[[options objectForKey:@"debug"] boolValue]];
+    } else {
+        self.debug = @NO;
+    }
+
+    if ([self.debug isEqual:@YES])  {
+        self.logLevel = kSentryLogLevelVerbose;
+    } else {
+        self.logLevel = kSentryLogLevelError;
+    }
     
     if ([[options objectForKey:@"release"] isKindOfClass:[NSString class]]) {
         self.releaseName = [options objectForKey:@"release"];

--- a/Sources/Sentry/SentryRequestOperation.m
+++ b/Sources/Sentry/SentryRequestOperation.m
@@ -12,12 +12,14 @@
 #import <Sentry/SentryLog.h>
 #import <Sentry/SentryError.h>
 #import <Sentry/SentryClient.h>
+#import <Sentry/SentrySDK.h>
 
 #else
 #import "SentryRequestOperation.h"
 #import "SentryLog.h"
 #import "SentryError.h"
 #import "SentryClient.h"
+#import "SentrySDK.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -42,7 +44,7 @@ NS_ASSUME_NONNULL_BEGIN
             
             // We only have these if's here because of performance reasons
             [SentryLog logWithMessage:[NSString stringWithFormat:@"Request status: %ld", (long) statusCode] andLevel:kSentryLogLevelDebug];
-            if (SentryClient.logLevel == kSentryLogLevelVerbose) {
+            if ([SentrySDK.currentHub getClient].options.logLevel == kSentryLogLevelVerbose) {
                 [SentryLog logWithMessage:[NSString stringWithFormat:@"Request response: %@", [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]] andLevel:kSentryLogLevelVerbose];
             }
             

--- a/Sources/Sentry/include/SentryClient.h
+++ b/Sources/Sentry/include/SentryClient.h
@@ -40,11 +40,6 @@ SENTRY_NO_INIT
  */
 @property(nonatomic, class, readonly, copy) NSString *sdkName;
 
-/**
- * Set logLevel for the current client default kSentryLogLevelError
- */
-@property(nonatomic, class) SentryLogLevel logLevel;
-
 @property(nonatomic, strong) SentryOptions *options;
 
 /**

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -34,6 +34,18 @@ SENTRY_NO_INIT
 @property(nonatomic, strong) SentryDsn *dsn;
 
 /**
+ * debug [mode] sets a more verbose log level. Default is @NO. If set to @YES sentry prints more log messages to the console.
+ */
+@property(nonatomic, copy) NSNumber *debug;
+
+/**
+ DEPRECATED: use debug bool instead (debug = @YES maps to logLevel kSentryLogLevelError, debug = @NO maps to loglevel kSentryLogLevelError).
+             thus kSentryLogLevelNone and kSentryLogLevelDebug will be dropped entirely.
+ defines the log level of sentry log (console output).
+ */
+@property(nonatomic, assign) SentryLogLevel logLevel;
+
+/**
  * This property will be filled before the event is sent.
  */
 @property(nonatomic, copy) NSString *_Nullable releaseName;


### PR DESCRIPTION
…and replaced it with `debug` and `logLevel` in `SentryOption`.

todo was:
 setLogLevel in SentryClient shouldn't exist. Instead, there should be an option in debug: boolean which enables the SDK to log Verbose or default should be Error level. Ideally, the debug option also supports boolean but also logLevel as string none | error | verbose | debug (default should be error, none and verbose are cocoa sdk specific - maybe deprecate at some point).