### PR TITLE
ci builds release mode

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -39,7 +39,7 @@ jobs:
           xcodebuild 
           -workspace Sentry.xcworkspace 
           -scheme Sentry 
-          -configuration Debug 
+          -configuration Release 
           GCC_GENERATE_TEST_COVERAGE_FILES=YES 
           -destination "${{matrix.destination}}" 
           test | xcpretty -t && exit ${PIPESTATUS[0]}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - ref: Discard unfinished spans when capturing transaction (#1066)
 - ref: Make calls to customSamplingContext nonnull (#1061)
 - fix: fix: performance headers (#1079)
+- fix: Release builds in CI (#1076)
 
 ## 7.0.0-beta.0
 

--- a/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
+++ b/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
@@ -14,13 +14,16 @@
     XCTAssertEqual([@"99" unsignedLongLongValue], 99);
     XCTAssertEqual([@"999" unsignedLongLongValue], 999);
 
-    NSString *longLongMaxValue = [NSString stringWithFormat:@"%llu", (unsigned long long)0x7FFFFFFFFFFFFFFF];
+    NSString *longLongMaxValue =
+        [NSString stringWithFormat:@"%llu", (unsigned long long)0x7FFFFFFFFFFFFFFF];
     XCTAssertEqual([longLongMaxValue unsignedLongLongValue], 9223372036854775807);
 
-    NSString *negativelongLongMaxValue = [NSString stringWithFormat:@"%llu", (unsigned long long)-0x8000000000000000];
+    NSString *negativelongLongMaxValue =
+        [NSString stringWithFormat:@"%llu", (unsigned long long)-0x8000000000000000];
     XCTAssertEqual([negativelongLongMaxValue unsignedLongLongValue], 0x8000000000000000);
 
-    NSString *unsignedLongLongMaxValue = [NSString stringWithFormat:@"%llu", (unsigned long long)0xFFFFFFFFFFFFFFFF];
+    NSString *unsignedLongLongMaxValue =
+        [NSString stringWithFormat:@"%llu", (unsigned long long)0xFFFFFFFFFFFFFFFF];
     XCTAssertEqual([unsignedLongLongMaxValue unsignedLongLongValue], 0xFFFFFFFFFFFFFFFF);
 }
 

--- a/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
+++ b/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
@@ -14,13 +14,13 @@
     XCTAssertEqual([@"99" unsignedLongLongValue], 99);
     XCTAssertEqual([@"999" unsignedLongLongValue], 999);
 
-    NSString *longLongMaxValue = [NSString stringWithFormat:@"%ld", 0x7FFFFFFFFFFFFFFF];
+    NSString *longLongMaxValue = [NSString stringWithFormat:@"%llu", (unsigned long long)0x7FFFFFFFFFFFFFFF];
     XCTAssertEqual([longLongMaxValue unsignedLongLongValue], 9223372036854775807);
 
-    NSString *negativelongLongMaxValue = [NSString stringWithFormat:@"%ld", -0x8000000000000000];
+    NSString *negativelongLongMaxValue = [NSString stringWithFormat:@"%llu", (unsigned long long)-0x8000000000000000];
     XCTAssertEqual([negativelongLongMaxValue unsignedLongLongValue], 0x8000000000000000);
 
-    NSString *unsignedLongLongMaxValue = [NSString stringWithFormat:@"%ld", 0xFFFFFFFFFFFFFFFF];
+    NSString *unsignedLongLongMaxValue = [NSString stringWithFormat:@"%llu", (unsigned long long)0xFFFFFFFFFFFFFFFF];
     XCTAssertEqual([unsignedLongLongMaxValue unsignedLongLongValue], 0xFFFFFFFFFFFFFFFF);
 }
 


### PR DESCRIPTION
Does this mean we've been shipping Debug builds?

Building in Release was failing to compile due to:

```
❌  /Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m:17:69: format specifies type 'long' but the argument has type 'long long' [-Werror,-Wformat]

    NSString *longLongMaxValue = [NSString stringWithFormat:@"%ld", 0x7FFFFFFFFFFFFFFF];
                                                              ~~~   ^~~~~~~~~~~~~~~~~~


❌  /Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m:20:77: format specifies type 'long' but the argument has type 'unsigned long long' [-Werror,-Wformat]

    NSString *negativelongLongMaxValue = [NSString stringWithFormat:@"%ld", -0x8000000000000000];
                                                                      ~~~   ^~~~~~~~~~~~~~~~~~~


❌  /Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m:23:77: format specifies type 'long' but the argument has type 'unsigned long long' [-Werror,-Wformat]

    NSString *unsignedLongLongMaxValue = [NSString stringWithFormat:@"%ld", 0xFFFFFFFFFFFFFFFF];
                                                                      ~~~   ^~~~~~~~~~~~~~~~~~

Testing failed:
	Format specifies type 'long' but the argument has type 'long long'
	Format specifies type 'long' but the argument has type 'unsigned long long'
	Format specifies type 'long' but the argument has type 'unsigned long long'
	Testing cancelled because the build failed.
```

The method being tested takes `unsigned long long`, but the test code passes some constant values that are inferred to be as it says above. Changing the test code to format it with `%llu` alone didn't do the job as it fails with a different error.

Ultimately I don't see the goal of the test to pass a negative value to an `unsigned long long` so casting to the expected type made sense to me and validates the code works as expected.

My goal in this PR is to compile the project in Release mode. Which is what customers will be doing when building from source, and what one expects when using Sentry through the framework.

Probably worth a changelog entry so discarded the skip changelog comment