### PR TITLE
ref: Use UUIDConversion in SentryCrashReport

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -217,11 +217,10 @@ addUUIDElement(const SentryCrashReportWriter *const writer, const char *const ke
         char uuidBuffer[uuidLength + 1]; // one for the null terminator
         const unsigned char *src = value;
         char *dst = uuidBuffer;
-        
+
         sentrycrashdl_convertBinaryImageUUID(src, dst);
 
-        sentrycrashjson_addStringElement(
-            getJsonContext(writer), key, uuidBuffer, uuidLength);
+        sentrycrashjson_addStringElement(getJsonContext(writer), key, uuidBuffer, uuidLength);
     }
 }
 

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -44,6 +44,7 @@
 #include "SentryCrashString.h"
 #include "SentryCrashSystemCapabilities.h"
 #include "SentryCrashThread.h"
+#include "SentryCrashUUIDConversion.h"
 
 //#define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
@@ -212,36 +213,15 @@ addUUIDElement(const SentryCrashReportWriter *const writer, const char *const ke
     if (value == NULL) {
         sentrycrashjson_addNullElement(getJsonContext(writer), key);
     } else {
-        char uuidBuffer[37];
+        int uuidLength = 36;
+        char uuidBuffer[uuidLength + 1]; // one for the null terminator
         const unsigned char *src = value;
         char *dst = uuidBuffer;
-        for (int i = 0; i < 4; i++) {
-            *dst++ = g_hexNybbles[(*src >> 4) & 15];
-            *dst++ = g_hexNybbles[(*src++) & 15];
-        }
-        *dst++ = '-';
-        for (int i = 0; i < 2; i++) {
-            *dst++ = g_hexNybbles[(*src >> 4) & 15];
-            *dst++ = g_hexNybbles[(*src++) & 15];
-        }
-        *dst++ = '-';
-        for (int i = 0; i < 2; i++) {
-            *dst++ = g_hexNybbles[(*src >> 4) & 15];
-            *dst++ = g_hexNybbles[(*src++) & 15];
-        }
-        *dst++ = '-';
-        for (int i = 0; i < 2; i++) {
-            *dst++ = g_hexNybbles[(*src >> 4) & 15];
-            *dst++ = g_hexNybbles[(*src++) & 15];
-        }
-        *dst++ = '-';
-        for (int i = 0; i < 6; i++) {
-            *dst++ = g_hexNybbles[(*src >> 4) & 15];
-            *dst++ = g_hexNybbles[(*src++) & 15];
-        }
+        
+        sentrycrashdl_convertBinaryImageUUID(src, dst);
 
         sentrycrashjson_addStringElement(
-            getJsonContext(writer), key, uuidBuffer, (int)(dst - uuidBuffer));
+            getJsonContext(writer), key, uuidBuffer, uuidLength);
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

Use sentrycrashdl_convertBinaryImageUUID in SentryCrashReport.addUUIDElemet.

## :bulb: Motivation and Context

We have the code for converting a binary image UUID twice.

## :green_heart: How did you test it?
With the emulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [ ] I added tests to verify the changes
- [x] All tests are passing
- [ ] I've updated the CHANGELOG

## :crystal_ball: Next steps
Add tests for SentryCrashReport