### PR TITLE
fix: Sanitize SentryEvent.sdk when serializing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Sanitize SentryEvent.sdk when serializing #642
 
 ## 5.1.10
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 		7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */; };
 		7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */; };
 		7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */; };
+		7B4C817024CF00EE0076ACE4 /* SentryEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4C816F24CF00ED0076ACE4 /* SentryEventTests.swift */; };
 		7B56D73124616CCD00B842DA /* SentryConcurrentRateLimitsDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B56D73024616CCD00B842DA /* SentryConcurrentRateLimitsDictionary.h */; };
 		7B56D73324616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B56D73224616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m */; };
 		7B56D73524616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B56D73424616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift */; };
@@ -620,6 +621,7 @@
 		7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimit.m; sourceTree = "<group>"; };
 		7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeRateLimitTests.swift; sourceTree = "<group>"; };
 		7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryClient+TestInit.h"; sourceTree = "<group>"; };
+		7B4C816F24CF00ED0076ACE4 /* SentryEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEventTests.swift; sourceTree = "<group>"; };
 		7B56D73024616CCD00B842DA /* SentryConcurrentRateLimitsDictionary.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryConcurrentRateLimitsDictionary.h; path = include/SentryConcurrentRateLimitsDictionary.h; sourceTree = "<group>"; };
 		7B56D73224616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryConcurrentRateLimitsDictionary.m; sourceTree = "<group>"; };
 		7B56D73424616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryConcurrentRateLimitsDictionaryTests.swift; sourceTree = "<group>"; };
@@ -1344,6 +1346,7 @@
 				7B26BBFA24C0A66D00A79CCC /* SentrySdkInfoNilTests.m */,
 				7B6D98E724C6D336005502FA /* SentrySdkInfo+Equality.h */,
 				7B6D98E824C6D336005502FA /* SentrySdkInfo+Equality.m */,
+				7B4C816F24CF00ED0076ACE4 /* SentryEventTests.swift */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1871,6 +1874,7 @@
 				631501BB1EE6F30B00512C5B /* SentrySwizzleTests.m in Sources */,
 				639FCF951EBC749B00778193 /* SentryRequestTests.m in Sources */,
 				15D0AC882459EE4D006541C2 /* SentryNSURLRequestTests.swift in Sources */,
+				7B4C817024CF00EE0076ACE4 /* SentryEventTests.swift in Sources */,
 				7BE3C78724472E9800A38442 /* TestRequestManager.swift in Sources */,
 				63FE722220DA66EC00CDBAE8 /* SentryCrashJSONCodec_Tests.m in Sources */,
 				7BE3C7752445C82300A38442 /* SentryCurrentDateTests.swift in Sources */,

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)addSimpleProperties:(NSMutableDictionary *)serializedData
 {
-    [serializedData setValue:self.sdk forKey:@"sdk"];
+    [serializedData setValue:[self.sdk sentry_sanitize] forKey:@"sdk"];
     [serializedData setValue:self.releaseName forKey:@"release"];
     [serializedData setValue:self.dist forKey:@"dist"];
     [serializedData setValue:self.environment forKey:@"environment"];

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+
+class SentryEventTests: XCTestCase {
+    
+    private let keyToSanitize = "sanitizeKey"
+
+    func testSerialize_Sdk() {
+        let expected = ["version": "1.0.0"]
+        
+        let event = Event()
+        event.sdk = expected
+        
+        let actual = event.serialize()["sdk"] as! [String: Any]
+        XCTAssertEqual(expected["version"], actual["version"] as? String)
+    }
+    
+    func testSerialize_SdkIsSanitized() {
+        let event = Event()
+        event.sdk = getDictToSanitize()
+        
+        let actual = event.serialize()["sdk"] as! [String: Any]
+        assertValueIsSanitized(dict: actual)
+    }
+    
+    func testSerialize_ExtraIsSanitized() {
+        let event = Event()
+        event.extra = getDictToSanitize()
+        
+        let actual = event.serialize()["extra"] as! [String: Any]
+        assertValueIsSanitized(dict: actual)
+    }
+    
+    private func getDictToSanitize() -> [String: Any] {
+        // When using a custom class as a value in the dict sentry_sanitize sets
+        // the NSObject.description of the custom class as the value.
+        return [keyToSanitize: CustomDescription()]
+    }
+    
+    private func assertValueIsSanitized(dict: [String: Any]) {
+        XCTAssertEqual(CustomDescription().description, dict[keyToSanitize] as? String)
+    }
+}
+
+/**
+ * We need to override CustomStringConvertible to be able to override NSObject.description.
+ */
+class CustomDescription: CustomStringConvertible {
+     var description: String {
+        return "sanitize"
+    }
+}


### PR DESCRIPTION
##  :scroll: Description

When serializing a SentryEvent the SDK property was not sanitized. Which can lead to
problems when serializing a SentryEvent to JSON.

## :bulb: Motivation and Context

We want proper JSON for SentryEvent.

## :green_heart: How did you test it?
Unit tests and smoke test on a simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
