### PR TITLE
feat: Store SentryEnvelopes in extra path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- feat: Store SentryEnvelopes in extra path
+- feat: Store SentryEnvelopes in extra path #468
 - feat: Add auto session starting for macOS #463
 
 ## 5.0.0-beta.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Store SentryEnvelopes in extra path
 - feat: Add auto session starting for macOS #463
 
 ## 5.0.0-beta.6

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -226,9 +226,7 @@ NSInteger const defaultMaxEnvelopes = 100;
 #pragma mark private methods
 
 - (void)createDirectoryIfNotExists:(NSString *)path didFailWithError:(NSError **)error {
-    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
-        [self.class createDirectoryAtPath:path withError:error];
-    }
+    [[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:error];
 }
 
 @end

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -9,7 +9,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 NSInteger const defaultMaxEvents = 10;
-NSInteger const defaultMaxEnvelopes = 10;
+NSInteger const defaultMaxEnvelopes = 100;
 
 @interface SentryFileManager ()
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -9,11 +9,13 @@
 NS_ASSUME_NONNULL_BEGIN
 
 NSInteger const defaultMaxEvents = 10;
+NSInteger const defaultMaxEnvelopes = 10;
 
 @interface SentryFileManager ()
 
 @property(nonatomic, copy) NSString *sentryPath;
-@property(nonatomic, copy) NSString *eventsAndEnvelopesPath;
+@property(nonatomic, copy) NSString *eventsPath;
+@property(nonatomic, copy) NSString *envelopesPath;
 @property(nonatomic, copy) NSString *currentSessionFilePath;
 @property(nonatomic, assign) NSUInteger currentFileCounter;
 
@@ -36,20 +38,24 @@ NSInteger const defaultMaxEvents = 10;
 
         self.currentSessionFilePath = [self.sentryPath stringByAppendingPathComponent:@"session.current"];
 
-        self.eventsAndEnvelopesPath = [self.sentryPath stringByAppendingPathComponent:@"events"];
-        if (![fileManager fileExistsAtPath:self.eventsAndEnvelopesPath]) {
-            [self.class createDirectoryAtPath:self.eventsAndEnvelopesPath withError:error];
-        }
+        self.eventsPath = [self.sentryPath stringByAppendingPathComponent:@"events"];
+        [self createDirectoryIfNotExists:self.eventsPath didFailWithError:error];
+        
+        self.envelopesPath = [self.sentryPath stringByAppendingPathComponent:@"envelopes"];
+        [self createDirectoryIfNotExists:self.envelopesPath didFailWithError:error];
+        
 
         self.currentFileCounter = 0;
         self.maxEvents = defaultMaxEvents;
+        self.maxEnvelopes = defaultMaxEnvelopes;
     }
     return self;
 }
 
 - (void)deleteAllFolders {
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    [fileManager removeItemAtPath:self.eventsAndEnvelopesPath error:nil];
+    [fileManager removeItemAtPath:self.eventsPath error:nil];
+    [fileManager removeItemAtPath:self.envelopesPath error:nil];
     [fileManager removeItemAtPath:self.sentryPath error:nil];
 }
 
@@ -60,8 +66,16 @@ NSInteger const defaultMaxEvents = 10;
                                       [NSUUID UUID].UUIDString];
 }
 
