### PR TITLE
fix: Mark SentryEvent.message as Nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Mark SentryEvent.message as Nullable #943
 - fix: Stacktrace inApp marking on Simulators #942
 - feat: Group NSError by domain and code #941
 - fix: Discard Sessions when JSON is faulty #939

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -17,9 +17,9 @@ NS_SWIFT_NAME(Event)
 @property (nonatomic, strong) SentryId *eventId;
 
 /**
- * Message of the event
+ * Message of the event.
  */
-@property (nonatomic, strong) SentryMessage *message;
+@property (nonatomic, strong) SentryMessage *_Nullable message;
 
 /**
  * NSDate of when the event occured

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -125,7 +125,9 @@ NS_ASSUME_NONNULL_BEGIN
 
     [serializedData setValue:self.context forKey:@"contexts"];
 
-    [serializedData setValue:[self.message serialize] forKey:@"message"];
+    if (nil != self.message) {
+        [serializedData setValue:[self.message serialize] forKey:@"message"];
+    }
     [serializedData setValue:self.logger forKey:@"logger"];
     [serializedData setValue:self.serverName forKey:@"server_name"];
     [serializedData setValue:self.type forKey:@"type"];

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -237,7 +237,7 @@ class SentryEnvelopeTests: XCTestCase {
         if let data = envelope.items.first?.data {
             let json = String(data: data, encoding: .utf8) ?? ""
 
-            json.assertContains("JSON conversion error for event with message: '\(event.message)'", "message")
+            json.assertContains("JSON conversion error for event with message: '\(event.message?.description ?? "")'", "message")
             json.assertContains("warning", "level")
             json.assertContains(event.releaseName ?? "", "releaseName")
             json.assertContains(event.environment ?? "", "environment")

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -79,4 +79,13 @@ class SentryEventTests: XCTestCase {
         let actual = event.serialize()
         XCTAssertNil(actual["breadcrumbs"])
     }
+    
+    func testSerializeWithoutMessage() {
+        let actual = Event().serialize()
+        XCTAssertNil(actual["message"])
+    }
+    
+    func testMessageIsNil() {
+        XCTAssertNil(Event().message)
+    }
 }


### PR DESCRIPTION


## :scroll: Description

The SentryEvent.message was marked as nonnullable. Actually, this property is optional.
Previously when initializing an Event, not setting a message and then accessing it in Swift
lead to a crash with bad access. This is fixed now by marking the property as nullable.

## :bulb: Motivation and Context

We don't want to crash.

## :green_heart: How did you test it?
Unit tests and CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
