### PR TITLE
feat: Add session recorder.

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -15,6 +15,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.logLevel = SentryLogLevel.verbose
             options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
+            options.recordSession = true
         }
         
         return true

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -400,6 +400,10 @@
 		7DC8310C2398283C0043DD9A /* SentryCrashIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DC831092398283C0043DD9A /* SentryCrashIntegration.m */; };
 		861265F92404EC1500C4AFDE /* NSArray+SentrySanitize.h in Headers */ = {isa = PBXBuildFile; fileRef = 861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */; };
 		861265FA2404EC1500C4AFDE /* NSArray+SentrySanitize.m in Sources */ = {isa = PBXBuildFile; fileRef = 861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */; };
+		8E92EA9725E48B0E00AB72A4 /* ScreenRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E92EA9525E48B0E00AB72A4 /* ScreenRecorder.m */; };
+		8E92EA9D25E48B3500AB72A4 /* ScreenRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E92EA9C25E48B3500AB72A4 /* ScreenRecorder.h */; };
+		8E92EAA325E48CA900AB72A4 /* SentrySessionRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E92EAA125E48CA900AB72A4 /* SentrySessionRecorder.m */; };
+		8E92EAA725E48CC900AB72A4 /* SentrySessionRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E92EAA625E48CC900AB72A4 /* SentrySessionRecorder.h */; };
 		A811D867248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A811D866248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift */; };
 		A839D89824864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = A839D89724864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h */; };
 		A839D89A24864BA8003B7AFD /* SentrySystemEventsBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = A839D89924864BA8003B7AFD /* SentrySystemEventsBreadcrumbs.m */; };
@@ -849,6 +853,10 @@
 		7DC831092398283C0043DD9A /* SentryCrashIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashIntegration.m; sourceTree = "<group>"; };
 		861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSArray+SentrySanitize.h"; path = "include/NSArray+SentrySanitize.h"; sourceTree = "<group>"; };
 		861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SentrySanitize.m"; sourceTree = "<group>"; };
+		8E92EA9525E48B0E00AB72A4 /* ScreenRecorder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ScreenRecorder.m; sourceTree = "<group>"; };
+		8E92EA9C25E48B3500AB72A4 /* ScreenRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ScreenRecorder.h; path = include/ScreenRecorder.h; sourceTree = "<group>"; };
+		8E92EAA125E48CA900AB72A4 /* SentrySessionRecorder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySessionRecorder.m; sourceTree = "<group>"; };
+		8E92EAA625E48CC900AB72A4 /* SentrySessionRecorder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentrySessionRecorder.h; path = include/SentrySessionRecorder.h; sourceTree = "<group>"; };
 		A811D866248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySystemEventsBreadcrumbsTest.swift; sourceTree = "<group>"; };
 		A839D89724864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySystemEventsBreadcrumbs.h; path = include/SentrySystemEventsBreadcrumbs.h; sourceTree = "<group>"; };
 		A839D89924864BA8003B7AFD /* SentrySystemEventsBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySystemEventsBreadcrumbs.m; sourceTree = "<group>"; };
@@ -1196,6 +1204,7 @@
 				6383953323ABA255000C1594 /* State */,
 				63AA769F1EB9C89800D153DE /* Supporting Files */,
 				630436011EBCB8CA00C4D3FA /* Protocol */,
+				8E92EA9325E48AE900AB72A4 /* SessionRecorder */,
 				63AA76931EB9C1C200D153DE /* Sentry.h */,
 				63AA76941EB9C1C200D153DE /* SentryClient.h */,
 				63AA75ED1EB8B3C400D153DE /* SentryClient.m */,
@@ -1620,6 +1629,17 @@
 			path = .github;
 			sourceTree = "<group>";
 		};
