### PR TITLE
fix: Keep maximum rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Keep maximum rate limit #498
 - fix: Ignore unknown rate limit categories #497
 
 ## 5.0.1

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -274,6 +274,9 @@
 		7BC8523724588115005A70F0 /* SentryRateLimitCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BC852392458830A005A70F0 /* SentryEnvelopeItemType.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BC8523B2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */; };
+		7BD729962463E83300EA3610 /* SentryDateUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD729952463E83300EA3610 /* SentryDateUtil.h */; };
+		7BD729982463E93500EA3610 /* SentryDateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BD729972463E93500EA3610 /* SentryDateUtil.m */; };
+		7BD7299A2463EA4A00EA3610 /* SentryDateUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */; };
 		7BE3C7672445C0CA00A38442 /* SentryCurrentDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BE3C7692445C1A800A38442 /* SentryCurrentDate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */; };
 		7BE3C76B2445C27A00A38442 /* SentryCurrentDateProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -592,6 +595,9 @@
 		7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRateLimitCategory.h; path = include/SentryRateLimitCategory.h; sourceTree = "<group>"; };
 		7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeItemType.h; path = include/SentryEnvelopeItemType.h; sourceTree = "<group>"; };
 		7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRateLimitCategoryMapperTests.swift; sourceTree = "<group>"; };
+		7BD729952463E83300EA3610 /* SentryDateUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDateUtil.h; path = include/SentryDateUtil.h; sourceTree = "<group>"; };
+		7BD729972463E93500EA3610 /* SentryDateUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDateUtil.m; sourceTree = "<group>"; };
+		7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDateUtilTests.swift; sourceTree = "<group>"; };
 		7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDate.h; path = include/SentryCurrentDate.h; sourceTree = "<group>"; };
 		7BE3C7682445C1A800A38442 /* SentryCurrentDate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCurrentDate.m; sourceTree = "<group>"; };
 		7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCurrentDateProvider.h; path = include/SentryCurrentDateProvider.h; sourceTree = "<group>"; };
@@ -869,6 +875,8 @@
 				7BE3C76A2445C27A00A38442 /* SentryCurrentDateProvider.h */,
 				7BE3C76E2445C2F800A38442 /* SentryDefaultCurrentDateProvider.h */,
 				7BE3C7702445C30D00A38442 /* SentryDefaultCurrentDateProvider.m */,
+				7BD729952463E83300EA3610 /* SentryDateUtil.h */,
+				7BD729972463E93500EA3610 /* SentryDateUtil.m */,
 			);
 			name = Helper;
 			sourceTree = "<group>";
@@ -922,6 +930,7 @@
 				7BE3C7742445C82300A38442 /* SentryCurrentDateTests.swift */,
 				7BE3C7762445E50A00A38442 /* TestCurrentDateProvider.swift */,
 				15D0AC872459EE4D006541C2 /* SentryNSURLRequestTests.swift */,
+				7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */,
 			);
 			path = SentryTests;
 			sourceTree = "<group>";
@@ -1412,6 +1421,7 @@
 				63FE716B20DA4C1100CDBAE8 /* SentryCrashJSONCodecObjC.h in Headers */,
 				63AA76A51EB9CBC200D153DE /* SentryDsn.h in Headers */,
 				636085131ED47BE600E8599E /* SentryFileManager.h in Headers */,
+				7BD729962463E83300EA3610 /* SentryDateUtil.h in Headers */,
 				63FE707B20DA4C1000CDBAE8 /* Container+SentryDeepSearch.h in Headers */,
 				6344DDB91EC3115C00D9160D /* SentryCrashReportConverter.h in Headers */,
 			);
@@ -1595,6 +1605,7 @@
 				7D65260E237F649E00113EA2 /* SentryScope.m in Sources */,
 				63FE712D20DA4C1100CDBAE8 /* SentryCrashJSONCodecObjC.m in Sources */,
 				7BBD18932449BEDD00427C76 /* SentryDefaultRateLimits.m in Sources */,
