### PR TITLE
feat: Group NSError by domain and code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Group NSError by domain and code #941
 - fix: Discard Sessions when JSON is faulty #939
 - feat: Add sendDefaultPii to SentryOptions #923
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -168,12 +168,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 - (SentryEvent *)buildErrorEvent:(NSError *)error
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
-    NSString *formatted = [NSString stringWithFormat:@"%@ %ld", error.domain, (long)error.code];
-    SentryMessage *message = [[SentryMessage alloc] initWithFormatted:formatted];
-    message.message = [error.domain stringByAppendingString:@" %s"];
-    message.params = @[ [NSString stringWithFormat:@"%ld", (long)error.code] ];
-    event.message = message;
+    NSString *errorCodeAsString = [NSString stringWithFormat:@"%ld", (long)error.code];
+    SentryException *sentryException = [[SentryException alloc] initWithValue:errorCodeAsString
+                                                                         type:error.domain];
+    event.exceptions = @[ sentryException ];
+    event.fingerprint = @[ error.domain, [NSString stringWithFormat:@"%ld", (long)error.code] ];
+
     [self setUserInfo:error.userInfo withEvent:event];
+
     return event;
 }
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -244,7 +244,7 @@ class SentryClientTest: XCTestCase {
         
         eventId.assertIsNotEmpty()
         assertLastSentEventWithAttachment { actual in
-            assertValidErrorEvent(actual)
+            assertValidErrorEvent(actual, error)
         }
     }
     
@@ -254,9 +254,7 @@ class SentryClientTest: XCTestCase {
         eventId.assertIsNotEmpty()
         let error = TestError.invalidTest as NSError
         assertLastSentEvent { actual in
-            XCTAssertEqual("\(error.domain) \(error.code)", actual.message.formatted)
-            XCTAssertEqual("\(error.domain) %s", actual.message.message)
-            XCTAssertEqual(["\(error.code)"], actual.message.params)
+            assertValidErrorEvent(actual, error)
         }
     }
 
@@ -278,7 +276,7 @@ class SentryClientTest: XCTestCase {
         eventId.assertIsNotEmpty()
         XCTAssertNotNil(fixture.transport.sentEventsWithSession.last)
         if let eventWithSessionArguments = fixture.transport.sentEventsWithSession.last {
-            assertValidErrorEvent(eventWithSessionArguments.event)
+            assertValidErrorEvent(eventWithSessionArguments.event, error)
             XCTAssertEqual(fixture.session, eventWithSessionArguments.session)
         }
     }
@@ -790,11 +788,20 @@ class SentryClientTest: XCTestCase {
         }
     }
     
-    private func assertValidErrorEvent(_ event: Event) {
+    private func assertValidErrorEvent(_ event: Event, _ error: NSError) {
         XCTAssertEqual(SentryLevel.error, event.level)
-        XCTAssertEqual("\(error.domain) \(error.code)", event.message.formatted)
-        XCTAssertEqual("\(error.domain) %s", event.message.message)
-        XCTAssertEqual(["\(error.code)"], event.message.params)
+        
+        guard let exceptions = event.exceptions else {
+            XCTFail("Event should contain one exception"); return
+        }
+        XCTAssertEqual(1, exceptions.count)
+        let exception = exceptions[0]
+        XCTAssertEqual(error.domain, exception.type)
+        XCTAssertEqual("\(error.code)", exception.value)
+        XCTAssertNil(exception.thread)
+        
+        XCTAssertEqual([error.domain, String(error.code)], event.fingerprint)
+        
         assertValidDebugMeta(actual: event.debugMeta)
         assertValidThreads(actual: event.threads)
     }
@@ -829,22 +836,22 @@ class SentryClientTest: XCTestCase {
     
     private func assertValidThreads(actual: [Sentry.Thread]?) {
         let expected = fixture.threadInspector.getCurrentThreads()
-
+        XCTAssertEqual(expected.count, actual?.count)
+        
         // We can only compare the stacktrace up to the test method. Therefore we
         // need to remove a few frames for the stacktraces.
-        removeFrames(threads: expected)
-        removeFrames(threads: actual ?? [])
+        removeFrames(thread: expected[0])
+        removeFrames(thread: actual![0])
         
-        XCTAssertEqual(expected.count, actual?.count)
-        XCTAssertEqual(expected, actual ?? [])
+        XCTAssertEqual(expected, actual)
     }
 
-    private func removeFrames(threads: [Sentry.Thread]) {
-        var actualFrames = threads[0].stacktrace?.frames ?? []
+    private func removeFrames(thread: Sentry.Thread) {
+        var actualFrames = thread.stacktrace?.frames ?? []
         XCTAssertTrue(actualFrames.count > 1, "Event has no stacktrace.")
         if actualFrames.count > 1 {
             actualFrames.removeLast(3)
-            threads[0].stacktrace?.frames = actualFrames
+            thread.stacktrace?.frames = actualFrames
         }
     }
 


### PR DESCRIPTION
## :scroll: Description

Use the exception interface for NSErrors and SDK Fingerprinting to group NSErrors by domain and
code. So MyDomain 1 and MyDomain 2 are going to be two separate issues in Sentry.

## :bulb: Motivation and Context

See https://github.com/getsentry/sentry-cocoa/discussions/929

## :green_heart: How did you test it?
Unit tests and Simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
