### PR TITLE
Fixed the warning "Method '-unsignedLongLongValue' in category from <another-sdk> conflicts with same method from another category"

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Samples/macOS-Swift/macOS-Swift.xcodeproj/xcshareddata/xcschemes/macOS-Swift.xcscheme
+++ b/Samples/macOS-Swift/macOS-Swift.xcodeproj/xcshareddata/xcschemes/macOS-Swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -2058,7 +2058,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Sentry;
 				TargetAttributes = {
 					63AA759A1EB8AEF500D153DE = {

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -460,6 +460,8 @@
 		A811D867248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = A811D866248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift */; };
 		A839D89824864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = A839D89724864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h */; };
 		A839D89A24864BA8003B7AFD /* SentrySystemEventsBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = A839D89924864BA8003B7AFD /* SentrySystemEventsBreadcrumbs.m */; };
+		DF72D6FC2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.h in Headers */ = {isa = PBXBuildFile; fileRef = DF72D6FA2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.h */; };
+		DF72D6FD2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.m in Sources */ = {isa = PBXBuildFile; fileRef = DF72D6FB2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -969,6 +971,8 @@
 		A811D866248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySystemEventsBreadcrumbsTest.swift; sourceTree = "<group>"; };
 		A839D89724864B80003B7AFD /* SentrySystemEventsBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySystemEventsBreadcrumbs.h; path = include/SentrySystemEventsBreadcrumbs.h; sourceTree = "<group>"; };
 		A839D89924864BA8003B7AFD /* SentrySystemEventsBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySystemEventsBreadcrumbs.m; sourceTree = "<group>"; };
+		DF72D6FA2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSNumber+SentryUnsignedLongLongValue.h"; sourceTree = "<group>"; };
+		DF72D6FB2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSNumber+SentryUnsignedLongLongValue.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1069,6 +1073,8 @@
 		630436031EC058FA00C4D3FA /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				DF72D6FA2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.h */,
+				DF72D6FB2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.m */,
 				637533562243A0100002F77F /* NSString+SentryUnsignedLongLongValue.h */,
 				637533572243A0100002F77F /* NSString+SentryUnsignedLongLongValue.m */,
 				630436081EC0595B00C4D3FA /* NSData+SentryCompression.h */,
@@ -1954,6 +1960,7 @@
 				63FE713920DA4C1100CDBAE8 /* SentryCrashMach.h in Headers */,
 				63EED6BE2237923600E02400 /* SentryOptions.h in Headers */,
 				63BE85701ECEC6DE00DC44F5 /* NSDate+SentryExtras.h in Headers */,
+				DF72D6FC2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.h in Headers */,
 				63FE709520DA4C1000CDBAE8 /* SentryCrashReportFilterBasic.h in Headers */,
 				63FE70A120DA4C1000CDBAE8 /* SentryCrashCString.h in Headers */,
 				7B7D873424864C6600D2ECFF /* SentryCrashDefaultMachineContextWrapper.h in Headers */,
@@ -2210,6 +2217,7 @@
 				7DC8310C2398283C0043DD9A /* SentryCrashIntegration.m in Sources */,
 				635B3F391EBC6E2500A6176D /* SentryAsynchronousOperation.m in Sources */,
 				63FE717520DA4C1100CDBAE8 /* SentryCrash.m in Sources */,
+				DF72D6FD2653AB8200853598 /* NSNumber+SentryUnsignedLongLongValue.m in Sources */,
 				7BE3C7712445C30D00A38442 /* SentryDefaultCurrentDateProvider.m in Sources */,
 				6344DDB11EC308E400D9160D /* SentryCrashInstallationReporter.m in Sources */,
 				7BAF3DCE243DCBFE008A5414 /* SentryTransportFactory.m in Sources */,

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTests.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Sentry/NSNumber+SentryUnsignedLongLongValue.h
+++ b/Sources/Sentry/NSNumber+SentryUnsignedLongLongValue.h
@@ -2,7 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface NSString (SentryUnsignedLongLongValue)
+@interface NSNumber (SentryUnsignedLongLongValue)
 - (unsigned long long)sentry_unsignedLongLongValue;
 @end
 

--- a/Sources/Sentry/NSNumber+SentryUnsignedLongLongValue.m
+++ b/Sources/Sentry/NSNumber+SentryUnsignedLongLongValue.m
@@ -1,0 +1,18 @@
+//
+//  NSNumber+SentryUnsignedLongLongValue.m
+//  Sentry
+//
+//  Created by MingLQ on 2021-05-18.
+//  Copyright © 2021 Sentry. All rights reserved.
+//
+
+#import "NSNumber+SentryUnsignedLongLongValue.h"
+
+@implementation NSNumber (SentryUnsignedLongLongValue)
+
+- (unsigned long long)sentry_unsignedLongLongValue
+{
+    return [self unsignedLongLongValue];
+}
+
+@end

