### PR TITLE
fix: End file at the right place with #ifdef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## unreleased
 
+## 5.0.4
+
+- fix: End file at the right place with #ifdef #521
+
 ## 5.0.3
 
 - fix: Exit session with timestamp #518

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -87,6 +87,7 @@ SentrySessionTracker ()
                 usingBlock:^(NSNotification *notification) {
                     [blockSelf willTerminate];
                 }];
+#endif
 }
 
 - (void)didBecomeActive
@@ -123,6 +124,5 @@ SentrySessionTracker ()
     [hub endSessionWithTimestamp:sessionEnded];
     [[[hub getClient] fileManager] deleteTimestampLastInForeground];
 }
-#endif
 
 @end


### PR DESCRIPTION
It seems we don't have anything in our build process that fails the condition:

`#if SENTRY_HAS_UIKIT || TARGET_OS_OSX || TARGET_OS_MACCATALYST`

But `pod trunk` validation does flag it out.