### PR TITLE
test: Wait with a timeout for DispatchGroup

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -142,7 +142,7 @@ class SentryFileManagerTests: XCTestCase {
             storeAsync(envelope: TestConstants.envelope)
         }
         fixture.queue.activate()
-        fixture.group.wait()
+        fixture.group.waitWithTimeout()
 
         let events = sut.getAllEnvelopes()
         XCTAssertEqual(events.count, 100)

--- a/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
@@ -73,7 +73,7 @@ class SentryConcurrentRateLimitsDictionaryTests: XCTestCase {
         
         queue1.activate()
         queue2.activate()
-        group.wait()
+        group.waitWithTimeout()
         
         for i in Array(0...10) {
             let date = self.currentDateProvider.date().addingTimeInterval(TimeInterval(i))

--- a/Tests/SentryTests/Networking/SentryHttpDateParserTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpDateParserTests.swift
@@ -36,7 +36,7 @@ class SentryHttpDateParserTests: XCTestCase {
         
         queue1.activate()
         queue2.activate()
-        group.wait()
+        group.waitWithTimeout()
     }
     
     func startWorkItemTest(i: Int, queue: DispatchQueue, group: DispatchGroup) {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -389,7 +389,7 @@ waitForAllRequests()
             }
 
             queue.activate()
-            group.wait()
+            group.waitWithTimeout()
 
             waitForAllRequests()
         }

--- a/Tests/SentryTests/Networking/TestRequestManager.swift
+++ b/Tests/SentryTests/Networking/TestRequestManager.swift
@@ -32,7 +32,7 @@ public class TestRequestManager: NSObject, RequestManager {
     }
     
     public func waitForAllRequests() {
-        group.wait()
+        group.waitWithTimeout()
     }
     
     public func cancelAllOperations() {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -408,7 +408,7 @@ class SentryHubTests: XCTestCase {
         }
 
         queue.activate()
-        group.wait()
+        group.waitWithTimeout()
     }
     
     private func givenCrashedSession() {

--- a/Tests/SentryTests/TestUtils/Async.swift
+++ b/Tests/SentryTests/TestUtils/Async.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 @available(OSX 10.10, *)
 func delayNonBlocking(timeout: Double = 0.2) {
@@ -11,4 +12,15 @@ func delayNonBlocking(timeout: Double = 0.2) {
     }
     
     group.wait()
+}
+
+extension DispatchGroup {
+    
+    /**
+     * Waits for a default of 100 milliseconds and fails the test if the group didn't finish before the timeout.
+     */
+    func waitWithTimeout(timeout: Double = 100) {
+        let result = self.wait(timeout: .now() + timeout)
+        XCTAssertEqual(DispatchTimeoutResult.success, result)
+    }
 }


### PR DESCRIPTION
## :scroll: Description

Add extension function waitWithTimeout to DispatchGroup so a test doesn't
get stuck forever.

## :bulb: Motivation and Context

We don't want our tests to get stuck and instead to fail fast.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
