### PR TITLE
feat: RateLimit for sendAllStoredEvents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: RateLimit for sendAllStoredEvents #458
 - fix: Use maxBreadcrumbs from options #451
 
 ## 5.0.0-beta.5


### PR DESCRIPTION
Check in sendAllStoredEvents in SentryHttpTransport if the RateLimit is
active or not.