### PR TITLE
perf: Drop global dispatch queue (thanks @tmm1 )

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/4487886E-B920-4AB1-99BD-1A9C5128C731.plist
+++ b/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/4487886E-B920-4AB1-99BD-1A9C5128C731.plist
@@ -27,6 +27,28 @@
 				</dict>
 			</dict>
 		</dict>
+		<key>SentrySDKTests</key>
+		<dict>
+			<key>testMemoryFootprintOfAddingBreadCrumbs()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Memory.physical</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>300</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+					<key>maxPercentRelativeStandardDeviation</key>
+					<real>200</real>
+				</dict>
+				<key>com.apple.dt.XCTMetric_Memory.physical-peak</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
 	</dict>
 </dict>
 </plist>

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -16,6 +16,8 @@ SentryDispatchQueueWrapper ()
 {
     self = [super init];
     if (self) {
+        // DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL is requires iOS 10. Since we are targeting
+        // iOS 9 we need to manually add the autoreleasepool.
         self.queue = dispatch_queue_create("sentry-dispatch", DISPATCH_QUEUE_SERIAL);
     }
     return self;

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -23,7 +23,11 @@ SentryDispatchQueueWrapper ()
 
 - (void)dispatchAsyncWithBlock:(void (^)(void))block
 {
-    dispatch_async(self.queue, block);
+    dispatch_async(self.queue, ^{
+        @autoreleasepool {
+            block();
+        }
+    });
 }
 
 - (void)dispatchOnce:(dispatch_once_t *)predicate block:(void (^)(void))block

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -3,7 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryDispatchQueueWrapper ()
+@interface
+SentryDispatchQueueWrapper ()
 
 @property (nonatomic, strong) dispatch_queue_t queue;
 

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -3,11 +3,26 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface SentryDispatchQueueWrapper ()
+
+@property (nonatomic, strong) dispatch_queue_t queue;
+
+@end
+
 @implementation SentryDispatchQueueWrapper
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        self.queue = dispatch_queue_create("sentry-dispatch", DISPATCH_QUEUE_SERIAL);
+    }
+    return self;
+}
 
 - (void)dispatchAsyncWithBlock:(void (^)(void))block
 {
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), block);
+    dispatch_async(self.queue, block);
 }
 
 - (void)dispatchOnce:(dispatch_once_t *)predicate block:(void (^)(void))block

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -364,6 +364,26 @@ class SentrySDKTests: XCTestCase {
         assertIntegrationsInstalled(integrations: [])
     }
     
+    @available(tvOS 13.0, *)
+    @available(OSX 10.15, *)
+    @available(iOS 13.0, *)
+    func testMemoryFootprintOfAddingBreadcrumbs() {
+        SentrySDK.start { options in
+            options.dsn = TestConstants.dsnAsString
+            options.debug = true
+            options.logLevel = SentryLogLevel.verbose
+            options.attachStacktrace = true
+        }
+        
+        self.measure(metrics: [XCTMemoryMetric()]) {
+            for i in Array(0...1_000) {
+                let crumb = TestData.crumb
+                crumb.message = "\(i)"
+                SentrySDK.addBreadcrumb(crumb: crumb)
+            }
+        }
+    }
+    
     private func givenSdkWithHub() {
         SentrySDK.setCurrentHub(fixture.hub)
     }


### PR DESCRIPTION
Applying the fix from @tmm1 (thanks for identifying the bottle neck)

https://github.com/getsentry/sentry-cocoa/commit/d2e3ad7555f0415fbfdd091bc3a4ee39c17b8ac0

First stab at addressing #868 