### PR TITLE
fix: Capture envelope updates session state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Capture envelope updates session state #906
+
 ## 6.1.2
 
 - fix: Clash with KSCrash functions #905

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -331,6 +331,9 @@
 		7BBD18B62451807600427C76 /* SentryDefaultRateLimitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18942449D3E200427C76 /* SentryDefaultRateLimitsTests.swift */; };
 		7BBD18B7245180FF00427C76 /* SentryDsnTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 639FCF921EBC746F00778193 /* SentryDsnTests.m */; };
 		7BBD18BB24530D2600427C76 /* SentryFileManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */; };
+		7BC3936825B1AB3E004F03D3 /* SentryLevelMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC3936725B1AB3E004F03D3 /* SentryLevelMapper.h */; };
+		7BC3936E25B1AB72004F03D3 /* SentryLevelMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC3936D25B1AB72004F03D3 /* SentryLevelMapper.m */; };
+		7BC3937425B1ACB7004F03D3 /* SentryLevelMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC3937325B1ACB7004F03D3 /* SentryLevelMapperTests.swift */; };
 		7BC6EBF4255C044A0059822A /* SentryEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC6EBF3255C044A0059822A /* SentryEventTests.swift */; };
 		7BC6EBF8255C05060059822A /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC6EBF7255C05060059822A /* TestData.swift */; };
 		7BC6EC04255C235F0059822A /* SentryFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC6EC03255C235F0059822A /* SentryFrameTests.swift */; };
@@ -751,6 +754,9 @@
 		7BBD189F244ED1A200427C76 /* SentryRetryAfterHeaderParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRetryAfterHeaderParserTests.swift; sourceTree = "<group>"; };
 		7BBD18A1244EE2FD00427C76 /* TestResponseFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestResponseFactory.swift; sourceTree = "<group>"; };
 		7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFileManagerTests.swift; sourceTree = "<group>"; };
+		7BC3936725B1AB3E004F03D3 /* SentryLevelMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryLevelMapper.h; path = include/SentryLevelMapper.h; sourceTree = "<group>"; };
+		7BC3936D25B1AB72004F03D3 /* SentryLevelMapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLevelMapper.m; sourceTree = "<group>"; };
+		7BC3937325B1ACB7004F03D3 /* SentryLevelMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLevelMapperTests.swift; sourceTree = "<group>"; };
 		7BC6EBF3255C044A0059822A /* SentryEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEventTests.swift; sourceTree = "<group>"; };
 		7BC6EBF7255C05060059822A /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
 		7BC6EC03255C235F0059822A /* SentryFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFrameTests.swift; sourceTree = "<group>"; };
@@ -1078,6 +1084,8 @@
 				15E0A8E9240F2C8F00F044E3 /* SentrySerialization.h */,
 				15E0A8EC240F2CB000F044E3 /* SentrySerialization.m */,
 				63AA76951EB9C1C200D153DE /* SentryDefines.h */,
+				7BC3936725B1AB3E004F03D3 /* SentryLevelMapper.h */,
+				7BC3936D25B1AB72004F03D3 /* SentryLevelMapper.m */,
 				63AA769B1EB9C57A00D153DE /* SentryError.h */,
 				63AA769C1EB9C57A00D153DE /* SentryError.m */,
 				63AA76961EB9C1C200D153DE /* SentryLog.h */,
@@ -1174,12 +1182,12 @@
 			children = (
 				630436031EC058FA00C4D3FA /* Categories */,
 				639889D51EDF10BE00EA7442 /* Helper */,
-				630436011EBCB8CA00C4D3FA /* Protocol */,
 				630436001EBCB87500C4D3FA /* Networking */,
 				6344DDB61EC3113C00D9160D /* SentryCrash */,
 				6383953423ABA269000C1594 /* Integrations */,
 				6383953323ABA255000C1594 /* State */,
 				63AA769F1EB9C89800D153DE /* Supporting Files */,
+				630436011EBCB8CA00C4D3FA /* Protocol */,
 				63AA76931EB9C1C200D153DE /* Sentry.h */,
 				63AA76941EB9C1C200D153DE /* SentryClient.h */,
 				63AA75ED1EB8B3C400D153DE /* SentryClient.m */,
@@ -1562,6 +1570,7 @@
 				7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */,
 				7B85BD8D24C5C3A6000A4225 /* SentryFileManagerTestExtension.swift */,
 				7B4C817124D1BC2B0076ACE4 /* SentryFileManager+TestProperties.h */,
+				7BC3937325B1ACB7004F03D3 /* SentryLevelMapperTests.swift */,
 			);
 			path = Helper;
 			sourceTree = "<group>";
@@ -1660,6 +1669,7 @@
 				63AA76981EB9C1C200D153DE /* SentryClient.h in Headers */,
 				63AA76971EB9C1C200D153DE /* Sentry.h in Headers */,
 				63FE711F20DA4C1000CDBAE8 /* SentryCrashObjC.h in Headers */,
+				7BC3936825B1AB3E004F03D3 /* SentryLevelMapper.h in Headers */,
 				631E6D331EBC679C00712345 /* SentryQueueableRequestManager.h in Headers */,
 				7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */,
 				6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */,
