### PR TITLE
ref: Make SentryFrameRemover static

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -60,9 +60,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         self.debugMetaBuilder =
             [[SentryDebugMetaBuilder alloc] initWithBinaryImageProvider:provider];
 
-        SentryFrameRemover *frameRemover = [[SentryFrameRemover alloc] init];
-        SentryStacktraceBuilder *stacktraceBuilder =
-            [[SentryStacktraceBuilder alloc] initWithSentryFrameRemover:frameRemover];
+        SentryStacktraceBuilder *stacktraceBuilder = [[SentryStacktraceBuilder alloc] init];
         id<SentryCrashMachineContextWrapper> machineContextWrapper =
             [[SentryCrashDefaultMachineContextWrapper alloc] init];
 

--- a/Sources/Sentry/SentryFrameRemover.m
+++ b/Sources/Sentry/SentryFrameRemover.m
@@ -4,7 +4,7 @@
 
 @implementation SentryFrameRemover
 
-- (NSArray<SentryFrame *> *)removeNonSdkFrames:(NSArray<SentryFrame *> *)frames
++ (NSArray<SentryFrame *> *)removeNonSdkFrames:(NSArray<SentryFrame *> *)frames
 {
     // When including Sentry via the Swift Package Manager the package is the same as the
     // application that includes Sentry. Therefore removing frames with a package containing

--- a/Sources/Sentry/SentryFrameRemover.m
+++ b/Sources/Sentry/SentryFrameRemover.m
@@ -6,11 +6,6 @@
 
 + (NSArray<SentryFrame *> *)removeNonSdkFrames:(NSArray<SentryFrame *> *)frames
 {
-    // When including Sentry via the Swift Package Manager the package is the same as the
-    // application that includes Sentry. Therefore removing frames with a package containing
-    // "sentry" doesn't work. We could instead look into the function name, but then we risk
-    // removing functions that are not from this SDK and contain "sentry", which would lead to a
-    // loss of frames on the stacktrace. Therefore we don't remove any frames.
     NSUInteger indexOfFirstNonSentryFrame = [frames indexOfObjectPassingTest:^BOOL(
         SentryFrame *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
         return ![[obj.package lowercaseString] containsString:@"sentry"];

--- a/Sources/Sentry/SentryStacktraceBuilder.m
+++ b/Sources/Sentry/SentryStacktraceBuilder.m
@@ -41,7 +41,7 @@ SentryStacktraceBuilder ()
         }
     }
 
-    NSArray<SentryFrame *> *framesCleared = [self.frameRemover removeNonSdkFrames:frames];
+    NSArray<SentryFrame *> *framesCleared = [SentryFrameRemover removeNonSdkFrames:frames];
 
     // The frames must be ordered from caller to callee, or oldest to youngest
     NSArray<SentryFrame *> *framesReversed = [[framesCleared reverseObjectEnumerator] allObjects];

--- a/Sources/Sentry/include/SentryFrameRemover.h
+++ b/Sources/Sentry/include/SentryFrameRemover.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Removes Sentry SDK frames until a frame from a different package is found.
  */
-- (NSArray<SentryFrame *> *)removeNonSdkFrames:(NSArray<SentryFrame *> *)frames;
++ (NSArray<SentryFrame *> *)removeNonSdkFrames:(NSArray<SentryFrame *> *)frames;
 
 @end
 

--- a/Sources/Sentry/include/SentryFrameRemover.h
+++ b/Sources/Sentry/include/SentryFrameRemover.h
@@ -8,6 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Removes Sentry SDK frames until a frame from a different package is found.
+ *
+ * When a user includes Sentry as a static library, the package is the same as the application.
+ * Therefore removing frames with a package containing "sentry" doesn't work. We can't look into the
+ * function name as in release builds, the function name can be obfuscated, or we remove functions
+ * that are not from this SDK and contain "sentry". Therefore this logic only works for apps
+ * including Sentry dynamically.
  */
 + (NSArray<SentryFrame *> *)removeNonSdkFrames:(NSArray<SentryFrame *> *)frames;
 

--- a/Sources/Sentry/include/SentryStacktraceBuilder.h
+++ b/Sources/Sentry/include/SentryStacktraceBuilder.h
@@ -8,9 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 /** Uses SentryCrash internally to retrieve the stacktrace.
  */
 @interface SentryStacktraceBuilder : NSObject
-SENTRY_NO_INIT
-
-- (id)initWithSentryFrameRemover:(SentryFrameRemover *)frameRemover;
 
 /**
  * Builds the stacktrace for the current thread removing frames from the SentrySDK until frames from

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -12,7 +12,7 @@ class SentryClientTest: XCTestCase {
         )
         
         let threadInspector = SentryThreadInspector(
-            stacktraceBuilder: SentryStacktraceBuilder(sentryFrameRemover: SentryFrameRemover()),
+            stacktraceBuilder: SentryStacktraceBuilder(),
             andMachineContextWrapper: SentryCrashDefaultMachineContextWrapper()
         )
         

--- a/Tests/SentryTests/SentryCrash/SentryFrameRemoverTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryFrameRemoverTests.swift
@@ -31,11 +31,6 @@ class SentryFrameRemoverTests: XCTestCase {
     }
     
     private let fixture = Fixture()
-    private var sut: SentryFrameRemover!
-    
-    override func setUp() {
-        sut = SentryFrameRemover()
-    }
     
     func testSdkFramesFirst_OnlyFirstSentryFramesRemoved() {
         let frames = fixture.sentryFrames +
@@ -46,7 +41,7 @@ class SentryFrameRemoverTests: XCTestCase {
         let expected = fixture.nonSentryFrames +
             [fixture.sentryFrame] +
             [fixture.nonSentryFrame]
-        let actual = sut.removeNonSdkFrames(frames)
+        let actual = SentryFrameRemover.removeNonSdkFrames(frames)
         
         XCTAssertEqual(expected, actual)
     }
@@ -56,17 +51,17 @@ class SentryFrameRemoverTests: XCTestCase {
             [fixture.sentryFrame] +
             [fixture.nonSentryFrame]
         
-        let actual = sut.removeNonSdkFrames(frames)
+        let actual = SentryFrameRemover.removeNonSdkFrames(frames)
                 XCTAssertEqual(frames, actual)
     }
     
     func testNoSdkFrames_NoFramesRemoved() {
-        let actual = sut.removeNonSdkFrames(fixture.nonSentryFrames)
+        let actual = SentryFrameRemover.removeNonSdkFrames(fixture.nonSentryFrames)
         XCTAssertEqual(fixture.nonSentryFrames, actual)
     }
     
     func testOnlySdkFrames_AllFramesRemoved() {
-        let actual = sut.removeNonSdkFrames(fixture.sentryFrames)
+        let actual = SentryFrameRemover.removeNonSdkFrames(fixture.sentryFrames)
         XCTAssertEqual(fixture.sentryFrames, actual)
     }
 }

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -5,7 +5,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
     
     private class Fixture {
         func getSut() -> SentryStacktraceBuilder {
-            SentryStacktraceBuilder(sentryFrameRemover: SentryFrameRemover())
+            SentryStacktraceBuilder()
         }
     }
     

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -11,7 +11,7 @@ class SentryThreadInspectorTests: XCTestCase {
             let machineContextWrapper = testWithRealMachineConextWrapper ? SentryCrashDefaultMachineContextWrapper() : testMachineContextWrapper as SentryCrashMachineContextWrapper
             
             return SentryThreadInspector(
-                stacktraceBuilder: SentryStacktraceBuilder(sentryFrameRemover: SentryFrameRemover()),
+                stacktraceBuilder: SentryStacktraceBuilder(),
                 andMachineContextWrapper: machineContextWrapper
             )
         }


### PR DESCRIPTION


## :scroll: Description

SentryFrameRemover had only one method that can be static. This is changed now
and simplifies some init methods.

## :bulb: Motivation and Context

Make the code simpler.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
