### PR TITLE
fix: Prefix category methods with sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Prefix categories methods with sentry #555
 - feat: Attach DebugMeta to Events #545
 - fix: Duplicate symbol for SentryMeta #549
 - feat: Set SUPPORTS_MACCATALYST to YES explicitly #547

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -327,7 +327,7 @@ SentryCrashReportFilterObjectForKey ()
     for (NSDictionary *report in reports) {
         id object = nil;
         if ([self.key isKindOfClass:[NSString class]]) {
-            object = [report objectForKeyPath:self.key];
+            object = [report sentry_objectForKeyPath:self.key];
         } else {
             object = [report objectForKey:self.key];
         }
@@ -406,7 +406,7 @@ SentryCrashReportFilterConcatenate ()
             } else {
                 [concatenated appendFormat:self.separatorFmt, key];
             }
-            id object = [report objectForKeyPath:key];
+            id object = [report sentry_objectForKeyPath:key];
             [concatenated appendFormat:@"%@", object];
         }
         [filteredReports addObject:concatenated];
@@ -463,7 +463,7 @@ SentryCrashReportFilterSubset ()
     for (NSDictionary *report in reports) {
         NSMutableDictionary *subset = [NSMutableDictionary dictionary];
         for (NSString *keyPath in self.keyPaths) {
-            id object = [report objectForKeyPath:keyPath];
+            id object = [report sentry_objectForKeyPath:keyPath];
             if (object == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
                     [NSError errorWithDomain:[[self class] description]

--- a/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.h
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.h
@@ -68,7 +68,7 @@
  *
  * @param deepKey A set of keys to drill down with.
  */
-- (id)objectForDeepKey:(NSArray *)deepKey;
+- (id)sentry_objectForDeepKey:(NSArray *)deepKey;
 
 /** Do a deep search using the specified keys.
  *
@@ -77,7 +77,7 @@
  *
  * @param keyPath A full key path, separated by slash (e.g. @"a/b/c")
  */
-- (id)objectForKeyPath:(NSString *)keyPath;
+- (id)sentry_objectForKeyPath:(NSString *)keyPath;
 
 #pragma mark - Mutators
 
@@ -90,7 +90,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)setObject:(id)anObject forDeepKey:(NSArray *)deepKey;
+- (void)sentry_setObject:(id)anObject forDeepKey:(NSArray *)deepKey;
 
 /** Set an associated object at the specified key path.
  *
@@ -101,7 +101,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)setObject:(id)anObject forKeyPath:(NSString *)keyPath;
+- (void)sentry_setObject:(id)anObject forKeyPath:(NSString *)keyPath;
 
 /** Remove an associated object at the specified deep key.
  *
@@ -112,7 +112,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)removeObjectForDeepKey:(NSArray *)deepKey;
+- (void)sentry_removeObjectForDeepKey:(NSArray *)deepKey;
 
 /** Remove an associated object at the specified key path.
  *
@@ -123,7 +123,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)removeObjectForKeyPath:(NSString *)keyPath;
+- (void)sentry_removeObjectForKeyPath:(NSString *)keyPath;
 
 @end
 
@@ -143,7 +143,7 @@
  *
  * @param deepKey A set of keys to drill down with.
  */
-- (id)objectForDeepKey:(NSArray *)deepKey;
+- (id)sentry_objectForDeepKey:(NSArray *)deepKey;
 
 /** Do a deep search using the specified keys.
  *
@@ -152,7 +152,7 @@
  *
  * @param keyPath A full key path, separated by slash (e.g. @"a/b/c")
  */
-- (id)objectForKeyPath:(NSString *)keyPath;
+- (id)sentry_objectForKeyPath:(NSString *)keyPath;
 
 #pragma mark - Mutators
 
@@ -165,7 +165,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)setObject:(id)anObject forDeepKey:(NSArray *)deepKey;
+- (void)sentry_setObject:(id)anObject forDeepKey:(NSArray *)deepKey;
 
 /** Set an associated object at the specified key path.
  *
@@ -176,7 +176,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)setObject:(id)anObject forKeyPath:(NSString *)keyPath;
+- (void)sentry_setObject:(id)anObject forKeyPath:(NSString *)keyPath;
 
 /** Remove an associated object at the specified deep key.
  *
@@ -187,7 +187,7 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)removeObjectForDeepKey:(NSArray *)deepKey;
+- (void)sentry_removeObjectForDeepKey:(NSArray *)deepKey;
 
 /** Remove an associated object at the specified key path.
  *
@@ -198,6 +198,6 @@
  * If the lookup fails at any level, it will throw an exception describing which
  * object in the hierarchy did not respond to any object accessor methods.
  */
-- (void)removeObjectForKeyPath:(NSString *)keyPath;
+- (void)sentry_removeObjectForKeyPath:(NSString *)keyPath;
 
 @end

--- a/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.m
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.m
@@ -175,32 +175,32 @@ removeObjectForKeyPath(id container, NSString *keyPath)
 
 @implementation NSDictionary (DeepSearch)
 
-- (id)objectForDeepKey:(NSArray *)deepKey
+- (id)sentry_objectForDeepKey:(NSArray *)deepKey
 {
     return objectForDeepKey(self, deepKey);
 }
 
-- (id)objectForKeyPath:(NSString *)keyPath
+- (id)sentry_objectForKeyPath:(NSString *)keyPath
 {
     return objectForKeyPath(self, keyPath);
 }
 
-- (void)setObject:(id)anObject forDeepKey:(NSArray *)deepKey
+- (void)sentry_setObject:(id)anObject forDeepKey:(NSArray *)deepKey
 {
     setObjectForDeepKey(self, anObject, deepKey);
 }
 
-- (void)setObject:(id)anObject forKeyPath:(NSString *)keyPath
+- (void)sentry_setObject:(id)anObject forKeyPath:(NSString *)keyPath
 {
     setObjectForKeyPath(self, anObject, keyPath);
 }
 
-- (void)removeObjectForDeepKey:(NSArray *)deepKey
+- (void)sentry_removeObjectForDeepKey:(NSArray *)deepKey
 {
     removeObjectForDeepKey(self, deepKey);
 }
 
-- (void)removeObjectForKeyPath:(NSString *)keyPath
+- (void)sentry_removeObjectForKeyPath:(NSString *)keyPath
 {
     removeObjectForKeyPath(self, keyPath);
 }
@@ -211,32 +211,32 @@ removeObjectForKeyPath(id container, NSString *keyPath)
 
 @implementation NSArray (DeepSearch)
 
-- (id)objectForDeepKey:(NSArray *)deepKey
+- (id)sentry_objectForDeepKey:(NSArray *)deepKey
 {
     return objectForDeepKey(self, deepKey);
 }
 
-- (id)objectForKeyPath:(NSString *)keyPath
+- (id)sentry_objectForKeyPath:(NSString *)keyPath
 {
     return objectForKeyPath(self, keyPath);
 }
 
-- (void)setObject:(id)anObject forDeepKey:(NSArray *)deepKey
+- (void)sentry_setObject:(id)anObject forDeepKey:(NSArray *)deepKey
 {
     setObjectForDeepKey(self, anObject, deepKey);
 }
 
-- (void)setObject:(id)anObject forKeyPath:(NSString *)keyPath
+- (void)sentry_setObject:(id)anObject forKeyPath:(NSString *)keyPath
 {
     setObjectForKeyPath(self, anObject, keyPath);
 }
 
-- (void)removeObjectForDeepKey:(NSArray *)deepKey
+- (void)sentry_removeObjectForDeepKey:(NSArray *)deepKey
 {
     removeObjectForDeepKey(self, deepKey);
 }
 
-- (void)removeObjectForKeyPath:(NSString *)keyPath
+- (void)sentry_removeObjectForKeyPath:(NSString *)keyPath
 {
     removeObjectForKeyPath(self, keyPath);
 }

--- a/Tests/SentryTests/SentryCrash/Container+DeepSearch_Tests.m
+++ b/Tests/SentryTests/SentryCrash/Container+DeepSearch_Tests.m
@@ -45,7 +45,7 @@
         @"key1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", @"key3", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -60,7 +60,7 @@
                 @"key2", nil],
         @"key1", nil];
 
