### PR TITLE
test: Use Invocations in TestRequestManager

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -350,7 +350,7 @@ class SentryHttpTransportTests: XCTestCase {
         let sessionData = try! SentrySerialization.data(with: sessionEnvelope)
         let sessionRequest = try! SentryNSURLRequest(envelopeRequestWith: SentryHttpTransportTests.dsn, andData: sessionData)
 
-        XCTAssertEqual(sessionRequest.httpBody, fixture.requestManager.requests[3].httpBody, "Envelope with only session item should be sent.")
+        XCTAssertEqual(sessionRequest.httpBody, fixture.requestManager.requests.invocations[3].httpBody, "Envelope with only session item should be sent.")
     }
 
     func testAllCachedEnvelopesCantDeserializeEnvelope() throws {
@@ -373,9 +373,9 @@ class SentryHttpTransportTests: XCTestCase {
 
         fixture.requestManager.waitForAllRequests()
         XCTAssertEqual(3, fixture.requestManager.requests.count)
-        XCTAssertEqual(fixture.eventWithAttachmentRequest.httpBody, fixture.requestManager.requests[1].httpBody, "Cached envelope was not sent first.")
+        XCTAssertEqual(fixture.eventWithAttachmentRequest.httpBody, fixture.requestManager.requests.invocations[1].httpBody, "Cached envelope was not sent first.")
 
-        XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests[2].httpBody, "Cached envelope was not sent first.")
+        XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests.invocations[2].httpBody, "Cached envelope was not sent first.")
     }
 
     func testPerformanceOfSending() {

--- a/Tests/SentryTests/Networking/TestRequestManager.swift
+++ b/Tests/SentryTests/Networking/TestRequestManager.swift
@@ -8,20 +8,9 @@ public class TestRequestManager: NSObject, RequestManager {
     private var nextResponse : () -> HTTPURLResponse? = { return nil }
     public var isReady: Bool
     
-    private var _requests: [URLRequest] = []
-    public var requests: [URLRequest] {
-        get {
-            var result: [URLRequest] = []
-            semaphore.wait()
-            result.append(contentsOf: _requests)
-            semaphore.signal()
-            return result
-        }
-    }
+    var requests = Invocations<URLRequest>()
     
     private let queue = DispatchQueue(label: "TestRequestManager", qos: .background, attributes: [])
-    
-    private let semaphore = DispatchSemaphore(value: 1)
     private let group = DispatchGroup()
     
     public required init(session: URLSession) {
@@ -31,9 +20,7 @@ public class TestRequestManager: NSObject, RequestManager {
     var responseDelay = 0.0
     public func add( _ request: URLRequest, completionHandler: SentryRequestOperationFinished? = nil) {
         
-        semaphore.wait()
-        _requests.append(request)
-        semaphore.signal()
+        requests.record(request)
         
         let response = self.nextResponse()
         group.enter()


### PR DESCRIPTION
Use Invocations in TestRequestManager to make
SentryHttpTransportTests less flaky.

#skip-changelog