### PR TITLE
ref: Making options available in SentrySDK

### DIFF
--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -40,6 +40,13 @@ static NSObject *appStartMeasurementLock;
     }
 }
 
++ (SentryOptions *)options
+{
+    @synchronized(self) {
+        return [[currentHub getClient] options];
+    }
+}
+
 /** Internal, only needed for testing. */
 + (void)setCurrentHub:(nullable SentryHub *)hub
 {

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (SentryHub *)currentHub;
 
-+ (nullable SentryOptions *)options;
+@property (nonatomic, nullable, readonly, class) SentryOptions *options;
 
 /**
  * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -19,6 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (SentryHub *)currentHub;
 
++ (nullable SentryOptions *)options;
+
 /**
  * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.
  */

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -460,6 +460,11 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(fixture.currentDate.date(), actual.timestamp)
     }
     
+    func testGlobalOptions() {
+        SentrySDK.setCurrentHub(fixture.hub)
+        XCTAssertEqual(SentrySDK.options(), fixture.options)
+    }
+    
     private func givenSdkWithHub() {
         SentrySDK.setCurrentHub(fixture.hub)
     }

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -462,7 +462,7 @@ class SentrySDKTests: XCTestCase {
     
     func testGlobalOptions() {
         SentrySDK.setCurrentHub(fixture.hub)
-        XCTAssertEqual(SentrySDK.options(), fixture.options)
+        XCTAssertEqual(SentrySDK.options, fixture.options)
     }
     
     private func givenSdkWithHub() {


### PR DESCRIPTION
## :scroll: Description

Added an internal method to SentrySDK that return the options used to initialize the SDK.

## :bulb: Motivation and Context

Options are required in many integrations across de SDK, every time we need to access options in the client from hub from SentrySDK.

Accessing options from a method in SentrySDK keeps things easier to maintain.

## :green_heart: How did you test it?

Unit Test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

_#skip-changelog_
## :crystal_ball: Next steps
