### PR TITLE
feat: Send Locale with Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- feat: Send Locale with Events (#1539)
+
 ## 7.6.1
 
 - fix: iOS13-Swift build (#1522)

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -14,6 +14,9 @@ SentryScope (Private)
 
 @property (atomic, strong) SentryUser *_Nullable userObject;
 
+@property (atomic, strong)
+    NSMutableDictionary<NSString *, NSDictionary<NSString *, id> *> *contextDictionary;
+
 - (void)addObserver:(id<SentryScopeObserver>)observer;
 
 @end

--- a/Tests/SentryTests/Integrations/TestNotificationCenter.swift
+++ b/Tests/SentryTests/Integrations/TestNotificationCenter.swift
@@ -65,4 +65,8 @@ class TestNotificationCenter {
         NotificationCenter.default.post(Notification(name: UIWindow.didBecomeVisibleNotification))
         #endif
     }
+    
+    static func localeDidChange() {
+        NotificationCenter.default.post(Notification(name: NSLocale.currentLocaleDidChangeNotification))
+    }
 }


### PR DESCRIPTION
## :scroll: Description

Send the current locale with events. The SDK puts the locale into the device
context of the event.

## :bulb: Motivation and Context

Fixes GH-1438

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
