### PR TITLE
ref: Enabling Auto UI Performance

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -121,16 +121,6 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableOutOfMemoryTracking;
 
 /**
- * Whether to enable measuring app start or not. Default is YES.
- */
-@property (nonatomic, assign) BOOL enableAppStartMeasuring;
-
-/**
- * Whether to enable measuring the rendering of frames of the UI or not. Default is YES.
- */
-@property (nonatomic, assign) BOOL enableFrameRenderMeasuring;
-
-/**
  * The interval to end a session if the App goes to the background.
  */
 @property (nonatomic, assign) NSUInteger sessionTrackingIntervalMillis;
@@ -168,8 +158,8 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL sendDefaultPii;
 
 /**
- * When enabled, the SDK tracks UI performance automatically for UIViewController subclasses.
- * The default is <code>YES</code>.
+ * When enabled, the SDK tracks UI performance automatically for UIViewController subclasses and
+ * measures the app start and slow and frozen frames. The default is <code>YES</code>.
  */
 @property (nonatomic, assign) BOOL enableAutoUIPerformanceTracking;
 
@@ -187,6 +177,12 @@ NS_SWIFT_NAME(Options)
  * be >= 0.0 and <= 1.0 or NIL. When returning a value out of range the SDK uses the default of 0.
  */
 @property (nullable, nonatomic) SentryTracesSamplerCallback tracesSampler;
