### PR TITLE
fix: Failing MacOS build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Failing MacOS build #530
 - ref: Session values are unsigned #527
 
 ## 5.0.4

--- a/Sources/Sentry/include/SentryCrashExceptionApplication.h
+++ b/Sources/Sentry/include/SentryCrashExceptionApplication.h
@@ -1,5 +1,8 @@
+// TargetConditionals.h is needed so that `#if TARGET_OS_OSX` is working
+// fine. If we remove this the SDK breaks for MacOS.
+#import "TargetConditionals.h"
 #if TARGET_OS_OSX
-#    import <Cocoa/Cocoa.h>
+#    import <AppKit/NSApplication.h>
 @interface SentryCrashExceptionApplication : NSApplication
 #else
 #    import <Foundation/Foundation.h>

--- a/Sources/Sentry/include/SentryCrashExceptionApplication.h
+++ b/Sources/Sentry/include/SentryCrashExceptionApplication.h
@@ -1,11 +1,13 @@
-// TargetConditionals.h is needed so that `#if TARGET_OS_OSX` is working
-// fine. If we remove this the SDK breaks for MacOS.
-#import "TargetConditionals.h"
+// Don't move Foundation.h. We need it here in order to have
+// TargetConditionals.h automatically imported. This is needed
+// so that `#if TARGET_OS_OSX` is working fine. If we move
+// this the SDK breaks for MacOS.
+#import <Foundation/Foundation.h>
+
 #if TARGET_OS_OSX
 #    import <AppKit/NSApplication.h>
 @interface SentryCrashExceptionApplication : NSApplication
 #else
-#    import <Foundation/Foundation.h>
 @interface SentryCrashExceptionApplication : NSObject
 #endif
 


### PR DESCRIPTION
## :scroll: Description

Import only NSApplication and move Foundation import to the top.

Fixes #526 

## :green_heart: How did you test it?
Trying sending crash events with macOS-Swift.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [ ] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
