### PR TITLE
fix: Apps crash when using a URLSessionTask subclass with currentRequest unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Apps crash when using a URLSessionTask subclass with currentRequest unavailable
+
 ## 7.2.3
 
 - fix: Build failure for SPM (#1284)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Apps crash when using a URLSessionTask subclass with currentRequest unavailable
+- fix: Apps crash when using a URLSessionTask subclass with currentRequest unavailable (#1294)
 
 ## 7.2.3
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -58,6 +58,8 @@ SentryNetworkTracker ()
             return;
         }
     }
+    
+    if (![self isTaskSupported:sessionTask]) return;
 
     // We need to check if this request was created by SentryHTTPInterceptor so we don't end up with
     // two spans for the same request.
@@ -73,7 +75,7 @@ SentryNetworkTracker ()
 
     NSURL *url = [[sessionTask currentRequest] URL];
 
-    if (url == nil || ![self isTaskSupported:sessionTask])
+    if (url == nil)
         return;
 
     // Don't measure requests to Sentry's backend

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -58,8 +58,9 @@ SentryNetworkTracker ()
             return;
         }
     }
-    
-    if (![self isTaskSupported:sessionTask]) return;
+
+    if (![self isTaskSupported:sessionTask])
+        return;
 
     // We need to check if this request was created by SentryHTTPInterceptor so we don't end up with
     // two spans for the same request.

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -1,6 +1,6 @@
+import AVFoundation
 import ObjectiveC
 import XCTest
-import AVFoundation
 
 class SentryNetworkTrackerTests: XCTestCase {
     

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -1,4 +1,3 @@
-import AVFoundation
 import ObjectiveC
 import XCTest
 

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -221,6 +221,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertTrue(spans!.first!.isFinished)
     }
     
+    func testTaskWithoutCurrentRequest() {
+        let task = URLSessionUnsupportedTaskMock()
+        let span = spanForTask(task: task)
+        
+        XCTAssertNil(span)
+        XCTAssertNil(task.observationInfo)
+    }
+    
     func testObserverForAnotherProperty() {
         let sut = fixture.getSut()
         let task = createDataTask()
@@ -522,7 +530,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         request.httpMethod = method
         return URLSessionStreamTaskMock(request: request)
     }
-
+    
     private func createInterceptedRequest() -> URLSessionDownloadTaskMock {
         let request = NSMutableURLRequest(url: SentryNetworkTrackerTests.testURL)
         URLProtocol.setProperty(true, forKey: SENTRY_INTERCEPTED_REQUEST, in: request)

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -1,5 +1,6 @@
 import ObjectiveC
 import XCTest
+import AVFoundation
 
 class SentryNetworkTrackerTests: XCTestCase {
     
@@ -222,7 +223,8 @@ class SentryNetworkTrackerTests: XCTestCase {
     }
     
     func testTaskWithoutCurrentRequest() {
-        let task = URLSessionUnsupportedTaskMock()
+        let request = URLRequest(url: SentryNetworkTrackerTests.testURL)
+        let task = URLSessionUnsupportedTaskMock(request: request)
         let span = spanForTask(task: task)
         
         XCTAssertNil(span)

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.h
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.h
@@ -54,4 +54,10 @@ static int64_t const DATA_BYTES_SENT = 652;
 
 @end
 
+@interface URLSessionUnsupportedTaskMock : NSURLSessionTask
+
+- (NSURLRequest *)currentRequest NS_UNAVAILABLE;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.h
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.h
@@ -56,6 +56,8 @@ static int64_t const DATA_BYTES_SENT = 652;
 
 @interface URLSessionUnsupportedTaskMock : NSURLSessionTask
 
+- (instancetype)initWithRequest:(NSURLRequest *)request;
+
 - (NSURLRequest *)currentRequest NS_UNAVAILABLE;
 
 @end

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.m
@@ -173,7 +173,7 @@
 
 @implementation URLSessionUnsupportedTaskMock
 
--(NSURLRequest *) currentRequest
+- (NSURLRequest *)currentRequest
 {
     @throw @"currentRequest not available";
 }

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.m
@@ -186,7 +186,6 @@
 }
 #pragma clang diagnostic pop
 
-
 - (NSURLRequest *)currentRequest
 {
     @throw @"currentRequest not available";

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.m
@@ -66,7 +66,9 @@
     }
     return self;
 }
+
 #pragma clang diagnostic pop
+
 @end
 
 @implementation URLSessionDownloadTaskMock {
@@ -172,6 +174,18 @@
 @end
 
 @implementation URLSessionUnsupportedTaskMock
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+- (instancetype)initWithRequest:(NSURLRequest *)request
+{
+    if (self = [super init]) {
+        // Empty on purpose
+    }
+    return self;
+}
+#pragma clang diagnostic pop
+
 
 - (NSURLRequest *)currentRequest
 {

--- a/Tests/SentryTests/Integrations/URLSessionTaskMock.m
+++ b/Tests/SentryTests/Integrations/URLSessionTaskMock.m
@@ -170,3 +170,12 @@
 }
 #pragma clang diagnostic pop
 @end
+
+@implementation URLSessionUnsupportedTaskMock
+
+-(NSURLRequest *) currentRequest
+{
+    @throw @"currentRequest not available";
+}
+
+@end


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Moved the URLSessionTask support check to the beginning of the interceptor method, now we don't try to retrieve any property before knowing if sentry supports that type of task.

## :bulb: Motivation and Context

Some type of tasks such as AVAggregateAssetDownloadTask throw an exception when currentRequest is accessed. 

Fixes #1293 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
