### PR TITLE
test: Fix testLongThreadName

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -101,7 +101,7 @@ class SentryThreadInspectorTests: XCTestCase {
     }
     
     func testLongThreadName() {
-        let threadName = String(repeating: "1", count: 128)
+        let threadName = String(repeating: "1", count: 127)
         fixture.testMachineContextWrapper.threadName = threadName
         fixture.testMachineContextWrapper.threadCount = 1
         


### PR DESCRIPTION
testLongThreadName was failing on MacBook Air with M1 chip.
This is fixed now.

#skip-changelog
