### PR TITLE
feat: UI auto performance tracking bind span to scope

### DIFF
--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -101,7 +101,8 @@ SentryPerformanceTracker ()
     }
 }
 
-- (id<SentrySpan>)getRootSpan:(id<SentrySpan>)span {
+- (id<SentrySpan>)getRootSpan:(id<SentrySpan>)span
+{
     while ([span.context parentSpanId] != nil) {
         span = self.spans[span.context.parentSpanId];
     }
@@ -119,13 +120,15 @@ SentryPerformanceTracker ()
         @synchronized(self.activeStack) {
             [self.activeStack addObject:toActiveSpan];
         }
-        
-        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan>  _Nullable span) {
-            if (span == nil) return;
-            
-            @synchronized (self.spans) {
-                if ([self.spans objectForKey:span.context.spanId] == nil) return;
-                
+
+        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
+            if (span == nil)
+                return;
+
+            @synchronized(self.spans) {
+                if ([self.spans objectForKey:span.context.spanId] == nil)
+                    return;
+
                 [SentrySDK.currentHub.scope setSpan:toActiveSpan];
             }
         }];
@@ -134,26 +137,28 @@ SentryPerformanceTracker ()
 
 - (void)popActiveSpan
 {
-    if (self.activeStack.count == 0) return;
-    
+    if (self.activeStack.count == 0)
+        return;
+
     id<SentrySpan> currentActiveSpan;
     id<SentrySpan> nextActiveSpan;
-    
+
     @synchronized(self.activeStack) {
         currentActiveSpan = [self.activeStack lastObject];
         [self.activeStack removeLastObject];
         nextActiveSpan = [self.activeStack lastObject];
-        
-        //if the stack is empty, we should find the root span.
-        if(nextActiveSpan == nil) {
+
+        // if the stack is empty, we should find the root span.
+        if (nextActiveSpan == nil) {
             nextActiveSpan = [self getRootSpan:currentActiveSpan];
-            //if the transaction is finish, there is no point in bind it to the scope.
+            // if the transaction is finish, there is no point in bind it to the scope.
             if ([nextActiveSpan isFinished])
                 nextActiveSpan = nil;
         }
-        
-        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan>  _Nullable span) {
-            if (![span.context.spanId isEqual:currentActiveSpan.context.spanId]) return;
+
+        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
+            if (![span.context.spanId isEqual:currentActiveSpan.context.spanId])
+                return;
             [SentrySDK.currentHub.scope setSpan:nextActiveSpan];
         }];
     }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

When the transaction in the scope was created by the UI auto performance tracking, every time a span is push or pop as the active span, SentryPerformanceTracker changes the span in the scope to property create a relationship between automatically created spans and user created spans.

## :bulb: Motivation and Context

Solves #1215.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