+		8E92EA9325E48AE900AB72A4 /* SessionRecorder */ = {
+			isa = PBXGroup;
+			children = (
+				8E92EA9C25E48B3500AB72A4 /* ScreenRecorder.h */,
+				8E92EA9525E48B0E00AB72A4 /* ScreenRecorder.m */,
+				8E92EAA625E48CC900AB72A4 /* SentrySessionRecorder.h */,
+				8E92EAA125E48CA900AB72A4 /* SentrySessionRecorder.m */,
+			);
+			name = SessionRecorder;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1731,9 +1751,11 @@
 				63FE709520DA4C1000CDBAE8 /* SentryCrashReportFilterBasic.h in Headers */,
 				63FE70A120DA4C1000CDBAE8 /* SentryCrashCString.h in Headers */,
 				7B7D873424864C6600D2ECFF /* SentryCrashDefaultMachineContextWrapper.h in Headers */,
+				8E92EA9D25E48B3500AB72A4 /* ScreenRecorder.h in Headers */,
 				7BA61CC8247D125400C130A8 /* SentryThreadInspector.h in Headers */,
 				7BE1E32824F7AE08009D3AD0 /* SentrySession+Private.h in Headers */,
 				63FE713320DA4C1100CDBAE8 /* SentryCrashCPU.h in Headers */,
+				8E92EAA725E48CC900AB72A4 /* SentrySessionRecorder.h in Headers */,
 				63FE715B20DA4C1100CDBAE8 /* SentryCrashSignalInfo.h in Headers */,
 				63FE70E520DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h in Headers */,
 				15360CD92432835400112302 /* SentryAutoSessionTrackingIntegration.h in Headers */,
@@ -1896,6 +1918,7 @@
 				637533592243A0100002F77F /* NSString+SentryUnsignedLongLongValue.m in Sources */,
 				63FE712F20DA4C1100CDBAE8 /* SentryCrashSysCtl.c in Sources */,
 				7B3B473825D6CC7E00D01640 /* SentryNSError.m in Sources */,
+				8E92EA9725E48B0E00AB72A4 /* ScreenRecorder.m in Sources */,
 				7BE3C77D2446112C00A38442 /* SentryRateLimitParser.m in Sources */,
 				15E0A8ED240F2CB000F044E3 /* SentrySerialization.m in Sources */,
 				7BC85235245880AE005A70F0 /* SentryRateLimitCategoryMapper.m in Sources */,
@@ -1963,6 +1986,7 @@
 				6304360B1EC0595B00C4D3FA /* NSData+SentryCompression.m in Sources */,
 				639889B81EDECFA800EA7442 /* SentryBreadcrumbTracker.m in Sources */,
 				7DC8310C2398283C0043DD9A /* SentryCrashIntegration.m in Sources */,
+				8E92EAA325E48CA900AB72A4 /* SentrySessionRecorder.m in Sources */,
 				635B3F391EBC6E2500A6176D /* SentryAsynchronousOperation.m in Sources */,
 				63FE717520DA4C1100CDBAE8 /* SentryCrash.m in Sources */,
 				7BE3C7712445C30D00A38442 /* SentryDefaultCurrentDateProvider.m in Sources */,
@@ -2280,7 +2304,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 63AA75C51EB8B00100D153DE /* Sentry.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;
@@ -2321,7 +2345,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 63AA75C51EB8B00100D153DE /* Sentry.xcconfig */;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				CLANG_CXX_LANGUAGE_STANDARD = "compiler-default";
 				CLANG_CXX_LIBRARY = "compiler-default";
 				CLANG_ENABLE_MODULES = YES;

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -148,6 +148,8 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) BOOL sendDefaultPii;
 
+@property (nonatomic) BOOL recordSession;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/ScreenRecorder.m
+++ b/Sources/Sentry/ScreenRecorder.m
@@ -1,0 +1,160 @@
+
+#import "ScreenRecorder.h"
+#import <AVFoundation/AVFoundation.h>
+
+@implementation ScreenRecorder {
+    AVAssetWriter *videoWriter;
+    AVAssetWriterInput* videoWriterInput;
+    AVAssetWriterInputPixelBufferAdaptor *adaptor;
+    UIView *_view;
+    int frameCount;
+    NSTimer *captureTimer;
+    UIGraphicsImageRenderer* renderer;
+    CGContextRef context;
+    CVPixelBufferRef pxbuffer;
+    NSURL* _targetFile;
+    NSDate * _endBy;
+    NSDate * _startedAt;
+}
+
+
+-(instancetype)init {
+    self = [super init];
+    return self;
+}
+
+-(bool) startWithTarget:(NSURL *)target {
+    return [self startWithTarget:target duration:0];
+}
+
+-(bool) startWithTarget:(NSURL *)target
+               duration:(NSTimeInterval)duration
+{
+    if (UIApplication.sharedApplication.windows.count == 0) return false;
+    
+    _view = UIApplication.sharedApplication.windows[0];
+    _targetFile = target;
+    
+    NSError *error = nil;
+    
+    videoWriter = [[AVAssetWriter alloc] initWithURL:target fileType:AVFileTypeMPEG4
+                                               error:&error];
+    
+    if (error != nil) return false;
+    
+    if (@available(iOS 11.0, *)) {
+        NSDictionary *videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:
+                                       AVVideoCodecTypeH264, AVVideoCodecKey,
+                                       [NSNumber numberWithInt:(int)_view.frame.size.width], AVVideoWidthKey,
+                                       [NSNumber numberWithInt:(int)_view.frame.size.height], AVVideoHeightKey,
+                                       nil];
+        
+        videoWriterInput = [AVAssetWriterInput
+                            assetWriterInputWithMediaType:AVMediaTypeVideo
+                            outputSettings:videoSettings];
+    } else {
+        return false;
+    }
+    
+    adaptor = [AVAssetWriterInputPixelBufferAdaptor
+               assetWriterInputPixelBufferAdaptorWithAssetWriterInput:videoWriterInput
+               sourcePixelBufferAttributes:nil];
+    
+    videoWriterInput.expectsMediaDataInRealTime = YES;
+    [videoWriter addInput:videoWriterInput];
+    
+    [videoWriter startWriting];
+    [videoWriter startSessionAtSourceTime:kCMTimeZero];
+    
+    frameCount = 0;
+    
+    captureTimer = [NSTimer scheduledTimerWithTimeInterval:1.0/15.0 target:self selector:@selector(tick) userInfo:nil repeats:true];
+    
+    //UIGraphicsImageRendererFormat * format = [[UIGraphicsImageRendererFormat alloc] init];
+    //format.scale = 1;
+    
+    //renderer = [[UIGraphicsImageRenderer alloc] initWithSize:_view.frame.size format:format];
+    if (context == nil) {
+        context = [self createContext:_view.frame.size];
+    }
+    _startedAt = [NSDate date];
+    _endBy = [NSDate dateWithTimeIntervalSinceNow:duration > 0 ? duration : 3600 ];
+    
+    return context != NULL;
+    return NULL;
+}
+
+
+-(void) finish {
+    [captureTimer invalidate];
+    captureTimer = nil;
+    
+    [videoWriterInput markAsFinished];
+    [videoWriter finishWritingWithCompletionHandler:^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"io.sentry.RECORD_ENDED" object:nil];
+    }];
+}
+
+-(void)tick {
+    if ([_endBy timeIntervalSinceNow] < 0) {
+        [self finish];
+    } else if (adaptor.assetWriterInput.readyForMoreMediaData) {
+        if (captureTimer == nil) return;
+        UIGraphicsPushContext(context);
+        [_view drawViewHierarchyInRect:_view.bounds afterScreenUpdates:false];
+        UIGraphicsPopContext();
+        [self writeNewFrame];
+    }
+}
+
+- (bool)writeNewFrame {
+    CMTime frameTime = CMTimeMake(frameCount,(int32_t) 15);
+    frameCount++;
+    bool res = [adaptor appendPixelBuffer:pxbuffer withPresentationTime:frameTime];
+    return res;
+}
+
++(ScreenRecorder*) shared {
+    static ScreenRecorder * _shared;
+    if (_shared == nil) {
+        _shared = [[ScreenRecorder alloc] init];
+    }
+    return _shared;
+}
+
+-(BOOL)isRecording {
+    return captureTimer != nil;
+}
+
+- (CGContextRef) createContext:(CGSize) size {
+    NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:
+                             [NSNumber numberWithBool:YES], kCVPixelBufferCGBitmapContextCompatibilityKey,
+                             nil];
+    
+    CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, (int)size.width,
+                                          (int)size.height, kCVPixelFormatType_32ARGB, (__bridge CFDictionaryRef) options,
+                                          &pxbuffer);
+    
+    NSParameterAssert(status == kCVReturnSuccess && pxbuffer != NULL);
+    
+    CVPixelBufferLockBaseAddress(pxbuffer, 0);
+    void *pxdata = CVPixelBufferGetBaseAddress(pxbuffer);
+    NSParameterAssert(pxdata != NULL);
+    
+    size_t bpr = CVPixelBufferGetBytesPerRow(pxbuffer);
+    
+    CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
+    CGContextRef _context = CGBitmapContextCreate(pxdata, (int)size.width,
+                                                  (int)size.height, 8, bpr, rgbColorSpace,
+                                                 kCGImageAlphaNoneSkipFirst);
+    CGContextConcatCTM(_context, CGAffineTransformMakeTranslation(0, (int)size.height));
+    CGContextConcatCTM(_context, CGAffineTransformMakeScale(1, -1));
+    
+    return _context;
+}
+
+-(NSTimeInterval) recordingLength {
+    return -[_startedAt timeIntervalSinceNow];
+}
+
+@end

