### PR TITLE
fix: Redundant x29 GP register on arm64 and UBSan crash

### DIFF
--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
@@ -39,7 +39,7 @@
 
 static const char *g_registerNames[] = { "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7", "x8", "x9",
     "x10", "x11", "x12", "x13", "x14", "x15", "x16", "x17", "x18", "x19", "x20", "x21", "x22",
-    "x23", "x24", "x25", "x26", "x27", "x28", "x29", "fp", "lr", "sp", "pc", "cpsr" };
+    "x23", "x24", "x25", "x26", "x27", "x28", "fp", "lr", "sp", "pc", "cpsr" };
 static const int g_registerNamesCount = sizeof(g_registerNames) / sizeof(*g_registerNames);
 
 static const char *g_exceptionRegisterNames[] = { "exception", "esr", "far" };
@@ -116,20 +116,20 @@ sentrycrashcpu_registerName(const int regNumber)
 uint64_t
 sentrycrashcpu_registerValue(const SentryCrashMachineContext *const context, const int regNumber)
 {
-    if (regNumber <= 29) {
+    if (regNumber < 29) {
         return context->machineContext.__ss.__x[regNumber];
     }
 
     switch (regNumber) {
-    case 30:
+    case 29:
         return context->machineContext.__ss.__fp;
-    case 31:
+    case 30:
         return context->machineContext.__ss.__lr;
-    case 32:
+    case 31:
         return context->machineContext.__ss.__sp;
-    case 33:
+    case 32:
         return context->machineContext.__ss.__pc;
-    case 34:
+    case 33:
         return context->machineContext.__ss.__cpsr;
     }
 


### PR DESCRIPTION
## :scroll: Description

UBSan detected an out-of-bounds read from machineContext.__ss.__x. The register that was previously shown as x29 in Sentry is in fact just the FP register. This commit removes the duplicate (and thus the out-of-bounds read that triggered UBSan).

## :bulb: Motivation and Context

Fixes #963

## :green_heart: How did you test it?

Ran it against my local Sentry instance, the stray register disappears and UBSan no longer reports errors:

<img width="621" alt="Screenshot 2021-02-25 at 22 12 51" src="https://user-images.githubusercontent.com/597682/109219901-242fe480-77b0-11eb-8744-68ad41939a8d.png">

## :pencil: Checklist

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes
