### PR TITLE
feat: Add isEnabled property to SentrySDK (#697)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Add isEnabled property to SentrySDK #697
 - fix: Remove redundant sdk options enable check in SentryHttpTransport #698
 
 ## 5.2.2

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -14,6 +14,7 @@ SentryHub ()
 @property (nonatomic, strong) SentryClient *_Nullable client;
 @property (nonatomic, strong) SentryScope *_Nullable scope;
 @property (nonatomic, strong) SentryCrashAdapter *sentryCrashWrapper;
+@property (nonatomic, strong) NSNumber *isEnabled;
 
 @end
 
@@ -27,6 +28,7 @@ SentryHub ()
                       andScope:(SentryScope *_Nullable)scope
 {
     if (self = [super init]) {
+        self.isEnabled = @NO;
         [self bindClient:client];
         self.scope = scope;
         _sessionLock = [[NSObject alloc] init];
@@ -256,6 +258,7 @@ SentryHub ()
 - (void)bindClient:(SentryClient *_Nullable)client
 {
     self.client = client;
+    self.isEnabled = client != nil ? @YES : @NO;
 }
 
 - (void)configureScope:(void (^)(SentryScope *scope))callback

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -207,6 +207,16 @@ static SentryHub *currentHub;
 {
     return SentryCrash.sharedInstance.crashedLastLaunch;
 }
+ 
++ (BOOL)isEnabled
+{
+    @synchronized(self) {
+        if (currentHub == nil) {
+            return NO;
+        }
+        return currentHub.isEnabled.boolValue;
+    }
+}
 
 /**
  * Install integrations and keeps ref in `SentryHub.integrations`

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -207,7 +207,7 @@ static SentryHub *currentHub;
 {
     return SentryCrash.sharedInstance.crashedLastLaunch;
 }
- 
+
 + (BOOL)isEnabled
 {
     @synchronized(self) {

--- a/Sources/Sentry/include/SentryHub.h
+++ b/Sources/Sentry/include/SentryHub.h
@@ -15,6 +15,7 @@ SENTRY_NO_INIT
 // Since there's no scope stack, single hub instance, experimenting with holding
 // session here.
 @property (nonatomic, readonly, strong) SentrySession *_Nullable session;
+@property (nonatomic, readonly, strong) NSNumber *isEnabled;
 
 - (void)startSession;
 - (void)endSessionWithTimestamp:(NSDate *)timestamp;

--- a/Sources/Sentry/include/SentrySDK.h
+++ b/Sources/Sentry/include/SentrySDK.h
@@ -141,6 +141,11 @@ SENTRY_NO_INIT
 @property (nonatomic, class, readonly) BOOL crashedLastRun;
 
 /**
+ * Checks if the SentrySDK was enabled or not.
+ */
+@property (nonatomic, class, readonly) BOOL isEnabled;
+
+/**
  * Set global user -> thus will be sent with every event
  */
 + (void)setUser:(SentryUser *_Nullable)user;

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -11,6 +11,8 @@ class SentrySDKTests: XCTestCase {
         }) as? SentryAutoSessionTrackingIntegration {
             autoSessionTracking.stop()
         }
+        
+        SentrySDK.setCurrentHub(.init(client: nil, andScope: nil))
     }
     
     func testStartWithConfigureOptions() {
@@ -124,6 +126,17 @@ class SentrySDKTests: XCTestCase {
     
     func testCrashedLastRun() {
         XCTAssertEqual(SentryCrash.sharedInstance().crashedLastLaunch, SentrySDK.crashedLastRun) 
+    }
+    
+    func testSentrySdkIsEnabled_BeforeStart() {
+        XCTAssertFalse(SentrySDK.isEnabled)
+    }
+    
+    func testSentrySdkIsEnabled_AfterStart() {
+        SentrySDK.start { options in
+            options.dsn = TestConstants.dsnAsString
+        }
+        XCTAssertTrue(SentrySDK.isEnabled)
     }
     
     private func assertIntegrationsInstalled(integrations: [String]) {


### PR DESCRIPTION
## :scroll: Description

There is no a convenient way for check was the sentry started on client or not, 
it could be achieved in 4.4.x via Client.shared != nil

I've just added a property `Bool isEnabled` to SDK and Hub.

## :bulb: Motivation and Context

From comment of @bruno-garcia: 

> That's fair and would be a good addition.
> 
> On Android we have isEnabled:
> https://github.com/getsentry/sentry-android/blob/282d224739ee6536e7517821aab92f3587bed783/sentry-core/src/main/java/io/sentry/core/Sentry.java#L52

## :green_heart: How did you test it?

Unit tests/AppDelegate

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed submitted code
- [x] I added tests to verify the changes
- [x] I've updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps