### PR TITLE
feat: Use error domain and code for event message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Use error domain and code for event message #750
 - feat: Replace passing nullable Scope with overloads #743 !Breaking
 - feat: Remove SDK frames when attaching stacktrace #739
 - fix: captureException crates a event type=error #746

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -45,7 +45,7 @@ ViewController ()
 - (IBAction)captureError:(id)sender
 {
     NSError *error =
-        [[NSError alloc] initWithDomain:@""
+        [[NSError alloc] initWithDomain:@"SampleErrorDomain"
                                    code:0
                                userInfo:@{ NSLocalizedDescriptionKey : @"Object does not exist" }];
     [SentrySDK captureError:error

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -35,7 +35,8 @@ class ViewController: UIViewController {
     }
     
     @IBAction func captureError(_ sender: Any) {
-        let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+        let error = NSError(domain: "SampleErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+
         SentrySDK.capture(error: error) { (scope) in
             // Changes in here will only be captured for this event
             // The scope in this callback is a clone of the current scope

--- a/Samples/tvOS-Swift/tvOS-Swift/ContentView.swift
+++ b/Samples/tvOS-Swift/tvOS-Swift/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     }
     
     var captureErrorAction: () -> Void = {
-        let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+        let error = NSError(domain: "SampleErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
         SentrySDK.capture(error: error) { (scope) in
             scope.setTag(value: "value", key: "myTag")
         }

--- a/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ContentView.swift
+++ b/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ContentView.swift
@@ -14,7 +14,7 @@ struct ContentView: View {
     }
     
     var captureErrorAction: () -> Void = {
-        let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+        let error = NSError(domain: "SampleErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
         SentrySDK.capture(error: error) { (scope) in
             scope.setTag(value: "value", key: "myTag")
         }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -159,7 +159,7 @@ SentryClient ()
 - (SentryEvent *)buildErrorEvent:(NSError *)error
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
-    event.message = error.localizedDescription;
+    event.message = [NSString stringWithFormat:@"%@ %ld", error.domain, (long)error.code];
     [self setUserInfo:error.userInfo withEvent:event];
     return event;
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -213,6 +213,16 @@ class SentryClientTest: XCTestCase {
         }
     }
     
+    func testCaptureErrorWithEnum() {
+        let eventId = fixture.getSut().capture(error: TestError.invalidTest)
+        
+        eventId.assertIsNotEmpty()
+        let error = TestError.invalidTest as NSError
+        assertLastSentEvent { actual in
+            XCTAssertEqual("\(error.domain) \(error.code)", actual.message)
+        }
+    }
+    
     func testCaptureErrorWithSession() {
         let eventId = fixture.getSut().captureError(error, with: fixture.session, with: Scope())
         
@@ -553,5 +563,11 @@ class SentryClientTest: XCTestCase {
         XCTAssertNil(fixture.transport.lastSentEnvelope)
         XCTAssertEqual(0, fixture.transport.sentEventsWithSession.count)
         XCTAssertEqual(0, fixture.transport.sentEvents.count)
+    }
+    
+    private enum TestError : Error {
+        case invalidTest
+        case testIsFailing
+        case somethingElse
     }
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -60,7 +60,7 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    private let error = NSError(domain: "domain", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+    private let error = NSError(domain: "domain", code: -20, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
 
     private let exception = NSException(name: NSExceptionName("My Custom exception"), reason: "User clicked the button", userInfo: nil)
 
@@ -495,7 +495,7 @@ class SentryClientTest: XCTestCase {
     
     private func assertValidErrorEvent(_ event: Event) {
         XCTAssertEqual(SentryLevel.error, event.level)
-        XCTAssertEqual(error.localizedDescription, event.message)
+        XCTAssertEqual("\(error.domain) \(error.code)", event.message)
         assertValidDebugMeta(actual: event.debugMeta)
         assertValidThreads(actual: event.threads)
     }


### PR DESCRIPTION
## :scroll: Description

When capturing an NSError combine the error message of the error.domain and error.code.
The error.localizedDescription is still set in the context of the event as user info. Issues with the
message coming from the domain and code might not be grouped to existing issues which messages
stem from the error.localizedDescription although there origin is the same. For new issues this
is not going to have a big impact on grouping as it is based upon stack trace, exception, and
message.

PR for updating docs: https://github.com/getsentry/sentry-docs/pull/2395

## :bulb: Motivation and Context

The localizedDescription can be in any language and might be confusing for our users when they don't speak this specific language. The domain and code are way more descriptive when an error happened.

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
