### PR TITLE
ci: Fix Validate SPM

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -107,13 +107,15 @@ jobs:
           path: |
             ${{ github.workspace }}/*.zip
           
+# Use github.event.pull_request.head.sha instead of github.sha as the github.sha will be the pre merge commit id.
+# See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
   validate-spm:
     name: Validate Swift Package Manager
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set SPM revision to current git commit
-        run: sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
+        run: sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
       - run: swift build
         working-directory: Samples/macOS-SPM-CommandLine
         shell: sh


### PR DESCRIPTION


## :scroll: Description

The job for validating the Swift Package Manager failed sometimes
because it was using the pre-merge commit id instead of the commit ID
of the PR. This is fixed now.

#skip-changelog

## :bulb: Motivation and Context

See description.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
