### PR TITLE
ref: Minimize header imports for Envelope and Serialization

### DIFF
--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -1,8 +1,10 @@
 #import "SentrySerialization.h"
 #import "SentryDefines.h"
+#import "SentryEnvelope.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryError.h"
 #import "SentryLog.h"
+#import "SentrySession.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryEnvelope.h
+++ b/Sources/Sentry/include/SentryEnvelope.h
@@ -1,7 +1,8 @@
 #import <Foundation/Foundation.h>
 
-#import "SentryEvent.h"
-#import "SentrySession.h"
+#import "SentryDefines.h"
+
+@class SentryEvent, SentrySession;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -1,7 +1,8 @@
 #import <Foundation/Foundation.h>
 
 #import "SentryDefines.h"
-#import "SentryEnvelope.h"
+
+@class SentrySession, SentryEnvelope;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Remove header imports in SentryEnvelope and SentrySerialization
and use class forward declaration.

