### PR TITLE
test: Close SDK after starting it

### DIFF
--- a/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrashIntegrationTests.swift
@@ -64,6 +64,8 @@ class SentryCrashIntegrationTests: XCTestCase {
         fixture.fileManager.deleteCurrentSession()
         fixture.fileManager.deleteCrashedSession()
         fixture.fileManager.deleteAppState()
+        
+        SentrySDK.close()
     }
     
     // Test for GH-581

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -18,6 +18,7 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     
     override func tearDown() {
         sentrycrash_deleteAllReports()
+        SentrySDK.close()
     }
     
     func testFaultyReportIsNotSentAndDeleted() throws {

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -9,6 +9,11 @@ class SentryStacktraceBuilderTests: XCTestCase {
         }
     }
     
+    override func tearDown() {
+        super.tearDown()
+        SentrySDK.close()
+    }
+    
     private let fixture = Fixture()
     
     func testEnoughFrames() {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -70,6 +70,8 @@ class SentrySDKTests: XCTestCase {
         }) as? SentryAutoSessionTrackingIntegration {
             autoSessionTracking.stop()
         }
+        
+        SentrySDK.close()
     }
     
     func testStartWithConfigureOptions() {

--- a/Tests/SentryTests/SentrySwiftTests.swift
+++ b/Tests/SentryTests/SentrySwiftTests.swift
@@ -14,6 +14,10 @@ class SentrySwiftTests: XCTestCase {
         SentrySDK.start(options: options)
     }
     
+    override func tearDown() {
+        super.tearDown()
+        SentrySDK.close()
+    }
     func testWrongDsn() {
         XCTAssertThrowsError(try Sentry.Options(dict: ["dsn": "http://sentry.io"]))
     }


### PR DESCRIPTION
We should close the SDK in tests after starting it to leave
the test in a clean state.

#skip-changelog
