### PR TITLE
ref: Remove Sentry prefixes in SentryHttpTransport

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -30,16 +30,16 @@ SentryHttpTransport ()
 @implementation SentryHttpTransport
 
 - (id)initWithOptions:(SentryOptions *)options
-          sentryFileManager:(SentryFileManager *)sentryFileManager
-       sentryRequestManager:(id<SentryRequestManager>)sentryRequestManager
-           sentryRateLimits:(id<SentryRateLimits>)sentryRateLimits
-    sentryEnvelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit
+          fileManager:(SentryFileManager *)fileManager
+       requestManager:(id<SentryRequestManager>)requestManager
+           rateLimits:(id<SentryRateLimits>)rateLimits
+    envelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit
 {
     if (self = [super init]) {
         self.options = options;
-        self.requestManager = sentryRequestManager;
-        self.fileManager = sentryFileManager;
-        self.rateLimits = sentryRateLimits;
+        self.requestManager = requestManager;
+        self.fileManager = fileManager;
+        self.rateLimits = rateLimits;
         self.envelopeRateLimit = envelopeRateLimit;
         _isSending = NO;
 

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -42,10 +42,10 @@ SentryTransportFactory ()
         [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
 
     return [[SentryHttpTransport alloc] initWithOptions:options
-                                      fileManager:sentryFileManager
-                                   requestManager:requestManager
-                                       rateLimits:rateLimits
-                                envelopeRateLimit:envelopeRateLimit];
+                                            fileManager:sentryFileManager
+                                         requestManager:requestManager
+                                             rateLimits:rateLimits
+                                      envelopeRateLimit:envelopeRateLimit];
 }
 
 @end

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -42,10 +42,10 @@ SentryTransportFactory ()
         [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
 
     return [[SentryHttpTransport alloc] initWithOptions:options
-                                      sentryFileManager:sentryFileManager
-                                   sentryRequestManager:requestManager
-                                       sentryRateLimits:rateLimits
-                                sentryEnvelopeRateLimit:envelopeRateLimit];
+                                      fileManager:sentryFileManager
+                                   requestManager:requestManager
+                                       rateLimits:rateLimits
+                                envelopeRateLimit:envelopeRateLimit];
 }
 
 @end

--- a/Sources/Sentry/include/SentryHttpTransport.h
+++ b/Sources/Sentry/include/SentryHttpTransport.h
@@ -13,10 +13,10 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 - (id)initWithOptions:(SentryOptions *)options
-          sentryFileManager:(SentryFileManager *)sentryFileManager
-       sentryRequestManager:(id<SentryRequestManager>)sentryRequestManager
-           sentryRateLimits:(id<SentryRateLimits>)sentryRateLimits
-    sentryEnvelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit;
+          fileManager:(SentryFileManager *)fileManager
+       requestManager:(id<SentryRequestManager>)requestManager
+           rateLimits:(id<SentryRateLimits>)rateLimits
+    envelopeRateLimit:(SentryEnvelopeRateLimit *)envelopeRateLimit;
 
 @end
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -50,10 +50,10 @@ class SentryHttpTransportTests: XCTestCase {
             get {
                 return SentryHttpTransport(
                     options: options,
-                    sentryFileManager: fileManager,
-                    sentryRequestManager: requestManager,
-                    sentryRateLimits: rateLimits,
-                    sentryEnvelopeRateLimit: EnvelopeRateLimit(rateLimits: rateLimits)
+                    fileManager: fileManager,
+                    requestManager: requestManager,
+                    rateLimits: rateLimits,
+                    envelopeRateLimit: EnvelopeRateLimit(rateLimits: rateLimits)
                 )
             }
         }


### PR DESCRIPTION
## :scroll: Description

Remove sentry prefixes for constructor of SentryHttpTransport.

## :bulb: Motivation and Context

We don't need those prefixes as they are just noise.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
