### PR TITLE
docs: Add code docs for Random.nextNumber

### DIFF
--- a/Sources/Sentry/include/Random.h
+++ b/Sources/Sentry/include/Random.h
@@ -4,6 +4,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol Random
 
+/**
+ * Returns a random number uniformly distributed over the interval [0.0 , 1.0].
+ */
 - (double)nextNumber;
 
 @end


### PR DESCRIPTION
## :scroll: Description

Add a comment that `[Random nextNumber]` returns a number between 0.0 and 1.0. Currently, you have to check the implementation to find out.

## :bulb: Motivation and Context

`[Random nextNumber]` doesn't by its name what it is doing. You have to look into the implementation to find out.

