### PR TITLE
fix: Remove Trace Headers below iOS 14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Remove Trace Headers below iOS 14.0 (#1309)
 - fix: XCFramework output not preserving symlinks for macOS (#1281)
 
 ## 7.2.6


### PR DESCRIPTION

## :scroll: Description

Remove support for trace headers below iOS 14.0, because we need to swizzle
a private class, which brings a risk of being rejected from Apple when submitting
to the App store.

This PR is basically a revert from https://github.com/getsentry/sentry-cocoa/pull/1302. I modified the comments a bit though.

## :bulb: Motivation and Context

We don't want apps to be rejected using private APIs.

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
Clarify in docs, that trace headers are only supported above iOS 14.
