### PR TITLE
feat: Implement NSCopying for SentrySession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Implement NSCopying for SentrySession #683
 - fix: Crash when SentryClient is nil in SentryHub #681
 - feat: Send cached envelopes first #676
 - feat: Use envelopes for sending events #650

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -238,8 +238,8 @@
 		71F116E8F40D530BB68A2987 /* SentryCrashUUIDConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 71F11CDEF5952DF5CC69AC74 /* SentryCrashUUIDConversion.h */; };
 		7B0002322477F0520035FEF1 /* SentrySessionTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B0002312477F0520035FEF1 /* SentrySessionTests.m */; };
 		7B0002342477F52D0035FEF1 /* SentrySessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B0002332477F52D0035FEF1 /* SentrySessionTests.swift */; };
-		7B04A9AF24EAC02C00E710B1 /* SentryRetryAfterHeaderParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBD189C244EC71A00427C76 /* SentryRetryAfterHeaderParser.h */; };
 		7B04A9AB24EA5F8D00E710B1 /* SentryUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B04A9AA24EA5F8D00E710B1 /* SentryUserTests.swift */; };
+		7B04A9AF24EAC02C00E710B1 /* SentryRetryAfterHeaderParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBD189C244EC71A00427C76 /* SentryRetryAfterHeaderParser.h */; };
 		7B05A61824A4D14A00EF211D /* SentrySessionGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B05A61724A4D14A00EF211D /* SentrySessionGeneratorTests.swift */; };
 		7B14089624878F090035403D /* SentryCrashStackEntryMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B14089524878F090035403D /* SentryCrashStackEntryMapper.h */; };
 		7B14089824878F950035403D /* SentryCrashStackEntryMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B14089724878F950035403D /* SentryCrashStackEntryMapper.m */; };
@@ -300,6 +300,8 @@
 		7BAF3DD4243DD40F008A5414 /* SentryTransportFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DD3243DD40F008A5414 /* SentryTransportFactory.h */; };
 		7BAF3DD7243DD4A1008A5414 /* TestConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DD6243DD4A1008A5414 /* TestConstants.swift */; };
 		7BAF3DD92440AEC8008A5414 /* SentryRequestManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DD82440AEC8008A5414 /* SentryRequestManager.h */; };
+		7BB42EF124F3B7B700D7B39A /* SentrySession+Equality.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BB42EF024F3B7B700D7B39A /* SentrySession+Equality.m */; };
+		7BB42EF424F3BA5600D7B39A /* SentryUser+Equality.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BB42EF324F3BA5600D7B39A /* SentryUser+Equality.m */; };
 		7BBD1889244841EC00427C76 /* SentryHttpDateParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */; };
 		7BBD188B244841FB00427C76 /* SentryHttpDateParser.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */; };
 		7BBD188D2448453600427C76 /* SentryHttpDateParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */; };
@@ -681,6 +683,10 @@
 		7BAF3DD3243DD40F008A5414 /* SentryTransportFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTransportFactory.h; path = include/SentryTransportFactory.h; sourceTree = "<group>"; };
 		7BAF3DD6243DD4A1008A5414 /* TestConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConstants.swift; sourceTree = "<group>"; };
 		7BAF3DD82440AEC8008A5414 /* SentryRequestManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryRequestManager.h; path = include/SentryRequestManager.h; sourceTree = "<group>"; };
+		7BB42EEF24F3B7B700D7B39A /* SentrySession+Equality.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentrySession+Equality.h"; sourceTree = "<group>"; };
+		7BB42EF024F3B7B700D7B39A /* SentrySession+Equality.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentrySession+Equality.m"; sourceTree = "<group>"; };
+		7BB42EF224F3BA5600D7B39A /* SentryUser+Equality.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryUser+Equality.h"; sourceTree = "<group>"; };
+		7BB42EF324F3BA5600D7B39A /* SentryUser+Equality.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentryUser+Equality.m"; sourceTree = "<group>"; };
 		7BBD1888244841EC00427C76 /* SentryHttpDateParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryHttpDateParser.h; path = include/SentryHttpDateParser.h; sourceTree = "<group>"; };
 		7BBD188A244841FB00427C76 /* SentryHttpDateParser.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryHttpDateParser.m; sourceTree = "<group>"; };
 		7BBD188C2448453600427C76 /* SentryHttpDateParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHttpDateParserTests.swift; sourceTree = "<group>"; };
@@ -1360,6 +1366,10 @@
 				7B6D98E824C6D336005502FA /* SentrySdkInfo+Equality.m */,
 				7B82D54824E2A2D400EE670F /* SentryIdTests.swift */,
 				7B04A9AA24EA5F8D00E710B1 /* SentryUserTests.swift */,
