### PR TITLE
fix: Duplicate symbol for SentryMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Duplicate symbol for SentryMeta #549
+
 ## 5.1.0
 
 - fix: Make properties of Session readonly #541

--- a/Sources/Sentry/SentryMeta.m
+++ b/Sources/Sentry/SentryMeta.m
@@ -2,8 +2,11 @@
 
 @implementation SentryMeta
 
-NSString *const versionString = @"5.1.0";
-NSString *const sdkName = @"sentry.cocoa";
+// Don't remove the static keyword. If you do the compiler adds the constant name to the global
+// symbol table and it might clash with other constants. When keeping the static keyword the
+// compiler replaces all occurences with the value.
+static NSString *const versionString = @"5.1.0";
+static NSString *const sdkName = @"sentry.cocoa";
 
 + (NSString *)versionString
 {

--- a/Sources/Sentry/SentryMeta.m
+++ b/Sources/Sentry/SentryMeta.m
@@ -4,7 +4,7 @@
 
 // Don't remove the static keyword. If you do the compiler adds the constant name to the global
 // symbol table and it might clash with other constants. When keeping the static keyword the
-// compiler replaces all occurences with the value.
+// compiler replaces all occurrences with the value.
 static NSString *const versionString = @"5.1.0";
 static NSString *const sdkName = @"sentry.cocoa";
 


### PR DESCRIPTION
## :scroll: Description

The constants in SentryMeta are defined with NSString *const which
can lead to clashes because the constant name appears in the global
symbol table. Adding the static keyword fixes this issue, because
the compiler replaces each occurrence of the constant.

## :bulb: Motivation and Context

Fixes GH-546

## :green_heart: How did you test it?
Adding another constant with the name `versionString` in the `SentryClient` failed before this fix and now it works.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
