### PR TITLE
ref: Remove not used cancelAllOperations

### DIFF
--- a/Sources/Sentry/SentryQueueableRequestManager.m
+++ b/Sources/Sentry/SentryQueueableRequestManager.m
@@ -49,11 +49,6 @@ SentryQueueableRequestManager ()
     [self.queue addOperation:operation];
 }
 
-- (void)cancelAllOperations
-{
-    [self.queue cancelAllOperations];
-}
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryRequestManager.h
+++ b/Sources/Sentry/include/SentryRequestManager.h
@@ -12,8 +12,6 @@ NS_SWIFT_NAME(RequestManager)
 - (void)addRequest:(NSURLRequest *)request
     completionHandler:(_Nullable SentryRequestOperationFinished)completionHandler;
 
-- (void)cancelAllOperations;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Networking/TestRequestManager.swift
+++ b/Tests/SentryTests/Networking/TestRequestManager.swift
@@ -49,10 +49,6 @@ public class TestRequestManager: NSObject, RequestManager {
         group.waitWithTimeout()
     }
     
-    public func cancelAllOperations() {
-        
-    }
-    
     func returnResponse(response: HTTPURLResponse?) {
         nextResponse = { return response }
     }


### PR DESCRIPTION


## :scroll: Description

Remove not public unused function cancelAllOperations in SentryRequestManager.

## :bulb: Motivation and Context

We don't want to maintain unused code.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
