### PR TITLE
feat: Remove deprecated SDK inits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Remove deprecated SDK inits #673
 - fix: Crash in SentryEnvelope.initWithEvent #643
 - fix: Build failure for Apple Silicon Macs #588
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -44,18 +44,6 @@ static SentryHub *currentHub;
     }
 }
 
-+ (id)initWithOptions:(NSDictionary<NSString *, id> *)optionsDict
-{
-    [SentrySDK startWithOptions:optionsDict];
-    return nil;
-}
-
-+ (id)initWithOptionsObject:(SentryOptions *)options
-{
-    [SentrySDK startWithOptionsObject:options];
-    return nil;
-}
-
 + (void)startWithOptions:(NSDictionary<NSString *, id> *)optionsDict
 {
     NSError *error = nil;

--- a/Sources/Sentry/include/SentrySDK.h
+++ b/Sources/Sentry/include/SentrySDK.h
@@ -33,20 +33,6 @@ SENTRY_NO_INIT
 + (void)setCurrentHub:(SentryHub *)hub;
 
 /**
- * Use [SentrySDK startWithOptionsObject] / SentrySDK.start(:) instead
- * @deprecated
- */
-+ (instancetype)initWithOptionsObject:(SentryOptions *)options NS_SWIFT_NAME(init(options:))
-                                          __attribute((deprecated(("Use startWithOptionsObject"))));
-
-/**
- * Use [SentrySDK startWithOptions] / SentrySDK.start(:) instead
- * @deprecated
- */
-+ (instancetype)initWithOptions:(NSDictionary<NSString *, id> *)optionsDict
-    NS_SWIFT_NAME(init(options:))__attribute((deprecated(("Use startWithOptions"))));
-
-/**
  * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations.
  */
 + (void)startWithOptions:(NSDictionary<NSString *, id> *)optionsDict NS_SWIFT_NAME(start(options:));

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -73,25 +73,6 @@ class SentrySDKTests: XCTestCase {
         XCTAssertTrue(wasBeforeSendCalled, "beforeSend was not called.")
     }
     
-    func testSetLogLevel_InitWithOptionsObject() {
-        let options = Options()
-        options.dsn = TestConstants.dsnAsString
-        options.logLevel = SentryLogLevel.debug
-        
-        SentrySDK(options: options)
-        
-        XCTAssertEqual(options.logLevel, SentrySDK.logLevel)
-    }
-    
-    func testSetLogLevel_InitWithOptionsDict() {
-        SentrySDK(options: [
-            "dsn": TestConstants.dsn,
-            "debug": true
-        ])
-        
-        XCTAssertEqual(SentryLogLevel.debug, SentrySDK.logLevel)
-    }
-    
     func testSetLogLevel_StartWithOptionsDict() {
         SentrySDK.start(options: [
             "dsn": TestConstants.dsn,

--- a/Tests/SentryTests/SentrySwiftTests.swift
+++ b/Tests/SentryTests/SentrySwiftTests.swift
@@ -9,7 +9,9 @@ class SentrySwiftTests: XCTestCase {
         let fileManager = try! SentryFileManager(dsn: SentryDsn(string: "https://username:password@app.getsentry.com/12345"), andCurrentDateProvider: TestCurrentDateProvider())
         fileManager.deleteAllStoredEventsAndEnvelopes()
         fileManager.deleteAllFolders()
-        _ = SentrySDK(options: ["dsn": "https://username:password@app.getsentry.com/12345"])
+        _ = SentrySDK.start { options in
+            options.dsn = "https://username:password@app.getsentry.com/12345"
+        }
 //        SentrySDK.init(options: ["dsn": "https://username:password@app.getsentry.com/12345"])
     }
     
@@ -83,7 +85,9 @@ class SentrySwiftTests: XCTestCase {
         let scope = Sentry.Scope()
         scope.setExtras(["ios": true])
         XCTAssertNotNil(event.serialize())
-        _ = SentrySDK(options: ["dsn": "https://username:password@app.getsentry.com/12345"])
+        _ = SentrySDK.start { options in
+            options.dsn = "https://username:password@app.getsentry.com/12345"
+        }
         print("#####################")
         print(SentrySDK.currentHub().getClient() ?? "no client")
 

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -41,7 +41,7 @@
 
 - (void)testSDKDefaultHub
 {
-    [SentrySDK initWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
+    [SentrySDK startWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
     XCTAssertNotNil([SentrySDK.currentHub getClient]);
     [SentrySDK.currentHub bindClient:nil];
     //[SentrySDK.currentHub reset];
@@ -125,7 +125,8 @@
 
 - (void)testSDKBreadCrumbAdd
 {
-    [SentrySDK initWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
+    [SentrySDK startWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
+
     // TODO(fetzig)
     //[[SentrySDK.currentHub getClient].breadcrumbs clear];
 
@@ -150,7 +151,7 @@
 
 - (void)testSDKCaptureEvent
 {
-    [SentrySDK initWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
+    [SentrySDK startWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
 
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelFatal];
 
@@ -165,7 +166,7 @@
 
 - (void)testSDKCaptureError
 {
-    [SentrySDK initWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
+    [SentrySDK startWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
 
     NSError *error =
         [NSError errorWithDomain:@"testworld"


### PR DESCRIPTION
## :scroll: Description

Both initWithOptionsObject and initWithOptions are marked as deprecated.
Those two methods are removed now from the SDK.

## :bulb: Motivation and Context

We want to get rid of deprecated code.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I've updated the CHANGELOG
- [ ] No breaking changes

## :crystal_ball: Next steps
