### PR TITLE
ci: Fix Cache for Test Server

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./test-server/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
       - run: swift build
         working-directory: test-server


### PR DESCRIPTION
Use Package.resolved as cache key instead of whole
folder.

Fixes GH-1528

#skip-changelog