### PR TITLE
ref: Improve envelope API for Hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- ref: Improve envelope API for Hybrid SDKs #1020: We removed `SentryClient.storeEnvelope`, which is reserved for Hybrid SDKs.
 - ref: Remove currentHub from SentrySDK #1019: We removed `SentrySDK.currentHub` and `SentrySDK.setCurrentHub`. In case you need this methods, please open up an issue.
 - feat: Add maxCacheItems #1017: This changes the maximum number of cached envelopes from 100 to 30. You can configure this number with `SentryOptions.maxCacheItems`.
 

--- a/Sources/Sentry/Public/SentryClient.h
+++ b/Sources/Sentry/Public/SentryClient.h
@@ -113,11 +113,6 @@ SENTRY_NO_INIT
 
 - (void)captureEnvelope:(SentryEnvelope *)envelope NS_SWIFT_NAME(capture(envelope:));
 
-/**
- * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.
- */
-- (void)storeEnvelope:(SentryEnvelope *)envelope;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -1,6 +1,6 @@
 #import "SentrySDK.h"
 #import "SentryBreadcrumb.h"
-#import "SentryClient.h"
+#import "SentryClient+Private.h"
 #import "SentryCrash.h"
 #import "SentryHub+Private.h"
 #import "SentryLog.h"
@@ -167,6 +167,24 @@ static BOOL crashedLastRunCalled;
 + (SentryId *)captureMessage:(NSString *)message withScope:(SentryScope *)scope
 {
     return [SentrySDK.currentHub captureMessage:message withScope:scope];
+}
+
+/**
+ * Needed by hybrid SDKs as react-native to synchronously capture an envelope.
+ */
++ (void)captureEnvelope:(SentryEnvelope *)envelope
+{
+    [SentrySDK.currentHub captureEnvelope:envelope];
+}
+
+/**
+ * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.
+ */
++ (void)storeEnvelope:(SentryEnvelope *)envelope
+{
+    if (nil != [SentrySDK.currentHub getClient]) {
+        [[SentrySDK.currentHub getClient] storeEnvelope:envelope];
+    }
 }
 
 + (void)captureUserFeedback:(SentryUserFeedback *)userFeedback

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -23,6 +23,11 @@ NS_ASSUME_NONNULL_BEGIN
                     withSession:(SentrySession *)session
                       withScope:(SentryScope *)scope;
 
+/**
+ * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.
+ */
+- (void)storeEnvelope:(SentryEnvelope *)envelope;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentrySDK+Tests.h
+++ b/Tests/SentryTests/SentrySDK+Tests.h
@@ -6,6 +6,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)setCurrentHub:(SentryHub *)hub;
 
++ (void)captureEnvelope:(SentryEnvelope *)envelope;
+
++ (void)storeEnvelope:(SentryEnvelope *)envelope;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -99,6 +99,11 @@ class TestClient: Client {
     override func capture(envelope: SentryEnvelope) {
         capturedEnvelopes.append(envelope)
     }
+    
+    var storedEnvelopes: [SentryEnvelope] = []
+    override func store(_ envelope: SentryEnvelope) {
+        storedEnvelopes.append(envelope)
+    }
 }
 
 class TestFileManager: SentryFileManager {


### PR DESCRIPTION


## :scroll: Description

Add captureEnvelope and storeEnvelope to SentrySDK.m, so hybrid SDKs
have a nicer API to interact. The hybrid SDKs can create a category to make
these two methods accessible. We use this pattern for the test initializers
already. Make SentryClient.storeEnvelope private.

## :bulb: Motivation and Context

https://github.com/getsentry/develop/issues/248#issuecomment-765206789

## :green_heart: How did you test it?
Units tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
