### PR TITLE
fix: Race Conditions in NetworkTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased 
 
+- fix: Race Conditions in NetworkTracker (#1250)
 - fix: Don't create transactions for HTTP Requests. (#1237)
 
 ## 7.2.0-beta.7

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -294,7 +294,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let queue = DispatchQueue(label: "SentryNetworkTrackerTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
         
-        for _ in 0...10_000 {
+        for _ in 0...100_000 {
             group.enter()
             queue.async {
                 sut.urlSessionTaskResume(task)
@@ -323,7 +323,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let queue = DispatchQueue(label: "SentryNetworkTrackerTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
         
-        for _ in 0...10_000 {
+        for _ in 0...100_000 {
             group.enter()
             queue.async {
                 task.state = .completed

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -46,13 +46,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         let span = spanForTask(task: task)!
         
-        XCTAssertNotNil(span)
-        XCTAssertFalse(span.isFinished)
-        task.state = .completed
-        XCTAssertTrue(span.isFinished)
-
-        //Test if it has observers. Nil means no observers
-        XCTAssertNil(task.observationInfo)
+        assertCompletedSpan(task, span)
     }
     
     func testCaptureDownloadTask() {
@@ -263,6 +257,96 @@ class SentryNetworkTrackerTests: XCTestCase {
         assertStatus(status: .undefined, state: .completed, response: URLResponse())
     }
     
+    func testResumeAfterCompleted_OnlyOneSpanCreated() {
+        let task = createDataTask()
+        let sut = fixture.getSut()
+        let transaction = startTransaction()
+        
+        sut.urlSessionTaskResume(task)
+        task.state = .completed
+        sut.urlSessionTaskResume(task)
+
+        assertOneSpanCreated(transaction)
+    }
+    
+    func testResumeAfterCancelled_OnlyOneSpanCreated() {
+        let task = createDataTask()
+        let sut = fixture.getSut()
+        let transaction = startTransaction()
+        
+        sut.urlSessionTaskResume(task)
+        task.state = .canceling
+        sut.urlSessionTaskResume(task)
+
+        assertOneSpanCreated(transaction)
+    }
+    
+    // Altough we only run this test above the below specified versions, we exped the
+    // implementation to be thread safe
+    @available(tvOS 10.0, *)
+    @available(OSX 10.12, *)
+    @available(iOS 10.0, *)
+    func testResumeCalledMultipleTimesConcurrent_OneSpanCreated() {
+        let task = createDataTask()
+        let sut = fixture.getSut()
+        let transaction = startTransaction()
+        
+        let queue = DispatchQueue(label: "SentryNetworkTrackerTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+        let group = DispatchGroup()
+        
+        // The number is kept small for the CI to not take to long.
+        // If you really want to test this increase to 1_000_000 or so.
+        for _ in 0...10_000 {
+            group.enter()
+            queue.async {
+                sut.urlSessionTaskResume(task)
+                task.state = .completed
+                group.leave()
+            }
+        }
+        
+        queue.activate()
+        group.waitWithTimeout(timeout: 500)
+        
+        assertOneSpanCreated(transaction)
+    }
+    
+    // Altough we only run this test above the below specified versions, we exped the
+    // implementation to be thread safe
+    @available(tvOS 10.0, *)
+    @available(OSX 10.12, *)
+    @available(iOS 10.0, *)
+    func testChangeStateMultipleTimesConcurrent_OneSpanFinished() {
+        let task = createDataTask()
+        let sut = fixture.getSut()
+        let transaction = startTransaction()
+        sut.urlSessionTaskResume(task)
+        
+        let queue = DispatchQueue(label: "SentryNetworkTrackerTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+        let group = DispatchGroup()
+        
+        // The number is kept small for the CI to not take to long.
+        // If you really want to test this increase to 1_000_000 or so.
+        for _ in 0...100_000 {
+            group.enter()
+            queue.async {
+                task.state = .completed
+                group.leave()
+            }
+        }
+        
+        queue.activate()
+        group.waitWithTimeout(timeout: 500)
+        
+        let spans = Dynamic(transaction).children as [Span]?
+        XCTAssertEqual(1, spans?.count)
+        let span = spans!.first!
+        
+        XCTAssertTrue(span.isFinished)
+        //Test if it has observers. Nil means no observers
+        XCTAssertNil(task.observationInfo)
+    }
+    
     func assertStatus(status: SentrySpanStatus, state: URLSessionTask.State, response: URLResponse) {
         let sut = fixture.getSut()
         let task = createDataTask()
@@ -287,6 +371,21 @@ class SentryNetworkTrackerTests: XCTestCase {
                 
         XCTAssertEqual(span.context.status, status)
         XCTAssertNil(task.observationInfo)
+    }
+    
+    private func assertCompletedSpan(_ task: URLSessionDataTaskMock, _ span: Span) {
+        XCTAssertNotNil(span)
+        XCTAssertFalse(span.isFinished)
+        task.state = .completed
+        XCTAssertTrue(span.isFinished)
+
+        //Test if it has observers. Nil means no observers
+        XCTAssertNil(task.observationInfo)
+    }
+    
+    private func assertOneSpanCreated(_ transaction: Span) {
+        let spans = Dynamic(transaction).children as [Span]?
+        XCTAssertEqual(1, spans?.count)
     }
     
     private func spanForTask(task: URLSessionTask) -> Span? {

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -294,8 +294,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         let queue = DispatchQueue(label: "SentryNetworkTrackerTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
         
-        // The number is kept small for the CI to not take to long.
-        // If you really want to test this increase to 1_000_000 or so.
         for _ in 0...10_000 {
             group.enter()
             queue.async {
@@ -306,7 +304,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         }
         
         queue.activate()
-        group.waitWithTimeout(timeout: 500)
+        group.waitWithTimeout(timeout: 100)
         
         assertOneSpanCreated(transaction)
     }
@@ -325,9 +323,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let queue = DispatchQueue(label: "SentryNetworkTrackerTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
         
-        // The number is kept small for the CI to not take to long.
-        // If you really want to test this increase to 1_000_000 or so.
-        for _ in 0...100_000 {
+        for _ in 0...10_000 {
             group.enter()
             queue.async {
                 task.state = .completed
@@ -336,7 +332,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         }
         
         queue.activate()
-        group.waitWithTimeout(timeout: 500)
+        group.waitWithTimeout(timeout: 100)
         
         let spans = Dynamic(transaction).children as [Span]?
         XCTAssertEqual(1, spans?.count)


### PR DESCRIPTION


## :scroll: Description

Adding concurrent tests for SentryNetworkTracker revealed some race
conditions that are now fixed.

## :bulb: Motivation and Context

We don't want to have race conditions in SentryNewtorkTracker.

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
