### PR TITLE
fix: Sentry level

### DIFF
--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -137,7 +137,7 @@ static inline NSString *hexAddress(NSNumber *value) {
     if (nil != [self.userContext objectForKey:@"breadcrumbs"]) {
         NSArray *storedBreadcrumbs = [self.userContext objectForKey:@"breadcrumbs"];
         for (NSDictionary *storedCrumb in storedBreadcrumbs) {
-            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:[self sentrySeverityFromLevel:[storedCrumb objectForKey:@"level"]]
+            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:[self sentryLevelFromString:[storedCrumb objectForKey:@"level"]]
                                                                      category:[storedCrumb objectForKey:@"category"]];
             crumb.message = [storedCrumb objectForKey:@"message"];
             crumb.type = [storedCrumb objectForKey:@"type"];
@@ -148,7 +148,7 @@ static inline NSString *hexAddress(NSNumber *value) {
     return breadcrumbs;
 }
 
-- (SentryLevel)sentrySeverityFromLevel:(NSString *)level {
+- (SentryLevel)sentryLevelFromString:(NSString *)level {
     if ([level isEqualToString:@"fatal"]) {
         return kSentryLevelFatal;
     } else if ([level isEqualToString:@"warning"]) {

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -38,6 +38,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryEvent
 
+- (instancetype)init {
+    return [self initWithLevel:kSentryLevelNone];
+}
+
 - (instancetype)initWithLevel:(enum SentryLevel)level {
     self = [super init];
     if (self) {
@@ -64,9 +68,12 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary *serializedData = @{
             @"event_id": self.eventId,
             @"timestamp": [self.timestamp sentry_toIso8601String],
-            @"level": SentryLevelNames[self.level],
             @"platform": @"cocoa",
     }.mutableCopy;
+    
+    if (self.level != kSentryLevelNone) {
+        [serializedData setValue:SentryLevelNames[self.level] forKey:@"level"];
+    }
     
     [self addSimpleProperties:serializedData];
     [self addOptionalListProperties:serializedData];

--- a/Sources/Sentry/SentryJavaScriptBridgeHelper.m
+++ b/Sources/Sentry/SentryJavaScriptBridgeHelper.m
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (level == nil) {
         level = @"info";
     }
-    SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] initWithLevel:[self.class sentryLevelFromLevel:level]
+    SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] initWithLevel:[self.class sentryLevelFromString:level]
                                                              category:jsonBreadcrumb[@"category"]];
     breadcrumb.message = jsonBreadcrumb[@"message"];
     if ([jsonBreadcrumb[@"timestamp"] integerValue] > 0) {
@@ -116,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (SentryEvent *)createSentryEventFromJavaScriptEvent:(NSDictionary *)jsonEvent {
-    SentryLevel level = [self.class sentryLevelFromLevel:jsonEvent[@"level"]];
+    SentryLevel level = [self.class sentryLevelFromString:jsonEvent[@"level"]];
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:level];
     if (jsonEvent[@"event_id"]) {
         event.eventId = jsonEvent[@"event_id"];
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
     return sentryUser;
 }
 
-+ (SentryLevel)sentryLevelFromLevel:(NSString *)level {
++ (SentryLevel)sentryLevelFromString:(NSString *)level {
     if ([level isEqualToString:@"fatal"]) {
         return kSentryLevelFatal;
     } else if ([level isEqualToString:@"warning"]) {

--- a/Sources/Sentry/SentryJavaScriptBridgeHelper.m
+++ b/Sources/Sentry/SentryJavaScriptBridgeHelper.m
@@ -101,7 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (level == nil) {
         level = @"info";
     }
-    SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] initWithLevel:[self.class sentrySeverityFromLevel:level]
+    SentryBreadcrumb *breadcrumb = [[SentryBreadcrumb alloc] initWithLevel:[self.class sentryLevelFromLevel:level]
                                                              category:jsonBreadcrumb[@"category"]];
     breadcrumb.message = jsonBreadcrumb[@"message"];
     if ([jsonBreadcrumb[@"timestamp"] integerValue] > 0) {
@@ -116,7 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (SentryEvent *)createSentryEventFromJavaScriptEvent:(NSDictionary *)jsonEvent {
-    SentryLevel level = [self.class sentrySeverityFromLevel:jsonEvent[@"level"]];
+    SentryLevel level = [self.class sentryLevelFromLevel:jsonEvent[@"level"]];
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:level];
     if (jsonEvent[@"event_id"]) {
         event.eventId = jsonEvent[@"event_id"];
@@ -228,7 +228,7 @@ NS_ASSUME_NONNULL_BEGIN
     return sentryUser;
 }
 
-+ (SentryLevel)sentrySeverityFromLevel:(NSString *)level {
++ (SentryLevel)sentryLevelFromLevel:(NSString *)level {
     if ([level isEqualToString:@"fatal"]) {
         return kSentryLevelFatal;
     } else if ([level isEqualToString:@"warning"]) {

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSArray<NSString *> *_Nullable fingerprint;
 
 /**
- * SentrySeverity of the event
+ * SentryLevel of the event
  */
 @property(nonatomic) enum SentryLevel level;
 

--- a/Sources/Sentry/include/SentryBreadcrumb.h
+++ b/Sources/Sentry/include/SentryBreadcrumb.h
@@ -58,7 +58,7 @@ SENTRY_NO_INIT
 /**
  * Initializer for SentryBreadcrumb
  *
- * @param level SentrySeverity
+ * @param level SentryLevel
  * @param category String
  * @return SentryBreadcrumb
  */

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -66,7 +66,7 @@ typedef NS_ENUM(NSInteger, SentryLogLevel) {
 };
 
 /**
- * Level of severity
+ * Sentry level
  */
 typedef NS_ENUM(NSUInteger, SentryLevel) {
     // Defaults to None which doesn't get serialized

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -68,22 +68,25 @@ typedef NS_ENUM(NSInteger, SentryLogLevel) {
 /**
  * Level of severity
  */
-typedef NS_ENUM(NSInteger, SentryLevel) {
-    kSentryLevelNone = -1,
-    kSentryLevelFatal = 0,
-    kSentryLevelError = 1,
-    kSentryLevelWarning = 2,
-    kSentryLevelInfo = 3,
-    kSentryLevelDebug = 4,
+typedef NS_ENUM(NSUInteger, SentryLevel) {
+    // Defaults to None which doesn't get serialized
+    kSentryLevelNone = 0,
+    // Goes from Debug to Fatal so possible to: (level > Info) { .. }
+    kSentryLevelDebug = 1,
+    kSentryLevelInfo = 2,
+    kSentryLevelWarning = 3,
+    kSentryLevelError = 4,
+    kSentryLevelFatal = 5,
 };
 
 /**
  * Static internal helper to convert enum to string
  */
 static NSString *_Nonnull const SentryLevelNames[] = {
-        @"fatal",
-        @"error",
-        @"warning",
-        @"info",
+        @"none",
         @"debug",
+        @"info",
+        @"warning",
+        @"error",
+        @"fatal",
 };

--- a/Sources/Sentry/include/SentryEvent.h
+++ b/Sources/Sentry/include/SentryEvent.h
@@ -44,7 +44,7 @@ NS_SWIFT_NAME(Event)
 @property(nonatomic, strong) NSDate *_Nullable startTimestamp;
 
 /**
- * SentrySeverity of the event
+ * SentryLevel of the event
  */
 @property(nonatomic) enum SentryLevel level;
 
@@ -171,7 +171,7 @@ NS_SWIFT_NAME(Event)
 
 /**
  * Init an SentryEvent will set all needed fields by default
- * @param level SentrySeverity
+ * @param level SentryLevel
  * @return SentryEvent
  */
 - (instancetype)initWithLevel:(enum SentryLevel)level NS_DESIGNATED_INITIALIZER;

--- a/Sources/Sentry/include/SentryEvent.h
+++ b/Sources/Sentry/include/SentryEvent.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(Event)
 @interface SentryEvent : NSObject <SentrySerializable>
-SENTRY_NO_INIT
 
 /**
  * This will be set by the initializer. Should be an UUID with the "-".
@@ -166,10 +165,16 @@ SENTRY_NO_INIT
 
 /**
  * Init an SentryEvent will set all needed fields by default
+ * @return SentryEvent
+ */
+- (instancetype)init;
+
+/**
+ * Init an SentryEvent will set all needed fields by default
  * @param level SentrySeverity
  * @return SentryEvent
  */
-- (instancetype)initWithLevel:(enum SentryLevel)level;
+- (instancetype)initWithLevel:(enum SentryLevel)level NS_DESIGNATED_INITIALIZER;
 
 /**
  * Init an SentryEvent with a JSON blob that completly bypasses all other attributes in the event.

--- a/Sources/Sentry/include/SentryScope.h
+++ b/Sources/Sentry/include/SentryScope.h
@@ -47,9 +47,6 @@ NS_SWIFT_NAME(Scope)
  */
 - (void)setTagValue:(id)value forKey:(NSString *)key NS_SWIFT_NAME(setTag(value:key:));
 
-// TODO: key is first arg.
-//- (void)setTagKey:(NSString *key withValue:(id)value;
-
 /**
  * Set global extra -> these will be sent with every event
  */
@@ -58,12 +55,12 @@ NS_SWIFT_NAME(Scope)
 /**
  * Set global extra -> these will be sent with every event
  */
-- (void)setExtraValue:(id)value forKey:(NSString *)key;
+- (void)setExtraValue:(id)value forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
 
 /**
  * Set release in the scope
  */
-- (void)setReleaseName:(NSString *_Nullable)releaseName;
+- (void)setRelease:(NSString *_Nullable)releaseName;
 
 /**
  * Set dist in the scope
@@ -109,7 +106,7 @@ NS_SWIFT_NAME(Scope)
  * Cets context values which will overwrite SentryEvent.context when event is
  * "enrichted" with scope before sending event.
  */
-- (void)setContextValue:(NSDictionary<NSString *, id>*)value forKey:(NSString *)key;
+- (void)setContextValue:(NSDictionary<NSString *, id>*)value forKey:(NSString *)key NS_SWIFT_NAME(setContext(value:key:));
 
 /**
  * Clears the current Scope

--- a/Tests/SentryTests/SentryBreadcrumbTests.m
+++ b/Tests/SentryTests/SentryBreadcrumbTests.m
@@ -99,7 +99,7 @@
 ////    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/12345" didFailWithError:&error];
 //    SentryScope *scope = [SentryScope new];
 //    XCTAssertNil(error);
-//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http"];
 //    NSDate *date = [NSDate date];
 //    crumb.timestamp = date;
 //    crumb.data = @{@"data": date, @"dict": @{@"date": date}};
@@ -124,22 +124,22 @@
 //    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/12345" didFailWithError:&error];
 //    SentryScope *scope = [SentryScope new];
 //    XCTAssertNil(error);
-//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http"];
 //    NSDate *date = [NSDate dateWithTimeIntervalSince1970:10];
 //    crumb.timestamp = date;
 //    [scope.breadcrumbs addBreadcrumb:crumb];
 //
-//    SentryBreadcrumb *crumb2 = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+//    SentryBreadcrumb *crumb2 = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http"];
 //    NSDate *date2 = [NSDate dateWithTimeIntervalSince1970:899990];
 //    crumb2.timestamp = date2;
 //    [scope.breadcrumbs addBreadcrumb:crumb2];
 //
-//    SentryBreadcrumb *crumb3 = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+//    SentryBreadcrumb *crumb3 = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http"];
 //    NSDate *date3 = [NSDate dateWithTimeIntervalSince1970:5];
 //    crumb3.timestamp = date3;
 //    [scope.breadcrumbs addBreadcrumb:crumb3];
 //
-//    SentryBreadcrumb *crumb4 = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityDebug category:@"http"];
+//    SentryBreadcrumb *crumb4 = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http"];
 //    NSDate *date4 = [NSDate dateWithTimeIntervalSince1970:11];
 //    crumb4.timestamp = date4;
 //    [scope.breadcrumbs addBreadcrumb:crumb4];

--- a/Tests/SentryTests/SentryFileManagerTests.m
+++ b/Tests/SentryTests/SentryFileManagerTests.m
@@ -60,7 +60,7 @@
 //    NSError *error = nil;
 //    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/12345" didFailWithError:&error];
 //    XCTAssertNil(error);
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    SentryScope *scope = [SentryScope new];
 //    [client storeEvent:event scope:scope];
 //    NSArray<NSDictionary<NSString *, NSData *>*> *events = [self.fileManager getAllStoredEvents];
@@ -116,7 +116,7 @@
 //    SentryClient *client = [[SentryClient alloc] initWithDsn:@"https://username:password@app.getsentry.com/12345" didFailWithError:&error];
 //    SentryScope *scope = [SentryScope new];
 //    XCTAssertNil(error);
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    client.maxEvents = 16;
 //    for (NSInteger i = 0; i <= 20; i++) {
 //        [client storeEvent:event scope:scope];

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -79,7 +79,7 @@
 
 //- (void)testEvent {
 //    NSDate *date = [NSDate date];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    event.timestamp = date;
 //    event.environment = @"bla";
 //    event.infoDict = @{@"CFBundleIdentifier": @"a", @"CFBundleShortVersionString": @"b", @"CFBundleVersion": @"c"};
@@ -96,7 +96,7 @@
 //                                 @"timestamp": [date sentry_toIso8601String]};
 //    XCTAssertEqualObjects([event serialize], serialized);
 //
-//    SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    event2.timestamp = date;
 //    NSDictionary *serialized2 = @{@"contexts": [[[SentryContext alloc] init] serialize],
 //                                 @"event_id": event2.eventId,
@@ -106,7 +106,7 @@
 //                                 @"timestamp": [date sentry_toIso8601String]};
 //    XCTAssertEqualObjects([event2 serialize], serialized2);
 //
-//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    event3.timestamp = date;
 //    event3.sdk = @{@"version": @"0.15.2", @"name": @"sentry-react-native", @"integrations": @[@"sentry-cocoa"]};
 //    NSDictionary *serialized3 = @{@"contexts": [[[SentryContext alloc] init] serialize],
@@ -122,7 +122,7 @@
 //- (void)testTransactionEvent {
 //    NSDate *date = [NSDate date];
 //
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    event.timestamp = date;
 //    event.extra = @{@"__sentry_transaction": @"yoyoyo"};
 //    event.sdk = @{@"version": @"0.15.2", @"name": @"sentry-react-native", @"integrations": @[@"sentry-cocoa"]};
@@ -137,7 +137,7 @@
 //                                 @"timestamp": [date sentry_toIso8601String]};
 //    XCTAssertEqualObjects([event serialize], serialized);
 //
-//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    event3.timestamp = date;
 //    event3.transaction = @"UIViewControllerTest";
 //    event3.sdk = @{@"version": @"0.15.2", @"name": @"sentry-react-native", @"integrations": @[@"sentry-cocoa"]};
@@ -305,7 +305,7 @@
 //- (void)testBreadcrumbStore {
 //    SentryBreadcrumbs *store = [[SentryBreadcrumbs alloc] init];
 //    [store clear];
-//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"http"];
+//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo category:@"http"];
 //    [store addBreadcrumb:crumb];
 //    NSDate *date = [NSDate date];
 //    crumb.timestamp = date;
@@ -324,7 +324,7 @@
 
 //- (void)testEventSdkIntegrations {
 //    NSDate *date = [NSDate date];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    event.timestamp = date;
 //    event.environment = @"bla";
 //    event.infoDict = @{@"CFBundleIdentifier": @"a", @"CFBundleShortVersionString": @"b", @"CFBundleVersion": @"c"};
@@ -345,7 +345,7 @@
 
 //- (void)testEventFingerprint {
 //    NSDate *date = [NSDate date];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    [event setFingerprint:@[@"test"]];
 //    event.environment = @"bla";
 //    event.infoDict = @{@"CFBundleIdentifier": @"a", @"CFBundleShortVersionString": @"b", @"CFBundleVersion": @"c"};

--- a/Tests/SentryTests/SentryJavaScriptBridgeHelperTests.m
+++ b/Tests/SentryTests/SentryJavaScriptBridgeHelperTests.m
@@ -18,7 +18,7 @@ NSString *rnReportPath = @"";
 + (NSArray *)parseRavenFrames:(NSArray *)ravenFrames;
 + (NSArray<SentryFrame *> *)convertReactNativeStacktrace:(NSArray *)stacktrace;
 + (void)addExceptionToEvent:(SentryEvent *)event type:(NSString *)type value:(NSString *)value frames:(NSArray *)frames;
-+ (SentryLevel)sentrySeverityFromLevel:(NSString *)level;
++ (SentryLevel)sentryLevelFromLevel:(NSString *)level;
 
 @end
 
@@ -28,15 +28,15 @@ NSString *rnReportPath = @"";
 
 @implementation SentryJavaScriptBridgeHelperTests
 
-- (void)testSentrySeverityFromLevel {
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:nil], kSentryLevelError);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"log"], kSentryLevelInfo);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"info"], kSentryLevelInfo);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"bla"], kSentryLevelError);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"error"], kSentryLevelError);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"fatal"], kSentryLevelFatal);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"debug"], kSentryLevelDebug);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentrySeverityFromLevel:@"warning"], kSentryLevelWarning);
+- (void)testSentryLevelFromString {
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:nil], kSentryLevelError);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"log"], kSentryLevelInfo);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"info"], kSentryLevelInfo);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"bla"], kSentryLevelError);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"error"], kSentryLevelError);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"fatal"], kSentryLevelFatal);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"debug"], kSentryLevelDebug);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"warning"], kSentryLevelWarning);
 }
 
 - (void)testSanitizeDictionary {

--- a/Tests/SentryTests/SentryJavaScriptBridgeHelperTests.m
+++ b/Tests/SentryTests/SentryJavaScriptBridgeHelperTests.m
@@ -18,7 +18,7 @@ NSString *rnReportPath = @"";
 + (NSArray *)parseRavenFrames:(NSArray *)ravenFrames;
 + (NSArray<SentryFrame *> *)convertReactNativeStacktrace:(NSArray *)stacktrace;
 + (void)addExceptionToEvent:(SentryEvent *)event type:(NSString *)type value:(NSString *)value frames:(NSArray *)frames;
-+ (SentryLevel)sentryLevelFromLevel:(NSString *)level;
++ (SentryLevel)sentryLevelFromString:(NSString *)level;
 
 @end
 
@@ -29,14 +29,14 @@ NSString *rnReportPath = @"";
 @implementation SentryJavaScriptBridgeHelperTests
 
 - (void)testSentryLevelFromString {
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:nil], kSentryLevelError);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"log"], kSentryLevelInfo);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"info"], kSentryLevelInfo);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"bla"], kSentryLevelError);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"error"], kSentryLevelError);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"fatal"], kSentryLevelFatal);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"debug"], kSentryLevelDebug);
-    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromLevel:@"warning"], kSentryLevelWarning);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:nil], kSentryLevelError);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"log"], kSentryLevelInfo);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"info"], kSentryLevelInfo);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"bla"], kSentryLevelError);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"error"], kSentryLevelError);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"fatal"], kSentryLevelFatal);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"debug"], kSentryLevelDebug);
+    XCTAssertEqual([SentryJavaScriptBridgeHelper sentryLevelFromString:@"warning"], kSentryLevelWarning);
 }
 
 - (void)testSanitizeDictionary {

--- a/Tests/SentryTests/SentryLogTests.m
+++ b/Tests/SentryTests/SentryLogTests.m
@@ -22,7 +22,7 @@
     [SentryLog logWithMessage:@"2" andLevel:kSentryLogLevelDebug];
     [SentryLog logWithMessage:@"3" andLevel:kSentryLogLevelVerbose];
     [SentryLog logWithMessage:@"4" andLevel:kSentryLogLevelNone];
-    //SentryClient.logLevel = kSentrySeverityError;
+    //SentryClient.logLevel = kSentryLevelError;
 }
 
 @end

--- a/Tests/SentryTests/SentryRequestTests.m
+++ b/Tests/SentryTests/SentryRequestTests.m
@@ -239,7 +239,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testRequestFailedSerialization {
 //    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request should finish1"];
-//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentrySeverityError];
+//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
 //
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    scope.extra = @{@"a": event1};
@@ -321,7 +321,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testRequestQueueWithDifferentEvents1 {
 //    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request should finish1"];
-//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentrySeverityError];
+//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event1 scope:scope withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -339,7 +339,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testRequestQueueWithDifferentEvents2 {
 //    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request should finish2"];
-//    SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentrySeverityInfo];
+//    SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event2 scope:scope withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -357,7 +357,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testRequestQueueWithDifferentEvents3 {
 //    XCTestExpectation *expectation3 = [self expectationWithDescription:@"Request should finish3"];
-//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentrySeverityFatal];
+//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentryLevelFatal];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event3 scope:scope withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -375,7 +375,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testRequestQueueWithDifferentEvents4 {
 //    XCTestExpectation *expectation4 = [self expectationWithDescription:@"Request should finish4"];
-//    SentryEvent *event4 = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event4 = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event4 scope:scope withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -393,7 +393,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testRequestQueueMultipleEvents {
 //    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request should finish1"];
-//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentrySeverityError];
+//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
 //
 //    SentryScope *scope1 = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event1 scope:scope1 withCompletionHandler:^(NSError * _Nullable error) {
@@ -409,7 +409,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    }];
 //
 //    XCTestExpectation *expectation4 = [self expectationWithDescription:@"Request should finish4"];
-//    SentryEvent *event4 = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event4 = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope4 = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event4 scope:scope4 withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -432,11 +432,11 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    scope.extra = @{@"c": @"d"};
 //    scope.user = [[SentryUser alloc] initWithUserId:@"XXXXXX"];
 //    NSDate *date = [NSDate date];
-//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"you"];
+//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo category:@"you"];
 //    crumb.timestamp = date;
 //    [scope.breadcrumbs addBreadcrumb:crumb];
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish4"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    event.infoDict = @{@"CFBundleIdentifier": @"a", @"CFBundleShortVersionString": @"b", @"CFBundleVersion": @"c"};
 //    crumb.timestamp = date;
 //    [self.client sendEvent:event scope:scope withCompletionHandler:^(NSError * _Nullable error) {
@@ -479,11 +479,11 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    scope.tags = @{@"a": @"b"};
 //    scope.extra = @{@"c": @"d"};
 //    NSDate *date = [NSDate date];
-//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"you"];
+//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo category:@"you"];
 //    crumb.timestamp = date;
 //    [scope.breadcrumbs addBreadcrumb:crumb];
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish4"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    event.infoDict = @{@"CFBundleIdentifier": @"a", @"CFBundleShortVersionString": @"b", @"CFBundleVersion": @"c"};
 //    event.timestamp = date;
 //    event.tags = @{@"1": @"2"};
@@ -528,14 +528,14 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    }];
 //
 //    NSDate *date = [NSDate date];
-//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentrySeverityInfo category:@"you"];
+//    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo category:@"you"];
 //    crumb.timestamp = date;
 //    [SentrySDK.currentHub configureScope:^(SentryScope * _Nonnull scope) {
 //        [scope.breadcrumbs addBreadcrumb:crumb];
 //    }];
 //
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish4"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.infoDict = @{@"CFBundleIdentifier": @"a", @"CFBundleShortVersionString": @"b", @"CFBundleVersion": @"c"};
 //    event.timestamp = date;
@@ -577,7 +577,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //- (void)testRequestQueueWithAndFlushItAfterSuccess {
 //    requestShouldReturnCode = 429;
 //    XCTestExpectation *expectation1 = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentrySeverityError];
+//    SentryEvent *event1 = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
 //    SentryScope *scope1 = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event1 scope:scope1 withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNotNil(error);
@@ -589,7 +589,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    requestShouldReturnCode = 200;
 //
 //    XCTestExpectation *expectation2 = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentrySeverityError];
+//    SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
 //    SentryScope *scope2 = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event2 scope:scope2 withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -602,7 +602,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    requestShouldReturnCode = 200;
 //
 //    XCTestExpectation *expectation3 = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentrySeverityError];
+//    SentryEvent *event3 = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
 //    SentryScope *scope3 = [[SentryScope alloc] initWithOptions:self.client.options];
 //    [self.client sendEvent:event3 scope:scope3 withCompletionHandler:^(NSError * _Nullable error) {
 //        XCTAssertNil(error);
@@ -635,7 +635,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //- (void)testBlockBeforeSerializeEvent {
 //    NSDictionary *tags = @{@"a": @"b"};
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    self.client.beforeSerializeEvent = ^(SentryEvent * _Nonnull event) {
 //        event.tags = tags;
@@ -658,7 +658,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig): fixme
 //- (void)testBlockBeforeSendRequest {
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    self.client.beforeSendRequest = ^(SentryNSURLRequest * _Nonnull request) {
 //        [request setValue:@"12345" forHTTPHeaderField:@"X-TEST"];
@@ -682,7 +682,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //- (void)testSnapshotStacktrace {
 //    XCTestExpectation *expectationSnap = [self expectationWithDescription:@"Snapshot"];
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //
 //    SentryThread *thread = [[SentryThread alloc] initWithThreadId:@(9999)];
@@ -717,7 +717,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testShouldSendEventNo {
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.message = @"abc";
 //    __weak id weakSelf = self;
@@ -746,7 +746,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testShouldSendEventYes {
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.message = @"abc";
 //    __weak id weakSelf = self;
@@ -775,7 +775,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testSamplingZero {
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.message = @"abc";
 //    self.client.sampleRate = 0.0;
@@ -795,7 +795,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testSamplingOne {
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.message = @"abc";
 //    self.client.sampleRate = 1.0;
@@ -816,7 +816,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 // TODO(fetzig) fixme
 //- (void)testSamplingBogus {
 //    XCTestExpectation *expectation = [self expectationWithDescription:@"Request should finish"];
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.message = @"abc";
 //    self.client.sampleRate = -123.0;
@@ -843,7 +843,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    NSMutableArray *expectations = [NSMutableArray new];
 //    for (NSInteger i = 0; i <= 20; i++) {
 //        XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"Request should fail %ld", (long)i]];
-//        SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//        SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //        SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //        event.message = @"abc";
 //        [self.client sendEvent:event scope:scope withCompletionHandler:^(NSError * _Nullable error) {
@@ -876,7 +876,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    NSMutableArray *expectations = [NSMutableArray new];
 //    for (NSInteger i = 0; i <= 3; i++) {
 //        XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"Request should fail %ld", (long)i]];
-//        SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//        SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //        SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //        event.message = @"abc";
 //        [self.client sendEvent:event scope:scope withCompletionHandler:^(NSError * _Nullable error) {
@@ -894,7 +894,7 @@ NSString *dsn = @"https://username:password@app.getsentry.com/12345";
 //    NSError *error = nil;
 //    SentryFileManager *fileManager = [[SentryFileManager alloc] initWithDsn:[[SentryDsn alloc] initWithString:dsn didFailWithError:nil] didFailWithError:&error];
 //
-//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentrySeverityWarning];
+//    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelWarning];
 //    SentryScope *scope = [[SentryScope alloc] initWithOptions:self.client.options];
 //    event.message = @"abc";
 //    SentryClient.logLevel = kSentryLogLevelDebug;

--- a/Tests/SentryTests/SentryScopeTests.m
+++ b/Tests/SentryTests/SentryScopeTests.m
@@ -79,7 +79,7 @@
 - (void)testReleaseSerializes {
     SentryScope *scope = [[SentryScope alloc] init];
     NSString *expectedReleaseName = @"io.sentry.cocoa@5.0.0-deadbeef";
-    [scope setReleaseName:expectedReleaseName];
+    [scope setRelease:expectedReleaseName];
     XCTAssertEqualObjects([[scope serialize] objectForKey:@"release"], expectedReleaseName);
 }
 
@@ -123,9 +123,10 @@
     [scope addBreadcrumb:[self getBreadcrumb]];
     [scope setUser:[[SentryUser alloc] initWithUserId:@"id"]];
     [scope setContextValue:@{@"e": @"f"} forKey:@"myContext"];
-    [scope setReleaseName:@"123"];
+    [scope setRelease:@"123"];
     [scope setDist:@"456"];
     [scope setEnvironment:@"789"];
+    [scope setFingerprint:@[@"a"]];
     
     NSMutableDictionary *snapshot = [scope serialize].mutableCopy;
     
@@ -137,7 +138,7 @@
     [cloned addBreadcrumb:[[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http2"]];
     [cloned setUser:[[SentryUser alloc] initWithUserId:@"aid"]];
     [cloned setContextValue:@{@"ae": @"af"} forKey:@"myContext"];
-    [cloned setReleaseName:@"a123"];
+    [cloned setRelease:@"a123"];
     [cloned setDist:@"a456"];
     [cloned setEnvironment:@"a789"];
     

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -191,12 +191,23 @@
 //    [client reportUserException:@"a" reason:@"b" language:@"c" lineOfCode:@"1" stackTrace:[NSArray new] logAllThreads:YES terminateProgram:NO];
 //}
 
-- (void)testSeverity {
-    XCTAssertEqualObjects(@"fatal", SentryLevelNames[kSentryLevelFatal]);
-    XCTAssertEqualObjects(@"error", SentryLevelNames[kSentryLevelError]);
-    XCTAssertEqualObjects(@"warning", SentryLevelNames[kSentryLevelWarning]);
-    XCTAssertEqualObjects(@"info", SentryLevelNames[kSentryLevelInfo]);
+- (void)testLevelNames {
+    NSInteger highest = kSentryLevelFatal;
+    XCTAssertEqualObjects(@"none", SentryLevelNames[kSentryLevelNone]);
     XCTAssertEqualObjects(@"debug", SentryLevelNames[kSentryLevelDebug]);
+    XCTAssertEqualObjects(@"info", SentryLevelNames[kSentryLevelInfo]);
+    XCTAssertEqualObjects(@"warning", SentryLevelNames[kSentryLevelWarning]);
+    XCTAssertEqualObjects(@"error", SentryLevelNames[kSentryLevelError]);
+    XCTAssertEqualObjects(@"fatal", SentryLevelNames[kSentryLevelFatal]);
+    XCTAssertEqualObjects(nil, SentryLevelNames[highest + 1]);
+}
+
+- (void)testLevelOrder {
+    XCTAssertGreaterThan(kSentryLevelFatal, kSentryLevelError);
+    XCTAssertGreaterThan(kSentryLevelError, kSentryLevelWarning);
+    XCTAssertGreaterThan(kSentryLevelWarning, kSentryLevelInfo);
+    XCTAssertGreaterThan(kSentryLevelInfo, kSentryLevelDebug);
+    XCTAssertGreaterThan(kSentryLevelDebug, kSentryLevelNone);
 }
 
 - (void)testDateCategory {


### PR DESCRIPTION
* SentryLevelName mapping was missing a value
* The order of values was inverted (the higher the more severe)
* Added parameterless ctor to Event: not sending level uses server default (error).
* SentryEvent doesn't add level if value is none
* assigned the SentryEvent `NS_DESIGNATED_INITIALIZER`