### PR TITLE
feat: Support XCFramework for Carthage

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -100,7 +100,7 @@ jobs:
       - run: make build-carthage
         shell: sh 
 
-      - name: Archiving Sentry.Framework.zip
+      - name: Archiving Carthage zips
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Support XCFramework for Carthage (#1175)
 - Remove invalid excludes from `Package.swift` (#1169)
 
 ## 7.2.0-beta.1

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,14 @@ test:
 	xcodebuild -workspace Sentry.xcworkspace -scheme Sentry -configuration Debug GCC_GENERATE_TEST_COVERAGE_FILES=YES -destination "platform=macOS" test | xcpretty -t
 .PHONY: test
 
+# Since Carthage 0.38.0 we need to create separate .framework.zip and .xcframework.zip archives
+# For more info check out: https://github.com/Carthage/Carthage/releases/tag/0.38.0
 build-carthage:
-	@echo "--> Creating Sentry framework package with carthage"
+	@echo "--> Carthage: creating Sentry xcframework"
+	carthage build --use-xcframeworks --no-skip-current
+	zip -r Sentry.xcframework.zip Carthage/Build
+
+	@echo "--> Carthage: creating Sentry framework"
 	./scripts/carthage-xcode12-workaround.sh build --no-skip-current
 	./scripts/carthage-xcode12-workaround.sh archive Sentry --output Sentry.framework.zip
 


### PR DESCRIPTION
Since Carthage 0.38.0 we can support XCFrameworks by creating separate
.framework.zip and .xcframework.zip archives.



## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

We want to support XCFrameworks with Carthage which is possible since [Carthage 0.38.0](https://github.com/Carthage/Carthage/releases/tag/0.38.0).
Fixes GH-945

## :green_heart: How did you test it?

I tested it locally by using a Carthage.json to link to the binary, like described here https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#binary-project-specification.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
