### PR TITLE
ci: Use single quotes for keychain password

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -53,9 +53,9 @@ platform :ios do
     # https://github.com/actions/virtual-environments/issues/1820#issuecomment-719549887
     # Doing this with Fastlane makes it easier to debug issues locally.
     sh("security delete-keychain #{keychain_name} || true") # Delete the keychain if it already exists
-    sh("security create-keychain -p #{keychain_password}  #{keychain_name}")
+    sh("security create-keychain -p '#{keychain_password}'  #{keychain_name}")
     sh("security set-keychain-settings -lut 21600 #{keychain_name}")
-    sh("security unlock-keychain -p #{keychain_password} #{keychain_name}")
+    sh("security unlock-keychain -p '#{keychain_password}' #{keychain_name}")
     sh("security list-keychain -d user -s #{keychain_name}")
 
     sync_code_signing(


### PR DESCRIPTION

## :scroll: Description

Using single quotes for the password allows special characters except for a single quote.

## :bulb: Motivation and Context

We want to allow special characters for the keychain password.

## :green_heart: How did you test it?
Running it locally.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
