### PR TITLE
fix: SentryOptions initWithDict type errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: SentryOptions initWithDict type errors (#1443)
 - fix: Transaction default status should be OK (#1439)
 
 ## 7.5.0

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -235,7 +235,7 @@ SentryOptions ()
 
     [self setBool:options[@"experimentalEnableTraceSampling"]
             block:^(BOOL value) { self->_experimentalEnableTraceSampling = value; }];
-    
+
     [self setBool:options[@"enableSwizzling"]
             block:^(BOOL value) { self->_enableSwizzling = value; }];
 }

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -235,6 +235,7 @@ SentryOptions ()
 
     [self setBool:options[@"experimentalEnableTraceSampling"]
             block:^(BOOL value) { self->_experimentalEnableTraceSampling = value; }];
+    
     [self setBool:options[@"enableSwizzling"]
             block:^(BOOL value) { self->_enableSwizzling = value; }];
 }
@@ -242,7 +243,7 @@ SentryOptions ()
 - (void)setBool:(id)value block:(void (^)(BOOL))block
 {
     // Entries in the dictionary can be NSNull. Especially, on React-Native, this can happen.
-    if (value != nil && ![value isEqualTo:[NSNull null]]) {
+    if (value != nil && ![value isEqual:[NSNull null]]) {
         block([value boolValue]);
     }
 }

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -118,9 +118,10 @@ SentryOptions ()
 - (void)validateOptions:(NSDictionary<NSString *, id> *)options
        didFailWithError:(NSError *_Nullable *_Nullable)error
 {
-    if (nil != options[@"debug"]) {
-        self.debug = [options[@"debug"] boolValue];
-    }
+    NSPredicate *isNSString = [NSPredicate predicateWithBlock:^BOOL(
+        id object, NSDictionary *bindings) { return [object isKindOfClass:[NSString class]]; }];
+
+    [self setBool:options[@"debug"] block:^(BOOL value) { self->_debug = value; }];
 
     if ([options[@"diagnosticLevel"] isKindOfClass:[NSString class]]) {
         for (SentryLevel level = 0; level <= kSentryLevelFatal; level++) {
@@ -132,9 +133,8 @@ SentryOptions ()
     }
 
     NSString *dsn = @"";
-    if (nil != [options valueForKey:@"dsn"] &&
-        [[options valueForKey:@"dsn"] isKindOfClass:[NSString class]]) {
-        dsn = [options valueForKey:@"dsn"];
+    if (nil != options[@"dsn"] && [options[@"dsn"] isKindOfClass:[NSString class]]) {
+        dsn = options[@"dsn"];
     }
 
     self.parsedDsn = [[SentryDsn alloc] initWithString:dsn didFailWithError:error];
@@ -151,9 +151,7 @@ SentryOptions ()
         self.dist = options[@"dist"];
     }
 
-    if (nil != options[@"enabled"]) {
-        self.enabled = [options[@"enabled"] boolValue];
-    }
+    [self setBool:options[@"enabled"] block:^(BOOL value) { self->_enabled = value; }];
 
     if ([options[@"maxBreadcrumbs"] isKindOfClass:[NSNumber class]]) {
         self.maxBreadcrumbs = [options[@"maxBreadcrumbs"] unsignedIntValue];
@@ -163,75 +161,63 @@ SentryOptions ()
         self.maxCacheItems = [options[@"maxCacheItems"] unsignedIntValue];
     }
 
-    if (nil != options[@"beforeSend"]) {
+    if ([self isBlock:options[@"beforeSend"]]) {
         self.beforeSend = options[@"beforeSend"];
     }
 
-    if (nil != options[@"beforeBreadcrumb"]) {
+    if ([self isBlock:options[@"beforeBreadcrumb"]]) {
         self.beforeBreadcrumb = options[@"beforeBreadcrumb"];
     }
 
-    if (nil != options[@"onCrashedLastRun"]) {
+    if ([self isBlock:options[@"onCrashedLastRun"]]) {
         self.onCrashedLastRun = options[@"onCrashedLastRun"];
     }
 
-    if (nil != options[@"integrations"]) {
-        self.integrations = options[@"integrations"];
+    if ([options[@"integrations"] isKindOfClass:[NSArray class]]) {
+        self.integrations = [options[@"integrations"] filteredArrayUsingPredicate:isNSString];
     }
 
-    NSNumber *sampleRate = options[@"sampleRate"];
-    if (nil != sampleRate) {
-        self.sampleRate = sampleRate;
+    if ([options[@"sampleRate"] isKindOfClass:[NSNumber class]]) {
+        self.sampleRate = options[@"sampleRate"];
     }
 
-    if (nil != options[@"enableAutoSessionTracking"]) {
-        self.enableAutoSessionTracking = [options[@"enableAutoSessionTracking"] boolValue];
-    }
+    [self setBool:options[@"enableAutoSessionTracking"]
+            block:^(BOOL value) { self->_enableAutoSessionTracking = value; }];
 
-    if (nil != options[@"enableOutOfMemoryTracking"]) {
-        self.enableOutOfMemoryTracking = [options[@"enableOutOfMemoryTracking"] boolValue];
-    }
+    [self setBool:options[@"enableOutOfMemoryTracking"]
+            block:^(BOOL value) { self->_enableOutOfMemoryTracking = value; }];
 
-    if (nil != options[@"sessionTrackingIntervalMillis"]) {
+    if ([options[@"sessionTrackingIntervalMillis"] isKindOfClass:[NSNumber class]]) {
         self.sessionTrackingIntervalMillis =
             [options[@"sessionTrackingIntervalMillis"] unsignedIntValue];
     }
 
-    if (nil != options[@"attachStacktrace"]) {
-        self.attachStacktrace = [options[@"attachStacktrace"] boolValue];
-    }
+    [self setBool:options[@"attachStacktrace"]
+            block:^(BOOL value) { self->_attachStacktrace = value; }];
 
-    if (nil != options[@"stitchAsyncCode"]) {
-        self.stitchAsyncCode = [options[@"stitchAsyncCode"] boolValue];
-    }
+    [self setBool:options[@"stitchAsyncCode"]
+            block:^(BOOL value) { self->_stitchAsyncCode = value; }];
 
-    if (nil != options[@"maxAttachmentSize"]) {
+    if ([options[@"maxAttachmentSize"] isKindOfClass:[NSNumber class]]) {
         self.maxAttachmentSize = [options[@"maxAttachmentSize"] unsignedIntValue];
     }
 
-    if (nil != options[@"sendDefaultPii"]) {
-        self.sendDefaultPii = [options[@"sendDefaultPii"] boolValue];
+    [self setBool:options[@"sendDefaultPii"]
+            block:^(BOOL value) { self->_sendDefaultPii = value; }];
+
+    [self setBool:options[@"enableAutoPerformanceTracking"]
+            block:^(BOOL value) { self->_enableAutoPerformanceTracking = value; }];
+
+    [self setBool:options[@"enableNetworkTracking"]
+            block:^(BOOL value) { self->_enableNetworkTracking = value; }];
+
+    if ([options[@"tracesSampleRate"] isKindOfClass:[NSNumber class]]) {
+        self.tracesSampleRate = options[@"tracesSampleRate"];
     }
 
-    if (nil != options[@"enableAutoPerformanceTracking"]) {
-        self.enableAutoPerformanceTracking = [options[@"enableAutoPerformanceTracking"] boolValue];
-    }
-
-    if (nil != options[@"enableNetworkTracking"]) {
-        self.enableNetworkTracking = [options[@"enableNetworkTracking"] boolValue];
-    }
-
-    NSNumber *tracesSampleRate = options[@"tracesSampleRate"];
-    if (nil != tracesSampleRate) {
-        self.tracesSampleRate = tracesSampleRate;
-    }
-
-    if (nil != options[@"tracesSampler"]) {
+    if ([self isBlock:options[@"tracesSampler"]]) {
         self.tracesSampler = options[@"tracesSampler"];
     }
-
-    NSPredicate *isNSString = [NSPredicate predicateWithBlock:^BOOL(
-        id object, NSDictionary *bindings) { return [object isKindOfClass:[NSString class]]; }];
 
     if ([options[@"inAppIncludes"] isKindOfClass:[NSArray class]]) {
         NSArray<NSString *> *inAppIncludes =
@@ -247,12 +233,17 @@ SentryOptions ()
         self.urlSessionDelegate = options[@"urlSessionDelegate"];
     }
 
-    if (options[@"experimentalEnableTraceSampling"] != nil) {
-        _experimentalEnableTraceSampling = [options[@"experimentalEnableTraceSampling"] boolValue];
-    }
+    [self setBool:options[@"experimentalEnableTraceSampling"]
+            block:^(BOOL value) { self->_experimentalEnableTraceSampling = value; }];
+    [self setBool:options[@"enableSwizzling"]
+            block:^(BOOL value) { self->_enableSwizzling = value; }];
+}
 
-    if (options[@"enableSwizzling"] != nil) {
-        _enableSwizzling = [options[@"enableSwizzling"] boolValue];
+- (void)setBool:(id)value block:(void (^)(BOOL))block
+{
+    // Entries in the dictionary can be NSNull. Especially, on React-Native, this can happen.
+    if (value != nil && ![value isEqualTo:[NSNull null]]) {
+        block([value boolValue]);
     }
 }
 
@@ -304,6 +295,28 @@ SentryOptions ()
 {
     return (_tracesSampleRate != nil && [_tracesSampleRate doubleValue] > 0)
         || _tracesSampler != nil;
+}
+
+/**
+ * Checks if the passed in block is actually of type block. We can't check if the block matches a
+ * specific block without some complex objc runtime method calls and therefore we only check if its
+ * a block or not. Assigning a wrong block to the SentryOption blocks still could lead to crashes at
+ * runtime, but when someone uses the initWithDict they should better know what they are doing.
+ *
+ * Taken from https://gist.github.com/steipete/6ee378bd7d87f276f6e0
+ */
+- (BOOL)isBlock:(nullable id)block
+{
+    static Class blockClass;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        blockClass = [^{} class];
+        while ([blockClass superclass] != NSObject.class) {
+            blockClass = [blockClass superclass];
+        }
+    });
+
+    return [block isKindOfClass:blockClass];
 }
 
 @end

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -212,7 +212,7 @@
 
 - (void)testBeforeSend
 {
-    SentryEvent * (^callback)(SentryEvent *event) = ^(SentryEvent *event) { return event; };
+    SentryBeforeSendEventCallback callback = ^(SentryEvent *event) { return event; };
     SentryOptions *options = [self getValidOptions:@{ @"beforeSend" : callback }];
 
     XCTAssertEqual(callback, options.beforeSend);
@@ -225,9 +225,23 @@
     XCTAssertNil(options.beforeSend);
 }
 
+- (void)testGarbageBeforeSend_ReturnsNil
+{
+    SentryOptions *options = [self getValidOptions:@{ @"beforeSend" : @"fault" }];
+
+    XCTAssertNil(options.beforeSend);
+}
+
+- (void)testNSNullBeforeSend_ReturnsNil
+{
+    SentryOptions *options = [self getValidOptions:@{ @"beforeSend" : [NSNull null] }];
+
+    XCTAssertFalse([options.beforeSend isEqual:[NSNull null]]);
+}
+
 - (void)testBeforeBreadcrumb
 {
-    SentryBreadcrumb * (^callback)(SentryBreadcrumb *event)
+    SentryBeforeBreadcrumbCallback callback
         = ^(SentryBreadcrumb *breadcrumb) { return breadcrumb; };
     SentryOptions *options = [self getValidOptions:@{ @"beforeBreadcrumb" : callback }];
 
@@ -241,10 +255,17 @@
     XCTAssertNil(options.beforeBreadcrumb);
 }
 
+- (void)testGarbageBeforeBreadcrumb_ReturnsNil
+{
+    SentryOptions *options = [self getValidOptions:@{ @"beforeBreadcrumb" : @"fault" }];
+
+    XCTAssertEqual(nil, options.beforeBreadcrumb);
+}
+
 - (void)testOnCrashedLastRun
 {
     __block BOOL onCrashedLastRunCalled = NO;
-    void (^callback)(SentryEvent *event) = ^(SentryEvent *event) {
+    SentryOnCrashedLastRunCallback callback = ^(SentryEvent *event) {
         onCrashedLastRunCalled = YES;
         XCTAssertNotNil(event);
     };
@@ -263,12 +284,19 @@
     XCTAssertNil(options.onCrashedLastRun);
 }
 
+- (void)testGarbageOnCrashedLastRun_ReturnsNil
+{
+    SentryOptions *options = [self getValidOptions:@{ @"onCrashedLastRun" : @"fault" }];
+
+    XCTAssertNil(options.onCrashedLastRun);
+}
+
 - (void)testIntegrations
 {
     NSArray<NSString *> *integrations = @[ @"integration1", @"integration2" ];
     SentryOptions *options = [self getValidOptions:@{ @"integrations" : integrations }];
 
-    XCTAssertEqual(integrations, options.integrations);
+    [self assertArrayEquals:integrations actual:options.integrations];
 }
 
 - (void)testDefaultIntegrations
@@ -389,13 +417,62 @@
 - (void)testEmptyConstructorSetsDefaultValues
 {
     SentryOptions *options = [[SentryOptions alloc] init];
+    XCTAssertNil(options.parsedDsn);
+    [self assertDefaultValues:options];
+}
 
+- (void)testNSNull_SetsDefaultValue
+{
+    SentryOptions *options = [[SentryOptions alloc] initWithDict:@{
+        @"dsn" : [NSNull null],
+        @"enabled" : [NSNull null],
+        @"debug" : [NSNull null],
+        @"diagnosticLevel" : [NSNull null],
+        @"release" : [NSNull null],
+        @"environment" : [NSNull null],
+        @"dist" : [NSNull null],
+        @"maxBreadcrumbs" : [NSNull null],
+        @"maxCacheItems" : [NSNull null],
+        @"beforeSend" : [NSNull null],
+        @"beforeBreadcrumb" : [NSNull null],
+        @"onCrashedLastRun" : [NSNull null],
+        @"integrations" : [NSNull null],
+        @"sampleRate" : [NSNull null],
+        @"enableAutoSessionTracking" : [NSNull null],
+        @"enableOutOfMemoryTracking" : [NSNull null],
+        @"sessionTrackingIntervalMillis" : [NSNull null],
+        @"attachStacktrace" : [NSNull null],
+        @"stitchAsyncCode" : [NSNull null],
+        @"maxAttachmentSize" : [NSNull null],
+        @"sendDefaultPii" : [NSNull null],
+        @"enableAutoPerformanceTracking" : [NSNull null],
+        @"enableNetworkTracking" : [NSNull null],
+        @"tracesSampleRate" : [NSNull null],
+        @"tracesSampler" : [NSNull null],
+        @"inAppIncludes" : [NSNull null],
+        @"inAppExcludes" : [NSNull null],
+        @"urlSessionDelegate" : [NSNull null],
+        @"experimentalEnableTraceSampling" : [NSNull null],
+        @"enableSwizzling" : [NSNull null],
+    }
+                                                didFailWithError:nil];
+
+    XCTAssertNotNil(options.parsedDsn);
+    [self assertDefaultValues:options];
+}
+
+- (void)assertDefaultValues:(SentryOptions *)options
+{
     XCTAssertEqual(YES, options.enabled);
     XCTAssertEqual(NO, options.debug);
     XCTAssertEqual(kSentryLevelDebug, options.diagnosticLevel);
-    XCTAssertNil(options.parsedDsn);
+    XCTAssertNil(options.environment);
+    XCTAssertNil(options.dist);
     XCTAssertEqual(defaultMaxBreadcrumbs, options.maxBreadcrumbs);
     XCTAssertEqual(30, options.maxCacheItems);
+    XCTAssertNil(options.beforeSend);
+    XCTAssertNil(options.beforeBreadcrumb);
+    XCTAssertNil(options.onCrashedLastRun);
     XCTAssertTrue([[SentryOptions defaultIntegrations] isEqualToArray:options.integrations],
         @"Default integrations are not set correctly");
     XCTAssertEqual(@1, options.sampleRate);
@@ -405,9 +482,16 @@
     XCTAssertEqual(YES, options.attachStacktrace);
     XCTAssertEqual(NO, options.stitchAsyncCode);
     XCTAssertEqual(20 * 1024 * 1024, options.maxAttachmentSize);
+    XCTAssertEqual(NO, options.sendDefaultPii);
     XCTAssertTrue(options.enableAutoPerformanceTracking);
     XCTAssertEqual(YES, options.enableNetworkTracking);
+    XCTAssertNil(options.tracesSampleRate);
+    XCTAssertNil(options.tracesSampler);
+    XCTAssertEqualObjects([self getDefaultInAppIncludes], options.inAppIncludes);
+    XCTAssertEqual(@[], options.inAppExcludes);
+    XCTAssertNil(options.urlSessionDelegate);
     XCTAssertFalse(options.experimentalEnableTraceSampling);
+    XCTAssertEqual(YES, options.enableSwizzling);
 }
 
 - (void)testSetValidDsn
@@ -565,6 +649,13 @@
     XCTAssertNil(options.tracesSampler);
 }
 
+- (void)testGarbageTracesSampler_ReturnsNil
+{
+    SentryOptions *options = [self getValidOptions:@{ @"tracesSampler" : @"fault" }];
+
+    XCTAssertNil(options.tracesSampler);
+}
+
 - (void)testIsTracingEnabled_NothingSet_IsDisabled
 {
     SentryOptions *options = [[SentryOptions alloc] init];
@@ -632,16 +723,7 @@
 - (void)testDefaultInAppIncludes
 {
     SentryOptions *options = [self getValidOptions:@{}];
-
-    NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
-    NSString *bundleExecutable = infoDict[@"CFBundleExecutable"];
-    NSArray<NSString *> *expected;
-    if (nil == bundleExecutable) {
-        expected = @[];
-    } else {
-        expected = @[ bundleExecutable ];
-    }
-    XCTAssertEqualObjects(expected, options.inAppIncludes);
+    XCTAssertEqualObjects([self getDefaultInAppIncludes], options.inAppIncludes);
 }
 
 - (void)testInAppExcludes
@@ -732,6 +814,19 @@
     BOOL result;
     [invocation getReturnValue:&result];
 
+    return result;
+}
+
+- (NSArray<NSString *> *)getDefaultInAppIncludes
+{
+    NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
+    NSString *bundleExecutable = infoDict[@"CFBundleExecutable"];
+    NSArray<NSString *> *result;
+    if (nil == bundleExecutable) {
+        result = @[];
+    } else {
+        result = @[ bundleExecutable ];
+    }
     return result;
 }
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -645,14 +645,12 @@
 - (void)testDefaultTracesSampler
 {
     SentryOptions *options = [self getValidOptions:@{}];
-
     XCTAssertNil(options.tracesSampler);
 }
 
 - (void)testGarbageTracesSampler_ReturnsNil
 {
     SentryOptions *options = [self getValidOptions:@{ @"tracesSampler" : @"fault" }];
-
     XCTAssertNil(options.tracesSampler);
 }
 


### PR DESCRIPTION




## :scroll: Description

When initializing the SentryOptions with a dictionary, you can pass in a different type
for a property than expected. The SentryOptions had some checks validating if the
types from the dictionary match the actual type of the property. Anyways, the logic
missed a few edge cases as NSNull or didn't check if callbacks are blocks. This is
fixed now by checking if all properties are not NSNull and if callbacks are of type block.

## :bulb: Motivation and Context

Fixes GH-1441

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
