### PR TITLE
ref: Specify dict and set types for SentrySwizzle

### DIFF
--- a/Sources/Sentry/SentrySwizzle.m
+++ b/Sources/Sentry/SentrySwizzle.m
@@ -103,7 +103,7 @@ swizzle(Class classToSwizzle, SEL selector, SentrySwizzleImpFactoryBlock factory
     pthread_mutex_unlock(&gLock);
 }
 
-static NSMutableDictionary *
+static NSMutableDictionary<NSValue *, NSMutableSet<Class> *> *
 swizzledClassesDictionary()
 {
     static NSMutableDictionary *swizzledClasses;
@@ -112,10 +112,11 @@ swizzledClassesDictionary()
     return swizzledClasses;
 }
 
-static NSMutableSet *
+static NSMutableSet<Class> *
 swizzledClassesForKey(const void *key)
 {
-    NSMutableDictionary *classesDictionary = swizzledClassesDictionary();
+    NSMutableDictionary<NSValue *, NSMutableSet<Class> *> *classesDictionary
+        = swizzledClassesDictionary();
     NSValue *keyValue = [NSValue valueWithPointer:key];
     NSMutableSet *swizzledClasses = [classesDictionary objectForKey:keyValue];
     if (!swizzledClasses) {
@@ -136,7 +137,7 @@ swizzledClassesForKey(const void *key)
 
     @synchronized(swizzledClassesDictionary()) {
         if (key) {
-            NSSet *swizzledClasses = swizzledClassesForKey(key);
+            NSSet<Class> *swizzledClasses = swizzledClassesForKey(key);
             if (mode == SentrySwizzleModeOncePerClass) {
                 if ([swizzledClasses containsObject:classToSwizzle]) {
                     return NO;


### PR DESCRIPTION


## :scroll: Description

The dictionaries and sets in SentrySwizzle didn't have the types
specified, which makes the code harder to read. This is fixed now
by adding the explicit types.

#skip-changelog

## :bulb: Motivation and Context

This change makes the code easier to understand.

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
