### PR TITLE
fix: Trying to swizzle a class without a library name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Trying to swizzle a class without a library name (#1332)
+
 ## 7.3.0-beta.0
 
 - Setting maxBreadcrumb to zero causes a crash when adding a breadcrumb (#1326)

--- a/Sources/Sentry/SentryUIViewControllerSwizziling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizziling.m
@@ -145,10 +145,13 @@ static SentryInAppLogic *inAppLogic;
  */
 + (BOOL)shouldSwizzleViewController:(Class)class
 {
+    //Some apple classes does not return an imageName
+    const char *imageName = class_getImageName(class);
+    if (imageName == nil) return false;
+    
     // Swizzling only inApp classes to avoid track every UIKit view controller
     // interaction.
-    NSString *classImageName = [NSString stringWithCString:class_getImageName(class)
-                                                  encoding:NSUTF8StringEncoding];
+    NSString *classImageName = [NSString stringWithCString:imageName encoding:NSUTF8StringEncoding];
     return [inAppLogic isInApp:classImageName];
 }
 

--- a/Tests/SentryTests/Integrations/SentryUIViewControllerSwizzlingTests.m
+++ b/Tests/SentryTests/Integrations/SentryUIViewControllerSwizzlingTests.m
@@ -40,6 +40,16 @@
     XCTAssertTrue(result);
 }
 
+- (void)testShouldSwizzle_NotImageClass
+{
+    Class class;
+    
+    BOOL result =
+        [SentryUIViewControllerSwizziling shouldSwizzleViewController:class];
+
+    XCTAssertFalse(result);
+}
+
 - (void)testShouldNotSwizzle_UIViewController
 {
     BOOL result =

--- a/Tests/SentryTests/Integrations/SentryUIViewControllerSwizzlingTests.m
+++ b/Tests/SentryTests/Integrations/SentryUIViewControllerSwizzlingTests.m
@@ -40,7 +40,7 @@
     XCTAssertTrue(result);
 }
 
-- (void)testShouldSwizzle_NotImageClass
+- (void)testShouldNotSwizzle_NoImageClass
 {
     Class class;
     


### PR DESCRIPTION
## :scroll: Description

Fixed a bug trying to get the image name from a class that does not have one.

## :bulb: Motivation and Context

Fixes #1331 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
