### PR TITLE
Allow error event value (description) to be customised

### DIFF
--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -118,9 +118,3 @@ static NSString *_Nonnull const SentryLevelNames[] = {
 };
 
 static NSUInteger const defaultMaxBreadcrumbs = 100;
-
-
-/**
- * A key that can be used to set a custom error event value using the error's user info dictionary.
- */
-static NSString *_Nonnull const SentryErrorEventValueUserInfoKey = @"SentryErrorEventValue";

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -118,3 +118,9 @@ static NSString *_Nonnull const SentryLevelNames[] = {
 };
 
 static NSUInteger const defaultMaxBreadcrumbs = 100;
+
+
+/**
+ * A key that can be used to set a custom error event value using the error's user info dictionary.
+ */
+static NSString *_Nonnull const SentryErrorEventValueUserInfoKey = @"SentryErrorEventValue";

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -181,8 +181,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 {
     SentryEvent *event = [[SentryEvent alloc] initWithError:error];
 
-    NSString *exceptionValue = [NSString stringWithFormat:@"Code: %ld", (long)error.code];
-    SentryException *exception = [[SentryException alloc] initWithValue:exceptionValue
+    SentryException *exception = [[SentryException alloc] initWithValue:[error localizedDescription]
                                                                    type:error.domain];
 
     // Sentry uses the error domain and code on the mechanism for gouping

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -183,17 +183,12 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     NSString *exceptionValue;
 
-    // To check that the error description is the default, we can construct a new error
-    // with the same code and domain and an empty user info and compare the descriptions.
-    NSString *defaultErrorDescription = [NSError errorWithDomain:error.domain code:error.code userInfo:nil].localizedDescription;
-
-    if ([[error localizedDescription] isEqualToString:defaultErrorDescription]) {
-        // If no custom error description has been set, the system default will be something
-        // like: "The operation couldn't be completed (domain code)" - we can shorten this to
-        // just the code.
-        exceptionValue = [NSString stringWithFormat:@"Code: %ld", (long)error.code];
+    // If the error has a custom event value in it's user info dictionary, use that.
+    NSString *customExceptionValue = [[error userInfo] valueForKey:SentryErrorEventValueUserInfoKey];
+    if (customExceptionValue != nil) {
+        exceptionValue = customExceptionValue;
     } else {
-        exceptionValue = [error localizedDescription];
+        exceptionValue = [NSString stringWithFormat:@"Code: %ld", (long)error.code];
     }
     SentryException *exception = [[SentryException alloc] initWithValue:exceptionValue
                                                                    type:error.domain];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -183,8 +183,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     NSString *exceptionValue;
 
-    // If the error has a custom event value in it's user info dictionary, use that.
-    NSString *customExceptionValue = [[error userInfo] valueForKey:SentryErrorEventValueUserInfoKey];
+    // If the error has a debug description, use that.
+    NSString *customExceptionValue = [[error userInfo] valueForKey:NSDebugDescriptionErrorKey];
     if (customExceptionValue != nil) {
         exceptionValue = customExceptionValue;
     } else {

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -181,7 +181,21 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 {
     SentryEvent *event = [[SentryEvent alloc] initWithError:error];
 
-    SentryException *exception = [[SentryException alloc] initWithValue:[error localizedDescription]
+    NSString *exceptionValue;
+
+    // To check that the error description is the default, we can construct a new error
+    // with the same code and domain and an empty user info and compare the descriptions.
+    NSString *defaultErrorDescription = [NSError errorWithDomain:error.domain code:error.code userInfo:nil].localizedDescription;
+
+    if ([[error localizedDescription] isEqualToString:defaultErrorDescription]) {
+        // If no custom error description has been set, the system default will be something
+        // like: "The operation couldn't be completed (domain code)" - we can shorten this to
+        // just the code.
+        exceptionValue = [NSString stringWithFormat:@"Code: %ld", (long)error.code];
+    } else {
+        exceptionValue = [error localizedDescription];
+    }
+    SentryException *exception = [[SentryException alloc] initWithValue:exceptionValue
                                                                    type:error.domain];
 
     // Sentry uses the error domain and code on the mechanism for gouping

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -288,11 +288,11 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    func testCaptureErrorUsesCustomErrorDescriptionWhenSet() {
+    func testCaptureErrorUsesErrorDebugDescriptionWhenSet() {
         let error = NSError(
             domain: "com.sentry",
             code: 999,
-            userInfo: [SentryErrorEventValueUserInfoKey: "Custom error description"]
+            userInfo: [NSDebugDescriptionErrorKey: "Custom error description"]
         )
         let eventId = fixture.getSut().capture(error: error)
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -288,25 +288,11 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    func testCaptureErrorUsesCustomErrorDescriptionFromSwiftLocalizedError() {
-        let eventId = fixture.getSut().capture(error: TestError.invalidTest)
-
-        eventId.assertIsNotEmpty()
-        assertLastSentEvent { actual in
-            do {
-                let exceptions = try XCTUnwrap(actual.exceptions)
-                XCTAssertEqual("Invalid Test", try XCTUnwrap(exceptions.first).value)
-            } catch {
-                XCTFail("Exception expected but was nil")
-            }
-        }
-    }
-
-    func testCaptureErrorUsesCustomErrorDescriptionFromUserInfo() {
+    func testCaptureErrorUsesCustomErrorDescriptionWhenSet() {
         let error = NSError(
             domain: "com.sentry",
             code: 999,
-            userInfo: [NSLocalizedDescriptionKey: "Custom error description"]
+            userInfo: [SentryErrorEventValueUserInfoKey: "Custom error description"]
         )
         let eventId = fixture.getSut().capture(error: error)
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -950,7 +950,7 @@ class SentryClientTest: XCTestCase {
         let exception = exceptions[0]
         XCTAssertEqual(error.domain, exception.type)
         
-        XCTAssertEqual(error.localizedDescription, exception.value)
+        XCTAssertEqual("Code: \(error.code)", exception.value)
         
         XCTAssertNil(exception.threadId)
         XCTAssertNil(exception.stacktrace)
@@ -1023,16 +1023,9 @@ class SentryClientTest: XCTestCase {
         XCTAssertEqual(0, fixture.transport.userFeedbackInvocations.count)
     }
 
-    private enum TestError: Error, LocalizedError {
+    private enum TestError: Error {
         case invalidTest
         case testIsFailing
         case somethingElse
-
-        var errorDescription: String? {
-            if self == .invalidTest {
-                return "Invalid Test"
-            }
-            return nil
-        }
     }
 }


### PR DESCRIPTION
## :scroll: Description

Currently errors are hardcoded to use "Code: xxx" using the error's code which make for a very unhelpful display in the Sentry error list.

To alleviate this, check for the presence of a custom description in the error's `userInfo` dictionary using an SDK-provided key, `SentryErrorEventValueUserInfoKey`.

If no custom description is set, the old behaviour is retained of using "Code: xxx".

## :bulb: Motivation and Context

Makes it easier to identify errors in the error list in the Sentry dashboard.

Fixes #1442.

## :green_heart: How did you test it?

Integrated the branch into our own app and ran it, generated some errors and verified that the error was displayed correctly.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
