### PR TITLE
test: Use TestConstant.dsn for FileManager

### DIFF
--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -41,7 +41,7 @@ class SentrySessionTrackerTests: XCTestCase {
         
         fixture = Fixture()
         
-        fileManager = try! SentryFileManager(dsn: SentryDsn(), andCurrentDateProvider: TestCurrentDateProvider())
+        fileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
         fileManager.deleteCurrentSession()
         fileManager.deleteTimestampLastInForeground()
         

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 class TestClient: Client {
-    var sentryFileManager: SentryFileManager = try! SentryFileManager(dsn: SentryDsn(), andCurrentDateProvider: TestCurrentDateProvider())
+    var sentryFileManager: SentryFileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
     override func fileManager() -> SentryFileManager {
         sentryFileManager
     }


### PR DESCRIPTION

## :scroll: Description

Use TestConstants.dsn in TestClient to use the same folder in SentryFileManager.

## :bulb: Motivation and Context

We want SentryFileManager to use the same folder for all tests.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
