### PR TITLE
ci: Increase SauceLabs timeout

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -5,7 +5,9 @@ sauce:
   concurrency: 2
 
 defaults:
-  timeout: 5m
+  # Tests timeout frequently when multiple GitHub Actions run in parallel and the timeout is 
+  # to small.
+  timeout: 20m
 
 retries: 2
 


### PR DESCRIPTION
When multiple tests for SauceLab run in parallel they often time out.
This is fixed now by increasing the timeout to 20m.

#skip-changelog