### PR TITLE
ref: Enable hidden local variables as warnings

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -2291,6 +2291,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_WARN_SHADOW = YES;
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Sources/Sentry/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -2331,6 +2332,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_WARN_SHADOW = YES;
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = Sources/Sentry/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -110,6 +110,12 @@
 - (void)swizzleSendAction
 {
 #if SENTRY_HAS_UIKIT
+
+    // SentrySwizzleInstanceMethod declaration shadows a local variable. The swizzling is working
+    // fine and we accept this warning.
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow"
+
     static const void *swizzleSendActionKey = &swizzleSendActionKey;
     SEL selector = NSSelectorFromString(@"sendAction:to:from:forEvent:");
     SentrySwizzleInstanceMethod(UIApplication.class, selector, SentrySWReturnType(BOOL),
@@ -131,6 +137,7 @@
             return SentrySWCallOriginal(action, target, sender, event);
         }),
         SentrySwizzleModeOncePerClassAndSuperclasses, swizzleSendActionKey);
+#    pragma clang diagnostic pop
 #else
     [SentryLog logWithMessage:@"NO UIKit -> [SentryBreadcrumbTracker "
                               @"swizzleSendAction] does nothing."
@@ -141,6 +148,12 @@
 - (void)swizzleViewDidAppear
 {
 #if SENTRY_HAS_UIKIT
+
+    // SentrySwizzleInstanceMethod declaration shadows a local variable. The swizzling is working
+    // fine and we accept this warning.
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow"
+
     static const void *swizzleViewDidAppearKey = &swizzleViewDidAppearKey;
     SEL selector = NSSelectorFromString(@"viewDidAppear:");
     SentrySwizzleInstanceMethod(UIViewController.class, selector, SentrySWReturnType(void),
@@ -162,6 +175,7 @@
             SentrySWCallOriginal(animated);
         }),
         SentrySwizzleModeOncePerClassAndSuperclasses, swizzleViewDidAppearKey);
+#    pragma clang diagnostic pop
 #else
     [SentryLog logWithMessage:@"NO UIKit -> [SentryBreadcrumbTracker "
                               @"swizzleViewDidAppear] does nothing."

--- a/Sources/Sentry/SentryInstallation.m
+++ b/Sources/Sentry/SentryInstallation.m
@@ -26,10 +26,11 @@ static NSString *volatile installationString;
 
         if (nil == installationData) {
             installationString = [NSUUID UUID].UUIDString;
-            NSData *installationData = [installationString dataUsingEncoding:NSUTF8StringEncoding];
+            NSData *installationStringData =
+                [installationString dataUsingEncoding:NSUTF8StringEncoding];
             NSFileManager *fileManager = [NSFileManager defaultManager];
             [fileManager createFileAtPath:installationFilePath
-                                 contents:installationData
+                                 contents:installationStringData
                                attributes:nil];
         } else {
             installationString = [[NSString alloc] initWithData:installationData

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -61,27 +61,28 @@ NS_ASSUME_NONNULL_BEGIN
 
     for (int i = 0; i < envelope.items.count; ++i) {
         [envelopeData appendData:[@"\n" dataUsingEncoding:NSUTF8StringEncoding]];
-        NSMutableDictionary *serializedData = [NSMutableDictionary new];
+        NSMutableDictionary *serializedItemHeaderData = [NSMutableDictionary new];
         if (nil != envelope.items[i].header) {
             if (nil != envelope.items[i].header.type) {
-                [serializedData setValue:envelope.items[i].header.type forKey:@"type"];
+                [serializedItemHeaderData setValue:envelope.items[i].header.type forKey:@"type"];
             }
 
             NSString *filename = envelope.items[i].header.filename;
             if (nil != filename) {
-                [serializedData setValue:filename forKey:@"filename"];
+                [serializedItemHeaderData setValue:filename forKey:@"filename"];
             }
 
             NSString *contentType = envelope.items[i].header.contentType;
             if (nil != contentType) {
-                [serializedData setValue:contentType forKey:@"content_type"];
+                [serializedItemHeaderData setValue:contentType forKey:@"content_type"];
             }
 
-            [serializedData
+            [serializedItemHeaderData
                 setValue:[NSNumber numberWithUnsignedInteger:envelope.items[i].header.length]
                   forKey:@"length"];
         }
-        NSData *itemHeader = [SentrySerialization dataWithJSONObject:serializedData error:error];
+        NSData *itemHeader = [SentrySerialization dataWithJSONObject:serializedItemHeaderData
+                                                               error:error];
         if (nil == itemHeader) {
             [SentryLog logWithMessage:[NSString stringWithFormat:@"Envelope item header cannot "
                                                                  @"be converted to JSON."]


### PR DESCRIPTION
## :scroll: Description

Including sentry-cocoa via the SPM prints shadow-ivar warnings, that are fixed now.
Furthermore, GCC_WARN_SHADOW is enabled to avoid shadow-ivar warnings.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/893.

## :bulb: Motivation and Context

GH-837

## :green_heart: How did you test it?
Adding sentry-cocoa to a Swift package to the hash of this commit like this: `.package(name: "Sentry", url: "https://github.com/getsentry/sentry-cocoa", .revision("d83582db32c15804f34a239297ff1d969df0c158"))` and building the package via `swift build` from the command line. 

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
