### PR TITLE
fix: Sanitize UserInfo of NSError and NSException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - fix: Carthage for Xcode 12 #780
 - fix: Add missing SentrySdkInfo.h to umbrella header #779
 - ref: Remove event.json field #768
+- fix: Sanitize user info of captured errors #770
 
 ## 6.0.1
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1,4 +1,5 @@
 #import "SentryClient.h"
+#import "NSDictionary+SentrySanitize.h"
 #import "SentryCrashDefaultBinaryImageProvider.h"
 #import "SentryCrashDefaultMachineContextWrapper.h"
 #import "SentryDebugMetaBuilder.h"
@@ -353,7 +354,7 @@ SentryClient ()
             context = [event.context mutableCopy];
         }
 
-        [context setValue:userInfo forKey:@"user info"];
+        [context setValue:[userInfo sentry_sanitize] forKey:@"user info"];
     }
 }
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -233,6 +233,18 @@ class SentryClientTest: XCTestCase {
         }
     }
 
+    func testCaptureErrorWithComplexUserInfo() {
+        let url = URL(string: "https://github.com/getsentry")!
+        let error = NSError(domain: "domain", code: 0, userInfo: ["url": url])
+        let eventId = fixture.getSut().capture(error: error, scope: fixture.scope)
+
+        eventId.assertIsNotEmpty()
+
+        assertLastSentEvent { actual in
+            XCTAssertEqual(url.absoluteString, actual.context!["user info"]!["url"] as? String)
+        }
+    }
+
     func testCaptureErrorWithSession() {
         let eventId = fixture.getSut().captureError(error, with: fixture.session, with: Scope())
         


### PR DESCRIPTION
## :scroll: Description

This PR add sanatizing to the error's user info dictionary.

## :bulb: Motivation and Context

Certain errors would cause the event to drop the sdk and context properties, because the error's user info contained values that couldn't be serialized as JSON.

## :green_heart: How did you test it?

Changed the library in my project locally, and saw the error being reported in Sentry without the "A value set to the context or sdk is not serializable. Dropping context and sdk." breadcrumb, and with the context and sdk properties present.

I'm not sure where I should introduce a test for it. Preferably I would like to add a test that handles an error with problematic user info, and fails without my changes. But since the formatting of the event happens in SentryClient (covered by SentryClientTests), and the serialization in `SentrySerialization` (covered by `SentrySerializationTests`), there currently is no way to do that.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