--- a/Sources/Sentry/ScreenRecorder.m
+++ b/Sources/Sentry/ScreenRecorder.m
@@ -4,102 +4,108 @@
 
 @implementation ScreenRecorder {
     AVAssetWriter *videoWriter;
-    AVAssetWriterInput* videoWriterInput;
+    AVAssetWriterInput *videoWriterInput;
     AVAssetWriterInputPixelBufferAdaptor *adaptor;
     UIView *_view;
     int frameCount;
     NSTimer *captureTimer;
-    UIGraphicsImageRenderer* renderer;
+    UIGraphicsImageRenderer *renderer;
     CGContextRef context;
     CVPixelBufferRef pxbuffer;
-    NSURL* _targetFile;
-    NSDate * _endBy;
-    NSDate * _startedAt;
+    NSURL *_targetFile;
+    NSDate *_endBy;
+    NSDate *_startedAt;
 }
 
-
--(instancetype)init {
+- (instancetype)init
+{
     self = [super init];
     return self;
 }
 
--(bool) startWithTarget:(NSURL *)target {
+- (bool)startWithTarget:(NSURL *)target
+{
     return [self startWithTarget:target duration:0];
 }
 
--(bool) startWithTarget:(NSURL *)target
-               duration:(NSTimeInterval)duration
+- (bool)startWithTarget:(NSURL *)target duration:(NSTimeInterval)duration
 {
-    if (UIApplication.sharedApplication.windows.count == 0) return false;
-    
+    if (UIApplication.sharedApplication.windows.count == 0)
+        return false;
+
     _view = UIApplication.sharedApplication.windows[0];
     _targetFile = target;
-    
+
     NSError *error = nil;
-    
-    videoWriter = [[AVAssetWriter alloc] initWithURL:target fileType:AVFileTypeMPEG4
-                                               error:&error];
-    
-    if (error != nil) return false;
-    
+
+    videoWriter = [[AVAssetWriter alloc] initWithURL:target fileType:AVFileTypeMPEG4 error:&error];
+
+    if (error != nil)
+        return false;
+
     if (@available(iOS 11.0, *)) {
-        NSDictionary *videoSettings = [NSDictionary dictionaryWithObjectsAndKeys:
-                                       AVVideoCodecTypeH264, AVVideoCodecKey,
-                                       [NSNumber numberWithInt:(int)_view.frame.size.width], AVVideoWidthKey,
-                                       [NSNumber numberWithInt:(int)_view.frame.size.height], AVVideoHeightKey,
-                                       nil];
-        
-        videoWriterInput = [AVAssetWriterInput
-                            assetWriterInputWithMediaType:AVMediaTypeVideo
-                            outputSettings:videoSettings];
+        NSDictionary *videoSettings = [NSDictionary
+            dictionaryWithObjectsAndKeys:AVVideoCodecTypeH264, AVVideoCodecKey,
+            [NSNumber numberWithInt:(int)_view.frame.size.width], AVVideoWidthKey,
+            [NSNumber numberWithInt:(int)_view.frame.size.height], AVVideoHeightKey, nil];
+
+        videoWriterInput = [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
+                                                              outputSettings:videoSettings];
     } else {
         return false;
     }
-    
+
     adaptor = [AVAssetWriterInputPixelBufferAdaptor
-               assetWriterInputPixelBufferAdaptorWithAssetWriterInput:videoWriterInput
-               sourcePixelBufferAttributes:nil];
-    
+        assetWriterInputPixelBufferAdaptorWithAssetWriterInput:videoWriterInput
+                                   sourcePixelBufferAttributes:nil];
+
     videoWriterInput.expectsMediaDataInRealTime = YES;
     [videoWriter addInput:videoWriterInput];
-    
+
     [videoWriter startWriting];
     [videoWriter startSessionAtSourceTime:kCMTimeZero];
-    
+
     frameCount = 0;
-    
-    captureTimer = [NSTimer scheduledTimerWithTimeInterval:1.0/15.0 target:self selector:@selector(tick) userInfo:nil repeats:true];
-    
-    //UIGraphicsImageRendererFormat * format = [[UIGraphicsImageRendererFormat alloc] init];
-    //format.scale = 1;
-    
-    //renderer = [[UIGraphicsImageRenderer alloc] initWithSize:_view.frame.size format:format];
+
+    captureTimer = [NSTimer scheduledTimerWithTimeInterval:1.0 / 15.0
+                                                    target:self
+                                                  selector:@selector(tick)
+                                                  userInfo:nil
+                                                   repeats:true];
+
+    // UIGraphicsImageRendererFormat * format = [[UIGraphicsImageRendererFormat alloc] init];
+    // format.scale = 1;
+
+    // renderer = [[UIGraphicsImageRenderer alloc] initWithSize:_view.frame.size format:format];
     if (context == nil) {
         context = [self createContext:_view.frame.size];
     }
     _startedAt = [NSDate date];
-    _endBy = [NSDate dateWithTimeIntervalSinceNow:duration > 0 ? duration : 3600 ];
-    
+    _endBy = [NSDate dateWithTimeIntervalSinceNow:duration > 0 ? duration : 3600];
+
     return context != NULL;
     return NULL;
 }
 
-
--(void) finish {
+- (void)finish
+{
     [captureTimer invalidate];
     captureTimer = nil;
-    
+
     [videoWriterInput markAsFinished];
     [videoWriter finishWritingWithCompletionHandler:^{
-        [[NSNotificationCenter defaultCenter] postNotificationName:@"io.sentry.RECORD_ENDED" object:nil];
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"io.sentry.RECORD_ENDED"
+                                                            object:nil];
     }];
 }
 
--(void)tick {
+- (void)tick
+{
     if ([_endBy timeIntervalSinceNow] < 0) {
         [self finish];
     } else if (adaptor.assetWriterInput.readyForMoreMediaData) {
-        if (captureTimer == nil) return;
+        if (captureTimer == nil)
+            return;
         UIGraphicsPushContext(context);
         [_view drawViewHierarchyInRect:_view.bounds afterScreenUpdates:false];
         UIGraphicsPopContext();
@@ -107,53 +113,56 @@
     }
 }
 
-- (bool)writeNewFrame {
-    CMTime frameTime = CMTimeMake(frameCount,(int32_t) 15);
+- (bool)writeNewFrame
+{
+    CMTime frameTime = CMTimeMake(frameCount, (int32_t)15);
     frameCount++;
     bool res = [adaptor appendPixelBuffer:pxbuffer withPresentationTime:frameTime];
     return res;
 }
 
-+(ScreenRecorder*) shared {
-    static ScreenRecorder * _shared;
++ (ScreenRecorder *)shared
+{
+    static ScreenRecorder *_shared;
     if (_shared == nil) {
         _shared = [[ScreenRecorder alloc] init];
     }
     return _shared;
 }
 
--(BOOL)isRecording {
+- (BOOL)isRecording
+{
     return captureTimer != nil;
 }
 
-- (CGContextRef) createContext:(CGSize) size {
-    NSDictionary *options = [NSDictionary dictionaryWithObjectsAndKeys:
-                             [NSNumber numberWithBool:YES], kCVPixelBufferCGBitmapContextCompatibilityKey,
-                             nil];
-    
-    CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, (int)size.width,
-                                          (int)size.height, kCVPixelFormatType_32ARGB, (__bridge CFDictionaryRef) options,
-                                          &pxbuffer);
-    
+- (CGContextRef)createContext:(CGSize)size
+{
+    NSDictionary *options =
+        [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:YES],
+                      kCVPixelBufferCGBitmapContextCompatibilityKey, nil];
+
+    CVReturn status = CVPixelBufferCreate(kCFAllocatorDefault, (int)size.width, (int)size.height,
+        kCVPixelFormatType_32ARGB, (__bridge CFDictionaryRef)options, &pxbuffer);
+
     NSParameterAssert(status == kCVReturnSuccess && pxbuffer != NULL);
-    
+
     CVPixelBufferLockBaseAddress(pxbuffer, 0);
     void *pxdata = CVPixelBufferGetBaseAddress(pxbuffer);
     NSParameterAssert(pxdata != NULL);
-    
+
     size_t bpr = CVPixelBufferGetBytesPerRow(pxbuffer);
-    
+
     CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
-    CGContextRef _context = CGBitmapContextCreate(pxdata, (int)size.width,
-                                                  (int)size.height, 8, bpr, rgbColorSpace,
-                                                 kCGImageAlphaNoneSkipFirst);
+    CGContextRef _context = CGBitmapContextCreate(pxdata, (int)size.width, (int)size.height, 8, bpr,
+        rgbColorSpace, kCGImageAlphaNoneSkipFirst);
     CGContextConcatCTM(_context, CGAffineTransformMakeTranslation(0, (int)size.height));
     CGContextConcatCTM(_context, CGAffineTransformMakeScale(1, -1));
-    
+
     return _context;
 }
 
--(NSTimeInterval) recordingLength {
+- (NSTimeInterval)recordingLength
+{
     return -[_startedAt timeIntervalSinceNow];
 }
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -28,6 +28,8 @@
 #import "SentryTransportFactory.h"
 #import "SentryUser.h"
 #import "SentryUserFeedback.h"
+#import "SentrySessionRecorder.h"
+#import "SentryAttachment.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -427,6 +429,12 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         SentrySDK.crashedLastRunCalled = YES;
     }
 
+    if (self.options.recordSession) {
+        NSURL* currentUrl = SentrySessionRecorder.shared.currentRecording;
+        [scope addAttachment: [[SentryAttachment alloc] initWithPath:currentUrl.path
+                                                            filename:@"sessionRecorder.mp4"
+                                                         contentType:@"video/mp4"] ];
+    }
     return event;
 }
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1,5 +1,6 @@
 #import "SentryClient.h"
 #import "NSDictionary+SentrySanitize.h"
+#import "SentryAttachment.h"
 #import "SentryCrashDefaultBinaryImageProvider.h"
 #import "SentryCrashDefaultMachineContextWrapper.h"
 #import "SentryDebugMetaBuilder.h"
@@ -22,14 +23,13 @@
 #import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"
 #import "SentryScope.h"
+#import "SentrySessionRecorder.h"
 #import "SentryStacktraceBuilder.h"
 #import "SentryThreadInspector.h"
 #import "SentryTransport.h"
 #import "SentryTransportFactory.h"
 #import "SentryUser.h"
 #import "SentryUserFeedback.h"
-#import "SentrySessionRecorder.h"
-#import "SentryAttachment.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -430,10 +430,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     if (self.options.recordSession) {
-        NSURL* currentUrl = SentrySessionRecorder.shared.currentRecording;
-        [scope addAttachment: [[SentryAttachment alloc] initWithPath:currentUrl.path
-                                                            filename:@"sessionRecorder.mp4"
-                                                         contentType:@"video/mp4"] ];
+        NSURL *currentUrl = SentrySessionRecorder.shared.currentRecording;
+        [scope addAttachment:[[SentryAttachment alloc] initWithPath:currentUrl.path
+                                                           filename:@"sessionRecorder.mp4"
+                                                        contentType:@"video/mp4"]];
     }
     return event;
 }

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -170,7 +170,6 @@
     if (nil != options[@"recordSession"]) {
         self.recordSession = [options[@"recordSession"] boolValue];
     }
-
 }
 
 @end

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -30,6 +30,9 @@
         self.attachStacktrace = YES;
         self.maxAttachmentSize = 20 * 1024 * 1024;
         self.sendDefaultPii = NO;
