### PR TITLE
ref: Rename Random to SentryRandom

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -423,8 +423,8 @@
 		861265FA2404EC1500C4AFDE /* NSArray+SentrySanitize.m in Sources */ = {isa = PBXBuildFile; fileRef = 861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */; };
 		8E133FA225E72DEF00ABD0BF /* SentrySamplingContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E133FA025E72DEF00ABD0BF /* SentrySamplingContext.m */; };
 		8E133FA625E72EB400ABD0BF /* SentrySamplingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E133FA525E72EB400ABD0BF /* SentrySamplingContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8E25C95325F836D000DC215B /* Random.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E25C95125F836D000DC215B /* Random.m */; };
-		8E25C95725F836EE00DC215B /* Random.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E25C95625F836EE00DC215B /* Random.h */; };
+		8E25C95325F836D000DC215B /* SentryRandom.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E25C95125F836D000DC215B /* SentryRandom.m */; };
+		8E25C95725F836EE00DC215B /* SentryRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E25C95625F836EE00DC215B /* SentryRandom.h */; };
 		8E25C97525F8511A00DC215B /* TestRandom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E25C97425F8511A00DC215B /* TestRandom.swift */; };
 		8E4A037825F6F52100000D77 /* SentrySampleDecision.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E4A037725F6F52100000D77 /* SentrySampleDecision.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8E4A037E25F76A1D00000D77 /* Dynamic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4A037D25F76A1D00000D77 /* Dynamic.swift */; };
@@ -929,8 +929,8 @@
 		861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SentrySanitize.m"; sourceTree = "<group>"; };
 		8E133FA025E72DEF00ABD0BF /* SentrySamplingContext.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySamplingContext.m; sourceTree = "<group>"; };
 		8E133FA525E72EB400ABD0BF /* SentrySamplingContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentrySamplingContext.h; path = Public/SentrySamplingContext.h; sourceTree = "<group>"; };
-		8E25C95125F836D000DC215B /* Random.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = Random.m; sourceTree = "<group>"; };
-		8E25C95625F836EE00DC215B /* Random.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Random.h; path = include/Random.h; sourceTree = "<group>"; };
+		8E25C95125F836D000DC215B /* SentryRandom.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryRandom.m; sourceTree = "<group>"; };
+		8E25C95625F836EE00DC215B /* SentryRandom.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryRandom.h; path = include/SentryRandom.h; sourceTree = "<group>"; };
 		8E25C97425F8511A00DC215B /* TestRandom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestRandom.swift; sourceTree = "<group>"; };
 		8E4A037725F6F52100000D77 /* SentrySampleDecision.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySampleDecision.h; path = Public/SentrySampleDecision.h; sourceTree = "<group>"; };
 		8E4A037D25F76A1D00000D77 /* Dynamic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Dynamic.swift; sourceTree = "<group>"; };
@@ -1769,8 +1769,8 @@
 		8E25C94F25F836AB00DC215B /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				8E25C95625F836EE00DC215B /* Random.h */,
-				8E25C95125F836D000DC215B /* Random.m */,
+				8E25C95625F836EE00DC215B /* SentryRandom.h */,
+				8E25C95125F836D000DC215B /* SentryRandom.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -1960,7 +1960,7 @@
 				7BA61CAB247BA98100C130A8 /* SentryDebugMetaBuilder.h in Headers */,
 				638DC9A01EBC6B6400A66E41 /* SentryRequestOperation.h in Headers */,
 				6344DDB01EC308E400D9160D /* SentryCrashInstallationReporter.h in Headers */,
-				8E25C95725F836EE00DC215B /* Random.h in Headers */,
+				8E25C95725F836EE00DC215B /* SentryRandom.h in Headers */,
 				63FE70ED20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h in Headers */,
 				7BA61CB4247BC3EB00C130A8 /* SentryCrashBinaryImageProvider.h in Headers */,
 				63FE713D20DA4C1100CDBAE8 /* SentryCrashLogger.h in Headers */,
@@ -2208,7 +2208,7 @@
 				7BA61CBB247BC5D800C130A8 /* SentryCrashDefaultBinaryImageProvider.m in Sources */,
 				63FE70E320DA4C1000CDBAE8 /* SentryCrashMonitor_Zombie.c in Sources */,
 				63FE713120DA4C1100CDBAE8 /* SentryCrashDynamicLinker.c in Sources */,
