### PR TITLE
fix: Add eventId to user feedback envelope header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Add eventId to user feedback envelope header #809
 - feat: Manually capturing User Feedback #804
 
 ## 6.0.4

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -181,7 +181,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithUserFeedback:userFeedback];
 
-    return [self initWithHeader:[[SentryEnvelopeHeader alloc] initWithId:nil] singleItem:item];
+    return [self initWithHeader:[[SentryEnvelopeHeader alloc] initWithId:userFeedback.eventId]
+                     singleItem:item];
 }
 
 - (instancetype)initWithId:(SentryId *_Nullable)id singleItem:(SentryEnvelopeItem *)item

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -230,7 +230,7 @@ class SentryEnvelopeTests: XCTestCase {
         let userFeedback = fixture.userFeedback
         
         let envelope = SentryEnvelope(userFeedback: userFeedback)
-        XCTAssertNil(envelope.header.eventId)
+        XCTAssertEqual(userFeedback.eventId, envelope.header.eventId)
         XCTAssertEqual(defaultSdkInfo, envelope.header.sdkInfo)
         
         XCTAssertEqual(1, envelope.items.count)


### PR DESCRIPTION
## :scroll: Description

The eventID should be set in the envelope header when sending user feedback, as mentioned
here: https://develop.sentry.dev/sdk/envelopes/#userreport.

## :bulb: Motivation and Context

https://develop.sentry.dev/sdk/envelopes/#userreport

## :green_heart: How did you test it?
CI and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
