### PR TITLE
ci: Fix Carthage Xcode 13 Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: make build-xcframework
         shell: sh
-      - run: make build-carthage-xcframework-sample
+      - run: make build-xcframework-sample
         shell: sh
 
       - name: Archiving XCFramework.zip
@@ -84,7 +84,7 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh
       - run: make build-framework
         shell: sh
-      - run: make build-carthage-framework-sample
+      - run: make build-framework-sample
         shell: sh
 
       - name: Archiving Framework.zip

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build-xcframework:
 # use ditto here to avoid clobbering symlinks which exist in macOS frameworks
 	ditto -c -k -X --rsrc --keepParent Carthage Sentry.xcframework.zip
 
-build-carthage-xcframework-sample:
+build-xcframework-sample:
 	./scripts/create-carthage-json.sh
 	cd Samples/Carthage-Validation/XCFramework/ && carthage update --use-xcframeworks
 	xcodebuild -project "Samples/Carthage-Validation/XCFramework/XCFramework.xcodeproj" -configuration Release CODE_SIGNING_ALLOWED="NO" build
@@ -43,7 +43,7 @@ build-framework:
 	./scripts/carthage-xcode12-workaround.sh build --no-skip-current
 	./scripts/carthage-xcode12-workaround.sh archive Sentry --output Sentry.framework.zip
 
-build-carthage-framework-sample:
+build-framework-sample:
 	./scripts/create-carthage-json.sh
 	cd Samples/Carthage-Validation/Framework/ && carthage update
 	xcodebuild -project "Samples/Carthage-Validation/Framework/Framework.xcodeproj" -configuration Release CODE_SIGNING_ALLOWED="NO" build


### PR DESCRIPTION
The default Xcode for GitHub Actions on macos-11 is 13, since October the
13th. As there is no workaround for the Carthage framework for Xcode 13,
we need to compile it with Xcode 12. We compile the XCFramework with
Xcode 13 though.

#skip-changelog

