### PR TITLE
ref: Use boxed literals in SentrySession

### DIFF
--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(self) {
         NSMutableDictionary *serializedData = @{
             @"sid" : _sessionId.UUIDString,
-            @"errors" : [NSNumber numberWithLong:_errors],
+            @"errors" : @(_errors),
             @"started" : [_started sentry_toIso8601String],
         }
                                                   .mutableCopy;
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
         }
 
         // TODO: seq to be just unix time in mills?
-        [serializedData setValue:[NSNumber numberWithLong:_sequence] forKey:@"seq"];
+        [serializedData setValue:@(_sequence) forKey:@"seq"];
 
         if (nil != _releaseName || nil != _environment) {
             NSMutableDictionary *attrs = [[NSMutableDictionary alloc] init];


### PR DESCRIPTION


## :scroll: Description

We used [NSNumber numberWithLong] to box an NSUInteger to an NSNumber. This can be
simplified by using boxed literals.

## :bulb: Motivation and Context

Simplify the code.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
