### PR TITLE
ref: Use CurrentDateProvider in SessionTracker

### DIFF
--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -4,6 +4,7 @@
 #import "SentryHub.h"
 #import "SentrySDK.h"
 #import "SentryLog.h"
+#import "SentryDefaultCurrentDateProvider.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)installWithOptions:(nonnull SentryOptions *)options {
     if ([options.enableAutoSessionTracking isEqual:@YES]) {
-        SentrySessionTracker *tracker = [[SentrySessionTracker alloc] initWithOptions:options];
+        id<SentryCurrentDateProvider> currentDateProvider = [[SentryDefaultCurrentDateProvider alloc] init];
+        SentrySessionTracker *tracker = [[SentrySessionTracker alloc] initWithOptions:options currentDateProvider:currentDateProvider];
         [tracker start];
         self.tracker = tracker;
     }

--- a/Sources/Sentry/include/SentryCurrentDateProvider.h
+++ b/Sources/Sentry/include/SentryCurrentDateProvider.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(CurrentDateProvider)
 @protocol SentryCurrentDateProvider <NSObject>
 
--(NSDate* _Nonnull) date;
+-(NSDate*) date;
 
 @end
 

--- a/Sources/Sentry/include/SentrySessionTracker.h
+++ b/Sources/Sentry/include/SentrySessionTracker.h
@@ -2,11 +2,13 @@
 
 #import "SentryEvent.h"
 #import "SentryOptions.h"
+#import "SentryCurrentDateProvider.h"
 
 NS_SWIFT_NAME(SessionTracker)
 @interface SentrySessionTracker : NSObject
 SENTRY_NO_INIT
 
-- (instancetype)initWithOptions:(SentryOptions *)options;
+- (instancetype)initWithOptions:(SentryOptions *)options
+         currentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider;
 - (void)start;
 @end


### PR DESCRIPTION
## :scroll: Description
Improve the testability of the SentrySessionTracker with using the
CurrentDateProvider for getting the current date.

## :bulb: Motivation and Context
Improve the testability of `SentrySessionTracker`.

## :green_heart: How did you test it?
Still compiles and looking at the code in detail. 

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [ ] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
Add tests for `SentrySessionTracker`.