### PR TITLE
fix: Make properties of Session readonly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Make properties of Session readonly #541
 - fix: Remove MemoryWarningIntegration #537
 - fix: Avoid Implicit conversion in SentrySession #540
 - fix: Change SentryScope setTagValue to NSString #524

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -48,8 +48,7 @@ SentryHub ()
         if (nil != _session) {
             lastSession = _session;
         }
-        _session = [[SentrySession alloc] init];
-        _session.releaseName = options.releaseName;
+        _session = [[SentrySession alloc] initWithReleaseName:options.releaseName];
         [scope applyToSession:_session];
 
         [self storeCurrentSession:_session];

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -7,7 +7,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentrySession
 
-- (instancetype)init
+@synthesize flagInit = _init;
+
+- (instancetype)initWithReleaseName:(NSString *)releaseName
 {
     if (self = [super init]) {
         _sessionId = [NSUUID UUID];
@@ -17,6 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
         _errors = 0;
         _init = @YES;
         _distinctId = [SentryInstallation id];
+        _releaseName = releaseName;
     }
     return self;
 }

--- a/Sources/Sentry/include/SentrySession.h
+++ b/Sources/Sentry/include/SentrySession.h
@@ -10,8 +10,9 @@ typedef NS_ENUM(NSUInteger, SentrySessionStatus) {
 };
 
 @interface SentrySession : NSObject
+SENTRY_NO_INIT
 
