### PR TITLE
fix: OutOfMemory exception type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: OutOfMemory exception type #1015
+
 ## 7.0.0-alpha.3
 
 - feat: Out Of Memory Tracking #1001

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -510,7 +510,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     SentryException *exception = event.exceptions[0];
     return nil != exception.mechanism &&
-        [exception.mechanism.type isEqualToString:SentryOutOfMemoryExceptionType];
+        [exception.mechanism.type isEqualToString:SentryOutOfMemoryMechanismType];
 }
 
 - (void)removeFreeMemoryFromDeviceContext:(SentryEvent *)event

--- a/Sources/Sentry/SentryOutOfMemoryTracker.m
+++ b/Sources/Sentry/SentryOutOfMemoryTracker.m
@@ -75,7 +75,7 @@ SentryOutOfMemoryTracker ()
                 [[SentryException alloc] initWithValue:SentryOutOfMemoryExceptionValue
                                                   type:SentryOutOfMemoryExceptionType];
             SentryMechanism *mechanism =
-                [[SentryMechanism alloc] initWithType:SentryOutOfMemoryExceptionType];
+                [[SentryMechanism alloc] initWithType:SentryOutOfMemoryMechanismType];
             mechanism.handled = @(NO);
             exception.mechanism = mechanism;
             event.exceptions = @[ exception ];

--- a/Sources/Sentry/include/SentryOutOfMemoryTracker.h
+++ b/Sources/Sentry/include/SentryOutOfMemoryTracker.h
@@ -4,9 +4,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString *const SentryOutOfMemoryExceptionType = @"Out Of Memory";
+static NSString *const SentryOutOfMemoryExceptionType = @"OutOfMemory";
 static NSString *const SentryOutOfMemoryExceptionValue
-    = @"The OS most likely terminated your app because it over-used RAM.";
+    = @"The OS most likely terminated your app because it overused RAM.";
+static NSString *const SentryOutOfMemoryMechanismType = @"out_of_memory";
 
 /**
  * Detect OOMs based on heuristics described in a blog post:

--- a/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
@@ -208,12 +208,12 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         XCTAssertEqual(1, crashEvent?.exceptions?.count)
         
         let exception = crashEvent?.exceptions?.first
-        XCTAssertEqual("The OS most likely terminated your app because it over-used RAM.", exception?.value)
+        XCTAssertEqual("The OS most likely terminated your app because it overused RAM.", exception?.value)
         XCTAssertEqual("Out Of Memory", exception?.type)
         
         XCTAssertNotNil(exception?.mechanism)
         XCTAssertEqual(false, exception?.mechanism?.handled)
-        XCTAssertEqual("Out Of Memory", exception?.mechanism?.type)
+        XCTAssertEqual("out_of_memory", exception?.mechanism?.type)
     }
 }
 

--- a/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
@@ -209,7 +209,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         let exception = crashEvent?.exceptions?.first
         XCTAssertEqual("The OS most likely terminated your app because it overused RAM.", exception?.value)
-        XCTAssertEqual("Out Of Memory", exception?.type)
+        XCTAssertEqual("OutOfMemory", exception?.type)
         
         XCTAssertNotNil(exception?.mechanism)
         XCTAssertEqual(false, exception?.mechanism?.handled)

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -150,7 +150,7 @@ class TestData {
     static var oomEvent: Event {
         let event = Event(level: SentryLevel.fatal)
         let exception = Exception(value: SentryOutOfMemoryExceptionValue, type: SentryOutOfMemoryExceptionType)
-        exception.mechanism = Mechanism(type: SentryOutOfMemoryExceptionType)
+        exception.mechanism = Mechanism(type: SentryOutOfMemoryMechanismType)
         event.exceptions = [exception]
         return event
     }


### PR DESCRIPTION
## :scroll: Description

The type of the mechanism and the exception were not set according to the Sentry standard.
This is fixed now.

## :bulb: Motivation and Context

https://github.com/getsentry/sentry-cocoa/pull/1001#discussion_r599165629

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
