### PR TITLE
ci: Replace deprecated Setup Ruby

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
 
       - name: Setup fastlane
         run: bundle install
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
 
       - name: Setup fastlane
         run: bundle install   

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
 
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli


### PR DESCRIPTION
actions/setup-ruby is deprecated and needs to be replaced with
ruby/setup-ruby, see https://github.com/actions/setup-ruby.

#skip-changelog
