### PR TITLE
ci: Replace not validated GitHub Actions

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -9,25 +9,12 @@ jobs:
 
   format-code:
     name: Format Code
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Format Objective-C, C++ and C
-        uses: DoozyX/clang-format-lint-action@v0.10
-        with:
-          source: '.'
-          extensions: 'h,cpp,m,c'
-          clangFormatVersion: 11
-          style: file
-          inplace: True
-      - name: Format Swift
-        uses: norio-nomura/action-swiftlint@3.1.0
-        with:
-          args: autocorrect    
-      - uses: EndBug/add-and-commit@v5
-        with:
-          author_name: Clang Robot
-          author_email: clang-robot@sentry.io
-          message: 'Committing formatted code'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+      - name: Install Clang-Format
+        run: brew install clang-format
+      - name: Format Code
+        run: make format
+      - name: Commit Formatted Code
+        run: ./scripts/commit-formatted-code.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,8 @@ on:
 jobs:
   swift-lint:
     name: Swift Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: GitHub Action for SwiftLint
-        uses: norio-nomura/action-swiftlint@3.1.0
+      - name: Run SwiftLint
+        run: swiftlint

--- a/scripts/commit-formatted-code.sh
+++ b/scripts/commit-formatted-code.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $(git status) == *"nothing to commit"* ]]; then
+    echo "Nothing to commit. All code formatted correctly."
+else
+    echo "Formatted some code. Going to push the changes."
+    git config --global user.name 'Sentry Github Bot'
+    git config --global user.email 'bot+github-bot@sentry.io'
+    git commit -am "Format code"
+    git push 
+fi


### PR DESCRIPTION
## :scroll: Description

Replaced all non validated GitHub Actions by replicating the functionality
manually.

## :bulb: Motivation and Context

For uploading the Swift iOS sample app to TestFlight with https://github.com/getsentry/sentry-cocoa/pull/918, we added some secrets to the repo that we don't want to be exploited. By removing not validated GitHub Actions we make it harder to steal those secrets.

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
