### PR TITLE
fix: Make SentryMessage formatted required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ For a detailed explanation  how to updgrade please checkout the [migration guide
 
 Breaking changes:
 
+- fix: Make SentryMessage formatted required #756
 - feat: Add SentryMessage #752
 - feat: Replace passing nullable Scope with overloads #743
 - feat: Remove SentryOptions.enabled #736

--- a/Sources/Sentry/Public/SentryMessage.h
+++ b/Sources/Sentry/Public/SentryMessage.h
@@ -1,3 +1,4 @@
+#import "SentryDefines.h"
 #import "SentrySerializable.h"
 #import <Foundation/Foundation.h>
 
@@ -10,19 +11,15 @@ NS_ASSUME_NONNULL_BEGIN
  * For more info checkout: https://develop.sentry.dev/sdk/event-payloads/message/
  */
 @interface SentryMessage : NSObject <SentrySerializable>
+SENTRY_NO_INIT
 
-- (instancetype)init;
-
-/**
- * Creates a new message containing the given formatted.
- */
-+ (instancetype)messageWithFormatted:(NSString *_Nullable)formatted NS_SWIFT_NAME(init(formatted:));
+- (instancetype)initWithFormatted:(NSString *)formatted;
 
 /**
  * The fully formatted message. If missing, Sentry will try to interpolate the message. It must not
  * exceed 8192 characters. Longer messages will be truncated.
  */
-@property (nonatomic, copy) NSString *_Nullable formatted;
+@property (nonatomic, readonly, copy) NSString *formatted;
 
 /**
  * The raw message string (uninterpolated). It must not exceed 8192 characters. Longer messages will

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -103,7 +103,7 @@ SentryClient ()
 - (SentryId *)captureMessage:(NSString *)message withScope:(SentryScope *)scope
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
-    event.message = [SentryMessage messageWithFormatted:message];
+    event.message = [[SentryMessage alloc] initWithFormatted:message];
     return [self sendEvent:event withScope:scope alwaysAttachStacktrace:NO];
 }
 
@@ -160,9 +160,10 @@ SentryClient ()
 - (SentryEvent *)buildErrorEvent:(NSError *)error
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
-    SentryMessage *message = [[SentryMessage alloc] init];
+    NSString *formatted = [NSString stringWithFormat:@"%@ %ld", error.domain, (long)error.code];
+    SentryMessage *message = [[SentryMessage alloc] initWithFormatted:formatted];
     message.message = [error.domain stringByAppendingString:@" %s"];
-    message.params = @[ [NSString stringWithFormat:@"error code: %ld", (long)error.code] ];
+    message.params = @[ [NSString stringWithFormat:@"%ld", (long)error.code] ];
     event.message = message;
     [self setUserInfo:error.userInfo withEvent:event];
     return event;

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
                 [NSString stringWithFormat:@"JSON conversion error for event with message: '%@'",
                           event.message];
 
-            errorEvent.message = [SentryMessage messageWithFormatted:message];
+            errorEvent.message = [[SentryMessage alloc] initWithFormatted:message];
             errorEvent.releaseName = event.releaseName;
             errorEvent.environment = event.environment;
             errorEvent.platform = event.platform;

--- a/Sources/Sentry/SentryMessage.m
+++ b/Sources/Sentry/SentryMessage.m
@@ -7,25 +7,16 @@ const NSUInteger MAX_STRING_LENGTH = 8192;
 
 @implementation SentryMessage
 
-- (instancetype)init
+- (instancetype)initWithFormatted:(NSString *)formatted
 {
-    return [super init];
-}
-
-+ (instancetype)messageWithFormatted:(NSString *_Nullable)formatted
-{
-    SentryMessage *message = [[SentryMessage alloc] init];
-    message.formatted = formatted;
-    return message;
-}
-
-- (void)setFormatted:(NSString *_Nullable)formatted
-{
-    if (nil != formatted && formatted.length > MAX_STRING_LENGTH) {
-        _formatted = [formatted substringToIndex:MAX_STRING_LENGTH];
-    } else {
-        _formatted = formatted;
+    if (self = [super init]) {
+        if (nil != formatted && formatted.length > MAX_STRING_LENGTH) {
+            _formatted = [formatted substringToIndex:MAX_STRING_LENGTH];
+        } else {
+            _formatted = formatted;
+        }
     }
+    return self;
 }
 
 - (void)setMessage:(NSString *_Nullable)message

--- a/Tests/SentryTests/Protocol/SentryMessageTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMessageTests.swift
@@ -17,20 +17,18 @@ class SentryMessageTests: XCTestCase {
     
     func testTruncateFormatted() {
         let message = SentryMessage(formatted: "aaaaa")
-        XCTAssertEqual(5, message.formatted?.count)
+        XCTAssertEqual(5, message.formatted.count)
         
-        message.formatted = fixture.maximumCount
-        XCTAssertEqual(fixture.stringMaxCount, message.formatted?.count)
+        XCTAssertEqual(fixture.stringMaxCount, SentryMessage(formatted: fixture.maximumCount).formatted.count)
         
-        message.formatted = fixture.tooLong
-        XCTAssertEqual(fixture.stringMaxCount, message.formatted?.count)
+        XCTAssertEqual(fixture.stringMaxCount, SentryMessage(formatted: fixture.tooLong).formatted.count)
     }
     
     func testTruncateMessage() {
-        let message = SentryMessage()
-        message.message = "aaaaa"
+        let message = SentryMessage(formatted: "")
+        message.message = "aaaaa %s"
         
-        XCTAssertEqual(5, message.message?.count)
+        XCTAssertEqual(8, message.message?.count)
         
         message.message = fixture.maximumCount
         XCTAssertEqual(fixture.stringMaxCount, message.message?.count)
@@ -40,9 +38,8 @@ class SentryMessageTests: XCTestCase {
     }
     
     func testSerialize() {
-        let message = SentryMessage()
-        message.formatted = "Something %s"
-        message.message = "A message"
+        let message = SentryMessage(formatted: "A message my params")
+        message.message = "A message %s %s"
         message.params = ["my", "params"]
         
         let actual = message.serialize()

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -222,9 +222,9 @@ class SentryClientTest: XCTestCase {
         eventId.assertIsNotEmpty()
         let error = TestError.invalidTest as NSError
         assertLastSentEvent { actual in
-            XCTAssertNil(actual.message.formatted)
+            XCTAssertEqual("\(error.domain) \(error.code)", actual.message.formatted)
             XCTAssertEqual("\(error.domain) %s", actual.message.message)
-            XCTAssertEqual(["error code: \(error.code)"], actual.message.params)
+            XCTAssertEqual(["\(error.code)"], actual.message.params)
         }
     }
 
@@ -510,9 +510,9 @@ class SentryClientTest: XCTestCase {
     
     private func assertValidErrorEvent(_ event: Event) {
         XCTAssertEqual(SentryLevel.error, event.level)
-        XCTAssertNil(event.message.formatted)
+        XCTAssertEqual("\(error.domain) \(error.code)", event.message.formatted)
         XCTAssertEqual("\(error.domain) %s", event.message.message)
-        XCTAssertEqual(["error code: \(error.code)"], event.message.params)
+        XCTAssertEqual(["\(error.code)"], event.message.params)
         assertValidDebugMeta(actual: event.debugMeta)
         assertValidThreads(actual: event.threads)
     }

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -157,7 +157,7 @@
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelFatal];
 
     event.timestamp = [NSDate date];
-    event.message = [SentryMessage messageWithFormatted:@"testy test"];
+    event.message = [[SentryMessage alloc] initWithFormatted:@"testy test"];
 
     [SentrySDK captureEvent:event];
 


### PR DESCRIPTION
## :scroll: Description

SentryMessage.formatted is required by our servers.

## :bulb: Motivation and Context

The message interface defines formatted as required https://develop.sentry.dev/sdk/event-payloads/message/, although it accepts an empty formatted for legacy reasons, as discussed with @jan-auer.

## :green_heart: How did you test it?
Travis and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
