### PR TITLE
ref: Log warning for serializing SentrySession

### DIFF
--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -2,6 +2,7 @@
 #import "NSDate+SentryExtras.h"
 #import "SentryCurrentDate.h"
 #import "SentryInstallation.h"
+#import "SentryLog.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -203,7 +204,9 @@ NS_ASSUME_NONNULL_BEGIN
             statusString = @"abnormal";
             break;
         default:
-            // TODO: Log warning
+            [SentryLog
+                logWithMessage:@"Missing string for SessionStatus when serializing SentrySession."
+                      andLevel:kSentryLevelWarning];
             break;
         }
 


### PR DESCRIPTION


## :scroll: Description

Log a warning when serializing and no string is found for SentrySessionStatus.

#skip-changelog

## :bulb: Motivation and Context

Saw the TODO in the code when checking some issue in the serialization of SentrySession.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the CHANGELOG if needed
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
