### PR TITLE
fix: Sanitize SentryMechanism.data on serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: Sanitize SentryMechanism.data on serialize #947
 - feat: Add error to SentryEvent #944
 - fix: Mark SentryEvent.message as Nullable #943
 - fix: Stacktrace inApp marking on Simulators #942

--- a/Sources/Sentry/SentryMechanism.m
+++ b/Sources/Sentry/SentryMechanism.m
@@ -1,4 +1,5 @@
 #import "SentryMechanism.h"
+#import "NSDictionary+SentrySanitize.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.handled forKey:@"handled"];
     [serializedData setValue:self.desc forKey:@"description"];
     [serializedData setValue:self.meta forKey:@"meta"];
-    [serializedData setValue:self.data forKey:@"data"];
+    [serializedData setValue:[self.data sentry_sanitize] forKey:@"data"];
     [serializedData setValue:self.helpLink forKey:@"help_link"];
 
     return serializedData;

--- a/Tests/SentryTests/Protocol/SentryMechanismTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismTests.swift
@@ -9,14 +9,22 @@ class SentryMechanismTests: XCTestCase {
         
         // Changing the original doesn't modify the serialized
         mechanism.data?["other"] = "object"
-        mechanism.meta?["other"] = "object"
+        mechanism.meta?["data"] = "object"
 
         let expected = TestData.mechanism
         XCTAssertEqual(expected.type, actual["type"] as! String)
-        XCTAssertEqual(1, (actual["data"] as! [String: Any]).count)
         XCTAssertEqual(expected.desc, actual["description"] as? String)
         XCTAssertEqual(expected.handled, actual["handled"] as? NSNumber)
         XCTAssertEqual(expected.helpLink, actual["help_link"] as? String)
         XCTAssertEqual(1, (actual["meta"] as! [String: Any]).count)
+        
+        guard let something = (actual["data"] as? [String: Any])?["something"] as? [String: Any] else {
+            XCTFail("Serialized SentryMechanism doesn't contain something.")
+            return
+        }
+        
+        let currentDateProvider = TestCurrentDateProvider()
+        let date = currentDateProvider.date() as NSDate
+        XCTAssertEqual(date.sentry_toIso8601String(), something["date"] as? String)
     }
 }

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -83,8 +83,9 @@ class TestData {
     }
     
     static var mechanism: Mechanism {
+        let currentDateProvider = TestCurrentDateProvider()
         let mechanism = Mechanism(type: "type")
-        mechanism.data = ["data": ["any": "some"]]
+        mechanism.data = ["something": ["date": currentDateProvider.date()]]
         mechanism.desc = "desc"
         mechanism.handled = true
         mechanism.helpLink = "https://www.sentry.io"


### PR DESCRIPTION


## :scroll: Description

When serializing SentryMechanism the SDK didn't sanitize the data dictionary.
This is fixed now.

## :bulb: Motivation and Context

I stumbled across this in https://github.com/getsentry/sentry-cocoa/pull/946.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
