### PR TITLE
fix: Serialization of SentryScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Serialization of SentryScope #841
+
 ## 6.0.8
 
 - feat: Add storeEnvelope on SentryClient #836

--- a/Sources/Sentry/Public/SentrySerializable.h
+++ b/Sources/Sentry/Public/SentrySerializable.h
@@ -7,6 +7,10 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol SentrySerializable <NSObject>
 SENTRY_NO_INIT
 
+/**
+ * Serialize the contents of the object into an NSDictionary. Make to copy all properties of the
+ * original object so modifications to it don't have an impact on the serialized NSDictionary.
+ */
 - (NSDictionary<NSString *, id> *)serialize;
 
 @end

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -6,12 +6,17 @@ class SentryBreadcrumbTests: XCTestCase {
         let breadcrumb: Breadcrumb
         let date: Date
         
+        let category = "category"
+        let type = "user"
+        let message = "Click something"
+        
         init() {
             date = Date(timeIntervalSince1970: 10)
             
             breadcrumb = Breadcrumb()
             breadcrumb.level = SentryLevel.info
             breadcrumb.timestamp = date
+            breadcrumb.category = category
             breadcrumb.type = "user"
             breadcrumb.message = "Click something"
             breadcrumb.data = ["some": ["data": "data", "date": date]]
@@ -62,5 +67,25 @@ class SentryBreadcrumbTests: XCTestCase {
         let breadcrumb = Fixture().breadcrumb
         block(breadcrumb)
         XCTAssertNotEqual(fixture.breadcrumb, breadcrumb)
+    }
+    
+    func testSerialize() {
+        let crumb = fixture.breadcrumb
+        let actual = crumb.serialize()
+        
+        // Changing the original doesn't modify the serialized
+        crumb.level = SentryLevel.debug
+        crumb.timestamp = nil
+        crumb.category = ""
+        crumb.type = ""
+        crumb.message = ""
+        crumb.data = nil
+        
+        XCTAssertEqual("info", actual["level"] as? String)
+        XCTAssertEqual(fixture.dateAs8601String, actual["timestamp"] as? String)
+        XCTAssertEqual(fixture.category, actual["category"] as? String)
+        XCTAssertEqual(fixture.type, actual["type"] as? String)
+        XCTAssertEqual(fixture.message, actual["message"] as? String)
+        XCTAssertEqual(["some": ["data": "data", "date": fixture.dateAs8601String]], actual["data"] as? Dictionary)
     }
 }

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -27,7 +27,15 @@ class SentryUserTests: XCTestCase {
     private let fixture = Fixture()
     
     func testSerializationWithAllProperties() {
-        let actual = fixture.user.serialize()
+        let user = fixture.user.copy() as! User
+        let actual = user.serialize()
+        
+        // Changing the original doesn't modify the serialized
+        user.userId = ""
+        user.email = ""
+        user.username = ""
+        user.ipAddress = ""
+        user.data?.removeAll()
         
         XCTAssertEqual(fixture.user.userId, actual["id"] as? String)
         XCTAssertEqual(fixture.user.email, actual["email"] as? String)


### PR DESCRIPTION


## :scroll: Description

The SentryScope contains several properties that are dictionaries or arrays. The serialize method
returned a dictionary with references. So when for example a tag is added to the scope it is also
added to the serialized dictionary of the scope. This can lead to crashes when iterating over the
tags of the serialized dictionary while another thread adds a tag to the scope. This is fixed now
by adding a copy of these properties to the serialization dictionary instead of adding them by
reference.

## :bulb: Motivation and Context

A customer was pointing out infrequently `EXC_BAD_ACCESS (SIGSEGV)` when adding breadcrumbs on a background thread inside `SentryCrashJSONCodec.encodeObject` when calling `objectForKeyedSubscript`. `SentryCrashJSONCodec.encodeObject` is called from `SentryCrashIntegration` when the scope changes, which also happens when a breadcrumb is added. This issue is very hard to reproduce, but I was able to reproduce it around 5 times when randomly modifying the scope and adding breadcrumbs on many background threads.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] No breaking changes

## :crystal_ball: Next steps
Fix the serialization of other classes as well.