### PR TITLE
test: Make SentryHTTPInterceptorTests works for MacCatalyst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Make SentryHTTPInterceptorTests works for MacCatalyst (#1256)
 - fix: Remove tags and data if empty for Span (#1246)
 - fix: Race Conditions in NetworkTracker (#1250)
 - fix: Don't create transactions for HTTP Requests. (#1237)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased
 
-- fix: Make SentryHTTPInterceptorTests works for MacCatalyst (#1256)
 - fix: Remove tags and data if empty for Span (#1246)
 - fix: Race Conditions in NetworkTracker (#1250)
 - fix: Don't create transactions for HTTP Requests. (#1237)

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -487,6 +487,7 @@
 		8E564AF0267AF24400FE117D /* SentryNetworkTrackingIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E564AED267AF24400FE117D /* SentryNetworkTrackingIntegration.h */; };
 		8E5D38DD261D4A3E000D363D /* SentryPerformanceTrackingIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E5D38DB261D4A3E000D363D /* SentryPerformanceTrackingIntegration.m */; };
 		8E5D38E3261D4B57000D363D /* SentryPerformanceTrackingIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E5D38E2261D4B57000D363D /* SentryPerformanceTrackingIntegration.h */; };
+		8E67F53026B0EE6200A07CB5 /* TestURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E67F52F26B0EE6200A07CB5 /* TestURLSession.m */; };
 		8E70B0FD25CB72BE002B3155 /* SentrySpanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E70B0FC25CB72BE002B3155 /* SentrySpanTests.swift */; };
 		8E70B10125CB8695002B3155 /* SentrySpanIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E70B10025CB8695002B3155 /* SentrySpanIdTests.swift */; };
 		8E7C982F2693D56000E6336C /* SentryTraceHeader.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E7C982D2693D56000E6336C /* SentryTraceHeader.m */; };
@@ -1068,6 +1069,8 @@
 		8E564AED267AF24400FE117D /* SentryNetworkTrackingIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNetworkTrackingIntegration.h; path = include/SentryNetworkTrackingIntegration.h; sourceTree = "<group>"; };
 		8E5D38DB261D4A3E000D363D /* SentryPerformanceTrackingIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPerformanceTrackingIntegration.m; sourceTree = "<group>"; };
 		8E5D38E2261D4B57000D363D /* SentryPerformanceTrackingIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryPerformanceTrackingIntegration.h; path = include/SentryPerformanceTrackingIntegration.h; sourceTree = "<group>"; };
+		8E67F52E26B0EE6200A07CB5 /* TestURLSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestURLSession.h; sourceTree = "<group>"; };
+		8E67F52F26B0EE6200A07CB5 /* TestURLSession.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestURLSession.m; sourceTree = "<group>"; };
 		8E70B0FC25CB72BE002B3155 /* SentrySpanTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySpanTests.swift; sourceTree = "<group>"; };
 		8E70B10025CB8695002B3155 /* SentrySpanIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySpanIdTests.swift; sourceTree = "<group>"; };
 		8E7C982D2693D56000E6336C /* SentryTraceHeader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTraceHeader.m; sourceTree = "<group>"; };
@@ -1925,6 +1928,8 @@
 				8ED2D27E26A6581C00CA8329 /* NSURLProtocolSwizzle.h */,
 				8ED2D27F26A6581C00CA8329 /* NSURLProtocolSwizzle.m */,
 				8E0551DF26A7A63C00400526 /* TestProtocolClient.swift */,
+				8E67F52E26B0EE6200A07CB5 /* TestURLSession.h */,
+				8E67F52F26B0EE6200A07CB5 /* TestURLSession.m */,
 			);
 			path = Networking;
 			sourceTree = "<group>";
@@ -2656,6 +2661,7 @@
 				7B6438A726A70DDB000D0F65 /* UIViewControllerSentryTests.swift in Sources */,
 				15E0A8F0240F638200F044E3 /* SentrySerializationNilTests.m in Sources */,
 				63FE722120DA66EC00CDBAE8 /* SentryCrashDynamicLinker_Tests.m in Sources */,
