### PR TITLE
feat: RateLimit for non cached Envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: RateLimit for non cached Envelopes #476
 - fix: Use RateLimitCategoryError for events #470
 - feat: Store SentryEnvelopes in extra path #468
 - feat: Adds setUser to SentrySDK and SentryHub #467

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -237,6 +237,9 @@
 		63FE722320DA66EC00CDBAE8 /* SentryCrashMonitor_Deadlock_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71FA20DA66EB00CDBAE8 /* SentryCrashMonitor_Deadlock_Tests.m */; };
 		63FE722420DA66EC00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71FB20DA66EB00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m */; };
 		63FE722520DA66EC00CDBAE8 /* SentryCrashFileUtils_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71FC20DA66EB00CDBAE8 /* SentryCrashFileUtils_Tests.m */; };
+		7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */; };
+		7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */; };
+		7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */; };
 		7BAF3DB5243C743E008A5414 /* SentryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */; };
 		7BAF3DB9243C9777008A5414 /* SentryTransport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DB8243C9777008A5414 /* SentryTransport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BAF3DC8243DB90E008A5414 /* TestTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DC7243DB90E008A5414 /* TestTransport.swift */; };
@@ -550,6 +553,9 @@
 		63FE71FA20DA66EB00CDBAE8 /* SentryCrashMonitor_Deadlock_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashMonitor_Deadlock_Tests.m; sourceTree = "<group>"; };
 		63FE71FB20DA66EB00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashMonitor_NSException_Tests.m; sourceTree = "<group>"; };
 		63FE71FC20DA66EB00CDBAE8 /* SentryCrashFileUtils_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashFileUtils_Tests.m; sourceTree = "<group>"; };
+		7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeRateLimit.h; path = include/SentryEnvelopeRateLimit.h; sourceTree = "<group>"; };
+		7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimit.m; sourceTree = "<group>"; };
+		7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeRateLimitTests.swift; sourceTree = "<group>"; };
 		7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryClientTests.swift; sourceTree = "<group>"; };
 		7BAF3DB8243C9777008A5414 /* SentryTransport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTransport.h; path = include/SentryTransport.h; sourceTree = "<group>"; };
 		7BAF3DC7243DB90E008A5414 /* TestTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTransport.swift; sourceTree = "<group>"; };
@@ -1190,6 +1196,8 @@
 				7BC852322458802C005A70F0 /* SentryRateLimitCategoryMapper.h */,
 				7BC85234245880AE005A70F0 /* SentryRateLimitCategoryMapper.m */,
 				7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */,
+				7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */,
+				7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */,
 			);
 			name = RateLimits;
 			sourceTree = "<group>";
@@ -1219,6 +1227,7 @@
 				7BE3C780244701A000A38442 /* SentryRateLimitsParserTests.m */,
 				7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */,
 				7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */,
+				7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */,
 			);
 			path = RateLimits;
 			sourceTree = "<group>";
@@ -1320,6 +1329,7 @@
 				63AA76971EB9C1C200D153DE /* Sentry.h in Headers */,
 				63FE711F20DA4C1000CDBAE8 /* SentryCrashObjC.h in Headers */,
 				631E6D331EBC679C00712345 /* SentryQueueableRequestManager.h in Headers */,
+				7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */,
 				6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */,
 				63FE718720DA4C1100CDBAE8 /* SentryCrashReportVersion.h in Headers */,
 				7BBD18912449BE9000427C76 /* SentryDefaultRateLimits.h in Headers */,
@@ -1501,6 +1511,7 @@
 			files = (
 				7DC27EC723997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m in Sources */,
 				63FE717B20DA4C1100CDBAE8 /* SentryCrashReport.c in Sources */,
+				7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */,
 				631E6D341EBC679C00712345 /* SentryQueueableRequestManager.m in Sources */,
 				7DC27EC123997D48006998B5 /* SentryUIKitMemoryWarningIntegration.m in Sources */,
 				63AA76A31EB9CBAA00D153DE /* SentryDsn.m in Sources */,
@@ -1619,6 +1630,7 @@
 				7BE3C78724472E9800A38442 /* TestRequestManager.swift in Sources */,
 				63FE722220DA66EC00CDBAE8 /* SentryCrashJSONCodec_Tests.m in Sources */,
 				7BE3C7752445C82300A38442 /* SentryCurrentDateTests.swift in Sources */,
+				7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */,
 				632331F62404FFA8008D91D6 /* SentryScopeTests.m in Sources */,
 				63FE720D20DA66EC00CDBAE8 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				7BAF3DC8243DB90E008A5414 /* TestTransport.swift in Sources */,

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -1,6 +1,7 @@
 #import "SentryEvent.h"
 #import "SentrySession.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemType.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -45,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                    options:0
             // TODO: handle error
                                                      error:nil];
