### PR TITLE
5.x improve behaviour if response is http 429 aka. retry after

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -64,10 +64,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
         self.options = options;
 
-        // We want to send all stored events on start up
-        if ([self.options.enabled boolValue]) {
-            [self.transport sendAllStoredEvents];
-        }
+        [self.transport sendAllStoredEvents];
     }
     return self;
 }

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -56,7 +56,6 @@ static SentryInstallation *installation = nil;
 }
 
 - (BOOL)installWithOptions:(nonnull SentryOptions *)options {
-    [SentryLog logWithMessage:@"SentryCrashIntegration attempts to install" andLevel:kSentryLogLevelDebug];
     self.options = options;
     NSError *error = nil;
     BOOL isInstalled = [self startCrashHandlerWithError:&error];
@@ -69,7 +68,6 @@ static SentryInstallation *installation = nil;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 - (BOOL)startCrashHandlerWithError:(NSError *_Nullable *_Nullable)error {
-    [SentryLog logWithMessage:@"SentryCrashIntegration installing" andLevel:kSentryLogLevelDebug];
     static dispatch_once_t onceToken = 0;
     dispatch_once(&onceToken, ^{
         installation = [[SentryInstallation alloc] init];

--- a/Sources/Sentry/SentryGlobalEventProcessor.m
+++ b/Sources/Sentry/SentryGlobalEventProcessor.m
@@ -36,9 +36,8 @@
     return self;
 }
 
-- (BOOL)addEventProcessor:(SentryEventProcessor)newProcessor {
+- (void)addEventProcessor:(SentryEventProcessor)newProcessor {
     [self.processors addObject:newProcessor];
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"SentryGlobalEventProcessor addEventProcessor: %lu", self.processors.count] andLevel:kSentryLogLevelDebug];
     return YES;
 }
 

--- a/Sources/Sentry/SentryGlobalEventProcessor.m
+++ b/Sources/Sentry/SentryGlobalEventProcessor.m
@@ -38,7 +38,6 @@
 
 - (void)addEventProcessor:(SentryEventProcessor)newProcessor {
     [self.processors addObject:newProcessor];
-    return YES;
 }
 
 @end

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -105,9 +105,8 @@
 
 /**
  * Install integrations and keeps ref in `SentryHub.integrations`
- * @return BOOL Count of installed integrations (`SentryHub.integrations`) is equal to `options.integrations`
  */
-- (BOOL)doInstallIntegrations {
+- (void)doInstallIntegrations {
     SentryOptions *options = [self getClient].options;
     for (NSString *integrationName in [self getClient].options.integrations) {
         Class integrationClass = NSClassFromString(integrationName);
@@ -122,9 +121,9 @@
         }
         id<SentryIntegrationProtocol> integrationInstance = [[integrationClass alloc] init];
         [integrationInstance installWithOptions:options];
+        [SentryLog logWithMessage:[NSString stringWithFormat:@"Integration installed: %@", integrationName] andLevel:kSentryLogLevelDebug];
         [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
     }
-    return [self getClient].options.integrations.count == SentrySDK.currentHub.installedIntegrations.count;
 }
 
 /**

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -62,7 +62,7 @@
     }
 
     if ([self.debug isEqual:@YES])  {
-        self.logLevel = kSentryLogLevelVerbose;
+        self.logLevel = kSentryLogLevelDebug;
     } else {
         self.logLevel = kSentryLogLevelError;
     }

--- a/Sources/Sentry/SentryTransport.m
+++ b/Sources/Sentry/SentryTransport.m
@@ -210,7 +210,7 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
  */
 - (BOOL)isReadySendEvent {
     if (![self.options.enabled boolValue]) {
-        [SentryLog logWithMessage:@"SentryClient is disabled. (options.enabled = fasle)" andLevel:kSentryLogLevelDebug];
+        [SentryLog logWithMessage:@"SentryClient is disabled. (options.enabled = false)" andLevel:kSentryLogLevelDebug];
         return NO;
     }
 

--- a/Sources/Sentry/SentryTransport.m
+++ b/Sources/Sentry/SentryTransport.m
@@ -215,7 +215,7 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
     }
 
     if ([self isRadioSilence]) {
-        [SentryLog logWithMessage:@"SentryClient radio silence. 'Rate Limit' of DNS reached." andLevel:kSentryLogLevelDebug];
+        [SentryLog logWithMessage:@"SentryClient radio silence. 'Rate Limit' of DSN reached." andLevel:kSentryLogLevelDebug];
         return NO;
     }
     return YES;

--- a/Sources/Sentry/include/SentryGlobalEventProcessor.h
+++ b/Sources/Sentry/include/SentryGlobalEventProcessor.h
@@ -23,7 +23,7 @@ SENTRY_NO_INIT
 
 + (instancetype)shared;
 
-- (BOOL)addEventProcessor:(SentryEventProcessor)newProcessor;
+- (void)addEventProcessor:(SentryEventProcessor)newProcessor;
 
 @end
 

--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -39,16 +39,6 @@ SENTRY_NO_INIT
  */
 @property(nonatomic, strong) SentryEvent *_Nullable lastEvent;
 
-/**
- * Increase the max number of events we store offline.
- * Be careful with this setting since too high numbers may cause your quota to exceed.
- */
-@property(nonatomic, assign) NSUInteger maxEvents;
-
-/**
- * Increase the max number of breadcrumbs we store offline.
- */
-@property(nonatomic, assign) NSUInteger maxBreadcrumbs;
 
 - (id)initWithOptions:(SentryOptions *)options;
 
@@ -79,15 +69,6 @@ NS_SWIFT_NAME(send(event:completion:));
  * Triggers NSNotification @"Sentry/allStoredEventsSent" when done.
  */
 - (void)sendAllStoredEvents;
-
-/**
- * This function stores an event to disk. It will be sent with the next batch.
- * This function is mainly used for react native.
- * @param event SentryEvent that should be sent
- */
-- (void)storeEvent:(SentryEvent *)event;
-
-
 
 @end
 

--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -25,9 +25,11 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 /**
- * This block can be used to prevent the event from being deleted after a failed send attempt.
- * Default is it will only be stored once after you hit a rate limit or there is no internet connect/cannot connect.
- * Also note that if an event fails to be sent again after it was queued, it will be discarded regardless.
+ * This is triggered after the first upload attempt of an event. Checks if event
+ * should stay on disk to be uploaded when `sendAllStoredEvents` is triggerd.
+ *
+ * Within `sendAllStoredEvents` this function isn't triggerd.
+ *
  * @return BOOL YES = store and try again later, NO = delete
  */
 @property(nonatomic, copy) SentryShouldQueueEvent _Nullable shouldQueueEvent;
@@ -50,17 +52,33 @@ SENTRY_NO_INIT
 
 - (id)initWithOptions:(SentryOptions *)options;
 
-- (void)sendAllStoredEvents;
-
 /**
- * Sends and event to sentry. Internally calls @selector(sendEvent:withCompletionHandler:)
+ * Sends and event to sentry.
+ * Triggerd when a event occurs. Thus the first try to upload an event.
  * CompletionHandler will be called if set.
+ *
+ * Failure to send will most likely keep this event on disk to batch upload with
+ * `sendAllStoredEvent` on next app launch.
+ *
  * @param event SentryEvent that should be sent
  * @param completionHandler SentryRequestFinished
  */
 - (void)    sendEvent:(SentryEvent *)event
 withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler
 NS_SWIFT_NAME(send(event:completion:));
+
+/**
+ * Sends all events stored on disk. Those events haven't been uploaded
+ * successfully at the first attempt (via `sendEvent:withCompletionHandler`)
+ * and have been kept on disk to retry.
+ *
+ * If an event fails to be sent (again), it will be discarded regardless.
+ *
+ * Triggered when SDK initializes (which is most likely on app startup).
+ *
+ * Triggers NSNotification @"Sentry/allStoredEventsSent" when done.
+ */
+- (void)sendAllStoredEvents;
 
 /**
  * This function stores an event to disk. It will be sent with the next batch.


### PR DESCRIPTION
### current behavior aka. 4.x
The response is checked for HTTP 429 and the corresponding event setup for queuing[sic!]. No actual radio silence implemented.

### This PR
If a response is HTTP 429, the "Retry-After" header is parsed. Resulting `radioSilenceDeadline` is set. No event is sent as long as this NSDate is after now.

This date isn't saved on disk. Thus requests will be triggered again after app restart. To fix this `NSUserDefaults` could be used (iOS 2.0+, macOS 10.0+, Mac Catalyst 13.0+, tvOS 9.0+, watchOS 2.0+). Can add this if wanted.

The batch upload `sendAllStoredEvents` should stop uploading as soon as a 429 occurs (AFAIK sentry-android is doing this `getQueue().clear();`). But `sendAllStoredEvents` is not a queue - it's a for loop with a `dispatchGroup` to get a callback when all responses have been processed. TTBOMK prematurely stopping this batch process when a 429 occurs makes little sense/has little effect because the requests are triggered all at once - most likely done before the first response arrives (before `radioSilenceDeadline` has been set/updated).

`sendAllStoredEvents` is triggered when SDK is initialized (most likely when app starts) and always removes events after sending the request (no matter if the request was successful or not`*`). Not sure if this is still intended. Since this basically means all events are removed as soon as the rate limit is exceeded and `sendAllStoredEvents` is triggered. 

What makes no sense to me right now is that `sendAllStoredEvents` is called at the end of `sendEvent` response processing of an event that just occurred. Thus immediately trying to resend an event if the first upload (via `sendEvent`) failed. This actually results in 2 requests for every event that fails at first. in case of an exceeded rate limit (or a bad internet connection, or any other thing that prevents successful upload): 2 failed requests for the first and remove all events from disk.

I would suggest this PR is good enough for now. Further changes require (at least a little) refactoring and more testing. Whenever we want to improve the batch process in regards to 429 I suggest the following improvements in transport:
 * implement request queueing - wait for the response to send the next request - with full control of the process to be able to stop whenever needed. This is less obtrusive for the actual app (in theory sentry-cocoa could upload a considerable amount of data right at app startup).
 * when sending the actual event, use out-of-process background networking (see #271). This is A) a significant improvement regarding QoS and B) This might work with a specific queueing implementation only. Thus we should consider/do both to assure we don't do extra laps.

UPDATE/ADDITION:
`*` only exception is when there was no internet connection at all (`response == nil`).