### PR TITLE
ref: Make SentryCrashAdapter a singleton

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -282,7 +282,6 @@
 		7B6D98ED24C703F8005502FA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D98EC24C703F8005502FA /* Async.swift */; };
 		7B7A30C624B48321005A4C6E /* SentryCrashAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */; };
 		7B7A30C824B48389005A4C6E /* SentryCrashAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */; };
-		7B7A30CD24B485FD005A4C6E /* TestSentryCrashWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A30CC24B485FD005A4C6E /* TestSentryCrashWrapper.swift */; };
 		7B7D872C2486480B00D2ECFF /* SentryStacktraceBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7D872B2486480B00D2ECFF /* SentryStacktraceBuilder.h */; };
 		7B7D872E2486482600D2ECFF /* SentryStacktraceBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D872D2486482600D2ECFF /* SentryStacktraceBuilder.m */; };
 		7B7D8730248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D872F248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift */; };
@@ -417,6 +416,7 @@
 		7BECF42226145C5D00D9826E /* SentryMechanismMeta.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BECF42126145C5D00D9826E /* SentryMechanismMeta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BECF42826145CD900D9826E /* SentryMechanismMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BECF42726145CD900D9826E /* SentryMechanismMeta.m */; };
 		7BECF432261463E600D9826E /* SentryMechanismMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BECF431261463E600D9826E /* SentryMechanismMetaTests.swift */; };
+		7BED3576266F7BFF00EAA70D /* TestSentryCrashAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BED3575266F7BFF00EAA70D /* TestSentryCrashAdapter.m */; };
 		7BF536D124BDF3E7004FA6A2 /* SentryEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF536D024BDF3E7004FA6A2 /* SentryEnvelopeTests.swift */; };
 		7BF536D424BEF255004FA6A2 /* SentryAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */; };
 		7BFC169B2524995700FF6266 /* SentryMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BFC169A2524995700FF6266 /* SentryMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -794,7 +794,6 @@
 		7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashAdapter.h; path = include/SentryCrashAdapter.h; sourceTree = "<group>"; };
 		7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashAdapter.m; sourceTree = "<group>"; };
 		7B7A30C924B48523005A4C6E /* SentryHub+TestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryHub+TestInit.h"; sourceTree = "<group>"; };
-		7B7A30CC24B485FD005A4C6E /* TestSentryCrashWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryCrashWrapper.swift; sourceTree = "<group>"; };
 		7B7D872B2486480B00D2ECFF /* SentryStacktraceBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryStacktraceBuilder.h; path = include/SentryStacktraceBuilder.h; sourceTree = "<group>"; };
 		7B7D872D2486482600D2ECFF /* SentryStacktraceBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryStacktraceBuilder.m; sourceTree = "<group>"; };
 		7B7D872F248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStacktraceBuilderTests.swift; sourceTree = "<group>"; };
@@ -934,6 +933,8 @@
 		7BECF42126145C5D00D9826E /* SentryMechanismMeta.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryMechanismMeta.h; path = Public/SentryMechanismMeta.h; sourceTree = "<group>"; };
 		7BECF42726145CD900D9826E /* SentryMechanismMeta.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMechanismMeta.m; sourceTree = "<group>"; };
 		7BECF431261463E600D9826E /* SentryMechanismMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMechanismMetaTests.swift; sourceTree = "<group>"; };
+		7BED3574266F7BC600EAA70D /* TestSentryCrashAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSentryCrashAdapter.h; sourceTree = "<group>"; };
+		7BED3575266F7BFF00EAA70D /* TestSentryCrashAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestSentryCrashAdapter.m; sourceTree = "<group>"; };
 		7BF536D024BDF3E7004FA6A2 /* SentryEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeTests.swift; sourceTree = "<group>"; };
 		7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAssertions.swift; sourceTree = "<group>"; };
 		7BFC169A2524995700FF6266 /* SentryMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryMessage.h; path = Public/SentryMessage.h; sourceTree = "<group>"; };
@@ -1667,10 +1668,11 @@
 				7BA61CCB247D14E600C130A8 /* SentryThreadInspectorTests.swift */,
 				7B7D872F248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift */,
 				7B140899248791660035403D /* SentryCrashStackEntryMapperTests.swift */,
