### PR TITLE
ref: Move rate limit logic to extra class

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -251,6 +251,11 @@
 		7BBD188B244841FB00427C76 /* SentryHttpDateParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */; };
 		7BBD188D2448453600427C76 /* SentryHttpDateParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */; };
 		7BBD188F2448469A00427C76 /* HttpDateFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188E2448469A00427C76 /* HttpDateFormatter.swift */; };
+		7BBD18912449BE9000427C76 /* SentryDefaultRateLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBD18902449BE9000427C76 /* SentryDefaultRateLimits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BBD18932449BEDD00427C76 /* SentryDefaultRateLimits.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18922449BEDD00427C76 /* SentryDefaultRateLimits.m */; };
+		7BBD18952449D3E200427C76 /* SentryDefaultRateLimitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */; };
+		7BBD18972449DC1D00427C76 /* SentryRateLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBD18962449DC1D00427C76 /* SentryRateLimits.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BBD18992449DE9D00427C76 /* TestRateLimits.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18982449DE9D00427C76 /* TestRateLimits.swift */; };
 		7BE3C7672445C0CA00A38442 /* SentryCurrentDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BE3C7692445C1A800A38442 /* SentryCurrentDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */; };
 		7BE3C76B2445C27A00A38442 /* SentryCurrentDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -548,6 +553,11 @@
 		7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryHttpDateParser.m; sourceTree = "<group>"; };
 		7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHttpDateParserTests.swift; sourceTree = "<group>"; };
 		7BBD188E2448469A00427C76 /* HttpDateFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HttpDateFormatter.swift; sourceTree = "<group>"; };
+		7BBD18902449BE9000427C76 /* SentryDefaultRateLimits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDefaultRateLimits.h; path = include/SentryDefaultRateLimits.h; sourceTree = "<group>"; };
+		7BBD18922449BEDD00427C76 /* SentryDefaultRateLimits.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDefaultRateLimits.m; sourceTree = "<group>"; };
+		7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDefaultRateLimitsTests.swift; sourceTree = "<group>"; };
+		7BBD18962449DC1D00427C76 /* SentryRateLimits.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRateLimits.h; path = include/SentryRateLimits.h; sourceTree = "<group>"; };
+		7BBD18982449DE9D00427C76 /* TestRateLimits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRateLimits.swift; sourceTree = "<group>"; };
 		7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDate.h; path = include/SentryCurrentDate.h; sourceTree = "<group>"; };
 		7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCurrentDate.m; sourceTree = "<group>"; };
 		7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDateProvider.h; path = include/SentryCurrentDateProvider.h; sourceTree = "<group>"; };
@@ -634,6 +644,13 @@
 				7DB3A684238EA75E00A2D442 /* SentryHttpTransport.m */,
 				7BAF3DD3243DD40F008A5414 /* SentryTransportFactory.h */,
 				7BAF3DCD243DCBFE008A5414 /* SentryTransportFactory.m */,
+				7BBD18962449DC1D00427C76 /* SentryRateLimits.h */,
+				7BBD18902449BE9000427C76 /* SentryDefaultRateLimits.h */,
+				7BBD18922449BEDD00427C76 /* SentryDefaultRateLimits.m */,
+				7BE3C77A2446111500A38442 /* SentryRateLimitParser.h */,
+				7BE3C77C2446112C00A38442 /* SentryRateLimitParser.m */,
+				7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */,
+				7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */,
 				635B3F361EBC6E2500A6176D /* SentryAsynchronousOperation.h */,
 				635B3F371EBC6E2500A6176D /* SentryAsynchronousOperation.m */,
 				63AA76A41EB9CBC200D153DE /* SentryDsn.h */,
@@ -645,10 +662,6 @@
 				631E6D321EBC679C00712345 /* SentryQueueableRequestManager.m */,
 				638DC99E1EBC6B6400A66E41 /* SentryRequestOperation.h */,
 				638DC99F1EBC6B6400A66E41 /* SentryRequestOperation.m */,
-				7BE3C77A2446111500A38442 /* SentryRateLimitParser.h */,
-				7BE3C77C2446112C00A38442 /* SentryRateLimitParser.m */,
-				7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */,
-				7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */,
 			);
 			name = Networking;
 			sourceTree = "<group>";
@@ -884,6 +897,8 @@
 				7BE3C78624472E9800A38442 /* TestRequestManager.swift */,
 				7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */,
 				7BBD188E2448469A00427C76 /* HttpDateFormatter.swift */,
+				7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */,
+				7BBD18982449DE9D00427C76 /* TestRateLimits.swift */,
 			);
 			path = SentryTests;
 			sourceTree = "<group>";
