### PR TITLE
ref: Remove out of date comment in Transport

### DIFF
--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -5,22 +5,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 // TODO: align with unified SDK api
-/**
- * Sends data to the Sentry server.
- */
 NS_SWIFT_NAME(Transport)
 @protocol SentryTransport <NSObject>
 
-/**
- * Sends an event to sentry.
- * Triggerd when a event occurs. Thus the first try to upload an event.
- * CompletionHandler will be called if set.
- *
- * Failure to send will most likely keep this event on disk to batch upload it
- * on next app launch.
- *
- * @param event SentryEvent that should be sent
- */
 - (void)sendEvent:(SentryEvent *)event NS_SWIFT_NAME(send(event:));
 
 - (void)sendEvent:(SentryEvent *)event withSession:(SentrySession *)session;


### PR DESCRIPTION


## :scroll: Description

The comment for sendEvent in SentryTransport is out of date and can be removed
as SentryTransport is currently not public.

## :bulb: Motivation and Context

Remove unnecessary comments.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
