### PR TITLE
fix: Duplicate symbol clash with KSCrash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- ref: prefix with category methods with sentry #902
+
 ## 6.1.0
 
 - perf: Improve locks in SentryScope #888

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- ref: prefix with category methods with sentry #902
+- fix: Duplicate symbol clash with KSCrash #902
 
 ## 6.1.0
 

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -245,7 +245,7 @@ SentryCrashInstallation ()
         }
     }
     if ([errors length] > 0) {
-        return [NSError errorWithDomain:[[self class] description]
+        return [NSError sentryErrorWithDomain:[[self class] description]
                                    code:0
                             description:@"Installation properties failed validation: %@", errors];
     }
@@ -310,7 +310,7 @@ SentryCrashInstallation ()
     id<SentryCrashReportFilter> sink = [self sink];
     if (sink == nil) {
         onCompletion(nil, NO,
-            [NSError errorWithDomain:[[self class] description]
+            [NSError sentryErrorWithDomain:[[self class] description]
                                 code:0
                          description:@"Sink was nil (subclasses must implement "
                                      @"method \"sink\")"]);

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -411,7 +411,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
     if (self.sink == nil) {
         sentrycrash_callCompletion(onCompletion, reports, NO,
-            [NSError errorWithDomain:[[self class] description]
+            [NSError sentryErrorWithDomain:[[self class] description]
                                 code:0
                          description:@"No sink set. Crash reports not sent."]);
         return;

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
@@ -39,7 +39,7 @@
  * @param fmt Description of the error (gets placed into the user data with the
  * key NSLocalizedDescriptionKey).
  */
-+ (NSError *)errorWithDomain:(NSString *)domain
++ (NSError *)sentryErrorWithDomain:(NSString *)domain
                         code:(NSInteger)code
                  description:(NSString *)fmt, ...;
 

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
@@ -53,9 +53,9 @@
  * @return NO (to keep the analyzer happy).
  */
 + (BOOL)sentryFillError:(NSError **)error
-       withDomain:(NSString *)domain
-             code:(NSInteger)code
-      description:(NSString *)fmt, ...;
+             withDomain:(NSString *)domain
+                   code:(NSInteger)code
+            description:(NSString *)fmt, ...;
 
 /** Clear a pointer-to-error to nil of its pointer is not nil.
  *

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
@@ -52,7 +52,7 @@
  * key NSLocalizedDescriptionKey).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL)fillError:(NSError **)error
++ (BOOL)sentryFillError:(NSError **)error
        withDomain:(NSString *)domain
              code:(NSInteger)code
       description:(NSString *)fmt, ...;
@@ -62,6 +62,6 @@
  * @param error Error pointer to fill (ignored if nil).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL)clearError:(NSError **)error;
++ (BOOL)sentryClearError:(NSError **)error;
 
 @end

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
@@ -28,7 +28,7 @@
 
 @implementation NSError (SentrySimpleConstructor)
 
-+ (NSError *)errorWithDomain:(NSString *)domain
++ (NSError *)sentryErrorWithDomain:(NSString *)domain
                         code:(NSInteger)code
                  description:(NSString *)fmt, ...
 {

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
@@ -44,7 +44,7 @@
                                                                 forKey:NSLocalizedDescriptionKey]];
 }
 
-+ (BOOL)fillError:(NSError *__autoreleasing *)error
++ (BOOL)sentryFillError:(NSError *__autoreleasing *)error
        withDomain:(NSString *)domain
              code:(NSInteger)code
       description:(NSString *)fmt, ...
@@ -65,7 +65,7 @@
     return NO;
 }
 
-+ (BOOL)clearError:(NSError *__autoreleasing *)error
++ (BOOL)sentryClearError:(NSError *__autoreleasing *)error
 {
     if (error != nil) {
         *error = nil;

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
@@ -45,9 +45,9 @@
 }
 
 + (BOOL)sentryFillError:(NSError *__autoreleasing *)error
-       withDomain:(NSString *)domain
-             code:(NSInteger)code
-      description:(NSString *)fmt, ...
+             withDomain:(NSString *)domain
+                   code:(NSInteger)code
+            description:(NSString *)fmt, ...
 {
     if (error != nil) {
         va_list args;

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -170,7 +170,7 @@ onElement(SentryCrashJSONCodec *codec, NSString *name, id element)
 {
     if (codec->_currentContainer == nil) {
         codec.error = [NSError
-            errorWithDomain:@"SentryCrashJSONCodecObjC"
+            sentryErrorWithDomain:@"SentryCrashJSONCodecObjC"
                        code:0
                 description:@"Type %@ not allowed as top level container", [element class]];
         return SentryCrashJSON_ERROR_INVALID_DATA;
@@ -276,7 +276,7 @@ onEndContainer(void *const userData)
 
     if ([codec->_containerStack count] == 0) {
         codec.error =
-            [NSError errorWithDomain:@"SentryCrashJSONCodecObjC"
+            [NSError sentryErrorWithDomain:@"SentryCrashJSONCodecObjC"
                                 code:0
                          description:@"Already at the top level; no container left to end"];
         return SentryCrashJSON_ERROR_INVALID_DATA;
@@ -315,7 +315,7 @@ encodeObject(
         NSData *data = [object dataUsingEncoding:NSUTF8StringEncoding];
         result = sentrycrashjson_addStringElement(context, cName, data.bytes, (int)data.length);
         if (result == SentryCrashJSON_ERROR_INVALID_CHARACTER) {
-            codec.error = [NSError errorWithDomain:@"SentryCrashJSONCodecObjC"
+            codec.error = [NSError sentryErrorWithDomain:@"SentryCrashJSONCodecObjC"
                                               code:0
                                        description:@"Invalid character in %@", object];
         }
@@ -396,7 +396,7 @@ encodeObject(
         return sentrycrashjson_addDataElement(context, cName, data.bytes, (int)data.length);
     }
 
-    codec.error = [NSError errorWithDomain:@"SentryCrashJSONCodecObjC"
+    codec.error = [NSError sentryErrorWithDomain:@"SentryCrashJSONCodecObjC"
                                       code:0
                                description:@"Could not determine type of %@", [object class]];
     return SentryCrashJSON_ERROR_INVALID_DATA;
@@ -434,7 +434,7 @@ encodeObject(
             (int)stringData.length, codec.callbacks, (__bridge void *)codec, &errorOffset);
     if (result != SentryCrashJSON_OK && codec.error == nil) {
         codec.error = [NSError
-            errorWithDomain:@"SentryCrashJSONCodecObjC"
+            sentryErrorWithDomain:@"SentryCrashJSONCodecObjC"
                        code:0
                 description:@"%s (offset %d)", sentrycrashjson_stringForError(result), errorOffset];
     }

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -129,7 +129,7 @@ SentryCrashReportFilterCombine ()
 
     if (filterCount != [keys count]) {
         sentrycrash_callCompletion(onCompletion, reports, NO,
-            [NSError errorWithDomain:[[self class] description]
+            [NSError sentryErrorWithDomain:[[self class] description]
                                 code:0
                          description:@"Key/filter mismatch (%d keys, %d filters", [keys count],
                          filterCount]);
@@ -151,7 +151,7 @@ SentryCrashReportFilterCombine ()
                 sentrycrash_callCompletion(onCompletion, filteredReports, completed, filterError);
             } else if (filteredReports == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError errorWithDomain:[[self class] description]
+                    [NSError sentryErrorWithDomain:[[self class] description]
                                         code:0
                                  description:@"filteredReports was nil"]);
             }
@@ -264,7 +264,7 @@ SentryCrashReportFilterPipeline ()
                 sentrycrash_callCompletion(onCompletion, filteredReports, completed, filterError);
             } else if (filteredReports == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError errorWithDomain:[[self class] description]
+                    [NSError sentryErrorWithDomain:[[self class] description]
                                         code:0
                                  description:@"filteredReports was nil"]);
             }
@@ -334,7 +334,7 @@ SentryCrashReportFilterObjectForKey ()
         if (object == nil) {
             if (!self.allowNotFound) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError errorWithDomain:[[self class] description]
+                    [NSError sentryErrorWithDomain:[[self class] description]
                                         code:0
                                  description:@"Key not found: %@", self.key]);
                 return;
@@ -466,7 +466,7 @@ SentryCrashReportFilterSubset ()
             id object = [report sentry_objectForKeyPath:keyPath];
             if (object == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError errorWithDomain:[[self class] description]
+                    [NSError sentryErrorWithDomain:[[self class] description]
                                         code:0
                                  description:@"Report did not have key path %@", keyPath]);
                 return;
@@ -516,7 +516,7 @@ SentryCrashReportFilterSubset ()
         NSData *converted = [report dataUsingEncoding:NSUTF8StringEncoding];
         if (converted == nil) {
             sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                [NSError errorWithDomain:[[self class] description]
+                [NSError sentryErrorWithDomain:[[self class] description]
                                     code:0
                              description:@"Could not convert report to UTF-8"]);
             return;

--- a/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
@@ -33,7 +33,7 @@
 
 @implementation NSError_SimpleConstructor_Tests
 
-- (void)testsentryErrorWithDomain
+- (void)testSentryErrorWithDomain
 {
     NSError *error = [NSError sentryErrorWithDomain:@"Domain"
                                                code:10
@@ -46,7 +46,7 @@
     XCTAssertEqualObjects(error.localizedDescription, expectedDescription, @"");
 }
 
-- (void)testsentryFillError
+- (void)testSentryFillError
 {
     NSError *error = nil;
     [NSError sentryFillError:&error
@@ -61,12 +61,12 @@
     XCTAssertEqualObjects(error.localizedDescription, expectedDescription, @"");
 }
 
-- (void)testsentryFillErrorNil
+- (void)testSentryFillErrorNil
 {
     [NSError sentryFillError:nil withDomain:@"Domain" code:10 description:@"A description %d", 1];
 }
 
-- (void)testsentryClearError
+- (void)testSentryClearError
 {
     NSError *error = [NSError sentryErrorWithDomain:@"" code:1 description:@""];
     XCTAssertNotNil(error, @"");
@@ -74,7 +74,7 @@
     XCTAssertNil(error, @"");
 }
 
-- (void)testsentryClearErrorNil
+- (void)testSentryClearErrorNil
 {
     [NSError sentryClearError:nil];
 }

--- a/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
@@ -49,7 +49,10 @@
 - (void)testsentryFillError
 {
     NSError *error = nil;
-    [NSError sentryFillError:&error withDomain:@"Domain" code:10 description:@"A description %d", 1];
+    [NSError sentryFillError:&error
+                  withDomain:@"Domain"
+                        code:10
+                 description:@"A description %d", 1];
     NSString *expectedDomain = @"Domain";
     NSInteger expectedCode = 10;
     NSString *expectedDescription = @"A description 1";

--- a/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
@@ -46,10 +46,10 @@
     XCTAssertEqualObjects(error.localizedDescription, expectedDescription, @"");
 }
 
-- (void)testFillError
+- (void)testsentryFillError
 {
     NSError *error = nil;
-    [NSError fillError:&error withDomain:@"Domain" code:10 description:@"A description %d", 1];
+    [NSError sentryFillError:&error withDomain:@"Domain" code:10 description:@"A description %d", 1];
     NSString *expectedDomain = @"Domain";
     NSInteger expectedCode = 10;
     NSString *expectedDescription = @"A description 1";
@@ -58,22 +58,22 @@
     XCTAssertEqualObjects(error.localizedDescription, expectedDescription, @"");
 }
 
-- (void)testFillErrorNil
+- (void)testsentryFillErrorNil
 {
-    [NSError fillError:nil withDomain:@"Domain" code:10 description:@"A description %d", 1];
+    [NSError sentryFillError:nil withDomain:@"Domain" code:10 description:@"A description %d", 1];
 }
 
-- (void)testClearError
+- (void)testsentryClearError
 {
     NSError *error = [NSError sentryErrorWithDomain:@"" code:1 description:@""];
     XCTAssertNotNil(error, @"");
-    [NSError clearError:&error];
+    [NSError sentryClearError:&error];
     XCTAssertNil(error, @"");
 }
 
-- (void)testClearErrorNil
+- (void)testsentryClearErrorNil
 {
-    [NSError clearError:nil];
+    [NSError sentryClearError:nil];
 }
 
 @end

--- a/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
@@ -33,9 +33,9 @@
 
 @implementation NSError_SimpleConstructor_Tests
 
-- (void)testErrorWithDomain
+- (void)testsentryErrorWithDomain
 {
-    NSError *error = [NSError errorWithDomain:@"Domain" code:10 description:@"A description %d", 1];
+    NSError *error = [NSError sentryErrorWithDomain:@"Domain" code:10 description:@"A description %d", 1];
     NSString *expectedDomain = @"Domain";
     NSInteger expectedCode = 10;
     NSString *expectedDescription = @"A description 1";
@@ -63,7 +63,7 @@
 
 - (void)testClearError
 {
-    NSError *error = [NSError errorWithDomain:@"" code:1 description:@""];
+    NSError *error = [NSError sentryErrorWithDomain:@"" code:1 description:@""];
     XCTAssertNotNil(error, @"");
     [NSError clearError:&error];
     XCTAssertNil(error, @"");

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -176,7 +176,7 @@
     [SentrySDK startWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
 
     NSError *error =
-        [NSError errorWithDomain:@"testworld"
+        [NSError sentryErrorWithDomain:@"testworld"
                             code:200
                         userInfo:@{ NSLocalizedDescriptionKey : @"test ran out of money" }];
     [SentrySDK captureError:error];

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -176,7 +176,7 @@
     [SentrySDK startWithOptions:@{ @"dsn" : @"https://username:password@app.getsentry.com/12345" }];
 
     NSError *error =
-        [NSError sentryErrorWithDomain:@"testworld"
+        [NSError errorWithDomain:@"testworld"
                                   code:200
                               userInfo:@{ NSLocalizedDescriptionKey : @"test ran out of money" }];
     [SentrySDK captureError:error];


### PR DESCRIPTION
## :scroll: Description

Rename the category SentrySimpleConstructor for  NSError that can conflict with other libraries using KSCrash.

## :bulb: Motivation and Context

It breaks people who use KSCrash on their own or as a transient dependency.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
