### PR TITLE
chore: introduce script to make a single XCFramework

### DIFF
--- a/Sources/Configuration/Sentry.xcconfig
+++ b/Sources/Configuration/Sentry.xcconfig
@@ -19,7 +19,7 @@ SDKROOT__CARTHAGE_ = iphoneos
 // ⋯ quite early in the process, queried values not compiled into Carthage will cause hard errors.
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY = 1,2,3,4
-SKIP_INSTALL = YES
+SKIP_INSTALL = NO
 
 DEFINES_MODULE = YES
 DYLIB_COMPATIBILITY_VERSION = 1

--- a/scripts/build-xcf.sh
+++ b/scripts/build-xcf.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Builds XCFramework of all the possible destinations
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR/.." || exit 1
+ARCHIVES_DIR="./Archives"
+XCF_OUTPUT="./Sentry.xcframework"
+
+mkdir -p "$ARCHIVES_DIR"
+rm -rf "$XCF_OUTPUT"
+
+archive() {
+    xcodebuild archive -workspace Sentry.xcworkspace -scheme Sentry -destination "$1" -archivePath "$ARCHIVES_DIR/$2"
+}
+
+archive "generic/platform=iOS" "Sentry-ios"
+archive "generic/platform=iOS Simulator" "Sentry-iossimulator"
+archive "generic/platform=watchOS" "Sentry-watchos"
+# This gets a warning due to matching both mac & mac-catalyst variants, but unclear how to be specific
+archive "generic/platform=macOS" "Sentry-mac"
+archive "generic/platform=macOS,variant=Mac Catalyst" "Sentry-maccatalyst"
+
+# Combine them all into an XCFramework
+XCARGS=()
+
+# Thanks to shellcheck this got a little weirder, likely simpler if switched to zsh due to macOS bash's age
+while IFS= read -r -d '' file
+do
+    XCARGS+=("-framework")
+    XCARGS+=("$file")
+done <   <(find "$ARCHIVES_DIR" -name 'Sentry.framework' -print0)
+
+xcodebuild -create-xcframework "${XCARGS[@]}" -output "$XCF_OUTPUT"


### PR DESCRIPTION
## :scroll: Description

1. Turns SKIP_INSTALL to no, this I'm wondering might be an issue for other distribution, open to suggestions to work around if so
2. Adds scripts/build-xcf.sh which builds an XCFramework for all destinations

## :bulb: Motivation and Context

Ran into recently released Xcode 12.3 being strict about iOS frameworks not allowing both iOS & iOS Simulator to be present. Ran across [this forum post](https://developer.apple.com/forums/thread/130684) which suggests pre-built frameworks should be XCFramework

## :green_heart: How did you test it?

I've tested the XCFramework output on iOS without issue, expect the only concern is the SKIP_INSTALL change with Cocoapods/Carthage methods, so wondering if that might have to be tweaked (maybe script can somehow force that setting?)

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the CHANGELOG
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps

Just needs someone familiar with the project to confirm if this won't break anything (SKIP_INSTALL) as otherwise this should leave everything else as is and is a script addition that could be added to release procedures in future.