### PR TITLE
fix: Increase precision of iso8601 date formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## unreleased
 
+- fix: Increase precision of iso8601 date formatter #860
+
 ## 6.0.10
 
 - feat: Add onCrashedLastRun #808
 - feat: Add SentrySdkInfo to SentryOptions #859
-- fix: Increase precision of iso8601 date formatter #860
 
 ## 6.0.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat: Add onCrashedLastRun #808
 - feat: Add SentrySdkInfo to SentryOptions #859
+- fix: Increase precision of iso8601 date formatter #860
 
 ## 6.0.9
 

--- a/Sources/Sentry/NSDate+SentryExtras.m
+++ b/Sources/Sentry/NSDate+SentryExtras.m
@@ -18,14 +18,33 @@ NS_ASSUME_NONNULL_BEGIN
     return isoFormatter;
 }
 
++ (NSDateFormatter *)getIso8601FormatterWithMillisecondPrecision
+{
+    static NSDateFormatter *isoFormatter = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        isoFormatter = [[NSDateFormatter alloc] init];
+        [isoFormatter setLocale:[NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"]];
+        isoFormatter.timeZone = [NSTimeZone timeZoneWithAbbreviation:@"UTC"];
+        [isoFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"];
+    });
+
+    return isoFormatter;
+}
+
 + (NSDate *)sentry_fromIso8601String:(NSString *)string
 {
-    return [[self.class getIso8601Formatter] dateFromString:string];
+    NSDate *date = [[self.class getIso8601FormatterWithMillisecondPrecision] dateFromString:string];
+    if (nil == date) {
+        return [[self.class getIso8601Formatter] dateFromString:string];
+    } else {
+        return date;
+    }
 }
 
 - (NSString *)sentry_toIso8601String
 {
-    return [[self.class getIso8601Formatter] stringFromDate:self];
+    return [[self.class getIso8601FormatterWithMillisecondPrecision] stringFromDate:self];
 }
 
 @end

--- a/Sources/Sentry/NSDate+SentryExtras.m
+++ b/Sources/Sentry/NSDate+SentryExtras.m
@@ -36,6 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSDate *date = [[self.class getIso8601FormatterWithMillisecondPrecision] dateFromString:string];
     if (nil == date) {
+        // Parse date with low precision formatter for backward compatible
         return [[self.class getIso8601Formatter] dateFromString:string];
     } else {
         return date;

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -131,10 +131,10 @@
     event4.timestamp = date;
     event4.sdk = @{ @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString };
     event4.extra =
-        @{ @"key" : @ { @1 : @"1", @2 : [NSDate dateWithTimeIntervalSince1970:1582803326] } };
+        @{ @"key" : @ { @1 : @"1", @2 : [NSDate dateWithTimeIntervalSince1970:1582803326.1235] } };
     NSDictionary *serialized4 = @{
         @"event_id" : [event4.eventId sentryIdString],
-        @"extra" : @ { @"key" : @ { @"1" : @"1", @"2" : @"2020-02-27T11:35:26Z" } },
+        @"extra" : @ { @"key" : @ { @"1" : @"1", @"2" : @"2020-02-27T11:35:26.124Z" } },
         @"level" : @"info",
         @"platform" : @"cocoa",
         @"sdk" : @ { @"name" : @"sentry.cocoa", @"version" : SentryMeta.versionString },
@@ -214,10 +214,10 @@
                 @"2" : @2,
                 @"3" : @ { @"a" : @0 },
                 @"4" : @[
-                    @"1", @2, @{ @"a" : @0 }, @[ @"a" ], @"2020-02-27T11:35:26Z",
+                    @"1", @2, @{ @"a" : @0 }, @[ @"a" ], @"2020-02-27T11:35:26.000Z",
                     @"https://sentry.io"
                 ],
-                @"5" : @"2020-02-27T11:35:26Z",
+                @"5" : @"2020-02-27T11:35:26.000Z",
                 @"6" : @"https://sentry.io"
             }
         },

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -259,8 +259,8 @@
 
 - (void)testDateCategoryCompactibility
 {
-    NSDate *date = [NSDate sentry_fromIso8601String:@"2001-01-01T00:00:00Z"];
-    XCTAssertEqual([date timeIntervalSinceReferenceDate], 0.0);
+    NSDate *date = [NSDate sentry_fromIso8601String:@"2020-02-27T11:35:26Z"];
+    XCTAssertEqual([date timeIntervalSince1970], 1582803326.0);
 }
 
 - (void)testBreadcrumbTracker

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -245,23 +245,22 @@
     NSDate *date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
     XCTAssertEqual(
         [[NSDate sentry_fromIso8601String:[date sentry_toIso8601String]] timeIntervalSince1970],
-        timeInterval
-    );
+        timeInterval);
 }
 
 - (void)testDateCategoryPrecision
 {
     NSDate *date1 = [NSDate dateWithTimeIntervalSinceReferenceDate:0.1234];
-    XCTAssertEqualObjects(
-        [date1 sentry_toIso8601String],
-        @"2001-01-01T00:00:00.123Z"
-    );
+    XCTAssertEqualObjects([date1 sentry_toIso8601String], @"2001-01-01T00:00:00.123Z");
 
     NSDate *date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:0.9995];
-    XCTAssertEqualObjects(
-        [date2 sentry_toIso8601String],
-        @"2001-01-01T00:00:01.000Z"
-    );
+    XCTAssertEqualObjects([date2 sentry_toIso8601String], @"2001-01-01T00:00:01.000Z");
+}
+
+- (void)testDateCategoryCompactibility
+{
+    NSDate *date = [NSDate sentry_fromIso8601String:@"2001-01-01T00:00:00Z"];
+    XCTAssertEqual([date timeIntervalSinceReferenceDate], 0.0);
 }
 
 - (void)testBreadcrumbTracker

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -241,11 +241,27 @@
 
 - (void)testDateCategory
 {
-    NSDate *date = [NSDate date];
+    NSTimeInterval timeInterval = 1605888590.123;
+    NSDate *date = [NSDate dateWithTimeIntervalSince1970:timeInterval];
     XCTAssertEqual(
-        (NSInteger)[
-            [NSDate sentry_fromIso8601String:[date sentry_toIso8601String]] timeIntervalSince1970],
-        (NSInteger)[date timeIntervalSince1970]);
+        [[NSDate sentry_fromIso8601String:[date sentry_toIso8601String]] timeIntervalSince1970],
+        timeInterval
+    );
+}
+
+- (void)testDateCategoryPrecision
+{
+    NSDate *date1 = [NSDate dateWithTimeIntervalSinceReferenceDate:0.1234];
+    XCTAssertEqualObjects(
+        [date1 sentry_toIso8601String],
+        @"2001-01-01T00:00:00.123Z"
+    );
+
+    NSDate *date2 = [NSDate dateWithTimeIntervalSinceReferenceDate:0.9995];
+    XCTAssertEqualObjects(
+        [date2 sentry_toIso8601String],
+        @"2001-01-01T00:00:01.000Z"
+    );
 }
 
 - (void)testBreadcrumbTracker


### PR DESCRIPTION
## :scroll: Description

Increase precision of iso8601 date formatter to millisecond

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #857

## :green_heart: How did you test it?

Add more test cases.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
