### PR TITLE
Ignore flaky test in SentryHttpTransportTests.swift

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -243,7 +243,7 @@ class SentryHttpTransportTests: XCTestCase {
         assertRateLimitUpdated(response: response)
     }
     
-    func testSendEventWithRateLimitResponse() {
+    func ignoredTestSendEventWithRateLimitResponse() {
         let response = givenRateLimitResponse(forCategory: SentryEnvelopeItemTypeSession)
         
         sendEvent()


### PR DESCRIPTION
Issue tracking addressing this: #1031