### PR TITLE
fix: Rate limiting for cached envelope items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Rate limiting for cached envelope items #685
 - fix: Crash when SentryClient is nil in SentryHub #681
 - feat: Send cached envelopes first #676
 - feat: Use envelopes for sending events #650

--- a/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/4487886E-B920-4AB1-99BD-1A9C5128C731.plist
+++ b/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/4487886E-B920-4AB1-99BD-1A9C5128C731.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.015</real>
+					<real>0.016</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -92,7 +92,7 @@ SentryHttpTransport ()
         }
 
         NSError *requestError = nil;
-        NSURLRequest *request = [self createEnvelopeRequest:fileContents.contents
+        NSURLRequest *request = [self createEnvelopeRequest:rateLimitedEnvelope
                                            didFailWithError:requestError];
 
         if (nil != requestError) {
@@ -106,12 +106,13 @@ SentryHttpTransport ()
     }
 }
 
-- (NSURLRequest *)createEnvelopeRequest:(NSData *)envelopeData
+- (NSURLRequest *)createEnvelopeRequest:(SentryEnvelope *)envelope
                        didFailWithError:(NSError *_Nullable)error
 {
-    return [[SentryNSURLRequest alloc] initEnvelopeRequestWithDsn:self.options.parsedDsn
-                                                          andData:envelopeData
-                                                 didFailWithError:&error];
+    return [[SentryNSURLRequest alloc]
+        initEnvelopeRequestWithDsn:self.options.parsedDsn
+                           andData:[SentrySerialization dataWithEnvelope:envelope error:&error]
+                  didFailWithError:&error];
 }
 
 - (void)sendCached:(NSURLRequest *)request withFilePath:(NSString *)filePath

--- a/Sources/Sentry/include/SentrySession.h
+++ b/Sources/Sentry/include/SentrySession.h
@@ -1,4 +1,6 @@
-#import "SentryEvent.h"
+#import "SentryDefines.h"
+
+@class SentryUser;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## :scroll: Description

When a SentryEnvelope contains multiple items and a rate limit is active for not all items
the SentryEnvelope gets send even with the rate-limited items. This is fixed now. The
downside is that we have to serialize the SentryEnvelope once more.

## :bulb: Motivation and Context
We want that rate-limiting also applies to cached envelope items.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
