### PR TITLE
docs: Document SentryMessage.initWithFormatted

### DIFF
--- a/Sources/Sentry/Public/SentryMessage.h
+++ b/Sources/Sentry/Public/SentryMessage.h
@@ -13,6 +13,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryMessage : NSObject <SentrySerializable>
 SENTRY_NO_INIT
 
+/**
+ * Returns a SentyMessage with setting formatted.
+ *
+ * @param formatted The fully formatted message. If missing, Sentry will try to interpolate the
+ * message. It must not exceed 8192 characters. Longer messages will be truncated.
+ */
 - (instancetype)initWithFormatted:(NSString *)formatted;
 
 /**


### PR DESCRIPTION
## :scroll: Description

The code docs for SentryMessage.initWithFormatted were missing. Now they are added.

## :bulb: Motivation and Context

While writing tests I used SentryMessage.initWithFormatted and saw that they are missing.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
