### PR TITLE
ref: Add internal init for SentryClient for testing

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -599,6 +599,7 @@
 		7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeRateLimit.h; path = include/SentryEnvelopeRateLimit.h; sourceTree = "<group>"; };
 		7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimit.m; sourceTree = "<group>"; };
 		7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeRateLimitTests.swift; sourceTree = "<group>"; };
+		7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryClient+TestInit.h"; sourceTree = "<group>"; };
 		7B56D73024616CCD00B842DA /* SentryConcurrentRateLimitsDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryConcurrentRateLimitsDictionary.h; path = include/SentryConcurrentRateLimitsDictionary.h; sourceTree = "<group>"; };
 		7B56D73224616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryConcurrentRateLimitsDictionary.m; sourceTree = "<group>"; };
 		7B56D73424616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryConcurrentRateLimitsDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1003,6 +1004,7 @@
 				15E0A8E2240C435900F044E3 /* SentryEnvelopeTests.m */,
 				15360CF22433C59500112302 /* SentryInstallationTests.m */,
 				7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */,
+				7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */,
 				7BAF3DD6243DD4A1008A5414 /* TestConstants.swift */,
 				15D0AC872459EE4D006541C2 /* SentryNSURLRequestTests.swift */,
 				7B0002312477F0520035FEF1 /* SentrySessionTests.m */,

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -50,7 +50,6 @@ SentryClient ()
     if (self = [super init]) {
         self.options = options;
 
-        // TODO: inject dependencies to make SentryClient testable
         SentryCrashDefaultBinaryImageProvider *provider =
             [[SentryCrashDefaultBinaryImageProvider alloc] init];
 
@@ -65,6 +64,19 @@ SentryClient ()
             [[SentryThreadInspector alloc] initWithStacktraceBuilder:stacktraceBuilder
                                             andMachineContextWrapper:machineContextWrapper];
     }
+    return self;
+}
+
+/** Internal constructor for testing */
+- (instancetype)initWithOptions:(SentryOptions *)options
+                   andTransport:(id<SentryTransport>)transport
+                 andFileManager:(SentryFileManager *)fileManager
+{
+    self = [self initWithOptions:options];
+
+    self.transport = transport;
+    self.fileManager = fileManager;
+
     return self;
 }
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -1,0 +1,14 @@
+#import <Sentry/Sentry.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** Expose the internal test init for testing. */
+@interface SentryClient (TestInit)
+
+- (instancetype)initWithOptions:(SentryOptions *)options
+                   andTransport:(id<SentryTransport>)transport
+                 andFileManager:(SentryFileManager *)fileManager;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -13,9 +13,12 @@ class SentryClientTest: XCTestCase {
         transport = TestTransport()
         
         do {
-            let options = try Options(dict: ["dsn": TestConstants.dsnAsString,
-                                             "transport": transport])
-            client = Client(options: options)
+            let options = try Options(dict: [
+                "attachStacktrace": true,
+                "dsn": TestConstants.dsnAsString
+            ])
+    
+            client = Client(options: options, andTransport: transport, andFileManager: try SentryFileManager(dsn: TestConstants.dsn))
         } catch {
             XCTFail("Options could not be created")
         }
@@ -26,8 +29,7 @@ class SentryClientTest: XCTestCase {
         super.tearDown()
     }
 
-    // Skips until we expose a way to replace the transport
-    func skipped_testCaptureMessage() {
+    func testCaptureMessage() {
         let message = "message"
         client.capture(message: message, scope: nil)
         

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -4,6 +4,7 @@
 //
 
 #import "NSDate+SentryExtras.h"
+#import "SentryClient+TestInit.h"
 #import "SentryConcurrentRateLimitsDictionary.h"
 #import "SentryCrashBinaryImageProvider.h"
 #import "SentryCrashDefaultBinaryImageProvider.h"


### PR DESCRIPTION
## :scroll: Description

Add a second internal initializer for SentryClient to be able to pass in dependencies
for testing. The internal initializer is exposed via a category in the tests.

## :bulb: Motivation and Context

We want to be able to test public classes with injecting internal test dependencies.

## :green_heart: How did you test it?
Unit tests and a quick test with the emulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing

## :crystal_ball: Next steps
Add tests for `SentryClient`
