### PR TITLE
fix: Use maxBreadcrumbs from options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Use maxBreadcrumbs from options #451
+
 ## 5.0.0-beta.5
 
 - fix: Limit number of breadcrumbs #450

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -22,8 +22,8 @@
 
 - (instancetype)initWithClient:(SentryClient *_Nullable)client andScope:(SentryScope *_Nullable)scope {
     if (self = [super init]) {
-        self.scope = scope;
         [self bindClient:client];
+        self.scope = scope;
         _sessionLock = [[NSObject alloc] init];
     }
     return self;
@@ -166,10 +166,17 @@
 }
 
 - (SentryScope *)getScope {
-    if (self.scope == nil) {
-        self.scope = [[SentryScope alloc] init];
+    @synchronized (self) {
+        if (self.scope == nil) {
+            SentryClient *client = [self getClient];
+            if (nil != client) {
+                self.scope = [[SentryScope alloc] initWithMaxBreadcrumbs:client.options.maxBreadcrumbs];
+            } else {
+                self.scope = [[SentryScope alloc] init];
+            }
+        }
+        return self.scope;
     }
-    return self.scope;
 }
 
 - (void)bindClient:(SentryClient * _Nullable)client {

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -87,7 +87,7 @@
         self.maxBreadcrumbs = [[options objectForKey:@"maxBreadcrumbs"] unsignedIntValue];
     } else {
         // fallback value
-        self.maxBreadcrumbs = [@100 unsignedIntValue];
+        self.maxBreadcrumbs = defaultMaxBreadcrumbs;
     }
 
     if (nil != [options objectForKey:@"beforeSend"]) {

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -7,6 +7,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSInteger const defaultMaxBreadcrumbsCap = 250;
+
 @interface SentryScope ()
 
 /**
@@ -83,7 +85,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (instancetype)init {
-    return [self initWithMaxBreadcrumbs:100];
+    return [self initWithMaxBreadcrumbs:defaultMaxBreadcrumbsCap];
 }
 
 - (instancetype)initWithScope:(SentryScope *)scope {
@@ -99,6 +101,7 @@ NS_ASSUME_NONNULL_BEGIN
             user.username = scopeUser.username;
             user.email = scopeUser.email;
         }
+        self.maxBreadcrumbs = scope.maxBreadcrumbs;
         self.userObject = user;
         self.contextDictionary = scope.contextDictionary.mutableCopy;
         self.breadcrumbArray = scope.breadcrumbArray.mutableCopy;

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -7,8 +7,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSInteger const defaultMaxBreadcrumbsCap = 250;
-
 @interface SentryScope ()
 
 /**
@@ -85,7 +83,7 @@ NSInteger const defaultMaxBreadcrumbsCap = 250;
 }
 
 - (instancetype)init {
-    return [self initWithMaxBreadcrumbs:defaultMaxBreadcrumbsCap];
+    return [self initWithMaxBreadcrumbs:defaultMaxBreadcrumbs];
 }
 
 - (instancetype)initWithScope:(SentryScope *)scope {

--- a/Sources/Sentry/include/SentryDefines.h
+++ b/Sources/Sentry/include/SentryDefines.h
@@ -88,3 +88,5 @@ static NSString *_Nonnull const SentryLevelNames[] = {
         @"error",
         @"fatal",
 };
+
+static NSUInteger const defaultMaxBreadcrumbs = 100;

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -56,7 +56,7 @@ SENTRY_NO_INIT
 
 /**
  * How many breadcrumbs do you want to keep in memory?
- * We have a hard cap limit on 250. Default is 100.
+ * We have a hard limit of 250. Default is 100.
  */
 @property(nonatomic, assign) NSUInteger maxBreadcrumbs;
 

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -54,6 +54,10 @@ SENTRY_NO_INIT
  */
 @property(nonatomic, copy) NSNumber *enabled;
 
+/**
+ * How many breadcrumbs do you want to keep in memory?
+ * We have a hard cap limit on 250. Default is 100.
+ */
 @property(nonatomic, assign) NSUInteger maxBreadcrumbs;
 
 /**

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -56,7 +56,7 @@ SENTRY_NO_INIT
 
 /**
  * How many breadcrumbs do you want to keep in memory?
- * We have a hard limit of 250. Default is 100.
+ * Default is 100.
  */
 @property(nonatomic, assign) NSUInteger maxBreadcrumbs;
 

--- a/Tests/SentryTests/SentryHubTests.m
+++ b/Tests/SentryTests/SentryHubTests.m
@@ -40,4 +40,71 @@
     XCTAssertNil(scopeBreadcrumbs);
 }
 
+- (void)testBreadcrumbLimitThroughOptionsUsingHubAddBreadcrumb {
+    NSError *error = nil;
+    SentryOptions *options = [[SentryOptions alloc] initWithDict:@{
+        @"dsn": @"https://username@sentry.io/1",
+        @"maxBreadcrumbs": @10
+        
+    } didFailWithError: &error];
+    SentryClient *client = [[SentryClient alloc] initWithOptions:options];
+    SentryHub *hub = [[SentryHub alloc] initWithClient:client andScope:nil];
+    [hub bindClient:client];
+
+    for (int i = 0; i <= 15; i++) {
+        SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelError category:@"default"];
+        [hub addBreadcrumb:crumb];
+    }
+    SentryScope *scope = [hub getScope];
+    NSArray *scopeBreadcrumbs = [[scope serialize] objectForKey:@"breadcrumbs"];
+    XCTAssertNotNil(scopeBreadcrumbs);
+    XCTAssertEqual([scopeBreadcrumbs count], 10);
+}
+
+- (void)testBreadcrumbLimitThroughOptionsUsingConfigureScope {
+    NSError *error = nil;
+    SentryOptions *options = [[SentryOptions alloc] initWithDict:@{
+        @"dsn": @"https://username@sentry.io/1",
+        @"maxBreadcrumbs": @10
+        
+    } didFailWithError: &error];
+    SentryClient *client = [[SentryClient alloc] initWithOptions:options];
+    SentryHub *hub = [[SentryHub alloc] initWithClient:client andScope:nil];
+    [hub bindClient:client];
+
+    
+    for (int i = 0; i <= 15; i++) {
+        [hub configureScope:^(SentryScope * _Nonnull scope) {
+            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelError category:@"default"];
+            [scope addBreadcrumb:crumb];
+        }];
+    }
+    SentryScope *scope = [hub getScope];
+    NSArray *scopeBreadcrumbs = [[scope serialize] objectForKey:@"breadcrumbs"];
+    XCTAssertNotNil(scopeBreadcrumbs);
+    XCTAssertEqual([scopeBreadcrumbs count], 10);
+}
+
+- (void)testBreadcrumbHardCapLimit {
+    NSError *error = nil;
+    SentryOptions *options = [[SentryOptions alloc] initWithDict:@{
+        @"dsn": @"https://username@sentry.io/1",
+    } didFailWithError: &error];
+    SentryClient *client = [[SentryClient alloc] initWithOptions:options];
+    SentryHub *hub = [[SentryHub alloc] initWithClient:client andScope:[[SentryScope alloc] init]];
+    [hub bindClient:client];
+
+    for (int i = 0; i <= 500; i++) {
+        [hub configureScope:^(SentryScope * _Nonnull scope) {
+            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelError category:@"default"];
+            [scope addBreadcrumb:crumb];
+        }];
+    }
+    
+    SentryScope *scope = [hub getScope];
+    NSArray *scopeBreadcrumbs = [[scope serialize] objectForKey:@"breadcrumbs"];
+    XCTAssertNotNil(scopeBreadcrumbs);
+    XCTAssertEqual([scopeBreadcrumbs count], 250);
+}
+
 @end


### PR DESCRIPTION
Using the option `maxBreadcrumbs` from `SentryOptions`.
Introduce hard cap for breadcrumbs.