### PR TITLE
ref: Make DispatchQueueWrapper configurable

### DIFF
--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -14,11 +14,18 @@ SentryDispatchQueueWrapper ()
 
 - (instancetype)init
 {
-    self = [super init];
-    if (self) {
-        // DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL is requires iOS 10. Since we are targeting
-        // iOS 9 we need to manually add the autoreleasepool.
-        self.queue = dispatch_queue_create("sentry-dispatch", DISPATCH_QUEUE_SERIAL);
+    // DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL is requires iOS 10. Since we are targeting
+    // iOS 9 we need to manually add the autoreleasepool.
+    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+    self = [self initWithName:"sentry-default" attributes:attributes];
+    return self;
+}
+
+- (instancetype)initWithName:(const char *)name attributes:(dispatch_queue_attr_t)attributes;
+{
+    if (self = [super init]) {
+        self.queue = dispatch_queue_create(name, attributes);
     }
     return self;
 }

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -42,7 +42,11 @@ SentryTransportFactory ()
     SentryEnvelopeRateLimit *envelopeRateLimit =
         [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];
 
-    SentryDispatchQueueWrapper *dispatchQueueWrapper = [[SentryDispatchQueueWrapper alloc] init];
+    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_LOW, 0);
+    SentryDispatchQueueWrapper *dispatchQueueWrapper =
+        [[SentryDispatchQueueWrapper alloc] initWithName:"sentry-http-transport"
+                                              attributes:attributes];
 
     return [[SentryHttpTransport alloc] initWithOptions:options
                                             fileManager:sentryFileManager

--- a/Sources/Sentry/include/SentryDispatchQueueWrapper.h
+++ b/Sources/Sentry/include/SentryDispatchQueueWrapper.h
@@ -7,6 +7,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SentryDispatchQueueWrapper : NSObject
 
+- (instancetype)initWithName:(const char *)name attributes:(dispatch_queue_attr_t)attributes;
+
 - (void)dispatchAsyncWithBlock:(void (^)(void))block;
 
 - (void)dispatchOnce:(dispatch_once_t *)predicate block:(void (^)(void))block;


### PR DESCRIPTION
## :scroll: Description

Add a 2nd constructor to SentryDispatchQueueWrapper to allow passing
the name and attributes for the dispatch queue. This allows us to create different
dispatch queues with different strategies and priorities.

## :bulb: Motivation and Context

We don't want to only use on dispatch queue across the whole SDK. We don't want to use the same dispatch queue for sending envelopes to Sentry and updating the app state in the OOM integration. Updating the app state should run on a higher priority.

## :green_heart: How did you test it?
CI and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
