### PR TITLE
fix: Callback issue for auto performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Callback issue for auto performance (#1275)
+
 ## 7.2.0
 
 This release contains support for [auto performance instrumentation](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/)

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -86,8 +86,10 @@ SentryPerformanceTracker ()
                       parentSpanId:(SentrySpanId *)parentSpanId
                            inBlock:(void (^)(void))block
 {
-    if (![self isSpanAlive:parentSpanId])
+    if (![self isSpanAlive:parentSpanId]) {
+        block();
         return;
+    }
 
     [self pushActiveSpan:parentSpanId];
     [self measureSpanWithDescription:description operation:operation inBlock:block];

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -37,188 +37,197 @@ SentryUIViewControllerPerformanceTracker ()
 #if SENTRY_HAS_UIKIT
 
 - (void)viewControllerLoadView:(UIViewController *)controller
-              callbackToOrigin:(void (^)(void))callback
+              callbackToOrigin:(void (^)(void))callbackToOrigin
 {
-    [self
-        limitOverride:@"loadView"
-               target:controller
-                block:^{
-                    SentrySpanId *spanId = objc_getAssociatedObject(
-                        controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
+    [self limitOverride:@"loadView"
+                  target:controller
+        callbackToOrigin:callbackToOrigin
+                   block:^{
+                       SentrySpanId *spanId = objc_getAssociatedObject(
+                           controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
 
-                    // If the user manually call loadView outside the lifecycle
-                    // we don't start a new transaction and override the previous id stored.
-                    if (spanId == nil) {
-                        NSString *name =
-                            [SentryUIViewControllerSanitizer sanitizeViewControllerName:controller];
-                        spanId = [self.tracker
-                            startSpanWithName:name
-                                    operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION];
+                       // If the user manually call loadView outside the lifecycle
+                       // we don't start a new transaction and override the previous id stored.
+                       if (spanId == nil) {
+                           NSString *name = [SentryUIViewControllerSanitizer
+                               sanitizeViewControllerName:controller];
+                           spanId = [self.tracker
+                               startSpanWithName:name
+                                       operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION];
 
-                        // use the target itself to store the spanId to avoid using a global mapper.
-                        objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID,
-                            spanId, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                    }
+                           // use the target itself to store the spanId to avoid using a global
+                           // mapper.
+                           objc_setAssociatedObject(controller,
+                               &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID, spanId,
+                               OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                       }
 
-                    [self measurePerformance:@"loadView" target:controller blockToMeasure:callback];
-                }];
+                       [self measurePerformance:@"loadView"
+                                         target:controller
+                               callbackToOrigin:callbackToOrigin];
+                   }];
 }
 
 - (void)viewControllerViewDidLoad:(UIViewController *)controller
-                 callbackToOrigin:(void (^)(void))callback
+                 callbackToOrigin:(void (^)(void))callbackToOrigin
 {
     [self limitOverride:@"viewDidLoad"
-                 target:controller
-                  block:^{
-                      [self measurePerformance:@"viewDidLoad"
-                                        target:controller
-                                blockToMeasure:callback];
-                  }];
+                  target:controller
+        callbackToOrigin:callbackToOrigin
+                   block:^{
+                       [self measurePerformance:@"viewDidLoad"
+                                         target:controller
+                               callbackToOrigin:callbackToOrigin];
+                   }];
 }
 
 - (void)viewControllerViewWillAppear:(UIViewController *)controller
-                    callbackToOrigin:(void (^)(void))callback
+                    callbackToOrigin:(void (^)(void))callbackToOrigin
 {
     [self limitOverride:@"viewWillAppear"
-                 target:controller
-                  block:^{
-                      SentrySpanId *spanId = objc_getAssociatedObject(
-                          controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
+                  target:controller
+        callbackToOrigin:callbackToOrigin
+                   block:^{
+                       SentrySpanId *spanId = objc_getAssociatedObject(
+                           controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
 
-                      if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
-                          // We are no longer tracking this UIViewController, just call the base
-                          // method.
-                          callback();
-                      } else {
-                          [self.tracker pushActiveSpan:spanId];
-                          [self.tracker
-                              measureSpanWithDescription:@"viewWillAppear"
-                                               operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                                 inBlock:callback];
+                       if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
+                           // We are no longer tracking this UIViewController, just call the base
+                           // method.
+                           callbackToOrigin();
+                       } else {
+                           [self.tracker pushActiveSpan:spanId];
+                           [self.tracker
+                               measureSpanWithDescription:@"viewWillAppear"
+                                                operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                                  inBlock:callbackToOrigin];
 
-                          SentrySpanId *viewAppearingId = [self.tracker
-                              startSpanWithName:@"viewAppearing"
-                                      operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION];
+                           SentrySpanId *viewAppearingId = [self.tracker
+                               startSpanWithName:@"viewAppearing"
+                                       operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION];
 
-                          objc_setAssociatedObject(controller,
-                              &SENTRY_UI_PERFORMANCE_TRACKER_VIEWAPPEARING_SPAN_ID, viewAppearingId,
-                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                           objc_setAssociatedObject(controller,
+                               &SENTRY_UI_PERFORMANCE_TRACKER_VIEWAPPEARING_SPAN_ID,
+                               viewAppearingId, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-                          [self.tracker pushActiveSpan:viewAppearingId];
-                      }
-                  }];
+                           [self.tracker pushActiveSpan:viewAppearingId];
+                       }
+                   }];
 }
 
 - (void)viewControllerViewDidAppear:(UIViewController *)controller
-                   callbackToOrigin:(void (^)(void))callback
+                   callbackToOrigin:(void (^)(void))callbackToOrigin
 {
-    [self
-        limitOverride:@"viewDidAppear"
-               target:controller
-                block:^{
-                    SentrySpanId *spanId = objc_getAssociatedObject(
-                        controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
+    [self limitOverride:@"viewDidAppear"
+                  target:controller
+        callbackToOrigin:callbackToOrigin
+                   block:^{
+                       SentrySpanId *spanId = objc_getAssociatedObject(
+                           controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
 
-                    if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
-                        // We are no longer tracking this UIViewController, just call the base
-                        // method.
-                        callback();
-                    } else {
-                        SentrySpanId *viewAppearingId = objc_getAssociatedObject(
-                            controller, &SENTRY_UI_PERFORMANCE_TRACKER_VIEWAPPEARING_SPAN_ID);
-                        if (viewAppearingId != nil) {
-                            [self.tracker popActiveSpan]; // pop viewAppearingSpan pushed at
-                                                          // viewWillAppear
-                            [self.tracker finishSpan:viewAppearingId];
-                            objc_setAssociatedObject(controller,
-                                &SENTRY_UI_PERFORMANCE_TRACKER_VIEWAPPEARING_SPAN_ID, nil,
-                                OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                        }
+                       if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
+                           // We are no longer tracking this UIViewController, just call the base
+                           // method.
+                           callbackToOrigin();
+                       } else {
+                           SentrySpanId *viewAppearingId = objc_getAssociatedObject(
+                               controller, &SENTRY_UI_PERFORMANCE_TRACKER_VIEWAPPEARING_SPAN_ID);
+                           if (viewAppearingId != nil) {
+                               [self.tracker popActiveSpan]; // pop viewAppearingSpan pushed at
+                                                             // viewWillAppear
+                               [self.tracker finishSpan:viewAppearingId];
+                               objc_setAssociatedObject(controller,
+                                   &SENTRY_UI_PERFORMANCE_TRACKER_VIEWAPPEARING_SPAN_ID, nil,
+                                   OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                           }
 
-                        [self.tracker
-                            measureSpanWithDescription:@"viewDidAppear"
-                                             operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                               inBlock:callback];
-                        [self.tracker
-                                popActiveSpan]; // Pop ViewControllerSpan pushed at viewWillAppear
+                           [self.tracker
+                               measureSpanWithDescription:@"viewDidAppear"
+                                                operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                                  inBlock:callbackToOrigin];
+                           [self.tracker popActiveSpan]; // Pop ViewControllerSpan pushed at
+                                                         // viewWillAppear
 
-                        // if we still tracking this UIViewController, finishes the transaction and
-                        // remove associated span id.
-                        [self.tracker finishSpan:spanId];
-                        objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID,
-                            nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                    }
-                }];
+                           // if we still tracking this UIViewController, finishes the transaction
+                           // and remove associated span id.
+                           [self.tracker finishSpan:spanId];
+                           objc_setAssociatedObject(controller,
+                               &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID, nil,
+                               OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                       }
+                   }];
 }
 
 - (void)viewControllerViewWillLayoutSubViews:(UIViewController *)controller
-                            callbackToOrigin:(void (^)(void))callback
+                            callbackToOrigin:(void (^)(void))callbackToOrigin
 {
     [self limitOverride:@"viewWillLayoutSubviews"
-                 target:controller
-                  block:^{
-                      SentrySpanId *spanId = objc_getAssociatedObject(
-                          controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
+                  target:controller
+        callbackToOrigin:callbackToOrigin
+                   block:^{
+                       SentrySpanId *spanId = objc_getAssociatedObject(
+                           controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
 
-                      if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
-                          // We are no longer tracking this UIViewController, just call the base
-                          // method.
-                          callback();
-                      } else {
-                          [self.tracker pushActiveSpan:spanId];
-                          [self.tracker
-                              measureSpanWithDescription:@"viewWillLayoutSubviews"
-                                               operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                                 inBlock:callback];
+                       if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
+                           // We are no longer tracking this UIViewController, just call the base
+                           // method.
+                           callbackToOrigin();
+                       } else {
+                           [self.tracker pushActiveSpan:spanId];
+                           [self.tracker
+                               measureSpanWithDescription:@"viewWillLayoutSubviews"
+                                                operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                                  inBlock:callbackToOrigin];
 
-                          SentrySpanId *layoutSubViewId = [self.tracker
-                              startSpanWithName:@"layoutSubViews"
-                                      operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION];
+                           SentrySpanId *layoutSubViewId = [self.tracker
+                               startSpanWithName:@"layoutSubViews"
+                                       operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION];
 
-                          objc_setAssociatedObject(controller,
-                              &SENTRY_UI_PERFORMANCE_TRACKER_LAYOUTSUBVIEW_SPAN_ID, layoutSubViewId,
-                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                           objc_setAssociatedObject(controller,
+                               &SENTRY_UI_PERFORMANCE_TRACKER_LAYOUTSUBVIEW_SPAN_ID,
+                               layoutSubViewId, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
-                          [self.tracker pushActiveSpan:layoutSubViewId];
-                      }
-                  }];
+                           [self.tracker pushActiveSpan:layoutSubViewId];
+                       }
+                   }];
 }
 
 - (void)viewControllerViewDidLayoutSubViews:(UIViewController *)controller
-                           callbackToOrigin:(void (^)(void))callback
+                           callbackToOrigin:(void (^)(void))callbackToOrigin
 {
     [self limitOverride:@"viewDidLayoutSubviews"
-                 target:controller
-                  block:^{
-                      SentrySpanId *spanId = objc_getAssociatedObject(
-                          controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
+                  target:controller
+        callbackToOrigin:callbackToOrigin
+                   block:^{
+                       SentrySpanId *spanId = objc_getAssociatedObject(
+                           controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
 
-                      if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
-                          // We are no longer tracking this UIViewController, just call the base
-                          // method.
-                          callback();
-                      } else {
-                          SentrySpanId *layoutSubViewId = objc_getAssociatedObject(
-                              controller, &SENTRY_UI_PERFORMANCE_TRACKER_LAYOUTSUBVIEW_SPAN_ID);
+                       if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
+                           // We are no longer tracking this UIViewController, just call the base
+                           // method.
+                           callbackToOrigin();
+                       } else {
+                           SentrySpanId *layoutSubViewId = objc_getAssociatedObject(
+                               controller, &SENTRY_UI_PERFORMANCE_TRACKER_LAYOUTSUBVIEW_SPAN_ID);
 
-                          if (layoutSubViewId != nil) {
-                              [self.tracker popActiveSpan]; // Pop layoutSubView span pushed at
-                                                            // viewWillAppear
-                              [self.tracker finishSpan:layoutSubViewId];
-                          }
+                           if (layoutSubViewId != nil) {
+                               [self.tracker popActiveSpan]; // Pop layoutSubView span pushed at
+                                                             // viewWillAppear
+                               [self.tracker finishSpan:layoutSubViewId];
+                           }
 
-                          [self.tracker
-                              measureSpanWithDescription:@"viewDidLayoutSubviews"
-                                               operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                                 inBlock:callback];
+                           [self.tracker
+                               measureSpanWithDescription:@"viewDidLayoutSubviews"
+                                                operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
+                                                  inBlock:callbackToOrigin];
 
-                          [self.tracker
-                                  popActiveSpan]; // Pop ViewControllerSpan pushed at viewWillAppear
-                          objc_setAssociatedObject(controller,
-                              &SENTRY_UI_PERFORMANCE_TRACKER_LAYOUTSUBVIEW_SPAN_ID, nil,
-                              OBJC_ASSOCIATION_RETAIN_NONATOMIC);
-                      }
-                  }];
+                           [self.tracker popActiveSpan]; // Pop ViewControllerSpan pushed at
+                                                         // viewWillAppear
+                           objc_setAssociatedObject(controller,
+                               &SENTRY_UI_PERFORMANCE_TRACKER_LAYOUTSUBVIEW_SPAN_ID, nil,
+                               OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+                       }
+                   }];
 }
 
 /**
@@ -228,7 +237,9 @@ SentryUIViewControllerPerformanceTracker ()
  */
 - (void)limitOverride:(NSString *)description
                target:(UIViewController *)viewController
+     callbackToOrigin:(void (^)(void))callbackToOrigin
                 block:(void (^)(void))block
+
 {
     NSMutableSet<NSString *> *spansInExecution;
 
@@ -245,24 +256,26 @@ SentryUIViewControllerPerformanceTracker ()
         [spansInExecution addObject:description];
         block();
         [spansInExecution removeObject:description];
+    } else {
+        callbackToOrigin();
     }
 }
 
 - (void)measurePerformance:(NSString *)description
                     target:(UIViewController *)viewController
-            blockToMeasure:(void (^)(void))callback
+          callbackToOrigin:(void (^)(void))callbackToOrigin
 {
     SentrySpanId *spanId
         = objc_getAssociatedObject(viewController, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID);
 
     if (spanId == nil) {
         // We are no longer tracking this UIViewController, just call the base method.
-        callback();
+        callbackToOrigin();
     } else {
         [self.tracker measureSpanWithDescription:description
                                        operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
                                     parentSpanId:spanId
-                                         inBlock:callback];
+                                         inBlock:callbackToOrigin];
     }
 }
 #endif

--- a/Tests/SentryTests/Integrations/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryPerformanceTrackerTests.swift
@@ -134,16 +134,34 @@ class SentryPerformanceTrackerTests: XCTestCase {
         let sut = fixture.getSut()
         var span: Span?
         
+        let expectation = expectation(description: "Callback Expectation")
+        
         sut.measureSpan(withDescription: fixture.someTransaction, operation: fixture.someOperation) {
             let spanId = sut.activeSpan()!
             
             span = sut.getSpan(spanId)
             
             XCTAssertFalse(span!.isFinished)
+            
+            expectation.fulfill()
         }
         
         XCTAssertNil(sut.activeSpan())
         XCTAssertTrue(span!.isFinished)
+        wait(for: [expectation], timeout: 0)
+    }
+    
+    func testMeasureSpanWithBlock_SpanNotIsAlive_BlockIsCalled() {
+        let sut = fixture.getSut()
+        
+        let expectation = expectation(description: "Callback Expectation")
+        
+        sut.measureSpan(withDescription: fixture.someTransaction, operation: fixture.someOperation, parentSpanId: SpanId()) {
+            expectation.fulfill()
+        }
+        
+        XCTAssertNil(sut.activeSpan())
+        wait(for: [expectation], timeout: 0)
     }
     
     func testFinishSpan() {


### PR DESCRIPTION


## :scroll: Description

The auto performance instrumentation was sometimes not calling the original
method of the swizzled UIViewController, which lead to crashes. This is fixed now,
by always calling the callback for every swizzled method.

## :bulb: Motivation and Context

A customer reported getting crashes from Sentry when upgrading to 7.2.0, which they didn't have in 7.1.4.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
