### PR TITLE
test: Add test for SentryCurrentDate

### DIFF
--- a/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
+++ b/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
@@ -2,32 +2,32 @@ import XCTest
 @testable import Sentry
 
 class SentryCurrentDateTests: XCTestCase {
-    
+
     func testSetNoCurrentDateProvider() {
-        let expected = Date.init()
-        
-        let actual =  CurrentDate.date()
-        
-        XCTAssertEqual(expected.timeIntervalSinceReferenceDate,
-                       actual.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        let firstDate = Date.init()
+        let secondDate = CurrentDate.date()
+        let thirdDate = Date.init()
+
+        XCTAssertGreaterThanOrEqual(secondDate, firstDate)
+        XCTAssertGreaterThanOrEqual(thirdDate, secondDate)
     }
 
-    func testDefaultCurrentDateProvider()  {
+    func testDefaultCurrentDateProvider() {
         CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider())
-        let expected = Date.init()
-        
-        let actual =  CurrentDate.date()
-        
-        XCTAssertEqual(expected.timeIntervalSinceReferenceDate,
-                       actual.timeIntervalSinceReferenceDate, accuracy: 0.001)
+        let firstDate = Date.init()
+        let secondDate = CurrentDate.date()
+        let thirdDate = Date.init()
+
+        XCTAssertGreaterThanOrEqual(secondDate, firstDate)
+        XCTAssertGreaterThanOrEqual(thirdDate, secondDate)
     }
-    
+
     func testTestCurrentDateProvider() {
         CurrentDate.setCurrentDateProvider(TestCurrentDateProvider())
         let expected = Date.init(timeIntervalSinceReferenceDate: 0)
-        
+
         let actual = CurrentDate.date()
-        
+
         XCTAssertEqual(expected, actual)
     }
 }

--- a/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
+++ b/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
@@ -2,6 +2,15 @@ import XCTest
 @testable import Sentry
 
 class SentryCurrentDateTests: XCTestCase {
+    
+    func testSetNoCurrentDateProvider() {
+        let expected = Date.init()
+        
+        let actual =  CurrentDate.date()
+        
+        XCTAssertEqual(expected.timeIntervalSinceReferenceDate,
+                       actual.timeIntervalSinceReferenceDate, accuracy: 0.001)
+    }
 
     func testDefaultCurrentDateProvider()  {
         CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider())


### PR DESCRIPTION
## :scroll: Description

Add test when no current date provider is set to reach 100%
code coverage for SentryCurrentDate.

## :pencil: Checklist

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing

