### PR TITLE
@philipphofmann test: DSN per TestCase

### DIFF
--- a/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
+++ b/Tests/SentryTests/Helper/SentryCurrentDateTests.swift
@@ -4,6 +4,7 @@ import XCTest
 class SentryCurrentDateTests: XCTestCase {
 
     func testSetNoCurrentDateProvider() {
+        CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider())
         let firstDate = Date()
         let secondDate = CurrentDate.date()
         let thirdDate = Date()

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -9,6 +9,9 @@ import XCTest
 @available(tvOS 10.0, *)
 class SentryFileManagerTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryFileManagerTests")
+    private static let dsn = TestConstants.dsn(username: "SentryFileManagerTests")
+    
     private class Fixture {
         let eventIds = (0...110).map { _ in SentryId() }
 
@@ -56,7 +59,7 @@ class SentryFileManagerTests: XCTestCase {
 
             fixture = Fixture()
 
-            sut = try SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: currentDateProvider)
+            sut = try SentryFileManager(dsn: SentryFileManagerTests.dsn, andCurrentDateProvider: currentDateProvider)
 
             sut.deleteAllEnvelopes()
             sut.deleteTimestampLastInForeground()
@@ -77,8 +80,8 @@ class SentryFileManagerTests: XCTestCase {
         sut.storeCurrentSession(SentrySession(releaseName: "1.0.0"))
         sut.storeTimestampLast(inForeground: Date())
 
-        _ = try SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
-        let fileManager = try SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+        _ = try SentryFileManager(dsn: SentryFileManagerTests.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+        let fileManager = try SentryFileManager(dsn: SentryFileManagerTests.dsn, andCurrentDateProvider: TestCurrentDateProvider())
 
         XCTAssertEqual(1, fileManager.getAllEnvelopes().count)
         XCTAssertNotNil(fileManager.readCurrentSession())
@@ -88,7 +91,7 @@ class SentryFileManagerTests: XCTestCase {
     func testInitDeletesEventsFolder() throws {
         storeEvent()
         
-        _ = try SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+        _ = try SentryFileManager(dsn: SentryFileManagerTests.dsn, andCurrentDateProvider: TestCurrentDateProvider())
         
         assertEventFolderDoesntExist()
     }

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -2,6 +2,9 @@ import XCTest
 
 class SentryCrashIntegrationTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryCrashIntegrationTests")
+    private static let dsn = TestConstants.dsn(username: "SentryCrashIntegrationTests")
+    
     private class Fixture {
         
         var session: SentrySession {
@@ -16,7 +19,7 @@ class SentryCrashIntegrationTests: XCTestCase {
         
         var options: Options {
             let options = Options()
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentryCrashIntegrationTests.dsnAsString
             return options
         }
         
@@ -33,7 +36,7 @@ class SentryCrashIntegrationTests: XCTestCase {
         }
         
         var fileManager: SentryFileManager {
-            return try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+            return try! SentryFileManager(dsn: dsn, andCurrentDateProvider: TestCurrentDateProvider())
         }
         
         func getSut() -> SentryCrashIntegration {
@@ -55,7 +58,7 @@ class SentryCrashIntegrationTests: XCTestCase {
         let releaseName = "1.0.0"
         let dist = "14G60"
         // The start of the SDK installs all integrations
-        SentrySDK.start(options: ["dsn": TestConstants.dsnAsString,
+        SentrySDK.start(options: ["dsn": SentryCrashIntegrationTests.dsnAsString,
                                   "release": releaseName,
                                   "dist": dist]
         )

--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -3,6 +3,9 @@ import XCTest
 
 class SentrySessionTrackerTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentrySessionTrackerTests")
+    private static let dsn = TestConstants.dsn(username: "SentrySessionTrackerTests")
+    
     private class Fixture {
         
         let options: Options
@@ -12,7 +15,7 @@ class SentrySessionTrackerTests: XCTestCase {
         
         init() {
             options = Options()
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentrySessionTrackerTests.dsnAsString
             options.releaseName = "SentrySessionTrackerIntegrationTests"
             options.sessionTrackingIntervalMillis = 10_000
             options.environment = "debug"
@@ -42,7 +45,7 @@ class SentrySessionTrackerTests: XCTestCase {
         
         fixture = Fixture()
         
-        fileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+        fileManager = try! SentryFileManager(dsn: SentrySessionTrackerTests.dsn, andCurrentDateProvider: TestCurrentDateProvider())
         fileManager.deleteCurrentSession()
         fileManager.deleteCrashedSession()
         fileManager.deleteTimestampLastInForeground()

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -7,6 +7,9 @@ import XCTest
 @available(iOS 10.0, *)
 class SentryHttpTransportTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryHttpTransportTests")
+    private static let dsn = TestConstants.dsn(username: "SentryHttpTransportTests")
+    
     private class Fixture {
         let event: Event
         let eventRequest: SentryNSURLRequest
@@ -45,10 +48,10 @@ class SentryHttpTransportTests: XCTestCase {
             eventWithSessionEnvelope = SentryEnvelope(id: event.eventId, items: items)
             eventWithSessionRequest = buildRequest(eventWithSessionEnvelope)
 
-            fileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: currentDateProvider)
+            fileManager = try! SentryFileManager(dsn: SentryHttpTransportTests.dsn, andCurrentDateProvider: currentDateProvider)
 
             options = Options()
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentryHttpTransportTests.dsnAsString
 
             requestManager = TestRequestManager(session: URLSession(configuration: URLSessionConfiguration.ephemeral))
             rateLimits = DefaultRateLimits(retryAfterHeaderParser: RetryAfterHeaderParser(httpDateParser: HttpDateParser()), andRateLimitParser: RateLimitParser())
@@ -77,7 +80,7 @@ class SentryHttpTransportTests: XCTestCase {
 
     class func buildRequest(_ envelope: SentryEnvelope) -> SentryNSURLRequest {
         let envelopeData = try! SentrySerialization.data(with: envelope)
-        return try! SentryNSURLRequest(envelopeRequestWith: TestConstants.dsn, andData: envelopeData)
+        return try! SentryNSURLRequest(envelopeRequestWith: SentryHttpTransportTests.dsn, andData: envelopeData)
     }
 
     private var fixture: Fixture!
@@ -344,7 +347,7 @@ class SentryHttpTransportTests: XCTestCase {
         let sessionEnvelope = SentryEnvelope(id: fixture.event.eventId, singleItem: SentryEnvelopeItem(session: fixture.session))
 
         let sessionData = try! SentrySerialization.data(with: sessionEnvelope)
-        let sessionRequest = try! SentryNSURLRequest(envelopeRequestWith: TestConstants.dsn, andData: sessionData)
+        let sessionRequest = try! SentryNSURLRequest(envelopeRequestWith: SentryHttpTransportTests.dsn, andData: sessionData)
 
         XCTAssertEqual(sessionRequest.httpBody, fixture.requestManager.requests[3].httpBody, "Envelope with only session item should be sent.")
     }

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -3,18 +3,21 @@ import XCTest
 
 class SentryTransportInitializerTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryTransportInitializerTests")
+    private static let dsn = TestConstants.dsn(username: "SentryTransportInitializerTests")
+    
     private var fileManager: SentryFileManager!
     
     override func setUp() {
         do {
-            fileManager = try SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+            fileManager = try SentryFileManager(dsn: SentryTransportInitializerTests.dsn, andCurrentDateProvider: TestCurrentDateProvider())
         } catch {
             XCTFail("SentryDsn could not be created")
         }
     }
 
     func testDefault() throws {
-        let options = try Options(dict: ["dsn": TestConstants.dsnAsString])
+        let options = try Options(dict: ["dsn": SentryTransportInitializerTests.dsnAsString])
         
         let result = TransportInitializer.initTransport(options, sentryFileManager: fileManager)
         

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -3,6 +3,9 @@
 import XCTest
 
 class SentryClientTest: XCTestCase {
+    
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryClientTest")
+    private static let dsn = TestConstants.dsn(username: "SentryClientTest")
 
     private class Fixture {
         let transport = TestTransport()
@@ -38,14 +41,14 @@ class SentryClientTest: XCTestCase {
             user.email = "someone@sentry.io"
             user.ipAddress = "127.0.0.1"
             
-            fileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+            fileManager = try! SentryFileManager(dsn: SentryClientTest.dsn, andCurrentDateProvider: TestCurrentDateProvider())
         }
 
         func getSut(configureOptions: (Options) -> Void = { _ in }) -> Client {
             var client: Client!
             do {
                 let options = try Options(dict: [
-                    "dsn": TestConstants.dsnAsString
+                    "dsn": SentryClientTest.dsnAsString
                 ])
                 configureOptions(options)
 
@@ -187,7 +190,7 @@ class SentryClientTest: XCTestCase {
             options.dsn = nil
         })
         
-        sut.options.dsn = TestConstants.dsnAsString
+        sut.options.dsn = SentryClientTest.dsnAsString
         
         let eventId = sut.capture(event: event)
         eventId.assertIsNotEmpty()
@@ -622,7 +625,7 @@ class SentryClientTest: XCTestCase {
         SentryFileManager.prepareInitError()
         
         let options = Options()
-        options.dsn = TestConstants.dsnAsString
+        options.dsn = SentryClientTest.dsnAsString
         let client = Client(options: options)
         
         XCTAssertNil(client)

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -4,6 +4,8 @@ import XCTest
 @available(OSX 10.10, *)
 class SentryCrashInstallationReporterTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryCrashInstallationReporterTests")
+    
     private var testClient: TestClient!
     private var sut: SentryCrashInstallationReporter!
     
@@ -36,9 +38,11 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     
     private func sdkStarted() {
         SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentryCrashInstallationReporterTests.dsnAsString
         }
-        testClient = TestClient(options: Options())!
+        let options = Options()
+        options.dsn = SentryCrashInstallationReporterTests.dsnAsString
+        testClient = TestClient(options: options)!
         let hub = SentryHub(client: testClient, andScope: nil)
         SentrySDK.setCurrentHub(hub)
     }

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -44,9 +44,13 @@ class SentryStacktraceBuilderTests: XCTestCase {
     
     func testFramesOrder() {
         let actual = fixture.getSut().buildStacktraceForCurrentThread()
-        let firstFrame = actual.frames.first
-        let areFramesOrderedCorrect = firstFrame?.function?.contains("start") ?? false
         
-        XCTAssertTrue(areFramesOrderedCorrect, "The frames must be ordered from caller to callee, or oldest to youngest.")
+        // Make sure the first 4 frames contain both start and main
+        let frames = actual.frames[...3]
+        let filteredFrames = frames.filter { frame in
+            return frame.function?.contains("start") ?? false || frame.function?.contains("main") ?? false
+        }
+        
+        XCTAssertTrue(filteredFrames.count == 2, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
 }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -2,6 +2,9 @@ import XCTest
 
 class SentryHubTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryHubTests")
+    private static let dsn = TestConstants.dsn(username: "SentryHubTests")
+    
     private class Fixture {
         let options: Options
         let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
@@ -18,7 +21,7 @@ class SentryHubTests: XCTestCase {
         
         init() {
             options = Options()
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentryHubTests.dsnAsString
             options.environment = "debug"
             
             scope.add(crumb)
@@ -26,7 +29,7 @@ class SentryHubTests: XCTestCase {
             event = Event()
             event.message = SentryMessage(formatted: message)
             
-            fileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: currentDateProvider)
+            fileManager = try! SentryFileManager(dsn: SentryHubTests.dsn, andCurrentDateProvider: currentDateProvider)
             
             CurrentDate.setCurrentDateProvider(currentDateProvider)
             
@@ -56,6 +59,7 @@ class SentryHubTests: XCTestCase {
         fixture.fileManager.deleteCurrentSession()
         fixture.fileManager.deleteCrashedSession()
         fixture.fileManager.deleteTimestampLastInForeground()
+        fixture.fileManager.deleteAllEnvelopes()
         
         sut = fixture.getSut()
     }
@@ -64,6 +68,7 @@ class SentryHubTests: XCTestCase {
         fixture.fileManager.deleteCurrentSession()
         fixture.fileManager.deleteCrashedSession()
         fixture.fileManager.deleteTimestampLastInForeground()
+        fixture.fileManager.deleteAllEnvelopes()
     }
 
     func testBeforeBreadcrumbWithoutCallbackStoresBreadcrumb() {
@@ -137,7 +142,7 @@ class SentryHubTests: XCTestCase {
     }
     
     func testAddBreadcrumb_WithCallbackReturnsNil() {
-        let options = Options()
+        let options = fixture.options
         options.beforeBreadcrumb = { _ in
             return nil
         }
@@ -151,7 +156,7 @@ class SentryHubTests: XCTestCase {
     
     func testAddBreadcrumb_WithCallbackModifies() {
         let crumbMessage = "modified"
-        let options = Options()
+        let options = fixture.options
         options.beforeBreadcrumb = { crumb in
             crumb.message = crumbMessage
             return crumb

--- a/Tests/SentryTests/SentryNSURLRequestTests.swift
+++ b/Tests/SentryTests/SentryNSURLRequestTests.swift
@@ -3,12 +3,15 @@ import XCTest
 
 class SentryNSURLRequestTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentryNSURLRequestTests")
+    private static let dsn = TestConstants.dsn(username: "SentryNSURLRequestTests")
+    
     func testRequestWithEnvelopeEndpoint() {
-        let request = try! SentryNSURLRequest(envelopeRequestWith: TestConstants.dsn, andData: Data())
+        let request = try! SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn, andData: Data())
         XCTAssertTrue(request.url!.absoluteString.hasSuffix("/envelope/"))
     }
     func testRequestWithStoreEndpoint() {
-        let request = try! SentryNSURLRequest(storeRequestWith: TestConstants.dsn, andData: Data())
+        let request = try! SentryNSURLRequest(storeRequestWith: SentryNSURLRequestTests.dsn, andData: Data())
         XCTAssertTrue(request.url!.absoluteString.hasSuffix("/store/"))
     }
 }

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -3,6 +3,9 @@ import XCTest
 
 class SentrySDKTests: XCTestCase {
     
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentrySDKTests")
+    private static let dsn = TestConstants.dsn(username: "SentrySDKTests")
+    
     private class Fixture {
     
         let event: Event
@@ -34,7 +37,9 @@ class SentrySDKTests: XCTestCase {
             scope = Scope()
             scope.setTag(value: "value", key: "key")
             
-            client = TestClient(options: Options())!
+            let options = Options()
+            options.dsn = SentrySDKTests.dsnAsString
+            client = TestClient(options: options)!
             hub = SentryHub(client: client, andScope: scope)
             
             userFeedback = UserFeedback(eventId: SentryId())
@@ -62,7 +67,7 @@ class SentrySDKTests: XCTestCase {
     
     func testStartWithConfigureOptions() {
         SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentrySDKTests.dsnAsString
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
             options.attachStacktrace = true
@@ -75,7 +80,7 @@ class SentrySDKTests: XCTestCase {
         
         let options = hub.getClient()?.options
         XCTAssertNotNil(options)
-        XCTAssertEqual(TestConstants.dsnAsString, options?.dsn)
+        XCTAssertEqual(SentrySDKTests.dsnAsString, options?.dsn)
         XCTAssertEqual(SentryLogLevel.verbose, options?.logLevel)
         XCTAssertEqual(true, options?.attachStacktrace)
         XCTAssertEqual(true, options?.enableAutoSessionTracking)
@@ -109,7 +114,7 @@ class SentrySDKTests: XCTestCase {
     func testStartWithConfigureOptions_BeforeSend() {
         var wasBeforeSendCalled = false
         SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentrySDKTests.dsnAsString
             options.beforeSend = { event in
                 wasBeforeSendCalled = true
                 return event
@@ -123,7 +128,7 @@ class SentrySDKTests: XCTestCase {
     
     func testSetLogLevel_StartWithOptionsDict() {
         SentrySDK.start(options: [
-            "dsn": TestConstants.dsn,
+            "dsn": SentrySDKTests.dsnAsString,
             "debug": true,
             "logLevel": "verbose"
         ])
@@ -133,7 +138,7 @@ class SentrySDKTests: XCTestCase {
     
     func testSetLogLevel_StartWithOptionsObject() {
         let options = Options()
-        options.dsn = TestConstants.dsnAsString
+        options.dsn = SentrySDKTests.dsnAsString
         options.logLevel = SentryLogLevel.debug
         
         SentrySDK.start(options: options)
@@ -144,7 +149,7 @@ class SentrySDKTests: XCTestCase {
     func testSetLogLevel_StartWithConfigureOptions() {
         let logLevel = SentryLogLevel.verbose
         SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentrySDKTests.dsnAsString
             options.logLevel = logLevel
         }
         
@@ -317,7 +322,7 @@ class SentrySDKTests: XCTestCase {
             return crumb
         }
         
-        SentrySDK.start(options: ["dsn": TestConstants.dsnAsString])
+        SentrySDK.start(options: ["dsn": SentrySDKTests.dsnAsString])
         
         SentrySDK.configureScope { scope in
             let user = User()
@@ -369,7 +374,7 @@ class SentrySDKTests: XCTestCase {
     @available(iOS 13.0, *)
     func testMemoryFootprintOfAddingBreadcrumbs() {
         SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString
+            options.dsn = SentrySDKTests.dsnAsString
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
             options.attachStacktrace = true

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -290,5 +290,6 @@ class SentryScopeSwiftTests: XCTestCase {
         }
         
         queue.activate()
-        group.waitWithTimeout()    }
+        group.waitWithTimeout(timeout: 500)
+    }
 }

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -17,6 +17,11 @@
 
 @implementation SentryTests
 
+- (void)setUp
+{
+    [SentrySDK.currentHub bindClient:nil];
+}
+
 - (void)testVersion
 {
     NSDictionary *info = [[NSBundle bundleForClass:[SentryClient class]] infoDictionary];

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -1,7 +1,18 @@
 import Foundation
 
 class TestClient: Client {
-    var sentryFileManager: SentryFileManager = try! SentryFileManager(dsn: TestConstants.dsn, andCurrentDateProvider: TestCurrentDateProvider())
+    
+    let sentryFileManager: SentryFileManager
+    
+    override init?(options: Options) {
+        guard let dsnAsString = options.dsn  else {
+            return nil
+        }
+        let dsn = try! SentryDsn(string: dsnAsString) 
+        sentryFileManager = try! SentryFileManager(dsn: dsn, andCurrentDateProvider: TestCurrentDateProvider())
+        super.init(options: options)
+    }
+    
     override func fileManager() -> SentryFileManager {
         sentryFileManager
     }

--- a/Tests/SentryTests/TestConstants.swift
+++ b/Tests/SentryTests/TestConstants.swift
@@ -1,12 +1,15 @@
 import XCTest
 
 struct TestConstants {
-    static let dsnAsString: String = "https://username:password@app.getsentry.com/12345"
-
-    static var dsn: SentryDsn {
+    
+    static func dsnAsString(username: String) -> String {
+        return "https://\(username):password@app.getsentry.com/12345"
+    }
+    
+    static func dsn(username: String) -> SentryDsn {
         var dsn: SentryDsn?
         do {
-            dsn = try SentryDsn(string: self.dsnAsString)
+            dsn = try SentryDsn(string: self.dsnAsString(username: username))
         } catch {
             XCTFail("SentryDsn could not be created")
         }


### PR DESCRIPTION
## :scroll: Description

Using a DSN per test case gives each test case a separate folder to store the envelopes,
reducing the chance of interference. This PR also contains a few minor fixes for other tests.

This is based on https://github.com/getsentry/sentry-cocoa/pull/968. 

## :bulb: Motivation and Context

Some tests as SentryClientTests or SentryHttpTransportTests are sometimes failing in CI.

## :green_heart: How did you test it?
CI and Xcode.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
