### PR TITLE
fix: SentryHub not checking spanContext sampled value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - fix: SpanProtocol add setData for Swift (#1305)
-- fix: Performance tracker not respecting traceSampleRate (#1318)
+- fix: SentryHub not checking spanContext sampled value (#1318)
 
 ## 7.2.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: SpanProtocol add setData for Swift (#1305)
+- fix: Performance tracker not respecting traceSampleRate (#1318)
 
 ## 7.2.7
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             options.debug = true
             // Sampling 100% - In Production you probably want to adjust this
-            options.tracesSampleRate = 1.0
+            options.tracesSampleRate = 0.001
             options.sessionTrackingIntervalMillis = 5_000
         }
         

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             options.debug = true
             // Sampling 100% - In Production you probably want to adjust this
-            options.tracesSampleRate = 0.001
+            options.tracesSampleRate = 1.0
             options.sessionTrackingIntervalMillis = 5_000
         }
         

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -284,6 +284,14 @@ SentryHub ()
                                   bindToScope:(BOOL)bindToScope
                         customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
+    return [self startTransactionWithContext:transactionContext bindToScope:bindToScope waitForChildren:NO customSamplingContext:customSamplingContext];
+}
+
+- (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                                  bindToScope:(BOOL)bindToScope
+                              waitForChildren:(BOOL)waitForChildren
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
+{
     SentrySamplingContext *samplingContext =
         [[SentrySamplingContext alloc] initWithTransactionContext:transactionContext
                                             customSamplingContext:customSamplingContext];
@@ -291,12 +299,14 @@ SentryHub ()
     transactionContext.sampled = [_sampler sample:samplingContext];
 
     id<SentrySpan> tracer = [[SentryTracer alloc] initWithTransactionContext:transactionContext
-                                                                         hub:self];
+                                                                         hub:self
+                                                             waitForChildren:waitForChildren];
     if (bindToScope)
         _scope.span = tracer;
 
     return tracer;
 }
+
 
 - (SentryId *)captureMessage:(NSString *)message
 {

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -15,6 +15,7 @@
 #import "SentryTracer.h"
 #import "SentryTracesSampler.h"
 #import "SentryTransactionContext.h"
+#import "SentryTransaction.h"
 
 @interface
 SentryHub ()
@@ -226,6 +227,12 @@ SentryHub ()
     }
 
     [client captureCrashEvent:event withScope:self.scope];
+}
+
+- (SentryId *)captureTransaction:(SentryTransaction *)transaction withScope:(SentryScope *)scope
+{
+    if (transaction.trace.context.sampled != kSentrySampleDecisionYes) return SentryId.empty;
+    return [self captureEvent:transaction withScope:scope];
 }
 
 - (SentryId *)captureEvent:(SentryEvent *)event

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -1,5 +1,5 @@
 #import "SentryPerformanceTracker.h"
-#import "SentryHub.h"
+#import "SentryHub+Private.h"
 #import "SentryLog.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope.h"
@@ -48,17 +48,11 @@ SentryPerformanceTracker ()
     if (activeSpanTracker != nil) {
         newSpan = [activeSpanTracker startChildWithOperation:operation description:name];
     } else {
-        newSpan = [[SentryTracer alloc]
-            initWithTransactionContext:[[SentryTransactionContext alloc] initWithName:name
-                                                                            operation:operation]
-                                   hub:SentrySDK.currentHub
-                       waitForChildren:YES];
-
-        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-            if (span == nil) {
-                [SentrySDK.currentHub.scope setSpan:newSpan];
-            }
-        }];
+        SentryTransactionContext* context = [[SentryTransactionContext alloc] initWithName:name operation:operation];
+        newSpan = [SentrySDK.currentHub startTransactionWithContext:context
+                                                        bindToScope:SentrySDK.currentHub.scope.span == nil
+                                                    waitForChildren:YES
+                                              customSamplingContext:@{}];
     }
 
     SentrySpanId *spanId = newSpan.context.spanId;

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -2,7 +2,7 @@
 #import "PrivateSentrySDKOnly.h"
 #import "SentryAppStartMeasurement.h"
 #import "SentryFramesTracker.h"
-#import "SentryHub.h"
+#import "SentryHub+Private.h"
 #import "SentryLog.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope.h"
@@ -270,9 +270,9 @@ static BOOL appStartMeasurementRead;
         }
     }];
 
-    if (self.context.sampled == kSentrySampleDecisionYes) {
-        [_hub captureEvent:[self toTransaction] withScope:_hub.scope];
-    }
+    
+    [_hub captureTransaction:[self toTransaction] withScope:_hub.scope];
+    
 }
 
 - (SentryTransaction *)toTransaction

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -270,7 +270,9 @@ static BOOL appStartMeasurementRead;
         }
     }];
 
-    [_hub captureEvent:[self toTransaction] withScope:_hub.scope];
+    if (self.context.sampled == kSentrySampleDecisionYes) {
+        [_hub captureEvent:[self toTransaction] withScope:_hub.scope];
+    }
 }
 
 - (SentryTransaction *)toTransaction

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -5,7 +5,6 @@
 @interface
 SentryTransaction ()
 