+				7BB42EEF24F3B7B700D7B39A /* SentrySession+Equality.h */,
+				7BB42EF024F3B7B700D7B39A /* SentrySession+Equality.m */,
+				7BB42EF224F3BA5600D7B39A /* SentryUser+Equality.h */,
+				7BB42EF324F3BA5600D7B39A /* SentryUser+Equality.m */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1903,6 +1913,7 @@
 				7BAF3DC8243DB90E008A5414 /* TestTransport.swift in Sources */,
 				63FE721920DA66EC00CDBAE8 /* SentryCrashReportStore_Tests.m in Sources */,
 				7B6D98EB24C6E84F005502FA /* SentryCrashInstallationReporterTests.swift in Sources */,
+				7BB42EF124F3B7B700D7B39A /* SentrySession+Equality.m in Sources */,
 				63717D63226746A000C37CAE /* SentryUnsignedLongLongValueTest.m in Sources */,
 				63FE722320DA66EC00CDBAE8 /* SentryCrashMonitor_Deadlock_Tests.m in Sources */,
 				63FE721F20DA66EC00CDBAE8 /* SentryCrashSignalInfo_Tests.m in Sources */,
@@ -1957,6 +1968,7 @@
 				63FE71FF20DA66EC00CDBAE8 /* SentryCrashReportConverter_Tests.m in Sources */,
 				15E0A8F0240F638200F044E3 /* SentrySerializationNilTests.m in Sources */,
 				63FE722120DA66EC00CDBAE8 /* SentryCrashDynamicLinker_Tests.m in Sources */,
+				7BB42EF424F3BA5600D7B39A /* SentryUser+Equality.m in Sources */,
 				63FE720120DA66EC00CDBAE8 /* RFC3339UTFString_Tests.m in Sources */,
 				63AA76701EB8CB4B00D153DE /* SentryTests.m in Sources */,
 				7BBD188F2448469A00427C76 /* HttpDateFormatter.swift in Sources */,

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -186,6 +186,28 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    SentrySession *copy = [[[self class] allocWithZone:zone] init];
+
+    if (copy != nil) {
+        copy->_sessionId = _sessionId;
+        copy->_started = _started;
+        copy->_status = _status;
+        copy->_errors = _errors;
+        copy->_sequence = _sequence;
+        copy->_distinctId = _distinctId;
+        copy->_timestamp = _timestamp;
+        copy->_duration = _duration;
+        copy->_releaseName = _releaseName;
+        copy.environment = self.environment;
+        copy.user = self.user;
+        copy->_init = _init;
+    }
+
+    return copy;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySession.h
+++ b/Sources/Sentry/include/SentrySession.h
@@ -11,7 +11,7 @@ typedef NS_ENUM(NSUInteger, SentrySessionStatus) {
     kSentrySessionStatusAbnormal = 3,
 };
 
-@interface SentrySession : NSObject
+@interface SentrySession : NSObject <NSCopying>
 SENTRY_NO_INIT
 
 - (instancetype)initWithReleaseName:(NSString *)releaseName;

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.h
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.h
@@ -1,0 +1,15 @@
+#import "SentrySession.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentrySession (Equality)
+
+- (BOOL)isEqual:(id)object;
+
+- (BOOL)isEqualToSession:(SentrySession *)session;
+
+- (NSUInteger)hash;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.m
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.m
@@ -1,0 +1,71 @@
+#import "SentrySession+Equality.h"
+#import "SentryUser.h"
+
+@implementation SentrySession (Equality)
+
+- (BOOL)isEqual:(id)other
+{
+    if (other == self)
+        return YES;
+    if (!other || ![[other class] isEqual:[self class]])
+        return NO;
+
+    return [self isEqualToSession:other];
+}
+
+- (BOOL)isEqualToSession:(SentrySession *)session
+{
+    if (self == session)
+        return YES;
+    if (session == nil)
+        return NO;
+    if (self.sessionId != session.sessionId && ![self.sessionId isEqual:session.sessionId])
+        return NO;
+    if (self.started != session.started && ![self.started isEqualToDate:session.started])
+        return NO;
+    if (self.status != session.status)
+        return NO;
+    if (self.errors != session.errors)
+        return NO;
+    if (self.sequence != session.sequence)
+        return NO;
+    if (self.distinctId != session.distinctId
+        && ![self.distinctId isEqualToString:session.distinctId])
+        return NO;
+    if (self.timestamp != session.timestamp && ![self.timestamp isEqualToDate:session.timestamp])
+        return NO;
+    if (self.duration != session.duration && ![self.duration isEqualToNumber:session.duration])
+        return NO;
+    if (self.releaseName != session.releaseName
+        && ![self.releaseName isEqualToString:session.releaseName])
+        return NO;
+    if (self.environment != session.environment
+        && ![self.environment isEqualToString:session.environment])
+        return NO;
+    if (self.user != session.user && ![self.user isEqual:session.user])
+        return NO;
+    if (self.flagInit != session.flagInit && ![self.flagInit isEqualToNumber:session.flagInit])
+        return NO;
+    return YES;
+}
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = 17;
+
+    hash = hash * 23 + [self.sessionId hash];
+    hash = hash * 23 + [self.started hash];
+    hash = hash * 23 + self.status;
+    hash = hash * 23 + self.errors;
+    hash = hash * 23 + self.sequence;
+    hash = hash * 23 + [self.distinctId hash];
+    hash = hash * 23 + [self.flagInit hash];
+    hash = hash * 23 + [self.timestamp hash];
+    hash = hash * 23 + [self.releaseName hash];
+    hash = hash * 23 + [self.environment hash];
+    hash = hash * 23 + [self.user hash];
+
+    return hash;
+}
+
+@end

