### PR TITLE
ref: Remove context only Span init

### DIFF
--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -15,17 +15,10 @@ SentrySpan ()
     NSMutableDictionary<NSString *, id> *_tags;
 }
 
-- (instancetype)initWithTracer:(SentryTracer *)tracer context:(SentrySpanContext *)context
-{
-    if (self = [self initWithContext:context]) {
-        _tracer = tracer;
-    }
-    return self;
-}
-
-- (instancetype)initWithContext:(SentrySpanContext *)context
+- (instancetype)initWithTransaction:(SentryTracer *)transaction context:(SentrySpanContext *)context
 {
     if (self = [super init]) {
+        _transaction = transaction;
         _context = context;
         self.startTimestamp = [SentryCurrentDate date];
         _data = [[NSMutableDictionary alloc] init];
@@ -42,9 +35,9 @@ SentrySpan ()
 - (id<SentrySpan>)startChildWithOperation:(NSString *)operation
                               description:(nullable NSString *)description
 {
-    return [self.tracer startChildWithParentId:[self.context spanId]
-                                     operation:operation
-                                   description:description];
+    return [self.transaction startChildWithParentId:[self.context spanId]
+                                          operation:operation
+                                        description:description];
 }
 
 - (void)setDataValue:(nullable id)value forKey:(NSString *)key
@@ -102,8 +95,8 @@ SentrySpan ()
 - (void)finish
 {
     self.timestamp = [SentryCurrentDate date];
-    if (self.tracer != nil) {
-        [self.tracer spanFinished:self];
+    if (self.transaction != nil) {
+        [self.transaction spanFinished:self];
     }
 }
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -72,7 +72,7 @@ static BOOL appStartMeasurementRead;
                            waitForChildren:(BOOL)waitForChildren
 {
     if (self = [super init]) {
-        self.rootSpan = [[SentrySpan alloc] initWithTracer:self context:transactionContext];
+        self.rootSpan = [[SentrySpan alloc] initWithTransaction:self context:transactionContext];
         self.name = transactionContext.name;
         self.children = [[NSMutableArray alloc] init];
         self.hub = hub;
@@ -121,7 +121,7 @@ static BOOL appStartMeasurementRead;
                                            sampled:_rootSpan.context.sampled];
     context.spanDescription = description;
 
-    SentrySpan *child = [[SentrySpan alloc] initWithTracer:self context:context];
+    SentrySpan *child = [[SentrySpan alloc] initWithTransaction:self context:context];
     @synchronized(self.children) {
         [self.children addObject:child];
     }
@@ -463,7 +463,7 @@ static BOOL appStartMeasurementRead;
                                            sampled:_rootSpan.context.sampled];
     context.spanDescription = description;
 
-    return [[SentrySpan alloc] initWithContext:context];
+    return [[SentrySpan alloc] initWithTransaction:self context:context];
 }
 
 - (NSDictionary *)serialize
@@ -490,7 +490,7 @@ static BOOL appStartMeasurementRead;
     if ([span isKindOfClass:[SentryTracer class]]) {
         return span;
     } else if ([span isKindOfClass:[SentrySpan class]]) {
-        return [(SentrySpan *)span tracer];
+        return [(SentrySpan *)span transaction];
     }
     return nil;
 }

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -31,28 +31,21 @@ SENTRY_NO_INIT
 @property (readonly) BOOL isFinished;
 
 /**
- * The SentryTracer this span is associated with.
+ * The Transaction this span is associated with.
  */
-@property (nonatomic, readonly, weak) SentryTracer *tracer;
+@property (nonatomic, readonly, weak) SentryTracer *transaction;
 
 /**
- * Init a SentrySpan with given tracer and context.
+ * Init a SentrySpan with given transaction and context.
  *
- * @param tracer The tracer responsible for this span.
+ * @param transaction The Transaction this span is associated with.
  * @param context This span context information.
  *
  * @return SentrySpan
  */
-- (instancetype)initWithTracer:(SentryTracer *)tracer context:(SentrySpanContext *)context;
+- (instancetype)initWithTransaction:(SentryTracer *)transaction
+                            context:(SentrySpanContext *)context;
 
-/**
- * Init a SentrySpan with given context.
- *
- * @param context This span context information.
- *
- * @return SentrySpan
- */
-- (instancetype)initWithContext:(SentrySpanContext *)context;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Performance/SentryTracerObjCTests.m
+++ b/Tests/SentryTests/Performance/SentryTracerObjCTests.m
@@ -30,7 +30,7 @@
     }
 
     XCTAssertNotNil(child);
-    XCTAssertNil(child.tracer);
+    XCTAssertNil(child.transaction);
     [child finish];
 }
 

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 
 class SentrySpanTests: XCTestCase {
+    
     private class Fixture {
         let someTransaction = "Some Transaction"
         let someOperation = "Some Operation"
@@ -9,6 +10,7 @@ class SentrySpanTests: XCTestCase {
         let extraValue = "extra_value"
         let options: Options
         let currentDateProvider = TestCurrentDateProvider()
+        let tracer = SentryTracer()
          
         init() {
             options = Options()
@@ -178,7 +180,7 @@ class SentrySpanTests: XCTestCase {
     func testMergeTagsInSerialization() {
         let context = SpanContext(operation: fixture.someOperation)
         context.setTag(value: fixture.someTransaction, key: fixture.extraKey)
-        let span = SentrySpan(context: context)
+        let span = SentrySpan(transaction: fixture.tracer, context: context)
         
         let originalSerialization = span.serialize()
         XCTAssertEqual((originalSerialization["tags"] as! Dictionary)[fixture.extraKey], fixture.someTransaction)
@@ -201,7 +203,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testTraceHeaderSampled() {
-        let span = SentrySpan(context: SpanContext(operation: fixture.someOperation, sampled: .yes))
+        let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .yes))
         let header = span.toTraceHeader()
         
         XCTAssertEqual(header.traceId, span.context.traceId)
@@ -211,7 +213,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testTraceHeaderUndecided() {
-        let span = SentrySpan(context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
+        let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
         let header = span.toTraceHeader()
         
         XCTAssertEqual(header.traceId, span.context.traceId)
@@ -221,7 +223,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testSetExtra_ForwardsToSetData() {
-        let sut = SentrySpan(context: SpanContext(operation: "test"))
+        let sut = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: "test"))
         sut.setExtra(value: 0, key: "key")
         
         XCTAssertEqual(["key": 0], sut.data as! [String: Int])

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -4,7 +4,7 @@ class SentryTransactionTests: XCTestCase {
     
     private class Fixture {
         static var transaction: Transaction {
-            let span = SentrySpan(context: SpanContext(operation: "some"))
+            let span = SentrySpan(transaction: SentryTracer(), context: SpanContext(operation: "some"))
             return Transaction(trace: span, children: [])
         }
     }


### PR DESCRIPTION


## :scroll: Description

SentrySpan should always have an associated transaction. It had an initializer
without a transaction. This is fixed now by removing this initializer. SentrySpan
and SentryTracer are not public, so this is not a breaking change.

#skip-changelog

## :bulb: Motivation and Context

I did this as a preparation for https://github.com/getsentry/sentry-cocoa/issues/1367

## :green_heart: How did you test it?
CI

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