-    return [self initWithHeader:[[SentryEnvelopeItemHeader alloc] initWithType:@"event" length:json.length] data:json];
+    return [self initWithHeader:[[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeEvent length:json.length] data:json];
 }
 
 - (instancetype)initWithSession:(SentrySession *)session {
@@ -53,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                    options:0
             // TODO: handle error
                                                      error:nil];
-    return [self initWithHeader:[[SentryEnvelopeItemHeader alloc] initWithType:@"session" length:json.length] data:json];
+    return [self initWithHeader:[[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeSession length:json.length] data:json];
 }
 @end
 

--- a/Sources/Sentry/SentryEnvelopeRateLimit.m
+++ b/Sources/Sentry/SentryEnvelopeRateLimit.m
@@ -1,0 +1,67 @@
+#import <Foundation/Foundation.h>
+#import "SentryEnvelopeRateLimit.h"
+#import "SentryRateLimits.h"
+#import "SentryEnvelope.h"
+#import "SentryRateLimitCategoryMapper.h"
+
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryEnvelopeRateLimit ()
+
+@property(nonatomic, strong) id <SentryRateLimits> rateLimits;
+
+@end
+
+@implementation SentryEnvelopeRateLimit
+
+- (instancetype) initWithRateLimits:(id<SentryRateLimits>) sentryRateLimits {
+    if (self = [super init]) {
+        self.rateLimits = sentryRateLimits;
+    }
+    return self;
+}
+
+- (SentryEnvelope *)removeRateLimitedItems:(SentryEnvelope *)envelope {
+    SentryEnvelope *result = envelope;
+    
+    NSArray<SentryEnvelopeItem *> *itemsToDrop = [self getEnvelopeItemsToDrop:envelope.items];
+    
+    if (itemsToDrop.count > 0) {
+        NSArray<SentryEnvelopeItem *> *itemsToSend = [self getItemsToSend:envelope.items withItemsToDrop:itemsToDrop];
+        
+        result = [[SentryEnvelope alloc] initWithId:envelope.header.eventId items:itemsToSend];
+    }
+    
+    return result;
+}
+
+- (NSArray<SentryEnvelopeItem *> *) getEnvelopeItemsToDrop:(NSArray<SentryEnvelopeItem *> *)items  {
+    NSMutableArray<SentryEnvelopeItem *> *itemsToDrop = [NSMutableArray new];
+    
+    for (SentryEnvelopeItem *item in items) {
+        NSString *rateLimitCategory = [SentryRateLimitCategoryMapper mapEnvelopeItemTypeToCategory:item.header.type];
+        if ([self.rateLimits isRateLimitActive:rateLimitCategory]) {
+            [itemsToDrop addObject:item];
+        }
+    }
+    
+    return itemsToDrop;
+}
+
+- (NSArray<SentryEnvelopeItem *> *) getItemsToSend:(NSArray<SentryEnvelopeItem *> *)allItems
+                                           withItemsToDrop:(NSArray<SentryEnvelopeItem *> *_Nonnull)itemsToDrop{
+    NSMutableArray<SentryEnvelopeItem *> *itemsToSend = [NSMutableArray new];
+    
+    for (SentryEnvelopeItem *item in allItems) {
+        if (![itemsToDrop containsObject:item]) {
+            [itemsToSend addObject:item];
+        }
+    }
+    
+    return itemsToSend;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryRateLimitCategoryMapper.m
+++ b/Sources/Sentry/SentryRateLimitCategoryMapper.m
@@ -15,4 +15,14 @@
     return SentryRateLimitCategoryError;
 }
 
++ (NSString *_Nonnull)mapEnvelopeItemTypeToCategory:(NSString *)itemType {
+    if ([itemType isEqualToString:SentryEnvelopeItemTypeEvent]) {
+        return SentryRateLimitCategoryError;
+    }
+    if ([itemType isEqualToString:SentryEnvelopeItemTypeSession]) {
+        return SentryRateLimitCategorySession;
+    }
+    return itemType;
+}
+
 @end

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -10,6 +10,7 @@
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentryHttpDateParser.h"
 #import "SentryRateLimitParser.h"
