### PR TITLE
test: Extract delayNonBlocking to be reusable

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 		7B59398224AB47650003AAD2 /* SentrySessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B59398124AB47650003AAD2 /* SentrySessionTrackerTests.swift */; };
 		7B59398424AB481B0003AAD2 /* TestNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B59398324AB481B0003AAD2 /* TestNotificationCenter.swift */; };
 		7B6D98E924C6D336005502FA /* SentrySdkInfo+Equality.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D98E824C6D336005502FA /* SentrySdkInfo+Equality.m */; };
+		7B6D98ED24C703F8005502FA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D98EC24C703F8005502FA /* Async.swift */; };
 		7B7A30C624B48321005A4C6E /* SentryCrashAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */; };
 		7B7A30C824B48389005A4C6E /* SentryCrashAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */; };
 		7B7A30CD24B485FD005A4C6E /* TestSentryCrashWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A30CC24B485FD005A4C6E /* TestSentryCrashWrapper.swift */; };
@@ -625,6 +626,7 @@
 		7B59398324AB481B0003AAD2 /* TestNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNotificationCenter.swift; sourceTree = "<group>"; };
 		7B6D98E724C6D336005502FA /* SentrySdkInfo+Equality.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentrySdkInfo+Equality.h"; sourceTree = "<group>"; };
 		7B6D98E824C6D336005502FA /* SentrySdkInfo+Equality.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentrySdkInfo+Equality.m"; sourceTree = "<group>"; };
+		7B6D98EC24C703F8005502FA /* Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Async.swift; sourceTree = "<group>"; };
 		7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashAdapter.h; path = include/SentryCrashAdapter.h; sourceTree = "<group>"; };
 		7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashAdapter.m; sourceTree = "<group>"; };
 		7B7A30C924B48523005A4C6E /* SentryHub+TestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryHub+TestInit.h"; sourceTree = "<group>"; };
@@ -1435,6 +1437,7 @@
 			isa = PBXGroup;
 			children = (
 				7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */,
+				7B6D98EC24C703F8005502FA /* Async.swift */,
 			);
 			path = TestUtils;
 			sourceTree = "<group>";
@@ -1904,6 +1907,7 @@
 				7B26BBFB24C0A66D00A79CCC /* SentrySdkInfoNilTests.m in Sources */,
 				7BAF3DD7243DD4A1008A5414 /* TestConstants.swift in Sources */,
 				A811D867248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift in Sources */,
+				7B6D98ED24C703F8005502FA /* Async.swift in Sources */,
 				63FE722520DA66EC00CDBAE8 /* SentryCrashFileUtils_Tests.m in Sources */,
 				7BAF3DB5243C743E008A5414 /* SentryClientTests.swift in Sources */,
 				7BBD18A2244EE2FD00427C76 /* TestResponseFactory.swift in Sources */,

--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -113,18 +113,6 @@ class SentrySessionGeneratorTests: XCTestCase {
         autoSessionTrackingIntegration.install(with: options)
     }
     
-    private func delayNonBlocking(timeout: Double = 0.2) {
-        let group = DispatchGroup()
-        group.enter()
-        let queue = DispatchQueue(label: "delay", qos: .background, attributes: [])
-        
-        queue.asyncAfter(deadline: .now() + timeout) {
-            group.leave()
-        }
-        
-        group.wait()
-    }
-    
     private func goToForeground(forSeconds: TimeInterval = 0.2) {
         TestNotificationCenter.willEnterForeground()
         TestNotificationCenter.didBecomeActive()

--- a/Tests/SentryTests/TestUtils/Async.swift
+++ b/Tests/SentryTests/TestUtils/Async.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+func delayNonBlocking(timeout: Double = 0.2) {
+    let group = DispatchGroup()
+    group.enter()
+    let queue = DispatchQueue(label: "delay", qos: .background, attributes: [])
+    
+    queue.asyncAfter(deadline: .now() + timeout) {
+        group.leave()
+    }
+    
+    group.wait()
+}


### PR DESCRIPTION
## :scroll: Description

Move `delayNonBlocking` to an extra file so it can be reused.

## :bulb: Motivation and Context

We need this functionality in multiple tests.

## :green_heart: How did you test it?
Travis does this for me.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
