### PR TITLE
fix: Clash with KSCrash functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Clash with KSCrash functions #905
+
 ## 6.1.1
 
 - fix: Duplicate symbol clash with KSCrash #902

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
@@ -189,7 +189,7 @@ timeSince(double timeInSeconds)
  *
  * @return true if the operation was successful.
  */
-bool
+static bool
 loadState(const char *const path)
 {
     // Stop if the file doesn't exist.
@@ -238,7 +238,7 @@ loadState(const char *const path)
  *
  * @return true if the operation was successful.
  */
-bool
+static bool
 saveState(const char *const path)
 {
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -84,7 +84,7 @@ static volatile bool g_isEnabled = false;
 #pragma mark - Utility -
 // ============================================================================
 
-const char *
+static const char *
 cString(NSString *str)
 {
     return str == NULL ? NULL : strdup(str.UTF8String);


### PR DESCRIPTION
## :scroll: Description

Fix clash with functions of KSCrash in SentryCrashMonitor_AppState.c and SentryCrashMonitor_System.m. Similar change as in https://github.com/kstenerud/KSCrash/commit/30fea9326e4eea76d6c737e78d0f523565bc9725.

## :bulb: Motivation and Context

This breaks people who use KSCrash on their own or as a transient dependency.

## :green_heart: How did you test it?
CI and smoke test on an emulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
