### PR TITLE
fix: Use RateLimitCategoryError for events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Use RateLimitCategoryError for events #470
 - feat: Store SentryEnvelopes in extra path #468
 - feat: Add auto session starting for macOS #463
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -263,6 +263,11 @@
 		7BBD18BB24530D2600427C76 /* SentryFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */; };
 		7BC8522F24581096005A70F0 /* SentryFileContents.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC8522E24581096005A70F0 /* SentryFileContents.h */; };
 		7BC85231245812EC005A70F0 /* SentryFileContents.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC85230245812EC005A70F0 /* SentryFileContents.m */; };
+		7BC852332458802C005A70F0 /* SentryRateLimitCategoryMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC852322458802C005A70F0 /* SentryRateLimitCategoryMapper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BC85235245880AE005A70F0 /* SentryRateLimitCategoryMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC85234245880AE005A70F0 /* SentryRateLimitCategoryMapper.m */; };
+		7BC8523724588115005A70F0 /* SentryRateLimitCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BC852392458830A005A70F0 /* SentryEnvelopeItemType.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BC8523B2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */; };
 		7BE3C7672445C0CA00A38442 /* SentryCurrentDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BE3C7692445C1A800A38442 /* SentryCurrentDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */; };
 		7BE3C76B2445C27A00A38442 /* SentryCurrentDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -569,6 +574,11 @@
 		7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFileManagerTests.swift; sourceTree = "<group>"; };
 		7BC8522E24581096005A70F0 /* SentryFileContents.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryFileContents.h; path = include/SentryFileContents.h; sourceTree = "<group>"; };
 		7BC85230245812EC005A70F0 /* SentryFileContents.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryFileContents.m; sourceTree = "<group>"; };
+		7BC852322458802C005A70F0 /* SentryRateLimitCategoryMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRateLimitCategoryMapper.h; path = include/SentryRateLimitCategoryMapper.h; sourceTree = "<group>"; };
+		7BC85234245880AE005A70F0 /* SentryRateLimitCategoryMapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryRateLimitCategoryMapper.m; sourceTree = "<group>"; };
+		7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRateLimitCategory.h; path = include/SentryRateLimitCategory.h; sourceTree = "<group>"; };
+		7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeItemType.h; path = include/SentryEnvelopeItemType.h; sourceTree = "<group>"; };
+		7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRateLimitCategoryMapperTests.swift; sourceTree = "<group>"; };
 		7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDate.h; path = include/SentryCurrentDate.h; sourceTree = "<group>"; };
 		7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCurrentDate.m; sourceTree = "<group>"; };
 		7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDateProvider.h; path = include/SentryCurrentDateProvider.h; sourceTree = "<group>"; };
@@ -678,6 +688,7 @@
 			children = (
 				15E0A8E0240C41CE00F044E3 /* SentryEnvelope.h */,
 				15E0A8E4240C457D00F044E3 /* SentryEnvelope.m */,
+				7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */,
 				6304360F1EC0600A00C4D3FA /* SentrySerializable.h */,
 				639FCF961EBC7B9700778193 /* SentryEvent.h */,
 				639FCF971EBC7B9700778193 /* SentryEvent.m */,
@@ -1176,6 +1187,9 @@
 				7BE3C77C2446112C00A38442 /* SentryRateLimitParser.m */,
 				7BBD189C244EC71A00427C76 /* SentryRetryAfterHeaderParser.h */,
 				7BBD189D244EC8D200427C76 /* SentryRetryAfterHeaderParser.m */,
+				7BC852322458802C005A70F0 /* SentryRateLimitCategoryMapper.h */,
+				7BC85234245880AE005A70F0 /* SentryRateLimitCategoryMapper.m */,
+				7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */,
 			);
 			name = RateLimits;
 			sourceTree = "<group>";
@@ -1204,6 +1218,7 @@
 				7BBD189F244ED1A200427C76 /* SentryRetryAfterHeaderParserTests.swift */,
 				7BE3C780244701A000A38442 /* SentryRateLimitsParserTests.m */,
 				7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */,
+				7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */,
 			);
 			path = RateLimits;
 			sourceTree = "<group>";
@@ -1324,6 +1339,7 @@
 				7D0FCFB22379B915004DD83A /* SentryHub.h in Headers */,
 				63FE717120DA4C1100CDBAE8 /* SentryCrashSystemCapabilities.h in Headers */,
 				632F43501F581D5400A18A36 /* SentryCrashExceptionApplication.h in Headers */,
+				7BC852332458802C005A70F0 /* SentryRateLimitCategoryMapper.h in Headers */,
 				639889B71EDECFA800EA7442 /* SentryBreadcrumbTracker.h in Headers */,
 				632331F9240506DF008D91D6 /* SentryScope+Private.h in Headers */,
 				63FE712B20DA4C1100CDBAE8 /* SentryCrashStackCursor.h in Headers */,
