### PR TITLE
feat: Enable auto session tracking per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Enable auto session tracking per default #689
 - fix: Rate limiting for cached envelope items #685
 - feat: Errors and sessions in the same envelope #686
 - feat: Implement NSCopying for SentrySession #683

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -17,7 +17,6 @@ AppDelegate ()
         options.dsn = @"https://8ee5199a90354faf995292b15c196d48@o19635.ingest.sentry.io/4394";
         options.debug = @YES;
         options.logLevel = kSentryLogLevelVerbose;
-        options.enableAutoSessionTracking = @YES;
         options.attachStacktrace = @YES;
         options.sessionTrackingIntervalMillis = [@5000 unsignedIntegerValue];
     }];

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.enableAutoSessionTracking = true
             options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }

--- a/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
+++ b/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
@@ -10,7 +10,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             options.dsn = "https://8ee5199a90354faf995292b15c196d48@o19635.ingest.sentry.io/4394"
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.enableAutoSessionTracking = true
             options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }

--- a/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
+++ b/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.dsn = "https://8ee5199a90354faf995292b15c196d48@o19635.ingest.sentry.io/4394"
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.enableAutoSessionTracking = true
             options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }

--- a/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ExtensionDelegate.swift
+++ b/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ExtensionDelegate.swift
@@ -13,7 +13,6 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
             }
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.enableAutoSessionTracking = true
             options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -25,7 +25,7 @@
         self.maxBreadcrumbs = defaultMaxBreadcrumbs;
         self.integrations = SentryOptions.defaultIntegrations;
         self.sampleRate = @1;
-        self.enableAutoSessionTracking = @NO;
+        self.enableAutoSessionTracking = @YES;
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
         self.attachStacktrace = @NO;
 

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -96,7 +96,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, copy) NSNumber *_Nullable sampleRate;
 
 /**
- * Whether to enable automatic session tracking.
+ * Whether to enable automatic session tracking or not. Default is @YES.
  */
 @property (nonatomic, copy) NSNumber *enableAutoSessionTracking;
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -250,7 +250,7 @@
 {
     SentryOptions *options = [self getValidOptions:@{}];
 
-    XCTAssertEqual(@NO, options.enableAutoSessionTracking);
+    XCTAssertEqual(@YES, options.enableAutoSessionTracking);
 }
 
 - (void)testSessionTrackingIntervalMillis
@@ -299,7 +299,7 @@
     XCTAssertTrue([[SentryOptions defaultIntegrations] isEqualToArray:options.integrations],
         @"Default integrations are not set correctly");
     XCTAssertEqual(@1, options.sampleRate);
-    XCTAssertEqual(@NO, options.enableAutoSessionTracking);
+    XCTAssertEqual(@YES, options.enableAutoSessionTracking);
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
     XCTAssertEqual(@NO, options.attachStacktrace);
 }


### PR DESCRIPTION
## :scroll: Description

The default value of enableAutoSessionTracking of SentryOptions is now @YES.

## :bulb: Motivation and Context

We want our customers to use this nice feature per default.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [ ] No breaking changes

## :crystal_ball: Next steps