--- a/Sources/Sentry/NSString+SentryUnsignedLongLongValue.m
+++ b/Sources/Sentry/NSString+SentryUnsignedLongLongValue.m
@@ -2,7 +2,7 @@
 
 @implementation NSString (SentryUnsignedLongLongValue)
 
-- (unsigned long long)unsignedLongLongValue
+- (unsigned long long)sentry_unsignedLongLongValue
 {
     return strtoull([self UTF8String], NULL, 0);
 }

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -14,6 +14,8 @@
 #import "SentryStacktrace.h"
 #import "SentryThread.h"
 #import "SentryUser.h"
+#import "NSString+SentryUnsignedLongLongValue.h"
+#import "NSNumber+SentryUnsignedLongLongValue.h"
 
 @interface
 SentryCrashReportConverter ()
@@ -206,9 +208,9 @@ SentryCrashReportConverter ()
 {
     NSDictionary *result = nil;
     for (NSDictionary *binaryImage in self.binaryImages) {
-        uintptr_t imageStart = (uintptr_t)[binaryImage[@"image_addr"] unsignedLongLongValue];
+        uintptr_t imageStart = (uintptr_t)[binaryImage[@"image_addr"] sentry_unsignedLongLongValue];
         uintptr_t imageEnd
-            = imageStart + (uintptr_t)[binaryImage[@"image_size"] unsignedLongLongValue];
+            = imageStart + (uintptr_t)[binaryImage[@"image_size"] sentry_unsignedLongLongValue];
         if (address >= imageStart && address < imageEnd) {
             result = binaryImage;
             break;
@@ -245,7 +247,7 @@ SentryCrashReportConverter ()
 {
     NSDictionary *frameDictionary = [self rawStackTraceForThreadIndex:threadIndex][frameIndex];
     uintptr_t instructionAddress
-        = (uintptr_t)[frameDictionary[@"instruction_addr"] unsignedLongLongValue];
+        = (uintptr_t)[frameDictionary[@"instruction_addr"] sentry_unsignedLongLongValue];
     NSDictionary *binaryImage = [self binaryImageForAddress:instructionAddress];
     SentryFrame *frame = [[SentryFrame alloc] init];
     frame.symbolAddress = sentry_formatHexAddress(frameDictionary[@"symbol_addr"]);
@@ -274,7 +276,7 @@ SentryCrashReportConverter ()
     for (NSInteger i = 0; i < frameCount; i++) {
         NSDictionary *frameDictionary = [self rawStackTraceForThreadIndex:threadIndex][i];
         uintptr_t instructionAddress
-            = (uintptr_t)[frameDictionary[@"instruction_addr"] unsignedLongLongValue];
+            = (uintptr_t)[frameDictionary[@"instruction_addr"] sentry_unsignedLongLongValue];
         if (instructionAddress == SentryCrashSC_ASYNC_MARKER) {
             if (lastFrame != nil) {
                 lastFrame.stackStart = @(YES);

--- a/Sources/Sentry/include/SentryHexAddressFormatter.h
+++ b/Sources/Sentry/include/SentryHexAddressFormatter.h
@@ -1,7 +1,9 @@
 #import <Foundation/Foundation.h>
+#import "NSString+SentryUnsignedLongLongValue.h"
+#import "NSNumber+SentryUnsignedLongLongValue.h"
 
 static inline NSString *
 sentry_formatHexAddress(NSNumber *value)
 {
-    return [NSString stringWithFormat:@"0x%016llx", [value unsignedLongLongValue]];
+    return [NSString stringWithFormat:@"0x%016llx", [value sentry_unsignedLongLongValue]];
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -30,6 +30,8 @@
 #include "SentryCrashMonitorContext.h"
 #import "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashThread.h"
+#import "NSString+SentryUnsignedLongLongValue.h"
+#import "NSNumber+SentryUnsignedLongLongValue.h"
 #import <Foundation/Foundation.h>
 
 //#define SentryCrashLogger_LocalLevel TRACE
@@ -71,7 +73,7 @@ handleException(NSException *exception, BOOL currentSnapshotUserReported)
         assert(callstack != NULL);
 
         for (NSUInteger i = 0; i < numFrames; i++) {
-            callstack[i] = (uintptr_t)[addresses[i] unsignedLongLongValue];
+            callstack[i] = (uintptr_t)[addresses[i] sentry_unsignedLongLongValue];
         }
 
         char eventID[37];

--- a/Sources/SentryCrash/Recording/SentryCrashDoctor.m
+++ b/Sources/SentryCrash/Recording/SentryCrashDoctor.m
@@ -9,6 +9,8 @@
 #import "SentryCrashDoctor.h"
 #import "SentryCrashMonitor_System.h"
 #import "SentryCrashReportFields.h"
+#import "NSString+SentryUnsignedLongLongValue.h"
+#import "NSNumber+SentryUnsignedLongLongValue.h"
 
 typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } CPUFamily;
 
@@ -368,7 +370,7 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
     NSMutableArray *params = [NSMutableArray arrayWithCapacity:4];
     for (NSString *regName in regNames) {
         SentryCrashDoctorParam *param = [[SentryCrashDoctorParam alloc] init];
-        param.address = (uintptr_t)[[registers objectForKey:regName] unsignedLongLongValue];
+        param.address = (uintptr_t)[[registers objectForKey:regName] sentry_unsignedLongLongValue];
         NSDictionary *notableAddress = [notableAddresses objectForKey:regName];
         if (notableAddress == nil) {
             param.value = [NSString stringWithFormat:@"%p", (void *)param.address];
@@ -465,7 +467,7 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
 
         if ([self isInvalidAddress:errorReport]) {
             uintptr_t address = (uintptr_t)[
-                [errorReport objectForKey:@SentryCrashField_Address] unsignedLongLongValue];
+                [errorReport objectForKey:@SentryCrashField_Address] sentry_unsignedLongLongValue];
             if (address == 0) {
                 return @"Attempted to dereference null pointer.";
             }

--- a/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
+++ b/Tests/SentryTests/Categories/SentryUnsignedLongLongValueTest.m
@@ -1,4 +1,5 @@
 #import "NSString+SentryUnsignedLongLongValue.h"
+#import "NSNumber+SentryUnsignedLongLongValue.h"
 #import <XCTest/XCTest.h>
 
 @interface SentryUnsignedLongLongValueTest : XCTestCase
@@ -9,22 +10,42 @@
 
 - (void)testNSStringUnsignedLongLongValue
 {
-    XCTAssertEqual([@"" unsignedLongLongValue], 0);
-    XCTAssertEqual([@"9" unsignedLongLongValue], 9);
-    XCTAssertEqual([@"99" unsignedLongLongValue], 99);
-    XCTAssertEqual([@"999" unsignedLongLongValue], 999);
+    XCTAssertEqual([@"" sentry_unsignedLongLongValue], 0);
+    XCTAssertEqual([@"9" sentry_unsignedLongLongValue], 9);
+    XCTAssertEqual([@"99" sentry_unsignedLongLongValue], 99);
+    XCTAssertEqual([@"999" sentry_unsignedLongLongValue], 999);
 
     NSString *longLongMaxValue =
         [NSString stringWithFormat:@"%llu", (unsigned long long)0x7FFFFFFFFFFFFFFF];
-    XCTAssertEqual([longLongMaxValue unsignedLongLongValue], 9223372036854775807);
+    XCTAssertEqual([longLongMaxValue sentry_unsignedLongLongValue], 9223372036854775807);
 
     NSString *negativelongLongMaxValue =
         [NSString stringWithFormat:@"%llu", (unsigned long long)-0x8000000000000000];
-    XCTAssertEqual([negativelongLongMaxValue unsignedLongLongValue], 0x8000000000000000);
+    XCTAssertEqual([negativelongLongMaxValue sentry_unsignedLongLongValue], 0x8000000000000000);
 
     NSString *unsignedLongLongMaxValue =
         [NSString stringWithFormat:@"%llu", (unsigned long long)0xFFFFFFFFFFFFFFFF];
-    XCTAssertEqual([unsignedLongLongMaxValue unsignedLongLongValue], 0xFFFFFFFFFFFFFFFF);
+    XCTAssertEqual([unsignedLongLongMaxValue sentry_unsignedLongLongValue], 0xFFFFFFFFFFFFFFFF);
+}
+
+- (void)testNSNumberUnsignedLongLongValue
+{
+    XCTAssertEqual([[NSNumber new] sentry_unsignedLongLongValue], 0);
+    XCTAssertEqual([@(9) sentry_unsignedLongLongValue], 9);
+    XCTAssertEqual([@(99) sentry_unsignedLongLongValue], 99);
+    XCTAssertEqual([@(999) sentry_unsignedLongLongValue], 999);
+
+    NSNumber *longLongMaxValue =
+    [NSNumber numberWithUnsignedLongLong:(unsigned long long)0x7FFFFFFFFFFFFFFF];
+    XCTAssertEqual([longLongMaxValue sentry_unsignedLongLongValue], 9223372036854775807);
+
+    NSNumber *negativelongLongMaxValue =
+    [NSNumber numberWithUnsignedLongLong:(unsigned long long)-0x8000000000000000];
+    XCTAssertEqual([negativelongLongMaxValue sentry_unsignedLongLongValue], 0x8000000000000000);
+
+    NSNumber *unsignedLongLongMaxValue =
+    [NSNumber numberWithUnsignedLongLong:(unsigned long long)0xFFFFFFFFFFFFFFFF];
+    XCTAssertEqual([unsignedLongLongMaxValue sentry_unsignedLongLongValue], 0xFFFFFFFFFFFFFFFF);
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description

The name of method `-unsignedLongLongValue` should start with prefix `sentry_` in your category `SentryUnsignedLongLongValue`.

## :bulb: Motivation and Context

Fixed the warning "Method '-unsignedLongLongValue' in category from <another-sdk> conflicts with same method from another category"

Fixed issue #1117 

## :green_heart: How did you test it?

Added test case and tested success.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps

Review and Merge?
