### PR TITLE
fix: Use getter for scope to receive an empty instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Deploy
         env: LANE=deploy XCWORKSPACE=Sentry.xcworkspace
         script: .travis/stage-carthage.sh
+        if: branch = /^release\/.+$/
         after_success:
           - npm install -g @zeus-ci/cli
           - zeus upload -t "application/zip+carthage" Sentry.framework.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 5.0.0-beta.3
+
+- fix: Persisting Scope with CrashReport
+
 ## 5.0.0-beta.2
 
 - fix: The order of how integrations are initalized (fixes not sending crashes on startup)

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -162,7 +162,7 @@
         [SentryLog logWithMessage:[NSString stringWithFormat:@"Discarded Breadcrumb in `beforeBreadcrumb`"] andLevel:kSentryLogLevelDebug];
         return;
     }
-    [self.scope addBreadcrumb:crumb];
+    [[self getScope] addBreadcrumb:crumb];
 }
 
 - (SentryClient *_Nullable)getClient {
@@ -181,8 +181,10 @@
 }
 
 - (void)configureScope:(void(^)(SentryScope *scope))callback {
-    if (nil != self.client && nil != self.scope) {
-        callback(self.scope);
+    SentryScope *scope = [self getScope];
+    SentryScope *client = [self getClient];
+    if (nil != client && nil != scope) {
+        callback(scope);
     }
 }
 


### PR DESCRIPTION
Fixes a bug where `configureScope` wasn't called for the SentryCrashIntegration and therefore not persisting scope data (breadcrumbs ...) for crashes because we were using `self.scope` instead of the getter `[self getScope]` which creates a new Scope instance in case there is none.