### PR TITLE
fix: Sessions for Hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- fix: Sessions for Hybrid SDKs #913
+
 ## 6.1.3
 
 - fix: Capture envelope updates session state #906

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -12,12 +12,25 @@
 #    import <Cocoa/Cocoa.h>
 #endif
 
+/**
+ * In hybrid SDKs, we might initialize the Cocoa SDK after the hybrid engine is ready. So, we may
+ * register the didBecomeActive notification after the OS posts it. Therefore the hybrid SDKs can
+ * post this internal notification after initializing the Cocoa SDK to start a session. We can't
+ * start the session in this method because we don't know if a background task or a hybrid SDK
+ * initialized the SDK. Hybrid SDKs must only post this notification if they are running in the
+ * foreground because the auto session tracking logic doesn't support background tasks. Posting the
+ * notification from the background would mess up the session stats.
+ */
+static NSString *const SentryHybridSdkDidBecomeActiveNotificationName
+    = @"SentryHybridSdkDidBecomeActive";
+
 @interface
 SentrySessionTracker ()
 
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) id<SentryCurrentDateProvider> currentDateProvider;
 @property (atomic, strong) NSDate *lastInForeground;
+@property (nonatomic, assign) BOOL wasDidBecomeActiveCalled;
 
 @end
 
@@ -29,6 +42,7 @@ SentrySessionTracker ()
     if (self = [super init]) {
         self.options = options;
         self.currentDateProvider = currentDateProvider;
+        self.wasDidBecomeActiveCalled = NO;
     }
     return self;
 }
@@ -75,6 +89,11 @@ SentrySessionTracker ()
                                              object:nil];
 
     [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(didBecomeActive)
+                                               name:SentryHybridSdkDidBecomeActiveNotificationName
+                                             object:nil];
+
+    [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(willResignActive)
                                                name:willResignActiveNotificationName
                                              object:nil];
@@ -111,10 +130,21 @@ SentrySessionTracker ()
 }
 
 /**
- * Is only called when an app is receiving events / it is in the foreground.
+ * Is called when an app is receiving events / it is in the foreground and when we receive a
+ * SentryHybridSdkDidBecomeActiveNotification. There is no guarantee if this method is called once
+ * or twice. We need to ensure that we execute it only once.
  */
 - (void)didBecomeActive
 {
+    // We don't know if the hybrid SDKs post the notification from a background thread, so we
+    // synchronize to be safe.
+    @synchronized(self) {
+        if (self.wasDidBecomeActiveCalled) {
+            return;
+        }
+        self.wasDidBecomeActiveCalled = YES;
+    }
+
     SentryHub *hub = [SentrySDK currentHub];
     self.lastInForeground = [[[hub getClient] fileManager] readTimestampLastInForeground];
 
@@ -149,6 +179,7 @@ SentrySessionTracker ()
     self.lastInForeground = [self.currentDateProvider date];
     SentryHub *hub = [SentrySDK currentHub];
     [[[hub getClient] fileManager] storeTimestampLastInForeground:self.lastInForeground];
+    self.wasDidBecomeActiveCalled = NO;
 }
 
 /**
@@ -161,6 +192,7 @@ SentrySessionTracker ()
     SentryHub *hub = [SentrySDK currentHub];
     [hub endSessionWithTimestamp:sessionEnded];
     [[[hub getClient] fileManager] deleteTimestampLastInForeground];
+    self.wasDidBecomeActiveCalled = NO;
 }
 
 @end

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -130,8 +130,8 @@ SentrySessionTracker ()
 }
 
 /**
- * Is called when an app is receiving events / it is in the foreground and when we receive a
- * SentryHybridSdkDidBecomeActiveNotification. There is no guarantee if this method is called once
+ * It is called when an App. is receiving events / It is in the foreground and when we receive a
+ * SentryHybridSdkDidBecomeActiveNotification. There is no guarantee that this method is called once
  * or twice. We need to ensure that we execute it only once.
  */
 - (void)didBecomeActive

--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -67,6 +67,33 @@ class SentrySessionTrackerTests: XCTestCase {
         assertSessionStored()
     }
     
+    func testOnlyHybridSdkDidBecomeActive() {
+        sut.start()
+        TestNotificationCenter.hybridSdkDidBecomeActive()
+        
+        assertInitSessionSent()
+        assertSessionStored()
+    }
+    
+    func testForeground_And_HybridSdkDidBecomeActive() {
+        sut.start()
+        goToForeground()
+        TestNotificationCenter.hybridSdkDidBecomeActive()
+        
+        assertInitSessionSent()
+        assertSessionStored()
+    }
+    
+    func testHybridSdkDidBecomeActive_and_Foreground() {
+        sut.start()
+        TestNotificationCenter.hybridSdkDidBecomeActive()
+        
+        goToForeground()
+        
+        assertInitSessionSent()
+        assertSessionStored()
+    }
+    
     func testForeground_Background_TrackingIntervalNotReached() {
         sut.start()
         

--- a/Tests/SentryTests/Integrations/TestNotificationCenter.swift
+++ b/Tests/SentryTests/Integrations/TestNotificationCenter.swift
@@ -47,4 +47,9 @@ class TestNotificationCenter {
         NotificationCenter.default.post(Notification(name: willTerminateNotification))
         #endif
     }
+    
+    static func hybridSdkDidBecomeActive() {
+        NotificationCenter.default.post(name: Notification.Name("SentryHybridSdkDidBecomeActive"), object: nil)
+        
+    }
 }


### PR DESCRIPTION

## :scroll: Description

The Cocoa SDK didn't start a session after a hybrid app finished its initialization. That's because, in hybrid SDKs, we might initialize the Cocoa SDK after the hybrid engine is ready. The `SessionTracker` then misses the `didBecomeActive` notification from the OS and fails to start a session. To solve this, hybrid SDKs can post an internal notification with the name `SentryHybridSdkDidBecomeActive`. The `SessionTracker` starts a session if it receives such a notification.

Related to https://github.com/getsentry/sentry-dart/pull/274.

## :bulb: Motivation and Context

Fixes GH-912

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
