### PR TITLE
ref: Rename CrashWrapper to CrashAdapter in Hub

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -13,7 +13,7 @@ SentryHub ()
 
 @property (nonatomic, strong) SentryClient *_Nullable client;
 @property (nonatomic, strong) SentryScope *_Nullable scope;
-@property (nonatomic, strong) SentryCrashAdapter *sentryCrashWrapper;
+@property (nonatomic, strong) SentryCrashAdapter *crashAdapter;
 
 @end
 
@@ -31,7 +31,7 @@ SentryHub ()
         self.scope = scope;
         _sessionLock = [[NSObject alloc] init];
         _installedIntegrations = [[NSMutableArray alloc] init];
-        self.sentryCrashWrapper = [[SentryCrashAdapter alloc] init];
+        self.crashAdapter = [[SentryCrashAdapter alloc] init];
     }
     return self;
 }
@@ -39,10 +39,10 @@ SentryHub ()
 /** Internal constructor for testing */
 - (instancetype)initWithClient:(SentryClient *_Nullable)client
                       andScope:(SentryScope *_Nullable)scope
-         andSentryCrashWrapper:(SentryCrashAdapter *)sentryCrashWrapper
+               andCrashAdapter:(SentryCrashAdapter *)crashAdapter
 {
     self = [self initWithClient:client andScope:scope];
-    self.sentryCrashWrapper = sentryCrashWrapper;
+    self.crashAdapter = crashAdapter;
 
     return self;
 }
@@ -128,7 +128,7 @@ SentryHub ()
 
     // The crashed session is handled in SentryCrashIntegration. Checkout the comments there to find
     // out more.
-    if (!self.sentryCrashWrapper.crashedLastLaunch) {
+    if (!self.crashAdapter.crashedLastLaunch) {
         if (nil == timestamp) {
             [SentryLog
                 logWithMessage:[NSString stringWithFormat:@"No timestamp to close session "

--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -117,7 +117,7 @@ class SentrySessionGeneratorTests: XCTestCase {
         
         sentryCrash = TestSentryCrashWrapper()
         let client = SentrySDK.currentHub().getClient()
-        let hub = SentryHub(client: client, andScope: nil, andSentryCrashWrapper: self.sentryCrash)
+        let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: self.sentryCrash)
         SentrySDK.setCurrentHub(hub)
         
         crashIntegration = SentryCrashIntegration(crashWrapper: sentryCrash, andDispatchQueueWrapper: TestSentryDispatchQueueWrapper())

--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -27,7 +27,7 @@ class SentrySessionTrackerTests: XCTestCase {
         }
         
         func setNewHubToSDK() {
-            let hub = SentryHub(client: client, andScope: nil, andSentryCrashWrapper: self.sentryCrash)
+            let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: self.sentryCrash)
             SentrySDK.setCurrentHub(hub)
         }
     }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -42,7 +42,7 @@ class SentryHubTests: XCTestCase {
         
         func getSut(_ options: Options, _ scope: Scope? = nil) -> SentryHub {
             client = TestClient(options: options)
-            let hub = SentryHub(client: client, andScope: scope, andSentryCrashWrapper: sentryCrash)
+            let hub = SentryHub(client: client, andScope: scope, andCrashAdapter: sentryCrash)
             hub.bindClient(client)
             return hub
         }

--- a/Tests/SentryTests/State/SentryHub+TestInit.h
+++ b/Tests/SentryTests/State/SentryHub+TestInit.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithClient:(SentryClient *_Nullable)client
                       andScope:(SentryScope *_Nullable)scope
-         andSentryCrashWrapper:(SentryCrashAdapter *)sentryCrashWrapper;
+               andCrashAdapter:(SentryCrashAdapter *)crashAdapter;
 
 @end
 


### PR DESCRIPTION


## :scroll: Description

The private property for SentryCrashWrapper is renamed to crashAdapter, because the type is
named SentryCrashAdapter.

## :bulb: Motivation and Context

Makes the code easier to read.

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