@@ -1363,9 +1379,11 @@
 				63FE713D20DA4C1100CDBAE8 /* SentryCrashLogger.h in Headers */,
 				15E0A8E1240C41CE00F044E3 /* SentryEnvelope.h in Headers */,
 				630435FE1EBCA9D900C4D3FA /* SentryNSURLRequest.h in Headers */,
+				7BC852392458830A005A70F0 /* SentryEnvelopeItemType.h in Headers */,
 				63AA769D1EB9C57A00D153DE /* SentryError.h in Headers */,
 				63FE714F20DA4C1100CDBAE8 /* NSError+SentrySimpleConstructor.h in Headers */,
 				7DC83100239826280043DD9A /* SentryIntegrationProtocol.h in Headers */,
+				7BC8523724588115005A70F0 /* SentryRateLimitCategory.h in Headers */,
 				63FE714B20DA4C1100CDBAE8 /* SentryCrashString.h in Headers */,
 				63FE715320DA4C1100CDBAE8 /* SentryCrashObjCApple.h in Headers */,
 				63FE710120DA4C1000CDBAE8 /* SentryCrashDate.h in Headers */,
@@ -1492,6 +1510,7 @@
 				63FE712F20DA4C1100CDBAE8 /* SentryCrashSysCtl.c in Sources */,
 				7BE3C77D2446112C00A38442 /* SentryRateLimitParser.m in Sources */,
 				15E0A8ED240F2CB000F044E3 /* SentrySerialization.m in Sources */,
+				7BC85235245880AE005A70F0 /* SentryRateLimitCategoryMapper.m in Sources */,
 				63FE713B20DA4C1100CDBAE8 /* SentryCrashFileUtils.c in Sources */,
 				63FE716920DA4C1100CDBAE8 /* SentryCrashStackCursor.c in Sources */,
 				63FE718D20DA4C1100CDBAE8 /* SentryCrashReportStore.c in Sources */,
@@ -1633,6 +1652,7 @@
 				7BBD18B7245180FF00427C76 /* SentryDsnTests.m in Sources */,
 				63FE721A20DA66EC00CDBAE8 /* SentryCrashSysCtl_Tests.m in Sources */,
 				636085101ED2C1CB00E8599E /* SentryBreadcrumbTests.m in Sources */,
+				7BC8523B2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift in Sources */,
 				63FE721220DA66EC00CDBAE8 /* SentryCrashMach_Tests.m in Sources */,
 				63FE71FF20DA66EC00CDBAE8 /* SentryCrashReportConverter_Tests.m in Sources */,
 				15E0A8F0240F638200F044E3 /* SentrySerializationTests.m in Sources */,

--- a/Sources/Sentry/SentryRateLimitCategoryMapper.m
+++ b/Sources/Sentry/SentryRateLimitCategoryMapper.m
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+#import "SentryRateLimitCategoryMapper.h"
+#import "SentryRateLimitCategory.h"
+#import "SentryEnvelopeItemType.h"
+
+@interface SentryRateLimitCategoryMapper ()
+
+@end
+
+@implementation SentryRateLimitCategoryMapper
+
++ (NSString *_Nonnull)mapEventTypeToCategory:(NSString *)eventType {
+    // Currently we classify every event type as error.
+    // This is going to change in the future.
+    return SentryRateLimitCategoryError;
+}
+
+@end

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -2,6 +2,7 @@
 #import "SentryDefines.h"
 #import "SentryLog.h"
 #import "SentryError.h"
+#import "SentryEnvelopeItemType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/Sentry.h
+++ b/Sources/Sentry/include/Sentry.h
@@ -16,6 +16,7 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 
 #import "SentrySerialization.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemType.h"
 #import "SentryCrash.h"
 #import "SentrySDK.h"
 #import "SentryHub.h"
@@ -53,4 +54,6 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #import "SentryRateLimitParser.h"
 #import "SentryRateLimits.h"
 #import "SentryDefaultRateLimits.h"
+#import "SentryRateLimitCategory.h"
+#import "SentryRateLimitCategoryMapper.h"
 #import "SentryHttpDateParser.h"

--- a/Sources/Sentry/include/SentryEnvelope.h
+++ b/Sources/Sentry/include/SentryEnvelope.h
@@ -34,9 +34,6 @@ SENTRY_NO_INIT
 
 @end
 
-static NSString * const SentryEnvelopeItemTypeEvent = @"event";
-static NSString * const SentryEnvelopeItemTypeSession = @"session";
-
 @interface SentryEnvelopeItem : NSObject
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/include/SentryEnvelopeItemType.h
+++ b/Sources/Sentry/include/SentryEnvelopeItemType.h
@@ -1,0 +1,2 @@
+static NSString * const SentryEnvelopeItemTypeEvent = @"event";
+static NSString * const SentryEnvelopeItemTypeSession = @"session";