+#import "SentryEnvelopeRateLimit.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -34,9 +35,12 @@ NS_ASSUME_NONNULL_BEGIN
         SentryRateLimitParser *rateLimitParser = [[SentryRateLimitParser alloc] init];
         id<SentryRateLimits> rateLimits = [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser andRateLimitParser:rateLimitParser];
         
+        SentryEnvelopeRateLimit * envelopeRateLimit = [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
+        
         return [[SentryHttpTransport alloc] initWithOptions:options
                                           sentryFileManager:sentryFileManager sentryRequestManager: requestManager
-                                           sentryRateLimits: rateLimits];
+                                           sentryRateLimits: rateLimits
+                                    sentryEnvelopeRateLimit: envelopeRateLimit];
     }
 }
 

--- a/Sources/Sentry/include/SentryEnvelopeRateLimit.h
+++ b/Sources/Sentry/include/SentryEnvelopeRateLimit.h
@@ -1,0 +1,20 @@
+#import <Foundation/Foundation.h>
+#import "SentryRateLimits.h"
+
+@class SentryEnvelope;
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(EnvelopeRateLimit)
+@interface SentryEnvelopeRateLimit : NSObject
+
+- (instancetype) initWithRateLimits:(id<SentryRateLimits>) sentryRateLimits;
+
+/**
+ Removes SentryEnvelopItems for which a rate limit is active.
+ */
+- (SentryEnvelope *)removeRateLimitedItems:(SentryEnvelope *)envelope;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryHttpTransport.h
+++ b/Sources/Sentry/include/SentryHttpTransport.h
@@ -8,6 +8,8 @@
 #import "SentryRequestManager.h"
 #import "SentryRateLimits.h"
 
+@class SentryEnvelopeRateLimit;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryHttpTransport : NSObject <SentryTransport>
@@ -15,8 +17,9 @@ SENTRY_NO_INIT
 
 - (id)initWithOptions:(SentryOptions *)options
     sentryFileManager:(SentryFileManager *)sentryFileManager
- sentryRequestManager:(id<SentryRequestManager>) sentryRequestManager
-     sentryRateLimits:(id<SentryRateLimits>) sentryRateLimits;
+ sentryRequestManager:(id<SentryRequestManager>)sentryRequestManager
+     sentryRateLimits:(id<SentryRateLimits>)sentryRateLimits
+sentryEnvelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit;
 
 /**
  * This is triggered after the first upload attempt of an event. Checks if event

--- a/Sources/Sentry/include/SentryRateLimitCategory.h
+++ b/Sources/Sentry/include/SentryRateLimitCategory.h
@@ -2,4 +2,4 @@
 
 static NSString * const SentryRateLimitCategoryError = @"error";
 static NSString * const SentryRateLimitCategorySession = @"session";
-// more categories exist, but we only use error currently.
+// more categories exist, but we only use error and session currently.

--- a/Sources/Sentry/include/SentryRateLimitCategory.h
+++ b/Sources/Sentry/include/SentryRateLimitCategory.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
 
 static NSString * const SentryRateLimitCategoryError = @"error";
+static NSString * const SentryRateLimitCategorySession = @"session";
 // more categories exist, but we only use error currently.

--- a/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
+++ b/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
@@ -9,6 +9,8 @@ NS_SWIFT_NAME(RateLimitCategoryMapper)
  */
 + (NSString *_Nonnull)mapEventTypeToCategory:(NSString *)eventType;
 
