### PR TITLE
test: Fix ThreadInspectorTests

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -132,7 +132,7 @@ private class TestMachineContextWrapper: NSObject, SentryCrashMachineContextWrap
         if threadName != nil {
             strcpy(buffer, threadName)
         } else {
-            _ = [].withUnsafeBufferPointer { bufferPointer in
+            _ = Array(repeating: 0, count: Int(bufLength)).withUnsafeBufferPointer { bufferPointer in
                 strcpy(buffer, bufferPointer.baseAddress)
             }
         }


### PR DESCRIPTION


## :scroll: Description

The SentryThreadInspectorTests.testThreadNameIsNull was sometimes failing in CI. The
thread name was set to some weird characters as ȕ`\r\u{01}. This was because we used
an empty array to fill the buffer for the thread name and therefore accessed memory, which
we shouldn't. Now we use an array with all zeros as big as the buffer.

## :bulb: Motivation and Context

Failing tests.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
