### PR TITLE
feat: Add maxAttachmentSize to SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Add maxAttachmentSize to SentryOptions #887
 - ref: Remove SentryAttachment.isEqual and hash #885
 - ref: Remove SentryScope.isEqual and hash #884
 

--- a/Sources/Sentry/Public/SentryEnvelope.h
+++ b/Sources/Sentry/Public/SentryEnvelope.h
@@ -69,7 +69,8 @@ SENTRY_NO_INIT
 - (instancetype)initWithEvent:(SentryEvent *)event;
 - (instancetype)initWithSession:(SentrySession *)session;
 - (instancetype)initWithUserFeedback:(SentryUserFeedback *)userFeedback;
-- (_Nullable instancetype)initWithAttachment:(SentryAttachment *)attachment;
+- (_Nullable instancetype)initWithAttachment:(SentryAttachment *)attachment
+                           maxAttachmentSize:(NSUInteger)maxAttachmentSize;
 - (instancetype)initWithHeader:(SentryEnvelopeItemHeader *)header
                           data:(NSData *)data NS_DESIGNATED_INITIALIZER;
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -130,6 +130,14 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, readonly, strong) SentrySdkInfo *sdkInfo;
 
+/**
+ * The maximum size for each attachment in MiB. Default is 5 MiB.
+ *
+ * Please also check the maxium attachment size of relay to make sure your attachments don't get
+ * discarded there: https://docs.sentry.io/product/relay/options/
+ */
+@property (nonatomic, assign) NSUInteger maxAttachmentSize;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -131,7 +131,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, readonly, strong) SentrySdkInfo *sdkInfo;
 
 /**
- * The maximum size for each attachment in MiB. Default is 5 MiB.
+ * The maximum size for each attachment in MiB. Default is 20 MiB.
  *
  * Please also check the maxium attachment size of relay to make sure your attachments don't get
  * discarded there: https://docs.sentry.io/product/relay/options/

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -163,11 +163,50 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (_Nullable instancetype)initWithAttachment:(SentryAttachment *)attachment
+                           maxAttachmentSize:(NSUInteger)maxAttachmentSize
 {
+    NSUInteger maxAttachmentSizeInBytes = 1024 * 1024 * maxAttachmentSize;
+
     NSData *data = nil;
     if (nil != attachment.data) {
+        if (attachment.data.length > maxAttachmentSizeInBytes) {
+            NSString *message =
+                [NSString stringWithFormat:@"Dropping attachment  with filename '%@', because the "
+                                           @"size of the passed data with %lu bytes is bigger than "
+                                           @"the maximum allowed attachment size of %lu bytes.",
+                          attachment.filename, attachment.data.length, maxAttachmentSizeInBytes];
+            [SentryLog logWithMessage:message andLevel:kSentryLogLevelDebug];
+
+            return nil;
+        }
         data = attachment.data;
     } else if (nil != attachment.path) {
+
+        NSError *error = nil;
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSDictionary<NSFileAttributeKey, id> *attr =
+            [fileManager attributesOfItemAtPath:attachment.path error:&error];
+
+        if (nil != error) {
+            NSString *message = [NSString
+                stringWithFormat:@"Couldn't check file size of attachment with path: %@. Error: %@",
+                attachment.path, error.localizedDescription];
+            [SentryLog logWithMessage:message andLevel:kSentryLogLevelError];
+            return nil;
+        }
+
+        unsigned long long fileSize = [attr fileSize];
+
+        if (fileSize > maxAttachmentSizeInBytes) {
+            NSString *message = [NSString
+                stringWithFormat:
+                    @"Dropping attachment, because the size of the it located at '%@' with %llu "
+                    @"bytes is bigger than the maximum allowed attachment size of %lu bytes.",
+                attachment.path, fileSize, maxAttachmentSizeInBytes];
+            [SentryLog logWithMessage:message andLevel:kSentryLogLevelDebug];
+            return nil;
+        }
+
         data = [[NSFileManager defaultManager] contentsAtPath:attachment.path];
     }
 

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -180,6 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
 
             return nil;
         }
+        
         data = attachment.data;
     } else if (nil != attachment.path) {
 
@@ -193,6 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
                 stringWithFormat:@"Couldn't check file size of attachment with path: %@. Error: %@",
                 attachment.path, error.localizedDescription];
             [SentryLog logWithMessage:message andLevel:kSentryLogLevelError];
+            
             return nil;
         }
 

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -174,7 +174,8 @@ NS_ASSUME_NONNULL_BEGIN
                 [NSString stringWithFormat:@"Dropping attachment with filename '%@', because the "
                                            @"size of the passed data with %lu bytes is bigger than "
                                            @"the maximum allowed attachment size of %lu bytes.",
-                          attachment.filename, attachment.data.length, maxAttachmentSizeInBytes];
+                          attachment.filename, (unsigned long)attachment.data.length,
+                          (unsigned long)maxAttachmentSizeInBytes];
             [SentryLog logWithMessage:message andLevel:kSentryLogLevelDebug];
 
             return nil;
@@ -202,7 +203,7 @@ NS_ASSUME_NONNULL_BEGIN
                 stringWithFormat:
                     @"Dropping attachment, because the size of the it located at '%@' with %llu "
                     @"bytes is bigger than the maximum allowed attachment size of %lu bytes.",
-                attachment.path, fileSize, maxAttachmentSizeInBytes];
+                attachment.path, fileSize, (unsigned long)maxAttachmentSizeInBytes];
             [SentryLog logWithMessage:message andLevel:kSentryLogLevelDebug];
             return nil;
         }

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
 
             return nil;
         }
-        
+
         data = attachment.data;
     } else if (nil != attachment.path) {
 
@@ -194,7 +194,7 @@ NS_ASSUME_NONNULL_BEGIN
                 stringWithFormat:@"Couldn't check file size of attachment with path: %@. Error: %@",
                 attachment.path, error.localizedDescription];
             [SentryLog logWithMessage:message andLevel:kSentryLogLevelError];
-            
+
             return nil;
         }
 

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (nil != attachment.data) {
         if (attachment.data.length > maxAttachmentSizeInBytes) {
             NSString *message =
-                [NSString stringWithFormat:@"Dropping attachment  with filename '%@', because the "
+                [NSString stringWithFormat:@"Dropping attachment with filename '%@', because the "
                                            @"size of the passed data with %lu bytes is bigger than "
                                            @"the maximum allowed attachment size of %lu bytes.",
                           attachment.filename, attachment.data.length, maxAttachmentSizeInBytes];

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -84,10 +84,12 @@ SentryHttpTransport ()
     [items addObject:[[SentryEnvelopeItem alloc] initWithEvent:event]];
 
     for (SentryAttachment *attachment in attachments) {
-        SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithAttachment:attachment];
+        SentryEnvelopeItem *item =
+            [[SentryEnvelopeItem alloc] initWithAttachment:attachment
+                                         maxAttachmentSize:self.options.maxAttachmentSize];
         // The item is nil, when creating the envelopeItem failed.
         if (nil != item) {
-            [items addObject:[[SentryEnvelopeItem alloc] initWithAttachment:attachment]];
+            [items addObject:item];
         }
     }
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -28,7 +28,7 @@
         self.enableAutoSessionTracking = YES;
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
         self.attachStacktrace = YES;
-        self.maxAttachmentSize = [@5 unsignedIntValue];
+        self.maxAttachmentSize = [@20 unsignedIntValue];
         _sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
                                             andVersion:SentryMeta.versionString];
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -28,6 +28,7 @@
         self.enableAutoSessionTracking = YES;
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
         self.attachStacktrace = YES;
+        self.maxAttachmentSize = [@5 unsignedIntValue];
         _sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
                                             andVersion:SentryMeta.versionString];
 
@@ -152,6 +153,10 @@
 
     if (nil != options[@"attachStacktrace"]) {
         self.attachStacktrace = [options[@"attachStacktrace"] boolValue];
+    }
+
+    if (nil != options[@"maxAttachmentSize"]) {
+        self.maxAttachmentSize = [options[@"maxAttachmentSize"] unsignedIntValue];
     }
 }
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -34,7 +34,7 @@ class SentryHttpTransportTests: XCTestCase {
             
             eventRequest = buildRequest(SentryEnvelope(event: event))
             
-            let eventEnvelope = SentryEnvelope(id: event.eventId, items: [SentryEnvelopeItem(event: event), SentryEnvelopeItem(attachment: TestData.dataAttachment)!])
+            let eventEnvelope = SentryEnvelope(id: event.eventId, items: [SentryEnvelopeItem(event: event), SentryEnvelopeItem(attachment: TestData.dataAttachment, maxAttachmentSize: 5)!])
             eventWithAttachmentRequest = buildRequest(eventEnvelope)
 
             session = SentrySession(releaseName: "2.0.1")

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -8,11 +8,19 @@ class SentryEnvelopeTests: XCTestCase {
         let path = "test.log"
         let data = "hello".data(using: .utf8)
         
+        let maxAttachmentSize: UInt = 5
+        let dataAllowed: Data
+        let dataTooBig: Data
+        
         init() {
             userFeedback = UserFeedback(eventId: SentryId())
             userFeedback.comments = "It doesn't work!"
             userFeedback.email = "john@me.com"
             userFeedback.name = "John Me"
+            
+            let maxAttachmentNumberOfBytes = 1_024 * 1_024 * maxAttachmentSize
+            dataAllowed = Data([UInt8](repeating: 1, count: Int(maxAttachmentNumberOfBytes)))
+            dataTooBig = Data([UInt8](repeating: 1, count: Int(maxAttachmentNumberOfBytes) + 1))
         }
 
         var breadcrumb: Breadcrumb {
@@ -261,7 +269,7 @@ class SentryEnvelopeTests: XCTestCase {
     func testInitWithDataAttachment() {
         let attachment = TestData.dataAttachment
         
-        let envelopeItem = SentryEnvelopeItem(attachment: attachment)!
+        let envelopeItem = SentryEnvelopeItem(attachment: attachment, maxAttachmentSize: fixture.maxAttachmentSize)!
         
         XCTAssertEqual("attachment", envelopeItem.header.type)
         XCTAssertEqual(UInt(attachment.data?.count ?? 0), envelopeItem.header.length)
@@ -270,15 +278,11 @@ class SentryEnvelopeTests: XCTestCase {
     }
     
     func testInitWithFileAttachment() {
-        do {
-            try fixture.data?.write(to: URL(fileURLWithPath: fixture.path))
-        } catch {
-            XCTFail("Failed to store attachment.")
-        }
+        writeDataToFile(data: fixture.data ?? Data())
         
         let attachment = Attachment(path: fixture.path)
         
-        let envelopeItem = SentryEnvelopeItem(attachment: attachment)!
+        let envelopeItem = SentryEnvelopeItem(attachment: attachment, maxAttachmentSize: fixture.maxAttachmentSize)!
         
         XCTAssertEqual("attachment", envelopeItem.header.type)
         XCTAssertEqual(UInt(fixture.data?.count ?? 0), envelopeItem.header.length)
@@ -289,9 +293,31 @@ class SentryEnvelopeTests: XCTestCase {
     func testInitWithNonExistentFileAttachment() {
         let attachment = Attachment(path: fixture.path)
         
-        let envelopeItem = SentryEnvelopeItem(attachment: attachment)
+        let envelopeItem = SentryEnvelopeItem(attachment: attachment, maxAttachmentSize: fixture.maxAttachmentSize)
         
         XCTAssertNil(envelopeItem)
+    }
+    
+    func testInitWithFileAttachment_MaxAttachmentSize() {
+        writeDataToFile(data: fixture.dataAllowed)
+        XCTAssertNotNil(SentryEnvelopeItem(attachment: Attachment(path: fixture.path), maxAttachmentSize: fixture.maxAttachmentSize))
+        
+        writeDataToFile(data: fixture.dataTooBig)
+        XCTAssertNil(SentryEnvelopeItem(attachment: Attachment(path: fixture.path), maxAttachmentSize: fixture.maxAttachmentSize))
+    }
+    
+    func testInitWithDataAttachment_MaxAttachmentSize() {
+        XCTAssertNil(SentryEnvelopeItem(attachment: Attachment(data: fixture.dataTooBig, filename: ""), maxAttachmentSize: fixture.maxAttachmentSize))
+        
+        XCTAssertNotNil(SentryEnvelopeItem(attachment: Attachment(data: fixture.dataAllowed, filename: ""), maxAttachmentSize: fixture.maxAttachmentSize))
+    }
+    
+    private func writeDataToFile(data: Data) {
+        do {
+            try data.write(to: URL(fileURLWithPath: fixture.path))
+        } catch {
+            XCTFail("Failed to store attachment.")
+        }
     }
 
     private func assertContainsBreadcrumbForDroppingContextAndSDK(_ json: String) {

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -18,9 +18,9 @@ class SentryEnvelopeTests: XCTestCase {
             userFeedback.email = "john@me.com"
             userFeedback.name = "John Me"
             
-            let maxAttachmentNumberOfBytes = 1_024 * 1_024 * maxAttachmentSize
-            dataAllowed = Data([UInt8](repeating: 1, count: Int(maxAttachmentNumberOfBytes)))
-            dataTooBig = Data([UInt8](repeating: 1, count: Int(maxAttachmentNumberOfBytes) + 1))
+            let maxAttachmentSizeInBytes = 1_024 * 1_024 * maxAttachmentSize
+            dataAllowed = Data([UInt8](repeating: 1, count: Int(maxAttachmentSizeInBytes)))
+            dataTooBig = Data([UInt8](repeating: 1, count: Int(maxAttachmentSizeInBytes) + 1))
         }
 
         var breadcrumb: Breadcrumb {
@@ -307,9 +307,13 @@ class SentryEnvelopeTests: XCTestCase {
     }
     
     func testInitWithDataAttachment_MaxAttachmentSize() {
-        XCTAssertNil(SentryEnvelopeItem(attachment: Attachment(data: fixture.dataTooBig, filename: ""), maxAttachmentSize: fixture.maxAttachmentSize))
+        let attachmentTooBig = Attachment(data: fixture.dataTooBig, filename: "")
+        XCTAssertNil(
+            SentryEnvelopeItem(attachment: attachmentTooBig, maxAttachmentSize: fixture.maxAttachmentSize))
         
-        XCTAssertNotNil(SentryEnvelopeItem(attachment: Attachment(data: fixture.dataAllowed, filename: ""), maxAttachmentSize: fixture.maxAttachmentSize))
+        let attachment = Attachment(data: fixture.dataAllowed, filename: "")
+        XCTAssertNotNil(
+            SentryEnvelopeItem(attachment: attachment, maxAttachmentSize: fixture.maxAttachmentSize))
     }
     
     private func writeDataToFile(data: Data) {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -334,7 +334,7 @@
     XCTAssertEqual(YES, options.enableAutoSessionTracking);
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
     XCTAssertEqual(YES, options.attachStacktrace);
-    XCTAssertEqual([@5 unsignedIntValue], options.maxAttachmentSize);
+    XCTAssertEqual([@20 unsignedIntValue], options.maxAttachmentSize);
 }
 
 - (void)testSetValidDsn
@@ -381,7 +381,7 @@
 
 - (void)testMaxAttachmentSize
 {
-    NSNumber *maxAttachmentSize = @6;
+    NSNumber *maxAttachmentSize = @21;
     SentryOptions *options = [self getValidOptions:@{ @"maxAttachmentSize" : maxAttachmentSize }];
 
     XCTAssertEqual([maxAttachmentSize unsignedIntValue], options.maxAttachmentSize);
@@ -391,7 +391,7 @@
 {
     SentryOptions *options = [self getValidOptions:@{}];
 
-    XCTAssertEqual([@5 unsignedIntValue], options.maxAttachmentSize);
+    XCTAssertEqual([@20 unsignedIntValue], options.maxAttachmentSize);
 }
 
 - (SentryOptions *)getValidOptions:(NSDictionary<NSString *, id> *)dict

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -334,6 +334,7 @@
     XCTAssertEqual(YES, options.enableAutoSessionTracking);
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
     XCTAssertEqual(YES, options.attachStacktrace);
+    XCTAssertEqual([@5 unsignedIntValue], options.maxAttachmentSize);
 }
 
 - (void)testSetValidDsn
@@ -376,6 +377,21 @@
 
     XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name);
     XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version);
+}
+
+- (void)testMaxAttachmentSize
+{
+    NSNumber *maxAttachmentSize = @6;
+    SentryOptions *options = [self getValidOptions:@{ @"maxAttachmentSize" : maxAttachmentSize }];
+
+    XCTAssertEqual([maxAttachmentSize unsignedIntValue], options.maxAttachmentSize);
+}
+
+- (void)testDefaultMaxAttachmentSize
+{
+    SentryOptions *options = [self getValidOptions:@{}];
+
+    XCTAssertEqual([@5 unsignedIntValue], options.maxAttachmentSize);
 }
 
 - (SentryOptions *)getValidOptions:(NSDictionary<NSString *, id> *)dict


### PR DESCRIPTION


## :scroll: Description

Drop attachments that are larger than the specified maxAttachmentSize in SentryOptions.

## :bulb: Motivation and Context

We want to give the users of the SDK the possibility to drop large attachments.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
