### PR TITLE
fix: SentryOptions.tracesSampleRate default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- fix: SentryOptions.tracesSampleRate default value (#1069)
 ref: Make calls to customSamplingContext nonnull #1061
 
 ## 7.0.0-beta.0

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -32,7 +32,7 @@
         self.attachStacktrace = YES;
         self.maxAttachmentSize = 20 * 1024 * 1024;
         self.sendDefaultPii = NO;
-        self.tracesSampleRate = 0;
+        self.tracesSampleRate = @0;
 
         // Use the name of the bundle’s executable file as inAppInclude, so SentryFrameInAppLogic
         // marks frames coming from there as inApp. With this approach, the SDK marks public

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -486,7 +486,30 @@
 {
     SentryOptions *options = [self getValidOptions:@{}];
 
+    XCTAssertNotNil(options.tracesSampleRate);
     XCTAssertEqual(options.tracesSampleRate.doubleValue, 0);
+}
+
+- (void)testTracesSampleRateLowerBound
+{
+    NSNumber *sampleRateLowerBound = @0;
+    SentryOptions *options = [self getValidOptions:@{ @"tracesSampleRate" : sampleRateLowerBound }];
+    XCTAssertEqual(sampleRateLowerBound, options.tracesSampleRate);
+
+    NSNumber *sampleRateTooLow = @-0.01;
+    options = [self getValidOptions:@{ @"tracesSampleRate" : sampleRateTooLow }];
+    XCTAssertEqual(@0, options.tracesSampleRate);
+}
+
+- (void)testTracesSampleRateUpperBound
+{
+    NSNumber *sampleRateUpperBound = @1;
+    SentryOptions *options = [self getValidOptions:@{ @"tracesSampleRate" : sampleRateUpperBound }];
+    XCTAssertEqual(sampleRateUpperBound, options.tracesSampleRate);
+
+    NSNumber *sampleRateTooHigh = @1.01;
+    options = [self getValidOptions:@{ @"tracesSampleRate" : sampleRateTooHigh }];
+    XCTAssertEqual(@0, options.tracesSampleRate);
 }
 
 - (double)tracesSamplerCallback:(NSDictionary *)context


### PR DESCRIPTION


## :scroll: Description

The default value of tracesSampleRate was 0 instead of @0.

## :bulb: Motivation and Context

See description.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
