### PR TITLE
ci: Let performance tests run

### DIFF
--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -21,8 +21,10 @@ case $PLATFORM in
         DESTINATION="platform=macOS,variant=Mac Catalyst"
         ;;
 
+    # Must be iPhone 8 as we have xcbaselines for it. If you change this, 
+    # make shure baselines exists.
     "iOS")
-        DESTINATION="platform=iOS Simulator,OS=latest,name=iPhone 11"
+        DESTINATION="platform=iOS Simulator,OS=latest,name=iPhone 8"
         ;;
 
     "tvOS")


### PR DESCRIPTION
The performance tests were not running in CI, because xcbaselines
were missing. This is fixed now for using an iPhone where xcbaselines
exist.

#skip-changelog