+
+/**
+ * If tracing should be enabled or not. Returns YES if either a tracesSampleRate > 0 and <=1 or a
+ * tracesSampler is set otherwise NO.
+ */
+@property (nonatomic, assign, readonly) BOOL isTracingEnabled;
 
 /**
  * A list of string prefixes of framework names that belong to the app. This option takes precedence

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -25,12 +25,6 @@ SentryAppStartTrackingIntegration ()
 - (void)installWithOptions:(SentryOptions *)options
 {
 #if SENTRY_HAS_UIKIT
-    if (!options.enableAppStartMeasuring) {
-        [SentryLog logWithMessage:@"AppStartMeasuring disabled. Will not track app start up time."
-                         andLevel:kSentryLevelDebug];
-        return;
-    }
-
     if (!options.enableAutoUIPerformanceTracking) {
         [SentryLog
             logWithMessage:@"AutoUIPerformanceTracking disabled. Will not track app start up time."
@@ -38,8 +32,7 @@ SentryAppStartTrackingIntegration ()
         return;
     }
 
-    if (!(options.tracesSampleRate != nil && [options.tracesSampleRate doubleValue] != 0.0)
-        && options.tracesSampler == nil) {
+    if (!options.isTracingEnabled) {
         [SentryLog
             logWithMessage:
                 @"No tracesSampleRate and tracesSampler set. Will not track app start up time."

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -20,10 +20,24 @@ SentryFramesTrackingIntegration ()
 - (void)installWithOptions:(SentryOptions *)options
 {
 #if SENTRY_HAS_UIKIT
-    if (options.enableFrameRenderMeasuring) {
-        self.tracker = [SentryFramesTracker sharedInstance];
-        [self.tracker start];
+    if (!options.enableAutoUIPerformanceTracking) {
+        [SentryLog logWithMessage:
+                       @"AutoUIPerformanceTracking disabled. Will not track slow and frozen frames."
+                         andLevel:kSentryLevelDebug];
+        return;
     }
+
+    if (!options.isTracingEnabled) {
+        [SentryLog
+            logWithMessage:
+                @"No tracesSampleRate and tracesSampler set. Will not track slow and frozen frames."
+                  andLevel:kSentryLevelDebug];
+        return;
+    }
+
+    self.tracker = [SentryFramesTracker sharedInstance];
+    [self.tracker start];
+
 #else
     [SentryLog
         logWithMessage:

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -39,8 +39,6 @@ SentryOptions ()
         self.sampleRate = _defaultSampleRate;
         self.enableAutoSessionTracking = YES;
         self.enableOutOfMemoryTracking = YES;
-        self.enableAppStartMeasuring = YES;
-        self.enableFrameRenderMeasuring = YES;
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
         self.attachStacktrace = YES;
         self.maxAttachmentSize = 20 * 1024 * 1024;
@@ -190,14 +188,6 @@ SentryOptions ()
         self.enableOutOfMemoryTracking = [options[@"enableOutOfMemoryTracking"] boolValue];
     }
 
-    if (nil != options[@"enableAppStartMeasuring"]) {
-        self.enableAppStartMeasuring = [options[@"enableAppStartMeasuring"] boolValue];
-    }
-
-    if (nil != options[@"enableFrameRenderMeasuring"]) {
-        self.enableFrameRenderMeasuring = [options[@"enableFrameRenderMeasuring"] boolValue];
-    }
-
     if (nil != options[@"sessionTrackingIntervalMillis"]) {
         self.sessionTrackingIntervalMillis =
             [options[@"sessionTrackingIntervalMillis"] unsignedIntValue];
@@ -289,6 +279,12 @@ SentryOptions ()
 {
     double rate = [tracesSampleRate doubleValue];
     return rate >= 0 && rate <= 1.0;
+}
+
+- (BOOL)isTracingEnabled
+{
+    return (_tracesSampleRate != nil && [_tracesSampleRate doubleValue] > 0)
+        || _tracesSampler != nil;
 }
 
 @end

--- a/Tests/SentryTests/Integrations/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryAppStartTrackingIntegrationTests.swift
@@ -69,15 +69,5 @@ class SentryAppStartTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(SentrySDK.getAndResetAppStartMeasurement())
     }
     
-    func testAppStartMeasuringDisabled_DoesNotUpdatesAppState() {
-        let options = fixture.options
-        options.enableAppStartMeasuring = false
-        sut.install(with: options)
-        
-        TestNotificationCenter.uiWindowDidBecomeVisible()
-        
-        XCTAssertNil(SentrySDK.getAndResetAppStartMeasurement())
-    }
-    
 }
 #endif

--- a/Tests/SentryTests/Integrations/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryFramesTrackingIntegrationTests.swift
@@ -23,15 +23,34 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
         sut = fixture.sut
     }
     
-    func testFrameRenderingEnabled_MeasuresFrames() {
-        sut.install(with: fixture.options)
+    func testTracesSampleRateSet_MeasuresFrames() {
+        let options = fixture.options
+        options.tracesSampleRate = 0.1
+        sut.install(with: options)
         
-        XCTAssertNotNil(Dynamic(sut).tracker)
+        XCTAssertNotNil(Dynamic(sut).tracker.asObject)
     }
     
-    func testFrameRenderingDisabled_DoesNotMeasureFrames() {
+    func testTracesSamplerSet_MeasuresFrames() {
         let options = fixture.options
-        options.enableFrameRenderMeasuring = false
+        options.tracesSampler = { _ in return 0 }
+        sut.install(with: options)
+        
+        XCTAssertNotNil(Dynamic(sut).tracker.asObject)
+    }
+    
+    func testZeroTracesSampleRate_DoesNotMeasureFrames() {
+        let options = fixture.options
+        options.tracesSampleRate = 0.0
+        sut.install(with: options)
+        
+        XCTAssertNil(Dynamic(sut).tracker.asObject)
+    }
+    
+    func testAutoUIPerformanceTrackingDisabled_DoesNotMeasureFrames() {
+        let options = fixture.options
+        options.tracesSampleRate = 0.1
+        options.enableAutoUIPerformanceTracking = false
         sut.install(with: options)
         
         XCTAssertNil(Dynamic(sut).tracker.asObject)

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -367,48 +367,6 @@
     XCTAssertEqual(NO, options.enableOutOfMemoryTracking);
 }
 
-- (void)testEnableAppStartMeasuring
-{
-    SentryOptions *options = [self getValidOptions:@{ @"enableAppStartMeasuring" : @YES }];
-
-    XCTAssertEqual(YES, options.enableAppStartMeasuring);
-}
-
-- (void)testDefaultAppStartMeasuring
-{
-    SentryOptions *options = [self getValidOptions:@{}];
-
-    XCTAssertEqual(YES, options.enableAppStartMeasuring);
-}
-
-- (void)testSetEnableAppStartMeasuringGargabe
-{
-    SentryOptions *options = [self getValidOptions:@{ @"enableAppStartMeasuring" : @"" }];
-
-    XCTAssertEqual(NO, options.enableAppStartMeasuring);
-}
-
-- (void)testEnableRenderFrameMeasuring
-{
-    SentryOptions *options = [self getValidOptions:@{ @"enableFrameRenderMeasuring" : @NO }];
-
-    XCTAssertEqual(NO, options.enableFrameRenderMeasuring);
-}
-
-- (void)testDefaultRenderFrameMeasuring
-{
-    SentryOptions *options = [self getValidOptions:@{}];
-
-    XCTAssertEqual(YES, options.enableFrameRenderMeasuring);
-}
-
-- (void)testSetEnableRenderFrameMeasuringGargabe
-{
-    SentryOptions *options = [self getValidOptions:@{ @"enableFrameRenderMeasuring" : @"" }];
-
-    XCTAssertEqual(NO, options.enableFrameRenderMeasuring);
-}
-
 - (void)testSessionTrackingIntervalMillis
 {
     NSNumber *sessionTracking = @2000;
@@ -458,8 +416,6 @@
     XCTAssertEqual(@1, options.sampleRate);
     XCTAssertEqual(YES, options.enableAutoSessionTracking);
     XCTAssertEqual(YES, options.enableOutOfMemoryTracking);
-    XCTAssertEqual(YES, options.enableAppStartMeasuring);
-    XCTAssertEqual(YES, options.enableFrameRenderMeasuring);
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
     XCTAssertEqual(YES, options.attachStacktrace);
     XCTAssertEqual(20 * 1024 * 1024, options.maxAttachmentSize);
@@ -632,6 +588,36 @@
     SentryOptions *options = [self getValidOptions:@{}];
 
     XCTAssertNil(options.tracesSampler);
+}
+
+- (void)testIsTracingEnabled_NothingSet_IsDisabled
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    XCTAssertFalse(options.isTracingEnabled);
+}
+
+- (void)testIsTracingEnabled_TracesSampleRateSetToZero_IsDisabled
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.tracesSampleRate = @0.00;
+    XCTAssertFalse(options.isTracingEnabled);
+}
+
+- (void)testIsTracingEnabled_TracesSampleRateSet_IsEnabled
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.tracesSampleRate = @0.01;
+    XCTAssertTrue(options.isTracingEnabled);
+}
+
+- (void)testIsTracingEnabled_TracesSamplerSet_IsEnabled
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.tracesSampler = ^(SentrySamplingContext *context) {
+        XCTAssertNotNil(context);
+        return @0.0;
+    };
+    XCTAssertTrue(options.isTracingEnabled);
 }
 
 - (void)testInAppIncludes


### PR DESCRIPTION


## :scroll: Description

Remove enableAppStartMeasuring and enableFrameRenderMeasuring. Check
enableAutoUIPerformanceTracking and isTracingEnabled instead to start
SentryAppStartTrackingIntegration and SentryAppStartTrackingIntegration.

#skip-changelog

## :bulb: Motivation and Context

https://github.com/getsentry/sentry-docs/pull/3712#discussion_r650949126

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
