### PR TITLE
ref: Rename initPath to initWithPath

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -22,9 +22,9 @@ ViewController ()
         [scope setUser:user];
 
         NSString *path = [[NSBundle mainBundle] pathForResource:@"Tongariro" ofType:@"jpg"];
-        [scope addAttachment:[[SentryAttachment alloc] initPath:path
-                                                       filename:@"Tongariro.jpg"
-                                                    contentType:@"image/jpeg"]];
+        [scope addAttachment:[[SentryAttachment alloc] initWithPath:path
+                                                           filename:@"Tongariro.jpg"
+                                                        contentType:@"image/jpeg"]];
 
         [scope addAttachment:[[SentryAttachment alloc]
                                  initWithData:[@"hello" dataUsingEncoding:NSUTF8StringEncoding]

--- a/Sources/Sentry/Public/SentryAttachment.h
+++ b/Sources/Sentry/Public/SentryAttachment.h
@@ -38,7 +38,7 @@ SENTRY_NO_INIT
  *
  * @param path The path of the file whose contents you want to upload to Sentry.
  */
-- (instancetype)initPath:(NSString *)path;
+- (instancetype)initWithPath:(NSString *)path;
 
 /**
  * Initializes an attachment with a path. Sets the content type to "application/octet-stream".
@@ -49,7 +49,7 @@ SENTRY_NO_INIT
  * @param path The path of the file whose contents you want to upload to Sentry.
  * @param filename The name of the attachment to display in Sentry.
  */
-- (instancetype)initPath:(NSString *)path filename:(NSString *)filename;
+- (instancetype)initWithPath:(NSString *)path filename:(NSString *)filename;
 
 /**
  * Initializes an attachment with a path.
@@ -61,9 +61,9 @@ SENTRY_NO_INIT
  * @param filename The name of the attachment to display in Sentry.
  * @param contentType The content type of the attachment. Default is "application/octet-stream".
  */
-- (instancetype)initPath:(NSString *)path
-                filename:(NSString *)filename
-             contentType:(NSString *)contentType;
+- (instancetype)initWithPath:(NSString *)path
+                    filename:(NSString *)filename
+                 contentType:(NSString *)contentType;
 
 /**
  * The data of the attachment.

--- a/Sources/Sentry/SentryAttachment.m
+++ b/Sources/Sentry/SentryAttachment.m
@@ -25,19 +25,19 @@ NSString *const DefaultContentType = @"application/octet-stream";
     return self;
 }
 
-- (instancetype)initPath:(NSString *)path
+- (instancetype)initWithPath:(NSString *)path
 {
-    return [self initPath:path filename:[path lastPathComponent]];
+    return [self initWithPath:path filename:[path lastPathComponent]];
 }
 
-- (instancetype)initPath:(NSString *)path filename:(NSString *)filename
+- (instancetype)initWithPath:(NSString *)path filename:(NSString *)filename
 {
-    return [self initPath:path filename:filename contentType:DefaultContentType];
+    return [self initWithPath:path filename:filename contentType:DefaultContentType];
 }
 
-- (instancetype)initPath:(NSString *)path
-                filename:(NSString *)filename
-             contentType:(NSString *)contentType
+- (instancetype)initWithPath:(NSString *)path
+                    filename:(NSString *)filename
+                 contentType:(NSString *)contentType
 {
     if (self = [super init]) {
         _path = path;


### PR DESCRIPTION


## :scroll: Description

Rename all constructors in SentryAttachment from initPath to initWithPath. Stick to the Objective-C way. No effect on Swift.

## :bulb: Motivation and Context

I noticed this when writing the docs for Objective-C.

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
Update the docs on the next alpha release.