### PR TITLE
fix: Set description for performance tracker spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Set description for performance tracker spans (#1041)
+- fix: Set description for performance tracker spans (#1042)
 - fix: Capturing Child Spans (#1139)
 - feat: Auto UI Performance Instrumentation (#1105)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Set description for performance tracker spans (#1041)
 - fix: Capturing Child Spans (#1139)
 - feat: Auto UI Performance Instrumentation (#1105)
 

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -46,7 +46,7 @@ SentryPerformanceTracker ()
 
     SentryTracer *newSpan;
     if (activeSpanTracker != nil) {
-        newSpan = [activeSpanTracker startChildWithOperation:name];
+        newSpan = [activeSpanTracker startChildWithOperation:operation description:name];
     } else {
         newSpan = [[SentryTracer alloc]
             initWithTransactionContext:[[SentryTransactionContext alloc] initWithName:name
@@ -70,11 +70,11 @@ SentryPerformanceTracker ()
     return spanId;
 }
 
-- (void)measureSpanWithName:(NSString *)name
-                  operation:(NSString *)operation
-                    inBlock:(void (^)(void))block
+- (void)measureSpanWithDescription:(NSString *)description
+                         operation:(NSString *)operation
+                           inBlock:(void (^)(void))block
 {
-    SentrySpanId *spanId = [self startSpanWithName:name operation:operation];
+    SentrySpanId *spanId = [self startSpanWithName:description operation:operation];
     [self pushActiveSpan:spanId];
     block();
     [self popActiveSpan];

--- a/Sources/Sentry/SentryUIPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIPerformanceTracker.m
@@ -106,9 +106,9 @@ static NSString *const SENTRY_VIEWCONTROLLER_RENDERING_OPERATION = @"ui.renderin
 
             [SentryPerformanceTracker.shared pushActiveSpan:spanId];
             [SentryPerformanceTracker.shared
-                measureSpanWithName:@"loadView"
-                          operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                            inBlock:^{ SentrySWCallOriginal(); }];
+                measureSpanWithDescription:@"loadView"
+                                 operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                   inBlock:^{ SentrySWCallOriginal(); }];
             [SentryPerformanceTracker.shared popActiveSpan];
         }),
         SentrySwizzleModeOncePerClassAndSuperclasses, (void *)selector);
@@ -127,9 +127,9 @@ static NSString *const SENTRY_VIEWCONTROLLER_RENDERING_OPERATION = @"ui.renderin
             } else {
                 [SentryPerformanceTracker.shared pushActiveSpan:spanId];
                 [SentryPerformanceTracker.shared
-                    measureSpanWithName:@"viewDidLoad"
-                              operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                inBlock:^{ SentrySWCallOriginal(); }];
+                    measureSpanWithDescription:@"viewDidLoad"
+                                     operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                       inBlock:^{ SentrySWCallOriginal(); }];
                 [SentryPerformanceTracker.shared popActiveSpan];
             }
         }),
@@ -149,9 +149,9 @@ static NSString *const SENTRY_VIEWCONTROLLER_RENDERING_OPERATION = @"ui.renderin
             } else {
                 [SentryPerformanceTracker.shared pushActiveSpan:spanId];
                 [SentryPerformanceTracker.shared
-                    measureSpanWithName:@"viewWillAppear"
-                              operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                inBlock:^{ SentrySWCallOriginal(animated); }];
+                    measureSpanWithDescription:@"viewWillAppear"
+                                     operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                       inBlock:^{ SentrySWCallOriginal(animated); }];
                 [SentryPerformanceTracker.shared popActiveSpan];
             }
         }),
@@ -171,9 +171,9 @@ static NSString *const SENTRY_VIEWCONTROLLER_RENDERING_OPERATION = @"ui.renderin
             } else {
                 [SentryPerformanceTracker.shared pushActiveSpan:spanId];
                 [SentryPerformanceTracker.shared
-                    measureSpanWithName:@"viewDidAppear"
-                              operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                inBlock:^{ SentrySWCallOriginal(animated); }];
+                    measureSpanWithDescription:@"viewDidAppear"
+                                     operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                       inBlock:^{ SentrySWCallOriginal(animated); }];
                 [SentryPerformanceTracker.shared popActiveSpan];
                 [SentryPerformanceTracker.shared finishSpan:spanId];
             }
@@ -194,9 +194,9 @@ static NSString *const SENTRY_VIEWCONTROLLER_RENDERING_OPERATION = @"ui.renderin
             } else {
                 [SentryPerformanceTracker.shared pushActiveSpan:spanId];
                 [SentryPerformanceTracker.shared
-                    measureSpanWithName:@"viewWillLayoutSubviews"
-                              operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                inBlock:^{ SentrySWCallOriginal(); }];
+                    measureSpanWithDescription:@"viewWillLayoutSubviews"
+                                     operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                       inBlock:^{ SentrySWCallOriginal(); }];
 
                 SentrySpanId *layoutSubViewId = [SentryPerformanceTracker.shared
                     startSpanWithName:@"layoutSubViews"
@@ -225,9 +225,9 @@ static NSString *const SENTRY_VIEWCONTROLLER_RENDERING_OPERATION = @"ui.renderin
                 [SentryPerformanceTracker.shared finishSpan:layoutSubViewId];
 
                 [SentryPerformanceTracker.shared
-                    measureSpanWithName:@"viewDidLayoutSubviews"
-                              operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                inBlock:^{ SentrySWCallOriginal(); }];
+                    measureSpanWithDescription:@"viewDidLayoutSubviews"
+                                     operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                       inBlock:^{ SentrySWCallOriginal(); }];
                 [SentryPerformanceTracker.shared popActiveSpan];
             }
         }),

--- a/Sources/Sentry/include/SentryPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryPerformanceTracker.h
@@ -33,13 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Measure the given block execution.
  *
- * @param name Span name.
+ * @param description The description of the span.
  * @param operation Span operation.
  * @param block Block to be measured.
  */
-- (void)measureSpanWithName:(NSString *)name
-                  operation:(NSString *)operation
-                    inBlock:(void (^)(void))block;
+- (void)measureSpanWithDescription:(NSString *)description
+                         operation:(NSString *)operation
+                           inBlock:(void (^)(void))block;
 
 /**
  * Gets the active span id.


### PR DESCRIPTION


## :scroll: Description

The performance tracker used the name for the operation. This is fixed
now by using both operation and description.

## :bulb: Motivation and Context

**Before**
Please ignore the app start spans
<img width="1257" alt="Screen Shot 2021-05-31 at 13 53 02" src="https://user-images.githubusercontent.com/2443292/120189356-879a3a00-c217-11eb-9c4c-50a83d90560d.png">

**After**
<img width="1263" alt="Screen Shot 2021-05-31 at 13 52 18" src="https://user-images.githubusercontent.com/2443292/120189270-6cc7c580-c217-11eb-9f3f-9273914a9775.png">

## :green_heart: How did you test it?
Sending transactions to Sentry.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
