### PR TITLE
fix: UUID for SentryCrashReport is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: UUID for SentryCrashReport is null #566
+
 ## 5.1.2
 
 - feat: Attach stacktrace of current thread to events #561

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -47,7 +47,6 @@
 
 //#define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
-#include "SentryCrashUUIDConversion.h"
 
 #include <errno.h>
 #include <fcntl.h>
@@ -213,10 +212,33 @@ addUUIDElement(const SentryCrashReportWriter *const writer, const char *const ke
     if (value == NULL) {
         sentrycrashjson_addNullElement(getJsonContext(writer), key);
     } else {
-        const unsigned char *src = value;
         char uuidBuffer[37];
+        const unsigned char *src = value;
         char *dst = uuidBuffer;
-        sentrycrashdl_convertBinaryImageUUID(src, dst);
+        for (int i = 0; i < 4; i++) {
+            *dst++ = g_hexNybbles[(*src >> 4) & 15];
+            *dst++ = g_hexNybbles[(*src++) & 15];
+        }
+        *dst++ = '-';
+        for (int i = 0; i < 2; i++) {
+            *dst++ = g_hexNybbles[(*src >> 4) & 15];
+            *dst++ = g_hexNybbles[(*src++) & 15];
+        }
+        *dst++ = '-';
+        for (int i = 0; i < 2; i++) {
+            *dst++ = g_hexNybbles[(*src >> 4) & 15];
+            *dst++ = g_hexNybbles[(*src++) & 15];
+        }
+        *dst++ = '-';
+        for (int i = 0; i < 2; i++) {
+            *dst++ = g_hexNybbles[(*src >> 4) & 15];
+            *dst++ = g_hexNybbles[(*src++) & 15];
+        }
+        *dst++ = '-';
+        for (int i = 0; i < 6; i++) {
+            *dst++ = g_hexNybbles[(*src >> 4) & 15];
+            *dst++ = g_hexNybbles[(*src++) & 15];
+        }
 
         sentrycrashjson_addStringElement(
             getJsonContext(writer), key, uuidBuffer, (int)(dst - uuidBuffer));


### PR DESCRIPTION
## :scroll: Description

Rollback to original conversion for UUID and not use
sentrycrashdl_convertBinaryImageUUID.


## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?
Trying it with a simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [ ] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
