### PR TITLE
ci: Fix code formatting

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -16,5 +16,9 @@ jobs:
         run: brew install clang-format
       - name: Format Code
         run: make format
+      
+      # actions/checkout fetches only a single commit in a detached HEAD state. Therefore
+      # we need to pass the current branch, otherwise we can't commit the changes.
+      # GITHUB_HEAD_REF is the name of the head branch. GitHub Actions only sets this for PRs.
       - name: Commit Formatted Code
-        run: ./scripts/commit-formatted-code.sh
+        run: ./scripts/commit-formatted-code.sh $GITHUB_HEAD_REF

--- a/Sources/Sentry/Public/SentryMechanism.h
+++ b/Sources/Sentry/Public/SentryMechanism.h
@@ -15,7 +15,7 @@ SENTRY_NO_INIT
  * A unique identifier of this mechanism determining rendering and processing
  * of the mechanism data
  */
-@property (nonatomic, copy) NSString *type;
+@property (nonatomic, copy) NSString * type;
 
 /**
  * Human readable description of the error mechanism and a possible hint on how to solve this error.

--- a/Sources/Sentry/Public/SentryMechanism.h
+++ b/Sources/Sentry/Public/SentryMechanism.h
@@ -15,7 +15,7 @@ SENTRY_NO_INIT
  * A unique identifier of this mechanism determining rendering and processing
  * of the mechanism data
  */
-@property (nonatomic, copy) NSString * type;
+@property (nonatomic, copy) NSString *type;
 
 /**
  * Human readable description of the error mechanism and a possible hint on how to solve this error.

--- a/scripts/commit-formatted-code.sh
+++ b/scripts/commit-formatted-code.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 set -euo pipefail
 
+GITHUB_BRANCH="${1}"
+
 if [[ $(git status) == *"nothing to commit"* ]]; then
     echo "Nothing to commit. All code formatted correctly."
 else
     echo "Formatted some code. Going to push the changes."
     git config --global user.name 'Sentry Github Bot'
     git config --global user.email 'bot+github-bot@sentry.io'
+    git fetch
+    git checkout ${GITHUB_BRANCH}
     git commit -am "Format code"
-    git push 
+    git push --set-upstream origin ${GITHUB_BRANCH}
 fi


### PR DESCRIPTION
## :scroll: Description

The code formatting workflow was not able to commit formatted code,
because the Github Actions checks out in a detached HEAD state.
This is fixed now by fetching, creating a branch, and then pushing it.

## :bulb: Motivation and Context

We don't want this workflow to fail.

## :green_heart: How did you test it?
By pushing false formatted code.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