-    id actual = [container objectForKeyPath:@"key1/key2/key3"];
+    id actual = [container sentry_objectForKeyPath:@"key1/key2/key3"];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -75,7 +75,7 @@
                 @"key2", nil],
         @"key1", nil];
 
-    id actual = [container objectForKeyPath:@"/key1/key2/key3"];
+    id actual = [container sentry_objectForKeyPath:@"/key1/key2/key3"];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -91,7 +91,7 @@
         @"1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"1", @"2", @"3", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -106,7 +106,7 @@
                 @"2", nil],
         @"1", nil];
 
-    id actual = [container objectForKeyPath:@"1/2/3"];
+    id actual = [container sentry_objectForKeyPath:@"1/2/3"];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -120,7 +120,7 @@
 
     id deepKey = [NSArray arrayWithObjects:[NSNumber numberWithInt:0], [NSNumber numberWithInt:1],
                           [NSNumber numberWithInt:1], nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -133,7 +133,7 @@
                  nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"1", @"1", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -145,7 +145,7 @@
                  nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"1", @"key", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertNil(actual, @"");
 }
 
@@ -158,7 +158,7 @@
                  nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"1", @"", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -170,7 +170,7 @@
                                            [NSArray arrayWithObjects:@"blah2", expected, nil], nil],
                  nil];
 
