### PR TITLE
feat: Add storeEnvelope on SentryClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Add storeEnvelope on SentryClient #836
 - perf: Async synching of scope on to SentryCrash #832
 
 ## 6.0.7

--- a/Sources/Sentry/Public/SentryClient.h
+++ b/Sources/Sentry/Public/SentryClient.h
@@ -113,7 +113,10 @@ SENTRY_NO_INIT
 
 - (void)captureEnvelope:(SentryEnvelope *)envelope NS_SWIFT_NAME(capture(envelope:));
 
-- (SentryFileManager *)fileManager;
+/**
+ * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.
+ */
+- (void)storeEnvelope:(SentryEnvelope *)envelope;
 
 @end
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -268,6 +268,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     [self.transport sendUserFeedback:userFeedback];
 }
 
+- (void)storeEnvelope:(SentryEnvelope *)envelope
+{
+    [self.fileManager storeEnvelope:envelope];
+}
+
 /**
  * returns BOOL chance of YES is defined by sampleRate.
  * if sample rate isn't within 0.0 - 1.0 it returns YES (like if sampleRate

--- a/Sources/Sentry/SentrySessionCrashedHandler.m
+++ b/Sources/Sentry/SentrySessionCrashedHandler.m
@@ -1,4 +1,5 @@
 #import "SentrySessionCrashedHandler.h"
+#import "SentryClient+Private.h"
 #import "SentryClient.h"
 #import "SentryCrashAdapter.h"
 #import "SentryCurrentDate.h"

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -1,4 +1,5 @@
 #import "SentrySessionTracker.h"
+#import "SentryClient+Private.h"
 #import "SentryClient.h"
 #import "SentryFileManager.h"
 #import "SentryHub.h"

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -7,6 +7,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryClient (Private)
 
+- (SentryFileManager *)fileManager;
+
 - (SentryId *)captureError:(NSError *)error
                withSession:(SentrySession *)session
                  withScope:(SentryScope *)scope;

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -80,7 +80,7 @@ class SentryHubTests: XCTestCase {
     
     func testBeforeBreadcrumbWithCallbackReturningNullDropsBreadcrumb() {
         let options = fixture.options
-        options.beforeBreadcrumb = { crumb in return nil }
+        options.beforeBreadcrumb = { _ in return nil }
         
         sut = fixture.getSut(options, nil)
         
@@ -138,7 +138,7 @@ class SentryHubTests: XCTestCase {
     
     func testAddBreadcrumb_WithCallbackReturnsNil() {
         let options = Options()
-        options.beforeBreadcrumb = { crumb in
+        options.beforeBreadcrumb = { _ in
             return nil
         }
         let hub = fixture.getSut(options)


### PR DESCRIPTION


## :scroll: Description

Hybrid SDKs as react-native need a way to synchronously store an envelope to disk. Previously, this
was possible by exposing SentryFileManager on the SentryClient, but this breaks users of
react-native that use use_frameworks!,
see https://github.com/getsentry/sentry-react-native/issues/1171. A way to fix this would be to expose
SentryFileManager and SentryCurrentDateProvider as proposed in
https://github.com/getsentry/sentry-cocoa/pull/835. This has the downside of making classes public,
that shouldn't be public. A better workaround is to expose storeEnvelope on the SentryClient.

## :bulb: Motivation and Context

See https://github.com/getsentry/sentry-cocoa/pull/835.

## :green_heart: How did you test it?
Unit tests and CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
