### PR TITLE
fix: Custom release name for crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Custom release name for crash reports #590
+
 ## 5.1.5
 
 - feat: Attach the stacktrace to custom events #583

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -303,6 +303,7 @@
 		7BC8523724588115005A70F0 /* SentryRateLimitCategory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BC852392458830A005A70F0 /* SentryEnvelopeItemType.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BC8523B2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */; };
+		7BD337E424A356180050DB6E /* SentryCrashIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD337E324A356180050DB6E /* SentryCrashIntegrationTests.swift */; };
 		7BD729962463E83300EA3610 /* SentryDateUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD729952463E83300EA3610 /* SentryDateUtil.h */; };
 		7BD729982463E93500EA3610 /* SentryDateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BD729972463E93500EA3610 /* SentryDateUtil.m */; };
 		7BD7299A2463EA4A00EA3610 /* SentryDateUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */; };
@@ -658,6 +659,7 @@
 		7BC8523624588115005A70F0 /* SentryRateLimitCategory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRateLimitCategory.h; path = include/SentryRateLimitCategory.h; sourceTree = "<group>"; };
 		7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeItemType.h; path = include/SentryEnvelopeItemType.h; sourceTree = "<group>"; };
 		7BC8523A2458849E005A70F0 /* SentryRateLimitCategoryMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRateLimitCategoryMapperTests.swift; sourceTree = "<group>"; };
+		7BD337E324A356180050DB6E /* SentryCrashIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCrashIntegrationTests.swift; sourceTree = "<group>"; };
 		7BD729952463E83300EA3610 /* SentryDateUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDateUtil.h; path = include/SentryDateUtil.h; sourceTree = "<group>"; };
 		7BD729972463E93500EA3610 /* SentryDateUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDateUtil.m; sourceTree = "<group>"; };
 		7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDateUtilTests.swift; sourceTree = "<group>"; };
@@ -1305,6 +1307,7 @@
 			children = (
 				7B944FAA24697EB100A10721 /* SentrySessionTrackerTests.swift */,
 				A811D866248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift */,
+				7BD337E324A356180050DB6E /* SentryCrashIntegrationTests.swift */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -1821,6 +1824,7 @@
 				63FE720520DA66EC00CDBAE8 /* FileBasedTestCase.m in Sources */,
 				63EED6C32237989300E02400 /* SentryOptionsTest.m in Sources */,
 				7BBD18B22451804C00427C76 /* SentryRetryAfterHeaderParserTests.swift in Sources */,
+				7BD337E424A356180050DB6E /* SentryCrashIntegrationTests.swift in Sources */,
 				7B56D73524616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift in Sources */,
 				7B7D8730248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift in Sources */,
 				630436131EC0A17100C4D3FA /* SentryLogTests.m in Sources */,

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -134,14 +134,14 @@ SentryCrashIntegration ()
                 NSMutableDictionary<NSString *, id> *userInfo =
                     [[NSMutableDictionary alloc] initWithDictionary:[scope serialize]];
 
-                // SentryCrashReportConverter.convertReportToEvent needs the release name of the
-                // SentryOptions in the UserInfo. When SentryCrash records a crash it writes the
-                // UserInfo into SentryCrashField_User of the report.
+                // SentryCrashReportConverter.convertReportToEvent needs the release name and the
+                // dist of the SentryOptions in the UserInfo. When SentryCrash records a crash it
+                // writes the UserInfo into SentryCrashField_User of the report.
                 // SentryCrashReportConverter.initWithReport loads the contents of
                 // SentryCrashField_User into self.userContext and convertReportToEvent can map the
-                // release name to the SentryEvent.
-                // Fixes GH-581
+                // release name and dist to the SentryEvent. Fixes GH-581
                 userInfo[@"release"] = self.options.releaseName;