+#if TARGET_OS_IOS
+        self.recordSession = NO;
+#endif
         _sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
                                             andVersion:SentryMeta.versionString];
 
@@ -163,6 +166,11 @@
     if (nil != options[@"sendDefaultPii"]) {
         self.sendDefaultPii = [options[@"sendDefaultPii"] boolValue];
     }
+
+    if (nil != options[@"recordSession"]) {
+        self.recordSession = [options[@"recordSession"] boolValue];
+    }
+
 }
 
 @end

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -6,6 +6,7 @@
 #import "SentryLog.h"
 #import "SentryMeta.h"
 #import "SentryScope.h"
+#import "SentrySessionRecorder.h"
 
 static SentryLogLevel logLevel = kSentryLogLevelError;
 
@@ -80,6 +81,11 @@ static BOOL crashedLastRunCalled;
                                         SentryMeta.versionString]
                      andLevel:kSentryLogLevelDebug];
     [SentrySDK installIntegrations];
+    
+
+    if (options.recordSession) {
+        [SentrySessionRecorder.shared start];
+    }
 }
 
 + (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -81,7 +81,6 @@ static BOOL crashedLastRunCalled;
                                         SentryMeta.versionString]
                      andLevel:kSentryLogLevelDebug];
     [SentrySDK installIntegrations];
