### PR TITLE
fix: Remove weak ref file contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Remove weak ref file contents #571
+
 ## 5.1.3
 
 - fix: UUID for SentryCrashReport is null #566

--- a/Sources/Sentry/include/SentryFileContents.h
+++ b/Sources/Sentry/include/SentryFileContents.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithPath:(NSString *)path andContents:(NSData *)contents;
 
 @property (nonatomic, readonly, copy) NSString *path;
-@property (nonatomic, readonly, weak) NSData *contents;
+@property (nonatomic, readonly, strong) NSData *contents;
 
 @end
 

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -48,7 +48,7 @@ class SentryFileManagerTests: XCTestCase {
 
         // swiftlint:disable force_cast
         // swiftlint:disable force_unwrapping
-        let actualDict = try JSONSerialization.jsonObject(with: events[0].contents! as Data) as! [String: Any]
+        let actualDict = try JSONSerialization.jsonObject(with: events[0].contents) as! [String: Any]
         // swiftlint:enable force_unwrapping
         
         let eventDict = event.serialize()
@@ -68,7 +68,7 @@ class SentryFileManagerTests: XCTestCase {
         sut.store(event)
         let events = sut.getAllStoredEventsAndEnvelopes()
         XCTAssertTrue(events.count == 1)
-        XCTAssertEqual(events[0].contents, jsonData as NSData)
+        XCTAssertEqual(events[0].contents, (jsonData as NSData) as Data)
     }
     
     func testStoreEnvelope() throws {
@@ -80,7 +80,7 @@ class SentryFileManagerTests: XCTestCase {
         let envelopes = sut.getAllEnvelopes()
         XCTAssertEqual(1, envelopes.count)
         
-        let actualData = envelopes[0].contents ?? NSData()
+        let actualData = envelopes[0].contents
         XCTAssertEqual(expectedData, actualData as Data)
     }
     


### PR DESCRIPTION
## :scroll: Description

This fixes a bug in the `SentryFileContents` object discarding `contents` (because it's weak) before we can actually use and send it. This resulted in an empty payload and therefore event being discarded.

## :bulb: Motivation and Context

## :green_heart: How did you test it?

React Native stores events to disk and sends it after restart. I notices that requests return `400` because the body we sent was empty.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