+				8E67F53026B0EE6200A07CB5 /* TestURLSession.m in Sources */,
 				63FE720120DA66EC00CDBAE8 /* RFC3339UTFString_Tests.m in Sources */,
 				63AA76701EB8CB4B00D153DE /* SentryTests.m in Sources */,
 				8E70B0FD25CB72BE002B3155 /* SentrySpanTests.swift in Sources */,

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.h
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nullable, readonly) NSDate *resumeDate;
 @property (nonatomic) NSURLSessionTaskState state;
 
+- (instancetype)init;
+
 - (instancetype)initWithRequest:(NSURLRequest *)request;
 
 - (void)setResponse:(NSURLResponse *)response;

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.m
@@ -42,6 +42,13 @@
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
+- (instancetype)init
+{
+    self = [super init];
+    return self;
+}
+
 - (instancetype)initWithRequest:(NSURLRequest *)request
 {
     if (self = [super init]) {

--- a/Tests/SentryTests/Networking/SentryHTTPInterceptorTests.swift
+++ b/Tests/SentryTests/Networking/SentryHTTPInterceptorTests.swift
@@ -1,27 +1,12 @@
 import XCTest
 
-#if !targetEnvironment(macCatalyst)
 class SentryHTTPInterceptorTests: XCTestCase {
     
     private static let httpUrl = "http://somedomain.com"
     private static let httpsUrl = "https://somedomain.com"
     private static let wsUrl = "ws://somedomain.com"
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentrySessionTrackerTests")
-    
-    class TestURLSession: URLSession {
-        var invalidateAndCancelDate: Date?
-        var lastDataTask: URLSessionDataTaskMock?
-        
-        override func dataTask(with request: URLRequest) -> URLSessionDataTask {
-            lastDataTask = URLSessionDataTaskMock(request: request)
-            return lastDataTask!
-        }
-        
-        override func invalidateAndCancel() {
-            invalidateAndCancelDate = CurrentDate.date()
-        }
-    }
-    
+       
     class TestSentryHTTPInterceptor: SentryHttpInterceptor {
         override func createSession() -> URLSession {
             return TestURLSession()
@@ -242,5 +227,3 @@ class SentryHTTPInterceptorTests: XCTestCase {
         XCTAssertTrue(testCallbackCalled)
     }
 }
-
-#endif

--- a/Tests/SentryTests/Networking/TestURLSession.h
+++ b/Tests/SentryTests/Networking/TestURLSession.h
@@ -1,0 +1,15 @@
+#import "URLSessionTaskMock.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface TestURLSession : NSURLSession
+
+@property (nullable, nonatomic, strong) NSDate *invalidateAndCancelDate;
+@property (nullable, nonatomic, strong) URLSessionDataTaskMock *lastDataTask;
+
+- (instancetype)init;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Networking/TestURLSession.m
+++ b/Tests/SentryTests/Networking/TestURLSession.m
@@ -1,0 +1,26 @@
+#import "TestURLSession.h"
+#import "SentryCurrentDate.h"
+
+@implementation TestURLSession
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (instancetype)init
+{
+    self = [super init];
+    return self;
+}
+#pragma clang diagnostic pop
+
+- (NSURLSessionDataTask *)dataTaskWithRequest:(NSURLRequest *)request
+{
+    self.lastDataTask = [[URLSessionDataTaskMock alloc] initWithRequest:request];
+    return self.lastDataTask;
+}
+
+- (void)invalidateAndCancel
+{
+    self.invalidateAndCancelDate = [SentryCurrentDate date];
+}
+
+@end

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -115,5 +115,6 @@
 #import "SentryUIViewControllerSwizziling.h"
 #import "SentryUserFeedback.h"
 #import "TestSentryCrashAdapter.h"
+#import "TestUrlSession.h"
 #import "UIViewController+Sentry.h"
 #import "URLSessionTaskMock.h"


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Fixed SentryHTTPInterceptorTests to work for MacCatalyst.

#skip-changelog

## :bulb: Motivation and Context

Test should work on as many platforms as possible.
Fixes GH-1238 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
