### PR TITLE
fix: EnvelopeRateLimit init envelope with header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: EnvelopeRateLimit init envelope with header #478
+
 ## 5.0.0-beta.7
 
 - feat: RateLimit for non cached Envelopes #476

--- a/Sources/Sentry/SentryEnvelopeRateLimit.m
+++ b/Sources/Sentry/SentryEnvelopeRateLimit.m
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (itemsToDrop.count > 0) {
         NSArray<SentryEnvelopeItem *> *itemsToSend = [self getItemsToSend:envelope.items withItemsToDrop:itemsToDrop];
         
-        result = [[SentryEnvelope alloc] initWithId:envelope.header.eventId items:itemsToSend];
+        result = [[SentryEnvelope alloc] initWithHeader:envelope.header items:itemsToSend];
     }
     
     return result;

--- a/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
@@ -28,7 +28,7 @@ class SentryEnvelopeRateLimitTests: XCTestCase {
         for item in actual.items {
             XCTAssertEqual(SentryEnvelopeItemTypeSession, item.header.type)
         }
-        XCTAssertEqual(envelope.header.eventId, actual.header.eventId)
+        XCTAssertEqual(envelope.header, actual.header)
     }
     
     func testLimitForSessionActive() {
@@ -41,7 +41,7 @@ class SentryEnvelopeRateLimitTests: XCTestCase {
         for item in actual.items {
             XCTAssertEqual(SentryEnvelopeItemTypeEvent, item.header.type)
         }
-        XCTAssertEqual(envelope.header.eventId, actual.header.eventId)
+        XCTAssertEqual(envelope.header, actual.header)
     }
     
     func testLimitForCustomType() {


### PR DESCRIPTION
Init new SentryEnvelope with header and not only headerId to avoid
the loss of details from the header.