### PR TITLE
fix: Check task support on `setState:` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Check task support on setState: (#1523)
 - fix: Create span for loadView (#1495)
 - feat: Add flag to control network requests breadcrumbs (#1505)
 - feat: Support for ignored signals with SIGN_IGN (#1489)

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -119,6 +119,14 @@ SentryNetworkTracker ()
 
 - (void)urlSessionTask:(NSURLSessionTask *)sessionTask setState:(NSURLSessionTaskState)newState
 {
+    if (self.isNetworkTrackingEnabled == false && self.isNetworkBreadcrumbEnabled == false) {
+        return;
+    }
+
+    if (![self isTaskSupported:sessionTask]) {
+        return;
+    }
+
     if (newState == NSURLSessionTaskStateRunning) {
         return;
     }

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -119,7 +119,7 @@ SentryNetworkTracker ()
 
 - (void)urlSessionTask:(NSURLSessionTask *)sessionTask setState:(NSURLSessionTaskState)newState
 {
-    if (self.isNetworkTrackingEnabled == false && self.isNetworkBreadcrumbEnabled == false) {
+    if (!self.isNetworkTrackingEnabled && !self.isNetworkBreadcrumbEnabled) {
         return;
     }
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -88,7 +88,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         
         XCTAssertNotNil(span)
         setTaskState(task, state: .completed)
-        XCTAssertNil(task.observationInfo)
         XCTAssertTrue(span!.isFinished)
     }
     
@@ -98,16 +97,20 @@ class SentryNetworkTrackerTests: XCTestCase {
         
         XCTAssertNotNil(span)
         setTaskState(task, state: .completed)
-        XCTAssertNil(task.observationInfo)
         XCTAssertTrue(span!.isFinished)
     }
     
     func testIgnoreStreamTask() {
         let task = createStreamTask()
         let span = spanForTask(task: task)
-        
+        //Ignored during resume
         XCTAssertNil(span)
-        XCTAssertNil(task.observationInfo)
+        
+        fixture.getSut().urlSessionTask(task, setState: .completed)
+        //ignored during state change
+        let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
+        let breadcrumb = breadcrumbs?.first
+        XCTAssertNil(breadcrumb)
     }
 
     func testIgnoreSentryApi() {


### PR DESCRIPTION
## :scroll: Description
Added a check to determine whether the SDK support the task passed to `SentryNetworkTracker` `urlSessionTask:setState:`.

## :bulb: Motivation and Context

When an app uses AVAggregateAssetDownloadTask, it crashes.
We need to ignore this kind of task and other non supported tasks

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
