### PR TITLE
fix: Swizzling crash on iOS 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- fix: Swizzling crash on iOS 13 (#1297)
+
 ## 7.2.4
 
 - fix: Sentry HTTP Trace Header Breaking Requests (#1295)


### PR DESCRIPTION



## :scroll: Description

iOS 13 doesn't have a method for HTTPAdditionalHeaders. Instead, it only
has a property. Therefore, the swizzling crashes on iOS 13. This is fixed now
by checking if NSURLSessionConfiguration has a method HTTPAdditionalHeaders.
The downside is that we don't add a trace header on iOS 13 anymore. This
is better than crashing though.

I will add a test matrix to run the tests on older iOS versions soon.

## :bulb: Motivation and Context

Fixes GH-1296

## :green_heart: How did you test it?

Running the tests on an iOS 13 simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
