### PR TITLE
test: Add iOS-SwiftUI XCScheme

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUI.xcscheme
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUI.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7BB6224826A56C4E00D0E75E"
+               BuildableName = "iOS-SwiftUI.app"
+               BlueprintName = "iOS-SwiftUI"
+               ReferencedContainer = "container:iOS-SwiftUI.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7BB6224826A56C4E00D0E75E"
+            BuildableName = "iOS-SwiftUI.app"
+            BlueprintName = "iOS-SwiftUI"
+            ReferencedContainer = "container:iOS-SwiftUI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7BB6224826A56C4E00D0E75E"
+            BuildableName = "iOS-SwiftUI.app"
+            BlueprintName = "iOS-SwiftUI"
+            ReferencedContainer = "container:iOS-SwiftUI.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUI.xcscheme
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUI.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B64385626A6C0A6000D0F65"
+               BuildableName = "iOS-SwiftUI-UITests.xctest"
+               BlueprintName = "iOS-SwiftUI-UITests"
+               ReferencedContainer = "container:iOS-SwiftUI.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
The iOS-SwiftUI.xcscheme was missing. This is fixed now by adding it.

#skip-changelog