### PR TITLE
perf: Init NSDateFormatter once for Transport

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -247,6 +247,10 @@
 		7BAF3DD4243DD40F008A5414 /* SentryTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DD3243DD40F008A5414 /* SentryTransportFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BAF3DD7243DD4A1008A5414 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DD6243DD4A1008A5414 /* TestConstants.swift */; };
 		7BAF3DD92440AEC8008A5414 /* SentryRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DD82440AEC8008A5414 /* SentryRequestManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BBD1889244841EC00427C76 /* SentryHttpDateParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BBD188B244841FB00427C76 /* SentryHttpDateParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */; };
+		7BBD188D2448453600427C76 /* SentryHttpDateParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */; };
+		7BBD188F2448469A00427C76 /* HttpDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188E2448469A00427C76 /* HttpDateFormatter.swift */; };
 		7BE3C7672445C0CA00A38442 /* SentryCurrentDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BE3C7692445C1A800A38442 /* SentryCurrentDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */; };
 		7BE3C76B2445C27A00A38442 /* SentryCurrentDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -540,6 +544,10 @@
 		7BAF3DD3243DD40F008A5414 /* SentryTransportFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTransportFactory.h; path = include/SentryTransportFactory.h; sourceTree = "<group>"; };
 		7BAF3DD6243DD4A1008A5414 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		7BAF3DD82440AEC8008A5414 /* SentryRequestManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRequestManager.h; path = include/SentryRequestManager.h; sourceTree = "<group>"; };
+		7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryHttpDateParser.h; path = include/SentryHttpDateParser.h; sourceTree = "<group>"; };
+		7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryHttpDateParser.m; sourceTree = "<group>"; };
+		7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHttpDateParserTests.swift; sourceTree = "<group>"; };
+		7BBD188E2448469A00427C76 /* HttpDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpDateFormatter.swift; sourceTree = "<group>"; };
 		7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDate.h; path = include/SentryCurrentDate.h; sourceTree = "<group>"; };
 		7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCurrentDate.m; sourceTree = "<group>"; };
 		7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDateProvider.h; path = include/SentryCurrentDateProvider.h; sourceTree = "<group>"; };
@@ -639,6 +647,8 @@
 				638DC99F1EBC6B6400A66E41 /* SentryRequestOperation.m */,
 				7BE3C77A2446111500A38442 /* SentryRateLimitParser.h */,
 				7BE3C77C2446112C00A38442 /* SentryRateLimitParser.m */,
+				7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */,
+				7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */,
 			);
 			name = Networking;
 			sourceTree = "<group>";
@@ -872,6 +882,8 @@
 				7BE3C77E2446116400A38442 /* SentryRateLimitsParserTests.swift */,
 				7BE3C780244701A000A38442 /* SentryRateLimitsParserTests.m */,
 				7BE3C78624472E9800A38442 /* TestRequestManager.swift */,
+				7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */,
+				7BBD188E2448469A00427C76 /* HttpDateFormatter.swift */,
 			);
 			path = SentryTests;
 			sourceTree = "<group>";
@@ -1277,6 +1289,7 @@
 				63FE715B20DA4C1100CDBAE8 /* SentryCrashSignalInfo.h in Headers */,
 				63FE70E520DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h in Headers */,
 				15360CD92432835400112302 /* SentryAutoSessionTrackingIntegration.h in Headers */,
+				7BBD1889244841EC00427C76 /* SentryHttpDateParser.h in Headers */,
 				7D9B07A023D1E89900C5FC8E /* SentryMeta.h in Headers */,
 				63FE716F20DA4C1100CDBAE8 /* SentryCrashCPU_Apple.h in Headers */,
 				639FCFA81EBC80CC00778193 /* SentryFrame.h in Headers */,
@@ -1449,6 +1462,7 @@
 				63FE717320DA4C1100CDBAE8 /* SentryCrashC.c in Sources */,
 				63FE712120DA4C1000CDBAE8 /* SentryCrashSymbolicator.c in Sources */,
 				63FE70D720DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.c in Sources */,
+				7BBD188B244841FB00427C76 /* SentryHttpDateParser.m in Sources */,
 				15E0A8E5240C457D00F044E3 /* SentryEnvelope.m in Sources */,
 				6360850E1ED2AFE100E8599E /* SentryBreadcrumb.m in Sources */,
 				63FE715F20DA4C1100CDBAE8 /* SentryCrashID.c in Sources */,
