### PR TITLE
ci: Fix SPM validation for branches

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -107,7 +107,8 @@ jobs:
           path: |
             ${{ github.workspace }}/*.zip
           
-# Use github.event.pull_request.head.sha instead of github.sha as the github.sha will be the pre merge commit id.
+# Use github.event.pull_request.head.sha instead of github.sha when available as 
+# the github.sha is be the pre merge commit id for PRs.
 # See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
   validate-spm:
     name: Validate Swift Package Manager
@@ -115,7 +116,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set SPM revision to current git commit
-        run: sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
+        run: >-
+          if [[ ${{ github.event.pull_request.head.sha }} != "" ]]; then
+            sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
+          else
+            sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
+          fi  
+        shell: sh
       - run: swift build
         working-directory: Samples/macOS-SPM-CommandLine
         shell: sh

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -119,12 +119,12 @@ jobs:
       - name: Set SPM revision to current git commit
         run: >-
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          if [[ ${HEAD_SHA} != "" ]]; then
+          if [[ $HEAD_SHA == "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           fi  
-        shell: sh
+        shell: bash
       - run: swift build
         working-directory: Samples/macOS-SPM-CommandLine
         shell: sh

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -119,6 +119,7 @@ jobs:
       - name: Set SPM revision to current git commit
         run: >-
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          
           if [[ $HEAD_SHA == "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set SPM revision to current git commit
         run: >-
-          if [[ "${{ github.event.pull_request.head.sha }}" == "" ]]; then
+          if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - release/**
-      - ci/fix-spm-validation
   pull_request:
 
 jobs:

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - ci/fix-spm-validation
   pull_request:
 
 jobs:
@@ -117,7 +118,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set SPM revision to current git commit
         run: >-
-          if [[ ${{ github.event.pull_request.head.sha }} != "" ]]; then
+          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          if [[ HEAD_SHA != "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -118,9 +118,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set SPM revision to current git commit
         run: >-
-          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
-          
-          if [[ $HEAD_SHA == "" ]]; then
+          if [[ "${{ github.event.pull_request.head.sha }}" == "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Set SPM revision to current git commit
         run: >-
           HEAD_SHA=${{ github.event.pull_request.head.sha }}
-          if [[ HEAD_SHA != "" ]]; then
+          if [[ ${HEAD_SHA} != "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set SPM revision to current git commit
         run: >-
-          HEAD_SHA=${{ github.event.pull_request.head.sha }}
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
           if [[ ${HEAD_SHA} != "" ]]; then
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else


### PR DESCRIPTION
## :scroll: Description

The validation for SPM packages didn't work on the master branch. This is fixed now.

#skip-changelog

## :bulb: Motivation and Context

See description

## :green_heart: How did you test it?
Running it in CI on this branch.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
