### PR TITLE
feat: Expose tracked screen frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Expose tracked screen frames (#1262)
 - feat: Expose AppStartMeasurment for Hybrid SDKs (#1251)
 - fix: Span serialization HTTP data in wrong place. (#1255)
 - feat: Add tags to Sentry Span (#1243)

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -293,6 +293,8 @@
 		7B6D98ED24C703F8005502FA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D98EC24C703F8005502FA /* Async.swift */; };
 		7B7A30C624B48321005A4C6E /* SentryCrashAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */; };
 		7B7A30C824B48389005A4C6E /* SentryCrashAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */; };
+		7B7A599526B692540060A676 /* SentryScreenFrames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A599426B692540060A676 /* SentryScreenFrames.h */; };
+		7B7A599726B692F00060A676 /* SentryScreenFrames.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A599626B692F00060A676 /* SentryScreenFrames.m */; };
 		7B7D872C2486480B00D2ECFF /* SentryStacktraceBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7D872B2486480B00D2ECFF /* SentryStacktraceBuilder.h */; };
 		7B7D872E2486482600D2ECFF /* SentryStacktraceBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D872D2486482600D2ECFF /* SentryStacktraceBuilder.m */; };
 		7B7D8730248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D872F248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift */; };
@@ -849,6 +851,8 @@
 		7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashAdapter.h; path = include/SentryCrashAdapter.h; sourceTree = "<group>"; };
 		7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashAdapter.m; sourceTree = "<group>"; };
 		7B7A30C924B48523005A4C6E /* SentryHub+TestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryHub+TestInit.h"; sourceTree = "<group>"; };
+		7B7A599426B692540060A676 /* SentryScreenFrames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryScreenFrames.h; path = Public/SentryScreenFrames.h; sourceTree = "<group>"; };
+		7B7A599626B692F00060A676 /* SentryScreenFrames.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryScreenFrames.m; sourceTree = "<group>"; };
 		7B7D872B2486480B00D2ECFF /* SentryStacktraceBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryStacktraceBuilder.h; path = include/SentryStacktraceBuilder.h; sourceTree = "<group>"; };
 		7B7D872D2486482600D2ECFF /* SentryStacktraceBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryStacktraceBuilder.m; sourceTree = "<group>"; };
 		7B7D872F248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStacktraceBuilderTests.swift; sourceTree = "<group>"; };
@@ -1375,10 +1379,12 @@
 				7BD86ED0264A7CF6005439DB /* SentryAppStartMeasurement.m */,
 				7B6C5ED9264E8D860010D138 /* SentryFramesTrackingIntegration.h */,
 				7B6C5EDB264E8DA80010D138 /* SentryFramesTrackingIntegration.m */,
-				7B6C5EDD264E8DF00010D138 /* SentryFramesTracker.m */,
 				7B30B67B26527886006B2752 /* SentryDisplayLinkWrapper.h */,
 				7B30B67D26527894006B2752 /* SentryDisplayLinkWrapper.m */,
 				7B6C5EDF264E8E050010D138 /* SentryFramesTracker.h */,
+				7B6C5EDD264E8DF00010D138 /* SentryFramesTracker.m */,
+				7B7A599426B692540060A676 /* SentryScreenFrames.h */,
+				7B7A599626B692F00060A676 /* SentryScreenFrames.m */,
 				8E564AED267AF24400FE117D /* SentryNetworkTrackingIntegration.h */,
 				8E564AE5267AF22600FE117D /* SentryNetworkTrackingIntegration.m */,
 				8E564AEB267AF24300FE117D /* SentryNetworkSwizzling.h */,
@@ -2231,6 +2237,7 @@
 				63FE714720DA4C1100CDBAE8 /* SentryCrashMachineContext.h in Headers */,
 				7BA61CAB247BA98100C130A8 /* SentryDebugImageProvider.h in Headers */,
 				638DC9A01EBC6B6400A66E41 /* SentryRequestOperation.h in Headers */,
+				7B7A599526B692540060A676 /* SentryScreenFrames.h in Headers */,
 				6344DDB01EC308E400D9160D /* SentryCrashInstallationReporter.h in Headers */,
 				8E25C95725F836EE00DC215B /* SentryRandom.h in Headers */,
 				63FE70ED20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h in Headers */,
