### PR TITLE
test: Add captureTransaction to sample apps

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -103,8 +103,9 @@ ViewController ()
 - (IBAction)captureTransaction:(id)sender
 {
     SentryTransaction *fakeTransaction = [SentrySDK startTransactionWithName:@"Some Transaction"];
-    [NSThread sleepForTimeInterval:1.0f];
-    [fakeTransaction finish];
+    dispatch_after(
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(arc4random_uniform(100) + 400 * NSEC_PER_MSEC)),
+        dispatch_get_main_queue(), ^{ [fakeTransaction finish]; });
 }
 
 - (IBAction)crash:(id)sender

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,7 +24,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
-                                <rect key="frame" x="8" y="95.5" width="398" height="210"/>
+                                <rect key="frame" x="8" y="95.5" width="398" height="240"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJW-l9-sD6">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
@@ -68,8 +68,15 @@
                                             <action selector="captureNSException:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BT7-dZ-MrB"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgF-Uq-3Bb">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cdR-H3-8fr">
                                         <rect key="frame" x="0.0" y="180" width="398" height="30"/>
+                                        <state key="normal" title="captureTransaction"/>
+                                        <connections>
+                                            <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kff-pT-Uf4"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgF-Uq-3Bb">
+                                        <rect key="frame" x="0.0" y="210" width="398" height="30"/>
                                         <state key="normal" title="crash"/>
                                         <connections>
                                             <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="imm-ZO-4Af"/>

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -78,6 +78,13 @@ class ViewController: UIViewController {
         SentrySDK.capture(exception: exception, scope: scope)
     }
     
+    @IBAction func captureTransaction(_ sender: Any) {
+        let transaction = SentrySDK.startTransaction(name: "Some Transaction")
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
+            transaction.finish()
+        })
+    }
+    
     @IBAction func crash(_ sender: Any) {
         SentrySDK.crash()
     }

--- a/Samples/macOS-Swift/macOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/macOS-Swift/macOS-Swift/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -732,15 +732,15 @@
                                     </connections>
                                 </buttonCell>
                             </button>
-                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0rS-ee-VAF">
-                                <rect key="frame" x="179" y="88" width="126" height="32"/>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c5W-zA-19P">
+                                <rect key="frame" x="163" y="89" width="160" height="32"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                <buttonCell key="cell" type="push" title="Sentry.crash()" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="k1V-IH-Ru7">
+                                <buttonCell key="cell" type="push" title="captureTransaction" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="OVU-vi-LRM">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="sentryCrash:" target="XfG-lQ-9wD" id="8gG-2n-QOP"/>
+                                    <action selector="captureTransaction:" target="XfG-lQ-9wD" id="5CC-xI-gEt"/>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nAm-U5-PON">
@@ -763,6 +763,17 @@
                                 </buttonCell>
                                 <connections>
                                     <action selector="captureUserFeedback:" target="XfG-lQ-9wD" id="gH0-NO-T7d"/>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0rS-ee-VAF">
+                                <rect key="frame" x="180" y="57" width="126" height="32"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="push" title="Sentry.crash()" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="k1V-IH-Ru7">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="sentryCrash:" target="XfG-lQ-9wD" id="8gG-2n-QOP"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Samples/macOS-Swift/macOS-Swift/ViewController.swift
+++ b/Samples/macOS-Swift/macOS-Swift/ViewController.swift
@@ -49,6 +49,13 @@ class ViewController: NSViewController {
         NSApp.perform("_crashOnException:", with: exception)
     }
     
+    @IBAction func captureTransaction(_ sender: Any) {
+        let transaction = SentrySDK.startTransaction(name: "Some Transaction")
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
+            transaction.finish()
+        })
+    }
+    
     @IBAction func sentryCrash(_ sender: Any) {
         SentrySDK.crash()
     }

--- a/Samples/tvOS-Swift/tvOS-Swift/ContentView.swift
+++ b/Samples/tvOS-Swift/tvOS-Swift/ContentView.swift
@@ -41,6 +41,13 @@ struct ContentView: View {
         SentrySDK.capture(exception: exception, scope: scope)
     }
     
+    var captureTransactionAction: () -> Void = {
+        let transaction = SentrySDK.startTransaction(name: "Some Transaction")
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
+            transaction.finish()
+        })
+    }
+    
     var body: some View {
         VStack {
             Button(action: addBreadcrumbAction) {
@@ -61,6 +68,10 @@ struct ContentView: View {
             
             Button(action: captureNSExceptionAction) {
                 Text("Capture NSException")
+            }
+            
+            Button(action: captureTransactionAction) {
+                Text("Capture Transaction")
             }
             
             Button(action: {

--- a/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ContentView.swift
+++ b/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ContentView.swift
@@ -27,6 +27,13 @@ struct ContentView: View {
         SentrySDK.capture(exception: exception, scope: scope)
     }
     
+    var captureTransaction: () -> Void = {
+        let transaction = SentrySDK.startTransaction(name: "Some Transaction")
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
+            transaction.finish()
+        })
+    }
+    
     var body: some View {
         ScrollView {
             VStack {
@@ -44,6 +51,10 @@ struct ContentView: View {
                 
                 Button(action: captureNSExceptionAction) {
                     Text("Capture NSException")
+                }
+                
+                Button(action: captureTransaction) {
+                    Text("Capture Transaction")
                 }
             }
         }


### PR DESCRIPTION
## :scroll: Description

Add captureTransaction to all sample apps.

## :bulb: Motivation and Context

We want to be able to test transactions on watchOS, iOS, macOS, and tvOS.

## :green_heart: How did you test it?
Simulators.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
