### PR TITLE
Use strcmp instead of == operator to compare threadName with literal

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -253,7 +253,7 @@ handleExceptions(void *const userData)
 
     const char *threadName = (const char *)userData;
     pthread_setname_np(threadName);
-    if (threadName == kThreadSecondary) {
+    if (strcmp(threadName, kThreadSecondary) == 0) {
         SentryCrashLOG_DEBUG("This is the secondary thread. Suspending.");
         thread_suspend((thread_t)sentrycrashthread_self());
         eventID = g_secondaryEventID;


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

I replaced a usage of the `==` equality operator with `strcmp()`.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes the Xcode 12 (beta 6) compiler warning `Result of comparison against a string literal is unspecified (use an explicit string comparison function instead)`.

## :green_heart: How did you test it?

I built it and I ran the tests via `make test`. I did both of this against Xcode 11.6 as well as Xcode 12 (beta 6).

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [ ] I added tests to verify the changes
- [ ] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps