### PR TITLE
fix: Overwriting stack trace for crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Overwriting stack trace for crashes #605
 - fix: Deployment target warning for Swift Package Manager for Xcode 12 #586
 
 ## 5.1.6

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -234,9 +234,16 @@ SentryClient ()
         event.sdk = sdk;
     }
 
-    if (alwaysAttachStacktrace || [self.options.attachStacktrace boolValue] ||
-        [event.exceptions count] > 0) {
+    BOOL shouldAttachStacktrace = alwaysAttachStacktrace ||
+        [self.options.attachStacktrace boolValue] || [event.exceptions count] > 0;
+
+    BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);
+    if (shouldAttachStacktrace && debugMetaNotAttached) {
         event.debugMeta = [self.debugMetaBuilder buildDebugMeta];
+    }
+
+    BOOL threadsNotAttached = !(nil != event.threads && event.threads.count > 0);
+    if (shouldAttachStacktrace && threadsNotAttached) {
         // We don't want to add the stacktrace of attaching the stacktrace.
         // Therefore we skip three frames.
         event.threads = [self.threadInspector getCurrentThreadsSkippingFrames:3];

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -84,7 +84,8 @@ class SentryClientTest: XCTestCase {
             XCTAssertEqual(SentryLevel.info, actual.level)
             XCTAssertEqual(message, actual.message)
             
-               assertValidStacktrace(actual: actual)
+               assertValidDebugMeta(actual: actual.debugMeta)
+               assertValidThreads(actual: actual.threads)
         }
     }
     
@@ -118,11 +119,40 @@ class SentryClientTest: XCTestCase {
         fixture.getSut().capture(event: event, scope: scope)
         
         assertLastSentEvent { actual in
-            assertValidStacktrace(actual: actual)
+            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidThreads(actual: actual.threads)
         }
     }
     
