### PR TITLE
test: Fix TestRequestManager

### DIFF
--- a/Tests/SentryTests/Networking/TestRequestManager.swift
+++ b/Tests/SentryTests/Networking/TestRequestManager.swift
@@ -21,10 +21,10 @@ public class TestRequestManager: NSObject, RequestManager {
         
         requests.append(request)
         
+        let response = self.nextResponse()
         group.enter()
         queue.asyncAfter(deadline: .now() + responseDelay, execute: {
             if let handler = completionHandler {
-                let response = self.nextResponse() ?? HTTPURLResponse(coder: NSCoder())
                 handler(response, nil)
             }
             self.group.leave()


### PR DESCRIPTION
## :scroll: Description

A reference to the nextResponse of the TestRequestManager inside an async block for a DispatchQueue
caused SentryHttpTransportTests to fail silently and writing a Namespace SIGNAL, Code 0xb to the
test diagnostics. This is solved now by getting a local reference to the nextResponse.

## :bulb: Motivation and Context

We want to be able to run all tests from xcodebuild so they run properly in the CI.

## :green_heart: How did you test it?
From the command line with `xcodebuild -workspace Sentry.xcworkspace -scheme Sentry -configuration Debug GCC_GENERATE_TEST_COVERAGE_FILES=YES -destination "platform=macOS" test | xcpretty -t`.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
