### PR TITLE
test: Make DSN changeable for iOS-Swift

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - build/test/changable-dsn
+      - test/changable-dsn
 
 jobs:
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - test/changable-dsn
 
 jobs:
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - build/test/changable-dsn
 
 jobs:
 

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		637AFDB3243B02770034958B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB2243B02770034958B /* Assets.xcassets */; };
 		637AFDB6243B02770034958B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB4243B02770034958B /* LaunchScreen.storyboard */; };
 		7B3427F825876A5200056519 /* Tongariro.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7B3427F725876A5200056519 /* Tongariro.jpg */; };
+		7B371C35268B08F300207D8D /* DSNStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B371C34268B08F300207D8D /* DSNStorage.swift */; };
 		7B4AC44025D16AA00070736A /* RandomErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4AC43F25D16AA00070736A /* RandomErrors.swift */; };
 		8E8C57AF25EF16E6001CEEFA /* TraceTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */; };
 /* End PBXBuildFile section */
@@ -71,6 +72,7 @@
 		637AFDB7243B02770034958B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63F93AA9245AC91600A500DB /* iOS-Swift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "iOS-Swift.entitlements"; sourceTree = "<group>"; };
 		7B3427F725876A5200056519 /* Tongariro.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Tongariro.jpg; sourceTree = "<group>"; };
+		7B371C34268B08F300207D8D /* DSNStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSNStorage.swift; sourceTree = "<group>"; };
 		7B4AC43F25D16AA00070736A /* RandomErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RandomErrors.swift; sourceTree = "<group>"; };
 		8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTestViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -130,6 +132,7 @@
 				637AFDAB243B02760034958B /* SceneDelegate.swift */,
 				637AFDAD243B02760034958B /* ViewController.swift */,
 				7B4AC43F25D16AA00070736A /* RandomErrors.swift */,
+				7B371C34268B08F300207D8D /* DSNStorage.swift */,
 				637AFDAF243B02760034958B /* Main.storyboard */,
 				637AFDB2243B02770034958B /* Assets.xcassets */,
 				7B3427F725876A5200056519 /* Tongariro.jpg */,
@@ -241,6 +244,7 @@
 				637AFDAA243B02760034958B /* AppDelegate.swift in Sources */,
 				8E8C57AF25EF16E6001CEEFA /* TraceTestViewController.swift in Sources */,
 				637AFDAC243B02760034958B /* SceneDelegate.swift in Sources */,
