### PR TITLE
feat: Add error to SentryEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- feat: Add error to SentryEvent #944
 - fix: Stacktrace inApp marking on Simulators #942
 - feat: Group NSError by domain and code #941
 - fix: Discard Sessions when JSON is faulty #939

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -22,6 +22,13 @@ NS_SWIFT_NAME(Event)
 @property (nonatomic, strong) SentryMessage *message;
 
 /**
+ * The error of the event. This property adds convenience to access the error directly in
+ * beforeSend. This property is not serialized. Instead when preparing the event the SentryClient
+ * puts the error into exceptions.
+ */
+@property (nonatomic, strong) NSError *_Nullable error;
+
+/**
  * NSDate of when the event occured
  */
 @property (nonatomic, strong) NSDate *timestamp;
@@ -163,6 +170,15 @@ NS_SWIFT_NAME(Event)
  * @return SentryEvent
  */
 - (instancetype)initWithLevel:(enum SentryLevel)level NS_DESIGNATED_INITIALIZER;
+
+/**
+ * Initializes a SentryEvent with an NSError and sets the level to SentryLevelError.
+ *
+ * @param error The error of the event.
+ *
+ * @return The initialized SentryEvent.
+ */
+- (instancetype)initWithError:(NSError *)error;
 
 @end
 

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -26,7 +26,7 @@ NS_SWIFT_NAME(Event)
  * beforeSend. This property is not serialized. Instead when preparing the event the SentryClient
  * puts the error into exceptions.
  */
-@property (nonatomic, strong) NSError *_Nullable error;
+@property (nonatomic, copy) NSError *_Nullable error;
 
 /**
  * NSDate of when the event occured

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -167,7 +167,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (SentryEvent *)buildErrorEvent:(NSError *)error
 {
-    SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
+    SentryEvent *event = [[SentryEvent alloc] initWithError:error];
     NSString *errorCodeAsString = [NSString stringWithFormat:@"%ld", (long)error.code];
     SentryException *sentryException = [[SentryException alloc] initWithValue:errorCodeAsString
                                                                          type:error.domain];

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -33,6 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (instancetype)initWithError:(NSError *)error
+{
+    self = [self initWithLevel:kSentryLevelError];
+    self.error = error;
+    return self;
+}
+
 - (NSDictionary<NSString *, id> *)serialize
 {
     if (nil == self.timestamp) {

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -79,4 +79,10 @@ class SentryEventTests: XCTestCase {
         let actual = event.serialize()
         XCTAssertNil(actual["breadcrumbs"])
     }
+    
+    func testInitWithError() {
+        let error = CocoaError(CocoaError.coderInvalidValue)
+        let event = Event(error: error)
+        XCTAssertEqual(error, event.error as? CocoaError)
+    }
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -790,6 +790,7 @@ class SentryClientTest: XCTestCase {
     
     private func assertValidErrorEvent(_ event: Event, _ error: NSError) {
         XCTAssertEqual(SentryLevel.error, event.level)
+        XCTAssertEqual(error, event.error as NSError?)
         
         guard let exceptions = event.exceptions else {
             XCTFail("Event should contain one exception"); return


### PR DESCRIPTION


## :scroll: Description

Add an initializer initWithError and property error to SentryEvent. This change gives
our users the possibility to access the error in beforeSend.

## :bulb: Motivation and Context

When trying to write the docs for [SDK Fingerprinting](https://docs.sentry.io/platforms/java/data-management/event-grouping/sdk-fingerprinting/) for Cocoa, I realized that there is no proper way to access the error in `beforeSend`. The [Java](https://github.com/getsentry/sentry-java/blob/404ff7b0e84bb88324d7d41a6d3b7913d5d7f72c/sentry/src/main/java/io/sentry/SentryBaseEvent.java#L63) and [.NET](https://github.com/getsentry/sentry-dotnet/blob/6ce7f933f64bd517677b5e837d6c7e8cc37b4217/src/Sentry/SentryEvent.cs#L29) SDK have a similar property too on the SentryEvent.

## :green_heart: How did you test it?
Unit tests and with `beforeSend` in the sample projects.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
