### PR TITLE
fix: `SDKROOT` build setting, interpolated when under `CARTHAGE` to set `macosx`, otherwise set `iphoneos` — allowing Xcode’s GUI to show Mac Catalyst destination

### DIFF
--- a/Sources/Configuration/Sentry.xcconfig
+++ b/Sources/Configuration/Sentry.xcconfig
@@ -1,4 +1,22 @@
-SDKROOT = iphoneos
+SDKROOT = $(SDKROOT__CARTHAGE_$(CARTHAGE)) //  basically, iphoneos (unless «CARTHAGE» == «YES»)
+// Carthage relies on this assumption, years standing — that SDKROOT is default or explicitly
+// set to `macosx` (or equivalent) under the ‘single target, multiple platform’ paradigm
+// because of a xcodebuild bug involving the sdk flag and implicit dependency: see «Carthage/Carthage#347».
+SDKROOT__CARTHAGE_YES = macosx
+// Importantly, the below two lines appease «Xcode.app», and get the UI to show Mac Catalyst destinations.
+SDKROOT__CARTHAGE_NO = iphoneos
+SDKROOT__CARTHAGE_ = iphoneos
+// …in order for ‘single target, multiple platform’ extrapolations to hold true,
+// all the above relies on the ability of Xcode GUI, xcodebuild, and Carthage via xcodebuild to
+// override «SDKROOT» based on selected destination (particularly for appletv* and watchos* platforms.)
+// …if the override behavior ever breaks, expect weird output and the probable need to migrate away from
+// the ‘single target, multiple platform’ paradigm.
+
+// …`SUPPORTED_PLATFORMS`, in service of ‘single target, multiple platform’ extrapolation, must never
+// engage in dollar-parentheses syntax — unless that dollar-parentheses basis is
+// entirely non-platform–derived, e.g. based upon `XCODE_VERSION_MAJOR`.
+// Note: Carthage, unfortunately, as current of v0.34.0 queries rather harshly on the platform values below
+// ⋯ quite early in the process, queried values not compiled into Carthage will cause hard errors.
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY = 1,2,3,4
 SKIP_INSTALL = YES


### PR DESCRIPTION
#### fix: `SDKROOT` build setting, interpolated when under `CARTHAGE` to set `macosx`, otherwise set `iphoneos` — allowing Xcode’s GUI to show Mac Catalyst destination.

Because of an xcodebuild bug involving the `sdk` flag and implicit dependency, Carthage is forced into a reliance (based on Xcode’s default) on `SDKROOT` as default or explicitly set to `macosx` (or equivalent) under the ‘single target, multiple platform’ paradigm.

`xcodebuild` itself has weird behavior: you’d see — as of commit «99f51f3» — `xcodebuild archive --showBuildSettings --skipUnavailableActions -project Sentry.xcodeproj -scheme Sentry` will no longer display the same `macosx`-`SDKROOT`–based build settings that `xcodebuild archive Sentry.xcodeproj` builds with (even when `-destination 'generic/platform=macOS'` is suffixed on at the end.)

This commit gets carthage building `sentry-cocoa` without the hangups above by switching over the `CARTHAGE` build setting value (or absence) to acquire the `SDKROOT` build setting value.

…and a couple notes on `SUPPORTED_PLATFORMS`. :+1: