### PR TITLE
ref: Align SentryException with unified API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking Changes
 
+- ref: Align SentryException with unified API #1026: Replaced `SentryException.thread` with `SentryException.threadId` and `SentryException.stacktrace`.
 - ref: Make closeCachedSessionWithTimestamp private #1022
 - ref: Improve envelope API for Hybrid SDKs #1020: We removed `SentryClient.storeEnvelope`, which is reserved for Hybrid SDKs.
 - ref: Remove currentHub from SentrySDK #1019: We removed `SentrySDK.currentHub` and `SentrySDK.setCurrentHub`. In case you need this methods, please open up an issue.

--- a/Sources/Sentry/Public/SentryException.h
+++ b/Sources/Sentry/Public/SentryException.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryThread, SentryMechanism;
+@class SentryStacktrace, SentryMechanism;
 
 NS_SWIFT_NAME(Exception)
 @interface SentryException : NSObject <SentrySerializable>
@@ -32,9 +32,14 @@ SENTRY_NO_INIT
 @property (nonatomic, copy) NSString *_Nullable module;
 
 /**
- * SentryThread of the SentryException
+ * An optional value which refers to a thread in `SentryEvent.threads`.
  */
-@property (nonatomic, strong) SentryThread *_Nullable thread;
+@property (nonatomic, copy) NSNumber *_Nullable threadId;
+
+/**
+ * Stacktrace containing frames of this exception.
+ */
+@property (nonatomic, strong) SentryStacktrace *_Nullable stacktrace;
 
 /**
  * Initialize an SentryException with value and type

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -357,7 +357,11 @@ SentryCrashReportConverter ()
 
     [self enhanceValueFromNotableAddresses:exception];
     exception.mechanism = [self extractMechanismOfType:exceptionType];
-    exception.thread = [self crashedThread];
+
+    SentryThread *crashedThread = [self crashedThread];
+    exception.threadId = crashedThread.threadId;
+    exception.stacktrace = crashedThread.stacktrace;
+
     if (nil != self.diagnosis && self.diagnosis.length > 0
         && ![self.diagnosis containsString:exception.value]) {
         exception.value = [exception.value

--- a/Sources/Sentry/SentryException.m
+++ b/Sources/Sentry/SentryException.m
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.type forKey:@"type"];
     [serializedData setValue:[self.mechanism serialize] forKey:@"mechanism"];
     [serializedData setValue:self.module forKey:@"module"];
-    [serializedData setValue:self.thread.threadId forKey:@"thread_id"];
-    [serializedData setValue:[self.thread.stacktrace serialize] forKey:@"stacktrace"];
+    [serializedData setValue:self.threadId forKey:@"thread_id"];
+    [serializedData setValue:[self.stacktrace serialize] forKey:@"stacktrace"];
 
     return serializedData;
 }

--- a/Tests/SentryTests/Protocol/SentryExceptionTests.swift
+++ b/Tests/SentryTests/Protocol/SentryExceptionTests.swift
@@ -9,7 +9,7 @@ class SentryExceptionTests: XCTestCase {
         
         // Changing the original doesn't modify the serialized
         exception.mechanism?.desc = ""
-        exception.thread?.stacktrace?.registers = [:]
+        exception.stacktrace?.registers = [:]
 
         let expected = TestData.exception
         XCTAssertEqual(expected.type, actual["type"] as! String)
@@ -19,7 +19,7 @@ class SentryExceptionTests: XCTestCase {
         XCTAssertEqual(TestData.mechanism.desc, mechanism["description"] as? String)
         
         XCTAssertEqual(expected.module, actual["module"] as? String)
-        XCTAssertEqual(expected.thread?.threadId, actual["thread_id"] as? NSNumber)
+        XCTAssertEqual(expected.threadId, actual["thread_id"] as? NSNumber)
         
         let stacktrace = actual["stacktrace"] as! [String: Any]
         XCTAssertEqual(TestData.stacktrace.registers, stacktrace["registers"] as? [String: String])

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -77,7 +77,8 @@ class TestData {
         let exception = Exception(value: "value", type: "type")
         exception.mechanism = mechanism
         exception.module = "module"
-        exception.thread = thread
+        exception.threadId = thread.threadId
+        exception.stacktrace = thread.stacktrace
         
         return exception
     }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -841,7 +841,8 @@ class SentryClientTest: XCTestCase {
         
         XCTAssertEqual("Code: \(error.code)", exception.value)
         
-        XCTAssertNil(exception.thread)
+        XCTAssertNil(exception.threadId)
+        XCTAssertNil(exception.stacktrace)
         
         guard let mechanism = exception.mechanism else {
             XCTFail("Exception doesn't contain a mechanism"); return

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -358,7 +358,9 @@
     thread2.stacktrace = [[SentryStacktrace alloc] initWithFrames:@[ frame ]
                                                         registers:@{ @"a" : @"1" }];
 
-    exception2.thread = thread2;
+    exception2.threadId = thread2.threadId;
+    exception2.stacktrace = thread2.stacktrace;
+
     exception2.mechanism = [[SentryMechanism alloc] initWithType:@"test"];
     exception2.module = @"module";
     NSDictionary *serialized2 = @{

--- a/Tests/SentryTests/SentryKSCrashReportConverterTests.m
+++ b/Tests/SentryTests/SentryKSCrashReportConverterTests.m
@@ -47,22 +47,19 @@
 
     SentryException *exception = event.exceptions.firstObject;
     XCTAssertEqualObjects(
-        exception.thread.stacktrace.frames.lastObject.symbolAddress, @"0x000000010014c1ec");
+        exception.stacktrace.frames.lastObject.symbolAddress, @"0x000000010014c1ec");
     XCTAssertEqualObjects(
-        exception.thread.stacktrace.frames.lastObject.instructionAddress, @"0x000000010014caa4");
+        exception.stacktrace.frames.lastObject.instructionAddress, @"0x000000010014caa4");
     XCTAssertEqualObjects(
-        exception.thread.stacktrace.frames.lastObject.imageAddress, @"0x0000000100144000");
-    XCTAssertEqualObjects(exception.thread.stacktrace.registers[@"x4"], @"0x0000000102468000");
-    XCTAssertEqualObjects(exception.thread.stacktrace.registers[@"x9"], @"0x32a77e172fd70062");
+        exception.stacktrace.frames.lastObject.imageAddress, @"0x0000000100144000");
+    XCTAssertEqualObjects(exception.stacktrace.registers[@"x4"], @"0x0000000102468000");
+    XCTAssertEqualObjects(exception.stacktrace.registers[@"x9"], @"0x32a77e172fd70062");
 
-    XCTAssertEqualObjects(exception.thread.crashed, @(YES));
-    XCTAssertEqualObjects(exception.thread.current, @(NO));
-    XCTAssertEqualObjects(exception.thread.name, @"com.apple.main-thread");
     XCTAssertEqual(event.threads.count, (unsigned long)9);
 
     XCTAssertEqual(event.exceptions.count, (unsigned long)1);
     SentryThread *firstThread = event.threads.firstObject;
-    XCTAssertEqualObjects(exception.thread.threadId, firstThread.threadId);
+    XCTAssertEqualObjects(exception.threadId, firstThread.threadId);
     NSString *code = [NSString
         stringWithFormat:@"%@", [exception.mechanism.meta valueForKeyPath:@"signal.code"]];
     NSString *number = [NSString
@@ -201,7 +198,7 @@
                                            frameInAppLogic:self.frameInAppLogic];
     SentryEvent *event = [reportConverter convertReportToEvent];
     SentryException *exception = event.exceptions.firstObject;
-    XCTAssertEqualObjects(exception.thread.stacktrace.frames.lastObject.function, @"<redacted>");
+    XCTAssertEqualObjects(exception.stacktrace.frames.lastObject.function, @"<redacted>");
 }
 
 - (void)testReactNative
@@ -232,7 +229,7 @@
                                            frameInAppLogic:self.frameInAppLogic];
     SentryEvent *event = [reportConverter convertReportToEvent];
     SentryException *exception = event.exceptions.firstObject;
-    XCTAssertEqual(exception.thread.stacktrace.frames.count, (unsigned long)22);
+    XCTAssertEqual(exception.stacktrace.frames.count, (unsigned long)22);
     XCTAssertEqualObjects(exception.value,
         @"-[__NSArrayI objectForKey:]: unrecognized selector sent to instance "
         @"0x1e59bc50");


### PR DESCRIPTION


## :scroll: Description

Replace SentryException.thread with threadId and stacktrace. This aligns
SentryException with the exception interface, see
https://develop.sentry.dev/sdk/event-payloads/exception/.

## :bulb: Motivation and Context

We want to align the SDK with our spec.

## :green_heart: How did you test it?
CI and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