-    
 
     if (options.recordSession) {
         [SentrySessionRecorder.shared start];

--- a/Sources/Sentry/SentrySessionRecorder.m
+++ b/Sources/Sentry/SentrySessionRecorder.m
@@ -1,0 +1,136 @@
+#import "SentrySessionRecorder.h"
+#import "ScreenRecorder.h"
+
+@implementation SentrySessionRecorder{
+    BOOL started;
+    NSURL* currentName;
+}
+
+
+-(instancetype)init
+{
+    self = [super init];
+    return self;
+}
+
+-(bool) start
+{
+    if (!started) {
+        if ((started = [self startNext]))
+            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(recordFinished) name:@"io.sentry.RECORD_ENDED" object:nil];
+    }
+    return started;
+}
+
+-(void) stop
+{
+    if (started)
+    {
+        started = false;
+        [ScreenRecorder.shared finish];
+    }
+    [NSNotificationCenter.defaultCenter removeObserver:self name:@"io.sentry.RECORD_ENDED" object:nil];
+}
+
+-(bool) startNext
+{
+    [self clearDirectory];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self->currentName = [self nextName];
+        [ScreenRecorder.shared startWithTarget:self->currentName duration:10];
+    });
+    
+    return true;
+}
+
+-(void)recordFinished
+{
+    if (started)
+        [self startNext];
+}
+
+-(void)clearDirectory
+{
+    NSString* dir = [self sessionDirectory];
+    NSArray<NSString *>* files = [self availableRecording];
+    if (files.count > 5) {
+        for (int i = 0; i < -(5-files.count); i++) {
+            [NSFileManager.defaultManager removeItemAtPath:[dir stringByAppendingPathComponent:files[i]] error:nil];
+        }
+    }
+}
+
+-(NSURL *)nextName {
+    NSString *sessionsDirectory = [self sessionDirectory];
+    
+    NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
+    [dateFormat setDateFormat:@"YYYY-MM-dd_HHmmss"];
+    NSString * today = [dateFormat stringFromDate:NSDate.date];
+    
+    NSString * filePath = [[sessionsDirectory stringByAppendingPathComponent:today] stringByAppendingPathExtension:@"mp4"];
+    NSLog(@"%@", filePath);
+    
+    return [NSURL fileURLWithPath:filePath];
+}
+
+-(NSString *)sessionDirectory {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *sessionsDirectory = [[paths objectAtIndex:0] stringByAppendingPathComponent:@"sessions"];
+    if (![NSFileManager.defaultManager fileExistsAtPath:sessionsDirectory])
+    {
+        [NSFileManager.defaultManager createDirectoryAtPath:sessionsDirectory withIntermediateDirectories:true attributes:nil error:nil];
+    }
+    return sessionsDirectory;
+}
+
+-(NSArray *)availableRecording
+{
+    NSArray* files = [[NSFileManager.defaultManager contentsOfDirectoryAtPath:[self sessionDirectory] error:nil] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSString * evaluatedObject, NSDictionary<NSString *,id> * bindings) {
+        return [evaluatedObject hasSuffix:@".mp4"];
+    }]];
+    
+    return [files sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        return [obj1 compare:obj2];
+    }] ;
+}
+
+-(nullable NSURL *)fileUrlForRecording:(NSString *)recordName {
+    NSString* path = [[self sessionDirectory] stringByAppendingPathComponent:recordName];
+    if ([NSFileManager.defaultManager fileExistsAtPath:path]) {
+        return [NSURL fileURLWithPath:path];
+    }
+    return NULL;
+}
+
+-(NSURL *)currentRecording {
+    NSURL* url = NULL;
+    NSTimeInterval length = [ScreenRecorder.shared recordingLength];
+    if (length > 1) {
+        url = currentName;
+        [ScreenRecorder.shared finish];
+        [NSThread sleepForTimeInterval:1]; //Hack just for now, to give time to finish saving video
+    } else {
+        NSArray<NSString *> * records = [self availableRecording];
+        if (records.count > 1)  {
+            url = [NSURL fileURLWithPath:[[self sessionDirectory] stringByAppendingPathComponent:records[records.count - 2]]];
+        }
+    }
+    
+    return url;
+}
+
++(SentrySessionRecorder*) shared {
+    static SentrySessionRecorder * _shared;
+    if (_shared == nil) {
+        _shared = [[SentrySessionRecorder alloc] init];
+    }
+    return _shared;
+}
+
+-(BOOL)isRecording {
+    return ScreenRecorder.shared.isRecording;
+}
+
+@end
+

