### PR TITLE
fix: iOS 13.4 Runtime Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 6.0.2
 
+- fix: iOS 13.4 Runtime Crash #786
 - fix: Using wrong SDK name #782
 - feat: Expose `captureEnvelope` on the client #784
 - fix: Remove initWithJSON from SentryEvent #781

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -105,6 +105,15 @@ extern "C" {
 #endif
 
 // ======================================================================
+#pragma mark - objc4-781/runtime/objc-internal.h -
+// ======================================================================
+#if __ARM_ARCH_7K__ >= 2 || (__arm64__ && !__LP64__)
+#    define SUPPORT_INDEXED_ISA 1
+#else
+#    define SUPPORT_INDEXED_ISA 0
+#endif
+
+// ======================================================================
 #pragma mark - objc4-680/runtime/objc-internal.h -
 // ======================================================================
 
@@ -220,20 +229,24 @@ typedef struct class_ro_t {
     property_list_t *baseProperties;
 } class_ro_t;
 
-typedef struct class_rw_t {
-    uint32_t flags;
-    uint32_t version;
-
+struct class_rw_ext_t {
     const class_ro_t *ro;
-
     method_array_t methods;
     property_array_t properties;
     protocol_array_t protocols;
+    char *demangledName;
+    uint32_t version;
+};
 
+typedef struct class_rw_t {
+    uint32_t flags;
+    uint16_t witness;
+#if SUPPORT_INDEXED_ISA
+    uint16_t index;
+#endif
+    uintptr_t ro_or_rw_ext;
     Class firstSubclass;
     Class nextSiblingClass;
-
-    char *demangledName;
 } class_rw_t;
 
 typedef struct class_t {


### PR DESCRIPTION
## :scroll: Description

On iOS 13.4, Apple changed the Objective-C runtime code (objc4-781). The structure `class_rw_t ro`
pointer has changed. This fix originates from https://github.com/kstenerud/KSCrash/pull/380.

## :bulb: Motivation and Context

`testWithFaultyReport` failed when running `make test` locally and also on Travis some tests failed randomly. The stacktrace below is from a local run and displays some problems in SentryCrashMonitor_Zombie. 

```
0   io.sentry.Sentry              	0x0000000104aded20 sentrycrashobjc_ivarNamed + 176 (SentryCrashObjC.c:1056)
1   io.sentry.Sentry              	0x0000000104ac8bd9 copyStringIvar + 105 (SentryCrashMonitor_Zombie.c:71)
2   io.sentry.Sentry              	0x0000000104ac8b41 storeException + 81 (SentryCrashMonitor_Zombie.c:99)
3   io.sentry.Sentry              	0x0000000104ac8ac7 handleDealloc + 263 (SentryCrashMonitor_Zombie.c:117)
4   io.sentry.Sentry              	0x0000000104ac89a0 handleDealloc_NSObject + 48 (SentryCrashMonitor_Zombie.c:144)
5   com.apple.CoreFoundation      	0x00007fff20439ed3 -[NSException dealloc] + 93
```

When looking at the issues at https://github.com/kstenerud/KSCrash/ a similar issue revealed this fix.

## :green_heart: How did you test it?
Travis and running this fix on Github Actions on tvOS, macOS, and watchOS: https://github.com/getsentry/sentry-cocoa/pull/773. Also crashing on simulators.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
