### PR TITLE
feat: Set SUPPORTS_MACCATALYST to YES explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 - fix: Duplicate symbol for SentryMeta #549
+- feat: Set SUPPORTS_MACCATALYST to YES explicitly #547
 
 ## 5.1.0
 

--- a/Sources/Configuration/Sentry.xcconfig
+++ b/Sources/Configuration/Sentry.xcconfig
@@ -57,3 +57,7 @@ MODULEMAP_FILE = $(SRCROOT)/Sources/Sentry/Sentry.modulemap
 // SWIFT_VERSION is only recognized by Xcode 8 and higher.
 // Prior versions of Xcode support only one Swift version.
 // SWIFT_VERSION = 3.1
+
+// Although `YES` is the default for iOS targets, command-line output via `xcodebuild -showBuildSettings`
+// will not emit this value unless it is explicitly set.
+SUPPORTS_MACCATALYST = YES


### PR DESCRIPTION
## :scroll: Description

Set `SUPPORTS_MACCATALYST` to `YES` explicitly instead of relying on the implicit default.

## :bulb: Motivation and Context

`xcodebuild -showBuildSettings` does not emit implicit settings, so setting it explicitly allows for its output to reflect Catalyst support.

## :green_heart: How did you test it?
Ran `xcodebuild -showBuildSettings` before and after the change.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [ ] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
Looking for CHANGELOG and commit naming guidance if approved.