### PR TITLE
ref: Disable Async Stacktraces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- ref: Disable Async Stacktraces (#1087)
+
 ## 7.0.0-beta.1
 
 ### Features and Fixes

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -74,7 +74,8 @@ SentryCrashIntegration ()
                                                  outOfMemoryLogic:logic];
 
     [self startCrashHandler];
-    sentrycrash_install_async_hooks();
+    // TODO: enable with feature flag from SentryOptions because this is still experimental
+    //    sentrycrash_install_async_hooks();
     [self configureScope];
 }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryHook.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryHook.c
@@ -25,11 +25,14 @@ static pthread_key_t async_caller_key = 0;
 sentrycrash_async_backtrace_t *
 sentrycrash_get_async_caller_for_thread(SentryCrashThread thread)
 {
-    const pthread_t pthread = pthread_from_mach_thread_np((thread_t)thread);
-    void **tsd_slots = (void *)((uint8_t *)pthread + TSD_OFFSET);
+    return NULL;
 
-    return (sentrycrash_async_backtrace_t *)__atomic_load_n(
-        &tsd_slots[async_caller_key], __ATOMIC_SEQ_CST);
+    // TODO: Disabled because still experimental.
+    //    const pthread_t pthread = pthread_from_mach_thread_np((thread_t)thread);
+    //    void **tsd_slots = (void *)((uint8_t *)pthread + TSD_OFFSET);
+    //
+    //    return (sentrycrash_async_backtrace_t *)__atomic_load_n(
+    //        &tsd_slots[async_caller_key], __ATOMIC_SEQ_CST);
 }
 
 void


### PR DESCRIPTION


## :scroll: Description

Due to some problems with arm64 devices, we disable this feature until we find out how to fix them.
We don't want this feature to block 7.0.0 GA. The plan is to add a flag to SentryOptions for enabling
and disabling this feature in the future, see #1086.

## :bulb: Motivation and Context

See description.

## :green_heart: How did you test it?
Unit tests and on a real device.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
