### PR TITLE
fix: only cache session instance

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -126,8 +126,10 @@
 
 - (void)incrementSessionErrors {
     @synchronized (_sessionLock) {
-        [_session incrementErrors];
-        [self storeCurrentSession:_session];
+        if (nil != _session) {
+            [_session incrementErrors];
+            [self storeCurrentSession:_session];
+        }
     }
 }
 


### PR DESCRIPTION
Relates to #442

This is the source of the `Sentry - Error:: Invalid JSON.` message.