### PR TITLE
feat: capture userinfo from NSError and NSException

### DIFF
--- a/Samples/macOS-Swift/macOS-Swift/ViewController.swift
+++ b/Samples/macOS-Swift/macOS-Swift/ViewController.swift
@@ -30,7 +30,8 @@ class ViewController: NSViewController {
     }
 
     @IBAction func crashOnException(_ sender: Any) {
-        let exception = NSException(name: NSExceptionName("My Custom exeption"), reason: "User clicked the button", userInfo: nil)
+        let userInfo:[String: String] = ["user-info-key-1":"user-info-value-1", "user-info-key-2": "user-info-value-2"]
+        let exception = NSException(name: NSExceptionName("My Custom exception"), reason: "User clicked the button", userInfo: userInfo)
         NSApp.perform("_crashOnException:", with: exception)
     }
     

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -96,6 +96,7 @@ SentryClient ()
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
     event.message = exception.reason;
+    [self setUserInfo:exception.userInfo withEvent: event];
     return [self sendEvent:event withScope:scope alwaysAttachStacktrace:YES];
 }
 
@@ -103,6 +104,7 @@ SentryClient ()
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
     event.message = error.localizedDescription;
+    [self setUserInfo:error.userInfo withEvent: event];
     return [self sendEvent:event withScope:scope alwaysAttachStacktrace:YES];
 }
 
@@ -251,6 +253,17 @@ SentryClient ()
         }
     }
     return newEvent;
+}
+
+- (void)setUserInfo:(NSDictionary *)userInfo
+        withEvent:(SentryEvent *)event
+{
+    if (nil != event && nil != userInfo && userInfo.count > 0) {
+        if (nil == event.context) {
+            event.context = [[NSMutableDictionary alloc] init];
+        }
+        [event.context setValue:userInfo forKey:@"user info"];
+    }
 }
 
 @end


### PR DESCRIPTION
Sentry is currently not capturing the `userInfo` map of either `NSError` or `NSException`.

This PR adds the data into a new context key called `user info`:
Sample triggers it:

![image](https://user-images.githubusercontent.com/1633368/90693956-becdca80-e245-11ea-85ce-779e32c9702a.png)

