### PR TITLE
test: Fix Race Conditions for TestClient

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -334,6 +334,7 @@
 		7B98D7E425FB7A7200C5A389 /* SentryAppState.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B98D7E325FB7A7200C5A389 /* SentryAppState.h */; };
 		7B98D7E825FB7BCD00C5A389 /* SentryAppState.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B98D7E725FB7BCD00C5A389 /* SentryAppState.m */; };
 		7B98D7EC25FB7C4900C5A389 /* SentryAppStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B98D7EB25FB7C4900C5A389 /* SentryAppStateTests.swift */; };
+		7BA1C51F2716DDB3005D75A4 /* Invocations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA1C51E2716DDB3005D75A4 /* Invocations.swift */; };
 		7BA235632600B61200E12865 /* SentryInternalNotificationNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */; };
 		7BA61CAB247BA98100C130A8 /* SentryDebugImageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA61CAA247BA98100C130A8 /* SentryDebugImageProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7BA61CAD247BAA0B00C130A8 /* SentryDebugImageProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA61CAC247BAA0B00C130A8 /* SentryDebugImageProvider.m */; };
@@ -890,6 +891,7 @@
 		7B98D7E325FB7A7200C5A389 /* SentryAppState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryAppState.h; path = include/SentryAppState.h; sourceTree = "<group>"; };
 		7B98D7E725FB7BCD00C5A389 /* SentryAppState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAppState.m; sourceTree = "<group>"; };
 		7B98D7EB25FB7C4900C5A389 /* SentryAppStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAppStateTests.swift; sourceTree = "<group>"; };
+		7BA1C51E2716DDB3005D75A4 /* Invocations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invocations.swift; sourceTree = "<group>"; };
 		7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalNotificationNames.h; path = include/SentryInternalNotificationNames.h; sourceTree = "<group>"; };
 		7BA61CAA247BA98100C130A8 /* SentryDebugImageProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDebugImageProvider.h; path = Public/SentryDebugImageProvider.h; sourceTree = "<group>"; };
 		7BA61CAC247BAA0B00C130A8 /* SentryDebugImageProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDebugImageProvider.m; sourceTree = "<group>"; };
@@ -1974,6 +1976,7 @@
 				7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */,
 				7B6D98EC24C703F8005502FA /* Async.swift */,
 				8E25C97425F8511A00DC215B /* TestRandom.swift */,
+				7BA1C51E2716DDB3005D75A4 /* Invocations.swift */,
 			);
 			path = TestUtils;
 			sourceTree = "<group>";
@@ -2649,6 +2652,7 @@
 				63FE721A20DA66EC00CDBAE8 /* SentryCrashSysCtl_Tests.m in Sources */,
 				7B88F30424BC8E6500ADF90A /* SentrySerializationTests.swift in Sources */,
 				8EC4CF5025C3A0070093DEE9 /* SentrySpanContextTests.swift in Sources */,
+				7BA1C51F2716DDB3005D75A4 /* Invocations.swift in Sources */,
 				7B869EBE249B964D004F4FDB /* SentryThreadEquality.swift in Sources */,
 				7BC6EBF8255C05060059822A /* TestData.swift in Sources */,
 				7B88F30224BC5C6D00ADF90A /* SentrySdkInfoTests.swift in Sources */,

