### PR TITLE
test: Remove redundant setting of sessionTracking

### DIFF
--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -17,7 +17,6 @@ class SentryCrashIntegrationTests: XCTestCase {
         var options: Options {
             let options = Options()
             options.dsn = TestConstants.dsnAsString
-            options.enableAutoSessionTracking = true
             return options
         }
         

--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -107,7 +107,6 @@ class SentrySessionGeneratorTests: XCTestCase {
         options.logLevel = SentryLogLevel.debug
         
         options.sessionTrackingIntervalMillis = 1
-        options.enableAutoSessionTracking = true
         
         // We want to start and stop the SentryAutoSessionTrackingIntegration ourselves so we can send crashed and abnormal sessions.
         options.integrations = Options.defaultIntegrations().filter { (name) -> Bool in

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -19,7 +19,6 @@ class SentryHubTests: XCTestCase {
         init() {
             options = Options()
             options.dsn = TestConstants.dsnAsString
-            options.enableAutoSessionTracking = true
             options.environment = "debug"
             
             scope.add(crumb)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -47,7 +47,6 @@ class SentrySDKTests: XCTestCase {
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
             options.attachStacktrace = true
-            options.enableAutoSessionTracking = true
         }
         
         let hub = SentrySDK.currentHub()


### PR DESCRIPTION
## :scroll: Description

Remove setting enableAutoSessionTracking to true as it is enabled per default.

## :bulb: Motivation and Context

Less code.

## :green_heart: How did you test it?
Tavis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
