### PR TITLE
feat: Add close method to SDK

### DIFF
--- a/Sources/Sentry/Public/SentryIntegrationProtocol.h
+++ b/Sources/Sentry/Public/SentryIntegrationProtocol.h
@@ -8,9 +8,15 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol SentryIntegrationProtocol <NSObject>
 
 /**
- * installs the integration and returns YES if successful.
+ * Installs the integration and returns YES if successful.
  */
 - (void)installWithOptions:(SentryOptions *)options;
+
+/**
+ * Uninstalls the integration.
+ */
+@optional
+- (void)uninstall;
 
 @end
 

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -300,6 +300,11 @@ SENTRY_NO_INIT
  */
 + (void)crash;
 
+/**
+ * Closes the SDK and uninstalls all the integrations.
+ */
++ (void)close;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -10,6 +10,9 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 @property (nonatomic, weak) SentryOptions *options;
 
+@property (nonatomic, strong) SentryBreadcrumbTracker *tracker;
+@property (nonatomic, strong) SentrySystemEventsBreadcrumbs *system_events;
+
 @end
 
 @implementation SentryAutoBreadcrumbTrackingIntegration
@@ -20,10 +23,22 @@ SentryAutoBreadcrumbTrackingIntegration ()
     [self enableAutomaticBreadcrumbTracking];
 }
 
+- (void)uninstall
+{
+    if (nil != self.tracker) {
+        [self.tracker stop];
+    }
+    if (nil != self.system_events) {
+        [self.system_events stop];
+    }
+}
+
 - (void)enableAutomaticBreadcrumbTracking
 {
-    [[SentryBreadcrumbTracker alloc] start];
-    [[SentrySystemEventsBreadcrumbs alloc] start];
+    self.tracker = [SentryBreadcrumbTracker alloc];
+    [self.tracker start];
+    self.system_events = [SentrySystemEventsBreadcrumbs alloc];
+    [self.system_events start];
 }
 
 @end

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -29,6 +29,11 @@ SentryAutoSessionTrackingIntegration ()
     }
 }
 
+- (void)uninstall
+{
+    [self stop];
+}
+
 - (void)stop
 {
     if (nil != self.tracker) {

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -24,6 +24,14 @@
     [self trackApplicationUIKitNotifications];
 }
 
+- (void)stop
+{
+    // This is a noop because the notifications are registered via blocks and monkey patching
+    // which is both super hard to clean up.
+    // Either way, all these are guarded by checking the client of the current hub, which
+    // we remove when uninstalling the SDK.
+}
+
 - (void)trackApplicationUIKitNotifications
 {
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -27,7 +27,7 @@
 - (void)stop
 {
     // This is a noop because the notifications are registered via blocks and monkey patching
-    // which is both super hard to clean up.
+    // which are both super hard to clean up.
     // Either way, all these are guarded by checking the client of the current hub, which
     // we remove when uninstalling the SDK.
 }

--- a/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
+++ b/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
@@ -36,6 +36,11 @@ SentryOutOfMemoryTrackingIntegration ()
     }
 }
 
+- (void)uninstall
+{
+    [self stop];
+}
+
 - (void)stop
 {
     if (nil != self.tracker) {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -293,6 +293,31 @@ static BOOL crashedLastRunCalled;
     }
 }
 
+/**
+ * Closes the SDK and uninstalls all the integrations.
+ */
++ (void)close
+{
+    // pop the hub and unset
+    SentryHub *hub = SentrySDK.currentHub;
+    [SentrySDK setCurrentHub:nil];
+
+    // uninstall all the integrations
+    for (NSObject<SentryIntegrationProtocol> *integration in hub.installedIntegrations) {
+        if ([integration respondsToSelector:@selector(uninstall)]) {
+            [integration uninstall];
+        }
+    }
+    [hub.installedIntegrations removeAllObjects];
+
+    // close the client
+    SentryClient *client = [hub getClient];
+    client.options.enabled = NO;
+    [hub bindClient:nil];
+
+    [SentryLog logWithMessage:@"SDK closed!" andLevel:kSentryLevelDebug];
+}
+
 #ifndef __clang_analyzer__
 // Code not to be analyzed
 + (void)crash

