### PR TITLE
fix: SentryCrashJSON encodeObject crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## unreleased
 
-feat: Added automatic breadcrumbs for system events #559
+- fix: SentryCrashJSON encodeObject crash #576
+- feat: Added automatic breadcrumbs for system events #559
 
 ## 5.1.4
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -345,15 +345,28 @@ encodeObject(
     }
 
     if ([object isKindOfClass:[NSDictionary class]]) {
+        NSDictionary *dict = (NSDictionary *)object;
         if ((result = sentrycrashjson_beginObject(context, cName)) != SentryCrashJSON_OK) {
             return result;
         }
-        NSArray *keys = [(NSDictionary *)object allKeys];
-        if (codec->_sorted) {
+        NSArray *keys = [dict allKeys];
+
+        bool allKeysOfSameType = true;
+        for (int i = 1; i < [keys count]; i++) {
+            if ([keys[i - 1] class] != [keys[i] class]) {
+                allKeysOfSameType = false;
+            }
+        }
+
+        // We can only sort the keys if all of them are of the same type, which is not guaranteed.
+        // Sorting an array with different types can cause a crash.
+        if (codec->_sorted && allKeysOfSameType) {
             keys = [keys sortedArrayUsingSelector:@selector(compare:)];
         }
+
         for (id key in keys) {
-            if ((result = encodeObject(codec, [object valueForKey:key], key, context))
+            // It is not guaranteed that a key is NSString.
+            if ((result = encodeObject(codec, dict[key], [key description], context))
                 != SentryCrashJSON_OK) {
                 return result;
             }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -351,10 +351,10 @@ encodeObject(
         }
         NSArray *keys = [dict allKeys];
 
-        bool allKeysOfSameType = true;
+        BOOL allKeysOfSameType = YES;
         for (int i = 1; i < [keys count]; i++) {
             if ([keys[i - 1] class] != [keys[i] class]) {
-                allKeysOfSameType = false;
+                allKeysOfSameType = NO;
             }
         }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
@@ -463,6 +463,47 @@ toString(NSData *data)
     XCTAssertEqualObjects(result, original, @"");
 }
 
+- (void)testSerializeDeserializeDictionaryDifferentKeyTypes
+{
+
+    NSString *expectedJson = @"{\"One\":\"Value\",\"3.01\":true,\"2\":1000}";
+    NSDictionary *expected = @{ @"One" : @"Value", @"3.01" : @YES, @"2" : @1000 };
+    NSDictionary *original = @{ @"One" : @"Value", @3.01 : @YES, @2 : @1000 };
+
+    [self testSerializeDeserializeDictionaryWith:original
+                                     andExpected:expected
+                                 andExpectedJSON:expectedJson];
+}
+
+- (void)testSerializeDeserializeDictionaryIntKeys
+{
+    NSString *expectedJson = @"{\"1\":\"Value\",\"2\":1000,\"3\":true}";
+    NSDictionary *expected = @{ @"1" : @"Value", @"2" : @1000, @"3" : @YES };
+    NSDictionary *original = @{ @1 : @"Value", @3 : @YES, @2 : @1000 };
+
+    [self testSerializeDeserializeDictionaryWith:original
+                                     andExpected:expected
+                                 andExpectedJSON:expectedJson];
+}
+
+- (void)testSerializeDeserializeDictionaryWith:(NSDictionary *)original
+                                   andExpected:(NSDictionary *)expected
+                               andExpectedJSON:(NSString *)expectedJson
+{
+    NSError *error = (NSError *)self;
+    NSString *jsonString = toString([SentryCrashJSONCodec encode:original
+                                                         options:SentryCrashJSONEncodeOptionSorted
+                                                           error:&error]);
+    XCTAssertNotNil(jsonString);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(jsonString, expectedJson);
+
+    NSDictionary *result = [SentryCrashJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result, expected);
+}
+
 - (void)testSerializeDeserializeDictionaryWithDictionary
 {
     NSError *error = (NSError *)self;

--- a/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
@@ -463,18 +463,6 @@ toString(NSData *data)
     XCTAssertEqualObjects(result, original, @"");
 }
 
-- (void)testSerializeDeserializeDictionaryDifferentKeyTypes
-{
-
-    NSString *expectedJson = @"{\"One\":\"Value\",\"3.01\":true,\"2\":1000}";
-    NSDictionary *expected = @{ @"One" : @"Value", @"3.01" : @YES, @"2" : @1000 };
-    NSDictionary *original = @{ @"One" : @"Value", @3.01 : @YES, @2 : @1000 };
-
-    [self testSerializeDeserializeDictionaryWith:original
-                                     andExpected:expected
-                                 andExpectedJSON:expectedJson];
-}
-
 - (void)testSerializeDeserializeDictionaryIntKeys
 {
     NSString *expectedJson = @"{\"1\":\"Value\",\"2\":1000,\"3\":true}";
@@ -497,6 +485,26 @@ toString(NSData *data)
     XCTAssertNotNil(jsonString);
     XCTAssertNil(error);
     XCTAssertEqualObjects(jsonString, expectedJson);
+
+    NSDictionary *result = [SentryCrashJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result);
+    XCTAssertNil(error);
+    XCTAssertEqualObjects(result, expected);
+}
+
+- (void)testSerializeDeserializeDictionaryDifferentKeyTypes
+{
+    NSDictionary *expected = @{ @"One" : @"Value", @"3.01" : @YES, @"2" : @1000 };
+    NSDictionary *original = @{ @"One" : @"Value", @3.01 : @YES, @2 : @1000 };
+
+    NSError *error = (NSError *)self;
+    NSString *jsonString = toString([SentryCrashJSONCodec encode:original
+                                                         options:SentryCrashJSONEncodeOptionSorted
+                                                           error:&error]);
+    XCTAssertNotNil(jsonString);
+    XCTAssertNil(error);
+    // When the keys are of different types the expectedJSON is not deterministic,
+    // because the keys of dictionary can't be sorted. So we only compare the dictionaries.
 
     NSDictionary *result = [SentryCrashJSONCodec decode:toData(jsonString) options:0 error:&error];
     XCTAssertNotNil(result);


### PR DESCRIPTION
## :scroll: Description

`SentryCrashJSONCodecObjC.encodeObject` crashes when receiving a dictionary
with keys different than an `NSString`. Now `encodeObject` supports all types
of keys without crashing by converting the keys to NSString and not sorting
keys of dictionaries when they are different types.

## :bulb: Motivation and Context

We have a customer who ran into this issue, but we don't know why `SentryCrashJSONCodecObjC.encodeObject` received a dictionary with keys different than an `NSString` and this caused the SDK to crash.

## :green_heart: How did you test it?
Unit tests and smoke tests with emulators.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
