### PR TITLE
fix: Header Imports for the Swift Package Manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Header Imports #721
 - fix: Async storing of envelope to disk #714
 - feat: Replace NSNumber with BOOL in SentryOptions #719 !Breaking
 - feat: Migrate session init for stored envelopes #693

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- fix: Header Imports #721
+- fix: Header Imports for the Swift Package Manager #721
 - fix: Async storing of envelope to disk #714
 - feat: Replace NSNumber with BOOL in SentryOptions #719 !Breaking
 - feat: Migrate session init for stored envelopes #693

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -1,4 +1,7 @@
-#import <Sentry/Sentry.h>
+#import <Foundation/Foundation.h>
+#import "SentryClient.h"
+
+@class SentryId;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -1,5 +1,5 @@
-#import <Foundation/Foundation.h>
 #import "SentryClient.h"
+#import <Foundation/Foundation.h>
 
 @class SentryId;
 

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -1,4 +1,5 @@
-#import <Sentry/Sentry.h>
+#import <Foundation/Foundation.h>
+#import "SentrySession.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -1,5 +1,5 @@
-#import <Foundation/Foundation.h>
 #import "SentrySession.h"
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
## :scroll: Description

The imports for SentryClient+Private.h and SentrySession+Private.h were broken.
Therefore the SDK couldn't be imported via the Swift Package Manager. This is
fixed now.

## :bulb: Motivation and Context

We want to be able to add the SDK via the Swift Package Manager.

## :green_heart: How did you test it?
Adding the SDK via the Swift Package Manager in a sample project with Xcode.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
