### PR TITLE
fix: Crash in SentrySession.serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Crash in SentrySession.serialize #870
+
 ## 6.0.11
 
 - perf: Drop global dispatch queue (#869)

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -236,6 +236,14 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
     }
     SentrySession *session = [[SentrySession alloc] initWithJSONObject:sessionDictionary];
+
+    if (nil == session.releaseName || [session.releaseName isEqualToString:@""]) {
+        [SentryLog
+            logWithMessage:@"Deserialized session doesn't contain a release name. Dropping it."
+                  andLevel:kSentryLogLevelError];
+        return nil;
+    }
+
     return session;
 }
 

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -57,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         id status = [jsonObject valueForKey:@"status"];
-        if (nil != status && [status isKindOfClass:[NSString class]]) {
+        if ([status isKindOfClass:[NSString class]]) {
             if ([@"ok" isEqualToString:status]) {
                 _status = kSentrySessionStatusOk;
             } else if ([@"exited" isEqualToString:status]) {
@@ -70,45 +70,45 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         id seq = [jsonObject valueForKey:@"seq"];
-        if (nil != seq && [seq isKindOfClass:[NSNumber class]]) {
+        if ([seq isKindOfClass:[NSNumber class]]) {
             _sequence = [seq unsignedIntegerValue];
         }
 
         id errors = [jsonObject valueForKey:@"errors"];
-        if (nil != errors && [errors isKindOfClass:[NSNumber class]]) {
+        if ([errors isKindOfClass:[NSNumber class]]) {
             _errors = [errors unsignedIntegerValue];
         }
 
         id did = [jsonObject valueForKey:@"did"];
-        if (nil != did && [did isKindOfClass:[NSString class]]) {
+        if ([did isKindOfClass:[NSString class]]) {
             _distinctId = did;
         }
 
         id init = [jsonObject valueForKey:@"init"];
-        if (nil != init && [init isKindOfClass:[NSNumber class]]) {
+        if ([init isKindOfClass:[NSNumber class]]) {
             _init = init;
         }
 
         id attrs = [jsonObject valueForKey:@"attrs"];
         if (nil != attrs) {
             id releaseName = [attrs valueForKey:@"release"];
-            if (nil != releaseName && [releaseName isKindOfClass:[NSString class]]) {
+            if ([releaseName isKindOfClass:[NSString class]]) {
                 _releaseName = releaseName;
             }
 
             id environment = [attrs valueForKey:@"environment"];
-            if (nil != environment && [environment isKindOfClass:[NSString class]]) {
+            if ([environment isKindOfClass:[NSString class]]) {
                 _environment = environment;
             }
         }
 
         id timestamp = [jsonObject valueForKey:@"timestamp"];
-        if (nil != timestamp && [timestamp isKindOfClass:[NSString class]]) {
+        if ([timestamp isKindOfClass:[NSString class]]) {
             _timestamp = [NSDate sentry_fromIso8601String:timestamp];
         }
 
         id duration = [jsonObject valueForKey:@"duration"];
-        if (nil != duration && [duration isKindOfClass:[NSNumber class]]) {
+        if ([duration isKindOfClass:[NSNumber class]]) {
             _duration = duration;
         }
     }

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -42,6 +42,8 @@ NS_ASSUME_NONNULL_BEGIN
     // because this could cause crashes, for example, in serialize.
     // With this approach we avoid crashes and accept the tradeoff that some session data might not
     // be 100% accurate.
+    // Ideally we would return nil, if the passed JSON is not valid, which we can't do because it
+    // would be a breaking change.
     if (self = [self initDefault]) {
         id sid = [jsonObject valueForKey:@"sid"];
         if (nil != sid && [sid isKindOfClass:[NSString class]]) {

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -145,6 +145,25 @@ class SentrySerializationTests: XCTestCase {
         let itemData = "{}".data(using: .utf8)!
         XCTAssertNil(SentrySerialization.envelope(with: itemData))
     }
+    
+    func testSerializeSessionWithNoReleaseName() throws {
+        var dict = SentrySession(releaseName: "1.0.0").serialize()
+        dict["attrs"] = nil // Remove release name
+        let session = SentrySession(jsonObject: dict)
+        
+        let data = try SentrySerialization.data(with: session)
+        
+        XCTAssertNil(SentrySerialization.session(with: data))
+    }
+    
+    func testSerializeSessionWithEmptyReleaseName() throws {
+        let dict = SentrySession(releaseName: "").serialize()
+        let session = SentrySession(jsonObject: dict)
+        
+        let data = try SentrySerialization.data(with: session)
+        
+        XCTAssertNil(SentrySerialization.session(with: data))
+    }
 
     private func serializeEnvelope(envelope: SentryEnvelope) -> Data {
         var serializedEnvelope: Data = Data()

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -70,4 +70,27 @@ class SentrySessionTestsSwift: XCTestCase {
         XCTAssertEqual(expected.errors, session.errors)
         XCTAssertNil(session.releaseName)
     }
+    
+    func testInitWithJson_IfJsonContainsWrongFields_DefaultValuesAreUsed() {
+        let expected = SentrySession(releaseName: "release")
+        var serialized = expected.serialize()
+        serialized["sid"] = 20
+        serialized["started"] = 20
+        serialized["status"] = 20
+        serialized["seq"] = "nil"
+        serialized["errors"] = nil
+        serialized["did"] = nil
+        serialized["init"] = nil
+        serialized["attrs"] = nil
+
+        let session = SentrySession(jsonObject: serialized)
+        
+        XCTAssertNotEqual(expected.sessionId, session.sessionId)
+        XCTAssertEqual(expected.started, session.started)
+        XCTAssertEqual(expected.status, session.status)
+        XCTAssertEqual(expected.sequence, session.sequence)
+        XCTAssertEqual(expected.errors, session.errors)
+        XCTAssertNil(session.releaseName)
+    }
+
 }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -48,4 +48,26 @@ class SentrySessionTestsSwift: XCTestCase {
         session.user?.email = "someone_else@sentry.io"
         XCTAssertNotEqual(session, copiedSession)
     }
+    
+    func testInitWithJson_IfJsonMissesField_DefaultValuesAreUsed() {
+        let expected = SentrySession(releaseName: "release")
+        var serialized = expected.serialize()
+        serialized["sid"] = nil
+        serialized["started"] = nil
+        serialized["status"] = nil
+        serialized["seq"] = nil
+        serialized["errors"] = nil
+        serialized["did"] = nil
+        serialized["init"] = nil
+        serialized["attrs"] = nil
+
+        let session = SentrySession(jsonObject: serialized)
+        
+        XCTAssertNotEqual(expected.sessionId, session.sessionId)
+        XCTAssertEqual(expected.started, session.started)
+        XCTAssertEqual(expected.status, session.status)
+        XCTAssertEqual(expected.sequence, session.sequence)
+        XCTAssertEqual(expected.errors, session.errors)
+        XCTAssertNil(session.releaseName)
+    }
 }


### PR DESCRIPTION



## :scroll: Description

Calling SentrySession.initWithJsonObject with an invalid dictionary didn't set any values for some
properties, which are non-nullable. When calling serialize afterward this lead to a
NSInvalidArgumentException from [SentrySession serialize] due to nil object. This is fixed now,
by setting some default values.

## :bulb: Motivation and Context

Fixes GH-870

## :green_heart: How did you test it?
Unit tests and `SentrySessionGeneratorTests`.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
