### PR TITLE
docs: Fix typo for bindToScope

### DIFF
--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -78,7 +78,7 @@ SENTRY_NO_INIT
  *
  * @param name The transaction name.
  * @param operation Short code identifying the type of operation the span is measuring.
- * @param bindToScope Indicates whether the new transaction should be bind to the scope.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
  *
  * @return The created transaction.
  */
@@ -101,7 +101,7 @@ SENTRY_NO_INIT
  * Creates a transaction, binds it to the hub and returns the instance.
  *
  * @param transactionContext The transaction context.
- * @param bindToScope Indicates whether the new transaction should be bind to the scope.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
  *
  * @return The created transaction.
  */
@@ -113,7 +113,7 @@ SENTRY_NO_INIT
  * Creates a transaction, binds it to the hub and returns the instance.
  *
  * @param transactionContext The transaction context.
- * @param bindToScope Indicates whether the new transaction should be bind to the scope.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
  * @param customSamplingContext Additional information about the sampling context.
  *
  * @return The created transaction.

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -91,7 +91,7 @@ SENTRY_NO_INIT
  *
  * @param name The transaction name.
  * @param operation Short code identifying the type of operation the span is measuring.
- * @param bindToScope Indicates whether the new transaction should be bind to the scope.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
  *
  * @return The created transaction.
  */
@@ -114,7 +114,7 @@ SENTRY_NO_INIT
  * Creates a transaction, binds it to the hub and returns the instance.
  *
  * @param transactionContext The transaction context.
- * @param bindToScope Indicates whether the new transaction should be bind to the scope.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
  *
  * @return The created transaction.
  */
@@ -126,7 +126,7 @@ SENTRY_NO_INIT
  * Creates a transaction, binds it to the hub and returns the instance.
  *
  * @param transactionContext The transaction context.
- * @param bindToScope Indicates whether the new transaction should be bind to the scope.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
  * @param customSamplingContext Additional information about the sampling context.
  *
  * @return The created transaction.


### PR DESCRIPTION

## :scroll: Description

The description for the param bindToScope contained a typo. This is fixed
now.

#skip-changelog

## :bulb: Motivation and Context

We don't want to have typos in our code docs.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
