### PR TITLE
test: Make SentrySDK.setCurrentHub nullable

### DIFF
--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -31,7 +31,7 @@ static BOOL crashedLastRunCalled;
 }
 
 /** Internal, only needed for testing. */
-+ (void)setCurrentHub:(SentryHub *)hub
++ (void)setCurrentHub:(nullable SentryHub *)hub
 {
     @synchronized(self) {
         currentHub = hub;

--- a/Tests/SentryTests/SentrySDK+Tests.h
+++ b/Tests/SentryTests/SentrySDK+Tests.h
@@ -4,7 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentrySDK (Tests)
 
-+ (void)setCurrentHub:(SentryHub *)hub;
++ (void)setCurrentHub:(nullable SentryHub *)hub;
 
 + (void)captureEnvelope:(SentryEnvelope *)envelope;
 


### PR DESCRIPTION


## :scroll: Description

It's handy to set the `currentHub` of the SentrySDK back to nil in the tearDown of a test.

#skip-changelog

## :bulb: Motivation and Context

https://github.com/getsentry/sentry-cocoa/pull/1144/files#r643885170

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