-@property (nonatomic, strong) id<SentrySpan> trace;
 @property (nonatomic, strong) NSArray<id<SentrySpan>> *spans;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, id> *measurements;
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -12,6 +12,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)closeCachedSessionWithTimestamp:(NSDate *_Nullable)timestamp;
 
+- (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                                  bindToScope:(BOOL)bindToScope
+                              waitForChildren:(BOOL)waitForChildren
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -1,6 +1,6 @@
 #import "SentryHub.h"
 
-@class SentryId, SentryScope;
+@class SentryId, SentryScope, SentryTransaction;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
                               waitForChildren:(BOOL)waitForChildren
                         customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext;
 
+- (SentryId *)captureTransaction:(SentryTransaction *)transaction withScope:(SentryScope *)scope;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -7,6 +7,8 @@ NS_SWIFT_NAME(Transaction)
 @interface SentryTransaction : SentryEvent
 SENTRY_NO_INIT
 
+@property (nonatomic, strong) id<SentrySpan> trace;
+
 - (instancetype)initWithTrace:(id<SentrySpan>)trace children:(NSArray<id<SentrySpan>> *)children;
 
 @end

--- a/Tests/SentryTests/Integrations/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryPerformanceTrackerTests.swift
@@ -164,6 +164,24 @@ class SentryPerformanceTrackerTests: XCTestCase {
         wait(for: [expect], timeout: 0)
     }
     
+    func testNotSampled() {
+        fixture.client.options.tracesSampleRate = 0
+        let sut = fixture.getSut()
+        let spanId = sut.startSpan(withName: fixture.someTransaction, operation: fixture.someOperation)
+        let span = sut.getSpan(spanId)
+        
+        XCTAssertEqual(span!.context.sampled, .no)
+    }
+    
+    func testSampled() {
+        fixture.client.options.tracesSampleRate = 1
+        let sut = fixture.getSut()
+        let spanId = sut.startSpan(withName: fixture.someTransaction, operation: fixture.someOperation)
+        let span = sut.getSpan(spanId)
+        
+        XCTAssertEqual(span!.context.sampled, .yes)
+    }
+    
     func testFinishSpan() {
         let sut = fixture.getSut()
         let spanId = startSpan(tracker: sut)

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -32,6 +32,7 @@ class SentryTracerTests: XCTestCase {
             
             scope = Scope()
             client = TestClient(options: Options())!
+            client.options.tracesSampleRate = 1
             hub = TestHub(client: client, andScope: scope)
             
             CurrentDate.setCurrentDateProvider(currentDateProvider)
@@ -54,7 +55,7 @@ class SentryTracerTests: XCTestCase {
         }
         
         func getSut(waitForChildren: Bool = true) -> SentryTracer {
-            return SentryTracer(transactionContext: transactionContext, hub: hub, waitForChildren: waitForChildren)
+            return hub.startTransaction(with: transactionContext, bindToScope: false, waitForChildren: waitForChildren, customSamplingContext: [:]) as! SentryTracer
         }
     }
     
@@ -175,7 +176,7 @@ class SentryTracerTests: XCTestCase {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
         SentrySDK.setAppStartMeasurement(appStartMeasurement)
         
-        let sut = SentryTracer(transactionContext: TransactionContext(name: "custom", operation: "custom"), hub: fixture.hub, waitForChildren: false)
+        let sut = fixture.hub.startTransaction(transactionContext: TransactionContext(name: "custom", operation: "custom")) as! SentryTracer
         sut.finish()
         fixture.hub.group.wait()
         

--- a/Tests/SentryTests/SentrySpanTests.swift
+++ b/Tests/SentryTests/SentrySpanTests.swift
@@ -12,6 +12,7 @@ class SentrySpanTests: XCTestCase {
          
         init() {
             options = Options()
+            options.tracesSampleRate = 1
             options.dsn = TestConstants.dsnAsString(username: "username")
             options.environment = "test"
             currentDateProvider.setDate(date: TestData.timestamp)
@@ -159,7 +160,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(serialization["timestamp"] as? TimeInterval, TestData.timestamp.timeIntervalSince1970)
         XCTAssertEqual(serialization["start_timestamp"] as? TimeInterval, TestData.timestamp.timeIntervalSince1970)
         XCTAssertEqual(serialization["type"] as? String, SpanContext.type)
-        XCTAssertEqual(serialization["sampled"] as? String, "false")
+        XCTAssertEqual(serialization["sampled"] as? String, "true")
         XCTAssertNotNil(serialization["data"])
         XCTAssertNotNil(serialization["tags"])
         XCTAssertEqual((serialization["data"] as! Dictionary)[fixture.extraKey], fixture.extraValue)
@@ -189,6 +190,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testTraceHeaderNotSampled() {
+        fixture.options.tracesSampleRate = 0
         let span = fixture.getSut()
         let header = span.toTraceHeader()
         


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Fixed SentryHub to check the spanContext `sampled` value.

## :bulb: Motivation and Context
 Every span capture should respect tracesSampleRate 

Fixes #1314 

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
