### PR TITLE
fix: Serialization of span description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Serialization of span description (#1128)
+
 ## 7.1.0
 
 - fix: Remove SentryUnsignedLongLongValue (#1118)

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -82,6 +82,12 @@ class ViewController: UIViewController {
     
     @IBAction func captureTransaction(_ sender: Any) {
         let transaction = SentrySDK.startTransaction(name: "Some Transaction", operation: "Some Operation")
+        let span = transaction.startChild(operation: "user", description: "calls out")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
+            span.finish()
+        })
+        
         DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
             transaction.finish()
         })

--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -91,6 +91,9 @@ SentrySpanContext () {
     if (self.operation != nil)
         [mutabledictionary setValue:self.operation forKey:@"op"];
 
+    if (self.spanDescription != nil)
+        [mutabledictionary setValue:self.spanDescription forKey:@"description"];
+
     if (self.parentSpanId != nil)
         [mutabledictionary setValue:self.parentSpanId.sentrySpanIdString forKey:@"parent_span_id"];
 

--- a/Tests/SentryTests/SentrySpanContextTests.swift
+++ b/Tests/SentryTests/SentrySpanContextTests.swift
@@ -48,6 +48,7 @@ class SentrySpanContextTests: XCTestCase {
         
         let spanContext = SpanContext(trace: id, spanId: spanId, parentId: parentId, operation: someOperation, sampled: .yes)
         spanContext.status = .ok
+        spanContext.spanDescription = "description"
         
         let data = spanContext.serialize()
         
@@ -55,6 +56,7 @@ class SentrySpanContextTests: XCTestCase {
         XCTAssertEqual(data["trace_id"] as? String, id.sentryIdString)
         XCTAssertEqual(data["type"] as? String, SpanContext.type)
         XCTAssertEqual(data["op"] as? String, someOperation)
+        XCTAssertEqual(data["description"] as? String, spanContext.spanDescription)
         XCTAssertEqual(data["sampled"] as? String, "true")
         XCTAssertEqual(data["parent_span_id"] as? String, parentId.sentrySpanIdString)
         XCTAssertEqual(data["status"] as? String, "ok")


### PR DESCRIPTION


## :scroll: Description

The serialization of the description of a span was missing. When setting
a description to a span the SDK didn't send it to Sentry. This is fixed now.

## :bulb: Motivation and Context

We want the span description to show up in Sentry like this
<img width="511" alt="Screen Shot 2021-05-26 at 11 25 53" src="https://user-images.githubusercontent.com/2443292/119636665-24726700-be15-11eb-900d-0fabe0e1d070.png">


## :green_heart: How did you test it?
Unit tests and Simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
