### PR TITLE
test: Remove flaky testNavigationTransaction

### DIFF
--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -25,12 +25,6 @@ class LaunchUITests: XCTestCase {
         XCTAssertTrue(app.textViews.firstMatch.waitForExistence(timeout: timeout), "Lorem Ipsum not loaded.")
     }
     
-    func testNavigationTransaction() {
-        app.buttons["testNavigationTransactionButton"].tap()
-        XCTAssertTrue(app.images.firstMatch.waitForExistence(timeout: timeout), "Navigation transaction not loaded.")
-        assertApp()
-    }
-    
     func testShowNib() {
         app.buttons["showNibButton"].tap()
         XCTAssertTrue(app.buttons["a lonely button"].waitForExistence(timeout: timeout), "Nib ViewController not loaded.")


### PR DESCRIPTION
testNavigationTransaction only validates if the image is loaded properly and
it doesn't validate more than the other tests. As it is flaky it can be removed.

Fixes GH-1529

#skip-changelog