-				8E25C95325F836D000DC215B /* Random.m in Sources */,
+				8E25C95325F836D000DC215B /* SentryRandom.m in Sources */,
 				7BC85231245812EC005A70F0 /* SentryFileContents.m in Sources */,
 				7B98D7CF25FB650F00C5A389 /* SentryOutOfMemoryTrackingIntegration.m in Sources */,
 				7B4E23C2251A2C2B00060D68 /* SentrySessionCrashedHandler.m in Sources */,

--- a/Sources/Sentry/SentryRandom.m
+++ b/Sources/Sentry/SentryRandom.m
@@ -1,6 +1,6 @@
-#import "Random.h"
+#import "SentryRandom.h"
 
-@implementation Random
+@implementation SentryRandom
 
 - (instancetype)init
 {

--- a/Sources/Sentry/TracesSampler.m
+++ b/Sources/Sentry/TracesSampler.m
@@ -7,7 +7,7 @@
     SentryOptions *_options;
 }
 
-- (instancetype)initWithOptions:(SentryOptions *)options random:(id<Random>)random
+- (instancetype)initWithOptions:(SentryOptions *)options random:(id<SentryRandom>)random
 {
     if (self = [super init]) {
         _options = options;
@@ -18,7 +18,7 @@
 
 - (instancetype)initWithOptions:(SentryOptions *)options
 {
-    return [self initWithOptions:options random:[[Random alloc] init]];
+    return [self initWithOptions:options random:[[SentryRandom alloc] init]];
 }
 
 - (SentrySampleDecision)sample:(SentrySamplingContext *)context

--- a/Sources/Sentry/include/SentryRandom.h
+++ b/Sources/Sentry/include/SentryRandom.h
@@ -2,7 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol Random
+@protocol SentryRandom
 
 /**
  * Returns a random number uniformly distributed over the interval [0.0 , 1.0].
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface Random : NSObject <Random>
+@interface SentryRandom : NSObject <SentryRandom>
 
 - (double)nextNumber;
 

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -81,7 +81,8 @@ SENTRY_NO_INIT
 /**
  * Sets an extra.
  */
-- (void)setDataValue:(nullable id)value forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
+- (void)setDataValue:(nullable id)value
+              forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
 
 /**
  * Finishes the span by setting the end time.

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -81,8 +81,7 @@ SENTRY_NO_INIT
 /**
  * Sets an extra.
  */
-- (void)setDataValue:(nullable id)value
-              forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
+- (void)setDataValue:(nullable id)value forKey:(NSString *)key NS_SWIFT_NAME(setExtra(value:key:));
 
 /**
  * Finishes the span by setting the end time.

--- a/Sources/Sentry/include/TracesSampler.h
+++ b/Sources/Sentry/include/TracesSampler.h
@@ -1,4 +1,4 @@
-#import "Random.h"
+#import "SentryRandom.h"
 #import "SentrySampleDecision.h"
 #import <Foundation/Foundation.h>
 
@@ -11,14 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  A random number generator
  */
-@property (nonatomic, strong) id<Random> random;
+@property (nonatomic, strong) id<SentryRandom> random;
 
 /**
  * Init a TracesSampler with given options and random generator.
  * @param options Sentry options with sampling configuration
  * @param random A random number generator
  */
-- (instancetype)initWithOptions:(SentryOptions *)options random:(id<Random>)random;
+- (instancetype)initWithOptions:(SentryOptions *)options random:(id<SentryRandom>)random;
 
 /**
  * Init a TracesSampler with given options and a default Random generator.

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -4,7 +4,6 @@
 //
 #import "NSData+SentryCompression.h"
 #import "NSDate+SentryExtras.h"
-#import "Random.h"
 #import "SentryAppState.h"
 #import "SentryAttachment.h"
 #import "SentryAutoSessionTrackingIntegration.h"
@@ -59,6 +58,7 @@
 #import "SentryNSURLRequest.h"
 #import "SentryOutOfMemoryLogic.h"
 #import "SentryOutOfMemoryTracker.h"
+#import "SentryRandom.h"
 #import "SentryRateLimitCategory.h"
 #import "SentryRateLimitCategoryMapper.h"
 #import "SentryRateLimitParser.h"

--- a/Tests/SentryTests/TestUtils/TestRandom.swift
+++ b/Tests/SentryTests/TestUtils/TestRandom.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class TestRandom: RandomProtocol {
+class TestRandom: SentryRandomProtocol {
 
     var value: Double
     


### PR DESCRIPTION




## :scroll: Description

Prefix Random with Sentry to avoid namespace clashes.

## :bulb: Motivation and Context

When bumping sentry-cocoa to 7.0.0-beta.0 in sentry-react-native the CI fails https://github.com/getsentry/sentry-react-native/pull/1459/checks?check_run_id=2408810984.

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