@@ -1241,6 +1256,7 @@
 				15E0A8EA240F2C9000F044E3 /* SentrySerialization.h in Headers */,
 				63FE70EF20DA4C1000CDBAE8 /* SentryCrashMonitor_AppState.h in Headers */,
 				635B3F381EBC6E2500A6176D /* SentryAsynchronousOperation.h in Headers */,
+				7BBD18972449DC1D00427C76 /* SentryRateLimits.h in Headers */,
 				630436101EC0600A00C4D3FA /* SentrySerializable.h in Headers */,
 				63FE70DD20DA4C1000CDBAE8 /* SentryCrashMonitor_Signal.h in Headers */,
 				63FE710320DA4C1000CDBAE8 /* SentryCrashMachineContext_Apple.h in Headers */,
@@ -1250,6 +1266,7 @@
 				631E6D331EBC679C00712345 /* SentryQueueableRequestManager.h in Headers */,
 				6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */,
 				63FE718720DA4C1100CDBAE8 /* SentryCrashReportVersion.h in Headers */,
+				7BBD18912449BE9000427C76 /* SentryDefaultRateLimits.h in Headers */,
 				63FE712320DA4C1000CDBAE8 /* SentryCrashID.h in Headers */,
 				7DC27EC523997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.h in Headers */,
 				63FE707F20DA4C1000CDBAE8 /* SentryCrashVarArgs.h in Headers */,
@@ -1494,6 +1511,7 @@
 				7D5C441A237C2E1F00DAB0A3 /* SentrySDK.m in Sources */,
 				7D65260E237F649E00113EA2 /* SentryScope.m in Sources */,
 				63FE712D20DA4C1100CDBAE8 /* SentryCrashJSONCodecObjC.m in Sources */,
+				7BBD18932449BEDD00427C76 /* SentryDefaultRateLimits.m in Sources */,
 				639FCF9D1EBC7F9500778193 /* SentryThread.m in Sources */,
 				63FE714120DA4C1100CDBAE8 /* SentryCrashDate.c in Sources */,
 				63FE70DB20DA4C1000CDBAE8 /* SentryCrashMonitor_System.m in Sources */,
@@ -1551,9 +1569,11 @@
 				63FE721420DA66EC00CDBAE8 /* SentryCrashMemory_Tests.m in Sources */,
 				63FE720520DA66EC00CDBAE8 /* FileBasedTestCase.m in Sources */,
 				63EED6C32237989300E02400 /* SentryOptionsTest.m in Sources */,
+				7BBD18952449D3E200427C76 /* SentryDefaultRateLimitsTests.swift in Sources */,
 				630436131EC0A17100C4D3FA /* SentryLogTests.m in Sources */,
 				63FE721620DA66EC00CDBAE8 /* SentryCrashReportFixer_Tests.m in Sources */,
 				7BE3C7772445E50A00A38442 /* TestCurrentDateProvider.swift in Sources */,
+				7BBD18992449DE9D00427C76 /* TestRateLimits.swift in Sources */,
 				639889D41EDF06C100EA7442 /* SentrySwiftTests.swift in Sources */,
 				7BBD188D2448453600427C76 /* SentryHttpDateParserTests.swift in Sources */,
 				63FE722020DA66EC00CDBAE8 /* SentryCrashObjC_Tests.m in Sources */,