-    id actual = [container objectForKeyPath:@"0/1/1"];
+    id actual = [container sentry_objectForKeyPath:@"0/1/1"];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -185,7 +185,7 @@
         @"key1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", [NSNumber numberWithInt:1], @"key3", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -199,7 +199,7 @@
                                               nil],
         @"key1", nil];
 
-    id actual = [container objectForKeyPath:@"key1/1/key3"];
+    id actual = [container sentry_objectForKeyPath:@"key1/1/key3"];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -207,7 +207,7 @@
 {
     id container = [NSDictionary dictionary];
     id deepKey = [NSArray arrayWithObjects:@"key1", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertNil(actual, @"");
 }
 
@@ -215,7 +215,7 @@
 {
     id container = [NSArray array];
     id deepKey = [NSArray arrayWithObjects:@"key1", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertNil(actual, @"");
 }
 
@@ -231,7 +231,7 @@
 
     id deepKey =
         [NSArray arrayWithObjects:@"key1", [NSNumber numberWithInt:1], @"key3", @"key4", nil];
-    id actual = [container objectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertNil(actual, @"");
 }
 
@@ -248,8 +248,8 @@
         @"key1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", @"key3", nil];
-    [container setObject:expected forDeepKey:deepKey];
-    id actual = [container objectForDeepKey:deepKey];
+    [container sentry_setObject:expected forDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -260,8 +260,8 @@
         [NSMutableDictionary dictionaryWithObjectsAndKeys:@"someObject", @"someKey", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", nil];
-    [container setObject:expected forDeepKey:deepKey];
-    id actual = [container objectForDeepKey:deepKey];
+    [container sentry_setObject:expected forDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -278,7 +278,7 @@
         @"key1", nil];
 
     id deepKey = [NSArray array];
-    XCTAssertThrows([container setObject:expected forDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_setObject:expected forDeepKey:deepKey], @"");
 }
 
 - (void)testSetObjectForDeepKeyArray
@@ -292,8 +292,8 @@
         nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"key2", @"0", nil];
-    [container setObject:expected forDeepKey:deepKey];
-    id actual = [container objectForDeepKey:deepKey];
+    [container sentry_setObject:expected forDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -308,8 +308,8 @@
         nil];
 
     id deepKey = @"0/key2/0";
-    [container setObject:expected forKeyPath:deepKey];
-    id actual = [container objectForKeyPath:deepKey];
+    [container sentry_setObject:expected forKeyPath:deepKey];
+    id actual = [container sentry_objectForKeyPath:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -319,7 +319,7 @@
     id container = [NSDate date];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", @"0", nil];
-    XCTAssertThrows([container setObject:expected forDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_setObject:expected forDeepKey:deepKey], @"");
 }
 
 - (void)testSetObjectForDeepKeyImmutableArray
@@ -333,7 +333,7 @@
         nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"key2", @"0", nil];