--- a/Sources/Sentry/SentrySessionRecorder.m
+++ b/Sources/Sentry/SentrySessionRecorder.m
@@ -1,136 +1,156 @@
 #import "SentrySessionRecorder.h"
 #import "ScreenRecorder.h"
 
-@implementation SentrySessionRecorder{
+@implementation SentrySessionRecorder {
     BOOL started;
-    NSURL* currentName;
+    NSURL *currentName;
 }
 
-
--(instancetype)init
+- (instancetype)init
 {
     self = [super init];
     return self;
 }
 
--(bool) start
+- (bool)start
 {
     if (!started) {
         if ((started = [self startNext]))
-            [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(recordFinished) name:@"io.sentry.RECORD_ENDED" object:nil];
+            [NSNotificationCenter.defaultCenter addObserver:self
+                                                   selector:@selector(recordFinished)
+                                                       name:@"io.sentry.RECORD_ENDED"
+                                                     object:nil];
     }
     return started;
 }
 
--(void) stop
+- (void)stop
 {
-    if (started)
-    {
+    if (started) {
         started = false;
         [ScreenRecorder.shared finish];
     }
-    [NSNotificationCenter.defaultCenter removeObserver:self name:@"io.sentry.RECORD_ENDED" object:nil];
+    [NSNotificationCenter.defaultCenter removeObserver:self
+                                                  name:@"io.sentry.RECORD_ENDED"
+                                                object:nil];
 }
 
--(bool) startNext
+- (bool)startNext
 {
     [self clearDirectory];
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         self->currentName = [self nextName];
         [ScreenRecorder.shared startWithTarget:self->currentName duration:10];
     });
-    
+
     return true;
 }
 
