### PR TITLE
Asserts are enabled in release when using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,9 @@ let package = Package(
                 "SentryCrash/"
             ],
             publicHeadersPath: "Sentry/Public/",
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))
+            ],
             cxxSettings: [
                 .define("GCC_ENABLE_CPP_EXCEPTIONS", to: "YES"),
                 .headerSearchPath("Sentry/include"),


### PR DESCRIPTION
## :scroll: Description
When using Swift Package Manager to integrate Sentry into an app, Xcode does not automatically set `NS_BLOCK_ASSERTIONS` to `1` when building the package in release. This means that any NSAsserts that are hit in release cause crashes. This appears to only be an issue with [ObjC packages](https://forums.swift.org/t/assertions-in-swift-packages/42692). 

The change I've made is to `Package.swift` to set `NS_BLOCK_ASSERTIONS` to `1` when building in release.

## :bulb: Motivation and Context
Stop asserts from crashing my app in production. 

Note: I haven't actually hit an assert in your package, but I'm planning on putting up a PR for all ObjC packages in my app that use `NSAssert`.

## :green_heart: How did you test it?
I created a fork of this repo and pointed the SPM to my fork. Without updating `Package.swift` I added an assert in the `startup` function, built in release mode and verified that the assert causes a crash. I then updated `Package.swift` to the changes in this PR, updated the package, ran the app and verified that the assert did not crash.

I'm not sure how to add a unit test since to repro I'd need to be using SPM.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps

Hopefully y'all can verify that asserts do cause crashes and merge this fix. I can then stop pointing to my fork in my app.