### PR TITLE
build: Undo Xcode 12 workaround for Cocoapods

### DIFF
--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -17,13 +17,7 @@ Pod::Spec.new do |s|
   s.frameworks = 'Foundation'
   s.libraries = 'z', 'c++'
   s.xcconfig = {
-      'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
-      # Default Xcode 12 settings fail to build CocoaPods-generate umbrella headers:
-      # https://github.com/CocoaPods/CocoaPods/issues/9902.
-      # The fix of cocoapods does the same:
-      # https://github.com/CocoaPods/CocoaPods/pull/9905/
-      # Remove this when cocoapods 1.10 is released
-      'CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER' => 'NO'
+      'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES'
 }
 
   s.default_subspecs = ['Core']


### PR DESCRIPTION
## :scroll: Description

Cocoapods didn't work with Xcode 12, so a workaround was needed. With CocoaPods 1.10 this issue is fixed, so we can remove this workaround now.

## :bulb: Motivation and Context

Remove a not needed workaround.

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
