### PR TITLE
build: Fix Gemfile for Dependabot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ gem "cocoapods", ">= 1.9.1"
 gem "fastlane"
 gem "rest-client"
 
-plugins_path = File.join(File.dirname(__FILE__), 'fastlane', 'Pluginfile')
-eval_gemfile(plugins_path) if File.exist?(plugins_path)
+eval_gemfile("fastlane/Pluginfile")


### PR DESCRIPTION

## :scroll: Description

Dependabot can't read the plugins path as fastlane specified it in the Gemfile. 
Using the path directly in eval_gemfile should fix the issue, see https://github.com/dependabot/feedback/issues/945#issuecomment-638235801.

## :bulb: Motivation and Context

Fixes GH-981

## :green_heart: How did you test it?
Let's see if Dependabot again opens up an issue.


## :crystal_ball: Next steps
