### PR TITLE
fix: Increase max report length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Increase max report length #569
+
 ## 5.1.3
 
 - fix: UUID for SentryCrashReport is null #566

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
@@ -233,7 +233,7 @@ sentrycrashcrf_fixupCrashReport(const char *crashReport)
         .onNullElement = onNullElement,
         .onStringElement = onStringElement,
     };
-    int stringBufferLength = SentryCrashMAX_ReportSize;
+    int stringBufferLength = SentryCrashMAX_STRINGBUFFERSIZE;
     char *stringBuffer = malloc((unsigned)stringBufferLength);
     if (stringBuffer == NULL) {
         SentryCrashLOG_ERROR("Failed to allocate string buffer of size %ul", stringBufferLength);

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
@@ -233,7 +233,7 @@ sentrycrashcrf_fixupCrashReport(const char *crashReport)
         .onNullElement = onNullElement,
         .onStringElement = onStringElement,
     };
-    int stringBufferLength = 10000;
+    int stringBufferLength = 100000;
     char *stringBuffer = malloc((unsigned)stringBufferLength);
     if (stringBuffer == NULL) {
         SentryCrashLOG_ERROR("Failed to allocate string buffer of size %ul", stringBufferLength);

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
@@ -233,7 +233,7 @@ sentrycrashcrf_fixupCrashReport(const char *crashReport)
         .onNullElement = onNullElement,
         .onStringElement = onStringElement,
     };
-    int stringBufferLength = 100000;
+    int stringBufferLength = SentryCrashMAX_ReportSize;
     char *stringBuffer = malloc((unsigned)stringBufferLength);
     if (stringBuffer == NULL) {
         SentryCrashLOG_ERROR("Failed to allocate string buffer of size %ul", stringBufferLength);

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
@@ -42,7 +42,7 @@ extern "C" {
  */
 #define SentryCrashJSON_SIZE_AUTOMATIC -1
 
-#define SentryCrashMAX_ReportSize 100000
+#define SentryCrashMAX_STRINGBUFFERSIZE 100000
 
 enum {
     /** Encoding or decoding: Everything completed without error */

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
@@ -42,6 +42,8 @@ extern "C" {
  */
 #define SentryCrashJSON_SIZE_AUTOMATIC -1
 
+#define SentryCrashMAX_ReportSize 100000
+
 enum {
     /** Encoding or decoding: Everything completed without error */
     SentryCrashJSON_OK = 0,

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -409,7 +409,7 @@ encodeObject(
        error:(NSError *__autoreleasing *)error
 {
     SentryCrashJSONCodec *codec = [self codecWithEncodeOptions:0 decodeOptions:decodeOptions];
-    NSMutableData *stringData = [NSMutableData dataWithLength:SentryCrashMAX_ReportSize+1];
+    NSMutableData *stringData = [NSMutableData dataWithLength:SentryCrashMAX_STRINGBUFFERSIZE+1];
     int errorOffset;
     int result
         = sentrycrashjson_decode(JSONData.bytes, (int)JSONData.length, stringData.mutableBytes,

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -409,7 +409,7 @@ encodeObject(
        error:(NSError *__autoreleasing *)error
 {
     SentryCrashJSONCodec *codec = [self codecWithEncodeOptions:0 decodeOptions:decodeOptions];
-    NSMutableData *stringData = [NSMutableData dataWithLength:100001];
+    NSMutableData *stringData = [NSMutableData dataWithLength:SentryCrashMAX_ReportSize+1];
     int errorOffset;
     int result
         = sentrycrashjson_decode(JSONData.bytes, (int)JSONData.length, stringData.mutableBytes,

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -409,7 +409,7 @@ encodeObject(
        error:(NSError *__autoreleasing *)error
 {
     SentryCrashJSONCodec *codec = [self codecWithEncodeOptions:0 decodeOptions:decodeOptions];
-    NSMutableData *stringData = [NSMutableData dataWithLength:10001];
+    NSMutableData *stringData = [NSMutableData dataWithLength:100001];
     int errorOffset;
     int result
         = sentrycrashjson_decode(JSONData.bytes, (int)JSONData.length, stringData.mutableBytes,


### PR DESCRIPTION
## :scroll: Description

Increases the max report length KSCrash can process by 10x

## :bulb: Motivation and Context

In react native it happens that sometimes when we try to process a crash we get this error:
```
2020-06-05 12:43:15.631482+0200 sample[70962:14350544] Sentry - Debug:: SDK initialized! Version: 5.1.3
ERROR: SentryCrashReportFixer.c (267): char *sentrycrashcrf_fixupCrashReport(const char *): Could not decode report: Data too long
ERROR: SentryCrashC.c (277): char *sentrycrash_readReport(int64_t): Failed to fixup report ID 56800000
```

## :green_heart: How did you test it?

Running this manually in react-native sample project. The fix removes this error.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed submitted code
- [ ] I added tests to verify the changes
- [ ] All tests are passing
- [ ] I've updated the CHANGELOG

## :crystal_ball: Next steps
