### PR TITLE
test: Try to fix flaky testAsyncStacktraces

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -16,6 +16,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
     override func setUp() {
         super.setUp()
         fixture = Fixture()
+        clearTestState()
     }
 
     override func tearDown() {


### PR DESCRIPTION
testAsyncStacktraces are flaky. Adding a clearTestState at the setUp, might fix
the problem as it also closes the SDK.

#skip-changelog