### PR TITLE
fix: Set environment for Sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Setting environment for Sessions #734
+
 ## 6.0.0-beta.1
 
 This release also enables by default the option `attackStacktrace` which includes

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -64,6 +64,12 @@ SentryHub ()
             lastSession = _session;
         }
         _session = [[SentrySession alloc] initWithReleaseName:options.releaseName];
+
+        NSString *environment = options.environment;
+        if (nil != environment) {
+            _session.environment = environment;
+        }
+
         [scope applyToSession:_session];
 
         [self storeCurrentSession:_session];

--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -15,6 +15,7 @@ class SentrySessionTrackerTests: XCTestCase {
             options.dsn = TestConstants.dsnAsString
             options.releaseName = "SentrySessionTrackerIntegrationTests"
             options.sessionTrackingIntervalMillis = 10_000
+            options.environment = "debug"
             
             client = TestClient(options: options)
             
@@ -442,7 +443,7 @@ class SentrySessionTrackerTests: XCTestCase {
     private func assertSessionFields(session: SentrySession) {
         XCTAssertNotNil(session.sessionId)
         XCTAssertNotNil(session.distinctId)
-        XCTAssertNil(session.environment)
+        XCTAssertEqual(fixture.options.environment, session.environment)
         XCTAssertNil(session.user)
     }
     
@@ -487,6 +488,7 @@ class SentrySessionTrackerTests: XCTestCase {
         // SentryCrashIntegration stores the crashed session to the disk. We emulate
         // the result here.
         let crashedSession = SentrySession(releaseName: "1.0.0")
+        crashedSession.environment = fixture.options.environment
         advanceTime(bySeconds: 5)
         crashedSession.endCrashed(withTimestamp: fixture.currentDateProvider.date())
         fileManager.storeCrashedSession(crashedSession)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -20,6 +20,7 @@ class SentryHubTests: XCTestCase {
             options = Options()
             options.dsn = TestConstants.dsnAsString
             options.enableAutoSessionTracking = true
+            options.environment = "debug"
             
             scope.add(crumb)
             
@@ -32,6 +33,7 @@ class SentryHubTests: XCTestCase {
             
             crashedSession = SentrySession(releaseName: "1.0.0")
             crashedSession.endCrashed(withTimestamp: currentDateProvider.date())
+            crashedSession.environment = options.environment
         }
         
         func getSut(withMaxBreadcrumbs maxBreadcrumbs: UInt = 100) -> SentryHub {
@@ -462,6 +464,7 @@ class SentryHubTests: XCTestCase {
         let session = argument?.second
         XCTAssertEqual(fixture.currentDateProvider.date(), session?.timestamp)
         XCTAssertEqual(SentrySessionStatus.crashed, session?.status)
+        XCTAssertEqual(fixture.options.environment, session?.environment)
 
         XCTAssertEqual(fixture.scope, argument?.third)
     }


### PR DESCRIPTION
## :scroll: Description

The environment set via the SentryOptions is now set on SentrySessions.

## :bulb: Motivation and Context

We want the environment also on sessions.

## :green_heart: How did you test it?
Unit tests and SentrySessionGeneratorTests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] No breaking changes

## :crystal_ball: Next steps
