### PR TITLE
fix: Crash when swizzling Nib UIViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Crash when swizzling Nib UIViewController (#1277)
+
 ## 7.2.1
 
 This release fixes a crucial issue for auto performance instrumentation that caused crashes when using nested ViewControllers.

--- a/Samples/iOS-Swift/iOS-Swift/NibViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/NibViewController.swift
@@ -6,6 +6,6 @@ class NibViewController: UIViewController {
     @IBOutlet var button: UIButton!
     
     override func viewDidLoad() {
-        button.backgroundColor = .systemBlue
+        button.backgroundColor = .systemPink
     }
 }

--- a/Sources/Sentry/SentryUIViewControllerSwizziling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizziling.m
@@ -159,13 +159,11 @@ static SentryInAppLogic *inAppLogic;
     // for a nib file and doesn't load a view. This would lead to crashes as no view is loaded. As a
     // workaround, we skip swizzling the loadView and accept that the SKD doesn't create a span for
     // loadView if the UIViewController doesn't implement it.
-    // Because you can still use the loadView to load a view manually with a UIViewController that
-    // uses a nib, we swizzle it if it loadView is overridden and implemented.
-    SEL selector = NSSelectorFromString(@"loadView");
-    if (isNib && ![class respondsToSelector:selector]) {
+    if (isNib) {
         return;
     }
 
+    SEL selector = NSSelectorFromString(@"loadView");
     SentrySwizzleInstanceMethod(class, selector, SentrySWReturnType(void), SentrySWArguments(),
         SentrySWReplacement({
             [SentryUIViewControllerPerformanceTracker.shared


### PR DESCRIPTION


## :scroll: Description

The SDK always swizzled the loadView method of an implementation of UIViewController.
When using an UIViewController with a nib, UIKit only loads the nib if the loadView method
is not overridden. Our swizzling confused the UIKit, and therefore, it didn't load the nib
leading to an empty view and then to a crash. This is fixed now by not swizzling
UIViewControllers with a nib file if they don't implement loadView.

## :bulb: Motivation and Context

UIViewController with nibs crashed.

## :green_heart: How did you test it?
With the simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
