### PR TITLE
Remove invalid excludes from Package.swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Remove invalid excludes from `Package.swift` (#1169)
+
 ## 7.2.0-beta.1
 
 - feat: Measure slow and frozen frames (#1123)

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,6 @@ let package = Package(
         .target(
             name: "Sentry",
             path: "Sources",
-            exclude: [
-                "Samples", 
-                "scripts",
-                "Tests",
-                "Utils"
-            ],
             sources: [
                 "Sentry/",
                 "SentryCrash/"


### PR DESCRIPTION
## :scroll: Description

Xcode 13 now shows issues with packages in the issue navigator.
A few issues popped up for this SDK, namely that there is are invalid excludes in the Package.swift, this PR removes them.

## :bulb: Motivation and Context

This removes warnings from the Xcode 13 issue navigator

## :green_heart: How did you test it?

N/A

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
