### PR TITLE
feat: Scope extra values

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -122,12 +122,6 @@ NS_ASSUME_NONNULL_BEGIN
     if (NO == [self checkSampleRate:self.options.sampleRate]) {
         [SentryLog logWithMessage:@"Event got sampled, will not send the event" andLevel:kSentryLogLevelDebug];
         return nil;
-    }    
-
-    
-    NSString *environment = self.options.environment;
-    if (nil != environment && nil == event.environment) {
-        event.environment = environment;
     }
     
     NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
@@ -137,6 +131,10 @@ NS_ASSUME_NONNULL_BEGIN
         event.dist = infoDict[@"CFBundleVersion"];
     }
 
+    event = [scope applyToEvent:event maxBreadcrumb:self.options.maxBreadcrumbs];
+
+    // Use the values from SentryOptions as a fallback,
+    // in case not yet set directly in the event nor in the scope:
     NSString *releaseName = self.options.releaseName;
     if (nil != releaseName) {
         event.releaseName = releaseName;
@@ -147,8 +145,11 @@ NS_ASSUME_NONNULL_BEGIN
         event.dist = dist;
     }
 
-    event = [scope applyToEvent:event maxBreadcrumb:self.options.maxBreadcrumbs];
-
+    NSString *environment = self.options.environment;
+    if (nil != environment && nil == event.environment) {
+        event.environment = environment;
+    }
+    
     return event;
 }
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -60,6 +60,21 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSDictionary<NSString *, NSString *> *_Nullable tags;
 
 /**
+ * The release version name of the application.
+ */
+@property(nonatomic, copy) NSString *_Nullable releaseName;
+
+/**
+ * This distribution of the application.
+ */
+@property(nonatomic, copy) NSString *_Nullable dist;
+
+/**
+ * The environment used in this scope.
+ */
+@property(nonatomic, copy) NSString *_Nullable environment;
+
+/**
  * Set global extra -> these will be sent with every event
  */
 @property(nonatomic, strong) NSDictionary<NSString *, id> *_Nullable extra;
@@ -83,6 +98,9 @@ NS_ASSUME_NONNULL_BEGIN
 @synthesize user = _user;
 @synthesize context = _context;
 @synthesize breadcrumbs = _breadcrumbs;
+@synthesize releaseName = _releaseName;
+@synthesize dist = _dist;
+@synthesize environment = _environment;
 
 #pragma mark Initializer
 
@@ -176,6 +194,9 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.extra forKey:@"extra"];
     [serializedData setValue:self.context forKey:@"context"];
     [serializedData setValue:[self.user serialize] forKey:@"user"];
+    [serializedData setValue:self.releaseName forKey:@"release"];
+    [serializedData setValue:self.dist forKey:@"dist"];
+    [serializedData setValue:self.environment forKey:@"environment"];
     return serializedData;
 }
 
@@ -204,6 +225,24 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (nil != self.user && nil == event.user) {
         event.user = self.user;
+    }
+    
+    NSString* releaseName = [self releaseName];
+    if (nil != releaseName && nil == event.releaseName) {
+        // release can also be set via options but scope takes precedence.
+        event.releaseName = releaseName;
+    }
+    
+    NSString* dist = self.dist;
+    if (nil != dist && nil == event.dist) {
+        // dist can also be set via options but scope takes precedence.
+        event.dist = dist;
+    }
+    
+    NSString* environment = self.environment;
+    if (nil != environment && nil == event.environment) {
+        // environment can also be set via options but scope takes precedence.
+        event.environment = environment;
     }
 
     if (nil != self.breadcrumbs) {

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -60,21 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSDictionary<NSString *, NSString *> *_Nullable tags;
 
 /**
- * The release version name of the application.
- */
-@property(nonatomic, copy) NSString *_Nullable releaseName;
-
-/**
- * This distribution of the application.
- */
-@property(nonatomic, copy) NSString *_Nullable dist;
-
-/**
- * The environment used in this scope.
- */
-@property(nonatomic, copy) NSString *_Nullable environment;
-
-/**
  * Set global extra -> these will be sent with every event
  */
 @property(nonatomic, strong) NSDictionary<NSString *, id> *_Nullable extra;

--- a/Sources/Sentry/include/SentryScope.h
+++ b/Sources/Sentry/include/SentryScope.h
@@ -83,6 +83,21 @@ NS_SWIFT_NAME(Scope)
 - (void)setContextValue:(NSDictionary<NSString *, id>*)value forKey:(NSString *)key;
 
 /**
+ * The release version name of the application.
+ */
+@property(nonatomic, copy) NSString *_Nullable releaseName;
+
+/**
+ * This distribution of the application.
+ */
+@property(nonatomic, copy) NSString *_Nullable dist;
+
+/**
+ * The environment used in this scope.
+ */
+@property(nonatomic, copy) NSString *_Nullable environment;
+
+/**
  * Clears the current Scope
  */
 - (void)clear;

--- a/Tests/SentryTests/SentryScopeTests.m
+++ b/Tests/SentryTests/SentryScopeTests.m
@@ -76,6 +76,30 @@
     #warning TODO implement
 }
 
+- (void)testReleaseSerializes {
+    SentryScope *scope = [[SentryScope alloc] init];
+    NSString *expectedReleaseName = @"io.sentry.cocoa@5.0.0-deadbeef";
+    scope.releaseName = expectedReleaseName;
+    XCTAssertEqual(scope.releaseName, expectedReleaseName);
+    XCTAssertEqualObjects([[scope serialize] objectForKey:@"release"], expectedReleaseName);
+}
+
+- (void)testDistSerializes {
+    SentryScope *scope = [[SentryScope alloc] init];
+    NSString *expectedDist = @"dist-1.0";
+    scope.dist = expectedDist;
+    XCTAssertEqual(scope.dist, expectedDist);
+    XCTAssertEqualObjects([[scope serialize] objectForKey:@"dist"], expectedDist);
+}
+
+- (void)testEnvironmentSerializes {
+    SentryScope *scope = [[SentryScope alloc] init];
+    NSString *expectedEnvironment = @"production";
+    scope.environment = expectedEnvironment;
+    XCTAssertEqual(scope.environment, expectedEnvironment);
+    XCTAssertEqualObjects([[scope serialize] objectForKey:@"environment"], expectedEnvironment);
+}
+
 - (void)testClearBreadcrumb {
     SentryScope *scope = [[SentryScope alloc] init];
     [scope clearBreadcrumbs];


### PR DESCRIPTION
Adds:
* release
* dist
* environment

To the scope, as properties with copy semantics.
Made sure values from the scope are applied before the values from `SentryOptions` since they are more "specific".