### PR TITLE
feat: Add SentryMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Add SentryMessage #752
 - feat: Replace passing nullable Scope with overloads #743 !Breaking
 - feat: Remove SDK frames when attaching stacktrace #739
 - fix: captureException crates a event type=error #746

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -54,7 +54,7 @@ We cleaned up our public headers and made most of our classes private. If you ca
 of the classes you need please [open an issue](https://github.com/getsentry/sentry-cocoa/issues/new/choose)
 and tell us your use case so we either make the class public again or provide another API for you.
 
-### Use new type SentryId for eventId
+### New type SentryId for eventId
 
 In 5.x we use a nullable NSString to represent an event ID. The SDK, Hub and Client returned this
 nullable NSString for the event ID for capturing messages, events, errors, etc. With 6.x we have a new type SentryId which is not nullable to represent an event ID.
@@ -98,6 +98,36 @@ if (eventId != SentryId.empty) {
 } else {
     // event wasn't queued for submission
 }
+```
+
+### New type SentryMessage for Event.message
+
+In 6.x we introduce a new type [SentryMessage](https://develop.sentry.dev/sdk/event-payloads/message/)
+for `event.message`. SentryMessage gives you the possibilty to pass a format string with parameters
+to Sentry, which can help to group similar messages into the same issue.
+
+`5.x`
+
+```swift
+let event = Event()
+event.message = "Hello World"
+```
+
+```objective-c
+SentryEvent *event = [[SentryEvent alloc] init];
+event.message = "Hello World";
+```
+
+`6.x`
+
+```swift
+let event = Event()
+event.message = SentryMessage(formatted: "Hello World")
+```
+
+```objective-c
+SentryEvent *event = [[SentryEvent alloc] init];
+event.message = [SentryMessage messageWithFormatted:"Hello World"];
 ```
 
 ### Make Scope nonnull for capture methods

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -360,6 +360,10 @@
 		7BEA110C24EEB9BB008725D7 /* Pair.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEA110B24EEB9BB008725D7 /* Pair.swift */; };
 		7BF536D124BDF3E7004FA6A2 /* SentryEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF536D024BDF3E7004FA6A2 /* SentryEnvelopeTests.swift */; };
 		7BF536D424BEF255004FA6A2 /* SentryAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */; };
+		7BFC169B2524995700FF6266 /* SentryMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BFC169A2524995700FF6266 /* SentryMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BFC16A125249A9D00FF6266 /* SentryMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BFC16A025249A9D00FF6266 /* SentryMessage.m */; };
+		7BFC16AD2524BCE700FF6266 /* SentryMessageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BFC16AC2524BCE700FF6266 /* SentryMessageTests.swift */; };
+		7BFC16BA2524D4AF00FF6266 /* SentryMessage+Equality.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BFC16B92524D4AF00FF6266 /* SentryMessage+Equality.m */; };
 		7D0637032382B34300B30749 /* SentryScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D0637022382B34300B30749 /* SentryScope.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D082B8323C628790029866B /* SentryMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D082B8023C628780029866B /* SentryMeta.m */; };
 		7D0FCFB22379B915004DD83A /* SentryHub.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D0FCFB02379B915004DD83A /* SentryHub.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -763,6 +767,11 @@
 		7BEA110B24EEB9BB008725D7 /* Pair.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pair.swift; sourceTree = "<group>"; };
 		7BF536D024BDF3E7004FA6A2 /* SentryEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeTests.swift; sourceTree = "<group>"; };
 		7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAssertions.swift; sourceTree = "<group>"; };
+		7BFC169A2524995700FF6266 /* SentryMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryMessage.h; path = Public/SentryMessage.h; sourceTree = "<group>"; };
+		7BFC16A025249A9D00FF6266 /* SentryMessage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMessage.m; sourceTree = "<group>"; };
+		7BFC16AC2524BCE700FF6266 /* SentryMessageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMessageTests.swift; sourceTree = "<group>"; };
+		7BFC16B82524D4AF00FF6266 /* SentryMessage+Equality.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryMessage+Equality.h"; sourceTree = "<group>"; };
+		7BFC16B92524D4AF00FF6266 /* SentryMessage+Equality.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentryMessage+Equality.m"; sourceTree = "<group>"; };
 		7D0637022382B34300B30749 /* SentryScope.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryScope.h; path = Public/SentryScope.h; sourceTree = "<group>"; };
 		7D082B8023C628780029866B /* SentryMeta.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMeta.m; sourceTree = "<group>"; };
 		7D0FCFB02379B915004DD83A /* SentryHub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryHub.h; path = Public/SentryHub.h; sourceTree = "<group>"; };
@@ -893,6 +902,8 @@
 				7B88F2FF24BC5A7D00ADF90A /* SentrySdkInfo.m */,
 				7B82D54424E2A05500EE670F /* SentryId.h */,
 				7B82D54624E2A1AB00EE670F /* SentryId.m */,
+				7BFC169A2524995700FF6266 /* SentryMessage.h */,
+				7BFC16A025249A9D00FF6266 /* SentryMessage.m */,
 			);
 			name = Protocol;
 			sourceTree = "<group>";
@@ -1419,6 +1430,9 @@
 				7BB42EEF24F3B7B700D7B39A /* SentrySession+Equality.h */,
 				7BB42EF024F3B7B700D7B39A /* SentrySession+Equality.m */,
 				7B0A5451252311CE00A71716 /* SentryBreadcrumbTests.swift */,
+				7BFC16AC2524BCE700FF6266 /* SentryMessageTests.swift */,
+				7BFC16B82524D4AF00FF6266 /* SentryMessage+Equality.h */,
+				7BFC16B92524D4AF00FF6266 /* SentryMessage+Equality.m */,
 			);
 			path = Protocol;
 			sourceTree = "<group>";
@@ -1616,6 +1630,7 @@
 				A839D89824864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h in Headers */,
 				7B14089624878F090035403D /* SentryCrashStackEntryMapper.h in Headers */,
 				63FE714920DA4C1100CDBAE8 /* SentryCrashStackCursor_Backtrace.h in Headers */,
+				7BFC169B2524995700FF6266 /* SentryMessage.h in Headers */,
 				63AA76991EB9C1C200D153DE /* SentryDefines.h in Headers */,
 				63FE70CF20DA4C1000CDBAE8 /* SentryCrashMonitor_User.h in Headers */,
 				63FE718520DA4C1100CDBAE8 /* SentryCrashC.h in Headers */,
@@ -1831,6 +1846,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BFC16A125249A9D00FF6266 /* SentryMessage.m in Sources */,
 				7DC27EC723997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m in Sources */,
 				63FE717B20DA4C1100CDBAE8 /* SentryCrashReport.c in Sources */,
 				7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */,
@@ -1958,6 +1974,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BFC16AD2524BCE700FF6266 /* SentryMessageTests.swift in Sources */,
 				7BA61CC6247CFC5F00C130A8 /* SentryCrashDefaultBinaryImageProviderTests.swift in Sources */,
 				7BD7299A2463EA4A00EA3610 /* SentryDateUtilTests.swift in Sources */,
 				630436161EC0AD3100C4D3FA /* SentryNSDataCompressionTests.m in Sources */,
@@ -2020,6 +2037,7 @@
 				7B82D54924E2A2D400EE670F /* SentryIdTests.swift in Sources */,
 				7B6D98ED24C703F8005502FA /* Async.swift in Sources */,
 				63FE722520DA66EC00CDBAE8 /* SentryCrashFileUtils_Tests.m in Sources */,
+				7BFC16BA2524D4AF00FF6266 /* SentryMessage+Equality.m in Sources */,
 				7BAF3DB5243C743E008A5414 /* SentryClientTests.swift in Sources */,
 				7BBD18A2244EE2FD00427C76 /* TestResponseFactory.swift in Sources */,
 				630C01941EC3402C00C52CEF /* SentryKSCrashReportConverterTests.m in Sources */,

--- a/Sources/Sentry/Public/Sentry.h
+++ b/Sources/Sentry/Public/Sentry.h
@@ -22,6 +22,7 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #import "SentryId.h"
 #import "SentryIntegrationProtocol.h"
 #import "SentryMechanism.h"
+#import "SentryMessage.h"
 #import "SentryOptions.h"
 #import "SentrySDK.h"
 #import "SentryScope.h"

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -6,7 +6,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryThread, SentryException, SentryStacktrace, SentryUser, SentryDebugMeta, SentryContext,
-    SentryBreadcrumb, SentryId;
+    SentryBreadcrumb, SentryId, SentryMessage;
 
 NS_SWIFT_NAME(Event)
 @interface SentryEvent : NSObject <SentrySerializable>
@@ -19,7 +19,7 @@ NS_SWIFT_NAME(Event)
 /**
  * Message of the event
  */
-@property (nonatomic, copy) NSString *message;
+@property (nonatomic, strong) SentryMessage *message;
 
 /**
  * NSDate of when the event occured

--- a/Sources/Sentry/Public/SentryMessage.h
+++ b/Sources/Sentry/Public/SentryMessage.h
@@ -1,0 +1,40 @@
+#import "SentrySerializable.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Carries a log message that describes an event or error. Optionally, it can carry a format string
+ * and structured parameters. This can help to group similar messages into the same issue.
+ *
+ * For more info checkout: https://develop.sentry.dev/sdk/event-payloads/message/
+ */
+@interface SentryMessage : NSObject <SentrySerializable>
+
+- (instancetype)init;
+
+/**
+ * Creates a new message containing the given formatted.
+ */
++ (instancetype)messageWithFormatted:(NSString *_Nullable)formatted NS_SWIFT_NAME(init(formatted:));
+
+/**
+ * The fully formatted message. If missing, Sentry will try to interpolate the message. It must not
+ * exceed 8192 characters. Longer messages will be truncated.
+ */
+@property (nonatomic, copy) NSString *_Nullable formatted;
+
+/**
+ * The raw message string (uninterpolated). It must not exceed 8192 characters. Longer messages will
+ * be truncated.
+ */
+@property (nonatomic, copy) NSString *_Nullable message;
+
+/**
+ * A list of formatting parameters for the raw message.
+ */
+@property (nonatomic, strong) NSArray<NSString *> *_Nullable params;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -12,6 +12,7 @@
 #import "SentryGlobalEventProcessor.h"
 #import "SentryId.h"
 #import "SentryLog.h"
+#import "SentryMessage.h"
 #import "SentryMeta.h"
 #import "SentryOptions.h"
 #import "SentryScope.h"
@@ -101,8 +102,9 @@ SentryClient ()
 
 - (SentryId *)captureMessage:(NSString *)message withScope:(SentryScope *)scope
 {
+
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
-    event.message = message;
+    event.message = [SentryMessage messageWithFormatted:message];
     return [self sendEvent:event withScope:scope alwaysAttachStacktrace:NO];
 }
 
@@ -159,7 +161,7 @@ SentryClient ()
 - (SentryEvent *)buildErrorEvent:(NSError *)error
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
-    event.message = error.localizedDescription;
+    event.message = [SentryMessage messageWithFormatted:error.localizedDescription];
     [self setUserInfo:error.userInfo withEvent:event];
     return event;
 }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -160,8 +160,10 @@ SentryClient ()
 - (SentryEvent *)buildErrorEvent:(NSError *)error
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
-    NSString *message = [NSString stringWithFormat:@"%@ %ld", error.domain, (long)error.code];
-    event.message = [SentryMessage messageWithFormatted:message];
+    SentryMessage *message = [[SentryMessage alloc] init];
+    message.message = [error.domain stringByAppendingString:@" %s"];
+    message.params = @[ [NSString stringWithFormat:@"error code: %ld", (long)error.code] ];
+    event.message = message;
     [self setUserInfo:error.userInfo withEvent:event];
     return event;
 }

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -3,6 +3,7 @@
 #import "SentryEnvelopeItemType.h"
 #import "SentryEvent.h"
 #import "SentryLog.h"
+#import "SentryMessage.h"
 #import "SentryMeta.h"
 #import "SentrySdkInfo.h"
 #import "SentrySerialization.h"
@@ -93,10 +94,11 @@ NS_ASSUME_NONNULL_BEGIN
 
             // Add some context to the event. We can only set simple properties otherwise we
             // risk that the conversion fails again.
-            NSString *messge =
+            NSString *message =
                 [NSString stringWithFormat:@"JSON conversion error for event with message: '%@'",
                           event.message];
-            errorEvent.message = messge;
+
+            errorEvent.message = [SentryMessage messageWithFormatted:message];
             errorEvent.releaseName = event.releaseName;
             errorEvent.environment = event.environment;
             errorEvent.platform = event.platform;

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -7,6 +7,7 @@
 #import "SentryDebugMeta.h"
 #import "SentryException.h"
 #import "SentryId.h"
+#import "SentryMessage.h"
 #import "SentryMeta.h"
 #import "SentryStacktrace.h"
 #import "SentryThread.h"
@@ -133,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     [serializedData setValue:self.context forKey:@"contexts"];
 
-    [serializedData setValue:self.message forKey:@"message"];
+    [serializedData setValue:[self.message serialize] forKey:@"message"];
     [serializedData setValue:self.logger forKey:@"logger"];
     [serializedData setValue:self.serverName forKey:@"server_name"];
     [serializedData setValue:self.type forKey:@"type"];

--- a/Sources/Sentry/SentryMessage.m
+++ b/Sources/Sentry/SentryMessage.m
@@ -1,0 +1,53 @@
+#import "SentryMessage.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+const NSUInteger MAX_STRING_LENGTH = 8192;
+
+@implementation SentryMessage
+
+- (instancetype)init
+{
+    return [super init];
+}
+
++ (instancetype)messageWithFormatted:(NSString *_Nullable)formatted
+{
+    SentryMessage *message = [[SentryMessage alloc] init];
+    message.formatted = formatted;
+    return message;
+}
+
+- (void)setFormatted:(NSString *_Nullable)formatted
+{
+    if (nil != formatted && formatted.length > MAX_STRING_LENGTH) {
+        _formatted = [formatted substringToIndex:MAX_STRING_LENGTH];
+    } else {
+        _formatted = formatted;
+    }
+}
+
+- (void)setMessage:(NSString *_Nullable)message
+{
+    if (nil != message && message.length > MAX_STRING_LENGTH) {
+        _message = [message substringToIndex:MAX_STRING_LENGTH];
+    } else {
+        _message = message;
+    }
+}
+
+- (NSDictionary<NSString *, id> *)serialize
+{
+    NSMutableDictionary *serializedData = [[NSMutableDictionary alloc] init];
+
+    [serializedData setValue:self.formatted forKey:@"formatted"];
+    [serializedData setValue:self.message forKey:@"message"];
+    [serializedData setValue:self.params forKey:@"params"];
+
+    return serializedData;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -1,6 +1,5 @@
-#import <Foundation/Foundation.h>
-
 #import "SentrySerializable.h"
+#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -80,7 +80,7 @@ class SentrySessionGeneratorTests: XCTestCase {
             // crash report on a background thread.
             let crashEvent = Event()
             crashEvent.level = SentryLevel.fatal
-            crashEvent.message = "Crash for SentrySessionGeneratorTests"
+            crashEvent.message = SentryMessage(formatted: "Crash for SentrySessionGeneratorTests")
             SentrySDK.captureCrash(crashEvent)
         }
         sentryCrash.internalCrashedLastLaunch = false

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -25,7 +25,7 @@ class SentryHttpTransportTests: XCTestCase {
             CurrentDate.setCurrentDateProvider(currentDateProvider)
 
             event = Event()
-            event.message = "Some message"
+            event.message = SentryMessage(formatted: "Some message")
             
             eventRequest = buildRequest(SentryEnvelope(event: event))
 

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -16,7 +16,7 @@ class SentryEnvelopeTests: XCTestCase {
         var event: Event {
             let event = Event()
             event.level = SentryLevel.info
-            event.message = "Don't do this"
+            event.message = SentryMessage(formatted: "Don't do this")
             event.releaseName = "releaseName1.0.0"
             event.environment = "save the environment"
             event.sdk = ["version": sdkVersion]
@@ -43,7 +43,7 @@ class SentryEnvelopeTests: XCTestCase {
 
         var eventWithContinousSerializationFailure: Event {
             let event = EventSerilazationFailure()
-            event.message = "Failure"
+            event.message = SentryMessage(formatted: "Failure")
             event.releaseName = "release"
             event.environment = "environment"
             event.platform = "platform"

--- a/Tests/SentryTests/Protocol/SentryMessage+Equality.h
+++ b/Tests/SentryTests/Protocol/SentryMessage+Equality.h
@@ -1,0 +1,15 @@
+#import "SentryMessage.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryMessage (Equality)
+
+- (BOOL)isEqual:(id _Nullable)object;
+
+- (BOOL)isEqualToMessage:(SentryMessage *)message;
+
+- (NSUInteger)hash;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Protocol/SentryMessage+Equality.m
+++ b/Tests/SentryTests/Protocol/SentryMessage+Equality.m
@@ -1,0 +1,42 @@
+#import "SentryMessage+Equality.h"
+
+@implementation SentryMessage (Equality)
+
+- (BOOL)isEqual:(id)other
+{
+    if (other == self)
+        return YES;
+    if (!other || ![[other class] isEqual:[self class]])
+        return NO;
+
+    return [self isEqualToMessage:other];
+}
+
+- (BOOL)isEqualToMessage:(SentryMessage *)message
+{
+    if (self == message)
+        return YES;
+    if (message == nil)
+        return NO;
+    if (self.formatted != message.formatted && ![self.formatted isEqualToString:message.formatted])
+        return NO;
+    if (self.message != message.message && ![self.message isEqualToString:message.message])
+        return NO;
+    if (self.params != message.params && ![self.params isEqualToArray:message.params])
+        return NO;
+
+    return YES;
+}
+
+- (NSUInteger)hash
+{
+    NSUInteger hash = 17;
+
+    hash = hash * 23 + [self.formatted hash];
+    hash = hash * 23 + [self.message hash];
+    hash = hash * 23 + [self.params hash];
+
+    return hash;
+}
+
+@end

--- a/Tests/SentryTests/Protocol/SentryMessageTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMessageTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+class SentryMessageTests: XCTestCase {
+    
+    private class Fixture {
+        let stringMaxCount = 8_192
+        let maximumCount: String
+        let tooLong: String
+        
+        init() {
+            maximumCount = String(repeating: "a", count: stringMaxCount)
+            tooLong = String(repeating: "a", count: stringMaxCount + 1)
+        }
+    }
+    
+    private let fixture = Fixture()
+    
+    func testTruncateFormatted() {
+        let message = SentryMessage(formatted: "aaaaa")
+        XCTAssertEqual(5, message.formatted?.count)
+        
+        message.formatted = fixture.maximumCount
+        XCTAssertEqual(fixture.stringMaxCount, message.formatted?.count)
+        
+        message.formatted = fixture.tooLong
+        XCTAssertEqual(fixture.stringMaxCount, message.formatted?.count)
+    }
+    
+    func testTruncateMessage() {
+        let message = SentryMessage()
+        message.message = "aaaaa"
+        
+        XCTAssertEqual(5, message.message?.count)
+        
+        message.message = fixture.maximumCount
+        XCTAssertEqual(fixture.stringMaxCount, message.message?.count)
+        
+        message.message = fixture.tooLong
+        XCTAssertEqual(fixture.stringMaxCount, message.message?.count)
+    }
+    
+    func testSerialize() {
+        let message = SentryMessage()
+        message.formatted = "Something %s"
+        message.message = "A message"
+        message.params = ["my", "params"]
+        
+        let actual = message.serialize()
+        
+        XCTAssertEqual(message.formatted, actual["formatted"] as? String)
+        XCTAssertEqual(message.message, actual["message"] as? String)
+        XCTAssertEqual(message.params, actual["params"] as? [String])
+    }
+}

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -222,7 +222,9 @@ class SentryClientTest: XCTestCase {
         eventId.assertIsNotEmpty()
         let error = TestError.invalidTest as NSError
         assertLastSentEvent { actual in
-            XCTAssertEqual("\(error.domain) \(error.code)", actual.message.formatted)
+            XCTAssertNil(actual.message.formatted)
+            XCTAssertEqual("\(error.domain) %s", actual.message.message)
+            XCTAssertEqual(["error code: \(error.code)"], actual.message.params)
         }
     }
 
@@ -508,7 +510,9 @@ class SentryClientTest: XCTestCase {
     
     private func assertValidErrorEvent(_ event: Event) {
         XCTAssertEqual(SentryLevel.error, event.level)
-        XCTAssertEqual("\(error.domain) \(error.code)", event.message.formatted)
+        XCTAssertNil(event.message.formatted)
+        XCTAssertEqual("\(error.domain) %s", event.message.message)
+        XCTAssertEqual(["error code: \(error.code)"], event.message.params)
         assertValidDebugMeta(actual: event.debugMeta)
         assertValidThreads(actual: event.threads)
     }
@@ -568,7 +572,7 @@ class SentryClientTest: XCTestCase {
         XCTAssertEqual(0, fixture.transport.sentEvents.count)
     }
 
-    private enum TestError : Error {
+    private enum TestError: Error {
         case invalidTest
         case testIsFailing
         case somethingElse

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -19,13 +19,17 @@ class SentryClientTest: XCTestCase {
         let session: SentrySession
         let event: Event
         let environment = "Environment"
+        let messageAsString = "message"
+        let message: SentryMessage
 
         init() {
             session = SentrySession(releaseName: "release")
             session.incrementErrors()
 
+            message = SentryMessage(formatted: messageAsString)
+            
             event = Event()
-            event.message = "some message"
+            event.message = message
         }
 
         func getSut(configureOptions: (Options) -> Void = { _ in }) -> Client {
@@ -64,7 +68,6 @@ class SentryClientTest: XCTestCase {
 
     private let exception = NSException(name: NSExceptionName("My Custom exception"), reason: "User clicked the button", userInfo: nil)
 
-    private let message = "message"
     private var fixture: Fixture!
 
     override func setUp() {
@@ -73,12 +76,12 @@ class SentryClientTest: XCTestCase {
     }
     
     func testCaptureMessage() {
-        let eventId = fixture.getSut().capture(message: message)
+        let eventId = fixture.getSut().capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
         assertLastSentEvent { actual in
             XCTAssertEqual(SentryLevel.info, actual.level)
-            XCTAssertEqual(message, actual.message)
+            XCTAssertEqual(fixture.message, actual.message)
 
             assertValidDebugMeta(actual: actual.debugMeta)
             assertValidThreads(actual: actual.threads)
@@ -88,12 +91,12 @@ class SentryClientTest: XCTestCase {
     func testCaptureMessageWithOutStacktrace() {
         let eventId = fixture.getSut(configureOptions: { options in
             options.attachStacktrace = false
-        }).capture(message: message)
+        }).capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
         assertLastSentEvent { actual in
             XCTAssertEqual(SentryLevel.info, actual.level)
-            XCTAssertEqual(message, actual.message)
+            XCTAssertEqual(fixture.message, actual.message)
             XCTAssertNil(actual.debugMeta)
             XCTAssertNil(actual.threads)
             XCTAssertNotNil(actual.dist)
@@ -102,7 +105,7 @@ class SentryClientTest: XCTestCase {
     
     func testCaptureEvent() {
         let event = Event(level: SentryLevel.warning)
-        event.message = message
+        event.message = fixture.message
         let scope = Scope()
         let expectedTags = ["tagKey": "tagValue"]
         scope.setTags(expectedTags)
@@ -188,7 +191,7 @@ class SentryClientTest: XCTestCase {
     
     func testCaptureEventWithAttachStacktrace() {
         let event = Event(level: SentryLevel.fatal)
-        event.message = message
+        event.message = fixture.message
         let eventId = fixture.getSut(configureOptions: { options in
             options.attachStacktrace = true
         }).capture(event: event)
@@ -303,7 +306,7 @@ class SentryClientTest: XCTestCase {
     }
 
     func testScopeIsNotNil() {
-        let eventId = fixture.getSut().capture(message: message, scope: fixture.scope)
+        let eventId = fixture.getSut().capture(message: fixture.messageAsString, scope: fixture.scope)
 
         eventId.assertIsNotEmpty()
         assertLastSentEvent { actual in
@@ -323,7 +326,7 @@ class SentryClientTest: XCTestCase {
             options.beforeSend = { _ in
                 nil
             }
-        }).capture(message: message)
+        }).capture(message: fixture.messageAsString)
 
         assertNoEventSent()
     }
@@ -336,7 +339,7 @@ class SentryClientTest: XCTestCase {
                 newEvent
             }
             options.releaseName = releaseName
-        }).capture(message: message)
+        }).capture(message: fixture.messageAsString)
 
         XCTAssertEqual(newEvent.eventId, eventId)
         assertLastSentEvent { actual in
@@ -353,7 +356,7 @@ class SentryClientTest: XCTestCase {
                 return event
             }
             options.attachStacktrace = true
-        }).capture(message: message)
+        }).capture(message: fixture.messageAsString)
 
         assertLastSentEvent { actual in
             XCTAssertEqual([], actual.debugMeta)
@@ -363,7 +366,7 @@ class SentryClientTest: XCTestCase {
 
     func testNoDsn_MessageNotSent() {
         let sut = fixture.getSutWithNoDsn()
-        let eventId = sut.capture(message: message)
+        let eventId = sut.capture(message: fixture.messageAsString)
         eventId.assertIsEmpty()
         assertNothingSent()
     }
@@ -425,7 +428,7 @@ class SentryClientTest: XCTestCase {
         let dist = "dist"
         let eventId = fixture.getSut(configureOptions: { options in
             options.dist = dist
-        }).capture(message: message)
+        }).capture(message: fixture.messageAsString)
 
         XCTAssertNotNil(eventId)
         assertLastSentEvent { actual in
@@ -437,7 +440,7 @@ class SentryClientTest: XCTestCase {
         let environment = "environment"
         let eventId = fixture.getSut(configureOptions: { options in
             options.environment = environment
-        }).capture(message: message)
+        }).capture(message: fixture.messageAsString)
 
         XCTAssertNotNil(eventId)
         assertLastSentEvent { actual in
@@ -495,7 +498,7 @@ class SentryClientTest: XCTestCase {
     
     private func assertValidErrorEvent(_ event: Event) {
         XCTAssertEqual(SentryLevel.error, event.level)
-        XCTAssertEqual(error.localizedDescription, event.message)
+        XCTAssertEqual(error.localizedDescription, event.message.formatted)
         assertValidDebugMeta(actual: event.debugMeta)
         assertValidThreads(actual: event.threads)
     }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -25,7 +25,7 @@ class SentryHubTests: XCTestCase {
             scope.add(crumb)
             
             event = Event()
-            event.message = message
+            event.message = SentryMessage(formatted: message)
             
             fileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: currentDateProvider)
             

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -14,7 +14,7 @@ class SentrySDKTests: XCTestCase {
         
         init() {
             event = Event()
-            event.message = "message"
+            event.message = SentryMessage(formatted: "message")
             
             scope = Scope()
             scope.setTag(value: "value", key: "key")

--- a/Tests/SentryTests/SentrySwiftTests.swift
+++ b/Tests/SentryTests/SentrySwiftTests.swift
@@ -58,7 +58,8 @@ class SentrySwiftTests: XCTestCase {
     
     func testFunctionCalls() {
         let event = Event(level: .debug)
-        event.message = "Test Message"
+        event.message = SentryMessage(formatted: "Test Message")
+    
         event.environment = "staging"
         let scope = Sentry.Scope()
         scope.setExtras(["ios": true])

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -1,5 +1,6 @@
 #import "NSDate+SentryExtras.h"
 #import "SentryBreadcrumbTracker.h"
+#import "SentryMessage.h"
 #import "SentryMeta.h"
 #import <Sentry/Sentry.h>
 #import <XCTest/XCTest.h>
@@ -156,7 +157,7 @@
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelFatal];
 
     event.timestamp = [NSDate date];
-    event.message = @"testy test";
+    event.message = [SentryMessage messageWithFormatted:@"testy test"];
 
     [SentrySDK captureEvent:event];
 

--- a/Tests/SentryTests/TestConstants.swift
+++ b/Tests/SentryTests/TestConstants.swift
@@ -17,7 +17,7 @@ struct TestConstants {
     
     static var eventWithSerializationError: Event {
         let event = Event()
-        event.message = ""
+        event.message = SentryMessage(formatted: "")
         event.sdk = ["event": Event()]
         return event
     }


### PR DESCRIPTION
## :scroll: Description

Add type SentryMessage for the event.message. SentryMessage can carry a format
string and structured parameters. This can help to group similar messages into
the same issue.

Fixes https://github.com/getsentry/sentry-cocoa/issues/747

## :bulb: Motivation and Context

We want to support this [new type](https://develop.sentry.dev/sdk/event-payloads/message/).

## :green_heart: How did you test it?
Tavis and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
