### PR TITLE
ref: Refactor out warnings

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -175,7 +175,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [self callEventProcessors:event];
 }
 
-- (SentryEvent *)callEventProcessors:(SentryEvent *)event {
+- (SentryEvent *_Nullable)callEventProcessors:(SentryEvent *)event {
     SentryEvent *newEvent = event;
 
     for (SentryEventProcessor processor in SentryGlobalEventProcessor.shared.processors) {

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -151,7 +151,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (NSMutableArray *)serializeBreadcrumbs {
+- (NSMutableArray *_Nullable)serializeBreadcrumbs {
     NSMutableArray *crumbs = [NSMutableArray new];
     for (SentryBreadcrumb *crumb in self.breadcrumbs) {
         [crumbs addObject:[crumb serialize]];

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -43,7 +43,6 @@ NSInteger const defaultMaxEnvelopes = 100;
         
         self.envelopesPath = [self.sentryPath stringByAppendingPathComponent:@"envelopes"];
         [self createDirectoryIfNotExists:self.envelopesPath didFailWithError:error];
-        
 
         self.currentFileCounter = 0;
         self.maxEvents = defaultMaxEvents;
@@ -225,8 +224,8 @@ NSInteger const defaultMaxEnvelopes = 100;
 
 #pragma mark private methods
 
-- (void)createDirectoryIfNotExists:(NSString *)path didFailWithError:(NSError **)error {
-    [[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:error];
+- (BOOL)createDirectoryIfNotExists:(NSString *)path didFailWithError:(NSError **)error {
+    return [[NSFileManager defaultManager] createDirectoryAtPath:path withIntermediateDirectories:YES attributes:nil error:error];
 }
 
 @end

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -19,11 +19,9 @@
                       didFailWithError:(NSError *_Nullable *_Nullable)error {
     self = [super init];
     if (self) {
-        BOOL success = [self validateOptions:options didFailWithError:error];
-        if (!success) {
-            if (nil != error && nil != *error) {
-                [SentryLog logWithMessage:[NSString stringWithFormat:@"Failed to initialize: %@", *error] andLevel:kSentryLogLevelError];
-            }
+        [self validateOptions:options didFailWithError:error];
+        if (nil != error && nil != *error) {
+            [SentryLog logWithMessage:[NSString stringWithFormat:@"Failed to initialize: %@", *error] andLevel:kSentryLogLevelError];
             return nil;
         }
 
@@ -44,7 +42,7 @@
 /**
  populates all `SentryOptions` values from `options` dict using fallbacks/defaults if needed.
  */
-- (BOOL)validateOptions:(NSDictionary<NSString *, id> *)options
+- (void)validateOptions:(NSDictionary<NSString *, id> *)options
        didFailWithError:(NSError *_Nullable *_Nullable)error {
     
     if (nil != [options objectForKey:@"debug"]) {
@@ -71,13 +69,12 @@
     if (nil == [options valueForKey:@"dsn"] || ![[options valueForKey:@"dsn"] isKindOfClass:[NSString class]]) {
         self.enabled = @NO;
         [SentryLog logWithMessage:@"DSN is empty, will disable the SDK" andLevel:kSentryLogLevelDebug];
-        return false;
+        return;
     }
     
     self.dsn = [[SentryDsn alloc] initWithString:[options valueForKey:@"dsn"] didFailWithError:error];
     if (nil != error && nil != *error) {
         self.enabled = @NO;
-        return false;
     }
     
     if ([[options objectForKey:@"release"] isKindOfClass:[NSString class]]) {
@@ -142,8 +139,6 @@
     if([[options objectForKey:@"transport"] conformsToProtocol:@protocol(SentryTransport)]) {
         self.transport = [options objectForKey:@"transport"];
     }
-
-    return true;
 }
 
 @end

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -19,8 +19,11 @@
                       didFailWithError:(NSError *_Nullable *_Nullable)error {
     self = [super init];
     if (self) {
-        [self validateOptions:options didFailWithError:error];
-        if (nil != error && nil != *error) {
+        BOOL success = [self validateOptions:options didFailWithError:error];
+        if (!success) {
+            if (nil != error && nil != *error) {
+                [SentryLog logWithMessage:[NSString stringWithFormat:@"Failed to initialize: %@", *error] andLevel:kSentryLogLevelError];
+            }
             return nil;
         }
 
@@ -41,7 +44,7 @@
 /**
  populates all `SentryOptions` values from `options` dict using fallbacks/defaults if needed.
  */
-- (void)validateOptions:(NSDictionary<NSString *, id> *)options
+- (BOOL)validateOptions:(NSDictionary<NSString *, id> *)options
        didFailWithError:(NSError *_Nullable *_Nullable)error {
     
     if (nil != [options objectForKey:@"debug"]) {
@@ -68,12 +71,13 @@
     if (nil == [options valueForKey:@"dsn"] || ![[options valueForKey:@"dsn"] isKindOfClass:[NSString class]]) {
         self.enabled = @NO;
         [SentryLog logWithMessage:@"DSN is empty, will disable the SDK" andLevel:kSentryLogLevelDebug];
-        return;
+        return false;
     }
     
     self.dsn = [[SentryDsn alloc] initWithString:[options valueForKey:@"dsn"] didFailWithError:error];
     if (nil != error && nil != *error) {
         self.enabled = @NO;
+        return false;
     }
     
     if ([[options objectForKey:@"release"] isKindOfClass:[NSString class]]) {
@@ -138,6 +142,8 @@
     if([[options objectForKey:@"transport"] conformsToProtocol:@protocol(SentryTransport)]) {
         self.transport = [options objectForKey:@"transport"];
     }
+
+    return true;
 }
 
 @end

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -192,7 +192,6 @@
 //}
 
 - (void)testLevelNames {
-    NSInteger highest = kSentryLevelFatal;
     XCTAssertEqualObjects(@"none", SentryLevelNames[kSentryLevelNone]);
     XCTAssertEqualObjects(@"debug", SentryLevelNames[kSentryLevelDebug]);
     XCTAssertEqualObjects(@"info", SentryLevelNames[kSentryLevelInfo]);


### PR DESCRIPTION
```
Method accepting NSError** should have a non-void return value to indicate whether or not an error occurred

4. nil returned from a method that is expected to return a non-null value
```