### PR TITLE
docs: Replace incorrect function reference

### DIFF
--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -25,7 +25,7 @@ SENTRY_NO_INIT
 - (void)startSession;
 
 /**
- * Ends the current SentrySession. You can use this method in combination with endSession to
+ * Ends the current SentrySession. You can use this method in combination with startSession to
  * manually track SentrySessions. The SDK uses SentrySession to inform Sentry about release and
  * project associated project health.
  */

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -294,7 +294,7 @@ SENTRY_NO_INIT
 + (void)startSession;
 
 /**
- * Ends the current SentrySession. You can use this method in combination with endSession to
+ * Ends the current SentrySession. You can use this method in combination with startSession to
  * manually track SentrySessions. The SDK uses SentrySession to inform Sentry about release and
  * project associated project health.
  */


### PR DESCRIPTION
## :scroll: Description

There was an incorrect self-reference to `endSession` in the in-line documentation.

#skip-changelog

## :bulb: Motivation and Context

Makes the documentation consistent with its intention.

## :green_heart: How did you test it?

Verified that the correct function is referenced.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
