### PR TITLE
fix: Stacktrace inApp marking on Simulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Stacktrace inApp marking on Simulators #942
 - fix: Discard Sessions when JSON is faulty #939
 - feat: Add sendDefaultPii to SentryOptions #923
 

--- a/Sources/Sentry/SentryCrashStackEntryMapper.m
+++ b/Sources/Sentry/SentryCrashStackEntryMapper.m
@@ -39,7 +39,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)isInApp:(NSString *)imageName
 {
-    return [imageName containsString:@"/Bundle/Application/"] || [imageName containsString:@".app"];
+    // We don't want to mark images from Xcode as inApp. As these images are located in
+    // "/Applications/Xcode.app/Contents" checking for ".app" would be true. Therefore we need to
+    // exclude them. We search for "/Applications/Xcode" and ".app/Contents/" to be more exclusive,
+    // but not too strict for future Xcode versions. We also can't use Xcode.app, because this
+    // wouldn't work if you have multiple Xcode versions installed. We don't support Xcode being
+    // installed in a different location than "/Applications".
+
+    BOOL isNotXcodeSimulatorImage = !([imageName containsString:@"/Applications/Xcode"] &&
+        [imageName containsString:@".app/Contents/"]);
+
+    return [imageName containsString:@"/Bundle/Application/"]
+        || ([imageName containsString:@".app"] && isNotXcodeSimulatorImage);
 }
 
 @end

--- a/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
@@ -61,6 +61,19 @@ class SentryCrashStackEntryMapperTests: XCTestCase {
         XCTAssertEqual(true, frame2.inApp)
     }
     
+    func testXcodeLibraries() {
+        let frame1 = getFrameWithImageName(imageName: "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime/Contents/Resources/RuntimeRoot/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore")
+        XCTAssertEqual(false, frame1.inApp)
+        
+        // If someone has multiple Xcode installations
+        let frame2 = getFrameWithImageName(imageName: "/Applications/Xcode 11.app/Contents/")
+        XCTAssertEqual(false, frame2.inApp)
+        
+        // We don't care if someone installed Xcode in a different location that Applications
+        let frame3 = getFrameWithImageName(imageName: "/Users/sentry/Downloads/Xcode.app/Contents/")
+        XCTAssertEqual(true, frame3.inApp)
+    }
+    
     func testImageAddress () {
         var cursor = SentryCrashStackCursor()
         cursor.stackEntry.imageAddress = 2_488_998_912


### PR DESCRIPTION


## :scroll: Description

The SDK marked almost all stack traces frames when capturing events on Simulators as inApp.
This is fixed now by changing the logic in SentryCrashStackEntryMapper.

## :bulb: Motivation and Context

Could fix https://github.com/getsentry/sentry-cocoa/issues/933.

## :green_heart: How did you test it?
Unit tests and simulators.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
