### PR TITLE
updates readme batches

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@
     <h1>Official Sentry SDK for iOS/macOS/tvOS/watchOS<sup>(1)</sup>.</h1>
 </p>
 
-[![Travis](https://img.shields.io/travis/getsentry/sentry-cocoa.svg?maxAge=2592000)](https://travis-ci.org/getsentry/sentry-cocoa)
-![platforms](https://img.shields.io/badge/platforms-iOS%20%7C%20tvOS%20%7C%20OSX-333333.svg)
-![langauges](https://img.shields.io/badge/languages-Swift%20%7C%20ObjC-333333.svg)
+[![Travis](https://img.shields.io/travis/getsentry/sentry-cocoa.svg?maxAge=2592000)](https://travis-ci.com/getsentry/sentry-cocoa)
+[![codecov](https://codecov.io/gh/getsentry/sentry-cocoa/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-cocoa)
 [![CocoaPods Shield](https://img.shields.io/cocoapods/v/Sentry.svg)](https://cocoapods.org/pods/Sentry)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-[![codecov](https://codecov.io/gh/getsentry/sentry-cocoa/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-cocoa)
+![platforms](https://img.shields.io/badge/platforms-iOS%20%7C%20tvOS%20%7C%20OSX-333333.svg)
+![langauges](https://img.shields.io/badge/languages-Swift%20%7C%20ObjC-333333.svg)
+[![Twitter](https://img.shields.io/badge/twitter-@getsentry-blue.svg?style=flat)](http://twitter.com/getsentry)
+
+
 
 This SDK is written in Objective-C but also works for Swift projects.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![SwiftPM compatible](https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager)
 [![platforms](https://img.shields.io/cocoapods/p/Sentry.svg?style=flat)](http://cocoadocs.org/docsets/Sentry)
-![langauges](https://img.shields.io/badge/languages-Swift%20%7C%20ObjC-333333.svg)
 [![Twitter](https://img.shields.io/badge/twitter-@getsentry-blue.svg?style=flat)](http://twitter.com/getsentry)
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![CocoaPods compadible](https://img.shields.io/cocoapods/v/Sentry.svg)](https://cocoapods.org/pods/Sentry)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 [![SwiftPM compatible](https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager)
-[![platforms](https://img.shields.io/cocoapods/p/Sentry.svg?style=flat)](http://cocoadocs.org/docsets/Sentry)
+![platforms](https://img.shields.io/cocoapods/p/Sentry.svg?style=flat)
 [![Twitter](https://img.shields.io/badge/twitter-@getsentry-blue.svg?style=flat)](http://twitter.com/getsentry)
 
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@
 </p>
 
 [![Travis](https://img.shields.io/travis/getsentry/sentry-cocoa.svg?maxAge=2592000)](https://travis-ci.com/getsentry/sentry-cocoa)
-[![codecov](https://codecov.io/gh/getsentry/sentry-cocoa/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-cocoa)
-[![CocoaPods Shield](https://img.shields.io/cocoapods/v/Sentry.svg)](https://cocoapods.org/pods/Sentry)
+[![codecov.io](https://codecov.io/gh/getsentry/sentry-cocoa/branch/master/graph/badge.svg)](https://codecov.io/gh/getsentry/sentry-cocoa)
+[![CocoaPods compadible](https://img.shields.io/cocoapods/v/Sentry.svg)](https://cocoapods.org/pods/Sentry)
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
-![platforms](https://img.shields.io/badge/platforms-iOS%20%7C%20tvOS%20%7C%20OSX-333333.svg)
+[![SwiftPM compatible](https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager)
+[![platforms](https://img.shields.io/cocoapods/p/Sentry.svg?style=flat)](http://cocoadocs.org/docsets/Sentry)
 ![langauges](https://img.shields.io/badge/languages-Swift%20%7C%20ObjC-333333.svg)
 [![Twitter](https://img.shields.io/badge/twitter-@getsentry-blue.svg?style=flat)](http://twitter.com/getsentry)
 


### PR DESCRIPTION
 * fixed link to travis from .org to .com (build batch)
 * added twitter batch
 * rearranged them (build, tests, releases, platforms, languages, twitter)

"old": https://github.com/getsentry/sentry-cocoa/blob/master/README.md
new: https://github.com/getsentry/sentry-cocoa/blob/updates-readme-batches/README.md