### PR TITLE
fix: Remove enum specifier for SentryLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Remove enum specifier for SentryLevel #822
+
 ## 6.0.6
 
 - fix: Call beforeBreadcrumb for Breadcrumb Tracker #815

--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -11,7 +11,7 @@ NS_SWIFT_NAME(Breadcrumb)
 /**
  * Level of breadcrumb
  */
-@property (nonatomic) enum SentryLevel level;
+@property (nonatomic) SentryLevel level;
 
 /**
  * Category of bookmark, can be any string
@@ -46,7 +46,7 @@ NS_SWIFT_NAME(Breadcrumb)
  * @param category String
  * @return SentryBreadcrumb
  */
-- (instancetype)initWithLevel:(enum SentryLevel)level category:(NSString *)category;
+- (instancetype)initWithLevel:(SentryLevel)level category:(NSString *)category;
 - (instancetype)init;
 + (instancetype)new NS_UNAVAILABLE;
 


### PR DESCRIPTION
## :scroll: Description

When importing Sentry into an Obj-C++ file a user receives the warning
typedef 'SentryLevel' cannot be referenced with an enum specifier. This is
fixed now by removing the redundant enum specifier.

## :bulb: Motivation and Context

Customer issue.

## :green_heart: How did you test it?
I couldn't reproduce the issue in an Objective-C++ file, but you don't need to specify `enum` for properties if your enum is strongly typed, in other words, if you use `typedef` or `NS_ENUM`. We don't use it for other enums for example on `SentryOptions`. The customer didn't get any errors for enum properties in `SentryOptions`.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
