### PR TITLE
ref: Add SentryFileContents

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -261,6 +261,8 @@
 		7BBD18B62451807600427C76 /* SentryDefaultRateLimitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */; };
 		7BBD18B7245180FF00427C76 /* SentryDsnTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 639FCF921EBC746F00778193 /* SentryDsnTests.m */; };
 		7BBD18BB24530D2600427C76 /* SentryFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */; };
+		7BC8522F24581096005A70F0 /* SentryFileContents.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC8522E24581096005A70F0 /* SentryFileContents.h */; };
+		7BC85231245812EC005A70F0 /* SentryFileContents.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC85230245812EC005A70F0 /* SentryFileContents.m */; };
 		7BE3C7672445C0CA00A38442 /* SentryCurrentDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BE3C7692445C1A800A38442 /* SentryCurrentDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */; };
 		7BE3C76B2445C27A00A38442 /* SentryCurrentDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -565,6 +567,8 @@
 		7BBD189F244ED1A200427C76 /* SentryRetryAfterHeaderParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRetryAfterHeaderParserTests.swift; sourceTree = "<group>"; };
 		7BBD18A1244EE2FD00427C76 /* TestResponseFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestResponseFactory.swift; sourceTree = "<group>"; };
 		7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFileManagerTests.swift; sourceTree = "<group>"; };
+		7BC8522E24581096005A70F0 /* SentryFileContents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryFileContents.h; path = include/SentryFileContents.h; sourceTree = "<group>"; };
+		7BC85230245812EC005A70F0 /* SentryFileContents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryFileContents.m; sourceTree = "<group>"; };
 		7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDate.h; path = include/SentryCurrentDate.h; sourceTree = "<group>"; };
 		7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCurrentDate.m; sourceTree = "<group>"; };
 		7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDateProvider.h; path = include/SentryCurrentDateProvider.h; sourceTree = "<group>"; };
@@ -831,6 +835,8 @@
 				63AA76781EB8D20500D153DE /* SentryLog.m */,
 				636085111ED47BE600E8599E /* SentryFileManager.h */,
 				636085121ED47BE600E8599E /* SentryFileManager.m */,
+				7BC8522E24581096005A70F0 /* SentryFileContents.h */,
+				7BC85230245812EC005A70F0 /* SentryFileContents.m */,
 				639889B91EDED18400EA7442 /* SentrySwizzle.h */,
 				639889BA1EDED18400EA7442 /* SentrySwizzle.m */,
 				632F434E1F581D5400A18A36 /* SentryCrashExceptionApplication.h */,
@@ -1323,6 +1329,7 @@
 				63FE712B20DA4C1100CDBAE8 /* SentryCrashStackCursor.h in Headers */,
 				637533582243A0100002F77F /* NSString+SentryNSUIntegerValue.h in Headers */,
 				63FE70EB20DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.h in Headers */,
+				7BC8522F24581096005A70F0 /* SentryFileContents.h in Headers */,
 				7DC8310A2398283C0043DD9A /* SentryCrashIntegration.h in Headers */,
 				63FE718320DA4C1100CDBAE8 /* SentryCrashReportFixer.h in Headers */,
 				63FE70F920DA4C1000CDBAE8 /* SentryCrashMonitor.h in Headers */,
@@ -1552,6 +1559,7 @@
 				63FE70DB20DA4C1000CDBAE8 /* SentryCrashMonitor_System.m in Sources */,
 				63FE70E320DA4C1000CDBAE8 /* SentryCrashMonitor_Zombie.c in Sources */,
 				63FE713120DA4C1100CDBAE8 /* SentryCrashDynamicLinker.c in Sources */,
+				7BC85231245812EC005A70F0 /* SentryFileContents.m in Sources */,
 				639FCFAD1EBC811400778193 /* SentryUser.m in Sources */,
 				7DAC589123D8B2E0001CF26B /* SentryGlobalEventProcessor.m in Sources */,
 				7BBD189E244EC8D200427C76 /* SentryRetryAfterHeaderParser.m in Sources */,

--- a/Sources/Sentry/SentryFileContents.m
+++ b/Sources/Sentry/SentryFileContents.m
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+#import "SentryFileContents.h"
+
+@interface SentryFileContents ()
+
+@end
+
+@implementation SentryFileContents
+
+- (instancetype)initWithPath:(NSString *) path andContents:(NSData *) contents
+{
+    if (self = [super init]) {
+        _path = path;
+        _contents = contents;
+    }
+    return self;
+}
+
+@end

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -4,6 +4,7 @@
 #import "SentryEvent.h"
 #import "SentryDsn.h"
 #import "SentrySerialization.h"
