### PR TITLE
ref: Don't clear scope on init

### DIFF
--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -71,7 +71,15 @@ SentryScope ()
     if (self = [super init]) {
         self.listeners = [NSMutableArray new];
         self.maxBreadcrumbs = maxBreadcrumbs;
-        [self clear];
+        self.breadcrumbArray = [NSMutableArray new];
+        self.userObject = nil;
+        self.tagDictionary = [NSMutableDictionary new];
+        self.extraDictionary = [NSMutableDictionary new];
+        self.contextDictionary = [NSMutableDictionary new];
+        self.distString = nil;
+        self.environmentString = nil;
+        self.levelEnum = kSentryLevelNone;
+        self.fingerprintArray = [NSMutableArray new];
     }
     return self;
 }


### PR DESCRIPTION
`[[SentryScope alloc] init]` gives you a brand new instance of the scope but already fired notifyListeners due to a call to `clear`. The call seems to be there to save up on allocating things by hand.

What if we simply allocate it all by hand and avoid the call to clear?

I got to this while tracing an issue on Unity that simply: `[[SentryScope alloc] init]` crashes the app with:
![image](https://user-images.githubusercontent.com/1633368/99205064-73b04e80-2785-11eb-889f-2f6023ee43e0.png)


Not that it's related, but led me to realizing `init` is triggering `notifyListeners`