### PR TITLE
ci: Switch back to Xcode 12.3

### DIFF
--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -3,4 +3,4 @@
 # For available Xcode versions on Github Action, see 
 # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
 
-sudo xcode-select -s /Applications/Xcode_12.4.app/Contents/Developer
+sudo xcode-select -s /Applications/Xcode_12.3.app/Contents/Developer


### PR DESCRIPTION
GitHub Actions can't find Xcode 12.4 and therefore the builds are failing.
