### PR TITLE
test: Remove attachStacktrace in SDK start

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -17,7 +17,6 @@ AppDelegate ()
         options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
         options.debug = YES;
         options.logLevel = kSentryLogLevelVerbose;
-        options.attachStacktrace = YES;
         options.sessionTrackingIntervalMillis = [@5000 unsignedIntegerValue];
     }];
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }
         

--- a/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
+++ b/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
@@ -10,7 +10,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }
         

--- a/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
+++ b/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }
         

--- a/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ExtensionDelegate.swift
+++ b/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ExtensionDelegate.swift
@@ -13,7 +13,6 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
             }
             options.debug = true
             options.logLevel = SentryLogLevel.verbose
-            options.attachStacktrace = true
             options.sessionTrackingIntervalMillis = 5_000
         }
         


### PR DESCRIPTION


## :scroll: Description

attachStacktrace is enabled per default. No need to pass it.

## :bulb: Motivation and Context

Make the SDK init slimmer.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
