### PR TITLE
test: Bring up test coverage for SentryHttpTransport

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -5,7 +5,6 @@
 #import "SentryUser.h"
 #import "SentryQueueableRequestManager.h"
 #import "SentryEvent.h"
-#import "SentryNSURLRequest.h"
 #import "SentryCrashInstallationReporter.h"
 #import "SentryFileManager.h"
 #import "SentryBreadcrumbTracker.h"

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -78,7 +78,7 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
     
     NSError *requestError = nil;
     // TODO: We do multiple serializations here, we can improve this
-    SentryNSURLRequest *request = [[SentryNSURLRequest alloc] initEnvelopeRequestWithDsn:self.options.dsn
+    NSURLRequest *request = [[SentryNSURLRequest alloc] initEnvelopeRequestWithDsn:self.options.dsn
                                                                                andData:[SentrySerialization dataWithEnvelope:envelope options:0 error:&requestError]
                                                                      didFailWithError:&requestError];
     if (nil != requestError) {

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -52,7 +52,7 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
     
     NSError *requestError = nil;
     // TODO: We do multiple serializations here, we can improve this
-    SentryNSURLRequest *request = [[SentryNSURLRequest alloc] initStoreRequestWithDsn:self.options.dsn
+    NSURLRequest *request = [[SentryNSURLRequest alloc] initStoreRequestWithDsn:self.options.dsn
                                                                              andEvent:event
                                                                      didFailWithError:&requestError];
     if (nil != requestError) {
@@ -171,7 +171,7 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
     };
 }
 
-- (void)sendRequest:(SentryNSURLRequest *)request withCompletionHandler:(_Nullable SentryRequestOperationFinished)completionHandler {
+- (void)sendRequest:(NSURLRequest *)request withCompletionHandler:(_Nullable SentryRequestOperationFinished)completionHandler {
     [self.requestManager addRequest:request
                   completionHandler:^(NSHTTPURLResponse * _Nullable response, NSError * _Nullable error) {
         if (completionHandler) {

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -125,7 +125,7 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
 
 - (void)setupQueueing {
     __block SentryHttpTransport *_self = self;
-    self.shouldQueueEvent = ^BOOL(SentryEnvelope *envelope, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
+    self.shouldQueueEvent = ^BOOL(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
         // Taken from Apple Docs:
         // If a response from the server is received, regardless of whether the
         // request completes successfully or fails, the response parameter
@@ -151,7 +151,7 @@ withEnvelope:(SentryEnvelope *)envelope
 withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
     __block SentryHttpTransport *_self = self;
     [self sendRequest:request withCompletionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
-        if (self.shouldQueueEvent == nil || self.shouldQueueEvent(envelope, response, error) == NO) {
+        if (self.shouldQueueEvent == nil || self.shouldQueueEvent(response, error) == NO) {
             // don't need to queue this -> it most likely got sent
             // thus we can remove the event from disk
             [_self.fileManager removeFileAtPath:storedEventPath];

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -52,7 +52,7 @@ typedef SentryEvent *_Nullable (^SentryBeforeSendEventCallback)(SentryEvent *_No
  * Note that this will only be called once the event is created and send manully.
  * Once it has been queued once it will be discarded if it fails again.
  */
-typedef BOOL (^SentryShouldQueueEvent)(SentryEnvelope *_Nullable envelope, NSHTTPURLResponse *_Nullable response, NSError *_Nullable error);
+typedef BOOL (^SentryShouldQueueEvent)(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error);
 /**
  * Loglevel
  */

--- a/Tests/SentryTests/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/SentryHttpTransportTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class SentryHttpTransportTests: XCTestCase {
-
+    
     private var fileManager: SentryFileManager!
     private var options: Options!
     private var requestManager: TestRequestManager!
@@ -17,6 +17,8 @@ class SentryHttpTransportTests: XCTestCase {
             fileManager = try SentryFileManager.init(dsn: TestConstants.dsn)
             
             requestManager = TestRequestManager(session: URLSession())
+            requestManager.returnResponse(response: HTTPURLResponse.init())
+            
             options = try Options(dict: ["dsn": TestConstants.dsnAsString])
             rateLimits = TestRateLimits()
             
@@ -34,49 +36,154 @@ class SentryHttpTransportTests: XCTestCase {
     override func tearDown() {
         fileManager.deleteAllStoredEvents()
     }
-
+    
     func testSendOneEvent()  {
         sendEvent()
         
         XCTAssertEqual(1, requestManager.requests.count)
+        XCTAssertEqual(0, fileManager.getAllStoredEvents().count)
     }
     
-    func testOptionsDisabled() {
+    func testSendEventOptionsDisabled() {
         options.enabled = false
-        sendEvent()
-        sendEvent()
+        sendEvent(callsCompletionHandler: false)
+        sendEvent(callsCompletionHandler: false)
         
         XCTAssertEqual(0, requestManager.requests.count)
     }
     
-    func test429ResponseUpdatesRateLimit() {
-        let response = createRetryAfterHeader(headerValue: "1")
-        requestManager.returnResponse(response: response)
-        
-        // First response parses Retry-After header
+    func testSendAllEvents() {
+        givenNoInternetConnection()
         sendEvent()
         
-        XCTAssertEqual(1, rateLimits.responses.count)
-        XCTAssertEqual(response, rateLimits.responses[0])
+        givenOkResponse()
+        sendEnvelope()
+        
+        XCTAssertEqual(3, requestManager.requests.count)
+        XCTAssertEqual(0, fileManager.getAllStoredEvents().count)
+    }
+    
+    func testSendAllEventsButNotReady() {
+        givenNoInternetConnection()
+        sendEnvelope()
+        
+        requestManager.isReady = false
+        givenOkResponse()
+        sendEvent()
+        
+        XCTAssertEqual(2, requestManager.requests.count)
+        XCTAssertEqual(1, fileManager.getAllStoredEvents().count)
+    }
+    
+    func testSendAllEventsButNotReady2() {
+        givenNoInternetConnection()
+        sendEnvelope()
+        
+        givenOkResponse()
+        // Rate limit changes between sending the event succesfully
+        // and calling sending all events. This can happen when for
+        // example when multiple requests run in parallel.
+        requestManager.returnResponse(response: {
+            self.rateLimits.isLimitRateReached = true
+            return HTTPURLResponse.init()
+        })
+        sendEvent()
+        
+        XCTAssertEqual(2, requestManager.requests.count)
+        XCTAssertEqual(1, fileManager.getAllStoredEvents().count)
+    }
+    
+    func testSendEvent429ResponseUpdatesRateLimit() {
+        let response = given429Response()
+        
+        sendEvent()
+        
+        assertRateLimitUpdated(response: response)
+    }
+    
+    func testSendEnvelopeWith429ResponseUpdatesRateLimit() {
+        let response = given429Response()
+        
+        sendEnvelope()
+        
+        assertRateLimitUpdated(response: response)
     }
     
     func testOptionsEnabledButRateLimitReached() {
         rateLimits.isLimitRateReached = true
         
-        sendEvent()
+        sendEvent(callsCompletionHandler: false)
+        
+        XCTAssertEqual(0, requestManager.requests.count)
+        XCTAssertEqual(0, fileManager.getAllStoredEvents().count)
+    }
+    
+    func testSendEventWithFaultyNSUrlRequest() {
+        var completionHandlerWasCalled = false
+        sut.send(event: TestConstants.eventWithSerializationError) { (error) in
+            XCTAssertNotNil(error)
+            XCTAssertTrue(error.debugDescription.contains("SentryErrorDomain"))
+            completionHandlerWasCalled = true
+        }
+        
+        XCTAssertTrue(completionHandlerWasCalled)
+    }
+    
+    func testSendOneEnvelope() {
+        sendEnvelope()
+        
+        XCTAssertEqual(1, requestManager.requests.count)
+        XCTAssertEqual(0, fileManager.getAllStoredEvents().count)
+    }
+    
+    
+    func testEnvelopeOptionsDisabled() {
+        options.enabled = false
+        sendEnvelope(callsCompletionHandler: false)
         
         XCTAssertEqual(0, requestManager.requests.count)
     }
-  
-    private func sendEvent() {
-        sut.send(event: Event(), completion: nil)
-    }
     
-    private func createRetryAfterHeader(headerValue: String) -> HTTPURLResponse {
-        return HTTPURLResponse.init(
+    private func given429Response() -> HTTPURLResponse {
+        let response = HTTPURLResponse.init(
             url: URL.init(fileURLWithPath: ""),
             statusCode: 429,
             httpVersion: nil,
-            headerFields: ["Retry-After": headerValue])!
+            headerFields: ["Retry-After": "1"])!
+        requestManager.returnResponse(response: response)
+        return response
+    }
+    
+    private func givenNoInternetConnection() {
+        requestManager.returnResponse(response: nil)
+    }
+    
+    private func givenOkResponse() {
+        requestManager.returnResponse(response: HTTPURLResponse.init())
+    }
+    
+    private func sendEvent(callsCompletionHandler: Bool = true) {
+        var completionHandlerWasCalled = false
+        sut.send(event: Event()) { (error) in
+            XCTAssertNil(error)
+            completionHandlerWasCalled = true
+        }
+        XCTAssertEqual(callsCompletionHandler, completionHandlerWasCalled)
+    }
+    
+    private func sendEnvelope(callsCompletionHandler: Bool = true) {
+        var completionHandlerWasCalled = false
+        sut.send(envelope: TestConstants.envelope) { (error) in
+            XCTAssertNil(error)
+            completionHandlerWasCalled = true
+        }
+        XCTAssertEqual(callsCompletionHandler, completionHandlerWasCalled)
+    }
+    
+    
+    private func assertRateLimitUpdated(response: HTTPURLResponse) {
+        XCTAssertEqual(1, requestManager.requests.count)
+        XCTAssertEqual(1, rateLimits.responses.count)
+        XCTAssertEqual(response, rateLimits.responses[0])
     }
 }

--- a/Tests/SentryTests/TestConstants.swift
+++ b/Tests/SentryTests/TestConstants.swift
@@ -13,4 +13,17 @@ struct TestConstants {
         
         return dsn!
     }
+    
+    static var eventWithSerializationError: Event {
+        let event = Event()
+        event.message = ""
+        event.sdk = ["event": Event()]
+        return event
+    }
+    
+    static var envelope: SentryEnvelope {
+        let event = Event()
+        let envelopeItem = SentryEnvelopeItem(event: event)
+        return SentryEnvelope(id: event.eventId, singleItem: envelopeItem)
+    }
 }

--- a/Tests/SentryTests/TestRequestManager.swift
+++ b/Tests/SentryTests/TestRequestManager.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public class TestRequestManager: NSObject, RequestManager {
     
-    private var nextResponse : HTTPURLResponse?
+    private var nextResponse : () -> HTTPURLResponse? = { return nil }
     public var isReady: Bool
     public var requests : [URLRequest] = []
     
@@ -15,7 +15,7 @@ public class TestRequestManager: NSObject, RequestManager {
         requests.append(request)
         
         if (nil != completionHandler) {
-            let response = nextResponse ?? HTTPURLResponse(coder: NSCoder())
+            let response = nextResponse() ?? HTTPURLResponse(coder: NSCoder())
             completionHandler!(response, nil)
         }
     }
@@ -24,7 +24,11 @@ public class TestRequestManager: NSObject, RequestManager {
         
     }
     
-    func returnResponse(response: HTTPURLResponse) {
+    func returnResponse(response: HTTPURLResponse?) {
+        nextResponse = { return response }
+    }
+    
+    func returnResponse(response: @escaping () -> HTTPURLResponse?) {
         nextResponse = response
     }
 }


### PR DESCRIPTION
Add more tests for SentryHttpTransport so that the coverage is almost 100%. Extracted duplicated code for sending a request from `sendEvent` and `sendEnvelope` to a new method.