### PR TITLE
ci: Fix VersionBump script

### DIFF
--- a/Utils/VersionBump/Package.swift
+++ b/Utils/VersionBump/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -7,8 +7,10 @@ let package = Package(
         .executable(name: "VersionBump", targets: ["VersionBump"])
     ],
     dependencies: [
-        .package(url: "https://github.com/kareman/SwiftShell.git", from: "4.1.2"),
-        .package(url: "https://github.com/sharplet/Regex.git", from: "2.0.0")
+        // We need to use the 5.1.0-beta.1, because otherwise we can't compile with Swift 5.3
+        // see https://github.com/kareman/SwiftShell/releases/tag/5.1.0-beta.1
+        .package(url: "https://github.com/kareman/SwiftShell.git", from: "5.1.0-beta.1"),
+        .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## :scroll: Description

Compiling the VersionBump script which is called from craft ended with an error since
Swift 5.3 which comes with Xcode 12. This is fixed by updating some dependencies.

## :bulb: Motivation and Context

We want to be able to use VersionBump to be able to release the SDK.

## :green_heart: How did you test it?
By calling `swift build` in `Utils/VersionBump`.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
