### PR TITLE
feat: Add remove methods for SentryScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Add remove methods for SentryScope #529
 - ref: Session values are unsigned #527
 
 ## 5.0.4

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -158,10 +158,26 @@ SentryScope ()
     [self notifyListeners];
 }
 
+- (void)removeContextForKey:(NSString *)key
+{
+    @synchronized(self) {
+        [self.contextDictionary removeObjectForKey:key];
+    }
+    [self notifyListeners];
+}
+
 - (void)setExtraValue:(id)value forKey:(NSString *)key
 {
     @synchronized(self) {
         [self.extraDictionary setValue:value forKey:key];
+    }
+    [self notifyListeners];
+}
+
+- (void)removeExtraForKey:(NSString *)key
+{
+    @synchronized(self) {
+        [self.extraDictionary removeObjectForKey:key];
     }
     [self notifyListeners];
 }
@@ -181,6 +197,14 @@ SentryScope ()
 {
     @synchronized(self) {
         [self.tagDictionary setValue:value forKey:key];
+    }
+    [self notifyListeners];
+}
+
+- (void)removeTagForKey:(NSString *)key
+{
+    @synchronized(self) {
+        [self.tagDictionary removeObjectForKey:key];
     }
     [self notifyListeners];
 }

--- a/Sources/Sentry/include/SentryScope.h
+++ b/Sources/Sentry/include/SentryScope.h
@@ -33,6 +33,11 @@ NS_SWIFT_NAME(Scope)
              forKey:(NSString *)key NS_SWIFT_NAME(setTag(value:key:));
 
 /**
+ * Remove the tag for the specified key.
+ */
+- (void)removeTagForKey:(NSString *)key NS_SWIFT_NAME(removeTag(key:));
+
+/**
  * Set global extra -> these will be sent with every event
  */
 - (void)setExtras:(NSDictionary<NSString *, id> *_Nullable)extras;
@@ -42,6 +47,11 @@ NS_SWIFT_NAME(Scope)
  */
 - (void)setExtraValue:(id)value
                forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
+
+/**
+ * Remove the extra for the specified key.
+ */
+- (void)removeExtraForKey:(NSString *)key NS_SWIFT_NAME(removeExtra(key:));
 
 /**
  * Set dist in the scope
@@ -87,11 +97,16 @@ NS_SWIFT_NAME(Scope)
 - (void)applyToSession:(SentrySession *)session;
 
 /**
- * Cets context values which will overwrite SentryEvent.context when event is
+ * Sets context values which will overwrite SentryEvent.context when event is
  * "enrichted" with scope before sending event.
  */
 - (void)setContextValue:(NSDictionary<NSString *, id> *)value
                  forKey:(NSString *)key NS_SWIFT_NAME(setContext(value:key:));
+
+/**
+ * Remove the context for the specified key.
+ */
+- (void)removeContextForKey:(NSString *)key NS_SWIFT_NAME(removeContext(key:));
 
 /**
  * Clears the current Scope


### PR DESCRIPTION
## :scroll: Description

Add remove methods for tag, context, and extra to SentryScope.

## :bulb: Motivation and Context

You can set tag, context, and extra on `SentryScope`, but you can't remove them. We have this implementation already on [Android](https://github.com/getsentry/sentry-android/blob/2798e65a6f9c5a15eecff6f79e4a59e60b083f87/sentry-core/src/main/java/io/sentry/core/Scope.java#L248).

## :green_heart: How did you test it?
Adding unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
None.