-    XCTAssertThrows([container setObject:expected forDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_setObject:expected forDeepKey:deepKey], @"");
 }
 
 - (void)testSetObjectForDeepKeyImmutableDict
@@ -349,7 +349,7 @@
         @"key1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", [NSDate date], nil];
-    XCTAssertThrows([container setObject:expected forDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_setObject:expected forDeepKey:deepKey], @"");
 }
 
 - (void)testSetObjectForKeyPathDict
@@ -365,8 +365,8 @@
         @"key1", nil];
 
     id deepKey = @"key1/key2/key3";
-    [container setObject:expected forKeyPath:deepKey];
-    id actual = [container objectForKeyPath:deepKey];
+    [container sentry_setObject:expected forKeyPath:deepKey];
+    id actual = [container sentry_objectForKeyPath:deepKey];
     XCTAssertEqualObjects(expected, actual, @"");
 }
 
@@ -382,8 +382,8 @@
         @"key1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", @"key3", nil];
-    [container removeObjectForDeepKey:deepKey];
-    id actual = [container objectForDeepKey:deepKey];
+    [container sentry_removeObjectForDeepKey:deepKey];
+    id actual = [container sentry_objectForDeepKey:deepKey];
     XCTAssertNil(actual, @"");
 }
 
@@ -399,8 +399,8 @@
         @"key1", nil];
 
     id deepKey = @"key1/key2/key3";
-    [container removeObjectForKeyPath:deepKey];
-    id actual = [container objectForKeyPath:deepKey];
+    [container sentry_removeObjectForKeyPath:deepKey];
+    id actual = [container sentry_objectForKeyPath:deepKey];
     XCTAssertNil(actual, @"");
 }
 
@@ -414,8 +414,8 @@
         nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"key2", @"0", nil];
-    [container removeObjectForDeepKey:deepKey];
-    XCTAssertThrows([container objectForDeepKey:deepKey], @"");
+    [container sentry_removeObjectForDeepKey:deepKey];
+    XCTAssertThrows([container sentry_objectForDeepKey:deepKey], @"");
 }
 
 - (void)testRemoveObjectForKeyPathArray
@@ -428,8 +428,8 @@
         nil];
 
     id deepKey = @"0/key2/0";
-    [container removeObjectForKeyPath:deepKey];
-    XCTAssertThrows([container objectForKeyPath:deepKey], @"");
+    [container sentry_removeObjectForKeyPath:deepKey];
+    XCTAssertThrows([container sentry_objectForKeyPath:deepKey], @"");
 }
 
 - (void)testRemoveObjectForDeepKeyInvalidContainer
@@ -437,7 +437,7 @@
     id container = [NSDate date];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", @"0", nil];
-    XCTAssertThrows([container removeObjectForDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_removeObjectForDeepKey:deepKey], @"");
 }
 
 - (void)testRemoveObjectForDeepKeyImmutableArray
@@ -450,7 +450,7 @@
         nil];
 
     id deepKey = [NSArray arrayWithObjects:@"0", @"key2", @"0", nil];
-    XCTAssertThrows([container removeObjectForDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_removeObjectForDeepKey:deepKey], @"");
 }
 
 - (void)testRemoveObjectForDeepKeyImmutableDict
@@ -465,7 +465,7 @@
         @"key1", nil];
 
     id deepKey = [NSArray arrayWithObjects:@"key1", @"key2", [NSDate date], nil];
-    XCTAssertThrows([container removeObjectForDeepKey:deepKey], @"");
+    XCTAssertThrows([container sentry_removeObjectForDeepKey:deepKey], @"");
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description

Prefix categories for NSDictionary and NSArray with sentry to avoid
accidental overriding.

## :bulb: Motivation and Context

Fixes GH-314

## :green_heart: How did you test it?
Tests are green.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
None.