@@ -1541,6 +1555,7 @@
 				63FE721620DA66EC00CDBAE8 /* SentryCrashReportFixer_Tests.m in Sources */,
 				7BE3C7772445E50A00A38442 /* TestCurrentDateProvider.swift in Sources */,
 				639889D41EDF06C100EA7442 /* SentrySwiftTests.swift in Sources */,
+				7BBD188D2448453600427C76 /* SentryHttpDateParserTests.swift in Sources */,
 				63FE722020DA66EC00CDBAE8 /* SentryCrashObjC_Tests.m in Sources */,
 				63FE720320DA66EC00CDBAE8 /* SentryCrashCPU_Tests.m in Sources */,
 				63FE721020DA66EC00CDBAE8 /* SentryCrashCachedData_Tests.m in Sources */,
@@ -1561,6 +1576,7 @@
 				63FE722120DA66EC00CDBAE8 /* SentryCrashDynamicLinker_Tests.m in Sources */,
 				63FE720120DA66EC00CDBAE8 /* RFC3339UTFString_Tests.m in Sources */,
 				63AA76701EB8CB4B00D153DE /* SentryTests.m in Sources */,
+				7BBD188F2448469A00427C76 /* HttpDateFormatter.swift in Sources */,
 				63FE720C20DA66EC00CDBAE8 /* SentryCrashMonitor_Tests.m in Sources */,
 				63FE721820DA66EC00CDBAE8 /* TestThread.m in Sources */,
 				63FE720720DA66EC00CDBAE8 /* SentryCrashReportFilter_Tests.m in Sources */,

