### PR TITLE
fix: Carthage for Xcode 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,12 @@
+name: build
+on:
+  pull_request:
+
+jobs:
+  validate-carthage:
+    name: Validate Carthage
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: make build-carthage
+        shell: sh  

--- a/.travis/stage-carthage.sh
+++ b/.travis/stage-carthage.sh
@@ -3,5 +3,5 @@
 brew update > /dev/null
 brew outdated carthage || brew upgrade carthage
 
-carthage build --no-skip-current
-carthage archive --output Sentry.framework.zip
+./scripts/carthage-xcode12-workaround.sh build --no-skip-current
+./scripts/carthage-xcode12-workaround.sh archive --output Sentry.framework.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Carthage for Xcode 12 #780
 - ref: Remove event.json field #768
 
 ## 6.0.1

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ test:
 
 build-carthage:
 	@echo "--> Creating Sentry framework package with carthage"
-	carthage build --no-skip-current
-	carthage archive Sentry --output Sentry.framework.zip
+	./scripts/carthage-xcode12-workaround.sh build --no-skip-current
+	./scripts/carthage-xcode12-workaround.sh archive Sentry --output Sentry.framework.zip
 
 ## Build Sentry as a XCFramework that can be used with watchOS and save it to
 ## the watchOS sample.

--- a/scripts/carthage-xcode12-workaround.sh
+++ b/scripts/carthage-xcode12-workaround.sh
@@ -1,0 +1,20 @@
+# carthage.sh
+# Usage example: ./carthage.sh build --platform iOS
+# Copied from: https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md
+
+set -euo pipefail
+
+xcconfig=$(mktemp /tmp/static.xcconfig.XXXXXX)
+trap 'rm -f "$xcconfig"' INT TERM HUP EXIT
+
+# For Xcode 12 make sure EXCLUDED_ARCHS is set to arm architectures otherwise
+# the build will fail on lipo due to duplicate architectures.
+
+CURRENT_XCODE_VERSION=$(xcodebuild -version | grep "Build version" | cut -d' ' -f3)
+echo "EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$CURRENT_XCODE_VERSION = arm64 arm64e armv7 armv7s armv6 armv8" >> $xcconfig
+
+echo 'EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200 = $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_simulator__NATIVE_ARCH_64_BIT_x86_64__XCODE_1200__BUILD_$(XCODE_PRODUCT_BUILD_VERSION))' >> $xcconfig
+echo 'EXCLUDED_ARCHS = $(inherited) $(EXCLUDED_ARCHS__EFFECTIVE_PLATFORM_SUFFIX_$(EFFECTIVE_PLATFORM_SUFFIX)__NATIVE_ARCH_64_BIT_$(NATIVE_ARCH_64_BIT)__XCODE_$(XCODE_VERSION_MAJOR))' >> $xcconfig
+
+export XCODE_XCCONFIG_FILE="$xcconfig"
+carthage "$@"


### PR DESCRIPTION
## :scroll: Description

The build for Carthage was failing since using Xcode 12. This is a known issue at
https://github.com/Carthage/Carthage/issues/3019. It can be fixed with using a
workaround script:
https://github.com/Carthage/Carthage/blob/master/Documentation/Xcode12Workaround.md.
Furthermore, we now run a check with Github actions to avoid this in the future.


## :bulb: Motivation and Context

Fix Carthage.

## :green_heart: How did you test it?
Github Actions.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
