### PR TITLE
feat: Replace NSNumber with BOOL in SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Replace NSNumber with BOOL in SentryOptions #719 !Breaking
 - feat: Migrate session init for stored envelopes #693
 - fix: Remove redundant sdk options enable check in SentryHttpTransport #698
 

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -15,9 +15,9 @@ AppDelegate ()
 
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"https://387714a4f3654858a6f0ff63fd551485@o447951.ingest.sentry.io/5428557";
-        options.debug = @YES;
+        options.debug = YES;
         options.logLevel = kSentryLogLevelVerbose;
-        options.attachStacktrace = @YES;
+        options.attachStacktrace = YES;
         options.sessionTrackingIntervalMillis = [@5000 unsignedIntegerValue];
     }];
 

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -18,7 +18,7 @@ SentryAutoSessionTrackingIntegration ()
 
 - (void)installWithOptions:(nonnull SentryOptions *)options
 {
-    if ([options.enableAutoSessionTracking isEqual:@YES]) {
+    if (options.enableAutoSessionTracking) {
         id<SentryCurrentDateProvider> currentDateProvider =
             [[SentryDefaultCurrentDateProvider alloc] init];
         SentrySessionTracker *tracker =

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -204,7 +204,7 @@ SentryClient ()
 {
     NSParameterAssert(event);
 
-    if (NO == [self.options.enabled boolValue]) {
+    if (!self.options.enabled) {
         [SentryLog logWithMessage:@"SDK is disabled, will not do anything"
                          andLevel:kSentryLogLevelDebug];
         return nil;
@@ -249,8 +249,7 @@ SentryClient ()
         event.sdk = sdk;
     }
 
-    BOOL shouldAttachStacktrace = alwaysAttachStacktrace ||
-        [self.options.attachStacktrace boolValue]
+    BOOL shouldAttachStacktrace = alwaysAttachStacktrace || self.options.attachStacktrace
         || (nil != event.exceptions && [event.exceptions count] > 0);
 
     BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -17,17 +17,17 @@
 - (instancetype)init
 {
     if (self = [super init]) {
-        self.enabled = @NO;
+        self.enabled = NO;
 
         self.logLevel = kSentryLogLevelError;
 
-        self.debug = @NO;
+        self.debug = NO;
         self.maxBreadcrumbs = defaultMaxBreadcrumbs;
         self.integrations = SentryOptions.defaultIntegrations;
         self.sampleRate = @1;
-        self.enableAutoSessionTracking = @YES;
+        self.enableAutoSessionTracking = YES;
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
-        self.attachStacktrace = @NO;
+        self.attachStacktrace = NO;
 
         // Set default release name
         NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
@@ -62,9 +62,9 @@
 
     if (nil == error) {
         _dsn = dsn;
-        self.enabled = @YES;
+        self.enabled = YES;
     } else {
-        self.enabled = @NO;
+        self.enabled = NO;
         NSString *errorMessage = [NSString stringWithFormat:@"Could not parse the DSN: %@", error];
         [SentryLog logWithMessage:errorMessage andLevel:kSentryLogLevelError];
     }
@@ -78,10 +78,10 @@
        didFailWithError:(NSError *_Nullable *_Nullable)error
 {
     if (nil != options[@"debug"]) {
-        self.debug = @([options[@"debug"] boolValue]);
+        self.debug = [options[@"debug"] boolValue];
     }
 
-    if ([self.debug isEqual:@YES]) {
+    if (self.debug) {
         // In other SDKs there's debug=true + diagnosticLevel where we can
         // control how chatty the SDK is. Ideally we'd support all the levels
         // here, and perhaps name it `diagnosticLevel` to align more.
@@ -94,7 +94,7 @@
 
     if (nil == [options valueForKey:@"dsn"]
         || ![[options valueForKey:@"dsn"] isKindOfClass:[NSString class]]) {
-        self.enabled = @NO;
+        self.enabled = NO;
         [SentryLog logWithMessage:@"DSN is empty, will disable the SDK"
                          andLevel:kSentryLogLevelDebug];
         return;
@@ -103,7 +103,7 @@
     self.parsedDsn = [[SentryDsn alloc] initWithString:[options valueForKey:@"dsn"]
                                       didFailWithError:error];
     if (nil != error && nil != *error) {
-        self.enabled = @NO;
+        self.enabled = NO;
     }
 
     if ([options[@"release"] isKindOfClass:[NSString class]]) {
@@ -119,9 +119,9 @@
     }
 
     if (nil != options[@"enabled"]) {
-        self.enabled = @([options[@"enabled"] boolValue]);
+        self.enabled = [options[@"enabled"] boolValue];
     } else {
-        self.enabled = @YES;
+        self.enabled = YES;
     }
 
     if (nil != options[@"maxBreadcrumbs"]) {
@@ -146,7 +146,7 @@
     }
 
     if (nil != options[@"enableAutoSessionTracking"]) {
-        self.enableAutoSessionTracking = @([options[@"enableAutoSessionTracking"] boolValue]);
+        self.enableAutoSessionTracking = [options[@"enableAutoSessionTracking"] boolValue];
     }
 
     if (nil != options[@"sessionTrackingIntervalMillis"]) {
@@ -155,7 +155,7 @@
     }
 
     if (nil != options[@"attachStacktrace"]) {
-        self.attachStacktrace = @([options[@"attachStacktrace"] boolValue]);
+        self.attachStacktrace = [options[@"attachStacktrace"] boolValue];
     }
 }
 

--- a/Sources/Sentry/include/SentryOptions.h
+++ b/Sources/Sentry/include/SentryOptions.h
@@ -27,14 +27,14 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, strong) SentryDsn *_Nullable parsedDsn;
 
 /**
- * debug [mode] sets a more verbose log level. Default is @NO. If set to @YES
+ * debug [mode] sets a more verbose log level. Default is NO. If set to YES
  * sentry prints more log messages to the console.
  */
-@property (nonatomic, copy) NSNumber *debug;
+@property (nonatomic, assign) BOOL debug;
 
 /**
- DEPRECATED: use debug bool instead (debug = @YES maps to logLevel
- kSentryLogLevelError, debug = @NO maps to loglevel kSentryLogLevelError). thus
+ DEPRECATED: use debug bool instead (debug = YES maps to logLevel
+ kSentryLogLevelError, debug = NO maps to loglevel kSentryLogLevelError). thus
  kSentryLogLevelNone and kSentryLogLevelDebug will be dropped entirely. defines
  the log level of sentry log (console output).
  */
@@ -56,10 +56,10 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, copy) NSString *_Nullable environment;
 
 /**
- * Is the client enabled?. Default is @YES, if set @NO sending of events will be
+ * Is the client enabled?. Default is YES, if set NO sending of events will be
  * prevented.
  */
-@property (nonatomic, copy) NSNumber *enabled;
+@property (nonatomic, assign) BOOL enabled;
 
 /**
  * How many breadcrumbs do you want to keep in memory?
@@ -96,9 +96,9 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, copy) NSNumber *_Nullable sampleRate;
 
 /**
- * Whether to enable automatic session tracking or not. Default is @YES.
+ * Whether to enable automatic session tracking or not. Default is YES.
  */
-@property (nonatomic, copy) NSNumber *enableAutoSessionTracking;
+@property (nonatomic, assign) BOOL enableAutoSessionTracking;
 
 /**
  * The interval to end a session if the App goes to the background.
@@ -112,7 +112,7 @@ NS_SWIFT_NAME(Options)
  *
  * This feature is disabled by default.
  */
-@property (nonatomic, copy) NSNumber *attachStacktrace;
+@property (nonatomic, assign) BOOL attachStacktrace;
 
 @end
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -30,8 +30,8 @@
 - (void)assertDisabled:(SentryOptions *)options andError:(NSError *)error
 {
     XCTAssertNil(options.parsedDsn);
-    XCTAssertEqual(@NO, options.enabled);
-    XCTAssertEqual(@NO, options.debug);
+    XCTAssertEqual(NO, options.enabled);
+    XCTAssertEqual(NO, options.debug);
     XCTAssertNil(error);
 }
 
@@ -95,18 +95,20 @@
 
 - (void)testValidDebug
 {
-    [self testDebugWith:@YES expected:@YES expectedLogLevel:kSentryLogLevelDebug];
-    [self testDebugWith:@"YES" expected:@YES expectedLogLevel:kSentryLogLevelDebug];
+    [self testDebugWith:@YES expected:YES expectedLogLevel:kSentryLogLevelDebug];
+    [self testDebugWith:@"YES" expected:YES expectedLogLevel:kSentryLogLevelDebug];
+    [self testDebugWith:@(YES) expected:YES expectedLogLevel:kSentryLogLevelDebug];
 }
 
 - (void)testInvalidDebug
 {
-    [self testDebugWith:@"Invalid" expected:@NO expectedLogLevel:kSentryLogLevelError];
-    [self testDebugWith:@NO expected:@NO expectedLogLevel:kSentryLogLevelError];
+    [self testDebugWith:@"Invalid" expected:NO expectedLogLevel:kSentryLogLevelError];
+    [self testDebugWith:@NO expected:NO expectedLogLevel:kSentryLogLevelError];
+    [self testDebugWith:@(NO) expected:NO expectedLogLevel:kSentryLogLevelError];
 }
 
 - (void)testDebugWith:(NSObject *)debugValue
-             expected:(NSNumber *)expectedDebugValue
+             expected:(BOOL)expectedDebugValue
      expectedLogLevel:(SentryLogLevel)expectedLogLevel
 {
     NSError *error = nil;
@@ -125,22 +127,24 @@
                            didFailWithError:&error];
 
     XCTAssertNil(error);
-    XCTAssertEqual(@YES, options.debug);
+    XCTAssertEqual(YES, options.debug);
 }
 
 - (void)testValidEnabled
 {
-    [self testEnabledWith:@YES expected:@YES];
-    [self testEnabledWith:@"YES" expected:@YES];
+    [self testEnabledWith:@YES expected:YES];
+    [self testEnabledWith:@"YES" expected:YES];
+    [self testEnabledWith:@(YES) expected:YES];
 }
 
 - (void)testInvalidEnabled
 {
-    [self testEnabledWith:@"Invalid" expected:@NO];
-    [self testEnabledWith:@NO expected:@NO];
+    [self testEnabledWith:@"Invalid" expected:NO];
+    [self testEnabledWith:@NO expected:NO];
+    [self testEnabledWith:@(NO) expected:NO];
 }
 
-- (void)testEnabledWith:(NSObject *)enabledValue expected:(NSNumber *)expectedValue
+- (void)testEnabledWith:(NSObject *)enabledValue expected:(BOOL)expectedValue
 {
     SentryOptions *options = [self getValidOptions:@{ @"enabled" : enabledValue }];
 
@@ -243,14 +247,14 @@
 {
     SentryOptions *options = [self getValidOptions:@{ @"enableAutoSessionTracking" : @YES }];
 
-    XCTAssertEqual(@YES, options.enableAutoSessionTracking);
+    XCTAssertEqual(YES, options.enableAutoSessionTracking);
 }
 
 - (void)testDefaultEnableAutoSessionTracking
 {
     SentryOptions *options = [self getValidOptions:@{}];
 
-    XCTAssertEqual(@YES, options.enableAutoSessionTracking);
+    XCTAssertEqual(YES, options.enableAutoSessionTracking);
 }
 
 - (void)testSessionTrackingIntervalMillis
@@ -272,36 +276,36 @@
 - (void)testAttachStackTraceDisabledPerDefault
 {
     SentryOptions *options = [self getValidOptions:@{}];
-    XCTAssertEqual(@NO, options.attachStacktrace);
+    XCTAssertEqual(NO, options.attachStacktrace);
 }
 
 - (void)testAttachStackTraceEnabled
 {
     SentryOptions *options = [self getValidOptions:@{ @"attachStacktrace" : @YES }];
-    XCTAssertEqual(@YES, options.attachStacktrace);
+    XCTAssertEqual(YES, options.attachStacktrace);
 }
 
 - (void)testInvalidAttachStackTrace
 {
     SentryOptions *options = [self getValidOptions:@{ @"attachStacktrace" : @"Invalid" }];
-    XCTAssertEqual(@NO, options.attachStacktrace);
+    XCTAssertEqual(NO, options.attachStacktrace);
 }
 
 - (void)testEmptyConstructorSetsDefaultValues
 {
     SentryOptions *options = [[SentryOptions alloc] init];
 
-    XCTAssertEqual(@NO, options.enabled);
-    XCTAssertEqual(@NO, options.debug);
+    XCTAssertEqual(NO, options.enabled);
+    XCTAssertEqual(NO, options.debug);
     XCTAssertEqual(kSentryLogLevelError, options.logLevel);
     XCTAssertNil(options.parsedDsn);
     XCTAssertEqual(defaultMaxBreadcrumbs, options.maxBreadcrumbs);
     XCTAssertTrue([[SentryOptions defaultIntegrations] isEqualToArray:options.integrations],
         @"Default integrations are not set correctly");
     XCTAssertEqual(@1, options.sampleRate);
-    XCTAssertEqual(@YES, options.enableAutoSessionTracking);
+    XCTAssertEqual(YES, options.enableAutoSessionTracking);
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
-    XCTAssertEqual(@NO, options.attachStacktrace);
+    XCTAssertEqual(NO, options.attachStacktrace);
 }
 
 - (void)testSetValidDsn
@@ -314,7 +318,7 @@
 
     XCTAssertEqual(dsnAsString, options.dsn);
     XCTAssertTrue([dsn.url.absoluteString isEqualToString:options.parsedDsn.url.absoluteString]);
-    XCTAssertEqual(@YES, options.enabled);
+    XCTAssertEqual(YES, options.enabled);
 }
 
 - (void)testSetNilDsn
@@ -322,7 +326,7 @@
     SentryOptions *options = [[SentryOptions alloc] init];
 
     [options setDsn:nil];
-    XCTAssertEqual(@NO, options.enabled);
+    XCTAssertEqual(NO, options.enabled);
     XCTAssertNil(options.dsn);
     XCTAssertNil(options.parsedDsn);
 }
@@ -334,7 +338,7 @@
     [options setDsn:@"https://username:passwordsentry.io/1"];
     XCTAssertNil(options.dsn);
     XCTAssertNil(options.parsedDsn);
-    XCTAssertEqual(@NO, options.enabled);
+    XCTAssertEqual(NO, options.enabled);
 }
 
 - (SentryOptions *)getValidOptions:(NSDictionary<NSString *, id> *)dict


### PR DESCRIPTION
## :scroll: Description

Use BOOL for debug, enabled, enableAutoSessionTracking and attachStacktrace in SentryOptions
instead of NSNumber.

## :bulb: Motivation and Context

A BOOL for storing booleans is more straightforward.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [ ] No breaking changes

## :crystal_ball: Next steps
