### PR TITLE
fix: RateLimitCategories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: RateLimitCategories #482
 - fix: RetryAfter treated like all categories #481
 - feat: RateLimiting for cached events and envelopes #480
 - fix: EnvelopeRateLimit init envelope with header #478

--- a/Sources/Sentry/SentryRateLimitCategoryMapper.m
+++ b/Sources/Sentry/SentryRateLimitCategoryMapper.m
@@ -3,26 +3,34 @@
 #import "SentryRateLimitCategory.h"
 #import "SentryEnvelopeItemType.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SentryRateLimitCategoryMapper ()
 
 @end
 
 @implementation SentryRateLimitCategoryMapper
 
-+ (NSString *_Nonnull)mapEventTypeToCategory:(NSString *)eventType {
++ (NSString *)mapEventTypeToCategory:(NSString *)eventType {
     // Currently we classify every event type as error.
     // This is going to change in the future.
     return SentryRateLimitCategoryError;
 }
 
-+ (NSString *_Nonnull)mapEnvelopeItemTypeToCategory:(NSString *)itemType {
++ (NSString *)mapEnvelopeItemTypeToCategory:(NSString *)itemType {
+    NSString *category = SentryRateLimitCategoryDefault;
     if ([itemType isEqualToString:SentryEnvelopeItemTypeEvent]) {
-        return SentryRateLimitCategoryError;
+        category = SentryRateLimitCategoryError;
     }
     if ([itemType isEqualToString:SentryEnvelopeItemTypeSession]) {
-        return SentryRateLimitCategorySession;
+        category = SentryRateLimitCategorySession;
     }
-    return itemType;
+    if ([itemType isEqualToString:SentryEnvelopeItemTypeTransaction]) {
+        category = SentryRateLimitCategoryTransaction;
+    }
+    return category;
 }
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryEnvelopeItemType.h
+++ b/Sources/Sentry/include/SentryEnvelopeItemType.h
@@ -1,2 +1,3 @@
 static NSString * const SentryEnvelopeItemTypeEvent = @"event";
 static NSString * const SentryEnvelopeItemTypeSession = @"session";
+static NSString * const SentryEnvelopeItemTypeTransaction = @"transaction";

--- a/Sources/Sentry/include/SentryRateLimitCategory.h
+++ b/Sources/Sentry/include/SentryRateLimitCategory.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
 
+static NSString * const SentryRateLimitCategoryDefault = @"default";
 static NSString * const SentryRateLimitCategoryError = @"error";
 static NSString * const SentryRateLimitCategorySession = @"session";
-// more categories exist, but we only use error and session currently.
+static NSString * const SentryRateLimitCategoryTransaction = @"transaction";

--- a/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
+++ b/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
@@ -7,9 +7,9 @@ NS_SWIFT_NAME(RateLimitCategoryMapper)
 
 /** Maps an event type to the category for rate limiting.
  */
-+ (NSString *_Nonnull)mapEventTypeToCategory:(NSString *)eventType;
++ (NSString *)mapEventTypeToCategory:(NSString *)eventType;
 
-+ (NSString *_Nonnull)mapEnvelopeItemTypeToCategory:(NSString *)itemType;
++ (NSString *)mapEnvelopeItemTypeToCategory:(NSString *)itemType;
 
 @end
 

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
@@ -4,35 +4,24 @@ import XCTest
 class SentryRateLimitCategoryMapperTests: XCTestCase {
     
     private let categoryError = "error"
-
-    func testAnyEventType() {
-        let actual = RateLimitCategoryMapper.mapEventType(toCategory: "any eventtype")
-        
-        XCTAssertEqual(categoryError, actual)
-    }
     
     func testEventItemType() {
-        let actual = RateLimitCategoryMapper.mapEventType(toCategory: "event")
-        
-        XCTAssertEqual(categoryError, actual)
+        XCTAssertEqual(categoryError, mapEventType(eventType: "event"))
+        XCTAssertEqual(categoryError, mapEventType(eventType: "any eventtype"))
     }
     
-
-    func testEnvelopeItemTypeEvent() {
-        let actual = RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: "event")
-        
-        XCTAssertEqual(categoryError, actual)
+    func testEnvelopeItemType() {
+        XCTAssertEqual(categoryError, mapEnvelopeItemType(itemType: "event"))
+        XCTAssertEqual("session", mapEnvelopeItemType(itemType: "session"))
+        XCTAssertEqual("transaction", mapEnvelopeItemType(itemType: "transaction"))
+        XCTAssertEqual("default", mapEnvelopeItemType(itemType: "unkown item type"))
     }
     
-    func testEnvelopeItemTypeSession() {
-        let actual = RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: "session")
-        
-        XCTAssertEqual("session", actual)
+    private func mapEnvelopeItemType(itemType: String) -> String {
+        return RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: itemType)
     }
     
-    func testAnyEnvelopeItemType() {
-        let actual = RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: "any envelope item type")
-        
-        XCTAssertEqual("any envelope item type", actual)
+    private func mapEventType(eventType: String) -> String {
+        return RateLimitCategoryMapper.mapEventType(toCategory: eventType)
     }
 }


### PR DESCRIPTION
Add default and transaction categories. mapEnvelopeItemTypeToCategory returns the default
category if the envelope item type is not known.