--(void)recordFinished
+- (void)recordFinished
 {
     if (started)
         [self startNext];
 }
 
--(void)clearDirectory
+- (void)clearDirectory
 {
-    NSString* dir = [self sessionDirectory];
-    NSArray<NSString *>* files = [self availableRecording];
+    NSString *dir = [self sessionDirectory];
+    NSArray<NSString *> *files = [self availableRecording];
     if (files.count > 5) {
-        for (int i = 0; i < -(5-files.count); i++) {
-            [NSFileManager.defaultManager removeItemAtPath:[dir stringByAppendingPathComponent:files[i]] error:nil];
+        for (int i = 0; i < -(5 - files.count); i++) {
+            [NSFileManager.defaultManager
+                removeItemAtPath:[dir stringByAppendingPathComponent:files[i]]
+                           error:nil];
         }
     }
 }
 
--(NSURL *)nextName {
+- (NSURL *)nextName
+{
     NSString *sessionsDirectory = [self sessionDirectory];
-    
+
     NSDateFormatter *dateFormat = [[NSDateFormatter alloc] init];
     [dateFormat setDateFormat:@"YYYY-MM-dd_HHmmss"];
-    NSString * today = [dateFormat stringFromDate:NSDate.date];
-    
-    NSString * filePath = [[sessionsDirectory stringByAppendingPathComponent:today] stringByAppendingPathExtension:@"mp4"];
+    NSString *today = [dateFormat stringFromDate:NSDate.date];
+
+    NSString *filePath = [[sessionsDirectory stringByAppendingPathComponent:today]
+        stringByAppendingPathExtension:@"mp4"];
     NSLog(@"%@", filePath);
-    
+
     return [NSURL fileURLWithPath:filePath];
 }
 
--(NSString *)sessionDirectory {
-    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
-    NSString *sessionsDirectory = [[paths objectAtIndex:0] stringByAppendingPathComponent:@"sessions"];
-    if (![NSFileManager.defaultManager fileExistsAtPath:sessionsDirectory])
-    {
-        [NSFileManager.defaultManager createDirectoryAtPath:sessionsDirectory withIntermediateDirectories:true attributes:nil error:nil];
+- (NSString *)sessionDirectory
+{
+    NSArray *paths
+        = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
+    NSString *sessionsDirectory =
+        [[paths objectAtIndex:0] stringByAppendingPathComponent:@"sessions"];
+    if (![NSFileManager.defaultManager fileExistsAtPath:sessionsDirectory]) {
+        [NSFileManager.defaultManager createDirectoryAtPath:sessionsDirectory
+                                withIntermediateDirectories:true
+                                                 attributes:nil
+                                                      error:nil];
     }
     return sessionsDirectory;
 }
 
--(NSArray *)availableRecording
+- (NSArray *)availableRecording
 {
-    NSArray* files = [[NSFileManager.defaultManager contentsOfDirectoryAtPath:[self sessionDirectory] error:nil] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSString * evaluatedObject, NSDictionary<NSString *,id> * bindings) {
-        return [evaluatedObject hasSuffix:@".mp4"];
-    }]];
-    
-    return [files sortedArrayUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
-        return [obj1 compare:obj2];
-    }] ;
+    NSArray *files = [[NSFileManager.defaultManager
+        contentsOfDirectoryAtPath:[self sessionDirectory]
+                            error:nil]
+        filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSString *evaluatedObject,
+                                        NSDictionary<NSString *, id> *bindings) {
+            return [evaluatedObject hasSuffix:@".mp4"];
+        }]];
+
+    return [files sortedArrayUsingComparator:^NSComparisonResult(
+        id _Nonnull obj1, id _Nonnull obj2) { return [obj1 compare:obj2]; }];
 }
 
