### PR TITLE
fix: XCF zip creation clobbered symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@
 
 - fix: Build failure for SPM (#1284)
 - fix: Set app state on main thread when terminating (#1272)
+## Unreleased
+
+- fix: XCFramework output not preserving symlinks for macOS
 
 ## 7.2.2
 
@@ -268,10 +271,10 @@ Features and fixes:
 ## 7.0.0-alpha.0
 
 **Breaking Change**: This version introduces a change to the grouping of issues. The SDK now sets the `inApp`
-flag for frames originating from only the main executable using [CFBundleExecutable](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleexecutable). 
+flag for frames originating from only the main executable using [CFBundleExecutable](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleexecutable).
 In previous versions, all frames originating from the application bundle were marked as `inApp`. This had the
 downside of marking frames of private frameworks inside the bundle as `inApp`. This problem is fixed now.
-Applications using static frameworks shouldn't be affected by this change. 
+Applications using static frameworks shouldn't be affected by this change.
 For more information on marking frames as inApp [docs](https://docs.sentry.io/platforms/apple/data-management/event-grouping/stack-trace-rules/#mark-in-app-frames).
 
 - fix: Mark frames as inApp #956
@@ -350,7 +353,7 @@ to group by domain only.
 
 - fix: Serialization of SentryScope #841
 - fix: Recrash parsing in SentryCrash #850
-- fix: Not crash during crash reporting #849 
+- fix: Not crash during crash reporting #849
 
 ## 6.0.8
 
@@ -454,11 +457,11 @@ Fix:
 This release also enables by default the option `attackStacktrace` which includes
 the stacktrace in all events, including `captureMessage` by default.
 
-Breaking Changes: 
+Breaking Changes:
 
 - feat: Attach stacktraces to all events by default #705
 
-Features and fixes: 
+Features and fixes:
 
 - feat: Crash event and session in same envelope #731
 - feat: Allow nil in setExtraValue on SentryScope to remove key #703
@@ -469,7 +472,7 @@ Breaking changes:
 
 - feat: Replace NSNumber with BOOL in SentryOptions #719
 
-Features and fixes: 
+Features and fixes:
 
 - fix: Header Imports for the Swift Package Manager #721
 - fix: Async storing of envelope to disk #714

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-carthage:
 
 	@echo "--> Carthage: creating Sentry xcframework"
 	carthage build --use-xcframeworks --no-skip-current
-	zip -r Sentry.xcframework.zip Carthage/Build
+	ditto -c -k -X --rsrc --keepParent Carthage Sentry.xcframework.zip
 
 	@echo "--> Carthage: creating Sentry framework"
 	./scripts/carthage-xcode12-workaround.sh build --no-skip-current

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ build-carthage:
 
 	@echo "--> Carthage: creating Sentry xcframework"
 	carthage build --use-xcframeworks --no-skip-current
+# use ditto here to avoid clobbering symlinks which exist in macOS frameworks
 	ditto -c -k -X --rsrc --keepParent Carthage Sentry.xcframework.zip
 
 	@echo "--> Carthage: creating Sentry framework"


### PR DESCRIPTION
## :scroll: Description

This fixes the zip command to use ditto which mimics Finder's zip which preserves things better.

## :bulb: Motivation and Context

While trying to use the Sentry.xcframework.zip in releases, I ran into issues getting it embedded & signed possibly due to framework symlinks not being present. (We don't use carthage but just the XCF directly)

## :green_heart: How did you test it?

Put it in place for our project, embed & sign succeeded now unlike before where there was a warning about Current not being a symlink.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
