### PR TITLE
fix: Remove SentryTransport from SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Remove SentryTransport from SentryOptions #489
+
 ## 5.0.0-rc.1
 
 - feat: Add support for mac catalyst #479

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -37,9 +37,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 #pragma mark Initializer
 
-- (_Nullable instancetype)initWithOptions:(SentryOptions *)options {
+- (instancetype)initWithOptions:(SentryOptions *)options {
     if (self = [super init]) {
         self.options = options;
+    }
+    return self;
+}
+
+- (instancetype)initWithOptions:(SentryOptions *)options withTransport:(id<SentryTransport>) transport {
+    if (self = [super init]) {
+        self.options = options;
+        self.transport = transport;
     }
     return self;
 }

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -135,10 +135,6 @@
     } else {
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
     }
-    
-    if([[options objectForKey:@"transport"] conformsToProtocol:@protocol(SentryTransport)]) {
-        self.transport = [options objectForKey:@"transport"];
-    }
 }
 
 @end

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -22,26 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (id<SentryTransport>_Nonnull) initTransport:(SentryOptions *) options
                             sentryFileManager:(SentryFileManager *) sentryFileManager {
-    if (nil != options.transport) {
-        return options.transport;
-    }
-    else {
-        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
-        id<SentryRequestManager> requestManager = [[SentryQueueableRequestManager alloc] initWithSession:session];
-        
-        SentryHttpDateParser *httpDateParser = [[SentryHttpDateParser alloc] init];
-        SentryRetryAfterHeaderParser * retryAfterHeaderParser = [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser];
-        SentryRateLimitParser *rateLimitParser = [[SentryRateLimitParser alloc] init];
-        id<SentryRateLimits> rateLimits = [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser andRateLimitParser:rateLimitParser];
-        
-        SentryEnvelopeRateLimit * envelopeRateLimit = [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
-        
-        return [[SentryHttpTransport alloc] initWithOptions:options
-                                          sentryFileManager:sentryFileManager sentryRequestManager: requestManager
-                                           sentryRateLimits: rateLimits
-                                    sentryEnvelopeRateLimit: envelopeRateLimit];
-    }
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
+    id<SentryRequestManager> requestManager = [[SentryQueueableRequestManager alloc] initWithSession:session];
+    
+    SentryHttpDateParser *httpDateParser = [[SentryHttpDateParser alloc] init];
+    SentryRetryAfterHeaderParser * retryAfterHeaderParser = [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser];
+    SentryRateLimitParser *rateLimitParser = [[SentryRateLimitParser alloc] init];
+    id<SentryRateLimits> rateLimits = [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser andRateLimitParser:rateLimitParser];
+    
+    SentryEnvelopeRateLimit * envelopeRateLimit = [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
+    
+    return [[SentryHttpTransport alloc] initWithOptions:options
+                                      sentryFileManager:sentryFileManager sentryRequestManager: requestManager
+                                       sentryRateLimits: rateLimits
+                                sentryEnvelopeRateLimit: envelopeRateLimit];
 }
 
 @end

--- a/Sources/Sentry/include/SentryClient.h
+++ b/Sources/Sentry/include/SentryClient.h
@@ -15,7 +15,7 @@
 #import "SentrySession.h"
 
 @class SentryEvent, SentryThread, SentryEnvelope;
-@class SentryFileManager;
+@class SentryFileManager, SentryTransport;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,7 +31,16 @@ SENTRY_NO_INIT
  * @param options Options dictionary
  * @return SentryClient
  */
-- (_Nullable instancetype)initWithOptions:(SentryOptions *)options;
+- (instancetype)initWithOptions:(SentryOptions *)options;
+
+/**
+ Initializes a SentryClient. Pass in an dictionary of options and a transport.
+
+ @param options Options dictionary
+ @param transport Sends events to the Sentry backend.
+ @return SentryClient
+*/
+- (instancetype)initWithOptions:(SentryOptions *)options withTransport:(id<SentryTransport>) transport;
 
 /**
  * Captures an SentryEvent

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -96,11 +96,6 @@ SENTRY_NO_INIT
  */
 @property(nonatomic, assign) NSUInteger sessionTrackingIntervalMillis;
 
-/**
- * Set a custom implementation of SentryTransport.
- */
-@property(nonatomic, strong) id<SentryTransport> _Nullable transport;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -20,12 +20,4 @@ class SentryTransportInitializerTests: XCTestCase {
         
         XCTAssertTrue(result.isKind(of: SentryHttpTransport.self))
     }
-    
-    func testCustom() throws {
-        let transport = TestTransport()
-        let options = try Options(dict: ["dsn": TestConstants.dsnAsString, "transport": transport])
-        let result = TransportInitializer.initTransport(options, sentryFileManager: fileManager)
-        
-        XCTAssertTrue( result.isKind(of: TestTransport.self))
-    }
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -14,9 +14,8 @@ class SentryClientTest: XCTestCase {
         transport = TestTransport()
         
         do {
-            let options = try Options(dict: ["dsn": TestConstants.dsnAsString,
-                                             "transport": transport])
-            client = Client(options: options)
+            let options = try Options(dict: ["dsn": TestConstants.dsnAsString])
+            client = Client(options: options, with: transport)
         } catch {
             XCTFail("Options could not be created")
         }

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -240,25 +240,6 @@
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
 }
 
--(void)testTransport {
-    TestTransport *transport = [[TestTransport alloc] init];
-    SentryOptions *options = [self getValidOptions:@{@"transport": transport }];
-    
-    XCTAssertEqual(transport, options.transport);
-}
-
--(void)testTransportNotSet {
-    SentryOptions *options = [self getValidOptions:@{ }];
-    
-    XCTAssertNil(options.transport);
-}
-
--(void)testTransportWithWrongType {
-    SentryOptions *options = [self getValidOptions:@{@"transport": @"hello" }];
-    
-    XCTAssertNil(options.transport);
-}
-
 -(SentryOptions *) getValidOptions:(NSDictionary<NSString *, id> *) dict {
     NSError *error = nil;
     

--- a/Tests/SentryTests/SentrySwiftTests.swift
+++ b/Tests/SentryTests/SentrySwiftTests.swift
@@ -56,7 +56,7 @@ class SentrySwiftTests: XCTestCase {
         let event2 = Event(level: .debug)
         let scope = Sentry.Scope()
         scope.setExtras(["a": "b"])
-        client!.capture(event: event2, scope: scope)
+        client.capture(event: event2, scope: scope)
         //send(event: event2, scope: scope)
     }
     
@@ -74,7 +74,7 @@ class SentrySwiftTests: XCTestCase {
         let event2 = Event(level: .debug)
         let scope = Sentry.Scope()
         scope.setExtras(["a": "b"])
-        client!.capture(event: event2, scope: scope)
+        client.capture(event: event2, scope: scope)
         // TODO(fetzig) this thest used to have a callback
         // 1) check if we should keep/drop the callback
         // 2) update test accordingly


### PR DESCRIPTION
Remove SentryTransport from SentryOptions, because SentryTransport
is not yet aligned with the unified SDK API and exposing it most likely
breaks the API for users soon. After aligning it with the
unified API we can add it again to the SentryOptions.