### PR TITLE
tests: Fix build error for Xcode 14.5

### DIFF
--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -30,7 +30,6 @@
     debugMeta2.name = @"name";
     NSDictionary *serialized2 = @{
         @"image_addr" : @"0x0000000100034000",
-        @"image_addr" : @"0x02",
         @"image_size" : @(4),
         @"type" : @"1",
         @"name" : @"name",


### PR DESCRIPTION


## :scroll: Description

SentryInterfacesTests contained a duplicate key in a dictionary	literal. This is fixed now.

#skip-changelog

## :bulb: Motivation and Context

Building tests with Xcode 14.5 results in a build error.

## :green_heart: How did you test it?
Building it locally.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
