### PR TITLE
fix: Build failure for SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Build failure for SPM (#1284)
+
 ## 7.2.2
 
 - fix: Crash when swizzling Nib UIViewController (#1277)

--- a/Samples/macOS-SPM-CommandLine/Package.swift
+++ b/Samples/macOS-SPM-CommandLine/Package.swift
@@ -12,6 +12,9 @@ let package = Package(
     targets: [
         .target(
             name: "macOS-SPM-CommandLine",
-            dependencies: ["Sentry"])
+            dependencies: ["Sentry"], 
+            swiftSettings: [
+                .unsafeFlags(["-warnings-as-errors"])
+            ])
     ]
 )

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -293,7 +293,7 @@
 		7B6D98ED24C703F8005502FA /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B6D98EC24C703F8005502FA /* Async.swift */; };
 		7B7A30C624B48321005A4C6E /* SentryCrashAdapter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A30C524B48321005A4C6E /* SentryCrashAdapter.h */; };
 		7B7A30C824B48389005A4C6E /* SentryCrashAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A30C724B48389005A4C6E /* SentryCrashAdapter.m */; };
-		7B7A599526B692540060A676 /* SentryScreenFrames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A599426B692540060A676 /* SentryScreenFrames.h */; };
+		7B7A599526B692540060A676 /* SentryScreenFrames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7A599426B692540060A676 /* SentryScreenFrames.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B7A599726B692F00060A676 /* SentryScreenFrames.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A599626B692F00060A676 /* SentryScreenFrames.m */; };
 		7B7D872C2486480B00D2ECFF /* SentryStacktraceBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B7D872B2486480B00D2ECFF /* SentryStacktraceBuilder.h */; };
 		7B7D872E2486482600D2ECFF /* SentryStacktraceBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B7D872D2486482600D2ECFF /* SentryStacktraceBuilder.m */; };

--- a/Sources/Sentry/Public/Sentry.h
+++ b/Sources/Sentry/Public/Sentry.h
@@ -34,6 +34,7 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #import "SentrySampleDecision.h"
 #import "SentrySamplingContext.h"
 #import "SentryScope.h"
+#import "SentryScreenFrames.h"
 #import "SentrySdkInfo.h"
 #import "SentrySerializable.h"
 #import "SentrySession.h"


### PR DESCRIPTION




## :scroll: Description

The build failed for users including the SDK via SPM. The CI should check such errors, but
it didn't treat warnings as errors. This is fixed now by treating warnings as errors and including
the missing header file in the umbrella header.

## :bulb: Motivation and Context

Fixes GH-1283

## :green_heart: How did you test it?
I checked that CI fails with the current version https://github.com/getsentry/sentry-cocoa/runs/3421733871?check_suite_focus=true. Now CI passes again.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
