### PR TITLE
fix: Crash When Observing Span Finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased 
+
+- fix: Crash When Observing Span Finished (#1360)
+
 ## 7.4.1
 
 - fix: HTTP instrumentation KVO crash (#1354)

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -440,6 +440,7 @@
 		7BECF42826145CD900D9826E /* SentryMechanismMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BECF42726145CD900D9826E /* SentryMechanismMeta.m */; };
 		7BECF432261463E600D9826E /* SentryMechanismMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BECF431261463E600D9826E /* SentryMechanismMetaTests.swift */; };
 		7BED3576266F7BFF00EAA70D /* TestSentryCrashAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BED3575266F7BFF00EAA70D /* TestSentryCrashAdapter.m */; };
+		7BEFB044270B0F630025F808 /* SentryTracerObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BEFB043270B0F630025F808 /* SentryTracerObjCTests.m */; };
 		7BF536D124BDF3E7004FA6A2 /* SentryEnvelopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF536D024BDF3E7004FA6A2 /* SentryEnvelopeTests.swift */; };
 		7BF536D424BEF255004FA6A2 /* SentryAssertions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */; };
 		7BFC169B2524995700FF6266 /* SentryMessage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BFC169A2524995700FF6266 /* SentryMessage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1003,6 +1004,7 @@
 		7BECF431261463E600D9826E /* SentryMechanismMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMechanismMetaTests.swift; sourceTree = "<group>"; };
 		7BED3574266F7BC600EAA70D /* TestSentryCrashAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSentryCrashAdapter.h; sourceTree = "<group>"; };
 		7BED3575266F7BFF00EAA70D /* TestSentryCrashAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestSentryCrashAdapter.m; sourceTree = "<group>"; };
+		7BEFB043270B0F630025F808 /* SentryTracerObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTracerObjCTests.m; sourceTree = "<group>"; };
 		7BF536D024BDF3E7004FA6A2 /* SentryEnvelopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeTests.swift; sourceTree = "<group>"; };
 		7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAssertions.swift; sourceTree = "<group>"; };
 		7BFC169A2524995700FF6266 /* SentryMessage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryMessage.h; path = Public/SentryMessage.h; sourceTree = "<group>"; };
@@ -1822,6 +1824,7 @@
 				7B42602D26302E0B00B36EDD /* TransactionGeneratorTests.swift */,
 				8EAC7FF7265C8910005B44E5 /* SentryTracerTests.swift */,
 				7BBEB16026AEE5EF00C06C03 /* SentryTracer+Test.h */,
+				7BEFB043270B0F630025F808 /* SentryTracerObjCTests.m */,
 			);
 			path = Performance;
 			sourceTree = "<group>";
@@ -2615,6 +2618,7 @@
 				8EA05EED267C2AB200C82B30 /* SentryNetworkTrackerTests.swift in Sources */,
 				7BA840A024A1EC6E00B718AA /* SentrySDKTests.swift in Sources */,
 				8E4A038525F76A7600000D77 /* Logger.swift in Sources */,
+				7BEFB044270B0F630025F808 /* SentryTracerObjCTests.m in Sources */,
 				7B0002322477F0520035FEF1 /* SentrySessionTests.m in Sources */,
 				7BC6EC08255C36DE0059822A /* SentryStacktraceTests.swift in Sources */,
 				D88817DD26D72BA500BF2251 /* SentryTraceStateTests.swift in Sources */,

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -102,6 +102,9 @@ SentrySpan ()
 - (void)finish
 {
     self.timestamp = [SentryCurrentDate date];
+    if (self.tracer != nil) {
+        [self.tracer spanFinished:self];
+    }
 }
 
 - (void)finishWithStatus:(SentrySpanStatus)status

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -84,6 +84,11 @@ NS_ASSUME_NONNULL_BEGIN
     NS_SWIFT_NAME(startChild(parentId:operation:description:));
 
 /**
+ * A method to inform the tracer that a span finished.
+ */
+- (void)spanFinished:(id<SentrySpan>)finishedSpan;
+
+/**
  * Get the tracer from a span.
  */
 + (nullable SentryTracer *)getTracer:(id<SentrySpan>)span;

