### PR TITLE
test: TearDown for SessionGeneratorTests

### DIFF
--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -30,10 +30,20 @@ class SentrySessionGeneratorTests: XCTestCase {
             fileManager = try SentryFileManager(dsn: dsn, andCurrentDateProvider: TestCurrentDateProvider())
             
             fileManager.deleteCurrentSession()
+            fileManager.deleteCrashedSession()
             fileManager.deleteTimestampLastInForeground()
         } catch {
             XCTFail("Could not delete session data")
         }
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        fileManager.deleteCurrentSession()
+        fileManager.deleteCrashedSession()
+        fileManager.deleteTimestampLastInForeground()
+        autoSessionTrackingIntegration.stop()
     }
     
     /**


### PR DESCRIPTION
## :scroll: Description

When leaving the `SessionGeneratorTests` on by accident, the `SessionTrackerTests` started to fail.
This is fixed now by adding a tearDown to SessionGeneratorTests.

## :bulb: Motivation and Context

When leaving the `SessionGeneratorTests` on by accident, the `SessionTrackerTests` start to fail.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
