### PR TITLE
test: Remove empty methods in SentryScopeTests

### DIFF
--- a/Tests/SentryTests/SentryScopeTests.m
+++ b/Tests/SentryTests/SentryScopeTests.m
@@ -10,18 +10,6 @@
 
 @implementation SentryScopeTests
 
-- (void)setUp
-{
-    // Put setup code here. This method is called before the invocation of each
-    // test method in the class.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here. This method is called after the invocation of
-    // each test method in the class.
-}
-
 - (SentryBreadcrumb *)getBreadcrumb
 {
     return [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug category:@"http"];


### PR DESCRIPTION
## :scroll: Description

Remove setUp and tearDown which are empty.

## :bulb: Motivation and Context

Remove empty methods.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
