### PR TITLE
fix: Xcode 12 warnings for Cocoapods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Xcode 12 warnings for Cocoapods #791
+
 ## 6.0.3
 
 - fix: Making SentrySdkInfo Public #788

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ release: bump-version git-commit-add
 
 pod-lint:
 	@echo "--> Build local pod"
-	pod lib lint --allow-warnings --verbose
+	pod lib lint --verbose
 
 git-commit-add:
 	@echo "\n\n\n--> Commting git ${TO}"

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -16,7 +16,15 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks = 'Foundation'
   s.libraries = 'z', 'c++'
-  s.xcconfig = { 'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES' }
+  s.xcconfig = {
+      'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
+      # Default Xcode 12 settings fail to build CocoaPods-generate umbrella headers:
+      # https://github.com/CocoaPods/CocoaPods/issues/9902.
+      # The fix of cocoapods does the same:
+      # https://github.com/CocoaPods/CocoaPods/pull/9905/
+      # Remove this when cocoapods 1.10 is released
+      'CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER' => 'NO'
+}
 
   s.default_subspecs = ['Core']
 


### PR DESCRIPTION
## :scroll: Description

When running pod lib lint the following warning was generated:
double-quoted include in framework header, expected angle-bracketed instead.
Override CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER
for Cocoapods with no solves this issue.

## :bulb: Motivation and Context

We don't want to have warnings when publishing CocoaPods.

## :green_heart: How did you test it?
Github Actions

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
