### PR TITLE
chore(ci): break if missing artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
+          if-no-files-found: error
           path: |
             ${{ github.workspace }}/*.zip
 
@@ -98,6 +99,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.sha }}
+          if-no-files-found: error
           path: |
             ${{ github.workspace }}/*.zip
  


### PR DESCRIPTION
Default is to warn and one must open the action details to spot that.

Example: A build that was successful, now fails with:

![image](https://user-images.githubusercontent.com/1633368/145738880-022b1d2a-34be-4772-adef-a68d17e32679.png)

#skip-changelog