### PR TITLE
fix: Memory Leak for Span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Memory Leak for Span (#1352)
+
 ## 7.3.0
 
 - fix: Trying to swizzle a class without a library name (#1332)

--- a/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/4487886E-B920-4AB1-99BD-1A9C5128C731.plist
+++ b/Sentry.xcodeproj/xcshareddata/xcbaselines/63AA76641EB8CB2F00D153DE.xcbaseline/4487886E-B920-4AB1-99BD-1A9C5128C731.plist
@@ -11,7 +11,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.0013329</real>
+					<real>0.001333</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -24,7 +24,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.012</real>
+					<real>0.012000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -34,7 +34,7 @@
 				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0.09</real>
+					<real>0.090000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>
@@ -47,16 +47,39 @@
 				<key>com.apple.dt.XCTMetric_Memory.physical</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>300</real>
+					<real>300.000000</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 					<key>maxPercentRelativeStandardDeviation</key>
-					<real>200</real>
+					<real>200.000000</real>
 				</dict>
 				<key>com.apple.dt.XCTMetric_Memory.physical-peak</key>
 				<dict>
 					<key>baselineAverage</key>
-					<real>0</real>
+					<real>0.000000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testMemoryFootprintOfTransactions()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Memory.physical</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>106.496000</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>SentryTracerTests</key>
+		<dict>
+			<key>testMemory()</key>
+			<dict>
+				<key>com.apple.dt.XCTMetric_Memory.physical</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>100.761600</real>
 					<key>baselineIntegrationDisplayName</key>
 					<string>Local Baseline</string>
 				</dict>

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -33,7 +33,7 @@ SENTRY_NO_INIT
 /**
  * The SentryTracer this span is associated with.
  */
-@property (nonatomic, readonly) SentryTracer *tracer;
+@property (nonatomic, readonly, weak) SentryTracer *tracer;
 
 /**
  * Init a SentrySpan with given tracer and context.

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -445,7 +445,7 @@ class SentrySDKTests: XCTestCase {
         
         self.measure(metrics: [XCTMemoryMetric()]) {
             for _ in 0...1_000 {
-                let trans = SentrySDK.startTransaction(name: "", operation: "")
+                let trans = SentrySDK.startTransaction(name: "no leak", operation: "")
                 
                 for _ in 0...10 {
                     let span = trans.startChild(operation: "ui.load")

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -435,6 +435,27 @@ class SentrySDKTests: XCTestCase {
         }
     }
     
+    @available(tvOS 13.0, *)
+    @available(OSX 10.15, *)
+    @available(iOS 13.0, *)
+    func testMemoryFootprintOfTransactions() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKTests.dsnAsString
+        }
+        
+        self.measure(metrics: [XCTMemoryMetric()]) {
+            for _ in 0...1000 {
+                let trans = SentrySDK.startTransaction(name: "", operation: "")
+                
+                for _ in 0...10 {
+                    let span = trans.startChild(operation: "ui.load")
+                    span.finish()
+                }
+                trans.finish()
+            }
+        }
+    }
+    
     func testStartSession() {
         givenSdkWithHub()
         

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -444,7 +444,7 @@ class SentrySDKTests: XCTestCase {
         }
         
         self.measure(metrics: [XCTMemoryMetric()]) {
-            for _ in 0...1000 {
+            for _ in 0...1_000 {
                 let trans = SentrySDK.startTransaction(name: "", operation: "")
                 
                 for _ in 0...10 {


### PR DESCRIPTION




## :scroll: Description

Creating multiple transactions with spans leads to an increased number
of performance objects that the ARC never deallocates. This problem
is fixed now by breaking a strong reference cycle between SentryTracer
and SentrySpan.

## :bulb: Motivation and Context

Fixes GH-1351

## :green_heart: How did you test it?
Unit tests and debug memory graph in Xcode.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
