### PR TITLE
fix: Crash when passing garbage to maxBreadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Crash when passing garbage to maxBreadcrumbs #1018
 - fix: OutOfMemory exception type #1015
 - fix: macOS version for Mac Catalyst #1011
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -137,7 +137,7 @@
         self.enabled = [options[@"enabled"] boolValue];
     }
 
-    if (nil != options[@"maxBreadcrumbs"]) {
+    if ([options[@"maxBreadcrumbs"] isKindOfClass:[NSNumber class]]) {
         self.maxBreadcrumbs = [options[@"maxBreadcrumbs"] unsignedIntValue];
     }
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -164,20 +164,27 @@
     XCTAssertEqual(expectedValue, options.enabled);
 }
 
-- (void)testMaxBreadCrumbs
+- (void)testMaxBreadcrumbs
 {
-    NSNumber *maxBreadCrumbs = @20;
+    NSNumber *maxBreadcrumbs = @20;
 
-    SentryOptions *options = [self getValidOptions:@{ @"maxBreadcrumbs" : maxBreadCrumbs }];
+    SentryOptions *options = [self getValidOptions:@{ @"maxBreadcrumbs" : maxBreadcrumbs }];
 
-    XCTAssertEqual([maxBreadCrumbs unsignedIntValue], options.maxBreadcrumbs);
+    XCTAssertEqual([maxBreadcrumbs unsignedIntValue], options.maxBreadcrumbs);
 }
 
-- (void)testDefaultMaxBreadCrumbs
+- (void)testDefaultMaxBreadcrumbs
 {
     SentryOptions *options = [self getValidOptions:@{}];
 
     XCTAssertEqual([@100 unsignedIntValue], options.maxBreadcrumbs);
+}
+
+- (void)testMaxBreadcrumbsGarbage
+{
+    SentryOptions *options = [self getValidOptions:@{ @"maxBreadcrumbs" : self }];
+
+    XCTAssertEqual(100, options.maxBreadcrumbs);
 }
 
 - (void)testBeforeSend


### PR DESCRIPTION


## :scroll: Description

When passing for example self to maxBreadcrumbs when using the dict initialiser
for SentryOptions the SDK crashed. This is fixed now by checking if maxBreadcrumbs
is a NSNumber.

## :bulb: Motivation and Context

We don't want the SDK to crash.

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