--- a/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentryOutOfMemoryTrackerTests.swift
@@ -93,7 +93,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         sut.start()
         
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
     }
     
     func testDifferentOSVersions_NoOOM() {
@@ -101,7 +101,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         sut.start()
         
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
     }
     
     func testIsDebugging_NoOOM() {
@@ -114,7 +114,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         sut.start()
         
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
     }
     
     func testTerminatedNormally_NoOOM() {
@@ -125,7 +125,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         sut.start()
         
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
     }
     
     func testCrashReport_NoOOM() {
@@ -135,7 +135,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         sut.start()
         
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
     }
     
     func testAppWasInBackground_NoOOM() {
@@ -146,7 +146,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         sut.stop()
         
         sut.start()
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
     }
     
     func testAppWasInForeground_OOM() {
@@ -216,8 +216,8 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
     }
     
     private func assertOOMEventSent() {
-        XCTAssertEqual(1, fixture.client.captureCrashEventArguments.count)
-        let crashEvent = fixture.client.captureCrashEventArguments.first?.event
+        XCTAssertEqual(1, fixture.client.captureCrashEventInvocations.count)
+        let crashEvent = fixture.client.captureCrashEventInvocations.first?.event
         
         XCTAssertEqual(SentryLevel.fatal, crashEvent?.level)
         XCTAssertEqual([], crashEvent?.breadcrumbs)

--- a/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SentrySessionTrackerTests.swift
@@ -411,17 +411,17 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func assertNoSessionSent() {
-        XCTAssertEqual(0, fixture.client.sessions.count)
+        XCTAssertEqual(0, fixture.client.captureSessionInvocations.count)
     }
     
     private func assertEndSessionSent(started: Date, duration: NSNumber, errors: UInt = 0) {
         
         // the end session is the second but last, because the sdk sends an session
         // init after sending the end of the session.
-        let endSessionIndex = fixture.client.sessions.count - 2
+        let endSessionIndex = fixture.client.captureSessionInvocations.count - 2
         
-        if fixture.client.sessions.indices.contains(endSessionIndex) {
-            let session = fixture.client.sessions[endSessionIndex]
+        if fixture.client.captureSessionInvocations.invocations.indices.contains(endSessionIndex) {
+            let session = fixture.client.captureSessionInvocations.invocations[endSessionIndex]
             XCTAssertFalse(session.flagInit?.boolValue ?? false)
             XCTAssertEqual(started, session.started)
             XCTAssertEqual(SentrySessionStatus.exited, session.status)
@@ -436,10 +436,10 @@ class SentrySessionTrackerTests: XCTestCase {
     
     private func assertSessionSent(started: Date, duration: NSNumber, status: SentrySessionStatus) {
 
-        let endSessionIndex = fixture.client.sessions.count - 1
+        let endSessionIndex = fixture.client.captureSessionInvocations.count - 1
 
-        if fixture.client.sessions.indices.contains(endSessionIndex) {
-            let session = fixture.client.sessions[endSessionIndex]
+        if fixture.client.captureSessionInvocations.invocations.indices.contains(endSessionIndex) {
+            let session = fixture.client.captureSessionInvocations.invocations[endSessionIndex]
             assertSession(session: session, started: started, status: status, duration: duration)
         } else {
             XCTFail("Can't find session.")
@@ -461,7 +461,7 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func assertSessionInitSent(sessionStarted: Date) {
-        if let session = fixture.client.sessions.last {
+        if let session = fixture.client.captureSessionInvocations.last {
             XCTAssertTrue(session.flagInit?.boolValue ?? false)
             XCTAssertEqual(sessionStarted, session.started)
             XCTAssertEqual(SentrySessionStatus.ok, session.status)
@@ -482,11 +482,11 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func assertNoInitSessionSent() {
-        let eventWithSessions = fixture.client.captureCrashEventWithSessionArguments.map({ triple in triple.session })
-        let errorWithSessions = fixture.client.captureErrorWithSessionArguments.map({ triple in triple.session })
-        let exceptionWithSessions = fixture.client.captureExceptionWithSessionArguments.map({ triple in triple.session })
+        let eventWithSessions = fixture.client.captureCrashEventWithSessionInvocations.invocations.map({ triple in triple.session })
+        let errorWithSessions = fixture.client.captureErrorWithSessionInvocations.invocations.map({ triple in triple.session })
+        let exceptionWithSessions = fixture.client.captureExceptionWithSessionInvocations.invocations.map({ triple in triple.session })
         
-        var sessions = fixture.client.sessions + eventWithSessions + errorWithSessions + exceptionWithSessions
+        var sessions = fixture.client.captureSessionInvocations.invocations + eventWithSessions + errorWithSessions + exceptionWithSessions
         
         sessions.sort { first, second in return first.started < second.started }
         
@@ -496,10 +496,10 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func assertSessionsSent(count: Int) {
-        let eventWithSessions = fixture.client.captureCrashEventWithSessionArguments.count
-        let errorWithSessions = fixture.client.captureErrorWithSessionArguments.count
-        let exceptionWithSessions = fixture.client.captureExceptionWithSessionArguments.count
-        let sessions = fixture.client.sessions.count
+        let eventWithSessions = fixture.client.captureCrashEventWithSessionInvocations.count
+        let errorWithSessions = fixture.client.captureErrorWithSessionInvocations.count
+        let exceptionWithSessions = fixture.client.captureExceptionWithSessionInvocations.count
+        let sessions = fixture.client.captureSessionInvocations.count
         
         let sessionsSent = eventWithSessions + errorWithSessions + exceptionWithSessions + sessions
         
@@ -530,7 +530,7 @@ class SentrySessionTrackerTests: XCTestCase {
         sut.start()
         SentrySDK.captureCrash(Event())
         
-        if let session = fixture.client.captureCrashEventWithSessionArguments.last?.session {
+        if let session = fixture.client.captureCrashEventWithSessionInvocations.last?.session {
             assertSession(session: session, started: sessionStartTime, status: SentrySessionStatus.crashed, duration: 5)
         } else {
             XCTFail("No session sent with event.")

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -14,8 +14,8 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         let envelope = TestConstants.envelope
         PrivateSentrySDKOnly.store(envelope)
         
-        XCTAssertEqual(1, client?.storedEnvelopes.count)
-        XCTAssertEqual(envelope, client?.storedEnvelopes.first)
+        XCTAssertEqual(1, client?.storedEnvelopeInvocations.count)
+        XCTAssertEqual(envelope, client?.storedEnvelopeInvocations.first)
     }
     
     func testCaptureEnvelope() {
@@ -25,8 +25,8 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         let envelope = TestConstants.envelope
         PrivateSentrySDKOnly.capture(envelope)
         
-        XCTAssertEqual(1, client?.capturedEnvelopes.count)
-        XCTAssertEqual(envelope, client?.capturedEnvelopes.first)
+        XCTAssertEqual(1, client?.captureEnvelopeInvocations.count)
+        XCTAssertEqual(envelope, client?.captureEnvelopeInvocations.first)
     }
 
     func testEnvelopeWithData() throws {

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -64,7 +64,7 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     }
     
     private func assertNoEventsSent() {
-        XCTAssertEqual(0, testClient.captureEventWithScopeArguments.count)
+        XCTAssertEqual(0, testClient.captureEventWithScopeInvocations.count)
     }
     
     private func assertNoReportsStored() {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -194,8 +194,8 @@ class SentryHubTests: XCTestCase {
     func testCaptureEventWithScope() {
         fixture.getSut().capture(event: fixture.event, scope: fixture.scope)
         
-        XCTAssertEqual(1, fixture.client.captureEventWithScopeArguments.count)
-        if let eventArguments = fixture.client.captureEventWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureEventWithScopeInvocations.count)
+        if let eventArguments = fixture.client.captureEventWithScopeInvocations.first {
             XCTAssertEqual(fixture.event.eventId, eventArguments.event.eventId)
             XCTAssertEqual(fixture.scope, eventArguments.scope)
         }
@@ -204,8 +204,8 @@ class SentryHubTests: XCTestCase {
     func testCaptureEventWithoutScope() {
         fixture.getSut().capture(event: fixture.event)
         
-        XCTAssertEqual(1, fixture.client.captureEventWithScopeArguments.count)
-        if let eventArguments = fixture.client.captureEventWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureEventWithScopeInvocations.count)
+        if let eventArguments = fixture.client.captureEventWithScopeInvocations.first {
             XCTAssertEqual(fixture.event.eventId, eventArguments.event.eventId)
             XCTAssertEqual(Scope(), eventArguments.scope)
         }
@@ -295,8 +295,8 @@ class SentryHubTests: XCTestCase {
     func testCaptureMessageWithScope() {
         fixture.getSut().capture(message: fixture.message, scope: fixture.scope)
         
-        XCTAssertEqual(1, fixture.client.captureMessageWithScopeArguments.count)
-        if let messageArguments = fixture.client.captureMessageWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureMessageWithScopeInvocations.count)
+        if let messageArguments = fixture.client.captureMessageWithScopeInvocations.first {
             XCTAssertEqual(fixture.message, messageArguments.message)
             XCTAssertEqual(fixture.scope, messageArguments.scope)
         }
@@ -305,8 +305,8 @@ class SentryHubTests: XCTestCase {
     func testCaptureMessageWithoutScope() {
         fixture.getSut().capture(message: fixture.message)
         
-        XCTAssertEqual(1, fixture.client.captureMessageWithScopeArguments.count)
-        if let messageArguments = fixture.client.captureMessageWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureMessageWithScopeInvocations.count)
+        if let messageArguments = fixture.client.captureMessageWithScopeInvocations.first {
             XCTAssertEqual(fixture.message, messageArguments.message)
             XCTAssertEqual(Scope(), messageArguments.scope)
         }
@@ -315,8 +315,8 @@ class SentryHubTests: XCTestCase {
     func testCatpureErrorWithScope() {
         fixture.getSut().capture(error: fixture.error, scope: fixture.scope).assertIsNotEmpty()
         
-        XCTAssertEqual(1, fixture.client.captureErrorWithScopeArguments.count)
-        if let errorArguments = fixture.client.captureErrorWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureErrorWithScopeInvocations.count)
+        if let errorArguments = fixture.client.captureErrorWithScopeInvocations.first {
             XCTAssertEqual(fixture.error, errorArguments.error as NSError)
             XCTAssertEqual(fixture.scope, errorArguments.scope)
         }
@@ -327,8 +327,8 @@ class SentryHubTests: XCTestCase {
         sut.startSession()
         sut.capture(error: fixture.error, scope: fixture.scope).assertIsNotEmpty()
         
-        XCTAssertEqual(1, fixture.client.captureErrorWithSessionArguments.count)
-        if let errorArguments = fixture.client.captureErrorWithSessionArguments.first {
+        XCTAssertEqual(1, fixture.client.captureErrorWithSessionInvocations.count)
+        if let errorArguments = fixture.client.captureErrorWithSessionInvocations.first {
             XCTAssertEqual(fixture.error, errorArguments.error as NSError)
             
             XCTAssertEqual(1, errorArguments.session.errors)
@@ -338,14 +338,14 @@ class SentryHubTests: XCTestCase {
         }
         
         // only session init is sent
-        XCTAssertEqual(1, fixture.client.sessions.count)
+        XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
     }
     
     func testCatpureErrorWithoutScope() {
         fixture.getSut().capture(error: fixture.error).assertIsNotEmpty()
         
-        XCTAssertEqual(1, fixture.client.captureErrorWithScopeArguments.count)
-        if let errorArguments = fixture.client.captureErrorWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureErrorWithScopeInvocations.count)
+        if let errorArguments = fixture.client.captureErrorWithScopeInvocations.first {
             XCTAssertEqual(fixture.error, errorArguments.error as NSError)
             XCTAssertEqual(Scope(), errorArguments.scope)
         }
@@ -354,8 +354,8 @@ class SentryHubTests: XCTestCase {
     func testCatpureExceptionWithScope() {
         fixture.getSut().capture(exception: fixture.exception, scope: fixture.scope).assertIsNotEmpty()
         
-        XCTAssertEqual(1, fixture.client.captureExceptionWithScopeArguments.count)
-        if let errorArguments = fixture.client.captureExceptionWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureExceptionWithScopeInvocations.count)
+        if let errorArguments = fixture.client.captureExceptionWithScopeInvocations.first {
             XCTAssertEqual(fixture.exception, errorArguments.exception)
             XCTAssertEqual(fixture.scope, errorArguments.scope)
         }
@@ -364,8 +364,8 @@ class SentryHubTests: XCTestCase {
     func testCatpureExceptionWithoutScope() {
         fixture.getSut().capture(exception: fixture.exception).assertIsNotEmpty()
         
-        XCTAssertEqual(1, fixture.client.captureExceptionWithScopeArguments.count)
-        if let errorArguments = fixture.client.captureExceptionWithScopeArguments.first {
+        XCTAssertEqual(1, fixture.client.captureExceptionWithScopeInvocations.count)
+        if let errorArguments = fixture.client.captureExceptionWithScopeInvocations.first {
             XCTAssertEqual(fixture.exception, errorArguments.exception)
             XCTAssertEqual(Scope(), errorArguments.scope)
         }
@@ -376,8 +376,8 @@ class SentryHubTests: XCTestCase {
         sut.startSession()
         sut.capture(exception: fixture.exception, scope: fixture.scope).assertIsNotEmpty()
         
-        XCTAssertEqual(1, fixture.client.captureExceptionWithSessionArguments.count)
-        if let exceptionArguments = fixture.client.captureExceptionWithSessionArguments.first {
+        XCTAssertEqual(1, fixture.client.captureExceptionWithSessionInvocations.count)
+        if let exceptionArguments = fixture.client.captureExceptionWithSessionInvocations.first {
             XCTAssertEqual(fixture.exception, exceptionArguments.exception)
             
             XCTAssertEqual(1, exceptionArguments.session.errors)
@@ -387,7 +387,7 @@ class SentryHubTests: XCTestCase {
         }
         
         // only session init is sent
-        XCTAssertEqual(1, fixture.client.sessions.count)
+        XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
     }
     
     @available(tvOS 10.0, *)
@@ -398,9 +398,9 @@ class SentryHubTests: XCTestCase {
             sut.capture(exception: self.fixture.exception, scope: self.fixture.scope)
         }
         
-        XCTAssertEqual(10, fixture.client.captureExceptionWithSessionArguments.count)
+        XCTAssertEqual(10, fixture.client.captureExceptionWithSessionInvocations.count)
         for i in 0...9 {
-            let arguments = fixture.client.captureExceptionWithSessionArguments[i]
+            let arguments = fixture.client.captureExceptionWithSessionInvocations.invocations[i]
             XCTAssertEqual(i + 1, Int(arguments.session.errors))
         }
     }
@@ -413,9 +413,9 @@ class SentryHubTests: XCTestCase {
             sut.capture(error: self.fixture.error, scope: self.fixture.scope)
         }
         
-        XCTAssertEqual(10, fixture.client.captureErrorWithSessionArguments.count)
+        XCTAssertEqual(10, fixture.client.captureErrorWithSessionInvocations.count)
         for i in 0...9 {
-            let arguments = fixture.client.captureErrorWithSessionArguments[i]
+            let arguments = fixture.client.captureErrorWithSessionInvocations.invocations[i]
             XCTAssertEqual(i + 1, Int(arguments.session.errors))
         }
     }
@@ -424,16 +424,16 @@ class SentryHubTests: XCTestCase {
         sut.bindClient(nil)
         
         XCTAssertEqual(SentryId.empty, sut.capture(error: fixture.error))
-        XCTAssertEqual(0, fixture.client.captureErrorWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureErrorWithScopeInvocations.count)
         
         XCTAssertEqual(SentryId.empty, sut.capture(message: fixture.message, scope: fixture.scope))
-        XCTAssertEqual(0, fixture.client.captureMessageWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureMessageWithScopeInvocations.count)
         
         XCTAssertEqual(SentryId.empty, sut.capture(event: fixture.event))
-        XCTAssertEqual(0, fixture.client.captureEventArguments.count)
+        XCTAssertEqual(0, fixture.client.captureEventInvocations.count)
         
         XCTAssertEqual(SentryId.empty, sut.capture(exception: fixture.exception))
-        XCTAssertEqual(0, fixture.client.captureExceptionWithScopeArguments.count)
+        XCTAssertEqual(0, fixture.client.captureExceptionWithScopeInvocations.count)
     }
     
     func testCaptureCrashEvent_CrashedSessionExists() {
@@ -558,8 +558,8 @@ class SentryHubTests: XCTestCase {
         let envelope = SentryEnvelope(session: SentrySession(releaseName: ""))
         sut.capture(envelope: envelope)
         
-        XCTAssertEqual(1, fixture.client.capturedEnvelopes.count)
-        XCTAssertEqual(envelope, fixture.client.capturedEnvelopes.first)
+        XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
+        XCTAssertEqual(envelope, fixture.client.captureEnvelopeInvocations.first)
     }
 
     private func addBreadcrumbThroughConfigureScope(_ hub: SentryHub) {
@@ -577,7 +577,7 @@ class SentryHubTests: XCTestCase {
         let sut = fixture.getSut()
         sut.startSession()
 
-        let queue = DispatchQueue(label: "SentryHubTests", qos: .utility, attributes: [.concurrent, .initiallyInactive])
+        let queue = DispatchQueue(label: "SentryHubTests", qos: .utility, attributes: [.concurrent])
 
         let group = DispatchGroup()
         for _ in 0...count - 1 {
@@ -588,7 +588,6 @@ class SentryHubTests: XCTestCase {
             }
         }
 
-        queue.activate()
         group.waitWithTimeout()
     }
     
@@ -637,30 +636,30 @@ class SentryHubTests: XCTestCase {
     }
     
     private func assertNoCrashedSessionSent() {
-        XCTAssertFalse(fixture.client.sessions.contains(where: { session in
+        XCTAssertFalse(fixture.client.captureSessionInvocations.invocations.contains(where: { session in
             return session.status == SentrySessionStatus.crashed
         }))
     }
     
     private func assertNoEventsSent() {
-        XCTAssertEqual(0, fixture.client.captureEventArguments.count)
-        XCTAssertEqual(0, fixture.client.captureCrashEventWithSessionArguments.count)
+        XCTAssertEqual(0, fixture.client.captureEventInvocations.count)
+        XCTAssertEqual(0, fixture.client.captureCrashEventWithSessionInvocations.count)
     }
     
     private func assertEventSent() {
-        let arguments = fixture.client.captureEventWithScopeArguments
+        let arguments = fixture.client.captureEventWithScopeInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
     }
     
     private func assertCrashEventSent() {
-        let arguments = fixture.client.captureCrashEventArguments
+        let arguments = fixture.client.captureCrashEventInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
     }
 
     private func assertEventSentWithSession() {
-        let arguments = fixture.client.captureCrashEventWithSessionArguments
+        let arguments = fixture.client.captureCrashEventWithSessionInvocations
         XCTAssertEqual(1, arguments.count)
 
         let argument = arguments.first
@@ -675,21 +674,21 @@ class SentryHubTests: XCTestCase {
     }
     
     private func assertSessionWithIncrementedErrorCountedAdded() {
-        XCTAssertEqual(1, fixture.client.capturedEnvelopes.count)
-        let envelope = fixture.client.capturedEnvelopes.first!
+        XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
+        let envelope = fixture.client.captureEnvelopeInvocations.first!
         XCTAssertEqual(2, envelope.items.count)
         let session = SentrySerialization.session(with: envelope.items[1].data)
         XCTAssertEqual(1, session?.errors)
     }
     
     private func assertNoSessionAddedToCapturedEnvelope() {
-        XCTAssertEqual(1, fixture.client.capturedEnvelopes.count)
-        let envelope = fixture.client.capturedEnvelopes.first!
+        XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
+        let envelope = fixture.client.captureEnvelopeInvocations.first!
         XCTAssertEqual(1, envelope.items.count)
     }
     
     private func assertNoEnvelopesCaptured() {
-        XCTAssertEqual(0, fixture.client.capturedEnvelopes.count)
+        XCTAssertEqual(0, fixture.client.captureEnvelopeInvocations.count)
     }
     
     private func testSampler(expected: SentrySampleDecision, options: (Options) -> Void) {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -304,8 +304,8 @@ class SentrySDKTests: XCTestCase {
         let envelope = SentryEnvelope(event: TestData.event)
         SentrySDK.capture(envelope)
         
-        XCTAssertEqual(1, fixture.client.capturedEnvelopes.count)
-        XCTAssertEqual(envelope.header.eventId, fixture.client.capturedEnvelopes.first?.header.eventId)
+        XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
+        XCTAssertEqual(envelope.header.eventId, fixture.client.captureEnvelopeInvocations.first?.header.eventId)
     }
     
     func testStoreEnvelope() {
@@ -314,14 +314,14 @@ class SentrySDKTests: XCTestCase {
         let envelope = SentryEnvelope(event: TestData.event)
         SentrySDK.store(envelope)
         
-        XCTAssertEqual(1, fixture.client.storedEnvelopes.count)
-        XCTAssertEqual(envelope.header.eventId, fixture.client.storedEnvelopes.first?.header.eventId)
+        XCTAssertEqual(1, fixture.client.storedEnvelopeInvocations.count)
+        XCTAssertEqual(envelope.header.eventId, fixture.client.storedEnvelopeInvocations.first?.header.eventId)
     }
     
     func testStoreEnvelope_WhenNoClient_NoCrash() {
         SentrySDK.store(SentryEnvelope(event: TestData.event))
         
-        XCTAssertEqual(0, fixture.client.storedEnvelopes.count)
+        XCTAssertEqual(0, fixture.client.storedEnvelopeInvocations.count)
     }
     
     func testCaptureUserFeedback() {
@@ -329,8 +329,8 @@ class SentrySDKTests: XCTestCase {
         
         SentrySDK.capture(userFeedback: fixture.userFeedback)
         let client = fixture.client
-        XCTAssertEqual(1, client.capturedUserFeedback.count)
-        if let actual = client.capturedUserFeedback.first {
+        XCTAssertEqual(1, client.captureUserFeedbackInvocations.count)
+        if let actual = client.captureUserFeedbackInvocations.first {
             let expected = fixture.userFeedback
             XCTAssertEqual(expected.eventId, actual.eventId)
             XCTAssertEqual(expected.name, actual.name)
@@ -461,9 +461,9 @@ class SentrySDKTests: XCTestCase {
         
         SentrySDK.startSession()
         
-        XCTAssertEqual(1, fixture.client.sessions.count)
+        XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
         
-        let actual = fixture.client.sessions.first
+        let actual = fixture.client.captureSessionInvocations.first
         let expected = SentrySession(releaseName: fixture.options.releaseName ?? "")
         
         XCTAssertEqual(expected.flagInit, actual?.flagInit)
@@ -483,9 +483,9 @@ class SentrySDKTests: XCTestCase {
         advanceTime(bySeconds: 1)
         SentrySDK.endSession()
         
-        XCTAssertEqual(2, fixture.client.sessions.count)
+        XCTAssertEqual(2, fixture.client.captureSessionInvocations.count)
         
-        let actual = fixture.client.sessions[1]
+        let actual = fixture.client.captureSessionInvocations.invocations[1]
         
         XCTAssertNil(actual.flagInit)
         XCTAssertEqual(0, actual.errors)
@@ -604,30 +604,30 @@ class SentrySDKTests: XCTestCase {
     
     private func assertEventCaptured(expectedScope: Scope) {
         let client = fixture.client
-        XCTAssertEqual(1, client.captureEventWithScopeArguments.count)
-        XCTAssertEqual(fixture.event, client.captureEventWithScopeArguments.first?.event)
-        XCTAssertEqual(expectedScope, client.captureEventWithScopeArguments.first?.scope)
+        XCTAssertEqual(1, client.captureEventWithScopeInvocations.count)
+        XCTAssertEqual(fixture.event, client.captureEventWithScopeInvocations.first?.event)
+        XCTAssertEqual(expectedScope, client.captureEventWithScopeInvocations.first?.scope)
     }
     
     private func assertErrorCaptured(expectedScope: Scope) {
         let client = fixture.client
-        XCTAssertEqual(1, client.captureErrorWithScopeArguments.count)
-        XCTAssertEqual(fixture.error.localizedDescription, client.captureErrorWithScopeArguments.first?.error.localizedDescription)
-        XCTAssertEqual(expectedScope, client.captureErrorWithScopeArguments.first?.scope)
+        XCTAssertEqual(1, client.captureErrorWithScopeInvocations.count)
+        XCTAssertEqual(fixture.error.localizedDescription, client.captureErrorWithScopeInvocations.first?.error.localizedDescription)
+        XCTAssertEqual(expectedScope, client.captureErrorWithScopeInvocations.first?.scope)
     }
     
     private func assertExceptionCaptured(expectedScope: Scope) {
         let client = fixture.client
-        XCTAssertEqual(1, client.captureExceptionWithScopeArguments.count)
-        XCTAssertEqual(fixture.exception, client.captureExceptionWithScopeArguments.first?.exception)
-        XCTAssertEqual(expectedScope, client.captureExceptionWithScopeArguments.first?.scope)
+        XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)
+        XCTAssertEqual(fixture.exception, client.captureExceptionWithScopeInvocations.first?.exception)
+        XCTAssertEqual(expectedScope, client.captureExceptionWithScopeInvocations.first?.scope)
     }
     
     private func assertMessageCaptured(expectedScope: Scope) {
         let client = fixture.client
-        XCTAssertEqual(1, client.captureMessageWithScopeArguments.count)
-        XCTAssertEqual(fixture.message, client.captureMessageWithScopeArguments.first?.message)
-        XCTAssertEqual(expectedScope, client.captureMessageWithScopeArguments.first?.scope)
+        XCTAssertEqual(1, client.captureMessageWithScopeInvocations.count)
+        XCTAssertEqual(fixture.message, client.captureMessageWithScopeInvocations.first?.message)
+        XCTAssertEqual(expectedScope, client.captureMessageWithScopeInvocations.first?.scope)
     }
     
     private func assertHubScopeNotChanged() {

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -3,6 +3,7 @@ import Foundation
 class TestClient: Client {
     
     let sentryFileManager: SentryFileManager
+    let queue = DispatchQueue(label: "TestClient", attributes: .concurrent)
     
     override init?(options: Options) {
         sentryFileManager = try! SentryFileManager(options: options, andCurrentDateProvider: TestCurrentDateProvider())
@@ -13,96 +14,96 @@ class TestClient: Client {
         sentryFileManager
     }
     
-    var sessions: [SentrySession] = []
+    var captureSessionInvocations = Invocations<SentrySession>()
     override func capture(session: SentrySession) {
-        sessions.append(session)
+        captureSessionInvocations.record(session)
     }
     
-    var captureEventArguments: [Event] = []
+    var captureEventInvocations = Invocations<Event>()
     override func capture(event: Event) -> SentryId {
-        captureEventArguments.append(event)
+        captureEventInvocations.record(event)
         return event.eventId
     }
     
-    var captureEventWithScopeArguments: [(event: Event, scope: Scope)] = []
+    var captureEventWithScopeInvocations = Invocations<(event: Event, scope: Scope)>()
     override func capture(event: Event, scope: Scope) -> SentryId {
-        captureEventWithScopeArguments.append((event, scope))
+        captureEventWithScopeInvocations.record((event, scope))
         return event.eventId
     }
     
-    var captureMessageArguments: [String] = []
+    var captureMessageInvocations = Invocations<String>()
     override func capture(message: String) -> SentryId {
-        captureMessageArguments.append(message)
+        self.captureMessageInvocations.record(message)
         return SentryId()
     }
     
-    var captureMessageWithScopeArguments: [(message: String, scope: Scope)] = []
+    var captureMessageWithScopeInvocations = Invocations<(message: String, scope: Scope)>()
     override func capture(message: String, scope: Scope) -> SentryId {
-        captureMessageWithScopeArguments.append((message, scope))
+        captureMessageWithScopeInvocations.record((message, scope))
         return SentryId()
     }
     
-    var captureErrorArguments: [Error] = []
+    var captureErrorInvocations = Invocations<Error>()
     override func capture(error: Error) -> SentryId {
-        captureErrorArguments.append(error)
+        captureErrorInvocations.record(error)
         return SentryId()
     }
     
-    var captureErrorWithScopeArguments: [(error: Error, scope: Scope)] = []
+    var captureErrorWithScopeInvocations = Invocations<(error: Error, scope: Scope)>()
     override func capture(error: Error, scope: Scope) -> SentryId {
-        captureErrorWithScopeArguments.append((error, scope))
+        captureErrorWithScopeInvocations.record((error, scope))
         return SentryId()
     }
     
-    var captureExceptionArguments: [NSException] = []
+    var captureExceptionInvocations = Invocations<NSException>()
     override func capture(exception: NSException) -> SentryId {
-        captureExceptionArguments.append(exception)
+        captureExceptionInvocations.record(exception)
         return SentryId()
     }
     
-    var captureExceptionWithScopeArguments: [(exception: NSException, scope: Scope)] = []
+    var captureExceptionWithScopeInvocations = Invocations<(exception: NSException, scope: Scope)>()
     override func capture(exception: NSException, scope: Scope) -> SentryId {
-        captureExceptionWithScopeArguments.append((exception, scope))
+        captureExceptionWithScopeInvocations.record((exception, scope))
         return SentryId()
     }
     
-    var captureErrorWithSessionArguments: [(error: Error, session: SentrySession, scope: Scope)] = []
+    var captureErrorWithSessionInvocations = Invocations<(error: Error, session: SentrySession, scope: Scope)>()
     override func captureError(_ error: Error, with session: SentrySession, with scope: Scope) -> SentryId {
-        captureErrorWithSessionArguments.append((error, session, scope))
-               return SentryId()
+        captureErrorWithSessionInvocations.record((error, session, scope))
+        return SentryId()
     }
     
-    var captureExceptionWithSessionArguments: [(exception: NSException, session: SentrySession, scope: Scope)] = []
+    var captureExceptionWithSessionInvocations = Invocations<(exception: NSException, session: SentrySession, scope: Scope)>()
     override func capture(_ exception: NSException, with session: SentrySession, with scope: Scope) -> SentryId {
-        captureExceptionWithSessionArguments.append((exception, session, scope))
+        captureExceptionWithSessionInvocations.record((exception, session, scope))
         return SentryId()
     }
     
-    var captureCrashEventArguments: [(event: Event, scope: Scope)] = []
+    var captureCrashEventInvocations = Invocations<(event: Event, scope: Scope)>()
     override func captureCrash(_ event: Event, with scope: Scope) -> SentryId {
-        captureCrashEventArguments.append((event, scope))
+        captureCrashEventInvocations.record((event, scope))
         return SentryId()
     }
     
-    var captureCrashEventWithSessionArguments: [(event: Event, session: SentrySession, scope: Scope)] = []
+    var captureCrashEventWithSessionInvocations = Invocations<(event: Event, session: SentrySession, scope: Scope)>()
     override func captureCrash(_ event: Event, with session: SentrySession, with scope: Scope) -> SentryId {
-        captureCrashEventWithSessionArguments.append((event, session, scope))
+        captureCrashEventWithSessionInvocations.record((event, session, scope))
         return SentryId()
     }
     
-    var capturedUserFeedback: [UserFeedback] = []
+    var captureUserFeedbackInvocations = Invocations<UserFeedback>()
     override func capture(userFeedback: UserFeedback) {
-        capturedUserFeedback.append(userFeedback)
+        captureUserFeedbackInvocations.record(userFeedback)
     }
     
-    var capturedEnvelopes: [SentryEnvelope] = []
+    var captureEnvelopeInvocations = Invocations<SentryEnvelope>()
     override func capture(envelope: SentryEnvelope) {
-        capturedEnvelopes.append(envelope)
+        captureEnvelopeInvocations.record(envelope)
     }
     
-    var storedEnvelopes: [SentryEnvelope] = []
+    var storedEnvelopeInvocations = Invocations<SentryEnvelope>()
     override func store(_ envelope: SentryEnvelope) {
-        storedEnvelopes.append(envelope)
+        storedEnvelopeInvocations.record(envelope)
     }
 }
 
@@ -126,5 +127,4 @@ class TestFileManager: SentryFileManager {
         deleteTimestampLastInForegroundInvocations += 1
         timestampLastInForeground = nil
     }
-    
 }

--- a/Tests/SentryTests/TestUtils/Invocations.swift
+++ b/Tests/SentryTests/TestUtils/Invocations.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/**
+ * For recording invocations of methods in a list in a thread safe manner.
+ */
+class Invocations<T> {
+    
+    private let queue = DispatchQueue(label: "Invocations", attributes: .concurrent)
+    
+    private var _invocations: [T] = []
+    
+    var invocations: [T] {
+        return queue.sync {
+            return self._invocations
+        }
+    }
+    
+    var count: Int {
+        return queue.sync {
+            return self._invocations.count
+        }
+    }
+    
+    var first: T? {
+        return queue.sync {
+            return self._invocations.first
+        }
+    }
+    
+    var last: T? {
+        return queue.sync {
+            return self._invocations.last
+        }
+    }
+    
+    func record(_ invocation: T) {
+        queue.async(flags: .barrier) {
+            self._invocations.append(invocation)
+        }
+    }
+}

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -53,7 +53,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(span.timestamp, TestData.timestamp)
         XCTAssertTrue(span.isFinished)
         
-        let lastEvent = client.captureEventWithScopeArguments[0].event
+        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
         XCTAssertEqual(lastEvent.transaction, fixture.someTransaction)
         XCTAssertEqual(lastEvent.timestamp, TestData.timestamp)
         XCTAssertEqual(lastEvent.startTimestamp, TestData.timestamp)
@@ -78,7 +78,7 @@ class SentrySpanTests: XCTestCase {
         childSpan.finish()
         span.finish()
         
-        let lastEvent = client.captureEventWithScopeArguments[0].event
+        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
         let serializedData = lastEvent.serialize()
         
         let spans = serializedData["spans"] as! [Any]
@@ -94,7 +94,7 @@ class SentrySpanTests: XCTestCase {
         span.startChild(operation: fixture.someOperation)
         
         span.finish()
-        let lastEvent = client.captureEventWithScopeArguments[0].event
+        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
         let serializedData = lastEvent.serialize()
         
         let spans = serializedData["spans"] as! [Any]


### PR DESCRIPTION
The TestClient recorded invocations of methods in a non-thread-safe way.
This is fixed now by adding a new class Invocations, that keeps record of
the invocations with a dispatch queue barrier.

#skip-changelog