### PR TITLE
fix: long string format test

### DIFF
--- a/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
+++ b/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
@@ -14,13 +14,13 @@
     XCTAssertEqual([@"99" unsignedLongLongValue], 99);
     XCTAssertEqual([@"999" unsignedLongLongValue], 999);
 
-    NSString *longLongMaxValue = [NSString stringWithFormat:@"%lu", 0x7FFFFFFFFFFFFFFF];
+    NSString *longLongMaxValue = [NSString stringWithFormat:@"%ld", 0x7FFFFFFFFFFFFFFF];
     XCTAssertEqual([longLongMaxValue unsignedLongLongValue], 9223372036854775807);
 
-    NSString *negativelongLongMaxValue = [NSString stringWithFormat:@"%lu", -0x8000000000000000];
+    NSString *negativelongLongMaxValue = [NSString stringWithFormat:@"%ld", -0x8000000000000000];
     XCTAssertEqual([negativelongLongMaxValue unsignedLongLongValue], 0x8000000000000000);
 
-    NSString *unsignedLongLongMaxValue = [NSString stringWithFormat:@"%lu", 0xFFFFFFFFFFFFFFFF];
+    NSString *unsignedLongLongMaxValue = [NSString stringWithFormat:@"%ld", 0xFFFFFFFFFFFFFFFF];
     XCTAssertEqual([unsignedLongLongMaxValue unsignedLongLongValue], 0xFFFFFFFFFFFFFFFF);
 }
 


### PR DESCRIPTION
Trying to address the breakage when building in Release mode:

https://github.com/getsentry/sentry-cocoa/pull/1076/checks?check_run_id=2415603793

#skip-changelog