@@ -1937,6 +1947,7 @@
 				63FE70D320DA4C1000CDBAE8 /* SentryCrashMonitor_AppState.c in Sources */,
 				639FCFA51EBC809A00778193 /* SentryStacktrace.m in Sources */,
 				63FE70DF20DA4C1000CDBAE8 /* SentryCrashMonitorType.c in Sources */,
+				7BC3936E25B1AB72004F03D3 /* SentryLevelMapper.m in Sources */,
 				63FE70AD20DA4C1000CDBAE8 /* SentryCrashCString.m in Sources */,
 				6304360B1EC0595B00C4D3FA /* NSData+SentryCompression.m in Sources */,
 				639889B81EDECFA800EA7442 /* SentryBreadcrumbTracker.m in Sources */,
@@ -2002,6 +2013,7 @@
 				63B819141EC352A7002FDF4C /* SentryInterfacesTests.m in Sources */,
 				7B14089A248791660035403D /* SentryCrashStackEntryMapperTests.swift in Sources */,
 				7B869EBC249B91D8004F4FDB /* SentryDebugMetaEquality.swift in Sources */,
+				7BC3937425B1ACB7004F03D3 /* SentryLevelMapperTests.swift in Sources */,
 				63FE720E20DA66EC00CDBAE8 /* SentryCrashCString_Tests.m in Sources */,
 				631501BB1EE6F30B00512C5B /* SentrySwizzleTests.m in Sources */,
 				15D0AC882459EE4D006541C2 /* SentryNSURLRequestTests.swift in Sources */,

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -2,7 +2,7 @@
 #import "SentryIntegrationProtocol.h"
 
 @class SentryEvent, SentryClient, SentryScope, SentrySession, SentryUser, SentryBreadcrumb,
-    SentryId, SentryUserFeedback;
+    SentryId, SentryUserFeedback, SentryEnvelope;
 
 NS_ASSUME_NONNULL_BEGIN
 @interface SentryHub : NSObject
@@ -151,6 +151,16 @@ SENTRY_NO_INIT
  * Set global user -> thus will be sent with every event
  */
 - (void)setUser:(SentryUser *_Nullable)user;