--- a/Tests/SentryTests/Protocol/SentryUser+Equality.h
+++ b/Tests/SentryTests/Protocol/SentryUser+Equality.h
@@ -1,0 +1,16 @@
+
+#import "SentryUser.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryUser (Equality)
+
+- (BOOL)isEqual:(id)other;
+
+- (BOOL)isEqualToUser:(SentryUser *)user;
+
+- (NSUInteger)hash;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Protocol/SentryUser+Equality.m
+++ b/Tests/SentryTests/Protocol/SentryUser+Equality.m
@@ -1,0 +1,47 @@
+#import "SentryUser+Equality.h"
+
+@implementation SentryUser (Equality)
+
+- (BOOL)isEqual:(id)other
+{
+    if (other == self)
+        return YES;
+    if (!other || ![[other class] isEqual:[self class]])
+        return NO;
+
+    return [self isEqualToUser:other];
+}
+
+- (BOOL)isEqualToUser:(SentryUser *)user
+{
+    if (self == user)
+        return YES;
+    if (user == nil)
+        return NO;
+    if (self.userId != user.userId && ![self.userId isEqualToString:user.userId])
+        return NO;
+    if (self.email != user.email && ![self.email isEqualToString:user.email])
+        return NO;
+    if (self.username != user.username && ![self.username isEqualToString:user.username])
+        return NO;
+    if (self.ipAddress != user.ipAddress && ![self.ipAddress isEqualToString:user.ipAddress])
+        return NO;
+    if (self.data != user.data && ![self.data isEqualToDictionary:user.data])
+        return NO;
+    return YES;
+}
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = 17;
+
+    hash = hash * 23 + [self.userId hash];
+    hash = hash * 23 + [self.email hash];
+    hash = hash * 23 + [self.username hash];
+    hash = hash * 23 + [self.ipAddress hash];
+    hash = hash * 23 + [self.data hash];
+
+    return hash;
+}
+
+@end

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -35,14 +35,17 @@ class SentrySessionTestsSwift: XCTestCase {
     }
     
     func testCopySession() {
+        let user = User()
+        user.email = "someone@sentry.io"
+        
         let session = SentrySession(releaseName: "1.0.0")
+        session.user = user
         let copiedSession = session.copy() as! SentrySession
         
         XCTAssertEqual(session, copiedSession)
         
-        let user = User()
-        user.email = "someone@sentry.io"
-        session.user = user
+        // The user is copied as well
+        session.user?.email = "someone_else@sentry.io"
         XCTAssertNotEqual(session, copiedSession)
     }
 }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -33,4 +33,16 @@ class SentrySessionTestsSwift: XCTestCase {
         let duration = sessionSerialized["duration"] as? Double ?? -1
         XCTAssertEqual(2, duration)
     }
+    
+    func testCopySession() {
+        let session = SentrySession(releaseName: "1.0.0")
+        let copiedSession = session.copy() as! SentrySession
+        
+        XCTAssertEqual(session, copiedSession)
+        
+        let user = User()
+        user.email = "someone@sentry.io"
+        session.user = user
+        XCTAssertNotEqual(session, copiedSession)
+    }
 }


### PR DESCRIPTION
## :scroll: Description

We want to be able to copy the SentrySession so we can pass a copy from the SentryHub
to the SentryClient and don't have to keep a lock so the same reference doesn't get modified
when sending it.

## :bulb: Motivation and Context

See description.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