@@ -2378,6 +2385,7 @@
 				7BD86ED1264A7CF6005439DB /* SentryAppStartMeasurement.m in Sources */,
 				7DC27EC723997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m in Sources */,
 				63FE717B20DA4C1100CDBAE8 /* SentryCrashReport.c in Sources */,
+				7B7A599726B692F00060A676 /* SentryScreenFrames.m in Sources */,
 				7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */,
 				A2475E1F25FB648B007D9080 /* fishhook.c in Sources */,
 				631E6D341EBC679C00712345 /* SentryQueueableRequestManager.m in Sources */,

--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -2,7 +2,7 @@
 
 #import "SentryDefines.h"
 
-@class SentryEnvelope, SentryDebugMeta, SentryAppStartMeasurement;
+@class SentryEnvelope, SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -55,6 +55,11 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * didFinishLaunchingTimestamp to timeIntervalSinceReferenceDate. Default is NO.
  */
 @property (class, nonatomic, assign) BOOL appStartMeasurementHybridSDKMode;
+
+#if SENTRY_HAS_UIKIT
+@property (class, nonatomic, assign, readonly) BOOL isFramesTrackingRunning;
+@property (class, nonatomic, assign, readonly) SentryScreenFrames *currentScreenFrames;
+#endif
 
 @end
 

--- a/Sources/Sentry/Public/SentryScreenFrames.h
+++ b/Sources/Sentry/Public/SentryScreenFrames.h
@@ -1,0 +1,20 @@
+#import "SentryDefines.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if SENTRY_HAS_UIKIT
+
+@interface SentryScreenFrames : NSObject
+SENTRY_NO_INIT
+
+- (instancetype)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow;
+
+@property (nonatomic, assign, readonly) NSUInteger total;
+@property (nonatomic, assign, readonly) NSUInteger frozen;
+@property (nonatomic, assign, readonly) NSUInteger slow;
+
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -2,6 +2,7 @@
 #import "SentryDisplayLinkWrapper.h"
 #import "SentryLog.h"
 #import "SentryOptions.h"
+#import <SentryScreenFrames.h>
 #include <stdatomic.h>
 
 #if SENTRY_HAS_UIKIT
@@ -114,19 +115,13 @@ SentryFramesTracker ()
     atomic_fetch_add_explicit(&_totalFrames, 1, SentryFramesMemoryOrder);
 }
 
-- (NSUInteger)currentTotalFrames
+- (SentryScreenFrames *)currentFrames
 {
-    return atomic_load_explicit(&_totalFrames, SentryFramesMemoryOrder);
-}
+    NSUInteger total = atomic_load_explicit(&_totalFrames, SentryFramesMemoryOrder);
+    NSUInteger slow = atomic_load_explicit(&_slowFrames, SentryFramesMemoryOrder);
+    NSUInteger frozen = atomic_load_explicit(&_frozenFrames, SentryFramesMemoryOrder);
 
-- (NSUInteger)currentSlowFrames
-{
-    return atomic_load_explicit(&_slowFrames, SentryFramesMemoryOrder);
-}
-
-- (NSUInteger)currentFrozenFrames
-{
-    return atomic_load_explicit(&_frozenFrames, SentryFramesMemoryOrder);
+    return [[SentryScreenFrames alloc] initWithTotal:total frozen:frozen slow:slow];
 }
 
 - (void)stop

--- a/Sources/Sentry/SentryHybridSKdsOnly.m
+++ b/Sources/Sentry/SentryHybridSKdsOnly.m
@@ -3,6 +3,7 @@
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import <Foundation/Foundation.h>
+#import <SentryFramesTracker.h>
 
 @interface
 PrivateSentrySDKOnly ()
@@ -69,5 +70,19 @@ static BOOL _appStartMeasurementHybridSDKMode = NO;
 {
     _appStartMeasurementHybridSDKMode = appStartMeasurementHybridSDKMode;
 }