++ (NSString *_Nonnull)mapEnvelopeItemTypeToCategory:(NSString *)itemType;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+
+class SentryEnvelopeRateLimitTests: XCTestCase {
+    
+    private var rateLimits : TestRateLimits!
+    private var sut: EnvelopeRateLimit!
+    
+    override func setUp() {
+        rateLimits = TestRateLimits()
+        sut = EnvelopeRateLimit(rateLimits: rateLimits)
+    }
+    
+    func testNoLimitsActive() {
+        let envelope = getEnvelope()
+        
+        let actual = sut.removeRateLimitedItems(envelope)
+        
+        XCTAssertEqual(envelope, actual)
+    }
+    
+    func testLimitForErrorActive() {
+        rateLimits.typeLimits = ["error"]
+        
+        let envelope = getEnvelope()
+        let actual = sut.removeRateLimitedItems(envelope)
+        
+        XCTAssertEqual(3, actual.items.count)
+        for item in actual.items {
+            XCTAssertEqual(SentryEnvelopeItemTypeSession, item.header.type)
+        }
+        XCTAssertEqual(envelope.header.eventId, actual.header.eventId)
+    }
+    
+    func testLimitForSessionActive() {
+        rateLimits.typeLimits = ["session"]
+        
+        let envelope = getEnvelope()
+        let actual = sut.removeRateLimitedItems(envelope)
+        
+        XCTAssertEqual(3, actual.items.count)
+        for item in actual.items {
+            XCTAssertEqual(SentryEnvelopeItemTypeEvent, item.header.type)
+        }
+        XCTAssertEqual(envelope.header.eventId, actual.header.eventId)
+    }
+    
+    func testLimitForCustomType() {
+        rateLimits.typeLimits = ["customType"]
+        var envelopeItems = [SentryEnvelopeItem]()
+        envelopeItems.append(SentryEnvelopeItem(event: Event()))
+        
+        let envelopeHeader = SentryEnvelopeItemHeader(type: "customType", length: 10)
+        envelopeItems.append(SentryEnvelopeItem(header: envelopeHeader, data: Data()))
+        envelopeItems.append(SentryEnvelopeItem(header: envelopeHeader, data: Data()))
+        
+        let envelope =  SentryEnvelope(id: "1", items: envelopeItems)
+        
+        let actual = sut.removeRateLimitedItems(envelope)
+        
+        XCTAssertEqual(1, actual.items.count)
+        XCTAssertEqual(SentryEnvelopeItemTypeEvent, actual.items[0].header.type)
+    }
+    
+    func getEnvelope() -> SentryEnvelope {
+        var envelopeItems = [SentryEnvelopeItem]()
+        for _ in Array(0...2) {
+            let event = Event()
+            envelopeItems.append(SentryEnvelopeItem(event: event))
+        }
+        
+        for _ in Array(0...2) {
+            let session = SentrySession()
+            envelopeItems.append(SentryEnvelopeItem(session: session))
+        }
+        
+        return SentryEnvelope(id: "1", items: envelopeItems)
+    }
+    
+}

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
@@ -2,17 +2,37 @@ import XCTest
 @testable import Sentry
 
 class SentryRateLimitCategoryMapperTests: XCTestCase {
+    
+    private let categoryError = "error"
 
     func testAnyEventType() {
         let actual = RateLimitCategoryMapper.mapEventType(toCategory: "any eventtype")
         
-        XCTAssertEqual(SentryRateLimitCategoryError, actual)
+        XCTAssertEqual(categoryError, actual)
     }
     
     func testEventItemType() {
-        let actual = RateLimitCategoryMapper.mapEventType(toCategory: SentryEnvelopeItemTypeEvent)
+        let actual = RateLimitCategoryMapper.mapEventType(toCategory: "event")
         
-        XCTAssertEqual(SentryRateLimitCategoryError, actual)
+        XCTAssertEqual(categoryError, actual)
     }
+    
 
+    func testEnvelopeItemTypeEvent() {
+        let actual = RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: "event")
+        
+        XCTAssertEqual(categoryError, actual)
+    }
+    
+    func testEnvelopeItemTypeSession() {
+        let actual = RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: "session")
+        
+        XCTAssertEqual("session", actual)
+    }
+    
+    func testAnyEnvelopeItemType() {
+        let actual = RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: "any envelope item type")
+        
+        XCTAssertEqual("any envelope item type", actual)
+    }
 }

--- a/Tests/SentryTests/Networking/TestRateLimits.swift
+++ b/Tests/SentryTests/Networking/TestRateLimits.swift
@@ -6,8 +6,8 @@ public class TestRateLimits : NSObject, RateLimits {
     public var isLimitForAllActive: Bool = false
     public var typeLimits : [String] = []
     
-    public func isRateLimitActive(_ type: String) -> Bool {
-        return isLimitForAllActive || typeLimits.contains(type)
+    public func isRateLimitActive(_ category: String) -> Bool {
+        return isLimitForAllActive || typeLimits.contains(category)
     }
     
     public func update(_ response: HTTPURLResponse) {

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -18,3 +18,4 @@
 #import "SentryEnvelopeItemType.h"
 #import "SentryRateLimitCategoryMapper.h"
 #import "SentryRateLimitCategory.h"
+#import "SentryEnvelopeRateLimit.h"


### PR DESCRIPTION
When sending an envelope the rate limit for envelope items are checked. If a rate
limit is active the envelope item is removed. Checking rate limits for on disk
cached envelopes is going to be done in another PR.