### PR TITLE
fix: RetryAfter treated like all categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: RetryAfter treated like all categories #481
 - fix: EnvelopeRateLimit init envelope with header #478
 
 ## 5.0.0-beta.7

--- a/Sources/Sentry/SentryDefaultRateLimits.m
+++ b/Sources/Sentry/SentryDefaultRateLimits.m
@@ -10,7 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /* Key is the type and value is valid until date */
 @property(nonatomic, strong) NSMutableDictionary<NSString *, NSDate *> *rateLimits;
-@property(nonatomic, strong) NSDate *_Nullable retryAfterHeaderDate;
 
 @property(nonatomic, strong) SentryRetryAfterHeaderParser *retryAfterHeaderParser;
 @property(nonatomic, strong) SentryRateLimitParser *rateLimitParser;
@@ -30,24 +29,17 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (BOOL)isRateLimitActive:(NSString *)category {
-    @synchronized (self) {
-        return [self isCustomHeaderRateLimitActive:category] ||
-        [self isRetryAfterHeaderLimitActive];
-    }
-}
-
-- (BOOL)isCustomHeaderRateLimitActive:(NSString *)category {
-    NSDate *rateLimitDate = self.rateLimits[category];
-    BOOL isActive = [self isInFuture: rateLimitDate];
+    NSDate *categoryDate = self.rateLimits[category];
+    NSDate *allCategoriesDate = self.rateLimits[@""];
     
-    NSDate *allTypesRateLimitDate = self.rateLimits[@""];
-    BOOL isAllTypesActive = [self isInFuture: allTypesRateLimitDate];
+    BOOL isActiveForCategory = [self isInFuture: categoryDate];
+    BOOL isActiveForCategories = [self isInFuture: allCategoriesDate];
     
-    if (isActive) {
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"X-Sentry-Rate-Limit reached for type %@ until: %@", category, rateLimitDate] andLevel:kSentryLogLevelDebug];
+    if (isActiveForCategory) {
+        [SentryLog logWithMessage:[NSString stringWithFormat:@"Rate-Limit reached for type %@ until: %@", category, categoryDate] andLevel:kSentryLogLevelDebug];
         return YES;
-    } else if (isAllTypesActive) {
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"X-Sentry-Rate-Limit reached for all types until: %@",  allTypesRateLimitDate] andLevel:kSentryLogLevelDebug];
+    } else if (isActiveForCategories) {
+        [SentryLog logWithMessage:[NSString stringWithFormat:@"Rate-Limit reached for all types until: %@",  allCategoriesDate] andLevel:kSentryLogLevelDebug];
         return YES;
     }
     else {
@@ -55,27 +47,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (BOOL)isRetryAfterHeaderLimitActive {
-    if (nil == self.retryAfterHeaderDate) {
-        return NO;
-    }
-    
-    BOOL isActive = [self isInFuture:self.retryAfterHeaderDate];
-    if (isActive) {
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"Retry-After limit reached until: %@",  self.retryAfterHeaderDate] andLevel:kSentryLogLevelDebug];
-        return YES;
-    } else {
-        return NO;
-    }
-}
-
 - (BOOL)isInFuture:(NSDate *)date {
     NSComparisonResult result = [[SentryCurrentDate date] compare:date];
-    if (result == NSOrderedAscending) {
-        return YES;
-    }
-    
-    return NO;
+    return result == NSOrderedAscending;
 }
 
 - (void)update:(NSHTTPURLResponse *)response {
@@ -95,7 +69,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
         
         @synchronized (self) {
-            self.retryAfterHeaderDate = retryAfterHeaderDate;
+            self.rateLimits[@""] = retryAfterHeaderDate;
         }
     }
 }

--- a/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
@@ -70,6 +70,18 @@ class SentryDefaultRateLimitsTests: XCTestCase {
 
         XCTAssertFalse(sut.isRateLimitActive("anyCategory"))
     }
+    
+    func testRetryHeaderIsLikeAllCategories() {
+        sut.update(TestResponseFactory.createRateLimitResponse(headerValue: "2::key"))
+        sut.update(TestResponseFactory.createRetryAfterResponse(headerValue: "1"))
+        
+        XCTAssertTrue(sut.isRateLimitActive("any"))
+        
+        // RateLimit expired
+        let date = currentDateProvider.date()
+        currentDateProvider.setDate(date: date.addingTimeInterval(1))
+        XCTAssertFalse(sut.isRateLimitActive("any"))
+    }
 
     func testRetryAfterHeaderDeltaSeconds() {
         testRetryHeaderWith1Second(value: "1")


### PR DESCRIPTION
Treat "Retry-After" exactly like "X-Sentry-Rate-Limits" for all categories.