### PR TITLE
fix: beforeSend callback in SentryClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- fix: beforeSend takes prepared event #608
+fix: beforeSend callback in SentryClient #608
 
 ## 5.1.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: beforeSend takes prepared event #608
+
 ## 5.1.8
 
 - fix: Cocoapods build

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -140,11 +140,11 @@ SentryClient ()
                              alwaysAttachStacktrace:alwaysAttachStacktrace];
     if (nil != preparedEvent) {
         if (nil != self.options.beforeSend) {
-            event = self.options.beforeSend(event);
+            preparedEvent = self.options.beforeSend(preparedEvent);
         }
-        if (nil != event) {
+        if (nil != preparedEvent) {
             [self.transport sendEvent:preparedEvent withCompletionHandler:nil];
-            return event.eventId;
+            return preparedEvent.eventId;
         }
     }
     return nil;

--- a/Tests/SentryTests/Networking/TestTransport.swift
+++ b/Tests/SentryTests/Networking/TestTransport.swift
@@ -3,11 +3,11 @@ import Foundation
 @objc
 public class TestTransport: NSObject, Transport {
     
-    var lastSentEvent: Event?
     var lastSentEnvelope: SentryEnvelope?
+    var sentEvents: [Event] = []
    
     public func send(event: Event, completion completionHandler: SentryRequestFinished? = nil) {
-        lastSentEvent = event
+        sentEvents.append(event)
     }
     
     public func send(envelope: SentryEnvelope, completion completionHandler: SentryRequestFinished? = nil) {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -231,6 +231,20 @@ class SentryClientTest: XCTestCase {
         assertEventNotSent(eventId: eventId)
     }
 
+    func testBeforeSendReturnsNewEvent_NewEventSent() {
+        let newEvent = Event()
+        let eventId = fixture.getSut(configureOptions: { options in
+            options.beforeSend = { _ in
+                newEvent
+            }
+        }).capture(message: message, scope: nil)
+
+        XCTAssertEqual(newEvent.eventId, eventId)
+        assertLastSentEvent { actual in
+            XCTAssertEqual(newEvent.eventId, actual.eventId)
+        }
+    }
+
     func testSdkDisabled_MessageNotSent() {
         let sut = fixture.getSutWithDisabledSdk()
         let eventId = sut.capture(message: message, scope: nil)

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -222,26 +222,45 @@ class SentryClientTest: XCTestCase {
     }
 
     func testBeforeSendReturnsNil_EventNotSent() {
-        let eventId = fixture.getSut(configureOptions: { options in
+        fixture.getSut(configureOptions: { options in
             options.beforeSend = { _ in
                 nil
             }
         }).capture(message: message, scope: nil)
 
-        assertEventNotSent(eventId: eventId)
+        assertNoEventSent()
     }
 
     func testBeforeSendReturnsNewEvent_NewEventSent() {
         let newEvent = Event()
+        let releaseName = "1.0.0"
         let eventId = fixture.getSut(configureOptions: { options in
             options.beforeSend = { _ in
                 newEvent
             }
+            options.releaseName = releaseName
         }).capture(message: message, scope: nil)
 
         XCTAssertEqual(newEvent.eventId, eventId)
         assertLastSentEvent { actual in
             XCTAssertEqual(newEvent.eventId, actual.eventId)
+            XCTAssertNil(actual.releaseName)
+        }
+    }
+    
+    func testBeforeSendModifiesEvent_ModifiedEventSent() {
+        fixture.getSut(configureOptions: { options in
+            options.beforeSend = { event in
+                event.threads = []
+                event.debugMeta = []
+                return event
+            }
+            options.attachStacktrace = true
+        }).capture(message: message, scope: nil)
+
+        assertLastSentEvent { actual in
+            XCTAssertEqual([], actual.debugMeta)
+            XCTAssertEqual([], actual.threads)
         }
     }
 
@@ -317,14 +336,20 @@ class SentryClientTest: XCTestCase {
         return event
     }
     
+    private func assertNoEventSent() {
+        XCTAssertEqual(0, fixture.transport.sentEvents.count, "No events should have been sent.")
+    }
+    
     private func assertEventNotSent(eventId: String?) {
-        XCTAssertNil(fixture.transport.lastSentEvent)
-        XCTAssertNil(eventId)
+        let eventWasSent = fixture.transport.sentEvents.contains { event in
+            event.eventId == eventId
+        }
+        XCTAssertFalse(eventWasSent)
     }
 
     private func assertLastSentEvent(assert: (Event) -> Void) {
-        XCTAssertNotNil(fixture.transport.lastSentEvent)
-        if let lastSentEvent = fixture.transport.lastSentEvent {
+        XCTAssertNotNil(fixture.transport.sentEvents.last)
+        if let lastSentEvent = fixture.transport.sentEvents.last {
             assert(lastSentEvent)
         }
     }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

When reading code to investigate #603 I noticed:

Prepared event isn't provided to the `beforeSend` callback.
Code isnt' using the reference returned by the `prepareEvent` method

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Wrote a test that fails, fixed the test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] All tests are passing
- [x] I've updated the CHANGELOG

## :crystal_ball: Next steps
