### PR TITLE
test: waitForRequests in Transport tearDown

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -97,6 +97,7 @@ class SentryHttpTransportTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         fixture.fileManager.deleteAllEnvelopes()
+        fixture.requestManager.waitForAllRequests()
     }
 
     func testInitSendsCachedEnvelopes() {
@@ -378,7 +379,7 @@ class SentryHttpTransportTests: XCTestCase {
         XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests.invocations[2].httpBody, "Cached envelope was not sent first.")
     }
 
-    func testPerformanceOfSending() {
+    func tesPerformanceOfSending() {
         self.measure {
             givenNoInternetConnection()
             for _ in 0...5 {
@@ -391,7 +392,7 @@ class SentryHttpTransportTests: XCTestCase {
         }
     }
 
-    func testSendEnvelopesConcurrent() {
+    func tesSendEnvelopesConcurrent() {
         self.measure {
             fixture.requestManager.responseDelay = 0.000_1
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -379,7 +379,7 @@ class SentryHttpTransportTests: XCTestCase {
         XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests.invocations[2].httpBody, "Cached envelope was not sent first.")
     }
 
-    func tesPerformanceOfSending() {
+    func testPerformanceOfSending() {
         self.measure {
             givenNoInternetConnection()
             for _ in 0...5 {
@@ -392,7 +392,7 @@ class SentryHttpTransportTests: XCTestCase {
         }
     }
 
-    func tesSendEnvelopesConcurrent() {
+    func testSendEnvelopesConcurrent() {
         self.measure {
             fixture.requestManager.responseDelay = 0.000_1
 


### PR DESCRIPTION
Some tests of SentryHttpTransportTests are a bit flaky. Maybe we can fix them
by calling waitForAllRequests in tearDown.

#skip-changelog