-    func testCaptureEventWithStacktrace() {
+    func testCaptureEventWithDebugMeta_KeepsDebugMeta() {
+        let sut = fixture.getSut(configureOptions: { options in
+            options.attachStacktrace = true
+        })
+        
+        let event = givenEventWithDebugMeta()
+        sut.capture(event: event, scope: nil)
+        
+        assertLastSentEvent { actual in
+            XCTAssertEqual(event.debugMeta, actual.debugMeta)
+            assertValidThreads(actual: actual.threads)
+        }
+    }
+    
+    func testCaptureEventWithAttachedThreads_KeepsThreads() {
+        let sut = fixture.getSut(configureOptions: { options in
+            options.attachStacktrace = true
+        })
+        
+        let event = givenEventWithThreads()
+        sut.capture(event: event, scope: nil)
+        
+        assertLastSentEvent { actual in
+            assertValidDebugMeta(actual: actual.debugMeta)
+            XCTAssertEqual(event.threads, actual.threads)
+        }
+    }
+    
+    func testCaptureEventWithAttachStacktrace() {
         let event = Event(level: SentryLevel.fatal)
         event.message = message
         let eventId = fixture.getSut(configureOptions: { options in
@@ -133,29 +163,32 @@ class SentryClientTest: XCTestCase {
         assertLastSentEvent { actual in
             XCTAssertEqual(event.level, actual.level)
             XCTAssertEqual(event.message, actual.message)
-            assertValidStacktrace(actual: actual)
+            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidThreads(actual: actual.threads)
         }
     }
     
-    func testCaptureError() {
+    func testCaptureErrorWithoutAttachStacktrace() {
         let eventId = fixture.getSut().capture(error: error, scope: scope)
         
         XCTAssertNotNil(eventId)
         assertLastSentEvent { actual in
             XCTAssertEqual(SentryLevel.error, actual.level)
             XCTAssertEqual(error.localizedDescription, actual.message)
-               assertValidStacktrace(actual: actual)
+            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidThreads(actual: actual.threads)
         }
     }
     
-    func testCaptureException() {
+    func testCaptureExceptionWithoutAttachStacktrace() {
         let eventId = fixture.getSut().capture(exception: exception, scope: scope)
         
         XCTAssertNotNil(eventId)
         assertLastSentEvent { actual in
             XCTAssertEqual(SentryLevel.error, actual.level)
             XCTAssertEqual(exception.reason, actual.message)
-               assertValidStacktrace(actual: actual)
+            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidThreads(actual: actual.threads)
         }
     }
 
@@ -252,42 +285,62 @@ class SentryClientTest: XCTestCase {
         }
     }
     
-    func assertEventNotSent(eventId: String?) {
+    private func givenEventWithDebugMeta() -> Event {
+        let event = Event(level: SentryLevel.fatal)
+        let debugMeta = DebugMeta()
+        debugMeta.name = "Me"
+        let debugMetas = [debugMeta]
+        event.debugMeta = debugMetas
+        return event
+    }
+    
+    private func givenEventWithThreads() -> Event {
+        let event = Event(level: SentryLevel.fatal)
+        let thread = Sentry.Thread(threadId: 1)
+        thread.crashed = true
+        let threads = [thread]
+        event.threads = threads
+        return event
+    }
+    
+    private func assertEventNotSent(eventId: String?) {
         XCTAssertNil(fixture.transport.lastSentEvent)
         XCTAssertNil(eventId)
     }
 
-    func assertLastSentEvent(assert: (Event) -> Void) {
+    private func assertLastSentEvent(assert: (Event) -> Void) {
         XCTAssertNotNil(fixture.transport.lastSentEvent)
         if let lastSentEvent = fixture.transport.lastSentEvent {
             assert(lastSentEvent)
         }
     }
     
-    func assertLastSentEnvelope(assert: (SentryEnvelope) -> Void) {
+    private func assertLastSentEnvelope(assert: (SentryEnvelope) -> Void) {
         XCTAssertNotNil(fixture.transport.lastSentEnvelope)
         if let lastSentEnvelope = fixture.transport.lastSentEnvelope {
             assert(lastSentEnvelope)
         }
     }
     
-    private func assertValidStacktrace(actual: Event) {
+    private func assertValidDebugMeta(actual: [DebugMeta]?) {
         let debugMetas = fixture.debugMetaBuilder.buildDebugMeta()
         
-        XCTAssertEqual(debugMetas, actual.debugMeta ?? [])
-        
+        XCTAssertEqual(debugMetas, actual ?? [])
+    }
+    
+    private func assertValidThreads(actual: [Sentry.Thread]?) {
         // We can only compare the stacktrace up to the test method. Therefore we
         // need to skip a few frames for the expected stacktrace and also two
         // frame for the actual stacktrace.
         let expected = fixture.threadInspector.getCurrentThreadsSkippingFrames(5)
-        var actualFrames = actual.threads?[0].stacktrace?.frames ?? []
+        var actualFrames = actual?[0].stacktrace?.frames ?? []
         XCTAssertTrue(actualFrames.count > 1, "Event has no stacktrace.")
         if actualFrames.count > 1 {
             actualFrames.remove(at: actualFrames.count - 1)
             actualFrames.remove(at: actualFrames.count - 1)
-            actual.threads?[0].stacktrace?.frames = actualFrames
+            actual?[0].stacktrace?.frames = actualFrames
         }
         
-        XCTAssertEqual(expected, actual.threads)
+        XCTAssertEqual(expected, actual ?? [])
     }
 }


### PR DESCRIPTION
## :scroll: Description

SentryClient overwrote the stack trace (debug meta and threads) when sending an event that already has `debugMeta` and
`threads`. This caused stack traces of crashes logged by SentryCrash being overwritten. Now SentryClient keeps the threads and debug meta when sending an event and still attaches the stack trace for events that don't have those set when `attachStacktrace` is enabled or that contain an error or exception.

## :bulb: Motivation and Context

This issue was reported by a customer and we want to fix it.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
