### PR TITLE
ref: Remove currentHub from SentrySDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- ref: Remove currentHub from SentrySDK #1019: We removed `SentrySDK.currentHub` and `SentrySDK.setCurrentHub`. In case you need this methods, please open up an issue.
 - feat: Add maxCacheItems #1017: This changes the maximum number of cached envelopes from 100 to 30. You can configure this number with `SentryOptions.maxCacheItems`.
 
 ### Features and Fixes

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -766,6 +766,7 @@
 		7B88F2FF24BC5A7D00ADF90A /* SentrySdkInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySdkInfo.m; sourceTree = "<group>"; };
 		7B88F30124BC5C6D00ADF90A /* SentrySdkInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySdkInfoTests.swift; sourceTree = "<group>"; };
 		7B88F30324BC8E6500ADF90A /* SentrySerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySerializationTests.swift; sourceTree = "<group>"; };
+		7B9421C4260CA393001F9349 /* SentrySDK+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentrySDK+Tests.h"; sourceTree = "<group>"; };
 		7B944FAD2469B43700A10721 /* TestHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHub.swift; sourceTree = "<group>"; };
 		7B944FAF2469B46000A10721 /* TestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestClient.swift; sourceTree = "<group>"; };
 		7B98D7BB25FB607300C5A389 /* SentryOutOfMemoryTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryOutOfMemoryTracker.h; path = include/SentryOutOfMemoryTracker.h; sourceTree = "<group>"; };
@@ -1261,6 +1262,7 @@
 				63AA75941EB8AEDB00D153DE /* Info.plist */,
 				639889D21EDF06C100EA7442 /* SentryTests-Bridging-Header.h */,
 				63AA75951EB8AEDB00D153DE /* SentryTests.m */,
+				7B9421C4260CA393001F9349 /* SentrySDK+Tests.h */,
 				7BA8409F24A1EC6E00B718AA /* SentrySDKTests.swift */,
 				630436151EC0AD3100C4D3FA /* SentryNSDataCompressionTests.m */,
 				630C01931EC3402C00C52CEF /* SentryKSCrashReportConverterTests.m */,

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -19,19 +19,9 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 /**
- * Returns current hub
- */
-+ (SentryHub *)currentHub;
-
-/**
  * This forces a crash, useful to test the SentryCrash integration
  */
 + (void)crash;
-
-/**
- * Sets current hub
- */
-+ (void)setCurrentHub:(SentryHub *)hub;
 
 /**
  * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations.

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -4,7 +4,7 @@
 #import "SentryDefines.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 #import "SentryScope.h"
 #import "SentrySwizzle.h"
 

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -6,7 +6,7 @@
 #import "SentryFrameInAppLogic.h"
 #import "SentryHub.h"
 #import "SentryOutOfMemoryLogic.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"
 #import "SentrySessionCrashedHandler.h"
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -7,7 +7,7 @@
 #import "SentryFileManager.h"
 #import "SentryId.h"
 #import "SentryLog.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 #import "SentrySamplingContext.h"
 #import "SentryScope.h"
 #import "SentrySerialization.h"

--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -7,7 +7,7 @@
 #import "SentryHub.h"
 #import "SentryLog.h"
 #import "SentryMeta.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -1,3 +1,4 @@
+#import "SentrySDK+Private.h"
 #import <Foundation/Foundation.h>
 #import <SentryAppState.h>
 #import <SentryClient+Private.h>
@@ -6,7 +7,6 @@
 #import <SentryHub.h>
 #import <SentryOptions.h>
 #import <SentryOutOfMemoryLogic.h>
-#import <SentrySDK.h>
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>

--- a/Sources/Sentry/SentryRequestOperation.m
+++ b/Sources/Sentry/SentryRequestOperation.m
@@ -3,7 +3,7 @@
 #import "SentryError.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -33,6 +33,7 @@ static BOOL crashedLastRunCalled;
     }
 }
 
+/** Internal, only needed for testing. */
 + (void)setCurrentHub:(SentryHub *)hub
 {
     @synchronized(self) {

--- a/Sources/Sentry/SentrySessionCrashedHandler.m
+++ b/Sources/Sentry/SentrySessionCrashedHandler.m
@@ -5,7 +5,7 @@
 #import "SentryFileManager.h"
 #import "SentryHub.h"
 #import "SentryOutOfMemoryLogic.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 
 @interface
 SentrySessionCrashedHandler ()

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -5,7 +5,7 @@
 #import "SentryHub.h"
 #import "SentryInternalNotificationNames.h"
 #import "SentryLog.h"
-#import "SentrySDK.h"
+#import "SentrySDK+Private.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -13,6 +13,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, class) BOOL crashedLastRunCalled;
 
++ (SentryHub *)currentHub;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentrySDK+Tests.h
+++ b/Tests/SentryTests/SentrySDK+Tests.h
@@ -1,0 +1,11 @@
+#import <Sentry/Sentry.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentrySDK (Tests)
+
++ (void)setCurrentHub:(SentryHub *)hub;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -63,6 +63,7 @@
 #import "SentryRateLimits.h"
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentrySDK+Private.h"
+#import "SentrySDK+Tests.h"
 #import "SentryScope+Private.h"
 #import "SentrySdkInfo.h"
 #import "SentrySerialization.h"

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -2,6 +2,7 @@
 #import "SentryBreadcrumbTracker.h"
 #import "SentryMessage.h"
 #import "SentryMeta.h"
+#import "SentrySDK+Private.h"
 #import <Sentry/Sentry.h>
 #import <XCTest/XCTest.h>
 


### PR DESCRIPTION
## :scroll: Description

Remove SentrySDK.currentHub and SentrySDK.setCurrentHub, which are only
needed internally and by hybrid SDKs. They are not intended to be public API.

This breaks Hybrid SDKs, but we are going to fix this with adding `captureEnvelope` and `storeEnvelope` to `SentrySDK.m` but not in the header. The hybrid SDKs can create a category to make these two methods accessible. We use this pattern for the test initializers already.

## :bulb: Motivation and Context

See https://github.com/getsentry/develop/issues/248#issuecomment-765206789

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
