### PR TITLE
fix: Remove initWithJSON from SentryEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Remove initWithJSON from SentryEvent #781
 - fix: Carthage for Xcode 12 #780
 - fix: Add missing SentrySdkInfo.h to umbrella header #779
 - ref: Remove event.json field #768

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -164,16 +164,6 @@ NS_SWIFT_NAME(Event)
  */
 - (instancetype)initWithLevel:(enum SentryLevel)level NS_DESIGNATED_INITIALIZER;
 
-/**
- * Init an SentryEvent with a JSON blob that completly bypasses all other
- * attributes in the event. Instead only the JSON will be sent, this is used in
- * react-native for example where we consider the event from JS as the source of
- * truth.
- * @param json NSData
- * @return SentryEvent
- */
-- (instancetype)initWithJSON:(NSData *)json;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION

## :scroll: Description

initWithJSON was removed with #768 in the .m file but not in the header.

## :bulb: Motivation and Context

Xcode displayed a warning for this.

## :green_heart: How did you test it?
Travis.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
