### PR TITLE
test: Fix a test in HttpTransportTests

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -220,7 +220,7 @@ class SentryHttpTransportTests: XCTestCase {
         givenFirstRateLimitGetsActiveWithSecondResponse()
         sendEvent()
         
-        XCTAssertEqual(7, fixture.requestManager.requests.count)
+        XCTAssertEqual(5, fixture.requestManager.requests.count)
         assertEnvelopesStored(envelopeCount: 0)
     }
     
@@ -462,7 +462,7 @@ class SentryHttpTransportTests: XCTestCase {
             if i == 0 {
                 return HTTPURLResponse()
             } else {
-                return TestResponseFactory.createRateLimitResponse(headerValue: "1:error:key")
+                return TestResponseFactory.createRateLimitResponse(headerValue: "1::key")
             }
         }
     }


### PR DESCRIPTION


## :scroll: Description

The rate limit in testRateLimitGetsActiveWhileSendAllEvents did
never apply. This is fixed now by setting the rate limit for all
envelopes and correcting the number of envelopes in the assert.

## :bulb: Motivation and Context

I found this problem while investigating flakey tests in SentryHttpTransportTests.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
