### PR TITLE
ref: All integrations implement SentryIntegrationProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## unreleased
 
-- fix: All integrations implement SentryIntegrationProtocol #602
 - fix: Deployment target warning for Swift Package Manager for Xcode 12 #586
 
 ## 5.1.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: All integrations implement SentryIntegrationProtocol #602
 - fix: Deployment target warning for Swift Package Manager for Xcode 12 #586
 
 ## 5.1.6

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,13 +1,12 @@
+#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
-
-#import "SentryAutoBreadcrumbTrackingIntegration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * This automatically adds breadcrumbs for different user actions.
  */
-@interface SentryAutoBreadcrumbTrackingIntegration : NSObject
+@interface SentryAutoBreadcrumbTrackingIntegration : NSObject <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -5,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Automatically tracks session start and end.
  */
-@interface SentryAutoSessionTrackingIntegration : NSObject
+@interface SentryAutoSessionTrackingIntegration : NSObject <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryCrashIntegration.h
+++ b/Sources/Sentry/include/SentryCrashIntegration.h
@@ -1,6 +1,5 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryIntegrationProtocol.h"
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## :scroll: Description

`SentryAutoBreadcrumbTrackingIntegration` and `SentryAutoSessionTrackingIntegration`
now implement `SentryIntegrationProtocol`.

## :bulb: Motivation and Context

`SentrySDK.installIntegrations` needs the `SentryIntegrationProtocol` in order to init the integrations.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] All tests are passing

## :crystal_ball: Next steps
