### PR TITLE
feat: Add sendDefaultPii to SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 
+- feat: Add sendDefaultPii to SentryOptions #923
+
 ## 6.1.4
 
 - fix: Sessions for Hybrid SDKs #913

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -138,6 +138,16 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) NSUInteger maxAttachmentSize;
 
+/**
+ * When enabled, the SDK sends personal identifiable along with events. The default is
+ * <code>NO</code>.
+ *
+ * @discussion When the user of an event doesn't contain an IP address, the SDK sets it to
+ * <code>{{auto}}</code> to instruct the server to use the connection IP address as the user
+ * address.
+ */
+@property (nonatomic, assign) BOOL sendDefaultPii;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -392,6 +392,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     // Need to do this after the scope is applied cause this sets the user if there is any
     [self setUserIdIfNoUserSet:event];
 
+    // User can't be nil as setUserIdIfNoUserSet sets it.
     if (self.options.sendDefaultPii && nil == event.user.ipAddress) {
         // Let Sentry infer the IP address from the connection.
         event.user.ipAddress = @"{{auto}}";

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -392,6 +392,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     // Need to do this after the scope is applied cause this sets the user if there is any
     [self setUserIdIfNoUserSet:event];
 
+    if (self.options.sendDefaultPii && nil == event.user.ipAddress) {
+        // Let Sentry infer the IP address from the connection.
+        event.user.ipAddress = @"{{auto}}";
+    }
+
     event = [self callEventProcessors:event];
 
     if (nil != self.options.beforeSend) {

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -29,6 +29,7 @@
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
         self.attachStacktrace = YES;
         self.maxAttachmentSize = 20 * 1024 * 1024;
+        self.sendDefaultPii = NO;
         _sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
                                             andVersion:SentryMeta.versionString];
 
@@ -157,6 +158,10 @@
 
     if (nil != options[@"maxAttachmentSize"]) {
         self.maxAttachmentSize = [options[@"maxAttachmentSize"] unsignedIntValue];
+    }
+
+    if (nil != options[@"sendDefaultPii"]) {
+        self.sendDefaultPii = [options[@"sendDefaultPii"] boolValue];
     }
 }
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -394,6 +394,27 @@
     XCTAssertEqual(20 * 1024 * 1024, options.maxAttachmentSize);
 }
 
+- (void)testSendDefaultPii
+{
+    SentryOptions *options = [self getValidOptions:@{ @"sendDefaultPii" : @YES }];
+
+    XCTAssertTrue(options.sendDefaultPii);
+}
+
+- (void)testSendDefaultPiiGarbage
+{
+    SentryOptions *options = [self getValidOptions:@{ @"sendDefaultPii" : @"no" }];
+
+    XCTAssertFalse(options.sendDefaultPii);
+}
+
+- (void)testDefaultSendDefaultPii
+{
+    SentryOptions *options = [self getValidOptions:@{}];
+
+    XCTAssertFalse(options.sendDefaultPii);
+}
+
 - (SentryOptions *)getValidOptions:(NSDictionary<NSString *, id> *)dict
 {
     NSError *error = nil;


### PR DESCRIPTION
## :scroll: Description

Add sendDefaultPii to SentryOptions. When enabled, the SDK sends personal identifiable along with
events. Currently, that only applies to the IP address of the user.

## :bulb: Motivation and Context

Fixes GH-910

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
Update the docs.
