### PR TITLE
Fix SentryContext OS name detection for tvOS and macCatalyst

### DIFF
--- a/Sources/Sentry/SentryContext.m
+++ b/Sources/Sentry/SentryContext.m
@@ -66,9 +66,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, id> *)generatedOsContext {
     NSMutableDictionary *serializedData = [NSMutableDictionary new];
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
     [serializedData setValue:@"iOS" forKey:@"name"];
-#elif TARGET_OS_OSX
+#elif TARGET_OS_OSX || TARGET_OS_MACCATALYST
     [serializedData setValue:@"macOS" forKey:@"name"];
 #elif TARGET_OS_TV
     [serializedData setValue:@"tvOS" forKey:@"name"];

--- a/Sources/Sentry/SentryContext.m
+++ b/Sources/Sentry/SentryContext.m
@@ -66,10 +66,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSDictionary<NSString *, id> *)generatedOsContext {
     NSMutableDictionary *serializedData = [NSMutableDictionary new];
 
-#if TARGET_OS_IOS
-    [serializedData setValue:@"iOS" forKey:@"name"];
-#elif TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if TARGET_OS_OSX || TARGET_OS_MACCATALYST
     [serializedData setValue:@"macOS" forKey:@"name"];
+#elif TARGET_OS_IOS
+    [serializedData setValue:@"iOS" forKey:@"name"];
 #elif TARGET_OS_TV
     [serializedData setValue:@"tvOS" forKey:@"name"];
 #elif TARGET_OS_WATCH


### PR DESCRIPTION
Manually created SentryEvents have `os.name=iOS` set, but should be `os.name=tvOS`.

This PR fixes this for tvOS (`os.name=tvOS`) and mac catalyst apps (`os.name=macOS`).

Original Issue: https://github.com/getsentry/sentry-cocoa/issues/361