### PR TITLE
ref: Remove deprecated SentryHub.getScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- ref: Remove deprecated SentryHub.getScope #1025: Use `SentryHub.scope` instead.
 - ref: Make closeCachedSessionWithTimestamp private #1022
 - ref: Improve envelope API for Hybrid SDKs #1020: We removed `SentryClient.storeEnvelope`, which is reserved for Hybrid SDKs.
 - ref: Remove currentHub from SentrySDK #1019: We removed `SentrySDK.currentHub` and `SentrySDK.setCurrentHub`. In case you need this methods, please open up an issue.

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -177,11 +177,6 @@ SENTRY_NO_INIT
 /**
  * Returns either the current scope and if nil a new one.
  */
-- (SentryScope *)getScope __deprecated_msg("Use SentryHub.scope instead.");
-
-/**
- * Returns either the current scope and if nil a new one.
- */
 @property (nonatomic, readonly, strong) SentryScope *scope;
 
 /**

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -363,11 +363,6 @@ SentryHub ()
     }
 }
 
-- (SentryScope *)getScope
-{
-    return self.scope;
-}
-
 - (void)configureScope:(void (^)(SentryScope *scope))callback
 {
     SentryScope *scope = self.scope;


### PR DESCRIPTION


## :scroll: Description

Removed deprecated SentryHub.getScope. Use SentryHub.scope instead.

## :bulb: Motivation and Context

We want to remove deprecated functions before GA 7.0.0

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
