### PR TITLE
test: Span and Trace Header for Get Request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
 
       # Only build when the cache couldn't be restored.
       - run: swift build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,8 @@ jobs:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}}
     runs-on: macos-11 
     strategy:
+      fail-fast: false        
       matrix:
-        fail-fast: false
         # Can't run tests on watchOS because XCTest is not available  
         platform: ["macOS","Catalyst", "iOS", "tvOS"]
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,7 @@ jobs:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server') }}
 
-      # Only build when the cache couldn't be restored.
       - run: swift build
-      # The hash is empty if the file doesn't exist.
-        if: hashFiles('./test-server/.build/debug/Run') == ''
         working-directory: test-server
 
       - name: Run Test Server in Background

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: macos-11 
     strategy:
       matrix:
+        fail-fast: false
         # Can't run tests on watchOS because XCTest is not available  
         platform: ["macOS","Catalyst", "iOS", "tvOS"]
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./test-server/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server') }}
           restore-keys: |
             ${{ runner.os }}-spm-
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,7 @@ jobs:
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}}
     runs-on: macos-11 
-    strategy:
-      fail-fast: false        
+    strategy:      
       matrix:
         # Can't run tests on watchOS because XCTest is not available  
         platform: ["macOS","Catalyst", "iOS", "tvOS"]

--- a/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
+++ b/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
@@ -54,8 +54,10 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/watchOS-Swift WatchKit App">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -63,7 +65,7 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,8 +73,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/watchOS-Swift WatchKit App">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -80,7 +84,16 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
+            BuildableName = "watchOS-Swift WatchKit App.app"
+            BlueprintName = "watchOS-Swift WatchKit App"
+            ReferencedContainer = "container:watchOS-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -266,7 +266,6 @@ class BlockAllRequestsProtocol: URLProtocol {
         } else {
             XCTFail("Couldn't block request because client was nil.")
         }
-        
     }
 
     override func stopLoading() {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -191,7 +191,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         let dataTask = session.dataTask(with: SentryNetworkTrackerIntegrationTests.testURL) { (data, _, _) in
             let response = String(data: data ?? Data(), encoding: .utf8) ?? ""
             
-            if (self.canHeaderBeAdded()) {
+            if self.canHeaderBeAdded() {
                 XCTAssertEqual("Hello, world! Trace header added.", response)
             } else {
                 XCTAssertEqual("Hello, world!", response)

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -190,7 +190,13 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         
         let dataTask = session.dataTask(with: SentryNetworkTrackerIntegrationTests.testURL) { (data, _, _) in
             let response = String(data: data ?? Data(), encoding: .utf8) ?? ""
-            XCTAssertEqual("Hello, world! Trace header added.", response)
+            
+            if (self.canHeaderBeAdded()) {
+                XCTAssertEqual("Hello, world! Trace header added.", response)
+            } else {
+                XCTAssertEqual("Hello, world!", response)
+            }
+            
             expect.fulfill()
         }
         

--- a/test-server/Sources/App/routes.swift
+++ b/test-server/Sources/App/routes.swift
@@ -5,7 +5,17 @@ func routes(_ app: Application) throws {
         return "It works!"
     }
 
-    app.get("hello") { _ -> String in
+    app.get("hello") { request -> String in
+        let tracestate = request.headers["tracestate"]
+        if let sentryTraceHeader = tracestate.first {
+            // We just validate if the trace header is there.
+            // The proper format of the trace header is covered
+            // with unit tests.
+            if sentryTraceHeader.starts(with: "sentry=") {
+                return "Hello, world! Trace header added."
+            }
+        }
+        
         return "Hello, world!"
     }
 }


### PR DESCRIPTION
Modify test in SentryNetworkTrackerIntegrationTests to validate that the SDK creates a span
for a simple GET request to the test server and adds the sentry trace header.

Fixes GH-1458

#skip-changelog