+                userInfo[@"dist"] = self.options.dist;
 
                 [SentryCrash.sharedInstance setUserInfo:userInfo];
             }];

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -131,7 +131,19 @@ SentryCrashIntegration ()
             [outerScope setContextValue:appData forKey:@"app"];
 
             [outerScope addScopeListener:^(SentryScope *_Nonnull scope) {
-                [SentryCrash.sharedInstance setUserInfo:[scope serialize]];
+                NSMutableDictionary<NSString *, id> *userInfo =
+                    [[NSMutableDictionary alloc] initWithDictionary:[scope serialize]];
+
+                // SentryCrashReportConverter.convertReportToEvent needs the release name of the
+                // SentryOptions in the UserInfo. When SentryCrash records a crash it writes the
+                // UserInfo into SentryCrashField_User of the report.
+                // SentryCrashReportConverter.initWithReport loads the contents of
+                // SentryCrashField_User into self.userContext and convertReportToEvent can map the
+                // release name to the SentryEvent.
+                // Fixes GH-581
+                userInfo[@"release"] = self.options.releaseName;
+
+                [SentryCrash.sharedInstance setUserInfo:userInfo];
             }];
         }];
     }

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -70,7 +70,10 @@ SentryCrashReportConverter ()
     event.debugMeta = [self convertDebugMeta];
     event.threads = [self convertThreads];
     event.exceptions = [self convertExceptions];
-    event.releaseName = self.userContext[@"release"]; // serialized the key is just release
+
+    // The releaseName must be set on the userInfo of SentryCrash.sharedInstance
+    event.releaseName = self.userContext[@"release"];
+
     event.dist = self.userContext[@"dist"];
     event.environment = self.userContext[@"environment"];
     event.context = self.userContext[@"context"];

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+
+class SentryCrashIntegrationTests: XCTestCase {
+
+    // Test for GH-581
+    func testReleaseNamePassedToSentryCrash() {
+        
+        let releaseName = "1.0.0"
+        // The start of the SDK installs all integrations
+        SentrySDK.start(options: ["dsn": TestConstants.dsnAsString,
+                                  "release": releaseName])
+        
+        let instance = SentryCrash.sharedInstance()
+        let userInfo = (instance?.userInfo ?? ["": ""]) as Dictionary
+        if let actual = userInfo["release"] as? String {
+            XCTAssertEqual(releaseName, actual)
+        } else {
+            XCTFail("Release not passed to SentryCrash.userInfo")
+        }
+    }
+}

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -1,21 +1,29 @@
 import XCTest
 
 class SentryCrashIntegrationTests: XCTestCase {
-
+    
     // Test for GH-581
     func testReleaseNamePassedToSentryCrash() {
         
         let releaseName = "1.0.0"
+        let dist = "14G60"
         // The start of the SDK installs all integrations
         SentrySDK.start(options: ["dsn": TestConstants.dsnAsString,
-                                  "release": releaseName])
+                                  "release": releaseName,
+                                  "dist": dist]
+        )
         
         let instance = SentryCrash.sharedInstance()
         let userInfo = (instance?.userInfo ?? ["": ""]) as Dictionary
-        if let actual = userInfo["release"] as? String {
-            XCTAssertEqual(releaseName, actual)
+        assertUserInfoField(userInfo: userInfo, key: "release", expected: releaseName)
+        assertUserInfoField(userInfo: userInfo, key: "dist", expected: dist)
+    }
+    
+    private func assertUserInfoField(userInfo: Dictionary<AnyHashable, Any>, key: String, expected: String) {
+        if let actual = userInfo[key] as? String {
+            XCTAssertEqual(expected, actual)
         } else {
-            XCTFail("Release not passed to SentryCrash.userInfo")
+            XCTFail("\(key) not passed to SentryCrash.userInfo")
         }
     }
 }

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -9,6 +9,7 @@
 #import "SentryCrashBinaryImageProvider.h"
 #import "SentryCrashDefaultBinaryImageProvider.h"
 #import "SentryCrashDefaultMachineContextWrapper.h"
+#import "SentryCrashIntegration.h"
 #import "SentryCrashMachineContext.h"
 #import "SentryCrashStackEntryMapper.h"
 #import "SentryCrashUUIDConversion.h"


### PR DESCRIPTION
## :scroll: Description

Custom release names configured in SentryOptions are ignored in crash reports.
This is fixed by passing the release name of the options to the user info of
SentryCrash.

## :bulb: Motivation and Context

Fixes GH-581

## :green_heart: How did you test it?
One unit test and with the sample projects.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