+- (NSArray<SentryFileContents *> *)getAllEvents {
+    return [self allFilesContentInFolder:self.eventsPath];
+}
+
+- (NSArray<SentryFileContents *> *)getAllEnvelopes {
+    return [self allFilesContentInFolder:self.envelopesPath];
+}
+
 - (NSArray<SentryFileContents *> *)getAllStoredEventsAndEnvelopes {
-    return [self allFilesContentInFolder:self.eventsAndEnvelopesPath];
+    return [[self getAllEvents] arrayByAddingObjectsFromArray:[self getAllEnvelopes]];
 }
 
 - (NSArray<SentryFileContents *> *)allFilesContentInFolder:(NSString *)path {
@@ -80,8 +94,12 @@ NSInteger const defaultMaxEvents = 10;
 }
 
 - (void)deleteAllStoredEventsAndEnvelopes {
-    for (NSString *path in [self allFilesInFolder:self.eventsAndEnvelopesPath]) {
-        [self removeFileAtPath:[self.eventsAndEnvelopesPath stringByAppendingPathComponent:path]];
+    for (NSString *path in [self allFilesInFolder:self.eventsPath]) {
+        [self removeFileAtPath:[self.eventsPath stringByAppendingPathComponent:path]];
+    }
+    
+    for (NSString *path in [self allFilesInFolder:self.envelopesPath]) {
+        [self removeFileAtPath:[self.envelopesPath stringByAppendingPathComponent:path]];
     }
 }
 
@@ -117,19 +135,19 @@ NSInteger const defaultMaxEvents = 10;
     @synchronized (self) {
         NSString *result;
         if (nil != event.json) {
-            result = [self storeData:event.json toPath:self.eventsAndEnvelopesPath];
+            result = [self storeData:event.json toPath:self.eventsPath];
         } else {
-            result = [self storeDictionary:[event serialize] toPath:self.eventsAndEnvelopesPath];
+            result = [self storeDictionary:[event serialize] toPath:self.eventsPath];
         }
-        [self handleFileManagerLimit:self.eventsAndEnvelopesPath maxCount:maxCount];
+        [self handleFileManagerLimit:self.eventsPath maxCount:maxCount];
         return result;
     }
 }
 
 - (NSString *)storeEnvelope:(SentryEnvelope *)envelope {
     @synchronized (self) {
-        NSString *result = [self storeData:[SentrySerialization dataWithEnvelope:envelope options:0 error:nil] toPath:self.eventsAndEnvelopesPath];
-        [self handleFileManagerLimit:self.eventsAndEnvelopesPath maxCount:self.maxEvents];
+        NSString *result = [self storeData:[SentrySerialization dataWithEnvelope:envelope options:0 error:nil] toPath:self.envelopesPath];
+        [self handleFileManagerLimit:self.envelopesPath maxCount:self.maxEnvelopes];
         return result;
     }
 }
@@ -203,6 +221,14 @@ NSInteger const defaultMaxEvents = 10;
                   withIntermediateDirectories:YES
                                    attributes:nil
                                         error:error];
+}
+
+#pragma mark private methods
+
+- (void)createDirectoryIfNotExists:(NSString *)path didFailWithError:(NSError **)error {
+    if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
+        [self.class createDirectoryAtPath:path withError:error];
+    }
 }
 
 @end

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -26,6 +26,8 @@ SENTRY_NO_INIT
 
 - (void)deleteAllFolders;
 
+- (NSArray<SentryFileContents *> *)getAllEvents;
+- (NSArray<SentryFileContents *> *)getAllEnvelopes;
 - (NSArray<SentryFileContents *> *)getAllStoredEventsAndEnvelopes;
 
 - (BOOL)removeFileAtPath:(NSString *)path;
@@ -35,6 +37,7 @@ SENTRY_NO_INIT
 - (NSString *)storeDictionary:(NSDictionary *)dictionary toPath:(NSString *)path;
 
 @property(nonatomic, assign) NSUInteger maxEvents;
+@property(nonatomic, assign) NSUInteger maxEnvelopes;
 
 @end
 

--- a/Tests/SentryTests/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/SentryFileManagerTests.swift
@@ -21,6 +21,19 @@ class SentryFileManagerTests: XCTestCase {
         sut.deleteAllFolders()
     }
     
+    func testInitDoesNotOverrideDirectories() throws {
+        sut.store(Event())
+        sut.store(TestConstants.envelope)
+        sut.storeCurrentSession(SentrySession())
+        
+        _ = try SentryFileManager.init(dsn: TestConstants.dsn)
+        let fileManager = try SentryFileManager.init(dsn: TestConstants.dsn)
+        
+        XCTAssertEqual(1, fileManager.getAllEvents().count)
+        XCTAssertEqual(1, fileManager.getAllEnvelopes().count)
+        XCTAssertNotNil(fileManager.readCurrentSession())
+    }
+    
     func testEventStoring() throws {
         let event = Event(level: SentryLevel.info)
         event.message = "message"

--- a/Tests/SentryTests/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/SentryFileManagerTests.swift
@@ -102,11 +102,11 @@ class SentryFileManagerTests: XCTestCase {
     }
     
     func testDefaultMaxEnvelopes() {
-        for _ in 0...10 {
+        for _ in 0...100 {
             sut.store(TestConstants.envelope)
         }
         let events = sut.getAllEnvelopes()
-        XCTAssertEqual(events.count, 10)
+        XCTAssertEqual(events.count, 100)
     }
     
     func testMaxEnvelopesSet() {


### PR DESCRIPTION
Add `getAllEvents` and `getAllEnvelopes` to `SentryFileManager`. `SentryHttpTransport` needs those methods to implement rate limiting.