-- (instancetype)init;
+- (instancetype)initWithReleaseName:(NSString *)releaseName;
 - (instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
 
 - (void)endSessionExitedWithTimestamp:(NSDate *)timestamp;
@@ -25,12 +26,15 @@ typedef NS_ENUM(NSUInteger, SentrySessionStatus) {
 @property (nonatomic, readonly) enum SentrySessionStatus status;
 @property (nonatomic, readonly) NSUInteger errors;
 @property (nonatomic, readonly) NSUInteger sequence;
-@property (nonatomic, strong) NSString *distinctId;
+@property (nonatomic, readonly, strong) NSString *distinctId;
+/**
+  We can't use init because it overlaps with NSObject.init
+ */
+@property (nonatomic, readonly, copy) NSNumber *_Nullable flagInit;
+@property (nonatomic, readonly, strong) NSDate *_Nullable timestamp;
+@property (nonatomic, readonly, strong) NSNumber *_Nullable duration;
 
-@property (nonatomic, copy) NSNumber *_Nullable init;
-@property (nonatomic, strong) NSDate *_Nullable timestamp;
-@property (nonatomic, strong) NSNumber *_Nullable duration;
-@property (nonatomic, copy) NSString *_Nullable releaseName;
+@property (nonatomic, readonly, copy) NSString *_Nullable releaseName;
 @property (nonatomic, copy) NSString *_Nullable environment;
 @property (nonatomic, copy) SentryUser *_Nullable user;
 

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -25,7 +25,7 @@ class SentryFileManagerTests: XCTestCase {
     func testInitDoesNotOverrideDirectories() throws {
         sut.store(Event())
         sut.store(TestConstants.envelope)
-        sut.storeCurrentSession(SentrySession())
+        sut.storeCurrentSession(SentrySession(releaseName: ""))
         sut.storeTimestampLast(inForeground: Date())
 
         _ = try SentryFileManager(dsn: TestConstants.dsn)
@@ -140,14 +140,14 @@ class SentryFileManagerTests: XCTestCase {
     }
     
     func testStoreAndReadCurrentSession() {
-        let expectedSession = SentrySession()
+        let expectedSession = SentrySession(releaseName: "")
         sut.storeCurrentSession(expectedSession)
         let actualSession = sut.readCurrentSession()
         XCTAssertTrue(expectedSession.distinctId == actualSession?.distinctId)
     }
 
     func testStoreDeleteCurrentSession() {
-        sut.storeCurrentSession(SentrySession())
+        sut.storeCurrentSession(SentrySession(releaseName: ""))
         sut.deleteCurrentSession()
         let actualSession = sut.readCurrentSession()
         XCTAssertNil(actualSession)
@@ -180,7 +180,7 @@ class SentryFileManagerTests: XCTestCase {
     func testDeleteAllFolders() {
         sut.store(TestConstants.envelope)
         sut.store(Event())
-        sut.storeCurrentSession(SentrySession())
+        sut.storeCurrentSession(SentrySession(releaseName: ""))
         
         sut.deleteAllFolders()
         

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -25,7 +25,7 @@ class SentryFileManagerTests: XCTestCase {
     func testInitDoesNotOverrideDirectories() throws {
         sut.store(Event())
         sut.store(TestConstants.envelope)
-        sut.storeCurrentSession(SentrySession(releaseName: ""))
+        sut.storeCurrentSession(SentrySession(releaseName: "1.0.0"))
         sut.storeTimestampLast(inForeground: Date())
 
         _ = try SentryFileManager(dsn: TestConstants.dsn)
@@ -140,14 +140,14 @@ class SentryFileManagerTests: XCTestCase {
     }
     
     func testStoreAndReadCurrentSession() {
-        let expectedSession = SentrySession(releaseName: "")
+        let expectedSession = SentrySession(releaseName: "1.0.0")
         sut.storeCurrentSession(expectedSession)
         let actualSession = sut.readCurrentSession()
         XCTAssertTrue(expectedSession.distinctId == actualSession?.distinctId)
     }
 
     func testStoreDeleteCurrentSession() {
-        sut.storeCurrentSession(SentrySession(releaseName: ""))
+        sut.storeCurrentSession(SentrySession(releaseName: "1.0.0"))
         sut.deleteCurrentSession()
         let actualSession = sut.readCurrentSession()
         XCTAssertNil(actualSession)
@@ -180,7 +180,7 @@ class SentryFileManagerTests: XCTestCase {
     func testDeleteAllFolders() {
         sut.store(TestConstants.envelope)
         sut.store(Event())
-        sut.storeCurrentSession(SentrySession(releaseName: ""))
+        sut.storeCurrentSession(SentrySession(releaseName: "1.0.1"))
         
         sut.deleteAllFolders()
         

--- a/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
@@ -69,7 +69,7 @@ class SentryEnvelopeRateLimitTests: XCTestCase {
         }
         
         for _ in Array(0...2) {
-            let session = SentrySession()
+            let session = SentrySession(releaseName: "")
             envelopeItems.append(SentryEnvelopeItem(session: session))
         }
         

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -95,7 +95,7 @@ class SentryHttpTransportTests: XCTestCase {
     
     func testSendAllCachedEnvelopes() {
         givenNoInternetConnection()
-        let envelope = SentryEnvelope(session: SentrySession(releaseName: ""))
+        let envelope = SentryEnvelope(session: SentrySession(releaseName: "1.9.0"))
         sendEnvelope(envelope: envelope)
         sendEnvelope()
         
@@ -363,7 +363,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     private func sendEnvelopeWithSession() {
-        let envelope = SentryEnvelope(id: "id", items: [SentryEnvelopeItem(event: Event()), SentryEnvelopeItem(session: SentrySession(releaseName: ""))])
+        let envelope = SentryEnvelope(id: "id", items: [SentryEnvelopeItem(event: Event()), SentryEnvelopeItem(session: SentrySession(releaseName: "2.0.1"))])
         sut.send(envelope: envelope, completion: nil)
     }
     

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -95,7 +95,7 @@ class SentryHttpTransportTests: XCTestCase {
     
     func testSendAllCachedEnvelopes() {
         givenNoInternetConnection()
-        let envelope = SentryEnvelope(session: SentrySession())
+        let envelope = SentryEnvelope(session: SentrySession(releaseName: ""))
         sendEnvelope(envelope: envelope)
         sendEnvelope()
         
@@ -363,7 +363,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     private func sendEnvelopeWithSession() {
-        let envelope = SentryEnvelope(id: "id", items: [SentryEnvelopeItem(event: Event()), SentryEnvelopeItem(session: SentrySession())])
+        let envelope = SentryEnvelope(id: "id", items: [SentryEnvelopeItem(event: Event()), SentryEnvelopeItem(session: SentrySession(releaseName: ""))])
         sut.send(envelope: envelope, completion: nil)
     }
     

--- a/Tests/SentryTests/SentrySessionTests.m
+++ b/Tests/SentryTests/SentrySessionTests.m
@@ -9,24 +9,24 @@
 
 - (void)testInitDefaultValues
 {
-    SentrySession *session = [[SentrySession alloc] init];
+    SentrySession *session = [[SentrySession alloc] initWithReleaseName:@"1.0.0"];
     XCTAssertNotNil(session.sessionId);
     XCTAssertEqual(1, session.sequence);
     XCTAssertEqual(0, session.errors);
-    XCTAssertTrue(session.init);
+    XCTAssertTrue(session.flagInit);
     XCTAssertNotNil(session.started);
     XCTAssertEqual(kSentrySessionStatusOk, session.status);
     XCTAssertNotNil(session.distinctId);
 
     XCTAssertNil(session.timestamp);
-    XCTAssertNil(session.releaseName);
+    XCTAssertEqual(@"1.0.0", session.releaseName);
     XCTAssertNil(session.environment);
     XCTAssertNil(session.duration);
 }
 
 - (void)testSerializeDefaultValues
 {
-    SentrySession *expected = [[SentrySession alloc] init];
+    SentrySession *expected = [[SentrySession alloc] initWithReleaseName:@"1.0.0"];
     NSDictionary<NSString *, id> *json = [expected serialize];
     SentrySession *actual = [[SentrySession alloc] initWithJSONObject:json];
 
@@ -41,8 +41,8 @@
     XCTAssertNil(expected.timestamp);
     // Serialize session always have a timestamp (time of serialization)
     XCTAssertNotNil(actual.timestamp);
-    XCTAssertNil(expected.releaseName);
-    XCTAssertNil(actual.releaseName);
+    XCTAssertEqual(@"1.0.0", expected.releaseName);
+    XCTAssertEqual(@"1.0.0", actual.releaseName);
     XCTAssertNil(expected.environment);
     XCTAssertNil(actual.environment);
     XCTAssertNil(expected.duration);
@@ -51,11 +51,10 @@
 
 - (void)testSerializeExtraFieldsEndedSessionWithNilStatus
 {
-    SentrySession *expected = [[SentrySession alloc] init];
+    SentrySession *expected = [[SentrySession alloc] initWithReleaseName:@"io.sentry@5.0.0-test"];
     NSDate *timestamp = [NSDate date];
     [expected endSessionExitedWithTimestamp:timestamp];
     expected.environment = @"prod";
-    expected.releaseName = @"io.sentry@5.0.0-test";
     NSDictionary<NSString *, id> *json = [expected serialize];
     SentrySession *actual = [[SentrySession alloc] initWithJSONObject:json];
 
@@ -78,7 +77,7 @@
 
 - (void)testSerializeErrorIncremented
 {
-    SentrySession *expected = [[SentrySession alloc] init];
+    SentrySession *expected = [[SentrySession alloc] initWithReleaseName:@""];
     [expected incrementErrors];
     [expected endSessionExitedWithTimestamp:[NSDate date]];
     NSDictionary<NSString *, id> *json = [expected serialize];
@@ -101,7 +100,7 @@
 
 - (void)testAbnormalSession
 {
-    SentrySession *expected = [[SentrySession alloc] init];
+    SentrySession *expected = [[SentrySession alloc] initWithReleaseName:@""];
     XCTAssertEqual(0, expected.errors);
     XCTAssertEqual(kSentrySessionStatusOk, expected.status);
     XCTAssertEqual(1, expected.sequence);
@@ -117,7 +116,7 @@
 
 - (void)testCrashedSession
 {
-    SentrySession *expected = [[SentrySession alloc] init];
+    SentrySession *expected = [[SentrySession alloc] initWithReleaseName:@""];
     XCTAssertEqual(1, expected.sequence);
     XCTAssertEqual(kSentrySessionStatusOk, expected.status);
     [expected endSessionCrashedWithTimestamp:[NSDate date]];
@@ -127,7 +126,7 @@
 
 - (void)testExitedSession
 {
-    SentrySession *expected = [[SentrySession alloc] init];
+    SentrySession *expected = [[SentrySession alloc] initWithReleaseName:@""];
     XCTAssertEqual(0, expected.errors);
     XCTAssertEqual(kSentrySessionStatusOk, expected.status);
     XCTAssertEqual(1, expected.sequence);

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -10,7 +10,7 @@ class SentrySessionTestsSwift: XCTestCase {
     }
     
     func testEndSession() {
-        let session = SentrySession()
+        let session = SentrySession(releaseName: "")
         let date = currentDateProvider.date().addingTimeInterval(1)
         session.endExited(withTimestamp: date)
         
@@ -20,14 +20,15 @@ class SentrySessionTestsSwift: XCTestCase {
     }
     
     func testInitAndDurationNilWhenSerialize() {
-        let session = SentrySession()
-        session.setInit(nil)
+        let session1 = SentrySession(releaseName: "")
+        var json = session1.serialize()
+        json.removeValue(forKey: "init")
+        json.removeValue(forKey: "duration")
         
-        let date = currentDateProvider.date()
-        session.endExited(withTimestamp: date.addingTimeInterval(2))
-        session.duration = nil
+        let date = currentDateProvider.date().addingTimeInterval(2)
+        json["timestamp"] = (date as NSDate).sentry_toIso8601String()
+        let session = SentrySession(jsonObject: json)
         
-        currentDateProvider.setDate(date: date.addingTimeInterval(3))
         let sessionSerialized = session.serialize()
         let duration = sessionSerialized["duration"] as? Double ?? -1
         XCTAssertEqual(2, duration)

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -10,7 +10,7 @@ class SentrySessionTestsSwift: XCTestCase {
     }
     
     func testEndSession() {
-        let session = SentrySession(releaseName: "")
+        let session = SentrySession(releaseName: "0.1.0")
         let date = currentDateProvider.date().addingTimeInterval(1)
         session.endExited(withTimestamp: date)
         
@@ -20,7 +20,7 @@ class SentrySessionTestsSwift: XCTestCase {
     }
     
     func testInitAndDurationNilWhenSerialize() {
-        let session1 = SentrySession(releaseName: "")
+        let session1 = SentrySession(releaseName: "1.4.0")
         var json = session1.serialize()
         json.removeValue(forKey: "init")
         json.removeValue(forKey: "duration")

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -3,6 +3,7 @@
 //  expose to Swift.
 //
 
+#import "NSDate+SentryExtras.h"
 #import "SentryConcurrentRateLimitsDictionary.h"
 #import "SentryCurrentDate.h"
 #import "SentryDateUtil.h"


### PR DESCRIPTION
## :scroll: Description

Make all properties of SentrySession read-only except environment and user,
because those are set in the scope after a session is initialized.

## :bulb: Motivation and Context

The session properties should not be changeable.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
