### PR TITLE
ref: Discard unfinished spans when capturing transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unreleased
+
+- ref: Discard unfinished spans when capturing transaction
+
 ## 7.0.0-beta.0
 
 - feat: Add close method to SDK #1046

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## unreleased
 
-- ref: Discard unfinished spans when capturing transaction #1066
-- ref: Make calls to customSamplingContext nonnull #1061
+- ref: Discard unfinished spans when capturing transaction (#1066)
+- ref: Make calls to customSamplingContext nonnull (#1061)
 
 ## 7.0.0-beta.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- ref: Discard unfinished spans when capturing transaction
+- ref: Discard unfinished spans when capturing transaction #1066
 
 ## 7.0.0-beta.0
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -109,7 +109,8 @@
 {
     NSArray *spans;
     @synchronized(_spans) {
-        //Make a new array with all finished child spans because if any of the transactions children is not finished the transaction is ignored by Sentry. 
+        // Make a new array with all finished child spans because if any of the transactions
+        // children is not finished the transaction is ignored by Sentry.
         spans = [_spans
             filteredArrayUsingPredicate:[NSPredicate
                                             predicateWithBlock:^BOOL(id<SentrySpan> _Nullable span,

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -109,6 +109,7 @@
 {
     NSArray *spans;
     @synchronized(_spans) {
+        //Make a new array with all finished child spans because if any of the transactions children is not finished the transaction is ignored by Sentry. 
         spans = [_spans
             filteredArrayUsingPredicate:[NSPredicate
                                             predicateWithBlock:^BOOL(id<SentrySpan> _Nullable span,

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -109,11 +109,14 @@
 {
     NSArray *spans;
     @synchronized(_spans) {
-        spans = [_spans filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id<SentrySpan>  _Nullable span, NSDictionary<NSString *,id> * _Nullable bindings) {
-            return span.isFinished;
-        }]];
+        spans = [_spans
+            filteredArrayUsingPredicate:[NSPredicate
+                                            predicateWithBlock:^BOOL(id<SentrySpan> _Nullable span,
+                                                NSDictionary<NSString *, id> *_Nullable bindings) {
+                                                return span.isFinished;
+                                            }]];
     }
-       
+
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
     transaction.transaction = self.name;
     [_hub captureEvent:transaction withScope:_hub.scope];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -109,9 +109,11 @@
 {
     NSArray *spans;
     @synchronized(_spans) {
-        spans = [_spans copy];
+        spans = [_spans filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(id<SentrySpan>  _Nullable span, NSDictionary<NSString *,id> * _Nullable bindings) {
+            return span.isFinished;
+        }]];
     }
-
+       
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
     transaction.transaction = self.name;
     [_hub captureEvent:transaction withScope:_hub.scope];

--- a/Tests/SentryTests/SentrySpanTests.swift
+++ b/Tests/SentryTests/SentrySpanTests.swift
@@ -87,7 +87,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(serializedChild["parent_span_id"] as? String, span.context.spanId.sentrySpanIdString)
     }
     
-    func testFinishWithUnfinishedChild() {
+    func testFinishWithUnfinishedSpanDropsSpan() {
         let client = TestClient(options: fixture.options)!
         let span = fixture.getSut(client: client)
         span.startChild(operation: fixture.someOperation)

--- a/Tests/SentryTests/SentrySpanTests.swift
+++ b/Tests/SentryTests/SentrySpanTests.swift
@@ -74,7 +74,9 @@ class SentrySpanTests: XCTestCase {
         let span = fixture.getSut(client: client)
         let childSpan = span.startChild(operation: fixture.someOperation)
         
+        childSpan.finish()
         span.finish()
+        
         let lastEvent = client.captureEventWithScopeArguments[0].event
         let serializedData = lastEvent.serialize()
         
@@ -83,6 +85,20 @@ class SentrySpanTests: XCTestCase {
         
         XCTAssertEqual(serializedChild["span_id"] as? String, childSpan.context.spanId.sentrySpanIdString)
         XCTAssertEqual(serializedChild["parent_span_id"] as? String, span.context.spanId.sentrySpanIdString)
+    }
+    
+    func testFinishWithUnfinishedChild() {
+        let client = TestClient(options: fixture.options)!
+        let span = fixture.getSut(client: client)
+        span.startChild(operation: fixture.someOperation)
+        
+        span.finish()
+        let lastEvent = client.captureEventWithScopeArguments[0].event
+        let serializedData = lastEvent.serialize()
+        
+        let spans = serializedData["spans"] as! [Any]
+        
+        XCTAssertEqual(spans.count, 0)
     }
     
     func testStartChildWithNameOperation() {


### PR DESCRIPTION
## :scroll: Description

Removeing the unfinished child spans from a transaction when capturing the transaction.

## :bulb: Motivation and Context

Issue #1057 

## :green_heart: How did you test it?

Unit Test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes
