### PR TITLE
ref: Remove completion handler in SentryTransport

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -123,7 +123,7 @@ SentryClient ()
             preparedEvent = self.options.beforeSend(preparedEvent);
         }
         if (nil != preparedEvent) {
-            [self.transport sendEvent:preparedEvent withCompletionHandler:nil];
+            [self.transport sendEvent:preparedEvent];
             return preparedEvent.eventId;
         }
     }
@@ -146,7 +146,7 @@ SentryClient ()
 - (NSString *_Nullable)captureEnvelope:(SentryEnvelope *)envelope
 {
     // TODO: What is about beforeSend
-    [self.transport sendEnvelope:envelope withCompletionHandler:nil];
+    [self.transport sendEnvelope:envelope];
     return envelope.header.eventId;
 }
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -125,8 +125,7 @@ SentryHttpTransport ()
                   didFailWithError:&error];
 }
 
-- (void)sendRequest:(NSURLRequest *)request
-           storedPath:(NSString *)storedPath
+- (void)sendRequest:(NSURLRequest *)request storedPath:(NSString *)storedPath
 {
     __block SentryHttpTransport *_self = self;
     [self sendRequest:request

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -43,7 +43,6 @@ SentryHttpTransport ()
 
 // TODO: needs refactoring
 - (void)sendEvent:(SentryEvent *)event
-    withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler
 {
     SentryRateLimitCategory category =
         [SentryRateLimitCategoryMapper mapEventTypeToCategory:event.type];
@@ -60,22 +59,17 @@ SentryHttpTransport ()
 
     if (nil != requestError) {
         [SentryLog logWithMessage:requestError.localizedDescription andLevel:kSentryLogLevelError];
-        if (completionHandler) {
-            completionHandler(requestError);
-        }
         return;
     }
 
     // TODO: We do multiple serializations here, we can improve this
     NSString *storedEventPath = [self.fileManager storeEvent:event];
-    [self sendRequest:request storedPath:storedEventPath completionHandler:completionHandler];
+    [self sendRequest:request storedPath:storedEventPath];
 }
 
 // TODO: needs refactoring
 - (void)sendEnvelope:(SentryEnvelope *)envelope
-    withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler
 {
-
     if (![self.options.enabled boolValue]) {
         [SentryLog logWithMessage:@"SentryClient is disabled. (options.enabled = false)"
                          andLevel:kSentryLogLevelDebug];
@@ -96,16 +90,13 @@ SentryHttpTransport ()
 
     if (nil != requestError) {
         [SentryLog logWithMessage:requestError.localizedDescription andLevel:kSentryLogLevelError];
-        if (completionHandler) {
-            completionHandler(requestError);
-        }
         return;
     }
 
     // TODO: We do multiple serializations here, we can improve this
     NSString *storedEnvelopePath = [self.fileManager storeEnvelope:envelope];
 
-    [self sendRequest:request storedPath:storedEnvelopePath completionHandler:completionHandler];
+    [self sendRequest:request storedPath:storedEnvelopePath];
 }
 
 #pragma mark private methods
@@ -136,7 +127,6 @@ SentryHttpTransport ()
 
 - (void)sendRequest:(NSURLRequest *)request
            storedPath:(NSString *)storedPath
-    completionHandler:(_Nullable SentryRequestFinished)completionHandler
 {
     __block SentryHttpTransport *_self = self;
     [self sendRequest:request
@@ -148,9 +138,6 @@ SentryHttpTransport ()
                 if (nil == error) {
                     [_self sendCachedEventsAndEnvelopes];
                 }
-            }
-            if (completionHandler) {
-                completionHandler(error);
             }
         }];
 }

--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -23,11 +23,9 @@ NS_SWIFT_NAME(Transport)
  *
  * @param event SentryEvent that should be sent
  */
-- (void)sendEvent:(SentryEvent *)event
-    NS_SWIFT_NAME(send(event:));
+- (void)sendEvent:(SentryEvent *)event NS_SWIFT_NAME(send(event:));
 
-- (void)sendEnvelope:(SentryEnvelope *)envelope
-    NS_SWIFT_NAME(send(envelope:));
+- (void)sendEnvelope:(SentryEnvelope *)envelope NS_SWIFT_NAME(send(envelope:));
 
 @end
 

--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -22,15 +22,12 @@ NS_SWIFT_NAME(Transport)
  * on next app launch.
  *
  * @param event SentryEvent that should be sent
- * @param completionHandler SentryRequestFinished
  */
 - (void)sendEvent:(SentryEvent *)event
-    withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler
-    NS_SWIFT_NAME(send(event:completion:));
+    NS_SWIFT_NAME(send(event:));
 
 - (void)sendEnvelope:(SentryEnvelope *)envelope
-    withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler
-    NS_SWIFT_NAME(send(envelope:completion:));
+    NS_SWIFT_NAME(send(envelope:));
 
 @end
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -66,8 +66,8 @@ class SentryHttpTransportTests: XCTestCase {
     
     func testSendEventOptionsDisabled() {
         options.enabled = false
-        sendEvent(callsCompletionHandler: false)
-        sendEvent(callsCompletionHandler: false)
+        sendEvent()
+        sendEvent()
         
         assertRequestsSent(requestCount: 0)
         assertEventsStored(eventCount: 0)
@@ -204,7 +204,7 @@ class SentryHttpTransportTests: XCTestCase {
         // Retry-After almost expired
         let date = currentDateProvider.date()
         currentDateProvider.setDate(date: date.addingTimeInterval(0.999))
-        sendEvent(callsCompletionHandler: false)
+        sendEvent()
         
         assertRequestsSent(requestCount: 1)
         
@@ -216,14 +216,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testSendEventWithFaultyNSUrlRequest() {
-        var completionHandlerWasCalled = false
-        sut.send(event: TestConstants.eventWithSerializationError) { (error) in
-            XCTAssertNotNil(error)
-            XCTAssertTrue(error.debugDescription.contains("SentryErrorDomain"))
-            completionHandlerWasCalled = true
-        }
-        
-        XCTAssertTrue(completionHandlerWasCalled)
+        sut.send(event: TestConstants.eventWithSerializationError)
     }
     
     func testSendOneEnvelope() {
@@ -234,7 +227,7 @@ class SentryHttpTransportTests: XCTestCase {
     
     func testEnvelopeOptionsDisabled() {
         options.enabled = false
-        sendEnvelope(callsCompletionHandler: false)
+        sendEnvelope()
         
         assertRequestsSent(requestCount: 0)
     }
@@ -243,7 +236,7 @@ class SentryHttpTransportTests: XCTestCase {
         givenRateLimitResponse(forCategory: "error")
         sendEvent()
         
-        sendEnvelope(callsCompletionHandler: false)
+        sendEnvelope()
         
         assertRequestsSent(requestCount: 1)
         assertEnvelopesStored(envelopeCount: 0)
@@ -344,27 +337,17 @@ class SentryHttpTransportTests: XCTestCase {
         }
     }
     
-    private func sendEvent(callsCompletionHandler: Bool = true) {
-        var completionHandlerWasCalled = false
-        sut.send(event: Event()) { (error) in
-            XCTAssertNil(error)
-            completionHandlerWasCalled = true
-        }
-        XCTAssertEqual(callsCompletionHandler, completionHandlerWasCalled)
+    private func sendEvent() {
+        sut.send(event: Event())
     }
     
-    private func sendEnvelope(envelope: SentryEnvelope = TestConstants.envelope, callsCompletionHandler: Bool = true) {
-        var completionHandlerWasCalled = false
-        sut.send(envelope: envelope) { (error) in
-            XCTAssertNil(error)
-            completionHandlerWasCalled = true
-        }
-        XCTAssertEqual(callsCompletionHandler, completionHandlerWasCalled)
+    private func sendEnvelope(envelope: SentryEnvelope = TestConstants.envelope) {
+        sut.send(envelope: envelope)
     }
     
     private func sendEnvelopeWithSession() {
         let envelope = SentryEnvelope(id: "id", items: [SentryEnvelopeItem(event: Event()), SentryEnvelopeItem(session: SentrySession(releaseName: "2.0.1"))])
-        sut.send(envelope: envelope, completion: nil)
+        sut.send(envelope: envelope)
     }
     
     private func assertRateLimitUpdated(response: HTTPURLResponse) {

--- a/Tests/SentryTests/Networking/TestTransport.swift
+++ b/Tests/SentryTests/Networking/TestTransport.swift
@@ -6,11 +6,11 @@ public class TestTransport: NSObject, Transport {
     var lastSentEnvelope: SentryEnvelope?
     var sentEvents: [Event] = []
    
-    public func send(event: Event, completion completionHandler: SentryRequestFinished? = nil) {
+    public func send(event: Event) {
         sentEvents.append(event)
     }
     
-    public func send(envelope: SentryEnvelope, completion completionHandler: SentryRequestFinished? = nil) {
+    public func send(envelope: SentryEnvelope) {
         lastSentEnvelope = envelope
     }
 }


### PR DESCRIPTION
## :scroll: Description

The completion handler for sending events and envelopes in SentryTransport is always nil so we can
remove it. It also simplifies things when sending cached envelopes and events first.

## :bulb: Motivation and Context

Remove complexity we don't need.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [ ] No breaking changes

## :crystal_ball: Next steps
Make SentryTransport private until we align it with the unified API or just align it with the unified API.
