### PR TITLE
ref: Make description in SpanProtocol nonnull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- ref: Make description in SpanProtocol nonnull #1059
+
 ## 7.0.0-beta.0
 
 - feat: Add close method to SDK #1046

--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -53,7 +53,7 @@ NS_SWIFT_NAME(Span)
  * @return SentrySpan
  */
 - (id<SentrySpan>)startChildWithOperation:(NSString *)operation
-                              description:(nullable NSString *)description
+                              description:(NSString *)description
     NS_SWIFT_NAME(startChild(operation:description:));
 
 /**

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -37,11 +37,16 @@ SentrySpan ()
 
 - (id<SentrySpan>)startChildWithOperation:(NSString *)operation
 {
-    return [self startChildWithOperation:operation description:nil];
+    return [self startChildWithOperationInternal:operation description:nil];
 }
 
-- (id<SentrySpan>)startChildWithOperation:(NSString *)operation
-                              description:(nullable NSString *)description
+- (id<SentrySpan>)startChildWithOperation:(NSString *)operation description:(NSString *)description
+{
+    return [self startChildWithOperationInternal:operation description:description];
+}
+
+- (id<SentrySpan>)startChildWithOperationInternal:(NSString *)operation
+                                      description:(nullable NSString *)description
 {
     return [self.tracer startChildWithParentId:[self.context spanId]
                                      operation:operation

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -67,18 +67,6 @@ SENTRY_NO_INIT
     NS_SWIFT_NAME(startChild(operation:));
 
 /**
- * Starts a child span.
- *
- * @param operation Defines the child span operation.
- * @param description Define the child span description.
- *
- * @return SentrySpan
- */
-- (id<SentrySpan>)startChildWithOperation:(NSString *)operation
-                              description:(nullable NSString *)description
-    NS_SWIFT_NAME(startChild(operation:description:));
-
-/**
  * Sets an extra.
  */
 - (void)setDataValue:(nullable id)value forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));


### PR DESCRIPTION
## :scroll: Description

SentrySpanProtocol.startChildWithOperation has an overload without a
description if you don't want to specify a description. We don't need
the description to be nullable.

## :bulb: Motivation and Context

Improves the API.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
