### PR TITLE
fix: HTTP instrumentation KVO crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased 
+
+- fix: HTTP instrumentation KVO crash (#1354)
+
 ## 7.4.0
 
 - feat: Add enableNetworkTracking flag (#1349)

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
@@ -133,7 +133,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         wait(for: [expect], timeout: 5)
     }
     
-    func testWhenTaskCancelledAndSuspended_OnlyOneBreadcrumb() {
+    func testWhenTaskCancelledOrSuspended_OnlyOneBreadcrumb() {
         startSDK()
         
         let expect = expectation(description: "Callback Expectation")

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
@@ -133,6 +133,27 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         wait(for: [expect], timeout: 5)
     }
     
+    func testWhenTaskCancelledAndSuspended_OnlyOneBreadcrumb() {
+        startSDK()
+        
+        let expect = expectation(description: "Callback Expectation")
+        let session = URLSession(configuration: URLSessionConfiguration.default)
+        
+        let dataTask = session.dataTask(with: SentryNetworkTrackerIntegrationTests.testURL) { (_, _, error) in
+            expect.fulfill()
+        }
+        
+        dataTask.resume()
+        dataTask.suspend()
+        dataTask.resume()
+        dataTask.cancel()
+        wait(for: [expect], timeout: 5)
+        
+        let scope = SentrySDK.currentHub().scope
+        let breadcrumbs = Dynamic(scope).breadcrumbArray as [Breadcrumb]?
+        XCTAssertEqual(1, breadcrumbs?.count)
+    }
+    
     private func testNetworkTrackerDisabled(configureOptions: (Options) -> Void) {
         configureOptions(fixture.options)
         

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
@@ -139,7 +139,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         let expect = expectation(description: "Callback Expectation")
         let session = URLSession(configuration: URLSessionConfiguration.default)
         
-        let dataTask = session.dataTask(with: SentryNetworkTrackerIntegrationTests.testURL) { (_, _, error) in
+        let dataTask = session.dataTask(with: SentryNetworkTrackerIntegrationTests.testURL) { (_, _, _) in
             expect.fulfill()
         }
         

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerIntegrationTests.swift
@@ -130,7 +130,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         }
         
         dataTask.resume()
-        wait(for: [expect], timeout: 1)
+        wait(for: [expect], timeout: 5)
     }
     
     private func testNetworkTrackerDisabled(configureOptions: (Options) -> Void) {

--- a/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryNetworkTrackerTests.swift
@@ -199,7 +199,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNotNil(task.observationInfo)
         
         task.state = .completed
-        XCTAssertNotNil(task.observationInfo)
+        XCTAssertNil(task.observationInfo)
         XCTAssertFalse(spans!.first!.isFinished)
     }
     
@@ -300,6 +300,19 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumbs!.count, 1)
         XCTAssertEqual(breadcrumb!.data!["url"] as! String, SentryNetworkTrackerTests.testURL.absoluteString)
         XCTAssertEqual(breadcrumb!.data!["method"] as! String, "GET")
+    }
+    
+    func testWhenNoSpan_RemoveObserver() {
+        let task = createDataTask()
+        let _ = spanForTask(task: task)!
+        
+        objc_removeAssociatedObjects(task)
+        
+        task.state = .completed
+        task.state = .completed
+        
+        let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
+        XCTAssertEqual(1, breadcrumbs?.count)
     }
     
     func testBreadcrumbNotFound() {


### PR DESCRIPTION




## :scroll: Description

The HTTP instrumentation in SentryNetworkTracker leads to EXC_BAD_ACCESS.
This problem could be due to not correctly removing the KVO observer in
SentryNetworkTracker. Other open-source projects had similar bugs due to
using KVO, which they fixed using swizzling instead. As swizzling doesn't work
for our current solution and removing KVO would be a lot of effort, this PR is the
best shot effort for fixing the crashes by removing the observer issue.

## :bulb: Motivation and Context

Fixes GH-1328

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