--- a/Sources/Sentry/SentryDefaultRateLimits.m
+++ b/Sources/Sentry/SentryDefaultRateLimits.m
@@ -1,0 +1,108 @@
+#import <Foundation/Foundation.h>
+#import "SentryDefaultRateLimits.h"
+#import "SentryCurrentDate.h"
+#import "SentryHttpDateParser.h"
+#import "SentryLog.h"
+
+NS_ASSUME_NONNULL_BEGIN
+/*
+ * This code was moved from SentryHttpTransport and needs to be updated.
+ */
+@interface SentryDefaultRateLimits ()
+
+@property(nonatomic, strong) NSDictionary<NSString *, NSDate *> *rateLimits;
+@property(nonatomic, strong) SentryHttpDateParser *httpDateParser;
+
+/**
+ * datetime until we keep radio silence. Populated when response has HTTP 429
+ * and "Retry-After" header -> rate limit exceeded.
+ */
+@property(atomic, strong) NSDate *_Nullable radioSilenceDeadline;
+
+@end
+
+@implementation SentryDefaultRateLimits
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        self.rateLimits = [[NSDictionary alloc] init];
+        self.httpDateParser = [[SentryHttpDateParser alloc] init];
+    }
+    return self;
+}
+
+- (BOOL)isRateLimitReached {
+    if (nil == self.radioSilenceDeadline) {
+        return NO;
+    }
+
+    NSDate *now = [SentryCurrentDate date];
+    NSComparisonResult result = [now compare:[self radioSilenceDeadline]];
+
+    if (result == NSOrderedAscending) {
+        [SentryLog logWithMessage:[NSString stringWithFormat:@"Rate limit reached until: %@",  self.radioSilenceDeadline] andLevel:kSentryLogLevelError];
+        return YES;
+    } else {
+        self.radioSilenceDeadline = nil;
+        return NO;
+    }
+}
+
+/**
+ * When rate limit has been exceeded we updates the radio silence deadline and
+ * therefor activates radio silence for at least
+ * 60 seconds (default, see `defaultRadioSilenceDeadline`).
+ */
+- (void)update:(NSHTTPURLResponse *)response {
+    self.radioSilenceDeadline = [self parseRetryAfterHeader:response.allHeaderFields[@"Retry-After"]];
+}
+
+/**
+ * used if actual time/deadline couldn't be determined.
+ */
+- (NSDate *)defaultRadioSilenceDeadline {
+    return [[SentryCurrentDate date] dateByAddingTimeInterval:60];
+}
+
+/**
+ * parses value of HTTP Header "Retry-After" which in most cases is sent in
+ * combination with HTTP status 429 Too Many Requests.
+ *
+ * Retry-After value is a time-delta in seconds or a date.
+ * In every case this method computes the date aka. `radioSilenceDeadline`.
+ *
+ * See RFC2616 for details on "Retry-After".
+ * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.37
+ *
+ * @return NSDate representation of Retry-After.
+ *         As fallback `defaultRadioSilenceDeadline` is returned if parsing was
+ *         unsuccessful.
+ */
+- (NSDate *)parseRetryAfterHeader:(NSString * __nullable)retryAfterHeader {
+    if (nil == retryAfterHeader || 0 == [retryAfterHeader length]) {
+        return [self defaultRadioSilenceDeadline];
+    }
+
+    NSDate *now = [SentryCurrentDate date];
+
+    // try to parse as double/seconds
+    double retryAfterSeconds = [retryAfterHeader doubleValue];
+    NSLog(@"parseRetryAfterHeader string '%@' to double: %f", retryAfterHeader, retryAfterSeconds);
+    if (0 != retryAfterSeconds) {
+        return [now dateByAddingTimeInterval:retryAfterSeconds];
+    }
+
+    // parsing as double/seconds failed, try to parse as date
+    NSDate *retryAfterDate = [self.httpDateParser dateFromString:retryAfterHeader];
+
+    if (nil == retryAfterDate) {
+        // parsing as seconds and date failed
+        return [self defaultRadioSilenceDeadline];
+    }
+    return retryAfterDate;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -5,6 +5,8 @@
 #import "SentryOptions.h"
 #import "SentryHttpTransport.h"
 #import "SentryQueueableRequestManager.h"
+#import "SentryRateLimits.h"
+#import "SentryDefaultRateLimits.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,8 +25,10 @@ NS_ASSUME_NONNULL_BEGIN
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
         NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
         id<SentryRequestManager> requestManager = [[SentryQueueableRequestManager alloc] initWithSession:session];
+        id<SentryRateLimits> rateLimits = [[SentryDefaultRateLimits alloc] init];
         return [[SentryHttpTransport alloc] initWithOptions:options
-                                          sentryFileManager:sentryFileManager sentryRequestManager: requestManager];
+                                          sentryFileManager:sentryFileManager sentryRequestManager: requestManager
+                                           sentryRateLimits: rateLimits];
     }
 }
 

--- a/Sources/Sentry/include/Sentry.h
+++ b/Sources/Sentry/include/Sentry.h
@@ -51,4 +51,6 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #import "SentryQueueableRequestManager.h"
 #import "SentryTransportFactory.h"
 #import "SentryRateLimitParser.h"
+#import "SentryRateLimits.h"
+#import "SentryDefaultRateLimits.h"
 #import "SentryHttpDateParser.h"

--- a/Sources/Sentry/include/SentryDefaultRateLimits.h
+++ b/Sources/Sentry/include/SentryDefaultRateLimits.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import "SentryRateLimits.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Implements only rate limits with status code 429. Needs to be updated.
+*/
+NS_SWIFT_NAME(DefaultRateLimits)
+@interface SentryDefaultRateLimits : NSObject <SentryRateLimits>
+
+- (BOOL)isRateLimitReached;
+
+- (void)update:(NSHTTPURLResponse *)response;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryHttpTransport.h
+++ b/Sources/Sentry/include/SentryHttpTransport.h
@@ -6,16 +6,17 @@
 #import "SentryEnvelope.h"
 #import "SentryTransport.h"
 #import "SentryRequestManager.h"
+#import "SentryRateLimits.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryHttpTransport : NSObject <SentryTransport>
 SENTRY_NO_INIT
 
-
 - (id)initWithOptions:(SentryOptions *)options
     sentryFileManager:(SentryFileManager *)sentryFileManager
