### PR TITLE
ref: Use NSArray for fingerprint on Scope

### DIFF
--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -234,7 +234,7 @@ SentryScope ()
 {
     @synchronized(self) {
         if (fingerprint == nil) {
-            self.fingerprintArray = [NSMutableArray new];
+            self.fingerprintArray = [NSArray new];
         } else {
             self.fingerprintArray = fingerprint.mutableCopy;
         }


### PR DESCRIPTION


## :scroll: Description

In SentryScope.setFingerprint NSMutableArray is used to init a new array, but
the fingerprintArray is of type NSArray. Therefore we can change it to NSArray.

## :bulb: Motivation and Context

Using immutable types when possible.

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
