### PR TITLE
feat: Add sentry_sanitize for NSArray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- feat: Convert values in dictioanry to string when sanitize #509
+
 ## 5.0.2
 
 - fix: Keep maximum rate limit #498

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- feat: Convert values in dictioanry to string when sanitize #509
+- feat: Add sentry_sanitize for NSArray #509
 
 ## 5.0.2
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -306,6 +306,8 @@
 		7DC83100239826280043DD9A /* SentryIntegrationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DC830FF239826280043DD9A /* SentryIntegrationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7DC8310A2398283C0043DD9A /* SentryCrashIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7DC831082398283C0043DD9A /* SentryCrashIntegration.h */; };
 		7DC8310C2398283C0043DD9A /* SentryCrashIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DC831092398283C0043DD9A /* SentryCrashIntegration.m */; };
+		861265F92404EC1500C4AFDE /* NSArray+SentrySanitize.h in Headers */ = {isa = PBXBuildFile; fileRef = 861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */; };
+		861265FA2404EC1500C4AFDE /* NSArray+SentrySanitize.m in Sources */ = {isa = PBXBuildFile; fileRef = 861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -653,6 +655,8 @@
 		7DC830FF239826280043DD9A /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = include/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
 		7DC831082398283C0043DD9A /* SentryCrashIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashIntegration.h; path = include/SentryCrashIntegration.h; sourceTree = "<group>"; };
 		7DC831092398283C0043DD9A /* SentryCrashIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashIntegration.m; sourceTree = "<group>"; };
+		861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSArray+SentrySanitize.h"; sourceTree = "<group>"; };
+		861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SentrySanitize.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -744,6 +748,8 @@
 				63BE856F1ECEC6DE00DC44F5 /* NSDate+SentryExtras.m */,
 				63295AF31EF3C7DB002D4490 /* NSDictionary+SentrySanitize.h */,
 				63295AF41EF3C7DB002D4490 /* NSDictionary+SentrySanitize.m */,
+				861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */,
+				861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -1360,6 +1366,7 @@
 				6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */,
 				63FE718720DA4C1100CDBAE8 /* SentryCrashReportVersion.h in Headers */,
 				7BBD18912449BE9000427C76 /* SentryDefaultRateLimits.h in Headers */,
+				861265F92404EC1500C4AFDE /* NSArray+SentrySanitize.h in Headers */,
 				63FE712320DA4C1000CDBAE8 /* SentryCrashID.h in Headers */,
 				7DC27EC523997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.h in Headers */,
 				63FE707F20DA4C1000CDBAE8 /* SentryCrashVarArgs.h in Headers */,
@@ -1630,6 +1637,7 @@
 				63FE710F20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m in Sources */,
 				6344DDB51EC309E000D9160D /* SentryCrashReportSink.m in Sources */,
 				639889BD1EDED18400EA7442 /* SentrySwizzle.m in Sources */,
+				861265FA2404EC1500C4AFDE /* NSArray+SentrySanitize.m in Sources */,
 				63FE711520DA4C1000CDBAE8 /* SentryCrashJSONCodec.c in Sources */,
 				636085141ED47BE600E8599E /* SentryFileManager.m in Sources */,
 				63FE710B20DA4C1000CDBAE8 /* SentryCrashMach.c in Sources */,

--- a/Sources/Sentry/NSArray+SentrySanitize.h
+++ b/Sources/Sentry/NSArray+SentrySanitize.h
@@ -2,9 +2,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSDictionary (SentrySanitize)
+@interface NSArray (SentrySanitize)
 
-- (NSDictionary *)sentry_sanitize;
+- (NSArray *)sentry_sanitize;
 
 @end
 

--- a/Sources/Sentry/NSArray+SentrySanitize.m
+++ b/Sources/Sentry/NSArray+SentrySanitize.m
@@ -1,0 +1,28 @@
+#import "NSArray+SentrySanitize.h"
+#import "NSDictionary+SentrySanitize.h"
+#import "NSDate+SentryExtras.h"
+
+@implementation NSArray (SentrySanitize)
+
+- (NSArray *)sentry_sanitize {
+    NSMutableArray *array = [NSMutableArray array];
+    for (id rawValue in self) {
+
+        if ([rawValue isKindOfClass:NSString.class]) {
+            [array addObject:rawValue];
+        } else if ([rawValue isKindOfClass:NSNumber.class]) {
+            [array addObject:rawValue];
+        } else if ([rawValue isKindOfClass:NSDictionary.class]) {
+            [array addObject:[(NSDictionary *)rawValue sentry_sanitize]];
+        } else if ([rawValue isKindOfClass:NSArray.class]) {
+            [array addObject:[(NSArray *)rawValue sentry_sanitize]];
+        } else if ([rawValue isKindOfClass:NSDate.class]) {
+            [array addObject:[(NSDate *)rawValue sentry_toIso8601String]];
+        } else {
+            [array addObject:[rawValue description]];
+        }
+    }
+    return array;
+}
+
+@end

--- a/Sources/Sentry/NSDictionary+SentrySanitize.m
+++ b/Sources/Sentry/NSDictionary+SentrySanitize.m
@@ -1,4 +1,5 @@
 #import "NSDictionary+SentrySanitize.h"
+#import "NSArray+SentrySanitize.h"
 #import "NSDate+SentryExtras.h"
 
 @implementation NSDictionary (SentrySanitize)
@@ -6,21 +7,31 @@
 - (NSDictionary *)sentry_sanitize {
     NSMutableDictionary *dict = [NSMutableDictionary dictionary];
     for (id rawKey in self.allKeys) {
+        id rawValue = [self objectForKey:rawKey];
+
         NSString *stringKey;
-        if ([rawKey isKindOfClass:[NSString class]]) {
+        if ([rawKey isKindOfClass:NSString.class]) {
             stringKey = rawKey;
         } else {
             stringKey = [rawKey description];
         }
 
-        if ([[self objectForKey:rawKey] isKindOfClass:NSDictionary.class]) {
-            [dict setValue:[((NSDictionary *)[self objectForKey:rawKey]) sentry_sanitize] forKey:stringKey];
-        } else if ([[self objectForKey:rawKey] isKindOfClass:NSDate.class]) {
-            [dict setValue:[((NSDate *)[self objectForKey:rawKey]) sentry_toIso8601String] forKey:stringKey];
-        } else if ([stringKey hasPrefix:@"__sentry"]) {
+        if ([stringKey hasPrefix:@"__sentry"]) {
             continue; // We don't want to add __sentry variables
+        }
+
+        if ([rawValue isKindOfClass:NSString.class]) {
+            [dict setValue:rawValue forKey:stringKey];
+        } else if ([rawValue isKindOfClass:NSNumber.class]) {
+            [dict setValue:rawValue forKey:stringKey];
+        } else if ([rawValue isKindOfClass:NSDictionary.class]) {
+            [dict setValue:[(NSDictionary *)rawValue sentry_sanitize] forKey:stringKey];
+        } else if ([rawValue isKindOfClass:NSArray.class]) {
+            [dict setValue:[(NSArray *)rawValue sentry_sanitize] forKey:stringKey];
+        } else if ([rawValue isKindOfClass:NSDate.class]) {
+            [dict setValue:[(NSDate *)rawValue sentry_toIso8601String] forKey:stringKey];
         } else {
-            [dict setValue:[self objectForKey:rawKey] forKey:stringKey];
+            [dict setValue:[rawValue description] forKey:stringKey];
         }
     }
     return dict;

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -155,13 +155,35 @@
     XCTAssertEqualObjects([event3 serialize], serialized3);
     SentryEvent *event4 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
     event4.timestamp = date;
-    event4.extra = @{@"key": @{@1: @"1", @2: [NSDate dateWithTimeIntervalSince1970:1582803326]}};
-    NSDictionary *serialized4 = @{@"event_id": event4.eventId,
-                                   @"extra": @{@"key": @{@"1": @"1", @"2": @"2020-02-27T11:35:26Z"}},
-                                   @"level": @"info",
-                                   @"platform": @"cocoa",
-                                   @"sdk": @{@"name": @"sentry.cocoa", @"version": SentryMeta.versionString},
-                                   @"timestamp": [date sentry_toIso8601String]};
+    NSDate *testDate = [NSDate dateWithTimeIntervalSince1970:1582803326];
+    NSURL *testURL = [NSURL URLWithString:@"https://sentry.io"];
+    event4.extra = @{
+        @"key": @{
+            @1: @"1",
+            @2: @2,
+            @3: @{@"a": @0},
+            @4: @[@"1", @2, @{@"a": @0}, @[@"a"], testDate, testURL],
+            @5: testDate,
+            @6: testURL
+        }
+    };
+    NSDictionary *serialized4 = @{
+        @"event_id": event4.eventId,
+        @"extra": @{
+            @"key": @{
+                @"1": @"1",
+                @"2": @2,
+                @"3": @{@"a": @0},
+                @"4": @[@"1", @2, @{@"a": @0}, @[@"a"], @"2020-02-27T11:35:26Z", @"https://sentry.io"],
+                @"5": @"2020-02-27T11:35:26Z",
+                @"6": @"https://sentry.io"
+            }
+        },
+        @"level": @"info",
+        @"platform": @"cocoa",
+        @"sdk": @{@"name": @"sentry.cocoa", @"version": SentryMeta.versionString},
+        @"timestamp": [date sentry_toIso8601String]
+    };
      XCTAssertEqualObjects([event4 serialize], serialized4);
 }
 


### PR DESCRIPTION
## :scroll: Description

Change `[NSDictionary sentry_sanitize]` and add `[NSArray sentry_sanitize]` to convert values which chould not be serialized by a JSONSerializaion to string.
So that we can make sure sanitize result will always be encoded to json string successfully.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
When reporting a network request failure, I tried to pass the userInfo property of NSError to `event.extra`. However, most of this kind of data are not convertable to json string. For example, decoding error from JSONDecoder has an array of `CodingKeys` in its userInfo to pointing out which key failed to decode. As a result, the whole event failed to send.

It seems pretty easy to pass data not created by ourself to an event. Crashlytics has apis to send NSError directly to SDK and makes this kind of conversion for userInfo. I think it will be good if we can handle this case in sentry SDK.

<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

I updated test cases to cover the change.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