--- a/Tests/SentryTests/Performance/SentryTracerObjCTests.m
+++ b/Tests/SentryTests/Performance/SentryTracerObjCTests.m
@@ -1,0 +1,37 @@
+#import "SentryHub.h"
+#import "SentrySpan.h"
+#import "SentryTracer.h"
+#import "SentryTransactionContext.h"
+#import <XCTest/XCTest.h>
+
+@interface SentryTracerObjCTests : XCTestCase
+
+@end
+
+@implementation SentryTracerObjCTests
+
+/**
+ * This test makes sure that the span has a weak reference to the tracer and doesn't call the
+ * tracer#spanFinished method.
+ */
+- (void)testSpanFinishesAfterTracerReleased_NoCrash_TracerIsNil
+{
+    SentrySpan *child;
+    // To make sure the tracer is deallocated.
+    @autoreleasepool {
+        SentryHub *hub = [[SentryHub alloc] initWithClient:nil andScope:nil];
+        SentryTransactionContext *context =
+            [[SentryTransactionContext alloc] initWithOperation:@""];
+        SentryTracer *tracer = [[SentryTracer alloc] initWithTransactionContext:context
+                                                                            hub:hub
+                                                                waitForChildren:YES];
+        [tracer finish];
+        child = [tracer startChildWithOperation:@"child"];
+    }
+
+    XCTAssertNotNil(child);
+    XCTAssertNil(child.tracer);
+    [child finish];
+}
+
+@end

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -361,25 +361,6 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(["key": 0], sut.data as! [String: Int])
     }
     
-    /**
-     * This test makes sure that the span has a weak reference to the tracer and doesn't call the tracer#spanFinished method.
-     */
-    func testSpanFinishesAfterTracerReleased_NoCrash_TracerIsNil() {
-        let child = getUnfinishedChildSpanOfFinishedTracer()
-        XCTAssertNil(Dynamic(child).tracer.asObject)
-        child.finish()
-    }
-    
-    /**
-     * The tracer is deallocated after calling this function as we don't have a reference to it anymore.s
-     */
-    private func getUnfinishedChildSpanOfFinishedTracer() -> Span {
-        let tracer = fixture.getSut()
-        let child = tracer.startChild(operation: "child")
-        tracer.finish()
-        return child
-    }
-    
     private func getSerializedTransaction() -> [String: Any] {
         guard let transaction = fixture.hub.capturedEventsWithScopes.first?.event else {
             fatalError("Event must not be nil.")

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -361,6 +361,25 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(["key": 0], sut.data as! [String: Int])
     }
     
+    /**
+     * This test makes sure that the span has a weak reference to the tracer and doesn't call the tracer#spanFinished method.
+     */
+    func testSpanFinishesAfterTracerReleased_NoCrash_TracerIsNil() {
+        let child = getUnfinishedChildSpanOfFinishedTracer()
+        XCTAssertNil(Dynamic(child).tracer.asObject)
+        child.finish()
+    }
+    
+    /**
+     * The tracer is deallocated after calling this function as we don't have a reference to it anymore.s
+     */
+    private func getUnfinishedChildSpanOfFinishedTracer() -> Span {
+        let tracer = fixture.getSut()
+        let child = tracer.startChild(operation: "child")
+        tracer.finish()
+        return child
+    }
+    
     private func getSerializedTransaction() -> [String: Any] {
         guard let transaction = fixture.hub.capturedEventsWithScopes.first?.event else {
             fatalError("Event must not be nil.")


### PR DESCRIPTION




## :scroll: Description

The tracer observes when one of its child spans finishes when waitForChildren
is enabled. A prior fix for memory leaks GH-1352 led to crashes when watching
the child spans with KVO. This problem is fixed now by replacing KVO with a
simple method call from span to tracer when the span finishes.

## :bulb: Motivation and Context

Fixes GH-1358

## :green_heart: How did you test it?
Unit tests and on iPhone.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
