### PR TITLE
ref: Make closeCachedSessionWithTimestamp private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- ref: Make closeCachedSessionWithTimestamp private #1022
 - ref: Improve envelope API for Hybrid SDKs #1020: We removed `SentryClient.storeEnvelope`, which is reserved for Hybrid SDKs.
 - ref: Remove currentHub from SentrySDK #1019: We removed `SentrySDK.currentHub` and `SentrySDK.setCurrentHub`. In case you need this methods, please open up an issue.
 - feat: Add maxCacheItems #1017: This changes the maximum number of cached envelopes from 100 to 30. You can configure this number with `SentryOptions.maxCacheItems`.

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -18,7 +18,6 @@ SENTRY_NO_INIT
 
 - (void)startSession;
 - (void)endSessionWithTimestamp:(NSDate *)timestamp;
-- (void)closeCachedSessionWithTimestamp:(NSDate *_Nullable)timestamp;
 
 @property (nonatomic, strong)
     NSMutableArray<NSObject<SentryIntegrationProtocol> *> *installedIntegrations;

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -2,7 +2,7 @@
 #import "SentryClient+Private.h"
 #import "SentryClient.h"
 #import "SentryFileManager.h"
-#import "SentryHub.h"
+#import "SentryHub+Private.h"
 #import "SentryInternalNotificationNames.h"
 #import "SentryLog.h"
 #import "SentrySDK+Private.h"

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -10,6 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)setSampleRandomValue:(NSNumber *)value;
 
+- (void)closeCachedSessionWithTimestamp:(NSDate *_Nullable)timestamp;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION


## :scroll: Description

Make Sentry.HubcloseCachedSessionWithTimestamp private as it is not intended
to be public API and is reserved for internal use only.

## :bulb: Motivation and Context

We don't want to have methods that are only supposed to be used internally to be public.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
