### PR TITLE
perf: Async synching of scope on to SentryCrash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- perf: Async synching of scope on to SentryCrash #832
+
 ## 6.0.7
 
 - fix: Drop Sessions without release name #826

--- a/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/1C0AB51E-7DAD-4469-8384-B6DE6A8E9023.plist
+++ b/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/1C0AB51E-7DAD-4469-8384-B6DE6A8E9023.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>SentryCrashIntegrationTests</key>
+		<dict>
+			<key>testPerformanceOfConfigureScope()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.006</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>SentrySDKTests</key>
+		<dict>
+			<key>testPerformanceOfConfigureScope()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.0065</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/Info.plist
+++ b/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/Info.plist
@@ -4,6 +4,30 @@
 <dict>
 	<key>runDestinationsByUUID</key>
 	<dict>
+		<key>1C0AB51E-7DAD-4469-8384-B6DE6A8E9023</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>400</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Quad-Core Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2800</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>8</integer>
+				<key>modelCode</key>
+				<string>MacBookPro15,2</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
 		<key>4487886E-B920-4AB1-99BD-1A9C5128C731</key>
 		<dict>
 			<key>localComputer</key>

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -173,19 +173,25 @@ SentryCrashIntegration ()
             [outerScope setContextValue:appData forKey:@"app"];
 
             [outerScope addScopeListener:^(SentryScope *_Nonnull scope) {
-                NSMutableDictionary<NSString *, id> *userInfo =
-                    [[NSMutableDictionary alloc] initWithDictionary:[scope serialize]];
+                // The serialization of the scope and synching it to SentryCrash can use quite some
+                // CPU time. We want to make sure that this doesn't happen on the main thread. We
+                // accept the tradeoff that in case of a crash the scope might not be 100% up to
+                // date over blocking the main thread.
+                [self.dispatchQueueWrapper dispatchAsyncWithBlock:^{
+                    NSMutableDictionary<NSString *, id> *userInfo =
+                        [[NSMutableDictionary alloc] initWithDictionary:[scope serialize]];
 
-                // SentryCrashReportConverter.convertReportToEvent needs the release name and the
-                // dist of the SentryOptions in the UserInfo. When SentryCrash records a crash it
-                // writes the UserInfo into SentryCrashField_User of the report.
-                // SentryCrashReportConverter.initWithReport loads the contents of
-                // SentryCrashField_User into self.userContext and convertReportToEvent can map the
-                // release name and dist to the SentryEvent. Fixes GH-581
-                userInfo[@"release"] = self.options.releaseName;
-                userInfo[@"dist"] = self.options.dist;
+                    // SentryCrashReportConverter.convertReportToEvent needs the release name and
+                    // the dist of the SentryOptions in the UserInfo. When SentryCrash records a
+                    // crash it writes the UserInfo into SentryCrashField_User of the report.
+                    // SentryCrashReportConverter.initWithReport loads the contents of
+                    // SentryCrashField_User into self.userContext and convertReportToEvent can map
+                    // the release name and dist to the SentryEvent. Fixes GH-581
+                    userInfo[@"release"] = self.options.releaseName;
+                    userInfo[@"dist"] = self.options.dist;
 
-                [SentryCrash.sharedInstance setUserInfo:userInfo];
+                    [SentryCrash.sharedInstance setUserInfo:userInfo];
+                }];
             }];
         }];
     }

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -60,6 +60,13 @@ class SentryCrashIntegrationTests: XCTestCase {
                                   "dist": dist]
         )
         
+        // To test this properly we need SentryCrash and SentryCrashIntegration installed and registered on the current hub of the SDK.
+        // Furthermore we would need to use TestSentryDispatchQueueWrapper to make make sure the sync of the scope to SentryCrash happened, which is complicated when we call
+        // SentrySDK.start.
+        // Setting this up needs quite some refactoring, which is complex and we accept this
+        // test smell of waiting a bit for now.
+        delayNonBlocking(timeout: 0.1)
+        
         let instance = SentryCrash.sharedInstance()
         let userInfo = (instance?.userInfo ?? ["": ""]) as Dictionary
         assertUserInfoField(userInfo: userInfo, key: "release", expected: releaseName)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -219,6 +219,38 @@ class SentrySDKTests: XCTestCase {
         }
     }
     
+    func testPerformanceOfConfigureScope() {
+        func buildCrumb(_ i: Int) -> Breadcrumb {
+            let crumb = Breadcrumb()
+            crumb.message = String(repeating: String(i), count: 100)
+            crumb.data = ["some": String(repeating: String(i), count: 1_000)]
+            crumb.category = String(i)
+            return crumb
+        }
+        
+        SentrySDK.start(options: ["dsn": TestConstants.dsnAsString])
+        
+        SentrySDK.configureScope { scope in
+            let user = User()
+            user.email = "someone@gmail.com"
+            scope.setUser(user)
+        }
+        
+        for i in Array(0...100) {
+            SentrySDK.configureScope { scope in
+                scope.add(buildCrumb(i))
+            }
+        }
+        
+        self.measure {
+            for i in Array(0...10) {
+                SentrySDK.configureScope { scope in
+                    scope.add(buildCrumb(i))
+                }
+            }
+        }
+    }
+    
     private func givenSdkWithHub() {
         SentrySDK.setCurrentHub(fixture.hub)
     }


### PR DESCRIPTION


## :scroll: Description

Synchronize the scope to SentryCrash on a background thread instead of the calling thread,
because this can block the calling thread which can be the main thread for a few ms. We
accept the tradeoff that in case of a crash the scope might not be 100% up to date over
blocking the main thread.

## :bulb: Motivation and Context

A customer reported that automatic breadcrumbs can block the UI thread for around 200ms in some cases, which is unacceptable because this leads to UI glitches.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
