### PR TITLE
test: Make captureError more realistic

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		637AFDB3243B02770034958B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB2243B02770034958B /* Assets.xcassets */; };
 		637AFDB6243B02770034958B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB4243B02770034958B /* LaunchScreen.storyboard */; };
 		7B3427F825876A5200056519 /* Tongariro.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7B3427F725876A5200056519 /* Tongariro.jpg */; };
+		7B4AC44025D16AA00070736A /* RandomErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4AC43F25D16AA00070736A /* RandomErrors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		637AFDB7243B02770034958B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63F93AA9245AC91600A500DB /* iOS-Swift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "iOS-Swift.entitlements"; sourceTree = "<group>"; };
 		7B3427F725876A5200056519 /* Tongariro.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Tongariro.jpg; sourceTree = "<group>"; };
+		7B4AC43F25D16AA00070736A /* RandomErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomErrors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -125,6 +127,7 @@
 				637AFDA9243B02760034958B /* AppDelegate.swift */,
 				637AFDAB243B02760034958B /* SceneDelegate.swift */,
 				637AFDAD243B02760034958B /* ViewController.swift */,
+				7B4AC43F25D16AA00070736A /* RandomErrors.swift */,
 				637AFDAF243B02760034958B /* Main.storyboard */,
 				637AFDB2243B02770034958B /* Assets.xcassets */,
 				7B3427F725876A5200056519 /* Tongariro.jpg */,
@@ -234,6 +237,7 @@
 				637AFDAE243B02760034958B /* ViewController.swift in Sources */,
 				637AFDAA243B02760034958B /* AppDelegate.swift in Sources */,
 				637AFDAC243B02760034958B /* SceneDelegate.swift in Sources */,
+				7B4AC44025D16AA00070736A /* RandomErrors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/iOS-Swift/iOS-Swift/RandomErrors.swift
+++ b/Samples/iOS-Swift/iOS-Swift/RandomErrors.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum SampleError: Error {
+    case bestDeveloper
+    case happyCustomer
+    case awesomeCentaur
+}
+
+class RandomErrorGenerator {
+    
+    static func generate() throws {
+        let random = Int.random(in: 0...2)
+        switch random {
+        case 0:
+            throw SampleError.bestDeveloper
+        case 1:
+            throw SampleError.happyCustomer
+        case 2:
+            throw SampleError.awesomeCentaur
+        default:
+            throw SampleError.bestDeveloper
+        }
+    }
+}

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -57,13 +57,15 @@ class ViewController: UIViewController {
     }
     
     @IBAction func captureError(_ sender: Any) {
-        let error = NSError(domain: "SampleErrorDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
-
-        SentrySDK.capture(error: error) { (scope) in
-            // Changes in here will only be captured for this event
-            // The scope in this callback is a clone of the current scope
-            // It contains all data but mutations only influence the event being sent
-            scope.setTag(value: "value", key: "myTag")
+        do {
+            try RandomErrorGenerator.generate()
+        } catch {
+            SentrySDK.capture(error: error) { (scope) in
+                // Changes in here will only be captured for this event
+                // The scope in this callback is a clone of the current scope
+                // It contains all data but mutations only influence the event being sent
+                scope.setTag(value: "value", key: "myTag")
+            }
         }
     }
     


### PR DESCRIPTION

## :scroll: Description

Add a do catch in `captureError` with randomly generated errors to make
the errors more realistic.

## :bulb: Motivation and Context

We want more realistic errors.

## :green_heart: How did you test it?
Simulator

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
