### PR TITLE
ci: Split Up UI Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,13 +41,16 @@ jobs:
         if: ${{ contains(matrix.platform, 'Mac Catalyst') || contains(matrix.platform, 'iOS') }}
 
   ui-tests:
-    name: UI for Sample Apps
+    name: UI Tests for ${{matrix.target}}
     runs-on: macos-11
+    strategy:
+      matrix:
+        target: ["ios_swiftui", "ios_objc", "ios_swift", "tvos_swift" ]
 
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh 
 
       - name: Run Fastlane
-        run: fastlane ui_tests
+        run: fastlane ui_tests_${{matrix.target}}
         shell: sh

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -106,27 +106,32 @@ platform :ios do
     )
   end
 
-  lane :ui_tests do
+  lane :ui_tests_ios_swiftui do
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-SwiftUI"
     )
+  end
 
+  lane :ui_tests_ios_objc do
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-ObjectiveC"
     )
+  end
 
+  lane :ui_tests_ios_swift do
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift"
     )
+  end
 
+  lane :ui_tests_tvos_swift do
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "tvOS-Swift"
     )
-
   end
 
 end


### PR DESCRIPTION
Run UI tests in different jobs by using a matrix. This
makes ci build faster.

#skip-changelog