--- a/Sources/Sentry/include/SentryRateLimitCategory.h
+++ b/Sources/Sentry/include/SentryRateLimitCategory.h
@@ -1,0 +1,4 @@
+#import <Foundation/Foundation.h>
+
+static NSString * const SentryRateLimitCategoryError = @"error";
+// more categories exist, but we only use error currently.

--- a/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
+++ b/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(RateLimitCategoryMapper)
+@interface SentryRateLimitCategoryMapper : NSObject
+
+/** Maps an event type to the category for rate limiting.
+ */
++ (NSString *_Nonnull)mapEventTypeToCategory:(NSString *)eventType;
+
+@end
+
+NS_ASSUME_NONNULL_END
+

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import Sentry
+
+class SentryRateLimitCategoryMapperTests: XCTestCase {
+
+    func testAnyEventType() {
+        let actual = RateLimitCategoryMapper.mapEventType(toCategory: "any eventtype")
+        
+        XCTAssertEqual(SentryRateLimitCategoryError, actual)
+    }
+    
+    func testEventItemType() {
+        let actual = RateLimitCategoryMapper.mapEventType(toCategory: SentryEnvelopeItemTypeEvent)
+        
+        XCTAssertEqual(SentryRateLimitCategoryError, actual)
+    }
+
+}

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -81,7 +81,7 @@ class SentryHttpTransportTests: XCTestCase {
         givenNoInternetConnection()
         sendEvent()
         
-        givenRateLimitResponse(forType: SentryEnvelopeItemTypeSession)
+        givenRateLimitResponse(forCategory: "someCat")
         sendEnvelope()
         
         XCTAssertEqual(3, requestManager.requests.count)
@@ -120,7 +120,7 @@ class SentryHttpTransportTests: XCTestCase {
         // Rate limit changes between sending the event succesfully
         // and calling sending all events. This can happen when for
         // example when multiple requests run in parallel.
-        givenRateLimitResponse(forType: SentryEnvelopeItemTypeEvent)
+        givenRateLimitResponse(forCategory: SentryRateLimitCategoryError)
         sendEvent()
         
         XCTAssertEqual(2, requestManager.requests.count)
@@ -152,7 +152,7 @@ class SentryHttpTransportTests: XCTestCase {
         sendEvent()
         assertEventsStored(eventCount: 2)
         
-        givenRateLimitResponse(forType: SentryEnvelopeItemTypeEvent)
+        givenRateLimitResponse(forCategory: SentryRateLimitCategoryError)
         sendEvent()
         assertEventsStored(eventCount: 0)
     }
@@ -166,7 +166,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testSendEventWithRateLimitResponse() {
-        let response = givenRateLimitResponse(forType: SentryEnvelopeItemTypeSession)
+        let response = givenRateLimitResponse(forCategory: SentryEnvelopeItemTypeSession)
         
         sendEvent()
         
@@ -182,7 +182,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testSendEnvelopeWithRateLimitResponse() {
-        let response = givenRateLimitResponse(forType: SentryEnvelopeItemTypeSession)
+        let response = givenRateLimitResponse(forCategory: SentryEnvelopeItemTypeSession)
         
         sendEnvelope()
         
@@ -190,7 +190,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testRateLimitForEvent() {
-        givenRateLimitResponse(forType: SentryEnvelopeItemTypeEvent)
+        givenRateLimitResponse(forCategory: SentryRateLimitCategoryError)
 
         sendEvent()
         
@@ -240,8 +240,8 @@ class SentryHttpTransportTests: XCTestCase {
         return response
     }
     
-    @discardableResult private func givenRateLimitResponse(forType type: String) -> HTTPURLResponse {
-        let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:\(type):key")
+    @discardableResult private func givenRateLimitResponse(forCategory category: String) -> HTTPURLResponse {
+        let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:\(category):key")
         requestManager.returnResponse(response: response)
         return response
     }
@@ -261,7 +261,7 @@ class SentryHttpTransportTests: XCTestCase {
             if (i == 0) {
                 return HTTPURLResponse.init()
             } else {
-                return TestResponseFactory.createRateLimitResponse(headerValue: "1:\(SentryEnvelopeItemTypeEvent):key")
+                return TestResponseFactory.createRateLimitResponse(headerValue: "1:\(SentryRateLimitCategoryError):key")
             }
         }
     }

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -15,3 +15,6 @@
 #import "SentryHttpDateParser.h"
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentryFileContents.h"
+#import "SentryEnvelopeItemType.h"
+#import "SentryRateLimitCategoryMapper.h"
+#import "SentryRateLimitCategory.h"


### PR DESCRIPTION
`SentryHttpTransport` used `SentryEnvelopeItemTypeEvent` as a category for
`SentryRateLimits`. This was not correct. Now `SentryRateLimitCategoryMapper`
takes care to map an event type to the correct category. Currently all eventTypes are
classified as `SentryRateLimitCategoryError` as discussed with @jan-auer.