### PR TITLE
fix: Remove redundant sdk options enable check in SentryHttpTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Remove redundant sdk options enable check in SentryHttpTransport #698
+
 ## 5.2.2
 
 - feat: Add crashedLastRun to SentrySDK #688

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -75,13 +75,6 @@ SentryHttpTransport ()
 - (void)sendEnvelope:(SentryEnvelope *)envelope
     withCompletionHandler:(_Nullable SentryRequestFinished)completionHandler
 {
-
-    if (![self.options.enabled boolValue]) {
-        [SentryLog logWithMessage:@"SentryClient is disabled. (options.enabled = false)"
-                         andLevel:kSentryLogLevelDebug];
-        return;
-    }
-
     envelope = [self.envelopeRateLimit removeRateLimitedItems:envelope];
 
     if (envelope.items.count == 0) {
@@ -172,16 +165,10 @@ SentryHttpTransport ()
 /**
  * validation for `sendEvent:...`
  *
- * @return BOOL NO if options.enabled = false or rate limit exceeded
+ * @return BOOL NO if rate limit exceeded
  */
 - (BOOL)isReadyToSend:(SentryRateLimitCategory)category
 {
-    if (![self.options.enabled boolValue]) {
-        [SentryLog logWithMessage:@"SentryClient is disabled. (options.enabled = false)"
-                         andLevel:kSentryLogLevelDebug];
-        return NO;
-    }
-
     return ![self.rateLimits isRateLimitActive:category];
 }
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -64,15 +64,6 @@ class SentryHttpTransportTests: XCTestCase {
         assertEventsStored(eventCount: 0)
     }
     
-    func testSendEventOptionsDisabled() {
-        options.enabled = false
-        sendEvent(callsCompletionHandler: false)
-        sendEvent(callsCompletionHandler: false)
-        
-        assertRequestsSent(requestCount: 0)
-        assertEventsStored(eventCount: 0)
-    }
-    
     func testSendEventWhenSessionRateLimitActive() {
         rateLimits.update(TestResponseFactory.createRateLimitResponse(headerValue: "1:\(SentryEnvelopeItemTypeSession):key"))
         
@@ -230,13 +221,6 @@ class SentryHttpTransportTests: XCTestCase {
         sendEnvelope()
         
         assertRequestsSent(requestCount: 1)
-    }
-    
-    func testEnvelopeOptionsDisabled() {
-        options.enabled = false
-        sendEnvelope(callsCompletionHandler: false)
-        
-        assertRequestsSent(requestCount: 0)
     }
     
     func testActiveRateLimitForAllEnvelopeItems() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -123,6 +123,30 @@ class SentryClientTest: XCTestCase {
             assertValidThreads(actual: actual.threads)
         }
     }
+
+    func testCaptureEventOptionsDisabled() {
+        let event = Event()
+
+        let eventId = fixture.getSut(configureOptions: { options in
+            options.enabled = false
+        }).capture(event: event, scope: nil)
+        
+        XCTAssertNil(eventId)
+    }
+
+    func testCaptureEventOptionsReEnabled() {
+        let event = Event()
+
+        let sut = fixture.getSut(configureOptions: { options in
+            options.enabled = false
+        })
+        
+        sut.options.enabled = true
+        
+        let eventId = sut.capture(event: event, scope: nil)
+        
+        XCTAssertNotNil(eventId)
+    }
     
     func testCaptureEventWithDebugMeta_KeepsDebugMeta() {
         let sut = fixture.getSut(configureOptions: { options in


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

These checks are actually redundant as `options.enabled` is already checked by the client in `prepareEvent`.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Customer is disabling the SDK by setting `enabled`.
https://app.asana.com/0/1142928854421177/1189984760680431/f

## :green_heart: How did you test it?

Removed enabled test cases for the transport, and added test cases to check that disabling or disabling then re-enabling the sdk in the options correctly ignores and captures the event respectively.

Tested on sample app.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
