### PR TITLE
fix: Remove tags and data if empty for Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Remove tags and data if empty for Span (#1246)
+
 ## 7.2.0-beta.7
 
 - fix: Swizzle only inApp ViewControllers (#1242)

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -95,9 +95,9 @@ SentrySpan ()
     [mutableDictionary setValue:@(self.startTimestamp.timeIntervalSince1970)
                          forKey:@"start_timestamp"];
 
-    if (_extras != nil) {
-        @synchronized(_extras) {
-            [mutableDictionary setValue:_extras.copy forKey:@"data"];
+    @synchronized(_extras) {
+        if (_extras.count > 0) {
+            mutableDictionary[@"data"] = _extras.copy;
         }
     }
 

--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -79,10 +79,15 @@ SentrySpanContext () {
         @"type" : SentrySpanContext.type,
         @"span_id" : self.spanId.sentrySpanIdString,
         @"trace_id" : self.traceId.sentryIdString,
-        @"tags" : _tags.copy,
         @"op" : self.operation
     }
                                                  .mutableCopy;
+
+    @synchronized(_tags) {
+        if (_tags.count > 0) {
+            mutabledictionary[@"tags"] = _tags.copy;
+        }
+    }
 
     // Since we guard for 'undecided', we'll
     // either send it if it's 'true' or 'false'.

--- a/Tests/SentryTests/SentrySpanContextTests.swift
+++ b/Tests/SentryTests/SentrySpanContextTests.swift
@@ -71,6 +71,7 @@ class SentrySpanContextTests: XCTestCase {
         XCTAssertNil(data["sampled"])
         XCTAssertNil(data["parent_span_id"])
         XCTAssertNil(data["status"])
+        XCTAssertNil(data["tags"])
     }
     
     func testSampledNoSerialization() {

--- a/Tests/SentryTests/SentrySpanTests.swift
+++ b/Tests/SentryTests/SentrySpanTests.swift
@@ -145,6 +145,13 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual((serialization["data"] as! Dictionary)[fixture.extraKey], fixture.extraValue)
     }
     
+    func testSerialization_WithNoData() {
+        let span = fixture.getSut()
+        
+        let serialization = span.serialize()
+        XCTAssertNil(serialization["data"])
+    }
+    
     func testTraceHeaderNotSampled() {
         let span = fixture.getSut()
         let header = span.toTraceHeader()


### PR DESCRIPTION




## :scroll: Description

Only add tags and data if they are not empty when serializing the span.

## :bulb: Motivation and Context

Fixes GH-1219

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