+				7BD729982463E93500EA3610 /* SentryDateUtil.m in Sources */,
 				639FCF9D1EBC7F9500778193 /* SentryThread.m in Sources */,
 				63FE714120DA4C1100CDBAE8 /* SentryCrashDate.c in Sources */,
 				63FE70DB20DA4C1000CDBAE8 /* SentryCrashMonitor_System.m in Sources */,
@@ -1631,6 +1642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BD7299A2463EA4A00EA3610 /* SentryDateUtilTests.swift in Sources */,
 				630436161EC0AD3100C4D3FA /* SentryNSDataCompressionTests.m in Sources */,
 				63FE722420DA66EC00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m in Sources */,
 				63B819141EC352A7002FDF4C /* SentryInterfacesTests.m in Sources */,

--- a/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
+++ b/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
@@ -17,15 +17,15 @@
     return self;
 }
 
-- (void)addRateLimits:(NSDictionary<NSNumber *, NSDate *> *)rateLimits {
+- (void)addRateLimit:(SentryRateLimitCategory)category validUntil:(NSDate *)date {
     @synchronized (self.rateLimits) {
-        [self.rateLimits addEntriesFromDictionary:rateLimits];
+        self.rateLimits[@(category)] = date;
     }
 }
 
 - (NSDate *)getRateLimitForCategory:(SentryRateLimitCategory)category {
     @synchronized (self.rateLimits) {
-        return self.rateLimits[[NSNumber numberWithInt:category]];
+        return self.rateLimits[@(category)];
     }
 }
 

--- a/Sources/Sentry/SentryDateUtil.m
+++ b/Sources/Sentry/SentryDateUtil.m
@@ -1,0 +1,35 @@
+#import <Foundation/Foundation.h>
+#import "SentryDateUtil.h"
+#import "SentryCurrentDate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryDateUtil ()
+
+@end
+
+@implementation SentryDateUtil
+
++ (BOOL)isInFuture:(NSDate *_Nullable)date {
+    if (nil == date) return NO;
+
+    NSComparisonResult result = [[SentryCurrentDate date] compare:date];
+    return result == NSOrderedAscending;
+}
+
++ (NSDate *_Nullable)getMaximumDate:(NSDate *_Nullable)first andOther:(NSDate *_Nullable)second {
+    if (nil == first && nil == second) return nil;
+    if (nil == first) return second;
+    if (nil == second) return first;
+
+    NSComparisonResult result = [first compare:second];
+    if (result == NSOrderedDescending) {
+        return first;
+    } else {
+        return second;
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryRateLimitCategoryMapper.m
+++ b/Sources/Sentry/SentryRateLimitCategoryMapper.m
@@ -34,6 +34,34 @@ NS_ASSUME_NONNULL_BEGIN
     return category;
 }
 
++ (SentryRateLimitCategory)mapIntegerToCategory:(NSUInteger)value {
+    SentryRateLimitCategory category = kSentryRateLimitCategoryUnknown;
+
+    if (value == kSentryRateLimitCategoryAll) {
+        category = kSentryRateLimitCategoryAll;
+    }
+    if (value == kSentryRateLimitCategoryDefault) {
+        category = kSentryRateLimitCategoryDefault;
+    }
+    if (value == kSentryRateLimitCategoryError) {
+        category = kSentryRateLimitCategoryError;
+    }
+    if (value == kSentryRateLimitCategorySession) {
+        category = kSentryRateLimitCategorySession;
+    }
+    if (value == kSentryRateLimitCategoryTransaction) {
+        category = kSentryRateLimitCategoryTransaction;
+    }
+    if (value == kSentryRateLimitCategoryAttachment) {
+        category = kSentryRateLimitCategoryAttachment;
+    }
+    if (value == kSentryRateLimitCategoryUnknown) {
+        category = kSentryRateLimitCategoryUnknown;
+    }
+
+    return category;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryConcurrentRateLimitsDictionary.h
+++ b/Sources/Sentry/include/SentryConcurrentRateLimitsDictionary.h
@@ -8,11 +8,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryConcurrentRateLimitsDictionary : NSObject
 
 /**
- Adds the passed rate limits. If a rate limit already exists it is overwritten.
- @param rateLimits The key is the SentryRateLimitCategory. We use NSNumber because we can't use an enum.
-    The value is valid until date
+ Adds the passed rate limit for the given category. If a rate limit already exists it is overwritten.
  */
-- (void)addRateLimits:(NSDictionary<NSNumber *, NSDate *> *)rateLimits;
+- (void)addRateLimit:(SentryRateLimitCategory)category validUntil:(NSDate *)date;
 
 /** Returns the date until the rate limit is active. */
 - (NSDate *)getRateLimitForCategory:(SentryRateLimitCategory)category;

--- a/Sources/Sentry/include/SentryDateUtil.h
+++ b/Sources/Sentry/include/SentryDateUtil.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+NS_SWIFT_NAME(DateUtil)
+@interface SentryDateUtil : NSObject
+
++ (BOOL)isInFuture:(NSDate *_Nullable)date;
+
++ (NSDate *_Nullable)getMaximumDate:(NSDate *_Nullable)first andOther:(NSDate *_Nullable)second;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
+++ b/Sources/Sentry/include/SentryRateLimitCategoryMapper.h
@@ -12,6 +12,8 @@ NS_SWIFT_NAME(RateLimitCategoryMapper)
 
 + (SentryRateLimitCategory)mapEnvelopeItemTypeToCategory:(NSString *)itemType;
 
++ (SentryRateLimitCategory)mapIntegerToCategory:(NSUInteger)value;
+
 
 @end
 

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitCategoryMapperTests.swift
@@ -2,25 +2,36 @@ import XCTest
 @testable import Sentry
 
 class SentryRateLimitCategoryMapperTests: XCTestCase {
-    
-    
+
+
     func testEventItemType() {
         XCTAssertEqual(SentryRateLimitCategory.error, mapEventType(eventType: "event"))
         XCTAssertEqual(SentryRateLimitCategory.error, mapEventType(eventType: "any eventtype"))
     }
-    
+
     func testEnvelopeItemType() {
         XCTAssertEqual(SentryRateLimitCategory.error, mapEnvelopeItemType(itemType: "event"))
         XCTAssertEqual(SentryRateLimitCategory.session, mapEnvelopeItemType(itemType: "session"))
-            XCTAssertEqual(SentryRateLimitCategory.transaction, mapEnvelopeItemType(itemType: "transaction"))
-            XCTAssertEqual(SentryRateLimitCategory.attachment, mapEnvelopeItemType(itemType: "attachment"))
-            XCTAssertEqual(SentryRateLimitCategory.default, mapEnvelopeItemType(itemType: "unkown item type"))
+        XCTAssertEqual(SentryRateLimitCategory.transaction, mapEnvelopeItemType(itemType: "transaction"))
+        XCTAssertEqual(SentryRateLimitCategory.attachment, mapEnvelopeItemType(itemType: "attachment"))
+        XCTAssertEqual(SentryRateLimitCategory.default, mapEnvelopeItemType(itemType: "unkown item type"))
     }
-    
+
+    func testMapIntegerToCategory() {
+        XCTAssertEqual(SentryRateLimitCategory.all, RateLimitCategoryMapper.mapInteger(toCategory: 0))
+        XCTAssertEqual(SentryRateLimitCategory.default, RateLimitCategoryMapper.mapInteger(toCategory: 1))
+        XCTAssertEqual(SentryRateLimitCategory.error, RateLimitCategoryMapper.mapInteger(toCategory: 2))
+        XCTAssertEqual(SentryRateLimitCategory.session, RateLimitCategoryMapper.mapInteger(toCategory: 3))
+        XCTAssertEqual(SentryRateLimitCategory.transaction, RateLimitCategoryMapper.mapInteger(toCategory: 4))
+        XCTAssertEqual(SentryRateLimitCategory.attachment, RateLimitCategoryMapper.mapInteger(toCategory: 5))
+        XCTAssertEqual(SentryRateLimitCategory.unknown, RateLimitCategoryMapper.mapInteger(toCategory: 6))
+        XCTAssertEqual(SentryRateLimitCategory.unknown, RateLimitCategoryMapper.mapInteger(toCategory: 7))
+    }
+
     private func mapEnvelopeItemType(itemType: String) -> SentryRateLimitCategory {
         return RateLimitCategoryMapper.mapEnvelopeItemType(toCategory: itemType)
     }
-    
+
     private func mapEventType(eventType: String) -> SentryRateLimitCategory {
         return RateLimitCategoryMapper.mapEventType(toCategory: eventType)
     }

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
@@ -47,6 +47,16 @@ class SentryRateLimitsParserTests: XCTestCase {
         XCTAssertEqual(expected, actual)
     }
     
+    func testKeepMaximumRateLimit() {
+        let expected = [
+            SentryRateLimitCategory.transaction.asNSNumber: CurrentDate.date().addingTimeInterval(50)
+        ]
+        
+        let actual = sut.parse("3:transaction:key,50:transaction:key,5:transaction:key")
+        
+        XCTAssertEqual(expected, actual)
+    }
+    
     func testInvalidRetryAfter() {
         let expected = [SentryRateLimitCategory.default.asNSNumber : CurrentDate.date().addingTimeInterval(1)]
         
@@ -123,5 +133,11 @@ class SentryRateLimitsParserTests: XCTestCase {
         let actual = sut.parse("A9813Hell,50:transaction:key,123Garbage")
         
         XCTAssertEqual(expected, actual)
+    }
+}
+
+extension SentryRateLimitCategory {
+    var asNSNumber: NSNumber {
+        return self.rawValue as NSNumber
     }
 }

--- a/Tests/SentryTests/SentryDateUtilTests.swift
+++ b/Tests/SentryTests/SentryDateUtilTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+class SentryDateUtilTests: XCTestCase {
+
+    private var currentDateProvider: TestCurrentDateProvider!
+
+    override func setUp() {
+        super.setUp()
+        currentDateProvider = TestCurrentDateProvider()
+        CurrentDate.setCurrentDateProvider(currentDateProvider)
+        
+    }
+    
+    func testIsInFutureWithFutureDte() {
+        XCTAssertTrue(DateUtil.is(inFuture:currentDateProvider.date().addingTimeInterval(1)))
+    }
+    
+    func testIsInFutureWithPresentDate() {
+        XCTAssertFalse(DateUtil.is(inFuture:currentDateProvider.date()))
+    }
+    
+    func testIsInFutureWithPastDate() {
+           XCTAssertFalse(DateUtil.is(inFuture:currentDateProvider.date().addingTimeInterval(-1)))
+       }
+    
+    func testIsInFutureWithNil() {
+        XCTAssertFalse(DateUtil.is(inFuture:nil))
+    }
+
+    func testGetMaximumFirstMaximum() {
+        let maximum = currentDateProvider.date().addingTimeInterval(1)
+        let actual = DateUtil.getMaximumDate(maximum, andOther: currentDateProvider.date())
+
+        XCTAssertEqual(maximum, actual)
+    }
+
+    func testGetMaximumSecondMaximum() {
+        let maximum = currentDateProvider.date().addingTimeInterval(1)
+        let actual = DateUtil.getMaximumDate(currentDateProvider.date(), andOther: maximum)
+
+        XCTAssertEqual(maximum, actual)
+    }
+
+    func testGetMaximumWithNil() {
+        let date = currentDateProvider.date()
+    
+        XCTAssertEqual(date, DateUtil.getMaximumDate(nil, andOther: date))
+        XCTAssertEqual(date, DateUtil.getMaximumDate(date, andOther: nil))
+        XCTAssertNil(DateUtil.getMaximumDate(nil, andOther: nil))
+    }
+
+}

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -20,3 +20,4 @@
 #import "SentryRateLimitCategory.h"
 #import "SentryEnvelopeRateLimit.h"
 #import "SentryConcurrentRateLimitsDictionary.h"
+#import "SentryDateUtil.h"


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement
- [ ] Refactoring


## :scroll: Description
Always keep the maximum rate limit if multiple rate limits reference the same bucket.
If a new rate limit is shorter than an already cached rate limit, then keep the longer one.


## :bulb: Motivation and Context
To be consistent with our internal spec for rate limits.


## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I reviewed submitted code
- [x] I added tests to verify changes
- [x] All tests passing
- [x] I've updated the CHANGELOG


## :crystal_ball: Next steps