- sentryRequestManager:(id<SentryRequestManager>) sentryRequestManager;
+ sentryRequestManager:(id<SentryRequestManager>) sentryRequestManager
+     sentryRateLimits:(id<SentryRateLimits>) sentryRateLimits;
 
 /**
  * This is triggered after the first upload attempt of an event. Checks if event

--- a/Sources/Sentry/include/SentryRateLimits.h
+++ b/Sources/Sentry/include/SentryRateLimits.h
@@ -1,0 +1,23 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+// TODO: implement new Rate Limit strategy.
+/*
+ * Parses http responses from the Sentry server for rate limits.
+ * The server sends either a 429 status code or a custom header
+ * "X-Sentry-Rate-Limits".
+ * If the server communicates that a rate limit is reached this
+ * component saves the rate limit and returns NO for
+ * isRateLimitReached.
+ */
+NS_SWIFT_NAME(RateLimits)
+@protocol SentryRateLimits <NSObject>
+
+- (BOOL)isRateLimitReached;
+
+- (void)update:(NSHTTPURLResponse *)response;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/SentryDefaultRateLimitsTests.swift
@@ -1,0 +1,73 @@
+import XCTest
+@testable import Sentry
+
+class SentryDefaultRateLimitsTests: XCTestCase {
+    
+    private let defaultRetryAfterInSeconds = 60.0
+
+    private var currentDateProvider: TestCurrentDateProvider!
+    private var sut: RateLimits!
+    
+    override func setUp() {
+        currentDateProvider = TestCurrentDateProvider()
+        CurrentDate.setCurrentDateProvider(currentDateProvider)
+        
+        sut = DefaultRateLimits()
+    }
+    
+    func testNoUpdateCalled() {
+        XCTAssertFalse(sut.isRateLimitReached())
+    }
+
+    func testRetryAfterHeaderDeltaSeconds() {
+        testRetryHeaderWith1Second(value: "1")
+    }
+    
+    func testRetryAfterHeaderHttpDate() {
+        let headerValue = HttpDateFormatter.string(from: CurrentDate.date().addingTimeInterval(1))
+        testRetryHeaderWith1Second(value: headerValue)
+    }
+    
+    private func testRetryHeaderWith1Second(value: String) {
+        let response = createRetryAfterHeader(headerValue: value)
+        sut.update(response)
+        XCTAssertTrue(sut.isRateLimitReached())
+        
+        // Retry-After almost expired
+        let date = currentDateProvider.date()
+        currentDateProvider.setDate(date: date.addingTimeInterval(0.999))
+        XCTAssertTrue(sut.isRateLimitReached())
+        
+        // Retry-After expired
+        currentDateProvider.setDate(date: date.addingTimeInterval(1))
+        XCTAssertFalse(sut.isRateLimitReached())
+    }
+    
+    func testFaultyRetryAfterHeader() {
+        let response = createRetryAfterHeader(headerValue: "ABC")
+        
+        assertSetsDefaultRetryAfter(response: response)
+    }
+    
+    func testRetryAfterHeaderIsEmpty() {
+        let response = createRetryAfterHeader(headerValue: "")
+     
+        assertSetsDefaultRetryAfter(response: response)
+    }
+    
+    private func createRetryAfterHeader(headerValue: String) -> HTTPURLResponse {
+        return HTTPURLResponse.init(
+            url: URL.init(fileURLWithPath: ""),
+            statusCode: 429,
+            httpVersion: nil,
+            headerFields: ["Retry-After": headerValue])!
+    }
+    
+    private func assertSetsDefaultRetryAfter(response: HTTPURLResponse) {
+        sut.update(response)
+        XCTAssertTrue(sut.isRateLimitReached())
+        
+        currentDateProvider.setDate(date: currentDateProvider.date().addingTimeInterval(defaultRetryAfterInSeconds))
+        XCTAssertFalse(sut.isRateLimitReached())
+    }
+}

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -10,4 +10,6 @@
 #import "SentryCurrentDate.h"
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryRateLimitParser.h"
+#import "SentryRateLimits.h"
+#import "SentryDefaultRateLimits.h"
 #import "SentryHttpDateParser.h"

--- a/Tests/SentryTests/TestRateLimits.swift
+++ b/Tests/SentryTests/TestRateLimits.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public class TestRateLimits : NSObject, RateLimits {
+    
+    public var responses : [HTTPURLResponse] = []
+    public var isLimitRateReached: Bool = false
+    
+    public func isRateLimitReached() -> Bool {
+        return isLimitRateReached
+    }
+    
+    public func update(_ response: HTTPURLResponse) {
+        responses.append(response)
+    }
+}


### PR DESCRIPTION
Move the code for the rate limit logic to an extra class SentryDefaultRateLimits.
SentryHttpTransport interacts now with the protocol SentryRateLimits to make it easier
to test. The current RateLimit logic with both status code 429 and the custom
HTTP header "X-Sentry-Rate-Limits" is not included in this PR.