+
+/**
+ * The SDK reserves this method for hybrid SDKs, which use it to capture events.
+ *
+ * @discussion We increase the session error count if an envelope is passed in containing an
+ * event with event.level error or higher. Ideally, we would check the mechanism and/or exception
+ * list, like the Java and Python SDK do this, but this would require full deserialization of the
+ * event.
+ */
+- (void)captureEnvelope:(SentryEnvelope *)envelope NS_SWIFT_NAME(capture(envelope:));
 
 @end
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -409,6 +409,7 @@ SentryHub ()
 {
     for (SentryEnvelopeItem *item in items) {
         if ([item.header.type isEqualToString:SentryEnvelopeItemTypeEvent]) {
+            // If there is no level the default is error
             SentryLevel level = [SentrySerialization levelFromData:item.data];
             if (level >= kSentryLevelError) {
                 return YES;

--- a/Sources/Sentry/SentryLevelMapper.m
+++ b/Sources/Sentry/SentryLevelMapper.m
@@ -1,0 +1,35 @@
+#import "SentryLevelMapper.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation SentryLevelMapper
+
++ (SentryLevel)levelWithString:(NSString *)string
+{
+    if ([string isEqualToString:SentryLevelNames[kSentryLevelNone]]) {
+        return kSentryLevelNone;
+    }
+    if ([string isEqualToString:SentryLevelNames[kSentryLevelDebug]]) {
+        return kSentryLevelDebug;
+    }
+    if ([string isEqualToString:SentryLevelNames[kSentryLevelInfo]]) {
+        return kSentryLevelInfo;
+    }
+    if ([string isEqualToString:SentryLevelNames[kSentryLevelWarning]]) {
+        return kSentryLevelWarning;
+    }
+    if ([string isEqualToString:SentryLevelNames[kSentryLevelError]]) {
+        return kSentryLevelError;
+    }
+    if ([string isEqualToString:SentryLevelNames[kSentryLevelFatal]]) {
+        return kSentryLevelFatal;
+    }
+
+    // Default is error, see https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
+    return kSentryLevelError;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -4,6 +4,7 @@
 #import "SentryEnvelopeItemType.h"
 #import "SentryError.h"
 #import "SentryId.h"
+#import "SentryLevelMapper.h"
 #import "SentryLog.h"
 #import "SentrySdkInfo.h"
 #import "SentrySession.h"
@@ -269,6 +270,25 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     return session;
+}
+
++ (SentryLevel)levelFromData:(NSData *)eventEnvelopeItemData
+{
+    NSError *error = nil;
+    NSDictionary *eventDictionary = [NSJSONSerialization JSONObjectWithData:eventEnvelopeItemData
+                                                                    options:0
+                                                                      error:&error];
+    if (nil != error) {
+        [SentryLog
+            logWithMessage:
+                [NSString
+                    stringWithFormat:@"Failed to retrieve event level from envelope item data: %@",
+                    error]
+                  andLevel:kSentryLogLevelError];
+        return kSentryLevelError;
+    }
+
+    return [SentryLevelMapper levelWithString:eventDictionary[@"level"]];
 }
 
 @end

--- a/Sources/Sentry/include/SentryLevelMapper.h
+++ b/Sources/Sentry/include/SentryLevelMapper.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Maps a string to a SentryLevel. If the passed string doesn't match any level this defaults to
- * error. See https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
+ * the 'error' level. See https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
  */
 + (SentryLevel)levelWithString:(NSString *)string;
 

--- a/Sources/Sentry/include/SentryLevelMapper.h
+++ b/Sources/Sentry/include/SentryLevelMapper.h
@@ -1,0 +1,17 @@
+#import <Foundation/Foundation.h>
+
+#import "SentryDefines.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryLevelMapper : NSObject
+
+/**
+ * Maps a string to a SentryLevel. If the passed string doesn't match any level this defaults to
+ * error. See https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
+ */
++ (SentryLevel)levelWithString:(NSString *)string;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 + (SentryEnvelope *_Nullable)envelopeWithData:(NSData *)data;
 
 /**
- * Extract the level from data of an envelopte item containing an event. Default is error, see
+ * Extract the level from data of an envelopte item containing an event. Default is the 'error' level, see
  * https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
  */
 + (SentryLevel)levelFromData:(NSData *)eventEnvelopeItemData;

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -24,8 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (SentryEnvelope *_Nullable)envelopeWithData:(NSData *)data;
 
 /**
- * Extract the level from data of an envelopte item containing an event. Default is the 'error' level, see
- * https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
+ * Extract the level from data of an envelopte item containing an event. Default is the 'error'
+ * level, see https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
  */
 + (SentryLevel)levelFromData:(NSData *)eventEnvelopeItemData;
 

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -23,6 +23,12 @@ NS_ASSUME_NONNULL_BEGIN
 // TODO: (NSInputStream *)inputStream
 + (SentryEnvelope *_Nullable)envelopeWithData:(NSData *)data;
 
+/**
+ * Extract the level from data of an envelopte item containing an event. Default is error, see
+ * https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
+ */
++ (SentryLevel)levelFromData:(NSData *)eventEnvelopeItemData;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Helper/SentryLevelMapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryLevelMapperTests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+class SentryLevelMapperTests: XCTestCase {
+
+    func testMapLevels() {
+        XCTAssertEqual(SentryLevel.error, SentryLevelMapper.level(with: ""))
+        XCTAssertEqual(SentryLevel.none, SentryLevelMapper.level(with: "none"))
+        XCTAssertEqual(SentryLevel.debug, SentryLevelMapper.level(with: "debug"))
+        XCTAssertEqual(SentryLevel.info, SentryLevelMapper.level(with: "info"))
+        XCTAssertEqual(SentryLevel.warning, SentryLevelMapper.level(with: "warning"))
+        XCTAssertEqual(SentryLevel.error, SentryLevelMapper.level(with: "error"))
+        XCTAssertEqual(SentryLevel.fatal, SentryLevelMapper.level(with: "fatal"))
+    }
+
+}

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -164,6 +164,18 @@ class SentrySerializationTests: XCTestCase {
         
         XCTAssertNil(SentrySerialization.session(with: data))
     }
+    
+    func testLevelFromEventData() {
+        let envelopeItem = SentryEnvelopeItem(event: TestData.event)
+        
+        let level = SentrySerialization.level(from: envelopeItem.data)
+        XCTAssertEqual(TestData.event.level, level)
+    }
+    
+    func testLevelFromEventData_WithGarbage() {
+        let level = SentrySerialization.level(from: "hi".data(using: .utf8)!)
+        XCTAssertEqual(SentryLevel.error, level)
+    }
 
     private func serializeEnvelope(envelope: SentryEnvelope) -> Data {
         var serializedEnvelope: Data = Data()

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -44,6 +44,7 @@
 #import "SentryHub+TestInit.h"
 #import "SentryId.h"
 #import "SentryInstallation.h"
+#import "SentryLevelMapper.h"
 #import "SentryMeta.h"
 #import "SentryMigrateSessionInit.h"
 #import "SentryNSURLRequest.h"

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -87,6 +87,11 @@ class TestClient: Client {
     override func capture(userFeedback: UserFeedback) {
         capturedUserFeedback.append(userFeedback)
     }
+    
+    var capturedEnvelopes: [SentryEnvelope] = []
+    override func capture(envelope: SentryEnvelope) {
+        capturedEnvelopes.append(envelope)
+    }
 }
 
 class TestFileManager: SentryFileManager {


### PR DESCRIPTION


## :scroll: Description

The SentryHub now increases the error count if an envelope is passed containing an event with
event.level error or higher. Ideally, we would check the mechanism and/or exception list, like the
Java and Python SDK do this, but this would require full deserialization of the event.


## :bulb: Motivation and Context

Fixes GH-861

## :green_heart: How did you test it?
Unit tests, before merging we still need to test it with React Native and Flutter.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
Properly fix it like mentioned in GH-861
