### PR TITLE
fix: Call beforeBreadcrumb for Breadcrumb Tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Call beforeBreadcrumb for Breadcrumb Tracker #815
+
 ## 6.0.5
 
 - fix: Add eventId to user feedback envelope header #809

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
-                                <rect key="frame" x="8" y="95.5" width="398" height="180"/>
+                                <rect key="frame" x="8" y="95.5" width="398" height="210"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJW-l9-sD6">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
@@ -33,36 +33,43 @@
                                             <action selector="addBreadcrumb:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QZb-n6-c67"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ls3-eR-jlU">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jwi-v3-e8T">
                                         <rect key="frame" x="0.0" y="30" width="398" height="30"/>
+                                        <state key="normal" title="navigate to Hello"/>
+                                        <connections>
+                                            <segue destination="2jd-n4-Ihk" kind="show" id="wcP-y8-kPR"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ls3-eR-jlU">
+                                        <rect key="frame" x="0.0" y="60" width="398" height="30"/>
                                         <state key="normal" title="captureMessage"/>
                                         <connections>
                                             <action selector="captureMessage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qLd-Cq-psO"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KU1-qd-h5w">
-                                        <rect key="frame" x="0.0" y="60" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="90" width="398" height="30"/>
                                         <state key="normal" title="captureUserFeedback"/>
                                         <connections>
                                             <action selector="captureUserFeedback:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ek5-6c-HRz"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WZK-C2-hjR">
-                                        <rect key="frame" x="0.0" y="90" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="120" width="398" height="30"/>
                                         <state key="normal" title="captureError"/>
                                         <connections>
                                             <action selector="captureError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XSc-zg-aee"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D9Z-XG-OJP">
-                                        <rect key="frame" x="0.0" y="120" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="150" width="398" height="30"/>
                                         <state key="normal" title="captureNSException"/>
                                         <connections>
                                             <action selector="captureNSException:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BT7-dZ-MrB"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgF-Uq-3Bb">
-                                        <rect key="frame" x="0.0" y="150" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="180" width="398" height="30"/>
                                         <state key="normal" title="crash"/>
                                         <connections>
                                             <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="imm-ZO-4Af"/>
@@ -86,6 +93,38 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="132" y="139"/>
+        </scene>
+        <!--View Controller-->
+        <scene sceneID="HP6-1Y-hca">
+            <objects>
+                <viewController id="2jd-n4-Ihk" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="hTi-ne-s8a">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-yg-zgj">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                                <items>
+                                    <navigationItem title="Hello" id="7le-ZX-hzV"/>
+                                </items>
+                            </navigationBar>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="I'm just here to test navigation breadcrumbs." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nyb-oP-3NJ">
+                                <rect key="frame" x="20" y="81" width="340" height="21"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="mFP-ho-mca"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="Zdf-8M-7gd"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="5Rz-Om-HMJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1053.6231884057972" y="137.94642857142856"/>
         </scene>
     </scenes>
     <resources>

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -152,9 +152,10 @@
                 NSString *viewControllerName = [SentryBreadcrumbTracker
                     sanitizeViewControllerName:[NSString stringWithFormat:@"%@", self]];
                 crumb.data = @ { @"screen" : viewControllerName };
-
+                
+                // Adding crumb via the SDK calls SentryBeforeBreadcrumbCallback
+                [SentrySDK addBreadcrumb:crumb];
                 [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull scope) {
-                    [scope addBreadcrumb:crumb];
                     [scope setExtraValue:viewControllerName forKey:@"__sentry_transaction"];
                 }];
             }

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -152,7 +152,7 @@
                 NSString *viewControllerName = [SentryBreadcrumbTracker
                     sanitizeViewControllerName:[NSString stringWithFormat:@"%@", self]];
                 crumb.data = @ { @"screen" : viewControllerName };
-                
+
                 // Adding crumb via the SDK calls SentryBeforeBreadcrumbCallback
                 [SentrySDK addBreadcrumb:crumb];
                 [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull scope) {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -136,6 +136,37 @@ class SentryHubTests: XCTestCase {
         assert(withScopeBreadcrumbsCount: 200, with: hub)
     }
     
+    func testAddBreadcrumb_WithCallbackReturnsNil() {
+        let options = Options()
+        options.beforeBreadcrumb = { crumb in
+            return nil
+        }
+        let hub = fixture.getSut(options)
+        
+        hub.add(fixture.crumb)
+        
+        let scope = hub.getScope()
+        XCTAssertNil(scope.serialize()["breadcrumbs"])
+    }
+    
+    func testAddBreadcrumb_WithCallbackModifies() {
+        let crumbMessage = "modified"
+        let options = Options()
+        options.beforeBreadcrumb = { crumb in
+            crumb.message = crumbMessage
+            return crumb
+        }
+        let hub = fixture.getSut(options)
+        
+        hub.add(fixture.crumb)
+        
+        let scope = hub.getScope()
+        let scopeBreadcrumbs = scope.serialize()["breadcrumbs"] as? [[String: Any]]
+        XCTAssertNotNil(scopeBreadcrumbs)
+        XCTAssertEqual(1, scopeBreadcrumbs?.count)
+        XCTAssertEqual(crumbMessage, scopeBreadcrumbs?.first?["message"] as? String)
+    }
+    
     func testAddUserToTheScope() {
         let client = Client(options: fixture.options)
         let hub = SentryHub(client: client, andScope: Scope())


### PR DESCRIPTION
## :scroll: Description

swizzleViewDidAppear in SentryBreadcrumbTracker called scope `addBreadcrumb` which
didn't call the SentryBeforeBreadcrumbCallback. This is fixed now.

## :bulb: Motivation and Context

A customer wants to drop breadcrumbs stemming from swizzleViewDidAppear.

## :green_heart: How did you test it?
Simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
