### PR TITLE
ci: Run Clang Format on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ addons:
   homebrew:
     packages:
       - swiftlint
+      - clang-format
     update: true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
     packages:
       - swiftlint
       - clang-format
+      - python
     update: true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Lint
         env: LANE=lint XCWORKSPACE=Sentry.xcworkspace
         script: .travis/run.sh
+      - name: DangerLint
+        env: LANE=dangerLint XCWORKSPACE=Sentry.xcworkspace
+        script: .travis/run.sh
       - name: Deploy
         env: LANE=deploy XCWORKSPACE=Sentry.xcworkspace
         script: .travis/stage-carthage.sh

--- a/.travis/run.sh
+++ b/.travis/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if [ "$LANE" = "lint" ]; then
+if [ "$LANE" = "dangerLint" ]; then
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         echo "We don't run linter for PRs, because Danger!"
         exit 0;

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,27 @@ bundle exec fastlane test
 
 ## Code Formatting
 
-We use [ClangFormat](http://clang.llvm.org/docs/ClangFormat.html) for formatting Objective-C and C. The configuration can be found in [`.clang-format`](./.clang-format).
+We use [Clang Format](http://clang.llvm.org/docs/ClangFormat.html) for formatting Objective-C and C. The configuration can be found in [`.clang-format`](./.clang-format). To install Clang Format:
+
+```
+npm install -g clang-format
+# OR
+brew install clang-format
+# OR
+sudo apt-get install clang-format
+```
+
+To format all Objcective-C, C++ and C files:
+
+```
+make format
+```
+
+To check if their are any style violations in Objcective-C, C++ and C files:
+
+```
+make lint
+```
 
 ## Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,38 +18,37 @@ gem install bundler
 bundle install
 ```
 
-With that, the repo is fully set up and you are ready to run all commands.
 
-## Run Tests
-
-Test can either be ran inside from Xcode or using `fastlane`:
-
-```
-bundle exec fastlane test
-```
-
-## Code Formatting
-
-We use [Clang Format](http://clang.llvm.org/docs/ClangFormat.html) for formatting Objective-C and C. The configuration can be found in [`.clang-format`](./.clang-format). To install Clang Format:
+All Objective-C, C and C++ needs to be formatted with [Clang Format](http://clang.llvm.org/docs/ClangFormat.html). The configuration can be found in [`.clang-format`](./.clang-format). To install Clang Format:
 
 ```
 npm install -g clang-format
 # OR
 brew install clang-format
 # OR
-sudo apt-get install clang-format
+apt-get install clang-format
 ```
 
-To format all Objcective-C, C++ and C files:
+[Install SwiftLint](https://github.com/realm/SwiftLint#installation) for linting and 
+formatting Swift code.
+
+With that, the repo is fully set up and you are ready to run all commands.
+
+## Run Tests
+
+Test can either be ran inside from Xcode or using [`fastlane`](https://docs.fastlane.tools/):
+
+```
+bundle exec fastlane test
+# OR
+make test 
+```
+
+## Code Formatting
+Only PRs with properly formatted code are acccepted. To format all code run:
 
 ```
 make format
-```
-
-To check if their are any style violations in Objcective-C, C++ and C files:
-
-```
-make lint
 ```
 
 ## Environment

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 lint:
 	@echo "--> Running swiftlint"
-	./scripts/check-clang-format.py -r .
-	# swiftlint
+	./scripts/check-clang-format.py -r Sources Tests
+	swiftlint
 .PHONY: lint
 
 format:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 lint:
 	@echo "--> Running swiftlint"
-	swiftlint
 	./scripts/check-clang-format.py -r .
+	swiftlint
 .PHONY: lint
 	
 format:

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
 lint:
-	@echo "--> Running swiftlint"
+	@echo "--> Running Swiftlint and Clang-Format"
 	./scripts/check-clang-format.py -r Sources Tests
 	swiftlint
 .PHONY: lint
 
+# Format all h,c,cpp and m files
 format:
 	@find . -type f \
 		-name "*.h" \
 		-o -name "*.c" \
-		-o -name "*.m" \
 		-o -name "*.cpp" \
+		-o -name "*.m" \
 		| xargs clang-format -i -style=file
+	swiftlint autocorrect
 .PHONY: format
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 lint:
 	@echo "--> Running swiftlint"
 	./scripts/check-clang-format.py -r .
-	swiftlint
+	# swiftlint
 .PHONY: lint
-	
+
 format:
 	@find . -type f \
 		-name "*.h" \

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,22 @@
 lint:
 	@echo "--> Running swiftlint"
 	swiftlint
+	./scripts/check-clang-format.py -r .
+.PHONY: lint
+	
+format:
+	@find . -type f \
+		-name "*.h" \
+		-o -name "*.c" \
+		-o -name "*.m" \
+		-o -name "*.cpp" \
+		| xargs clang-format -i -style=file
+.PHONY: format
 
 test:
 	@echo "--> Running all tests"
-	fastlane test
+	bundle exec fastlane test
+.PHONY: test
 
 build-carthage:
 	@echo "--> Creating Sentry framework package with carthage"
@@ -12,15 +24,16 @@ build-carthage:
 	carthage archive Sentry --output Sentry.framework.zip
 
 # call this like `make bump-version TO=5.0.0-rc.0`
-bump-version: clean-version-bump	
-	@echo "--> Bumping version from ${TO}"	
-	./Utils/VersionBump/.build/debug/VersionBump ${TO}	
+bump-version: clean-version-bump
+	@echo "--> Bumping version from ${TO}"
+	./Utils/VersionBump/.build/debug/VersionBump ${TO}
 
-clean-version-bump:	
-	@echo "--> Clean VersionBump"	
+clean-version-bump:
+	@echo "--> Clean VersionBump"
 	cd Utils/VersionBump && rm -rf .build && swift build
 
 release: bump-version git-commit-add
+.PHONY: release
 
 pod-lint:
 	@echo "--> Build local pod"

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -38,7 +38,7 @@ SentryHttpTransport ()
            sentryRateLimits:(id<SentryRateLimits>)sentryRateLimits
     sentryEnvelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit
 {
-    if(self = [super init]) {
+    if (self = [super init]) {
         self.options = options;
         self.requestManager = sentryRequestManager;
         self.fileManager = sentryFileManager;

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -38,7 +38,7 @@ SentryHttpTransport ()
            sentryRateLimits:(id<SentryRateLimits>)sentryRateLimits
     sentryEnvelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit
 {
-    if (self = [super init]) {
+    if(self = [super init]) {
         self.options = options;
         self.requestManager = sentryRequestManager;
         self.fileManager = sentryFileManager;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,12 @@ lane :dangerLint do
 end
 
 lane :lint do
-    sh('cd ..; make lint')
+    sh('cd ..; ./scripts/check-clang-format.py -r Sources Tests')
+    swiftlint(
+        mode: :lint,
+        config_file: ".swiftlint.yml",
+        raise_if_swiftlint_error: true
+    )
 end
 
 lane :test do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -14,7 +14,9 @@ lane :localcoverage do
     )
 end
 
-lane :lint do
+# Danger is already taken by the fastlane danger action:
+# https://docs.fastlane.tools/actions/danger/
+lane :dangerLint do
     if ENV["DANGER_GITHUB_API_TOKEN"]
         danger(
             github_api_token: ENV["DANGER_GITHUB_API_TOKEN"],
@@ -23,7 +25,10 @@ lane :lint do
             verbose: true
         )
     end
-    sh('cd ..; swiftlint')
+end
+
+lane :lint do
+    sh('cd ..; make lint')
 end
 
 lane :test do

--- a/scripts/check-clang-format.py
+++ b/scripts/check-clang-format.py
@@ -1,0 +1,406 @@
+#!/usr/bin/env python
+
+# This is taken from: https://github.com/Sarcasm/run-clang-format
+
+# MIT License
+#
+# Copyright (c) 2017 Guillaume Papin
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""A wrapper script around clang-format, suitable for linting multiple files
+and to use for continuous integration.
+
+This is an alternative API for the clang-format command line.
+It runs over multiple files and directories in parallel.
+A diff output is produced and a sensible exit code is returned.
+
+"""
+
+from __future__ import print_function, unicode_literals
+
+import argparse
+import codecs
+import difflib
+import fnmatch
+import io
+import errno
+import multiprocessing
+import os
+import signal
+import subprocess
+import sys
+import traceback
+
+from functools import partial
+
+try:
+    from subprocess import DEVNULL  # py3k
+except ImportError:
+    DEVNULL = open(os.devnull, "wb")
+
+
+DEFAULT_EXTENSIONS = 'c,h,C,H,cpp,hpp,cc,hh,c++,h++,cxx,hxx,m'
+DEFAULT_CLANG_FORMAT_IGNORE = '.clang-format-ignore'
+
+
+class ExitStatus:
+    SUCCESS = 0
+    DIFF = 1
+    TROUBLE = 2
+
+
+def excludes_from_file(ignore_file):
+    excludes = []
+    try:
+        with io.open(ignore_file, 'r', encoding='utf-8') as f:
+            for line in f:
+                if line.startswith('#'):
+                    # ignore comments
+                    continue
+                pattern = line.rstrip()
+                if not pattern:
+                    # allow empty lines
+                    continue
+                excludes.append(pattern)
+    except EnvironmentError as e:
+        if e.errno != errno.ENOENT:
+            raise
+    return excludes
+
+
+def list_files(files, recursive=False, extensions=None, exclude=None):
+    if extensions is None:
+        extensions = []
+    if exclude is None:
+        exclude = []
+
+    out = []
+    for file in files:
+        if recursive and os.path.isdir(file):
+            for dirpath, dnames, fnames in os.walk(file):
+                fpaths = [os.path.join(dirpath, fname) for fname in fnames]
+                for pattern in exclude:
+                    # os.walk() supports trimming down the dnames list
+                    # by modifying it in-place,
+                    # to avoid unnecessary directory listings.
+                    dnames[:] = [
+                        x for x in dnames
+                        if
+                        not fnmatch.fnmatch(os.path.join(dirpath, x), pattern)
+                    ]
+                    fpaths = [
+                        x for x in fpaths if not fnmatch.fnmatch(x, pattern)
+                    ]
+                for f in fpaths:
+                    ext = os.path.splitext(f)[1][1:]
+                    if ext in extensions:
+                        out.append(f)
+        else:
+            out.append(file)
+    return out
+
+
+def make_diff(file, original, reformatted):
+    return list(
+        difflib.unified_diff(
+            original,
+            reformatted,
+            fromfile='{}\t(original)'.format(file),
+            tofile='{}\t(reformatted)'.format(file),
+            n=3))
+
+
+class DiffError(Exception):
+    def __init__(self, message, errs=None):
+        super(DiffError, self).__init__(message)
+        self.errs = errs or []
+
+
+class UnexpectedError(Exception):
+    def __init__(self, message, exc=None):
+        super(UnexpectedError, self).__init__(message)
+        self.formatted_traceback = traceback.format_exc()
+        self.exc = exc
+
+
+def run_clang_format_diff_wrapper(args, file):
+    try:
+        ret = run_clang_format_diff(args, file)
+        return ret
+    except DiffError:
+        raise
+    except Exception as e:
+        raise UnexpectedError('{}: {}: {}'.format(file, e.__class__.__name__,
+                                                  e), e)
+
+
+def run_clang_format_diff(args, file):
+    try:
+        with io.open(file, 'r', encoding='utf-8') as f:
+            original = f.readlines()
+    except IOError as exc:
+        raise DiffError(str(exc))
+    invocation = [args.clang_format_executable, file]
+
+    # Use of utf-8 to decode the process output.
+    #
+    # Hopefully, this is the correct thing to do.
+    #
+    # It's done due to the following assumptions (which may be incorrect):
+    # - clang-format will returns the bytes read from the files as-is,
+    #   without conversion, and it is already assumed that the files use utf-8.
+    # - if the diagnostics were internationalized, they would use utf-8:
+    #   > Adding Translations to Clang
+    #   >
+    #   > Not possible yet!
+    #   > Diagnostic strings should be written in UTF-8,
+    #   > the client can translate to the relevant code page if needed.
+    #   > Each translation completely replaces the format string
+    #   > for the diagnostic.
+    #   > -- http://clang.llvm.org/docs/InternalsManual.html#internals-diag-translation
+    #
+    # It's not pretty, due to Python 2 & 3 compatibility.
+    encoding_py3 = {}
+    if sys.version_info[0] >= 3:
+        encoding_py3['encoding'] = 'utf-8'
+
+    try:
+        proc = subprocess.Popen(
+            invocation,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True,
+            **encoding_py3)
+    except OSError as exc:
+        raise DiffError(
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(invocation), exc
+            )
+        )
+    proc_stdout = proc.stdout
+    proc_stderr = proc.stderr
+    if sys.version_info[0] < 3:
+        # make the pipes compatible with Python 3,
+        # reading lines should output unicode
+        encoding = 'utf-8'
+        proc_stdout = codecs.getreader(encoding)(proc_stdout)
+        proc_stderr = codecs.getreader(encoding)(proc_stderr)
+    # hopefully the stderr pipe won't get full and block the process
+    outs = list(proc_stdout.readlines())
+    errs = list(proc_stderr.readlines())
+    proc.wait()
+    if proc.returncode:
+        raise DiffError(
+            "Command '{}' returned non-zero exit status {}".format(
+                subprocess.list2cmdline(invocation), proc.returncode
+            ),
+            errs,
+        )
+    return make_diff(file, original, outs), errs
+
+
+def bold_red(s):
+    return '\x1b[1m\x1b[31m' + s + '\x1b[0m'
+
+
+def colorize(diff_lines):
+    def bold(s):
+        return '\x1b[1m' + s + '\x1b[0m'
+
+    def cyan(s):
+        return '\x1b[36m' + s + '\x1b[0m'
+
+    def green(s):
+        return '\x1b[32m' + s + '\x1b[0m'
+
+    def red(s):
+        return '\x1b[31m' + s + '\x1b[0m'
+
+    for line in diff_lines:
+        if line[:4] in ['--- ', '+++ ']:
+            yield bold(line)
+        elif line.startswith('@@ '):
+            yield cyan(line)
+        elif line.startswith('+'):
+            yield green(line)
+        elif line.startswith('-'):
+            yield red(line)
+        else:
+            yield line
+
+
+def print_diff(diff_lines, use_color):
+    if use_color:
+        diff_lines = colorize(diff_lines)
+    if sys.version_info[0] < 3:
+        sys.stdout.writelines((l.encode('utf-8') for l in diff_lines))
+    else:
+        sys.stdout.writelines(diff_lines)
+
+
+def print_trouble(prog, message, use_colors):
+    error_text = 'error:'
+    if use_colors:
+        error_text = bold_red(error_text)
+    print("{}: {} {}".format(prog, error_text, message), file=sys.stderr)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--clang-format-executable',
+        metavar='EXECUTABLE',
+        help='path to the clang-format executable',
+        default='clang-format')
+    parser.add_argument(
+        '--extensions',
+        help='comma separated list of file extensions (default: {})'.format(
+            DEFAULT_EXTENSIONS),
+        default=DEFAULT_EXTENSIONS)
+    parser.add_argument(
+        '-r',
+        '--recursive',
+        action='store_true',
+        help='run recursively over directories')
+    parser.add_argument('files', metavar='file', nargs='+')
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help="disable output, useful for the exit code")
+    parser.add_argument(
+        '-j',
+        metavar='N',
+        type=int,
+        default=0,
+        help='run N clang-format jobs in parallel'
+        ' (default number of cpus + 1)')
+    parser.add_argument(
+        '--color',
+        default='auto',
+        choices=['auto', 'always', 'never'],
+        help='show colored diff (default: auto)')
+    parser.add_argument(
+        '-e',
+        '--exclude',
+        metavar='PATTERN',
+        action='append',
+        default=[],
+        help='exclude paths matching the given glob-like pattern(s)'
+        ' from recursive search')
+
+    args = parser.parse_args()
+
+    # use default signal handling, like diff return SIGINT value on ^C
+    # https://bugs.python.org/issue14229#msg156446
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
+    try:
+        signal.SIGPIPE
+    except AttributeError:
+        # compatibility, SIGPIPE does not exist on Windows
+        pass
+    else:
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    colored_stdout = False
+    colored_stderr = False
+    if args.color == 'always':
+        colored_stdout = True
+        colored_stderr = True
+    elif args.color == 'auto':
+        colored_stdout = sys.stdout.isatty()
+        colored_stderr = sys.stderr.isatty()
+
+    version_invocation = [args.clang_format_executable, str("--version")]
+    try:
+        subprocess.check_call(version_invocation, stdout=DEVNULL)
+    except subprocess.CalledProcessError as e:
+        print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+        return ExitStatus.TROUBLE
+    except OSError as e:
+        print_trouble(
+            parser.prog,
+            "Command '{}' failed to start: {}".format(
+                subprocess.list2cmdline(version_invocation), e
+            ),
+            use_colors=colored_stderr,
+        )
+        return ExitStatus.TROUBLE
+
+    retcode = ExitStatus.SUCCESS
+
+    excludes = excludes_from_file(DEFAULT_CLANG_FORMAT_IGNORE)
+    excludes.extend(args.exclude)
+
+    files = list_files(
+        args.files,
+        recursive=args.recursive,
+        exclude=excludes,
+        extensions=args.extensions.split(','))
+
+    if not files:
+        return
+
+    njobs = args.j
+    if njobs == 0:
+        njobs = multiprocessing.cpu_count() + 1
+    njobs = min(len(files), njobs)
+
+    if njobs == 1:
+        # execute directly instead of in a pool,
+        # less overhead, simpler stacktraces
+        it = (run_clang_format_diff_wrapper(args, file) for file in files)
+        pool = None
+    else:
+        pool = multiprocessing.Pool(njobs)
+        it = pool.imap_unordered(
+            partial(run_clang_format_diff_wrapper, args), files)
+    while True:
+        try:
+            outs, errs = next(it)
+        except StopIteration:
+            break
+        except DiffError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            retcode = ExitStatus.TROUBLE
+            sys.stderr.writelines(e.errs)
+        except UnexpectedError as e:
+            print_trouble(parser.prog, str(e), use_colors=colored_stderr)
+            sys.stderr.write(e.formatted_traceback)
+            retcode = ExitStatus.TROUBLE
+            # stop at the first unexpected error,
+            # something could be very wrong,
+            # don't process all files unnecessarily
+            if pool:
+                pool.terminate()
+            break
+        else:
+            sys.stderr.writelines(errs)
+            if outs == []:
+                continue
+            if not args.quiet:
+                print_diff(outs, use_color=colored_stdout)
+            if retcode == ExitStatus.SUCCESS:
+                retcode = ExitStatus.DIFF
+    return retcode
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## :scroll: Description

Let the lint job fail on Travis if Objective-C, C++, or C code is not properly formatted. 

## :bulb: Motivation and Context

With running Clang Format on the CI we can enforce that the code is properly formatted.

## :green_heart: How did you test it?

I [committed a line of code](https://github.com/getsentry/sentry-cocoa/pull/514/commits/876f4e26c9b1e0d155f19e7fd1eec6a5f28fd878) that is not properly formatted to check if the Travis lint job fails.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] All tests are passing

## :crystal_ball: Next steps
Format all Swift code, enforce Swiftlint on Travis.