### PR TITLE
feat: Add start and endSession to SentrySDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Features and Fixes
 
+- feat: Add start and endSession to SentrySDK #1021
 - fix: Crash when passing garbage to maxBreadcrumbs #1018
 - fix: OutOfMemory exception type #1015
 - fix: macOS version for Mac Catalyst #1011

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -16,8 +16,23 @@ SENTRY_NO_INIT
 // session here.
 @property (nonatomic, readonly, strong) SentrySession *_Nullable session;
 
+/**
+ * Starts a new session. If there's a running session, it ends it before starting the new one.
+ */
 - (void)startSession;
+
+/**
+ * Ends the current session.
+ */
+- (void)endSession;
+
+/**
+ * Ends the current session with the given timestamp.
+ *
+ * @param timestamp The timestamp to end the session with.
+ */
 - (void)endSessionWithTimestamp:(NSDate *)timestamp;
+
 - (void)closeCachedSessionWithTimestamp:(NSDate *_Nullable)timestamp;
 
 @property (nonatomic, strong)

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -225,6 +225,16 @@ SENTRY_NO_INIT
  */
 + (void)setUser:(SentryUser *_Nullable)user;
 
+/**
+ * Starts a new session. If there's a running session, it ends it before starting the new one.
+ */
++ (void)startSession;
+
+/**
+ * Ends the current session.
+ */
++ (void)endSession;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -86,6 +86,11 @@ SentryHub ()
     [self captureSession:lastSession];
 }
 
+- (void)endSession
+{
+    [self endSessionWithTimestamp:[SentryCurrentDate date]];
+}
+
 - (void)endSessionWithTimestamp:(NSDate *)timestamp
 {
     SentrySession *currentSession = nil;

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -224,6 +224,16 @@ static BOOL crashedLastRunCalled;
     return SentryCrash.sharedInstance.crashedLastLaunch;
 }
 
++ (void)startSession
+{
+    [SentrySDK.currentHub startSession];
+}
+
++ (void)endSession
+{
+    [SentrySDK.currentHub endSession];
+}
+
 /**
  * Install integrations and keeps ref in `SentryHub.integrations`
  */

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -8,6 +8,7 @@ class SentrySDKTests: XCTestCase {
     
     private class Fixture {
     
+        let options: Options
         let event: Event
         let scope: Scope
         let client: TestClient
@@ -15,6 +16,7 @@ class SentrySDKTests: XCTestCase {
         let error: Error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
         let exception = NSException(name: NSExceptionName("My Custom exeption"), reason: "User clicked the button", userInfo: nil)
         let userFeedback: UserFeedback
+        let currentDate = TestCurrentDateProvider()
         
         let scopeBlock: (Scope) -> Void = { scope in
             scope.setTag(value: "tag", key: "tag")
@@ -31,14 +33,17 @@ class SentrySDKTests: XCTestCase {
         let message = "message"
         
         init() {
+            CurrentDate.setCurrentDateProvider(currentDate)
+            
             event = Event()
             event.message = SentryMessage(formatted: message)
             
             scope = Scope()
             scope.setTag(value: "value", key: "key")
             
-            let options = Options()
+            options = Options()
             options.dsn = SentrySDKTests.dsnAsString
+            options.releaseName = "1.0.0"
             client = TestClient(options: options)!
             hub = SentryHub(client: client, andScope: scope)
             
@@ -387,6 +392,46 @@ class SentrySDKTests: XCTestCase {
         }
     }
     
+    func testStartSession() {
+        givenSdkWithHub()
+        
+        SentrySDK.startSession()
+        
+        XCTAssertEqual(1, fixture.client.sessions.count)
+        
+        let actual = fixture.client.sessions.first
+        let expected = SentrySession(releaseName: fixture.options.releaseName ?? "")
+        
+        XCTAssertEqual(expected.flagInit, actual?.flagInit)
+        XCTAssertEqual(expected.errors, actual?.errors)
+        XCTAssertEqual(expected.sequence, actual?.sequence)
+        XCTAssertEqual(expected.releaseName, actual?.releaseName)
+        XCTAssertEqual(fixture.currentDate.date(), actual?.started)
+        XCTAssertEqual(SentrySessionStatus.ok, actual?.status)
+        XCTAssertNil(actual?.timestamp)
+        XCTAssertNil(actual?.duration)
+    }
+    
+    func testEndSession() {
+        givenSdkWithHub()
+        
+        SentrySDK.startSession()
+        advanceTime(bySeconds: 1)
+        SentrySDK.endSession()
+        
+        XCTAssertEqual(2, fixture.client.sessions.count)
+        
+        let actual = fixture.client.sessions[1]
+        
+        XCTAssertNil(actual.flagInit)
+        XCTAssertEqual(0, actual.errors)
+        XCTAssertEqual(2, actual.sequence)
+        XCTAssertEqual(SentrySessionStatus.exited, actual.status)
+        XCTAssertEqual(fixture.options.releaseName ?? "", actual.releaseName)
+        XCTAssertEqual(1, actual.duration)
+        XCTAssertEqual(fixture.currentDate.date(), actual.timestamp)
+    }
+    
     private func givenSdkWithHub() {
         SentrySDK.setCurrentHub(fixture.hub)
     }
@@ -436,5 +481,9 @@ class SentrySDKTests: XCTestCase {
     private func assertHubScopeNotChanged() {
         let hubScope = SentrySDK.currentHub().scope
         XCTAssertEqual(fixture.scope, hubScope)
+    }
+    
+    private func advanceTime(bySeconds: TimeInterval) {
+        fixture.currentDate.setDate(date: fixture.currentDate.date().addingTimeInterval(bySeconds))
     }
 }


### PR DESCRIPTION


## :scroll: Description

Add SentrySDK.startSession and SentrySDK.endSession to provide an
easy to use API for manual session tracking.

## :bulb: Motivation and Context

https://github.com/getsentry/develop/issues/248

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