-				7B7A30CC24B485FD005A4C6E /* TestSentryCrashWrapper.swift */,
 				7B6D98EA24C6E84F005502FA /* SentryCrashInstallationReporterTests.swift */,
 				7B0A542D2521C62400A71716 /* SentryFrameRemoverTests.swift */,
 				7BBC827825DFD7D7005F1ED8 /* SentryFrameInAppLogicTests.swift */,
+				7BED3574266F7BC600EAA70D /* TestSentryCrashAdapter.h */,
+				7BED3575266F7BFF00EAA70D /* TestSentryCrashAdapter.m */,
 			);
 			path = SentryCrash;
 			sourceTree = "<group>";
@@ -2402,7 +2404,6 @@
 				63FE720D20DA66EC00CDBAE8 /* NSError+SimpleConstructor_Tests.m in Sources */,
 				69BEE6F72620729E006DF9DF /* UrlSessionDelegateSpy.swift in Sources */,
 				7B98D7EC25FB7C4900C5A389 /* SentryAppStateTests.swift in Sources */,
-				7B7A30CD24B485FD005A4C6E /* TestSentryCrashWrapper.swift in Sources */,
 				7BAF3DC8243DB90E008A5414 /* TestTransport.swift in Sources */,
 				7B0A54562523178700A71716 /* SentryScopeSwiftTests.swift in Sources */,
 				7B5B94332657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift in Sources */,
@@ -2454,6 +2455,7 @@
 				8E25C97525F8511A00DC215B /* TestRandom.swift in Sources */,
 				7B26BBFB24C0A66D00A79CCC /* SentrySdkInfoNilTests.m in Sources */,
 				7BAF3DD7243DD4A1008A5414 /* TestConstants.swift in Sources */,
+				7BED3576266F7BFF00EAA70D /* TestSentryCrashAdapter.m in Sources */,
 				7BC6EC18255C44540059822A /* SentryDebugMetaTests.swift in Sources */,
 				A811D867248E2770008A41EA /* SentrySystemEventsBreadcrumbsTest.swift in Sources */,
 				7B82D54924E2A2D400EE670F /* SentryIdTests.swift in Sources */,

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -49,7 +49,7 @@ SentryAppStartTrackingIntegration ()
 
     SentryDefaultCurrentDateProvider *currentDateProvider =
         [[SentryDefaultCurrentDateProvider alloc] init];
-    SentryCrashAdapter *crashAdapter = [[SentryCrashAdapter alloc] init];
+    SentryCrashAdapter *crashAdapter = [SentryCrashAdapter sharedInstance];
     SentrySysctl *sysctl = [[SentrySysctl alloc] init];
 
     SentryAppStateManager *appStateManager = [[SentryAppStateManager alloc]

--- a/Sources/Sentry/SentryCrashAdapter.m
+++ b/Sources/Sentry/SentryCrashAdapter.m
@@ -7,6 +7,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryCrashAdapter
 
++ (instancetype)sharedInstance
+{
+    static SentryCrashAdapter *instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ instance = [[self alloc] init]; });
+    return instance;
+}
+
 - (BOOL)crashedLastLaunch
 {
     return SentryCrash.sharedInstance.crashedLastLaunch;

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -38,7 +38,7 @@ SentryCrashIntegration ()
 - (instancetype)init
 {
     if (self = [super init]) {
-        self.crashAdapter = [[SentryCrashAdapter alloc] init];
+        self.crashAdapter = [SentryCrashAdapter sharedInstance];
         self.dispatchQueueWrapper = [[SentryDispatchQueueWrapper alloc] init];
     }
     return self;

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -37,7 +37,7 @@ SentryHub ()
         _scope = scope;
         _sessionLock = [[NSObject alloc] init];
         _installedIntegrations = [[NSMutableArray alloc] init];
-        _crashAdapter = [[SentryCrashAdapter alloc] init];
+        _crashAdapter = [SentryCrashAdapter sharedInstance];
         _sampler = [[SentryTracesSampler alloc] initWithOptions:client.options];
     }
     return self;

--- a/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
+++ b/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
@@ -32,7 +32,7 @@ SentryOutOfMemoryTrackingIntegration ()
                                                   attributes:attributes];
 
         SentryFileManager *fileManager = [[[SentrySDK currentHub] getClient] fileManager];
