### PR TITLE
fix: Pass SentryTracer to span child.

### DIFF
--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -46,7 +46,7 @@
                                            sampled:_rootSpan.context.sampled];
     context.spanDescription = description;
 
-    SentrySpan *span = [[SentrySpan alloc] initWithContext:context];
+    SentrySpan *span = [[SentrySpan alloc] initWithTracer:self context:context];
     @synchronized(_spans) {
         [_spans addObject:span];
     }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Every new span child created need a reference to SentryTracer to be able to also create child.

## :bulb: Motivation and Context

To fix a problem.

## :green_heart: How did you test it?

Unit test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes
