### PR TITLE
ref: Event sdk info is now set in prepareEvent instead of during serialization

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -11,6 +11,7 @@
 #import "SentryHttpTransport.h"
 #import "SentryIntegrationProtocol.h"
 #import "SentryLog.h"
+#import "SentryMeta.h"
 #import "SentryOptions.h"
 #import "SentryQueueableRequestManager.h"
 #import "SentrySDK.h"
@@ -178,6 +179,15 @@ SentryClient ()
     NSString *environment = self.options.environment;
     if (nil != environment && nil == event.environment) {
         event.environment = environment;
+    }
+
+    NSMutableDictionary *sdk =
+        @{ @"name" : SentryMeta.sdkName, @"version" : SentryMeta.versionString }.mutableCopy;
+    if (nil != sdk && nil == event.sdk) {
+        if (event.extra[@"__sentry_sdk_integrations"]) {
+            [sdk setValue:event.extra[@"__sentry_sdk_integrations"] forKey:@"integrations"];
+        }
+        event.sdk = sdk;
     }
 
     if (nil != scope) {

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -109,24 +109,9 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)addSdkInformation:(NSMutableDictionary *)serializedData
-{
-    // If sdk was set, we don't take the default
-    if (nil != self.sdk) {
-        serializedData[@"sdk"] = self.sdk;
-        return;
-    }
-    NSMutableDictionary *sdk =
-        @{ @"name" : SentryMeta.sdkName, @"version" : SentryMeta.versionString }.mutableCopy;
-    if (self.extra[@"__sentry_sdk_integrations"]) {
-        [sdk setValue:self.extra[@"__sentry_sdk_integrations"] forKey:@"integrations"];
-    }
-    serializedData[@"sdk"] = sdk;
-}
-
 - (void)addSimpleProperties:(NSMutableDictionary *)serializedData
 {
-    [self addSdkInformation:serializedData];
+    [serializedData setValue:self.sdk forKey:@"sdk"];
     [serializedData setValue:self.releaseName forKey:@"release"];
     [serializedData setValue:self.dist forKey:@"dist"];
     [serializedData setValue:self.environment forKey:@"environment"];

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -88,7 +88,6 @@
         @"level" : @"info",
         @"environment" : @"bla",
         @"platform" : @"cocoa",
-        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event serialize], serialized);
@@ -99,7 +98,6 @@
         @"event_id" : event2.eventId,
         @"level" : @"info",
         @"platform" : @"cocoa",
-        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event2 serialize], serialized2);
@@ -133,7 +131,6 @@
         @"extra" : @ { @"key" : @ { @"1" : @"1", @"2" : @"2020-02-27T11:35:26Z" } },
         @"level" : @"info",
         @"platform" : @"cocoa",
-        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event4 serialize], serialized4);
@@ -218,7 +215,6 @@
         },
         @"level" : @"info",
         @"platform" : @"cocoa",
-        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event4 serialize], serialized4);

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -81,6 +81,7 @@
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
     event.timestamp = date;
     event.environment = @"bla";
+    event.sdk = @{ @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString };
     event.extra = @{ @"__sentry_stacktrace" : @"f", @"date" : date };
     NSDictionary *serialized = @{
         @"event_id" : event.eventId,
@@ -88,16 +89,19 @@
         @"level" : @"info",
         @"environment" : @"bla",
         @"platform" : @"cocoa",
+        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event serialize], serialized);
 
     SentryEvent *event2 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
     event2.timestamp = date;
+    event2.sdk = @{ @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString };
     NSDictionary *serialized2 = @{
         @"event_id" : event2.eventId,
         @"level" : @"info",
         @"platform" : @"cocoa",
+        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event2 serialize], serialized2);
@@ -124,6 +128,7 @@
 
     SentryEvent *event4 = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
     event4.timestamp = date;
+    event4.sdk = @{ @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString };
     event4.extra =
         @{ @"key" : @ { @1 : @"1", @2 : [NSDate dateWithTimeIntervalSince1970:1582803326] } };
     NSDictionary *serialized4 = @{
@@ -131,6 +136,7 @@
         @"extra" : @ { @"key" : @ { @"1" : @"1", @"2" : @"2020-02-27T11:35:26Z" } },
         @"level" : @"info",
         @"platform" : @"cocoa",
+        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event4 serialize], serialized4);
@@ -198,6 +204,7 @@
             @6 : testURL
         }
     };
+    event4.sdk = @{ @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString };
     NSDictionary *serialized4 = @{
         @"event_id" : event4.eventId,
         @"extra" : @ {
@@ -215,6 +222,7 @@
         },
         @"level" : @"info",
         @"platform" : @"cocoa",
+        @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
         @"timestamp" : [date sentry_toIso8601String]
     };
     XCTAssertEqualObjects([event4 serialize], serialized4);


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->
Moved setting the default event sdk info from `SentryEvent.m` to `SentryClient.m`.
Removed the `addSdkInformation` method from `SentryEvent`, and added the sdk setting code
to `SentryClient.prepareEvent`. `SentryEvent.addSimpleProperties` now just copies the sdk info from `self.sdk` instead.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Setting sdk info should be in `prepareEvent` and not be set on serialization only.
This is also so the sdk info can be accessed in `beforeSend`.

## :green_heart: How did you test it?

Removed `event.sdk` from interfaces tests and ran the provided tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [ ] I've updated the CHANGELOG

## :crystal_ball: Next steps