--(nullable NSURL *)fileUrlForRecording:(NSString *)recordName {
-    NSString* path = [[self sessionDirectory] stringByAppendingPathComponent:recordName];
+- (nullable NSURL *)fileUrlForRecording:(NSString *)recordName
+{
+    NSString *path = [[self sessionDirectory] stringByAppendingPathComponent:recordName];
     if ([NSFileManager.defaultManager fileExistsAtPath:path]) {
         return [NSURL fileURLWithPath:path];
     }
     return NULL;
 }
 
--(NSURL *)currentRecording {
-    NSURL* url = NULL;
+- (NSURL *)currentRecording
+{
+    NSURL *url = NULL;
     NSTimeInterval length = [ScreenRecorder.shared recordingLength];
     if (length > 1) {
         url = currentName;
         [ScreenRecorder.shared finish];
-        [NSThread sleepForTimeInterval:1]; //Hack just for now, to give time to finish saving video
+        [NSThread sleepForTimeInterval:1]; // Hack just for now, to give time to finish saving video
     } else {
-        NSArray<NSString *> * records = [self availableRecording];
-        if (records.count > 1)  {
-            url = [NSURL fileURLWithPath:[[self sessionDirectory] stringByAppendingPathComponent:records[records.count - 2]]];
+        NSArray<NSString *> *records = [self availableRecording];
+        if (records.count > 1) {
+            url = [NSURL
+                fileURLWithPath:[[self sessionDirectory]
+                                    stringByAppendingPathComponent:records[records.count - 2]]];
         }
     }
-    
+
     return url;
 }
 
-+(SentrySessionRecorder*) shared {
-    static SentrySessionRecorder * _shared;
++ (SentrySessionRecorder *)shared
+{
+    static SentrySessionRecorder *_shared;
     if (_shared == nil) {
         _shared = [[SentrySessionRecorder alloc] init];
     }
     return _shared;
 }
 
--(BOOL)isRecording {
+- (BOOL)isRecording
+{
     return ScreenRecorder.shared.isRecording;
 }
 
 @end
-

--- a/Sources/Sentry/include/ScreenRecorder.h
+++ b/Sources/Sentry/include/ScreenRecorder.h
@@ -8,18 +8,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (class, nonatomic, readonly) ScreenRecorder *shared;
 
--(instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 @property (readonly) BOOL isRecording;
 
--(bool) startWithTarget:(NSURL *)target;
+- (bool)startWithTarget:(NSURL *)target;
 
--(bool) startWithTarget:(NSURL *)target
-               duration:(NSTimeInterval)duration;
+- (bool)startWithTarget:(NSURL *)target duration:(NSTimeInterval)duration;
 
--(void) finish;
+- (void)finish;
 
--(NSTimeInterval) recordingLength;
+- (NSTimeInterval)recordingLength;
 
 @end
 

--- a/Sources/Sentry/include/ScreenRecorder.h
+++ b/Sources/Sentry/include/ScreenRecorder.h
@@ -1,0 +1,26 @@
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ScreenRecorder : NSObject
+
+@property (class, nonatomic, readonly) ScreenRecorder *shared;
+
+-(instancetype)init NS_UNAVAILABLE;
+
+@property (readonly) BOOL isRecording;
+
+-(bool) startWithTarget:(NSURL *)target;
+
+-(bool) startWithTarget:(NSURL *)target
+               duration:(NSTimeInterval)duration;
+
+-(void) finish;
+
+-(NSTimeInterval) recordingLength;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySessionRecorder.h
+++ b/Sources/Sentry/include/SentrySessionRecorder.h
@@ -6,20 +6,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentrySessionRecorder : NSObject
 @property (class, nonatomic, readonly) SentrySessionRecorder *shared;
 
--(instancetype)init NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
 
 @property (readonly) BOOL isRecording;
 
--(bool) start;
+- (bool)start;
 
--(void) stop;
+- (void)stop;
 
--(nullable NSURL *)fileUrlForRecording:(NSString *)recordName;
+- (nullable NSURL *)fileUrlForRecording:(NSString *)recordName;
 
--(nullable NSURL *)currentRecording;
--(NSArray<NSString *> *)availableRecording;
+- (nullable NSURL *)currentRecording;
+- (NSArray<NSString *> *)availableRecording;
 @end
 
 NS_ASSUME_NONNULL_END
-
-

--- a/Sources/Sentry/include/SentrySessionRecorder.h
+++ b/Sources/Sentry/include/SentrySessionRecorder.h
@@ -1,0 +1,25 @@
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentrySessionRecorder : NSObject
+@property (class, nonatomic, readonly) SentrySessionRecorder *shared;
+
+-(instancetype)init NS_UNAVAILABLE;
+
+@property (readonly) BOOL isRecording;
+
+-(bool) start;
+
+-(void) stop;
+
+-(nullable NSURL *)fileUrlForRecording:(NSString *)recordName;
+
+-(nullable NSURL *)currentRecording;
+-(NSArray<NSString *> *)availableRecording;
+@end
+
+NS_ASSUME_NONNULL_END
+
+


### PR DESCRIPTION
## :scroll: Description

Added a session recorder to the SentrySDK. 
Creates a mp4 video of the session.

Caveats:
* Currently adding to the scope reference passed to capture. So if it's the actual scope available on the Hub, it'll have side effects. Perhaps we need to clone the Scope or find another strategy
* App Extensions aren't supported. Need to opt-out to get it to compile
* Currently needs iOS 11+ 

## :bulb: Motivation and Context

Have the user session recorded.

## :green_heart: How did you test it?

## :pencil: Checklist

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps

Concatenate the last two videos for a longer period or change the capture process to deal with individual frames.
