### PR TITLE
fix: Drop Sessions without release name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Drop Sessions without release name #826
 - feat: Bring back SentryOptions.enabled #818
 - fix: Remove enum specifier for SentryLevel #822
 - feat: Send environment 'production' if nothing was set #825

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -355,6 +355,21 @@ class SentryClientTest: XCTestCase {
 
         assertLastSentEnvelopeIsASession()
     }
+    
+    func testCaptureSessionWithoutReleaseName() {
+        let session = SentrySession(releaseName: "")
+        
+        fixture.getSut().capture(session: session)
+        fixture.getSut().capture(exception, with: session, with: Scope())
+            .assertIsNotEmpty()
+        fixture.getSut().capture(fixture.event, with: session, with: Scope())
+            .assertIsNotEmpty()
+        
+        // No sessions sent
+        XCTAssertNil(fixture.transport.lastSentEnvelope)
+        XCTAssertEqual(0, fixture.transport.sentEventsWithSession.count)
+        XCTAssertEqual(2, fixture.transport.sentEvents.count)
+    }
 
     func testBeforeSendReturnsNil_EventNotSent() {
         fixture.getSut(configureOptions: { options in


### PR DESCRIPTION
##  :scroll: Description

Currently, the client sends Sessions without a release name to Sentry, which doesn't make sense, because
Sessions need a release name set. This is fixed now by dropping such sessions in the client.

## :bulb: Motivation and Context

We don't want to send Sessions that get dropped on the server anyway.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
