### PR TITLE
fix: Discard Sessions when JSON is faulty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Crash in Session Init with JSON #939
 - feat: Add sendDefaultPii to SentryOptions #923
 
 ## 6.1.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- fix: Crash in Session Init with JSON #939
+- fix: Discard Sessions when JSON is faulty #939
 - feat: Add sendDefaultPii to SentryOptions #923
 
 ## 6.1.4

--- a/Sources/Sentry/Public/SentrySession.h
+++ b/Sources/Sentry/Public/SentrySession.h
@@ -16,7 +16,15 @@ typedef NS_ENUM(NSUInteger, SentrySessionStatus) {
 SENTRY_NO_INIT
 
 - (instancetype)initWithReleaseName:(NSString *)releaseName;
-- (instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
+
+/**
+ * Initializes SentrySession from a JSON object.
+ *
+ * @param jsonObject The jsonObject containing the session.
+ *
+ * @return The SentrySession or nil if the JSONObject contained an error.
+ */
+- (nullable instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
 
 - (void)endSessionExitedWithTimestamp:(NSDate *)timestamp;
 - (void)endSessionCrashedWithTimestamp:(NSDate *)timestamp;

--- a/Sources/Sentry/Public/SentrySession.h
+++ b/Sources/Sentry/Public/SentrySession.h
@@ -22,7 +22,7 @@ SENTRY_NO_INIT
  *
  * @param jsonObject The jsonObject containing the session.
  *
- * @return The SentrySession or nil if the JSONObject contained an error.
+ * @return The SentrySession or nil if the JSONObject contains an error.
  */
 - (nullable instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -262,6 +262,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
     SentrySession *session = [[SentrySession alloc] initWithJSONObject:sessionDictionary];
 
+    if (nil == session) {
+        [SentryLog logWithMessage:@"Failed to initialize session from dictionary. Dropping it."
+                         andLevel:kSentryLogLevelError];
+        return nil;
+    }
+
     if (nil == session.releaseName || [session.releaseName isEqualToString:@""]) {
         [SentryLog
             logWithMessage:@"Deserialized session doesn't contain a release name. Dropping it."

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -55,7 +55,12 @@ NS_ASSUME_NONNULL_BEGIN
 
         id started = [jsonObject valueForKey:@"started"];
         if ([started isKindOfClass:[NSString class]]) {
-            _started = [NSDate sentry_fromIso8601String:started];
+            NSDate *startedDate = [NSDate sentry_fromIso8601String:started];
+            // When the string can't be converted to a date we don't override the
+            // default value.
+            if (nil != startedDate) {
+                _started = startedDate;
+            }
         }
 
         id status = [jsonObject valueForKey:@"status"];

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -36,60 +36,56 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-- (instancetype)initWithJSONObject:(NSDictionary *)jsonObject
+- (nullable instancetype)initWithJSONObject:(NSDictionary *)jsonObject
 {
-    // We use the default constructor here to set the non nullable values to a default values,
-    // because this could cause crashes, for example, in serialize.
-    // With this approach we avoid crashes and accept the tradeoff that some session data might not
-    // be 100% accurate.
-    // Ideally we would return nil, if the passed JSON is not valid, which we can't do because it
-    // would be a breaking change.
-    if (self = [self initDefault]) {
+    if (self = [super init]) {
+
         id sid = [jsonObject valueForKey:@"sid"];
-        if ([sid isKindOfClass:[NSString class]]) {
-            NSUUID *sessionId = [[NSUUID UUID] initWithUUIDString:sid];
-            if (nil != sessionId) {
-                _sessionId = sessionId;
-            }
-        }
+        if (sid == nil || ![sid isKindOfClass:[NSString class]])
+            return nil;
+        NSUUID *sessionId = [[NSUUID UUID] initWithUUIDString:sid];
+        if (nil == sessionId)
+            return nil;
+        _sessionId = sessionId;
 
         id started = [jsonObject valueForKey:@"started"];
-        if ([started isKindOfClass:[NSString class]]) {
-            NSDate *startedDate = [NSDate sentry_fromIso8601String:started];
-            // When the string can't be converted to a date we don't override the
-            // default value.
-            if (nil != startedDate) {
-                _started = startedDate;
-            }
+        if (started == nil || ![started isKindOfClass:[NSString class]])
+            return nil;
+        NSDate *startedDate = [NSDate sentry_fromIso8601String:started];
+        if (nil == startedDate) {
+            return nil;
         }
+        _started = startedDate;
 
         id status = [jsonObject valueForKey:@"status"];
-        if ([status isKindOfClass:[NSString class]]) {
-            if ([@"ok" isEqualToString:status]) {
-                _status = kSentrySessionStatusOk;
-            } else if ([@"exited" isEqualToString:status]) {
-                _status = kSentrySessionStatusExited;
-            } else if ([@"crashed" isEqualToString:status]) {
-                _status = kSentrySessionStatusCrashed;
-            } else if ([@"abnormal" isEqualToString:status]) {
-                _status = kSentrySessionStatusAbnormal;
-            }
+        if (status == nil || ![status isKindOfClass:[NSString class]])
+            return nil;
+        if ([@"ok" isEqualToString:status]) {
+            _status = kSentrySessionStatusOk;
+        } else if ([@"exited" isEqualToString:status]) {
+            _status = kSentrySessionStatusExited;
+        } else if ([@"crashed" isEqualToString:status]) {
+            _status = kSentrySessionStatusCrashed;
+        } else if ([@"abnormal" isEqualToString:status]) {
+            _status = kSentrySessionStatusAbnormal;
+        } else {
+            return nil;
         }
 
         id seq = [jsonObject valueForKey:@"seq"];
-        if ([seq isKindOfClass:[NSNumber class]]) {
-            _sequence = [seq unsignedIntegerValue];
-        }
+        if (seq == nil || ![seq isKindOfClass:[NSNumber class]])
+            return nil;
+        _sequence = [seq unsignedIntegerValue];
 
         id errors = [jsonObject valueForKey:@"errors"];
-        if ([errors isKindOfClass:[NSNumber class]]) {
-            _errors = [errors unsignedIntegerValue];
-        }
+        if (errors == nil || ![errors isKindOfClass:[NSNumber class]])
+            return nil;
+        _errors = [errors unsignedIntegerValue];
 
         id did = [jsonObject valueForKey:@"did"];
-        if ([did isKindOfClass:[NSString class]]) {
-            _distinctId = did;
-        }
+        if (did == nil || ![did isKindOfClass:[NSString class]])
+            return nil;
+        _distinctId = did;
 
         id init = [jsonObject valueForKey:@"init"];
         if ([init isKindOfClass:[NSNumber class]]) {
@@ -119,6 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
             _duration = duration;
         }
     }
+
     return self;
 }
 

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -29,7 +29,7 @@ class SentryFileManagerTests: XCTestCase {
             let sessionCopy = session.copy() as! SentrySession
             sessionCopy.incrementErrors()
             // We need to serialize in order to set the timestamp and the duration
-            sessionUpdate = SentrySession(jsonObject: sessionCopy.serialize())
+            sessionUpdate = SentrySession(jsonObject: sessionCopy.serialize())!
 
             let event = Event()
             let items = [SentryEnvelopeItem(session: sessionUpdate), SentryEnvelopeItem(event: event)]
@@ -37,7 +37,7 @@ class SentryFileManagerTests: XCTestCase {
 
             let sessionUpdateCopy = sessionUpdate.copy() as! SentrySession
             // We need to serialize in order to set the timestamp and the duration
-            expectedSessionUpdate = SentrySession(jsonObject: sessionUpdateCopy.serialize())
+            expectedSessionUpdate = SentrySession(jsonObject: sessionUpdateCopy.serialize())!
             // We can only set the init flag after serialize, because the duration is not set if the init flag is set
             expectedSessionUpdate.setFlagInit()
         }

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -146,10 +146,19 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertNil(SentrySerialization.envelope(with: itemData))
     }
     
+    func testSerializeSession() throws {
+        let dict = SentrySession(releaseName: "1.0.0").serialize()
+        let session = SentrySession(jsonObject: dict)!
+        
+        let data = try SentrySerialization.data(with: session)
+        
+        XCTAssertNotNil(SentrySerialization.session(with: data))
+    }
+    
     func testSerializeSessionWithNoReleaseName() throws {
         var dict = SentrySession(releaseName: "1.0.0").serialize()
         dict["attrs"] = nil // Remove release name
-        let session = SentrySession(jsonObject: dict)
+        let session = SentrySession(jsonObject: dict)!
         
         let data = try SentrySerialization.data(with: session)
         
@@ -158,9 +167,25 @@ class SentrySerializationTests: XCTestCase {
     
     func testSerializeSessionWithEmptyReleaseName() throws {
         let dict = SentrySession(releaseName: "").serialize()
-        let session = SentrySession(jsonObject: dict)
+        let session = SentrySession(jsonObject: dict)!
         
         let data = try SentrySerialization.data(with: session)
+        
+        XCTAssertNil(SentrySerialization.session(with: data))
+    }
+    
+    func testSerializeSessionWithGarbageInDict() throws {
+        var dict = SentrySession(releaseName: "").serialize()
+        dict["started"] = "20"
+        let data = try SentrySerialization.data(withJSONObject: dict)
+        
+        XCTAssertNil(SentrySerialization.session(with: data))
+    }
+    
+    func testSerializeSessionWithGarbage() throws {
+        guard let data = "started".data(using: .ascii) else {
+            XCTFail("Failed to create data"); return
+        }
         
         XCTAssertNil(SentrySerialization.session(with: data))
     }

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -127,7 +127,7 @@ class SentryCrashIntegrationTests: XCTestCase {
     
     private func givenCurrentSession() -> SentrySession {
         // serialize sets the timestamp
-        let session = SentrySession(jsonObject: fixture.session.serialize())
+        let session = SentrySession(jsonObject: fixture.session.serialize())!
         fixture.fileManager.storeCurrentSession(session)
         return session
     }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -27,7 +27,9 @@ class SentrySessionTestsSwift: XCTestCase {
         
         let date = currentDateProvider.date().addingTimeInterval(2)
         json["timestamp"] = (date as NSDate).sentry_toIso8601String()
-        let session = SentrySession(jsonObject: json)
+        guard let session = SentrySession(jsonObject: json) else {
+            XCTFail("Couldn't create session from JSON"); return
+        }
         
         let sessionSerialized = session.serialize()
         let duration = sessionSerialized["duration"] as? Double ?? -1
@@ -49,65 +51,49 @@ class SentrySessionTestsSwift: XCTestCase {
         XCTAssertNotEqual(session, copiedSession)
     }
     
-    func testInitWithJson_IfJsonMissesField_DefaultValuesAreUsed() {
-        let expected = SentrySession(releaseName: "release")
-        var serialized = expected.serialize()
-        serialized["sid"] = nil
-        serialized["started"] = nil
-        serialized["status"] = nil
-        serialized["seq"] = nil
-        serialized["errors"] = nil
-        serialized["did"] = nil
-        serialized["init"] = nil
-        serialized["attrs"] = nil
-
-        let session = SentrySession(jsonObject: serialized)
+    func testInitWithJson_Status_MapsToCorrectStatus() {
+        func testStatus(status: SentrySessionStatus, statusAsString: String) {
+            let expected = SentrySession(releaseName: "release")
+            var serialized = expected.serialize()
+            serialized["status"] = statusAsString
+            let actual = SentrySession(jsonObject: serialized)!
+            XCTAssertEqual(status, actual.status)
+        }
         
-        XCTAssertNotEqual(expected.sessionId, session.sessionId)
-        XCTAssertEqual(expected.started, session.started)
-        XCTAssertEqual(expected.status, session.status)
-        XCTAssertEqual(expected.sequence, session.sequence)
-        XCTAssertEqual(expected.errors, session.errors)
-        XCTAssertNil(session.releaseName)
+        testStatus(status: SentrySessionStatus.ok, statusAsString: "ok")
+        testStatus(status: SentrySessionStatus.exited, statusAsString: "exited")
+        testStatus(status: SentrySessionStatus.crashed, statusAsString: "crashed")
+        testStatus(status: SentrySessionStatus.abnormal, statusAsString: "abnormal")
     }
     
-    func testInitWithJson_IfJsonContainsWrongFields_DefaultValuesAreUsed() {
-        let expected = SentrySession(releaseName: "release")
-        var serialized = expected.serialize()
-        serialized["sid"] = 20
-        serialized["started"] = 20
-        serialized["status"] = 20
-        serialized["seq"] = "nil"
-        serialized["errors"] = nil
-        serialized["did"] = nil
-        serialized["init"] = nil
-        serialized["attrs"] = nil
-
-        let session = SentrySession(jsonObject: serialized)
-        
-        XCTAssertNotEqual(expected.sessionId, session.sessionId)
-        XCTAssertEqual(expected.started, session.started)
-        XCTAssertEqual(expected.status, session.status)
-        XCTAssertEqual(expected.sequence, session.sequence)
-        XCTAssertEqual(expected.errors, session.errors)
-        XCTAssertNil(session.releaseName)
+    func testInitWithJson_IfJsonMissesField_SessionIsNil() {
+        withValue { $0["sid"] = nil }
+        withValue { $0["started"] = nil }
+        withValue { $0["status"] = nil }
+        withValue { $0["seq"] = nil }
+        withValue { $0["errors"] = nil }
+        withValue { $0["did"] = nil }
     }
     
-    func testInitWithJson_IfJsonContainsWrongValues_DefaultValuesAreUsed() {
+    func testInitWithJson_IfJsonContainsWrongFields_SessionIsNil() {
+        withValue { $0["sid"] = 20 }
+        withValue { $0["started"] = 20 }
+        withValue { $0["status"] = 20 }
+        withValue { $0["seq"] = "nil" }
+        withValue { $0["errors"] = "nil" }
+        withValue { $0["did"] = 20 }
+    }
+    
+    func testInitWithJson_IfJsonContainsWrongValues_SessionIsNil() {
+        withValue { $0["sid"] = "" }
+        withValue { $0["started"] = "20" }
+        withValue { $0["status"] = "20" }
+    }
+    
+    func withValue(setValue: (inout [String: Any]) -> Void) {
         let expected = SentrySession(releaseName: "release")
         var serialized = expected.serialize()
-        serialized["sid"] = ""
-        serialized["started"] = "20"
-        serialized["status"] = "20"
-        serialized["timestamp"] = "20"
-
-        let session = SentrySession(jsonObject: serialized)
-        
-        XCTAssertNotEqual(expected.sessionId, session.sessionId)
-        XCTAssertEqual(expected.started, session.started)
-        XCTAssertEqual(expected.status, session.status)
-        XCTAssertEqual(expected.sequence, session.sequence)
-        XCTAssertEqual(expected.errors, session.errors)
-        XCTAssertNil(session.timestamp)
+        setValue(&serialized)
+        XCTAssertNil(SentrySession(jsonObject: serialized))
     }
 }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -92,5 +92,22 @@ class SentrySessionTestsSwift: XCTestCase {
         XCTAssertEqual(expected.errors, session.errors)
         XCTAssertNil(session.releaseName)
     }
+    
+    func testInitWithJson_IfJsonContainsWrongValues_DefaultValuesAreUsed() {
+        let expected = SentrySession(releaseName: "release")
+        var serialized = expected.serialize()
+        serialized["sid"] = ""
+        serialized["started"] = "20"
+        serialized["status"] = "20"
+        serialized["timestamp"] = "20"
 
+        let session = SentrySession(jsonObject: serialized)
+        
+        XCTAssertNotEqual(expected.sessionId, session.sessionId)
+        XCTAssertEqual(expected.started, session.started)
+        XCTAssertEqual(expected.status, session.status)
+        XCTAssertEqual(expected.sequence, session.sequence)
+        XCTAssertEqual(expected.errors, session.errors)
+        XCTAssertNil(session.timestamp)
+    }
 }


### PR DESCRIPTION
## :scroll: Description

When the JSON contains a started that can't be converted to an NSDate the SDK sets
the _started to nil, which leads to a crash later as _started is nonnull. This is fixed now
by returning `nil` when the JSON passed to initWithJSONObject contains an error.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-cocoa/issues/937

## :green_heart: How did you test it?
Unit tests and SentrySessionGeneratorTests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
