### PR TITLE
ref: Remove captureSessions from SentryClient

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -139,13 +139,6 @@ SentryClient ()
     [self captureEnvelope:envelope];
 }
 
-// TODO: We remove this function It is not in the header and nobody uses it
-- (void)captureSessions:(NSArray<SentrySession *> *)sessions
-{
-    SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithSessions:sessions];
-    [self captureEnvelope:envelope];
-}
-
 - (NSString *_Nullable)captureEnvelope:(SentryEnvelope *)envelope
 {
     // TODO: What is about beforeSend


### PR DESCRIPTION
## :scroll: Description

captureSessions is internal and not used. Let's remove it to reduce complexity.

## :bulb: Motivation and Context

We want to remove code that is not used.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