-        SentryCrashAdapter *crashAdapter = [[SentryCrashAdapter alloc] init];
+        SentryCrashAdapter *crashAdapter = [SentryCrashAdapter sharedInstance];
         SentryAppStateManager *appStateManager = [[SentryAppStateManager alloc]
                 initWithOptions:options
                    crashAdapter:crashAdapter

--- a/Sources/Sentry/include/SentryCrashAdapter.h
+++ b/Sources/Sentry/include/SentryCrashAdapter.h
@@ -1,3 +1,4 @@
+#import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -5,6 +6,9 @@ NS_ASSUME_NONNULL_BEGIN
 /** A wrapper around SentryCrash for testability.
  */
 @interface SentryCrashAdapter : NSObject
+SENTRY_NO_INIT
+
++ (instancetype)sharedInstance;
 
 - (BOOL)crashedLastLaunch;
 

--- a/Tests/SentryTests/Integrations/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryAppStartTrackerTests.swift
@@ -12,7 +12,7 @@ class SentryAppStartTrackerTests: XCTestCase {
         let currentDate = TestCurrentDateProvider()
         let sysctl = TestSysctl()
         let fileManager: SentryFileManager
-        let crashAdapter = TestSentryCrashWrapper()
+        let crashAdapter = TestSentryCrashAdapter.sharedInstance()
         let appStateManager: SentryAppStateManager
         
         let appStartDuration: TimeInterval = 0.4

--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -24,8 +24,8 @@ class SentryCrashIntegrationTests: XCTestCase {
             return options
         }
         
-        var sentryCrash: TestSentryCrashWrapper {
-            let sentryCrash = TestSentryCrashWrapper()
+        var sentryCrash: TestSentryCrashAdapter {
+            let sentryCrash = TestSentryCrashAdapter.sharedInstance()
             sentryCrash.internalActiveDurationSinceLastCrash = 5.0
             sentryCrash.internalCrashedLastLaunch = true
             return sentryCrash

--- a/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
@@ -10,7 +10,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         let options: Options
         let client: TestClient!
-        let crashWrapper: TestSentryCrashWrapper
+        let crashWrapper: TestSentryCrashAdapter
         let fileManager: SentryFileManager
         let currentDate = TestCurrentDateProvider()
         let sysctl = TestSysctl()
@@ -22,7 +22,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
             
             client = TestClient(options: options)
             
-            crashWrapper = TestSentryCrashWrapper()
+            crashWrapper = TestSentryCrashAdapter.sharedInstance()
             
             let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: crashWrapper)
             SentrySDK.setCurrentHub(hub)

--- a/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionGeneratorTests.swift
@@ -15,7 +15,7 @@ class SentrySessionGeneratorTests: XCTestCase {
         var abnormal = 0
     }
     
-    private var sentryCrash: TestSentryCrashWrapper!
+    private var sentryCrash: TestSentryCrashAdapter!
     private var autoSessionTrackingIntegration: SentryAutoSessionTrackingIntegration!
     private var crashIntegration: SentryCrashIntegration!
     private var options: Options!
@@ -143,7 +143,7 @@ class SentrySessionGeneratorTests: XCTestCase {
         
         SentrySDK.start(options: options)
         
-        sentryCrash = TestSentryCrashWrapper()
+        sentryCrash = TestSentryCrashAdapter.sharedInstance()
         let client = SentrySDK.currentHub().getClient()
         let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: self.sentryCrash)
         SentrySDK.setCurrentHub(hub)

--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -11,7 +11,7 @@ class SentrySessionTrackerTests: XCTestCase {
         let options: Options
         let currentDateProvider = TestCurrentDateProvider()
         let client: TestClient!
-        let sentryCrash: TestSentryCrashWrapper
+        let sentryCrash: TestSentryCrashAdapter
         
         init() {
             options = Options()
@@ -22,7 +22,7 @@ class SentrySessionTrackerTests: XCTestCase {
             
             client = TestClient(options: options)
             
-            sentryCrash = TestSentryCrashWrapper()
+            sentryCrash = TestSentryCrashAdapter.sharedInstance()
         }
         
         func getSut() -> SessionTracker {

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashAdapter.h
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashAdapter.h
@@ -1,0 +1,22 @@
+#import "SentryCrashAdapter.h"
+#import "SentryDefines.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Written in Objective-C because Swift doesn't allow you to call the constructor of
+ * TestSentryCrashAdapter.
+ */
+@interface TestSentryCrashAdapter : SentryCrashAdapter
+SENTRY_NO_INIT
+
+@property (nonatomic, assign) BOOL internalCrashedLastLaunch;
+
+@property (nonatomic, assign) NSTimeInterval internalActiveDurationSinceLastCrash;
+
+@property (nonatomic, assign) BOOL internalIsBeingTraced;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashAdapter.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashAdapter.m
@@ -1,0 +1,30 @@
+#import "TestSentryCrashAdapter.h"
+#import <Foundation/Foundation.h>
+
+@implementation TestSentryCrashAdapter
+
++ (instancetype)sharedInstance
+{
+    TestSentryCrashAdapter *instance = [[self alloc] init];
+    instance.internalActiveDurationSinceLastCrash = NO;
+    instance.internalActiveDurationSinceLastCrash = 0;
+    instance.internalIsBeingTraced = NO;
+    return instance;
+}
+
+- (BOOL)crashedLastLaunch
+{
+    return self.internalCrashedLastLaunch;
+}
+
+- (NSTimeInterval)activeDurationSinceLastCrash
+{
+    return self.internalActiveDurationSinceLastCrash;
+}
+
+- (BOOL)isBeingTraced
+{
+    return self.internalIsBeingTraced;
+}
+
+@end

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -15,7 +15,7 @@ class SentryHubTests: XCTestCase {
         let message = "some message"
         let event: Event
         let currentDateProvider = TestCurrentDateProvider()
-        let sentryCrash = TestSentryCrashWrapper()
+        let sentryCrash = TestSentryCrashAdapter.sharedInstance()
         let fileManager: SentryFileManager
         let crashedSession: SentrySession
         let transactionName = "Some Transaction"

--- a/Tests/SentryTests/SentrySpanTests.swift
+++ b/Tests/SentryTests/SentrySpanTests.swift
@@ -20,7 +20,7 @@ class SentrySpanTests: XCTestCase {
         }
         
         func getSut(client: Client) -> Span {
-            let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: TestSentryCrashWrapper())
+            let hub = SentryHub(client: client, andScope: nil, andCrashAdapter: TestSentryCrashAdapter.sharedInstance())
             return hub.startTransaction(name: someTransaction, operation: someOperation)
         }
         

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -94,3 +94,4 @@
 #import "SentryTransportFactory.h"
 #import "SentryUIViewControllerSanitizer.h"
 #import "SentryUserFeedback.h"
+#import "TestSentryCrashAdapter.h"


### PR DESCRIPTION


## :scroll: Description

The SDK uses several instances of SentryCrashAdapter. This is fixed now,
by making it a singleton.

#skip-changelog

## :bulb: Motivation and Context

Use fewer objects.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
