### PR TITLE
ci: Fix let building samples fail CI

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -81,7 +81,7 @@ jobs:
           -scheme ${{matrix.scheme}}
           -configuration Debug
           CODE_SIGNING_ALLOWED="NO"
-          build | xcpretty
+          build
 
   validate-podspec:
     name: Validate Podspec

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -102,7 +102,8 @@ ViewController ()
 
 - (IBAction)captureTransaction:(id)sender
 {
-    SentryTransaction *fakeTransaction = [SentrySDK startTransactionWithName:@"Some Transaction" operation:@"some operation"];
+    SentryTransaction *fakeTransaction = [SentrySDK startTransactionWithName:@"Some Transaction"
+                                                                   operation:@"some operation"];
 
     dispatch_after(
         dispatch_time(DISPATCH_TIME_NOW, (int64_t)(arc4random_uniform(100) + 400 * NSEC_PER_MSEC)),


### PR DESCRIPTION
When building the samples failed in CI the CI job didn't fail. This is fixed now.
