### PR TITLE
ci: Build samples with xcodebuild

### DIFF
--- a/.github/workflows/samples.yml
+++ b/.github/workflows/samples.yml
@@ -28,11 +28,12 @@ jobs:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh
       - run: ${{matrix.beforeXcode}}
-      - uses: sersoft-gmbh/xcodebuild-action@v1
-        with:
-          workspace: Sentry.xcworkspace
-          scheme: ${{matrix.scheme}}
-          configuration: Debug
-          action: build
-          # Disable code signing. We just want to make sure these compile
-          build-settings: CODE_SIGNING_ALLOWED="NO"
+      
+      # Disable code signing. We just want to make sure these compile
+      - run: >-
+          xcodebuild
+          -workspace Sentry.xcworkspace
+          -scheme ${{matrix.scheme}}
+          -configuration Debug
+          CODE_SIGNING_ALLOWED="NO"
+          build | xcpretty


### PR DESCRIPTION
## :scroll: Description

Call xcodebuild directly.

## :bulb: Motivation and Context

Calling xcodebuild directly gives us more control and we don't depend on an external Github Action.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] No breaking changes

## :crystal_ball: Next steps
