### PR TITLE
feat: Add crashedLastRun to SentrySDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- feat: Add crashedLastRun to SentrySDK #688
+
 ## 5.2.1
 
 - fix: Add IP address to user serialization #665

--- a/Samples/macOS-Swift/macOS-Swift/ViewController.swift
+++ b/Samples/macOS-Swift/macOS-Swift/ViewController.swift
@@ -30,7 +30,7 @@ class ViewController: NSViewController {
     }
 
     @IBAction func crashOnException(_ sender: Any) {
-        let userInfo:[String: String] = ["user-info-key-1":"user-info-value-1", "user-info-key-2": "user-info-value-2"]
+        let userInfo: [String: String] = ["user-info-key-1": "user-info-value-1", "user-info-key-2": "user-info-value-2"]
         let exception = NSException(name: NSExceptionName("My Custom exception"), reason: "User clicked the button", userInfo: userInfo)
         NSApp.perform("_crashOnException:", with: exception)
     }

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -2,6 +2,7 @@
 #import "SentryBreadcrumb.h"
 #import "SentryBreadcrumbTracker.h"
 #import "SentryClient.h"
+#import "SentryCrash.h"
 #import "SentryDefines.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
@@ -201,6 +202,11 @@ static SentryHub *currentHub;
     *p = 0;
 }
 #endif
+
++ (BOOL)crashedLastRun
+{
+    return SentryCrash.sharedInstance.crashedLastLaunch;
+}
 
 /**
  * Install integrations and keeps ref in `SentryHub.integrations`

--- a/Sources/Sentry/include/SentrySDK.h
+++ b/Sources/Sentry/include/SentrySDK.h
@@ -136,6 +136,11 @@ SENTRY_NO_INIT
 @property (nonatomic, class) SentryLogLevel logLevel;
 
 /**
+ * Checks if the last program execution terminated with a crash.
+ */
+@property (nonatomic, class, readonly) BOOL crashedLastRun;
+
+/**
  * Set global user -> thus will be sent with every event
  */
 + (void)setUser:(SentryUser *_Nullable)user;

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -5,7 +5,7 @@ class SentryUserTests: XCTestCase {
     private class Fixture {
         
         let date: Date
-        let user : User
+        let user: User
         
         init() {
             date = Date(timeIntervalSince1970: 10)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -122,6 +122,10 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(logLevel, SentrySDK.logLevel)
     }
     
+    func testCrashedLastRun() {
+        XCTAssertEqual(SentryCrash.sharedInstance().crashedLastLaunch, SentrySDK.crashedLastRun) 
+    }
+    
     private func assertIntegrationsInstalled(integrations: [String]) {
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {


### PR DESCRIPTION
## :scroll: Description

Add a property crashedLastRun to SentrySDK to check if the last program execution terminated
with a crash.

## :bulb: Motivation and Context

A customer nicely asked for this feature and we already had a similar feature in [4.x.x](https://github.com/getsentry/sentry-cocoa/blob/4.5.0/Sources/Sentry/include/SentryClient.h#L238).

## :green_heart: How did you test it?
Unit tests and with a simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
