### PR TITLE
ref: Move SentrySDK.crash method to bottom

### DIFF
--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -19,11 +19,6 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 /**
- * This forces a crash, useful to test the SentryCrash integration
- */
-+ (void)crash;
-
-/**
  * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations.
  */
 + (void)startWithOptions:(NSDictionary<NSString *, id> *)optionsDict NS_SWIFT_NAME(start(options:));
@@ -234,6 +229,11 @@ SENTRY_NO_INIT
  * Ends the current session.
  */
 + (void)endSession;
+
+/**
+ * This forces a crash, useful to test the SentryCrash integration
+ */
++ (void)crash;
 
 @end
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -210,15 +210,6 @@ static BOOL crashedLastRunCalled;
     [SentrySDK.currentHub setUser:user];
 }
 
-#ifndef __clang_analyzer__
-// Code not to be analyzed
-+ (void)crash
-{
-    int *p = 0;
-    *p = 0;
-}
-#endif
-
 + (BOOL)crashedLastRun
 {
     return SentryCrash.sharedInstance.crashedLastLaunch;
@@ -268,6 +259,15 @@ static BOOL crashedLastRunCalled;
         [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
     }
 }
+
+#ifndef __clang_analyzer__
+// Code not to be analyzed
++ (void)crash
+{
+    int *p = 0;
+    *p = 0;
+}
+#endif
 
 @end
 


### PR DESCRIPTION


## :scroll: Description

The SentrySDK.crash method is the first one defined in the header. The
first functions in a class are usually the initializers. This is fixed now by
moving the method down.

## :bulb: Motivation and Context

Cleaning up the public header files for 7.0.0 GA.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