+
+#if SENTRY_HAS_UIKIT
+
++ (BOOL)isFramesTrackingRunning
+{
+    return [SentryFramesTracker sharedInstance].isRunning;
+}
+
++ (SentryScreenFrames *)currentScreenFrames
+{
+    return [SentryFramesTracker sharedInstance].currentFrames;
+}
+
+#endif
 
 @end

--- a/Sources/Sentry/SentryScreenFrames.m
+++ b/Sources/Sentry/SentryScreenFrames.m
@@ -1,0 +1,21 @@
+#import <Foundation/Foundation.h>
+#import <SentryScreenFrames.h>
+
+#if SENTRY_HAS_UIKIT
+
+@implementation SentryScreenFrames
+
+- (instancetype)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow
+{
+    if (self = [super init]) {
+        _total = total;
+        _slow = slow;
+        _frozen = frozen;
+    }
+
+    return self;
+}
+
+@end
+
+#endif

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -13,6 +13,7 @@
 #import "SentryTransaction.h"
 #import "SentryTransactionContext.h"
 #import "SentryUIViewControllerPerformanceTracker.h"
+#import <SentryScreenFrames.h>
 
 static const void *spanTimestampObserver = &spanTimestampObserver;
 
@@ -82,9 +83,10 @@ static BOOL appStartMeasurementRead;
         // frames at the end of the transaction.
         SentryFramesTracker *framesTracker = [SentryFramesTracker sharedInstance];
         if (framesTracker.isRunning) {
-            initTotalFrames = framesTracker.currentTotalFrames;
-            initSlowFrames = framesTracker.currentSlowFrames;
-            initFrozenFrames = framesTracker.currentFrozenFrames;
+            SentryScreenFrames *currentFrames = framesTracker.currentFrames;
+            initTotalFrames = currentFrames.total;
+            initSlowFrames = currentFrames.slow;
+            initFrozenFrames = currentFrames.frozen;
         }
 #endif
     }
