### PR TITLE
fix: Avoid Implicit conversion in SentrySession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Avoid Implicit conversion in SentrySession #540
+
 ## 5.0.5
 
 - feat: Add remove methods for SentryScope #529

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		63FE722420DA66EC00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71FB20DA66EB00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m */; };
 		63FE722520DA66EC00CDBAE8 /* SentryCrashFileUtils_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71FC20DA66EB00CDBAE8 /* SentryCrashFileUtils_Tests.m */; };
 		7B0002322477F0520035FEF1 /* SentrySessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B0002312477F0520035FEF1 /* SentrySessionTests.m */; };
+		7B0002342477F52D0035FEF1 /* SentrySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0002332477F52D0035FEF1 /* SentrySessionTests.swift */; };
 		7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */; };
 		7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */; };
 		7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */; };
@@ -567,6 +568,7 @@
 		63FE71FB20DA66EB00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashMonitor_NSException_Tests.m; sourceTree = "<group>"; };
 		63FE71FC20DA66EB00CDBAE8 /* SentryCrashFileUtils_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashFileUtils_Tests.m; sourceTree = "<group>"; };
 		7B0002312477F0520035FEF1 /* SentrySessionTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySessionTests.m; sourceTree = "<group>"; };
+		7B0002332477F52D0035FEF1 /* SentrySessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySessionTests.swift; sourceTree = "<group>"; };
 		7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeRateLimit.h; path = include/SentryEnvelopeRateLimit.h; sourceTree = "<group>"; };
 		7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimit.m; sourceTree = "<group>"; };
 		7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeRateLimitTests.swift; sourceTree = "<group>"; };
@@ -942,6 +944,7 @@
 				7BAF3DD6243DD4A1008A5414 /* TestConstants.swift */,
 				15D0AC872459EE4D006541C2 /* SentryNSURLRequestTests.swift */,
 				7B0002312477F0520035FEF1 /* SentrySessionTests.m */,
+				7B0002332477F52D0035FEF1 /* SentrySessionTests.swift */,
 				7B944FAF2469B46000A10721 /* TestClient.swift */,
 			);
 			path = SentryTests;
@@ -1759,6 +1762,7 @@
 				7BBD18B32451805500427C76 /* SentryRateLimitsParserTests.swift in Sources */,
 				63FE720920DA66EC00CDBAE8 /* XCTestCase+SentryCrash.m in Sources */,
 				59A96DCC0E0016BD7CAF45CC /* (null) in Sources */,
+				7B0002342477F52D0035FEF1 /* SentrySessionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -1,7 +1,7 @@
 #import "SentrySession.h"
 #import "NSDate+SentryExtras.h"
-#import "SentryInstallation.h"
 #import "SentryCurrentDate.h"
+#import "SentryInstallation.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -159,8 +159,7 @@ NS_ASSUME_NONNULL_BEGIN
             [serializedData setValue:_duration forKey:@"duration"];
         } else if (nil == _init) {
             NSTimeInterval secondsBetween = [_timestamp timeIntervalSinceDate:_started];
-            [serializedData setValue:[NSNumber numberWithDouble:secondsBetween]
-                              forKey:@"duration"];
+            [serializedData setValue:[NSNumber numberWithDouble:secondsBetween] forKey:@"duration"];
         }
 
         // TODO: seq to be just unix time in mills?

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -1,6 +1,7 @@
 #import "SentrySession.h"
 #import "NSDate+SentryExtras.h"
 #import "SentryInstallation.h"
+#import "SentryCurrentDate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         _sessionId = [NSUUID UUID];
-        _started = [NSDate date];
+        _started = [SentryCurrentDate date];
         _status = kSentrySessionStatusOk;
         _sequence = 1;
         _errors = 0;
@@ -96,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(self) {
         _timestamp = timestamp;
         NSTimeInterval secondsBetween = [_timestamp timeIntervalSinceDate:_started];
-        _duration = [NSNumber numberWithLongLong:secondsBetween];
+        _duration = [NSNumber numberWithDouble:secondsBetween];
     }
 }
 
@@ -151,14 +152,14 @@ NS_ASSUME_NONNULL_BEGIN
             [serializedData setValue:statusString forKey:@"status"];
         }
 
-        NSDate *timestamp = nil != _timestamp ? _timestamp : [NSDate date];
+        NSDate *timestamp = nil != _timestamp ? _timestamp : [SentryCurrentDate date];
         [serializedData setValue:[timestamp sentry_toIso8601String] forKey:@"timestamp"];
 
         if (nil != _duration) {
             [serializedData setValue:_duration forKey:@"duration"];
         } else if (nil == _init) {
             NSTimeInterval secondsBetween = [_timestamp timeIntervalSinceDate:_started];
-            [serializedData setValue:[NSNumber numberWithLongLong:secondsBetween]
+            [serializedData setValue:[NSNumber numberWithDouble:secondsBetween]
                               forKey:@"duration"];
         }
 

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -29,6 +29,7 @@ class SentrySessionTestsSwift: XCTestCase {
         
         currentDateProvider.setDate(date: date.addingTimeInterval(3))
         let sessionSerialized = session.serialize()
-        XCTAssertEqual(2, sessionSerialized["duration"] as! Double)
+        let duration = sessionSerialized["duration"] as? Double ?? -1
+        XCTAssertEqual(2, duration)
     }
 }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+
+class SentrySessionTestsSwift: XCTestCase {
+    
+    private var currentDateProvider: TestCurrentDateProvider!
+    
+    override func setUp() {
+        currentDateProvider = TestCurrentDateProvider()
+        CurrentDate.setCurrentDateProvider(currentDateProvider)
+    }
+    
+    func testEndSession() {
+        let session = SentrySession()
+        let date = currentDateProvider.date().addingTimeInterval(1)
+        session.endExited(withTimestamp: date)
+        
+        XCTAssertEqual(1, session.duration)
+        XCTAssertEqual(date, session.timestamp)
+        XCTAssertEqual(SentrySessionStatus.exited, session.status)
+    }
+    
+    func testInitAndDurationNilWhenSerialize() {
+        let session = SentrySession()
+        session.setInit(nil)
+        
+        let date = currentDateProvider.date()
+        session.endExited(withTimestamp: date.addingTimeInterval(2))
+        session.duration = nil
+        
+        currentDateProvider.setDate(date: date.addingTimeInterval(3))
+        let sessionSerialized = session.serialize()
+        XCTAssertEqual(2, sessionSerialized["duration"] as! Double)
+    }
+}


### PR DESCRIPTION
##  :scroll: Description

Use `numberWithDouble` instead of `numberWithLongLong` for
initialising the duration in `SentrySession`.

## :bulb: Motivation and Context

Implicit conversion may lose precision.

## :green_heart: How did you test it?
Adding unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