--- a/Sources/Sentry/SentrySystemEventsBreadcrumbs.m
+++ b/Sources/Sentry/SentrySystemEventsBreadcrumbs.m
@@ -21,6 +21,14 @@
 #endif
 }
 
+- (void)stop
+{
+#if TARGET_OS_IOS
+    NSNotificationCenter *defaultCenter = [NSNotificationCenter defaultCenter];
+    [defaultCenter removeObserver:self];
+#endif
+}
+
 #if TARGET_OS_IOS
 /**
  * Only used for testing, call start() instead.

--- a/Sources/Sentry/include/SentryBreadcrumbTracker.h
+++ b/Sources/Sentry/include/SentryBreadcrumbTracker.h
@@ -4,4 +4,6 @@
 
 - (void)start;
 
+- (void)stop;
+
 @end

--- a/Sources/Sentry/include/SentrySystemEventsBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventsBreadcrumbs.h
@@ -12,4 +12,6 @@
 - (void)start:(UIDevice *)currentDevice;
 #endif
 
+- (void)stop;
+
 @end

--- a/Sources/SentryCrash/Recording/Tools/SentryHook.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryHook.c
@@ -68,11 +68,17 @@ sentrycrash__async_backtrace_capture(void)
     return bt;
 }
 
+static bool hooks_active = true;
+
 static void (*real_dispatch_async)(dispatch_queue_t queue, dispatch_block_t block);
 
 void
 sentrycrash__hook_dispatch_async(dispatch_queue_t queue, dispatch_block_t block)
 {
+    if (!__atomic_load_n(&hooks_active, __ATOMIC_RELAXED)) {
+        return real_dispatch_async(queue, block);
+    }
+
     // create a backtrace, capturing the async callsite
     sentrycrash_async_backtrace_t *bt = sentrycrash__async_backtrace_capture();
 
@@ -96,6 +102,9 @@ void
 sentrycrash__hook_dispatch_async_f(
     dispatch_queue_t queue, void *_Nullable context, dispatch_function_t work)
 {
+    if (!__atomic_load_n(&hooks_active, __ATOMIC_RELAXED)) {
+        return real_dispatch_async_f(queue, context, work);
+    }
     sentrycrash__hook_dispatch_async(queue, ^{ work(context); });
 }
 
@@ -106,6 +115,10 @@ void
 sentrycrash__hook_dispatch_after(
     dispatch_time_t when, dispatch_queue_t queue, dispatch_block_t block)
 {
+    if (!__atomic_load_n(&hooks_active, __ATOMIC_RELAXED)) {
+        return real_dispatch_after(when, queue, block);
+    }
+
     // create a backtrace, capturing the async callsite
     sentrycrash_async_backtrace_t *bt = sentrycrash__async_backtrace_capture();
 
@@ -129,6 +142,9 @@ void
 sentrycrash__hook_dispatch_after_f(
     dispatch_time_t when, dispatch_queue_t queue, void *_Nullable context, dispatch_function_t work)
 {
+    if (!__atomic_load_n(&hooks_active, __ATOMIC_RELAXED)) {
+        return real_dispatch_after_f(when, queue, context, work);
+    }
     sentrycrash__hook_dispatch_after(when, queue, ^{ work(context); });
 }
 
@@ -137,6 +153,10 @@ static void (*real_dispatch_barrier_async)(dispatch_queue_t queue, dispatch_bloc
 void
 sentrycrash__hook_dispatch_barrier_async(dispatch_queue_t queue, dispatch_block_t block)
 {
+    if (!__atomic_load_n(&hooks_active, __ATOMIC_RELAXED)) {
+        return real_dispatch_barrier_async(queue, block);
+    }
+
     // create a backtrace, capturing the async callsite
     sentrycrash_async_backtrace_t *bt = sentrycrash__async_backtrace_capture();
 
@@ -160,6 +180,9 @@ void
 sentrycrash__hook_dispatch_barrier_async_f(
     dispatch_queue_t queue, void *_Nullable context, dispatch_function_t work)
 {
+    if (!__atomic_load_n(&hooks_active, __ATOMIC_RELAXED)) {
+        return real_dispatch_barrier_async_f(queue, context, work);
+    }
     sentrycrash__hook_dispatch_barrier_async(queue, ^{ work(context); });
 }
 
@@ -168,6 +191,8 @@ static bool hooks_installed = false;
 void
 sentrycrash_install_async_hooks(void)
 {
+    __atomic_store_n(&hooks_active, true, __ATOMIC_RELAXED);
+
     if (__atomic_exchange_n(&hooks_installed, true, __ATOMIC_SEQ_CST)) {
         return;
     }
@@ -176,39 +201,19 @@ sentrycrash_install_async_hooks(void)
     }
 
     sentrycrash__hook_rebind_symbols(
-        (struct rebinding[1]) {
+        (struct rebinding[6]) {
             { "dispatch_async", sentrycrash__hook_dispatch_async, (void *)&real_dispatch_async },
-        },
-        1);
-    sentrycrash__hook_rebind_symbols(
-        (struct rebinding[1]) {
             { "dispatch_async_f", sentrycrash__hook_dispatch_async_f,
                 (void *)&real_dispatch_async_f },
-        },
-        1);
-    sentrycrash__hook_rebind_symbols(
-        (struct rebinding[1]) {
             { "dispatch_after", sentrycrash__hook_dispatch_after, (void *)&real_dispatch_after },
-        },
-        1);
-    sentrycrash__hook_rebind_symbols(
-        (struct rebinding[1]) {
             { "dispatch_after_f", sentrycrash__hook_dispatch_after_f,
                 (void *)&real_dispatch_after_f },
-        },
-        1);
-    sentrycrash__hook_rebind_symbols(
-        (struct rebinding[1]) {
             { "dispatch_barrier_async", sentrycrash__hook_dispatch_barrier_async,
                 (void *)&real_dispatch_barrier_async },
-        },
-        1);
-    sentrycrash__hook_rebind_symbols(
-        (struct rebinding[1]) {
             { "dispatch_barrier_async_f", sentrycrash__hook_dispatch_barrier_async_f,
                 (void *)&real_dispatch_barrier_async_f },
         },
-        1);
+        6);
 
     // NOTE: We will *not* hook the following functions:
     //
@@ -224,4 +229,11 @@ sentrycrash_install_async_hooks(void)
     // https://github.com/apple/swift-corelibs-libdispatch/blob/f13ea5dcc055e5d2d7c02e90d8c9907ca9dc72e1/private/workloop_private.h#L321-L326
 }
 
-// TODO: uninstall hooks
+void
+sentrycrash_deactivate_async_hooks()
+{
+    // Instead of reverting the rebinding (which is not really possible), we rather
+    // deactivate the hooks. They still exist, and still get called, but they will just
+    // call through to the real libdispatch functions immediately.
+    __atomic_store_n(&hooks_active, false, __ATOMIC_RELAXED);
+}

--- a/Sources/SentryCrash/Recording/Tools/SentryHook.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryHook.h
@@ -35,4 +35,12 @@ sentrycrash_async_backtrace_t *sentrycrash_get_async_caller_for_thread(SentryCra
  */
 void sentrycrash_install_async_hooks(void);
 
+/**
+ * Deactivates the previously installed hooks.
+ *
+ * It is not really possible to uninstall the previously installed hooks, so we rather just
+ * deactivate them.
+ */
+void sentrycrash_deactivate_async_hooks(void);
+
 #endif /* SENRTY_HOOK_h */


### PR DESCRIPTION
## :scroll: Description

This disables the Client and unsets the Hub.
It also tries to uninstall all the integrations, however some do not support
*really* uninstalling them, so they are being disabled instead.

## :bulb: Motivation and Context

It should be possible to completely disable the SDK in such cases where there is no user consent.

## :green_heart: How did you test it?

Inserted a `[SentrySDK close]` after the init and manually tested that none of the event methods do anything.

**However**, I noticed that a (automatic) Session is still being closed/sent.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
