### PR TITLE
feat: RateLimiting for cached events and envelopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- feat: RateLimiting for cached events and envelopes #480
+
 ## 5.0.0-beta.7
 
 - feat: RateLimit for non cached Envelopes #476

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */; };
 		7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */; };
 		7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */; };
+		7B339869245ACCA500BD9C96 /* SentryEnvelopeRateLimitTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B339868245ACCA500BD9C96 /* SentryEnvelopeRateLimitTests.m */; };
 		7BAF3DB5243C743E008A5414 /* SentryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */; };
 		7BAF3DB9243C9777008A5414 /* SentryTransport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DB8243C9777008A5414 /* SentryTransport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BAF3DC8243DB90E008A5414 /* TestTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DC7243DB90E008A5414 /* TestTransport.swift */; };
@@ -558,6 +559,7 @@
 		7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeRateLimit.h; path = include/SentryEnvelopeRateLimit.h; sourceTree = "<group>"; };
 		7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimit.m; sourceTree = "<group>"; };
 		7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeRateLimitTests.swift; sourceTree = "<group>"; };
+		7B339868245ACCA500BD9C96 /* SentryEnvelopeRateLimitTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimitTests.m; sourceTree = "<group>"; };
 		7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryClientTests.swift; sourceTree = "<group>"; };
 		7BAF3DB8243C9777008A5414 /* SentryTransport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTransport.h; path = include/SentryTransport.h; sourceTree = "<group>"; };
 		7BAF3DC7243DB90E008A5414 /* TestTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTransport.swift; sourceTree = "<group>"; };
@@ -1231,6 +1233,7 @@
 				7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */,
 				7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */,
 				7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */,
+				7B339868245ACCA500BD9C96 /* SentryEnvelopeRateLimitTests.m */,
 			);
 			path = RateLimits;
 			sourceTree = "<group>";
@@ -1665,6 +1668,7 @@
 				630C01941EC3402C00C52CEF /* SentryKSCrashReportConverterTests.m in Sources */,
 				63FE721720DA66EC00CDBAE8 /* SentryCrashThread_Tests.m in Sources */,
 				15360CF52433C59B00112302 /* SentryInstallationTests.m in Sources */,
+				7B339869245ACCA500BD9C96 /* SentryEnvelopeRateLimitTests.m in Sources */,
 				7BBD18B7245180FF00427C76 /* SentryDsnTests.m in Sources */,
 				63FE721A20DA66EC00CDBAE8 /* SentryCrashSysCtl_Tests.m in Sources */,
 				636085101ED2C1CB00E8599E /* SentryBreadcrumbTests.m in Sources */,

--- a/Sources/Sentry/SentryEnvelopeRateLimit.m
+++ b/Sources/Sentry/SentryEnvelopeRateLimit.m
@@ -23,6 +23,10 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (SentryEnvelope *)removeRateLimitedItems:(SentryEnvelope *)envelope {
+    if(nil == envelope) {
+        return envelope;
+    }
+    
     SentryEnvelope *result = envelope;
     
     NSArray<SentryEnvelopeItem *> *itemsToDrop = [self getEnvelopeItemsToDrop:envelope.items];

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -66,7 +66,7 @@ NSInteger const defaultMaxEnvelopes = 100;
                                       [NSUUID UUID].UUIDString];
 }
 
