### PR TITLE
fix: Make public isEqual _Nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Make public isEqual _Nullable #751
 - feat: Replace passing nullable Scope with overloads #743 !Breaking
 - feat: Remove SDK frames when attaching stacktrace #739
 - fix: captureException crates a event type=error #746

--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -52,7 +52,7 @@ NS_SWIFT_NAME(Breadcrumb)
 
 - (NSDictionary<NSString *, id> *)serialize;
 
-- (BOOL)isEqual:(id)other;
+- (BOOL)isEqual:(id _Nullable)other;
 
 - (BOOL)isEqualToBreadcrumb:(SentryBreadcrumb *)breadcrumb;
 

--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -110,7 +110,7 @@ NS_SWIFT_NAME(Scope)
  */
 - (void)clear;
 
-- (BOOL)isEqual:(id)other;
+- (BOOL)isEqual:(id _Nullable)other;
 
 - (BOOL)isEqualToScope:(SentryScope *)scope;
 

--- a/Sources/Sentry/Public/SentryUser.h
+++ b/Sources/Sentry/Public/SentryUser.h
@@ -41,7 +41,7 @@ NS_SWIFT_NAME(User)
 - (instancetype)init;
 + (instancetype)new NS_UNAVAILABLE;
 
-- (BOOL)isEqual:(id)other;
+- (BOOL)isEqual:(id _Nullable)other;
 
 - (BOOL)isEqualToUser:(SentryUser *)user;
 

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -34,7 +34,7 @@
     return serializedData;
 }
 
-- (BOOL)isEqual:(id)other
+- (BOOL)isEqual:(id _Nullable)other
 {
     if (other == self)
         return YES;

--- a/Sources/Sentry/SentryId.m
+++ b/Sources/Sentry/SentryId.m
@@ -63,7 +63,7 @@ static SentryId *_empty = nil;
     return [self sentryIdString];
 }
 
-- (BOOL)isEqual:(id)object
+- (BOOL)isEqual:(id _Nullable)object
 {
     if (object == self) {
         return YES;

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -380,7 +380,7 @@ SentryScope ()
     }
 }
 
-- (BOOL)isEqual:(id)other
+- (BOOL)isEqual:(id _Nullable)other
 {
     if (other == self)
         return YES;

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -47,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
     return serializedData;
 }
 
-- (BOOL)isEqual:(id)other
+- (BOOL)isEqual:(id _Nullable)other
 {
     if (other == self)
         return YES;

--- a/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.h
+++ b/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.h
@@ -4,7 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentrySdkInfo (Equality)
 
-- (BOOL)isEqual:(id)object;
+- (BOOL)isEqual:(id _Nullable)object;
 
 - (NSUInteger)hash;
 

--- a/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.m
+++ b/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.m
@@ -2,7 +2,7 @@
 
 @implementation SentrySdkInfo (Equality)
 
-- (BOOL)isEqual:(id)object
+- (BOOL)isEqual:(id _Nullable)object
 {
     if (object == self)
         return YES;

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.h
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.h
@@ -4,7 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentrySession (Equality)
 
-- (BOOL)isEqual:(id)object;
+- (BOOL)isEqual:(id _Nullable)object;
 
 - (BOOL)isEqualToSession:(SentrySession *)session;
 

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.m
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.m
@@ -3,7 +3,7 @@
 
 @implementation SentrySession (Equality)
 
-- (BOOL)isEqual:(id)other
+- (BOOL)isEqual:(id _Nullable)other
 {
     if (other == self)
         return YES;


### PR DESCRIPTION
## :scroll: Description

isEqual accepts nil. As we use NS_ASSUME_NONNULL_BEGIN we have to
make the id _Nullable explicitly.

## :bulb: Motivation and Context

We don't want warnings.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