+				7B371C35268B08F300207D8D /* DSNStorage.swift in Sources */,
 				7B4AC44025D16AA00070736A /* RandomErrors.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -6,8 +6,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
+        // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
+        let dsn = DSNStorage.shared.getDSN() ?? "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+        
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = dsn
             options.beforeSend = { event in
                 return event
             }

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -3,11 +3,14 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    static let defaultDSN = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
-        let dsn = DSNStorage.shared.getDSN() ?? "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+        let dsn = DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
+        DSNStorage.shared.saveDSN(dsn: dsn)
         
         SentrySDK.start { options in
             options.dsn = dsn

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,7 +24,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
-                                <rect key="frame" x="8" y="95.5" width="398" height="300"/>
+                                <rect key="frame" x="8" y="95.5" width="398" height="394"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJW-l9-sD6">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
@@ -97,10 +97,40 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xur-X2-ih4">
-                                        <rect key="frame" x="0.0" y="210" width="398" height="30"/>
+                                        <rect key="frame" x="0.0" y="300" width="398" height="30"/>
                                         <state key="normal" title="async crash"/>
                                         <connections>
                                             <action selector="asyncCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mqi-sE-R7d"/>
+                                        </connections>
+                                    </button>
+                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLV-Py-beK">
+                                        <rect key="frame" x="0.0" y="330" width="398" height="34"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Change DSN  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m3h-wb-Xfa">
+                                                <rect key="frame" x="0.0" y="0.0" width="107" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="L2a-LY-eQ7">
+                                                <rect key="frame" x="107" y="0.0" width="291" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="dsnChanged:" destination="BYZ-38-t0r" eventType="editingChanged" id="PSj-ja-pxV"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="L2a-LY-eQ7" firstAttribute="leading" secondItem="m3h-wb-Xfa" secondAttribute="trailing" constant="10" id="hqS-ar-27F"/>
+                                            <constraint firstItem="L2a-LY-eQ7" firstAttribute="leading" secondItem="m3h-wb-Xfa" secondAttribute="trailing" constant="20" id="y2d-Y4-4Bg"/>
+                                        </constraints>
+                                    </stackView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
+                                        <rect key="frame" x="0.0" y="364" width="398" height="30"/>
+                                        <state key="normal" title="Reset DSN"/>
+                                        <connections>
+                                            <action selector="resetDSNWith_sender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TET-Ei-fEy"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
-                                <rect key="frame" x="8" y="95.5" width="398" height="394"/>
+                                <rect key="frame" x="8" y="95.5" width="398" height="454.5"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJW-l9-sD6">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
@@ -103,36 +103,33 @@
                                             <action selector="asyncCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mqi-sE-R7d"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SLV-Py-beK">
-                                        <rect key="frame" x="0.0" y="330" width="398" height="34"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UrL-kT-AJU">
+                                        <rect key="frame" x="0.0" y="330" width="398" height="124.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Change DSN  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m3h-wb-Xfa">
-                                                <rect key="frame" x="0.0" y="0.0" width="107" height="34"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DSN  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m3h-wb-Xfa">
+                                                <rect key="frame" x="8" y="32" width="382" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="L2a-LY-eQ7">
-                                                <rect key="frame" x="107" y="0.0" width="291" height="34"/>
+                                                <rect key="frame" x="8" y="52.5" width="382" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
                                                     <action selector="dsnChanged:" destination="BYZ-38-t0r" eventType="editingChanged" id="PSj-ja-pxV"/>
                                                 </connections>
                                             </textField>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
+                                                <rect key="frame" x="8" y="86.5" width="382" height="30"/>
+                                                <state key="normal" title="Reset DSN"/>
+                                                <connections>
+                                                    <action selector="resetDSN:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mc6-d3-jaa"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstItem="L2a-LY-eQ7" firstAttribute="leading" secondItem="m3h-wb-Xfa" secondAttribute="trailing" constant="10" id="hqS-ar-27F"/>
-                                            <constraint firstItem="L2a-LY-eQ7" firstAttribute="leading" secondItem="m3h-wb-Xfa" secondAttribute="trailing" constant="20" id="y2d-Y4-4Bg"/>
-                                        </constraints>
+                                        <edgeInsets key="layoutMargins" top="32" left="8" bottom="8" right="8"/>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
-                                        <rect key="frame" x="0.0" y="364" width="398" height="30"/>
-                                        <state key="normal" title="Reset DSN"/>
-                                        <connections>
-                                            <action selector="resetDSNWith_sender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="TET-Ei-fEy"/>
-                                        </connections>
-                                    </button>
                                 </subviews>
                             </stackView>
                         </subviews>
@@ -147,6 +144,9 @@
                             <constraint firstItem="480-5y-FtF" firstAttribute="top" secondItem="0cD-fk-8Ft" secondAttribute="bottom" constant="8" id="vtN-F3-wwN"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="dsnTextField" destination="L2a-LY-eQ7" id="TWn-0u-2v7"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/Samples/iOS-Swift/iOS-Swift/DSNStorage.swift
+++ b/Samples/iOS-Swift/iOS-Swift/DSNStorage.swift
@@ -11,7 +11,9 @@ class DSNStorage {
     private let dsnFile: URL
     
     private init() {
+        // swiftlint:disable force_unwrapping
         let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        // swiftlint:enable force_unwrapping
         dsnFile = cachesDirectory.appendingPathComponent("dsn")
     }
     

--- a/Samples/iOS-Swift/iOS-Swift/DSNStorage.swift
+++ b/Samples/iOS-Swift/iOS-Swift/DSNStorage.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Sentry
+
+/**
+ * Stores the DSN to a file in the cache directory.
+ */
+class DSNStorage {
+    
+    static let shared = DSNStorage()
+    
+    private let dsnFile: URL
+    
+    private init() {
+        let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
+        dsnFile = cachesDirectory.appendingPathComponent("dsn")
+    }
+    
+    func saveDSN(dsn: String) {
+        do {
+            deleteDSN()
+            try dsn.write(to: dsnFile, atomically: true, encoding: .utf8)
+        } catch {
+            SentrySDK.capture(error: error)
+        }
+    }
+    
+    func getDSN() -> String? {
+        let fileManager = FileManager.default
+        do {
+            if fileManager.fileExists(atPath: dsnFile.path) {
+                return try String(contentsOfFile: dsnFile.path)
+            }
+        } catch {
+            SentrySDK.capture(error: error)
+        }
+        
+        return nil
+    }
+    
+    func deleteDSN() {
+        let fileManager = FileManager.default
+        do {
+            
+            if fileManager.fileExists(atPath: dsnFile.path) {
+                try fileManager.removeItem(at: dsnFile)
+            }
+        } catch {
+            SentrySDK.capture(error: error)
+        }
+    }
+}

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -135,16 +135,16 @@ class ViewController: UIViewController {
         let options = Options()
         options.dsn = sender.text
         
-        if options.dsn == nil {
+        if let dsn = options.dsn {
+            sender.backgroundColor = UIColor.systemGreen
+            DSNStorage.shared.saveDSN(dsn: dsn)
+        } else {
             sender.backgroundColor = UIColor.systemRed
             DSNStorage.shared.deleteDSN()
-        } else {
-            sender.backgroundColor = UIColor.systemGreen
-            DSNStorage.shared.saveDSN(dsn: options.dsn!)
         }
     }
     
-    @IBAction func resetDSN(_sender: Any) {
+    @IBAction func resetDSN(_ sender: Any) {
         DSNStorage.shared.deleteDSN()
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -130,4 +130,21 @@ class ViewController: UIViewController {
             }
         }
     }
+
+    @IBAction func dsnChanged(_ sender: UITextField) {
+        let options = Options()
+        options.dsn = sender.text
+        
+        if options.dsn == nil {
+            sender.backgroundColor = UIColor.systemRed
+            DSNStorage.shared.deleteDSN()
+        } else {
+            sender.backgroundColor = UIColor.systemGreen
+            DSNStorage.shared.saveDSN(dsn: options.dsn!)
+        }
+    }
+    
+    @IBAction func resetDSN(_sender: Any) {
+        DSNStorage.shared.deleteDSN()
+    }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -2,6 +2,10 @@ import Sentry
 import UIKit
 
 class ViewController: UIViewController {
+    
+    @IBOutlet weak var dsnTextField: UITextField!
+    
+    private let dispatchQueue = DispatchQueue(label: "ViewController")
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,6 +30,16 @@ class ViewController: UIViewController {
         let user = Sentry.User(userId: "1")
         user.email = "tony1@example.com"
         SentrySDK.setUser(user)
+        
+        dispatchQueue.async {
+            let dsn = DSNStorage.shared.getDSN()
+            
+            DispatchQueue.main.async {
+                self.dsnTextField.text = dsn
+                self.dsnTextField.backgroundColor = UIColor.systemGreen
+            }
+        }
+        
     }
     
     @IBAction func addBreadcrumb(_ sender: Any) {
@@ -137,14 +151,25 @@ class ViewController: UIViewController {
         
         if let dsn = options.dsn {
             sender.backgroundColor = UIColor.systemGreen
-            DSNStorage.shared.saveDSN(dsn: dsn)
+            
+            dispatchQueue.async {
+                DSNStorage.shared.saveDSN(dsn: dsn)
+            }
         } else {
             sender.backgroundColor = UIColor.systemRed
-            DSNStorage.shared.deleteDSN()
+            
+            dispatchQueue.async {
+                DSNStorage.shared.deleteDSN()
+            }
         }
     }
     
     @IBAction func resetDSN(_ sender: Any) {
-        DSNStorage.shared.deleteDSN()
+        self.dsnTextField.text = AppDelegate.defaultDSN
+        self.dsnTextField.backgroundColor = UIColor.systemGreen
+        
+        dispatchQueue.async {
+            DSNStorage.shared.saveDSN(dsn: AppDelegate.defaultDSN)
+        }
     }
 }


### PR DESCRIPTION

## :scroll: Description

Add a text field to be able to change the DSN. A restart of the app is required
to make the adjusted DSN effective.

#skip-changelog

## :bulb: Motivation and Context

For testing purposes, we want to be able to change the DSN after the app is built. 

## :green_heart: How did you test it?
With the simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
