### PR TITLE
fix: Add missing entitlement in iOS-Swift sample.

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/iOS-Swift.entitlements
+++ b/Samples/iOS-Swift/iOS-Swift/iOS-Swift.entitlements
@@ -6,5 +6,9 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.developer.associated-appclip-app-identifiers</key>
+	<array>
+		<string>io.sentry.sample.iOS-Swift.Clip</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Since we added an App Clip in iOS-Swift sample, we need to update de app entitlement to point to the clip.

_#skip-changelog_