@@ -416,9 +418,11 @@ static BOOL appStartMeasurementRead;
     // Frames
     SentryFramesTracker *framesTracker = [SentryFramesTracker sharedInstance];
     if (framesTracker.isRunning && !_startTimeChanged) {
-        NSInteger totalFrames = framesTracker.currentTotalFrames - initTotalFrames;
-        NSInteger slowFrames = framesTracker.currentSlowFrames - initSlowFrames;
-        NSInteger frozenFrames = framesTracker.currentFrozenFrames - initFrozenFrames;
+
+        SentryScreenFrames *currentFrames = framesTracker.currentFrames;
+        NSInteger totalFrames = currentFrames.total - initTotalFrames;
+        NSInteger slowFrames = currentFrames.slow - initSlowFrames;
+        NSInteger frozenFrames = currentFrames.frozen - initFrozenFrames;
 
         BOOL allBiggerThanZero = totalFrames >= 0 && slowFrames >= 0 && frozenFrames >= 0;
         BOOL oneBiggerThanZero = totalFrames > 0 || slowFrames > 0 || frozenFrames > 0;

--- a/Sources/Sentry/include/SentryFramesTracker.h
+++ b/Sources/Sentry/include/SentryFramesTracker.h
@@ -1,6 +1,6 @@
 #import "SentryDefines.h"
 
-@class SentryOptions, SentryDisplayLinkWrapper;
+@class SentryOptions, SentryDisplayLinkWrapper, SentryScreenFrames;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,11 +14,9 @@ SENTRY_NO_INIT
 
 + (instancetype)sharedInstance;
 
-@property (nonatomic, assign, readonly) NSUInteger currentTotalFrames;
-@property (nonatomic, assign, readonly) NSUInteger currentFrozenFrames;
-@property (nonatomic, assign, readonly) NSUInteger currentSlowFrames;
-
+@property (nonatomic, assign, readonly) SentryScreenFrames *currentFrames;
 @property (nonatomic, assign, readonly) BOOL isRunning;
+
 - (void)start;
 - (void)stop;
 

--- a/Tests/SentryTests/ClearTestState.swift
+++ b/Tests/SentryTests/ClearTestState.swift
@@ -8,4 +8,10 @@ func clearTestState() {
     SentrySDK.setAppStartMeasurement(nil)
     CurrentDate.setCurrentDateProvider(nil)
     SentryNetworkTracker.sharedInstance.disable()
+    
+    #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    let framesTracker = SentryFramesTracker.sharedInstance()
+    framesTracker.stop()
+    framesTracker.resetFrames()
+    #endif
 }

--- a/Tests/SentryTests/Integrations/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryFramesTrackerTests.swift
@@ -53,9 +53,10 @@ class SentryFramesTrackerTests: XCTestCase {
         fixture.displayLinkWrapper.internalTimestamp += TestData.frozenFrameThreshold
         fixture.displayLinkWrapper.call()
         
-        XCTAssertEqual(2, sut.currentSlowFrames)
-        XCTAssertEqual(3, sut.currentTotalFrames)
-        XCTAssertEqual(0, sut.currentFrozenFrames)
+        let currentFrames = sut.currentFrames
+        XCTAssertEqual(2, currentFrames.slow)
+        XCTAssertEqual(3, currentFrames.total)
+        XCTAssertEqual(0, currentFrames.frozen)
     }
     
     func testFrozenFrame() {
@@ -68,9 +69,10 @@ class SentryFramesTrackerTests: XCTestCase {
         fixture.displayLinkWrapper.internalTimestamp += TestData.frozenFrameThreshold
         fixture.displayLinkWrapper.call()
         
-        XCTAssertEqual(1, sut.currentSlowFrames)
-        XCTAssertEqual(2, sut.currentTotalFrames)
-        XCTAssertEqual(1, sut.currentFrozenFrames)
+        let currentFrames = sut.currentFrames
+        XCTAssertEqual(1, currentFrames.slow)
+        XCTAssertEqual(2, currentFrames.total)
+        XCTAssertEqual(1, currentFrames.frozen)
     }
     
     func testAllFrames_ConcurrentRead() {
@@ -79,9 +81,10 @@ class SentryFramesTrackerTests: XCTestCase {
         
         let group = DispatchGroup()
         
-        assertPreviousCountBiggerThanCurrent(group) { return sut.currentFrozenFrames }
-        assertPreviousCountBiggerThanCurrent(group) { return sut.currentSlowFrames }
-        assertPreviousCountBiggerThanCurrent(group) { return sut.currentTotalFrames }
+        var currentFrames = sut.currentFrames
+        assertPreviousCountBiggerThanCurrent(group) { return currentFrames.frozen }
+        assertPreviousCountBiggerThanCurrent(group) { return currentFrames.slow }
+        assertPreviousCountBiggerThanCurrent(group) { return currentFrames.total }
         
         fixture.displayLinkWrapper.call()
         
@@ -95,9 +98,10 @@ class SentryFramesTrackerTests: XCTestCase {
         }
         
         group.wait()
-        XCTAssertEqual(2 * frames, sut.currentTotalFrames)
-        XCTAssertEqual(frames, sut.currentSlowFrames)
-        XCTAssertEqual(frames, sut.currentFrozenFrames)
+        currentFrames = sut.currentFrames
+        XCTAssertEqual(2 * frames, currentFrames.total)
+        XCTAssertEqual(frames, currentFrames.slow)
+        XCTAssertEqual(frames, currentFrames.frozen)
     }
     
     func testPerformanceOfTrackingFrames() {

--- a/Tests/SentryTests/Integrations/TestDisplayLinkWrapper.swift
+++ b/Tests/SentryTests/Integrations/TestDisplayLinkWrapper.swift
@@ -25,6 +25,28 @@ class TestDiplayLinkWrapper: SentryDisplayLinkWrapper {
         target = nil
         selector = nil
     }
+    
+    func givenFrames(_ slow: Int, _ frozen: Int, _ normal: Int) {
+        self.call()
+
+        // Slow frames
+        for _ in 0..<slow {
+            self.internalTimestamp += TestData.slowFrameThreshold + 0.001
+            self.call()
+        }
+
+        // Frozen frames
+        for _ in 0..<frozen {
+            self.internalTimestamp += TestData.frozenFrameThreshold + 0.001
+            self.call()
+        }
+
+        // Normal frames.
+        for _ in 0..<(normal - 1) {
+            self.internalTimestamp += TestData.slowFrameThreshold - 0.01
+            self.call()
+        }
+    }
 }
 
 #endif

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -307,7 +307,7 @@ class SentryTracerTests: XCTestCase {
 
     func testChangeStartTimeStamp_RemovesFramesMeasurement() {
         let sut = fixture.getSut()
-        givenFrames(1, 1, 1)
+        fixture.displayLinkWrapper.givenFrames(1, 1, 1)
         sut.startTimestamp = Date(timeIntervalSince1970: 0)
 
         sut.finish()
@@ -322,7 +322,7 @@ class SentryTracerTests: XCTestCase {
         let frozenFrames = 1
         let normalFrames = 100
         let totalFrames = slowFrames + frozenFrames + normalFrames
-        givenFrames(slowFrames, frozenFrames, normalFrames)
+        fixture.displayLinkWrapper.givenFrames(slowFrames, frozenFrames, normalFrames)
 
         sut.finish()
 
@@ -341,7 +341,7 @@ class SentryTracerTests: XCTestCase {
     }
     
     func testNegativeFramesAmount_NoMeasurmentAdded() {
-        givenFrames(10, 10, 10)
+        fixture.displayLinkWrapper.givenFrames(10, 10, 10)
         
         let sut = fixture.getSut()
         
@@ -350,28 +350,6 @@ class SentryTracerTests: XCTestCase {
         sut.finish()
         
         assertNoMeasurementsAdded()
-    }
-    
-    private func givenFrames(_ slow: Int, _ frozen: Int, _ normal: Int) {
-        fixture.displayLinkWrapper.call()
-
-        // Slow frames
-        for _ in 0..<slow {
-            fixture.displayLinkWrapper.internalTimestamp += TestData.slowFrameThreshold + 0.001
-            fixture.displayLinkWrapper.call()
-        }
-
-        // Frozen frames
-        for _ in 0..<frozen {
-            fixture.displayLinkWrapper.internalTimestamp += TestData.frozenFrameThreshold + 0.001
-            fixture.displayLinkWrapper.call()
-        }
-
-        // Normal frames.
-        for _ in 0..<(normal - 1) {
-            fixture.displayLinkWrapper.internalTimestamp += TestData.slowFrameThreshold - 0.01
-            fixture.displayLinkWrapper.call()
-        }
     }
     #endif
     

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -59,4 +59,33 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true
         XCTAssertTrue(PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode)
     }
+    
+    #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    
+    func testIsFramesTrackingRunning() {
+        XCTAssertFalse(PrivateSentrySDKOnly.isFramesTrackingRunning)
+        SentryFramesTracker.sharedInstance().start()
+        XCTAssertTrue(PrivateSentrySDKOnly.isFramesTrackingRunning)
+    }
+    
+    func testGetFrames() {
+        let tracker = SentryFramesTracker.sharedInstance()
+        let displayLink = TestDiplayLinkWrapper()
+        
+        tracker.setDisplayLinkWrapper(displayLink)
+        tracker.start()
+        displayLink.call()
+        
+        let slow = 2
+        let frozen = 1
+        let normal = 100
+        displayLink.givenFrames(slow, frozen, normal)
+        
+        let currentFrames = PrivateSentrySDKOnly.currentScreenFrames
+        XCTAssertEqual(UInt(slow + frozen + normal), currentFrames.total)
+        XCTAssertEqual(UInt(frozen), currentFrames.frozen)
+        XCTAssertEqual(UInt(slow), currentFrames.slow)
+    }
+
+    #endif
 }

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -92,6 +92,7 @@
 #import "SentryScope+Private.h"
 #import "SentryScopeObserver.h"
 #import "SentryScopeSyncC.h"
+#import "SentryScreenFrames.h"
 #import "SentrySdkInfo.h"
 #import "SentrySerialization.h"
 #import "SentrySession+Private.h"


### PR DESCRIPTION


## :scroll: Description

Expose a method for HybridSDKs to get the current slow, frozen and total frames.

## :bulb: Motivation and Context

Hybrid SDKs want to add the frame rates to transactions.

## :green_heart: How did you test it?
CI and unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
