### PR TITLE
Fix spelling in doc comments

### DIFF
--- a/Sources/Sentry/include/SentryClient.h
+++ b/Sources/Sentry/include/SentryClient.h
@@ -165,7 +165,7 @@ NS_SWIFT_NAME(Client)
 - (void)enableAutomaticBreadcrumbTracking;
 
 /**
- * Track memory pressure notifcation on UIApplications and send an event for it to Sentry.
+ * Track memory pressure notification on UIApplications and send an event for it to Sentry.
  */
 - (void)trackMemoryPressureAsEvent;
 


### PR DESCRIPTION
Tiny change to fix a little spelling mistake in doc comments.

`notifcation` => `notification`