-- (NSArray<SentryFileContents *> *)getAllEvents {
+- (NSArray<SentryFileContents *> *)getAllEventsAndMaybeEnvelopes {
     return [self allFilesContentInFolder:self.eventsPath];
 }
 
@@ -75,7 +75,7 @@ NSInteger const defaultMaxEnvelopes = 100;
 }
 
 - (NSArray<SentryFileContents *> *)getAllStoredEventsAndEnvelopes {
-    return [[self getAllEvents] arrayByAddingObjectsFromArray:[self getAllEnvelopes]];
+    return [[self getAllEventsAndMaybeEnvelopes] arrayByAddingObjectsFromArray:[self getAllEnvelopes]];
 }
 
 - (NSArray<SentryFileContents *> *)allFilesContentInFolder:(NSString *)path {

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -246,9 +246,9 @@ completionHandler:(_Nullable SentryRequestFinished)completionHandler {
     [self sendRequest:request withCompletionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
         // TODO: How does beforeSend work here
         
-        // If the response is not nil we had an internet connection and we can
-        // delete the cached event or envelope no an error happened or not.
-        if (response != nil) {
+        // If the response is not nil we had an internet connection.
+        // We don't worry about errors here.
+        if (nil != response) {
             [self.fileManager removeFileAtPath:filePath];
         }
     }];

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -95,9 +95,8 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
     
     NSError *requestError = nil;
     // TODO: We do multiple serializations here, we can improve this
-    NSURLRequest *request = [[SentryNSURLRequest alloc] initEnvelopeRequestWithDsn:self.options.dsn
-                                                                               andData:[SentrySerialization dataWithEnvelope:envelope options:0 error:&requestError]
-                                                                     didFailWithError:&requestError];
+    NSURLRequest *request = [self createEnvelopeRequest:envelope didFailWithError:requestError];
+    
     if (nil != requestError) {
         [SentryLog logWithMessage:requestError.localizedDescription andLevel:kSentryLogLevelError];
         if (completionHandler) {
@@ -128,6 +127,14 @@ withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler {
         // In all other cases we don't want to retry sending it and just discard the event
         return NO;
     };
+}
+
+- (NSURLRequest *)createEnvelopeRequest:(SentryEnvelope *)envelope
+                        didFailWithError:(NSError *_Nullable)error {
+    return [[SentryNSURLRequest alloc]
+            initEnvelopeRequestWithDsn:self.options.dsn
+            andData:[SentrySerialization dataWithEnvelope:envelope options:0 error:&error]
+            didFailWithError:&error];
 }
 
 - (void)sendRequest:(NSURLRequest *)request
@@ -184,35 +191,67 @@ completionHandler:(_Nullable SentryRequestFinished)completionHandler {
         return;
     }
     
-    dispatch_group_t dispatchGroup = dispatch_group_create();
-    for (SentryFileContents *fileContents in [self.fileManager getAllStoredEventsAndEnvelopes]) {
-        dispatch_group_enter(dispatchGroup);
-        
-        
-        // TODO: Check RateLimit for EnvelopeItemType
-        
-        // TODO: Get EventType from event and not use SentryEnvelopeItemTypeEvent
+    [self sendAllCachedEvents];
+    [self sendAllCachedEnvelopes];
+}
+
+- (void)sendAllCachedEvents {
+    for (SentryFileContents *fileContents in [self.fileManager getAllEventsAndMaybeEnvelopes]) {
+        // The fileContents don't give insights on the event type. We would have
+        // to deserialize the contents, which is unnecessary at the moment, because
+        // we classify every event with the same category. We still call
+        // SentryRateLimitCategoryMapper to keep the code stable if the category
+        // for event changes.
         NSString *category = [SentryRateLimitCategoryMapper mapEventTypeToCategory:SentryEnvelopeItemTypeEvent];
         if (![self isReadyToSend:category]) {
             [self.fileManager removeFileAtPath:fileContents.path];
         } else {
-            SentryNSURLRequest *request = [[SentryNSURLRequest alloc] initStoreRequestWithDsn:self.options.dsn
-                                                                                      andData:fileContents.contents
-                                                                             didFailWithError:nil];
-            
-            
-            [self sendRequest:request withCompletionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
-                // TODO: How does beforeSend work here
-                // We want to delete the event here no matter what (if we had an internet connection)
-                // since it has been tried already.
-                if (response != nil) {
-                    [self.fileManager removeFileAtPath:fileContents.path];
-                }
-
-                dispatch_group_leave(dispatchGroup);
-            }];
+            NSURLRequest *request = [[SentryNSURLRequest alloc]
+            initStoreRequestWithDsn:self.options.dsn
+            andData:fileContents.contents
+            didFailWithError:nil];
+            [self sendCached:request withFilePath:fileContents.path];
         }
     }
+}
+
+- (void)sendAllCachedEnvelopes {
+    for (SentryFileContents *fileContents in [self.fileManager getAllEnvelopes]) {
+        SentryEnvelope *envelope = [SentrySerialization envelopeWithData:fileContents.contents];
+        if (nil == envelope) {
+            [self.fileManager removeFileAtPath:fileContents.path];
+            continue;
+        }
+        
+        SentryEnvelope *rateLimitedEnvelope = [self.envelopeRateLimit removeRateLimitedItems:envelope];
+        if (rateLimitedEnvelope.items.count == 0) {
+            [self.fileManager removeFileAtPath:fileContents.path];
+            continue;
+        }
+        
+        NSError *requestError = nil;
+        NSURLRequest *request = [self createEnvelopeRequest:envelope didFailWithError:requestError];
+        
+        if (nil != requestError) {
+            [SentryLog logWithMessage:requestError.localizedDescription andLevel:kSentryLogLevelError];
+            [self.fileManager removeFileAtPath:fileContents.path];
+            continue;
+        } else {
+            [self sendCached:request withFilePath:fileContents.path];
+        }
+    }
+}
+
+- (void)sendCached:(NSURLRequest *)request withFilePath:(NSString *)filePath {
+    [self sendRequest:request withCompletionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
+        // TODO: How does beforeSend work here
+        
+        // If the response is not nil we had an internet connection and we can
+        // delete the cached event or envelope no an error happened or not.
+        if (response != nil) {
+            [self.fileManager removeFileAtPath:filePath];
+        }
+    }];
 }
 
 @end

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -27,7 +27,7 @@ SENTRY_NO_INIT
 - (void)deleteAllFolders;
 
 /**
- In a previous version of SentryFileManager envelopes where stored in the same path as events.
+ In a previous version of SentryFileManager envelopes were stored in the same path as events.
  Now events and envelopes are stored in two different paths. We decided that there is no need
  for a migration strategy, because in worst case only a few envelopes get lost and this is not
  worth the effort. Since there is no migration strategy this method could also return envelopes.

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -26,7 +26,13 @@ SENTRY_NO_INIT
 
 - (void)deleteAllFolders;
 
-- (NSArray<SentryFileContents *> *)getAllEvents;
+/**
+ In a previous version of SentryFileManager envelopes where stored in the same path as events.
+ Now events and envelopes are stored in two different paths. We decided that there is no need
+ for a migration strategy, because in worst case only a few envelopes get lost and this is not
+ worth the effort. Since there is no migration strategy this method could also return envelopes.
+ */
+- (NSArray<SentryFileContents *> *)getAllEventsAndMaybeEnvelopes;
 - (NSArray<SentryFileContents *> *)getAllEnvelopes;
 - (NSArray<SentryFileContents *> *)getAllStoredEventsAndEnvelopes;
 

--- a/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.m
+++ b/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.m
@@ -1,0 +1,23 @@
+#import <XCTest/XCTest.h>
+#import "SentryEnvelopeRateLimit.h"
+#import "SentryTests-Bridging-Header.h"
+
+@interface SentryEnvelopeRateLimitTests : XCTestCase
+
+@end
+
+/**
+* This class exists only for testing SentryEnvelopeRateLimitTests with nil. All other tests are in
+* SentryEnvelopeRateLimitTests.swift
+*/
+@implementation SentryEnvelopeRateLimitTests
+
+- (void)testNil {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wnonnull"
+    SentryEnvelopeRateLimit *sut = [[SentryEnvelopeRateLimit alloc] initWithRateLimits:nil];
+    XCTAssertNil([sut removeRateLimitedItems:nil]);
+    #pragma clang diagnostic pop
+}
+
+@end

--- a/Tests/SentryTests/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/SentryFileManagerTests.swift
@@ -29,7 +29,7 @@ class SentryFileManagerTests: XCTestCase {
         _ = try SentryFileManager.init(dsn: TestConstants.dsn)
         let fileManager = try SentryFileManager.init(dsn: TestConstants.dsn)
         
-        XCTAssertEqual(1, fileManager.getAllEvents().count)
+        XCTAssertEqual(1, fileManager.getAllEventsAndMaybeEnvelopes().count)
         XCTAssertEqual(1, fileManager.getAllEnvelopes().count)
         XCTAssertNotNil(fileManager.readCurrentSession())
     }
@@ -39,7 +39,7 @@ class SentryFileManagerTests: XCTestCase {
         event.message = "message"
         sut.store(event)
         
-        let events = sut.getAllEvents()
+        let events = sut.getAllEventsAndMaybeEnvelopes()
         XCTAssertTrue(events.count == 1)
         XCTAssertEqual(0, sut.getAllEnvelopes().count)
         
@@ -100,7 +100,7 @@ class SentryFileManagerTests: XCTestCase {
         for _ in 0...10 {
             sut.store(Event(level: SentryLevel.info))
         }
-        let events = sut.getAllEvents()
+        let events = sut.getAllEventsAndMaybeEnvelopes()
         XCTAssertEqual(events.count, 10)
     }
     
@@ -110,7 +110,7 @@ class SentryFileManagerTests: XCTestCase {
         for _ in 0...15 {
             sut.store(Event(level: SentryLevel.info))
         }
-        let events = sut.getAllEvents()
+        let events = sut.getAllEventsAndMaybeEnvelopes()
         XCTAssertEqual(events.count, 15)
     }
     
@@ -153,7 +153,7 @@ class SentryFileManagerTests: XCTestCase {
         
         XCTAssertEqual(3, sut.getAllStoredEventsAndEnvelopes().count)
         XCTAssertEqual(2, sut.getAllEnvelopes().count)
-        XCTAssertEqual(1, sut.getAllEvents().count)
+        XCTAssertEqual(1, sut.getAllEventsAndMaybeEnvelopes().count)
     }
     
     func testDeleteAllFolders() {
@@ -165,7 +165,7 @@ class SentryFileManagerTests: XCTestCase {
         
         XCTAssertEqual(0, sut.getAllStoredEventsAndEnvelopes().count)
         XCTAssertEqual(0, sut.getAllEnvelopes().count)
-        XCTAssertEqual(0, sut.getAllEvents().count)
+        XCTAssertEqual(0, sut.getAllEventsAndMaybeEnvelopes().count)
         XCTAssertNil(sut.readCurrentSession())
     }
     
@@ -177,6 +177,6 @@ class SentryFileManagerTests: XCTestCase {
         
         XCTAssertEqual(0, sut.getAllStoredEventsAndEnvelopes().count)
         XCTAssertEqual(0, sut.getAllEnvelopes().count)
-        XCTAssertEqual(0, sut.getAllEvents().count)
+        XCTAssertEqual(0, sut.getAllEventsAndMaybeEnvelopes().count)
     }
 }


### PR DESCRIPTION
Check if a rate limit is active for cached events and envelopes. The
sending of cached events and envelopes is split up. We don't deserialize
events because we use anyways always the rate limit category error. For
cached envelopes the same logic is applied as for sending envelopes in
the first place.

I removed the `dispatchGroup` for sending the cached events and envelopes, because if I'm not mistaken it was useless, because only the code only called `enter` and `leave` but never `wait` or `notify`. Please double-check @HazAT if don't break something here and this was here for a reason.