### PR TITLE
ref: Make calls to customSamplingContext nonnull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+ref: Make calls to customSamplingContext nonnull #1061
+
 ## 7.0.0-beta.0
 
 - feat: Add close method to SDK #1046

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -116,8 +116,7 @@ SENTRY_NO_INIT
  */
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
     NS_SWIFT_NAME(startTransaction(transactionContext:bindToScope:customSamplingContext:));
 
 /**
@@ -129,8 +128,7 @@ SENTRY_NO_INIT
  * @return The created transaction.
  */
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
     NS_SWIFT_NAME(startTransaction(transactionContext:customSamplingContext:));
 
 /**

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -131,8 +131,7 @@ SENTRY_NO_INIT
  */
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
     NS_SWIFT_NAME(startTransaction(transactionContext:bindToScope:customSamplingContext:));
 
 /**
@@ -144,8 +143,7 @@ SENTRY_NO_INIT
  * @return The created transaction.
  */
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
     NS_SWIFT_NAME(startTransaction(transactionContext:customSamplingContext:));
 
 /**

--- a/Sources/Sentry/Public/SentrySamplingContext.h
+++ b/Sources/Sentry/Public/SentrySamplingContext.h
@@ -21,11 +21,17 @@ NS_SWIFT_NAME(SamplingContext)
  * Init a SentryTransactionSamplingContext.
  *
  * @param transactionContext The context of the transaction being sampled.
+ */
+- (instancetype)initWithTransactionContext:(SentryTransactionContext *)transactionContext;
+
+/**
+ * Init a SentryTransactionSamplingContext.
+ *
+ * @param transactionContext The context of the transaction being sampled.
  * @param customSamplingContext Custom data used for sampling.
  */
 - (instancetype)initWithTransactionContext:(SentryTransactionContext *)transactionContext
-                     customSamplingContext:
-                         (nullable NSDictionary<NSString *, id> *)customSamplingContext;
+                     customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext;
 
 @end
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -256,7 +256,7 @@ SentryHub ()
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
 {
-    return [self startTransactionWithContext:transactionContext customSamplingContext:nil];
+    return [self startTransactionWithContext:transactionContext customSamplingContext:@{}];
 }
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
@@ -264,12 +264,11 @@ SentryHub ()
 {
     return [self startTransactionWithContext:transactionContext
                                  bindToScope:bindToScope
-                       customSamplingContext:nil];
+                       customSamplingContext:@{}];
 }
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
     return [self startTransactionWithContext:transactionContext
                                  bindToScope:false
@@ -278,8 +277,7 @@ SentryHub ()
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
     SentrySamplingContext *samplingContext =
         [[SentrySamplingContext alloc] initWithTransactionContext:transactionContext

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -137,8 +137,7 @@ static BOOL crashedLastRunCalled;
 
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
     return [SentrySDK.currentHub startTransactionWithContext:transactionContext
                                                  bindToScope:bindToScope
@@ -146,8 +145,7 @@ static BOOL crashedLastRunCalled;
 }
 
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
-                        customSamplingContext:
-                            (nullable NSDictionary<NSString *, id> *)customSamplingContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
     return [SentrySDK.currentHub startTransactionWithContext:transactionContext
                                        customSamplingContext:customSamplingContext];

--- a/Sources/Sentry/SentrySamplingContext.m
+++ b/Sources/Sentry/SentrySamplingContext.m
@@ -3,13 +3,18 @@
 @implementation SentrySamplingContext
 
 - (instancetype)initWithTransactionContext:(SentryTransactionContext *)transactionContext
-                     customSamplingContext:
-                         (nullable NSDictionary<NSString *, id> *)customSamplingContext
 {
     if (self = [super init]) {
         _transactionContext = transactionContext;
-        _customSamplingContext = customSamplingContext;
     }
+    return self;
+}
+
+- (instancetype)initWithTransactionContext:(SentryTransactionContext *)transactionContext
+                     customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
+{
+    self = [self initWithTransactionContext:transactionContext];
+    _customSamplingContext = customSamplingContext;
     return self;
 }
 


### PR DESCRIPTION
Make method overloads with customSamplingContext nonnullable for the sake
of null safety and API consistency.

## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
