### PR TITLE
ref: Fix naming for test init of CrashIntegration

### DIFF
--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -38,13 +38,13 @@ SentryCrashIntegration ()
 }
 
 /** Internal constructor for testing */
-- (instancetype)initWithCrashWrapper:(SentryCrashAdapter *)crashWrapper
+- (instancetype)initWithCrashAdapter:(SentryCrashAdapter *)crashAdapter
              andDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
 {
     self = [self init];
     self.dispatchQueueWrapper = dispatchQueueWrapper;
     self.crashedSessionHandler =
-        [[SentrySessionCrashedHandler alloc] initWithCrashWrapper:crashWrapper];
+        [[SentrySessionCrashedHandler alloc] initWithCrashWrapper:crashAdapter];
 
     return self;
 }

--- a/Tests/SentryTests/Integrations/SentryCrashIntegration+TestInit.h
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegration+TestInit.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryCrashIntegration (TestInit)
 
-- (instancetype)initWithCrashWrapper:(SentryCrashAdapter *)crashWrapper
+- (instancetype)initWithCrashAdapter:(SentryCrashAdapter *)crashWrapper
              andDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 
 @end

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -40,7 +40,7 @@ class SentryCrashIntegrationTests: XCTestCase {
         }
         
         func getSut() -> SentryCrashIntegration {
-            return SentryCrashIntegration(crashWrapper: sentryCrash, andDispatchQueueWrapper: dispatchQueueWrapper)
+            return SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: dispatchQueueWrapper)
         }
     }
     
@@ -109,7 +109,7 @@ class SentryCrashIntegrationTests: XCTestCase {
         
         let sentryCrash = fixture.sentryCrash
         sentryCrash.internalCrashedLastLaunch = false
-        let sut = SentryCrashIntegration(crashWrapper: sentryCrash, andDispatchQueueWrapper: fixture.dispatchQueueWrapper)
+        let sut = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: fixture.dispatchQueueWrapper)
         sut.install(with: Options())
         
         let fileManager = fixture.fileManager

--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -119,7 +119,7 @@ class SentrySessionGeneratorTests: XCTestCase {
         let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: self.sentryCrash)
         SentrySDK.setCurrentHub(hub)
         
-        crashIntegration = SentryCrashIntegration(crashWrapper: sentryCrash, andDispatchQueueWrapper: TestSentryDispatchQueueWrapper())
+        crashIntegration = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: TestSentryDispatchQueueWrapper())
         crashIntegration.install(with: options)
         
         autoSessionTrackingIntegration = SentryAutoSessionTrackingIntegration()


### PR DESCRIPTION


## :scroll: Description

Rename parameter crashWrapper to crashAdapter as the name of the
class ins crashAdapter.

## :bulb: Motivation and Context

We want to have consistent naming.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
