### PR TITLE
test: Use integer literal in example code

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -16,7 +16,7 @@ AppDelegate ()
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
         options.debug = YES;
-        options.sessionTrackingIntervalMillis = [@5000 unsignedIntegerValue];
+        options.sessionTrackingIntervalMillis = 5000UL;
         // Sampling 100% - In Production you probably want to adjust this
         options.tracesSampleRate = @1.0;
     }];


### PR DESCRIPTION
No need to instantiate an `NSNumber` and extract the unsigned integer value back out of it, we can just use the `UL` suffix on an integer literal (although even that is unnecessary in this case since, the magnitude is so small).

#skip-changelog