+#import "SentryFileContents.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -59,19 +60,19 @@ NSInteger const defaultMaxEvents = 10;
                                       [NSUUID UUID].UUIDString];
 }
 
-- (NSArray<NSDictionary<NSString *, id> *> *)getAllStoredEventsAndEnvelopes {
+- (NSArray<SentryFileContents *> *)getAllStoredEventsAndEnvelopes {
     return [self allFilesContentInFolder:self.eventsAndEnvelopesPath];
 }
 
-- (NSArray<NSDictionary<NSString *, id> *> *)allFilesContentInFolder:(NSString *)path {
+- (NSArray<SentryFileContents *> *)allFilesContentInFolder:(NSString *)path {
     @synchronized (self) {
-        NSMutableArray *contents = [NSMutableArray new];
+        NSMutableArray<SentryFileContents *> *contents = [NSMutableArray new];
         NSFileManager *fileManager = [NSFileManager defaultManager];
         for (NSString *filePath in [self allFilesInFolder:path]) {
             NSString *finalPath = [path stringByAppendingPathComponent:filePath];
             NSData *content = [fileManager contentsAtPath:finalPath];
             if (nil != content) {
-                [contents addObject:@{@"path": finalPath, @"data": content}];
+                [contents addObject:[[SentryFileContents alloc] initWithPath:finalPath andContents:content]];
             }
         }
         return contents;

--- a/Sources/Sentry/include/SentryFileContents.h
+++ b/Sources/Sentry/include/SentryFileContents.h
@@ -1,0 +1,12 @@
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryFileContents : NSObject
+
+- (instancetype)initWithPath:(NSString *) path andContents:(NSData *) contents;
+
+@property(nonatomic, readonly, copy) NSString *path;
+@property(nonatomic, readonly, weak) NSData *contents;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryEvent, SentryDsn, SentryEnvelope;
+@class SentryEvent, SentryDsn, SentryEnvelope, SentryFileContents;
 
 NS_SWIFT_NAME(SentryFileManager)
 @interface SentryFileManager : NSObject
@@ -26,7 +26,7 @@ SENTRY_NO_INIT
 
 - (void)deleteAllFolders;
 
-- (NSArray<NSDictionary<NSString *, id> *> *)getAllStoredEventsAndEnvelopes;
+- (NSArray<SentryFileContents *> *)getAllStoredEventsAndEnvelopes;
 
 - (BOOL)removeFileAtPath:(NSString *)path;
 

--- a/Tests/SentryTests/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/SentryFileManagerTests.swift
@@ -29,8 +29,7 @@ class SentryFileManagerTests: XCTestCase {
         let events = sut.getAllStoredEventsAndEnvelopes()
         XCTAssertTrue(events.count == 1)
         
-        let actualData = events[0]["data"] as! Data
-        let actualDict = try JSONSerialization.jsonObject(with: actualData) as! Dictionary<String, Any>
+        let actualDict = try JSONSerialization.jsonObject(with: events[0].contents! as Data) as! Dictionary<String, Any>
         
         let eventDict = event.serialize()
         XCTAssertEqual(eventDict.count, actualDict.count)
@@ -48,7 +47,7 @@ class SentryFileManagerTests: XCTestCase {
         sut.store(event)
         let events = sut.getAllStoredEventsAndEnvelopes()
         XCTAssertTrue(events.count == 1)
-        XCTAssertEqual(events[0]["data"] as! Data, jsonData)
+        XCTAssertEqual(events[0].contents, jsonData as NSData)
     }
     
     func testCreateDirDoesnotThrow() throws {

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -14,3 +14,4 @@
 #import "SentryDefaultRateLimits.h"
 #import "SentryHttpDateParser.h"
 #import "SentryRetryAfterHeaderParser.h"
+#import "SentryFileContents.h"


### PR DESCRIPTION
`SentryFileManager.getAllStoredEventsAndEnvelopes` returned `NSDictionary<NSString *, id>`. That dictionary was filled with `path` and `data`. A new class `SentryFileContents` is added that contains two properties for `path` and `contents`. The consumer of `getAllStoredEventsAndEnvelopes` doesn't have to look into the implementation to understand what the function returns.