### PR TITLE
ref: Remove Transport from Options

### DIFF
--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -135,10 +135,6 @@
     } else {
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
     }
-    
-    if([[options objectForKey:@"transport"] conformsToProtocol:@protocol(SentryTransport)]) {
-        self.transport = [options objectForKey:@"transport"];
-    }
 }
 
 @end

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -22,26 +22,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (id<SentryTransport>_Nonnull) initTransport:(SentryOptions *) options
                             sentryFileManager:(SentryFileManager *) sentryFileManager {
-    if (nil != options.transport) {
-        return options.transport;
-    }
-    else {
-        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-        NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
-        id<SentryRequestManager> requestManager = [[SentryQueueableRequestManager alloc] initWithSession:session];
-        
-        SentryHttpDateParser *httpDateParser = [[SentryHttpDateParser alloc] init];
-        SentryRetryAfterHeaderParser * retryAfterHeaderParser = [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser];
-        SentryRateLimitParser *rateLimitParser = [[SentryRateLimitParser alloc] init];
-        id<SentryRateLimits> rateLimits = [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser andRateLimitParser:rateLimitParser];
-        
-        SentryEnvelopeRateLimit * envelopeRateLimit = [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
-        
-        return [[SentryHttpTransport alloc] initWithOptions:options
-                                          sentryFileManager:sentryFileManager sentryRequestManager: requestManager
-                                           sentryRateLimits: rateLimits
-                                    sentryEnvelopeRateLimit: envelopeRateLimit];
-    }
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:configuration];
+    id<SentryRequestManager> requestManager = [[SentryQueueableRequestManager alloc] initWithSession:session];
+
+    SentryHttpDateParser *httpDateParser = [[SentryHttpDateParser alloc] init];
+    SentryRetryAfterHeaderParser * retryAfterHeaderParser = [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser];
+    SentryRateLimitParser *rateLimitParser = [[SentryRateLimitParser alloc] init];
+    id<SentryRateLimits> rateLimits = [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser andRateLimitParser:rateLimitParser];
+
+    SentryEnvelopeRateLimit * envelopeRateLimit = [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
+
+    return [[SentryHttpTransport alloc] initWithOptions:options
+                                      sentryFileManager:sentryFileManager sentryRequestManager: requestManager
+                                       sentryRateLimits: rateLimits
+                                sentryEnvelopeRateLimit: envelopeRateLimit];
 }
 
 @end

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -96,11 +96,6 @@ SENTRY_NO_INIT
  */
 @property(nonatomic, assign) NSUInteger sessionTrackingIntervalMillis;
 
-/**
- * Set a custom implementation of SentryTransport.
- */
-@property(nonatomic, strong) id<SentryTransport> _Nullable transport;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -20,12 +20,4 @@ class SentryTransportInitializerTests: XCTestCase {
         
         XCTAssertTrue(result.isKind(of: SentryHttpTransport.self))
     }
-    
-    func testCustom() throws {
-        let transport = TestTransport()
-        let options = try Options(dict: ["dsn": TestConstants.dsnAsString, "transport": transport])
-        let result = TransportInitializer.initTransport(options, sentryFileManager: fileManager)
-        
-        XCTAssertTrue( result.isKind(of: TestTransport.self))
-    }
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -26,8 +26,9 @@ class SentryClientTest: XCTestCase {
         client = nil
         super.tearDown()
     }
-    
-    func testCaptureMessage() {
+
+    // Skippes until we expose a way to replace the transport
+    func skipped_testCaptureMessage() {
         let message = "message"
         client.capture(message: message, scope: nil)
         

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -27,7 +27,7 @@ class SentryClientTest: XCTestCase {
         super.tearDown()
     }
 
-    // Skippes until we expose a way to replace the transport
+    // Skips until we expose a way to replace the transport
     func skipped_testCaptureMessage() {
         let message = "message"
         client.capture(message: message, scope: nil)

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -240,25 +240,6 @@
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
 }
 
--(void)testTransport {
-    TestTransport *transport = [[TestTransport alloc] init];
-    SentryOptions *options = [self getValidOptions:@{@"transport": transport }];
-    
-    XCTAssertEqual(transport, options.transport);
-}
-
--(void)testTransportNotSet {
-    SentryOptions *options = [self getValidOptions:@{ }];
-    
-    XCTAssertNil(options.transport);
-}
-
--(void)testTransportWithWrongType {
-    SentryOptions *options = [self getValidOptions:@{@"transport": @"hello" }];
-    
-    XCTAssertNil(options.transport);
-}
-
 -(SentryOptions *) getValidOptions:(NSDictionary<NSString *, id> *) dict {
     NSError *error = nil;
     


### PR DESCRIPTION
Removing `HttpTransport` from options.

We plan to add a way to replace the transport further on. It'll probably be through ` `TransportFactory` instead.

Addresses #486 