### PR TITLE
ref: Remove not needed todos in HttpTransport

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -145,7 +145,6 @@ SentryHttpTransport ()
 
 #pragma mark private methods
 
-// TODO: This has to move somewhere else, we are missing the whole beforeSend flow
 - (void)sendAllCachedEnvelopes
 {
     @synchronized(self) {
@@ -207,7 +206,6 @@ SentryHttpTransport ()
     [self.requestManager
                addRequest:request
         completionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
-            // TODO: How does beforeSend work here
 
             // If the response is not nil we had an internet connection.
             // We don't worry about errors here.

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -206,7 +206,6 @@ SentryHttpTransport ()
     [self.requestManager
                addRequest:request
         completionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
-
             // If the response is not nil we had an internet connection.
             // We don't worry about errors here.
             if (nil != response) {


### PR DESCRIPTION
The todos in SentryHttpTransport are out of date and don't make
any sense. Hence, they can be removed.

#skip-changelog