### PR TITLE
Min Sentry version for SDK 6.0.0 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ For more information checkout the [docs](https://docs.sentry.io/platforms/apple)
 
 <sup>(1)</sup>limited symbolication support and no crash handling.
 
+# Sentry Self Hosted Compatibility
+
+Since version 6.0.0 of this SDK, Sentry version >= v20.6.0 is required. This only applies to on-premise Sentry, if you are using [sentry.io](http://sentry.io/) no action is needed.
+
 # Resources
 
 * [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/apple/)


### PR DESCRIPTION
Note min version for on-prem users