--- a/Sources/Sentry/SentryHttpDateParser.m
+++ b/Sources/Sentry/SentryHttpDateParser.m
@@ -1,0 +1,37 @@
+#import <Foundation/Foundation.h>
+#import "SentryHttpDateParser.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryHttpDateParser ()
+
+@property(nonatomic, strong) NSDateFormatter *dateFormatter;
+
+@end
+
+/**
+ *  According to https://developer.apple.com/documentation/foundation/nsdateformatter
+ *  NSDateFormatter is not guaranteed to be thread safe on all macOS applications yet. Therefore
+ *  it must not be mutated from multiple threads. As we only modify NSDateFormatter during init
+ *  we don't need any locks.
+ */
+@implementation SentryHttpDateParser
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        self.dateFormatter = [[NSDateFormatter alloc] init];
+        [self.dateFormatter setDateFormat:@"EEE',' dd' 'MMM' 'yyyy HH':'mm':'ss zzz"];
+        // Http dates are always expressed in GMT, never in local time.
+        [self.dateFormatter setTimeZone:[NSTimeZone timeZoneWithName:@"GMT"]];
+    }
+    return self;
+}
+
+- (NSDate * _Nullable)dateFromString:(NSString *)string {
+    return [self.dateFormatter dateFromString:string];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryHttpDateParser.m
+++ b/Sources/Sentry/SentryHttpDateParser.m
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (NSDate * _Nullable)dateFromString:(NSString *)string {
+- (NSDate *_Nullable)dateFromString:(NSString *)string {
     return [self.dateFormatter dateFromString:string];
 }
 

--- a/Sources/Sentry/SentryRateLimitParser.m
+++ b/Sources/Sentry/SentryRateLimitParser.m
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryRateLimitParser
 
-+ (NSDictionary<NSString *, NSDate *> * _Nonnull)parse:(NSString *)header {
++ (NSDictionary<NSString *, NSDate *> *_Nonnull)parse:(NSString *)header {
     
     NSMutableDictionary<NSString *, NSDate *> *rateLimits = [[NSMutableDictionary alloc] init];
     

--- a/Sources/Sentry/include/Sentry.h
+++ b/Sources/Sentry/include/Sentry.h
@@ -51,5 +51,4 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #import "SentryQueueableRequestManager.h"
 #import "SentryTransportFactory.h"
 #import "SentryRateLimitParser.h"
-
-
+#import "SentryHttpDateParser.h"

--- a/Sources/Sentry/include/SentryHttpDateParser.h
+++ b/Sources/Sentry/include/SentryHttpDateParser.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Parses a string in the format of http date to NSDate. For more details see:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date.
+ * SentryHttpDateParser is thread safe.
+*/
+NS_SWIFT_NAME(HttpDateParser)
+@interface SentryHttpDateParser : NSObject
+
+- (NSDate * _Nullable)dateFromString:(NSString *)string;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryHttpDateParser.h
+++ b/Sources/Sentry/include/SentryHttpDateParser.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(HttpDateParser)
 @interface SentryHttpDateParser : NSObject
 
-- (NSDate * _Nullable)dateFromString:(NSString *)string;
+- (NSDate *_Nullable)dateFromString:(NSString *)string;
 
 @end
 

--- a/Sources/Sentry/include/SentryRateLimitParser.h
+++ b/Sources/Sentry/include/SentryRateLimitParser.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(RateLimitParser)
 @interface SentryRateLimitParser : NSObject
 
-+ (NSDictionary<NSString *, NSDate *> * _Nonnull)parse:(NSString *) header;
++ (NSDictionary<NSString *, NSDate *> * _Nonnull)parse:(NSString *)header;
 
 @end
 

--- a/Sources/Sentry/include/SentryRateLimitParser.h
+++ b/Sources/Sentry/include/SentryRateLimitParser.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(RateLimitParser)
 @interface SentryRateLimitParser : NSObject
 
-+ (NSDictionary<NSString *, NSDate *> * _Nonnull)parse:(NSString *)header;
++ (NSDictionary<NSString *, NSDate *> *_Nonnull)parse:(NSString *)header;
 
 @end
 

--- a/Tests/SentryTests/HttpDateFormatter.swift
+++ b/Tests/SentryTests/HttpDateFormatter.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+class HttpDateFormatter {
+    static func string(from date: Date) -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "EEE',' dd' 'MMM' 'yyyy HH':'mm':'ss zzz"
+        dateFormatter.timeZone = TimeZone.init(abbreviation: "GMT")
+        
+        return dateFormatter.string(from: date)
+    }
+}

--- a/Tests/SentryTests/SentryHttpDateParserTests.swift
+++ b/Tests/SentryTests/SentryHttpDateParserTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Sentry
+
+class SentryHttpDateParserTests: XCTestCase {
+    
+    private var currentDateProvider: TestCurrentDateProvider!
+    private var sut: HttpDateParser!
+    
+
+    override func setUp() {
+        currentDateProvider = TestCurrentDateProvider()
+        sut = HttpDateParser()
+    }
+
+    func testDefaultDate()  {
+        let expected = currentDateProvider.date()
+        let httpDateAsString = HttpDateFormatter.string(from: expected)
+        let actual = sut.date(from: httpDateAsString)
+        
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testWithMultipleWorkItemsInParallel() {
+        let queue1 = DispatchQueue(label: "1", qos: .utility, attributes: [.concurrent, .initiallyInactive])
+        let queue2 = DispatchQueue(label: "2", qos: .utility, attributes: [.concurrent, .initiallyInactive])
+        
+        let group = DispatchGroup()
+        for i in Array(0...1000) {
+            startWorkItemTest(i: i, queue: queue1, group: group)
+            startWorkItemTest(i: i, queue: queue2, group: group)
+        }
+        
+        queue1.activate()
+        queue2.activate()
+        group.wait()
+    }
+    
+    func startWorkItemTest(i: Int, queue: DispatchQueue, group: DispatchGroup) {
+        group.enter()
+        queue.async {
+            let expected = self.currentDateProvider.date().addingTimeInterval(TimeInterval(i))
+            let httpDateAsString = HttpDateFormatter.string(from: expected)
+            let actual = self.sut.date(from: httpDateAsString)
+            
+            XCTAssertEqual(expected, actual)
+            group.leave()
+        }
+    }
+}

--- a/Tests/SentryTests/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/SentryHttpTransportTests.swift
@@ -52,7 +52,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testRetryAfterHeaderHttpDate() {
-        let headerValue = formatAsHttpDate(date: CurrentDate.date().addingTimeInterval(1))
+        let headerValue = HttpDateFormatter.string(from: CurrentDate.date().addingTimeInterval(1))
         testRetryHeaderWith1Second(value: headerValue)
     }
     
@@ -110,13 +110,5 @@ class SentryHttpTransportTests: XCTestCase {
         currentDateProvider.setDate(date: currentDateProvider.date().addingTimeInterval(defaultRetryAfterInSeconds))
         sendEvent()
         XCTAssertEqual(2, requestManager.requests.count)
-    }
-    
-    private func formatAsHttpDate(date: Date) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "EEE',' dd' 'MMM' 'yyyy HH':'mm':'ss zzz"
-        dateFormatter.timeZone = TimeZone.init(abbreviation: "GMT")
-        
-        return dateFormatter.string(from: date)
     }
 }

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -10,3 +10,4 @@
 #import "SentryCurrentDate.h"
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryRateLimitParser.h"
+#import "SentryHttpDateParser.h"


### PR DESCRIPTION
Encapsulate the parsing of the http date into SentryHttpDateParser
so that NSDateFormatter is only initialised once for SentryHttpTransport
and not on each http response.