### PR TITLE
ref: Remove redundant nonnull for TransportFactory

### DIFF
--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -21,7 +21,7 @@ SentryTransportFactory ()
 
 @implementation SentryTransportFactory
 
-+ (id<SentryTransport> _Nonnull)initTransport:(SentryOptions *)options
++ (id<SentryTransport>)initTransport:(SentryOptions *)options
                             sentryFileManager:(SentryFileManager *)sentryFileManager
 {
     NSURLSessionConfiguration *configuration =

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -22,7 +22,7 @@ SentryTransportFactory ()
 @implementation SentryTransportFactory
 
 + (id<SentryTransport>)initTransport:(SentryOptions *)options
-                            sentryFileManager:(SentryFileManager *)sentryFileManager
+                   sentryFileManager:(SentryFileManager *)sentryFileManager
 {
     NSURLSessionConfiguration *configuration =
         [NSURLSessionConfiguration ephemeralSessionConfiguration];

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -9,7 +9,7 @@ NS_SWIFT_NAME(TransportInitializer)
 @interface SentryTransportFactory : NSObject
 
 + (id<SentryTransport>)initTransport:(SentryOptions *)options
-                            sentryFileManager:(SentryFileManager *)sentryFileManager;
+                   sentryFileManager:(SentryFileManager *)sentryFileManager;
 
 @end
 

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(TransportInitializer)
 @interface SentryTransportFactory : NSObject
 
-+ (id<SentryTransport> _Nonnull)initTransport:(SentryOptions *)options
++ (id<SentryTransport>)initTransport:(SentryOptions *)options
                             sentryFileManager:(SentryFileManager *)sentryFileManager;
 
 @end


### PR DESCRIPTION
## :scroll: Description

Simplify code in `SentryTransportFactory` by removing the `_Nonnull`, which is not needed because of `NS_ASSUME_NONNULL`.

## :bulb: Motivation and Context

Simplify the code.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
