### PR TITLE
fix: Don't use API blocked by AppStore

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -402,8 +402,8 @@ getDeviceAndAppHash()
                          [nsstringSysctl(@"hw.machine") dataUsingEncoding:NSUTF8StringEncoding]];
     [data appendData:(NSData * _Nonnull)
                          [nsstringSysctl(@"hw.model") dataUsingEncoding:NSUTF8StringEncoding]];
-    const char *cpuArch = getCurrentCPUArch();
-    [data appendBytes:cpuArch length:strlen(cpuArch)];
+//    const char *cpuArch = getCurrentCPUArch();
+//    [data appendBytes:cpuArch length:strlen(cpuArch)];
 
     // Append the bundle ID.
     NSData *bundleID =

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
@@ -37,8 +37,11 @@
 const char *
 sentrycrashcpu_currentArch(void)
 {
-    const NXArchInfo *archInfo = NXGetLocalArchInfo();
-    return archInfo == NULL ? NULL : archInfo->name;
+    // This is blocking App Store submissions and must be worked around
+    // TODO: Figure out a replacement
+    //    const NXArchInfo *archInfo = NXGetLocalArchInfo();
+    //    return archInfo == NULL ? NULL : archInfo->name;
+    return NULL;
 }
 
 #if SentryCrashCRASH_HAS_THREADS_API


### PR DESCRIPTION
This is blocking customers from publishing their apps and needs to be dealt with ASAP.
Resolves #635

This removes the architecture that used to be reported as:

![image](https://user-images.githubusercontent.com/1633368/88869058-cf0efe80-d1df-11ea-867a-294ce6a76c68.png)
