### PR TITLE
fix: Access async stacktrace safely

### DIFF
--- a/Sources/Sentry/SentryStacktraceBuilder.m
+++ b/Sources/Sentry/SentryStacktraceBuilder.m
@@ -48,6 +48,7 @@ SentryStacktraceBuilder ()
             [frames addObject:frame];
         }
     }
+    sentrycrash_async_backtrace_decref(stackCursor.async_caller);
 
     NSArray<SentryFrame *> *framesCleared = [SentryFrameRemover removeNonSdkFrames:frames];
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -80,6 +80,7 @@ void
 __cxa_throw(void *thrown_exception, std::type_info *tinfo, void (*dest)(void *))
 {
     if (g_captureNextStackTrace) {
+        sentrycrash_async_backtrace_decref(g_stackCursor.async_caller);
         sentrycrashsc_initSelfThread(&g_stackCursor, 1);
     }
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Deadlock.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Deadlock.m
@@ -123,6 +123,7 @@ static NSTimeInterval g_watchdogInterval = 0;
 
     sentrycrashcm_handleException(crashContext);
     sentrycrashmc_resumeEnvironment();
+    sentrycrash_async_backtrace_decref(stackCursor.async_caller);
 
     SentryCrashLOG_DEBUG(@"Calling abort()");
     abort();

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -340,6 +340,7 @@ handleExceptions(void *const userData)
         SentryCrashLOG_DEBUG("Crash handling complete. Restoring original handlers.");
         g_isHandlingCrash = false;
         sentrycrashmc_resumeEnvironment();
+        sentrycrash_async_backtrace_decref(g_stackCursor.async_caller);
     }
 
     SentryCrashLOG_DEBUG("Replying to mach exception message.");

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -106,6 +106,7 @@ handleException(NSException *exception, BOOL currentSnapshotUserReported)
             SentryCrashLOG_DEBUG(@"Calling original exception handler.");
             g_previousUncaughtExceptionHandler(exception);
         }
+        sentrycrash_async_backtrace_decref(cursor.async_caller);
     }
 }
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -105,6 +105,7 @@ handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
 
         sentrycrashcm_handleException(crashContext);
         sentrycrashmc_resumeEnvironment();
+        sentrycrash_async_backtrace_decref(g_stackCursor.async_caller);
     }
 
     SentryCrashLOG_DEBUG("Re-raising signal for regular handlers to catch.");

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
@@ -75,6 +75,7 @@ sentrycrashcm_reportUserException(const char *name, const char *reason, const ch
         context.stackCursor = &stackCursor;
 
         sentrycrashcm_handleException(&context);
+        sentrycrash_async_backtrace_decref(stackCursor.async_caller);
 
         if (logAllThreads) {
             sentrycrashmc_resumeEnvironment();

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1097,6 +1097,8 @@ writeThread(const SentryCrashReportWriter *const writer, const char *const key,
         "Writing thread %x (index %d). is crashed: %d", thread, threadIndex, isCrashedThread);
 
     SentryCrashStackCursor stackCursor;
+    stackCursor.async_caller = NULL;
+    
     bool hasBacktrace = getStackCursor(crash, machineContext, &stackCursor);
 
     writer->beginObject(writer, key);
@@ -1128,6 +1130,8 @@ writeThread(const SentryCrashReportWriter *const writer, const char *const key,
         }
     }
     writer->endContainer(writer);
+
+    sentrycrash_async_backtrace_decref(stackCursor.async_caller);
 }
 
 /** Write information about all threads to the report.

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1098,7 +1098,7 @@ writeThread(const SentryCrashReportWriter *const writer, const char *const key,
 
     SentryCrashStackCursor stackCursor;
     stackCursor.async_caller = NULL;
-    
+
     bool hasBacktrace = getStackCursor(crash, machineContext, &stackCursor);
 
     writer->beginObject(writer, key);

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -55,7 +55,9 @@ isStackOverflow(const SentryCrashMachineContext *const context)
     sentrycrashsc_initWithMachineContext(
         &stackCursor, SentryCrashSC_STACK_OVERFLOW_THRESHOLD, context);
     while (stackCursor.advanceCursor(&stackCursor)) { }
-    return stackCursor.state.hasGivenUp;
+    bool rv = stackCursor.state.hasGivenUp;
+    sentrycrash_async_backtrace_decref(stackCursor.async_caller);
+    return rv;
 }
 
 static inline bool

--- a/Sources/SentryCrash/Recording/Tools/SentryHook.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryHook.h
@@ -20,13 +20,13 @@ struct sentrycrash_async_backtrace_s {
 
 /**
  * Returns the async caller of the current calling context, if any.
- * The async stacktrace returned has an owned reference, so it needs to be freed using `sentrycrash_async_backtrace_decref`.
+ * The async stacktrace returned has an owned reference, so it needs to be freed using
+ * `sentrycrash_async_backtrace_decref`.
  */
 sentrycrash_async_backtrace_t *sentrycrash_get_async_caller_for_thread(SentryCrashThread);
 
 /** Decrements the refcount on the given `bt`. */
-void
-sentrycrash_async_backtrace_decref(sentrycrash_async_backtrace_t *bt);
+void sentrycrash_async_backtrace_decref(sentrycrash_async_backtrace_t *bt);
 
 /**
  * Installs the various async hooks that sentry offers.

--- a/Sources/SentryCrash/Recording/Tools/SentryHook.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryHook.h
@@ -20,8 +20,13 @@ struct sentrycrash_async_backtrace_s {
 
 /**
  * Returns the async caller of the current calling context, if any.
+ * The async stacktrace returned has an owned reference, so it needs to be freed using `sentrycrash_async_backtrace_decref`.
  */
 sentrycrash_async_backtrace_t *sentrycrash_get_async_caller_for_thread(SentryCrashThread);
+
+/** Decrements the refcount on the given `bt`. */
+void
+sentrycrash_async_backtrace_decref(sentrycrash_async_backtrace_t *bt);
 
 /**
  * Installs the various async hooks that sentry offers.


### PR DESCRIPTION
The access to cross-thread thread locals was made extra safe.
Also async stacktraces that are being used by SentryCrash are properly refcounted.

#skip-changelog

## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the CHANGELOG if needed
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
