### PR TITLE
ci: Skip Flaky Alamofire Tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -64,7 +64,7 @@ jobs:
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
           xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" \
-          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \ 
+          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \
           && break ; done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
           chmod +x apply-patch.sh
         shell: bash
 
-      - name: Download and Apply Patch
-        run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
+      # - name: Download and Apply Patch
+      #   run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
 
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - ci/**
+      - ci/*
 
 jobs:
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro"\
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" \
           -skip-testing:Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried \
           test | xcpretty \
           && break ; done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,13 +17,6 @@ jobs:
     name: Integration Web Requests
     runs-on: macos-11
     timeout-minutes: 15
-    
-    strategy:
-      fail-fast: false
-      matrix:
-        a: [1,2,3,4,5]
-        b: [1,2,3,4,5]
-
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ci/**
 
 jobs:
 
@@ -51,7 +52,14 @@ jobs:
 
       - name: Run tests
         # Run the tests twice in case they are flaky.
-        run: for i in {1..2}; do set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" test | xcpretty && break ; done
+        # We skip one test because it also fails sometimes when not adding Sentry to Alamofire.
+        run: |
+          for i in {1..2}; do \
+          set -o pipefail && env NSUnbufferedIO=YES \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro"\
+          -skip-testing:Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried \
+          test | xcpretty \
+          && break ; done
 
   # We borrow the tests of Home Assistant under the Apache license: https://github.com/home-assistant/iOS.
   # The following steps checkout Home Assistant and apply a github patch to the project. The patch adds

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,13 @@ jobs:
     name: Integration Web Requests
     runs-on: macos-11
     timeout-minutes: 15
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        a: [1,2,3,4,5]
+        b: [1,2,3,4,5]
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -56,8 +63,7 @@ jobs:
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" \
-          -skip-testing:Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
           test | xcpretty \
           && break ; done
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - ci/*
 
 jobs:
 
@@ -58,14 +57,13 @@ jobs:
         run: curl http://localhost:8080/
 
       - name: Run tests
-        # Run the tests twice in case they are flaky.
+        # Run the tests twice, because they are sometimes flaky.
         # We skip two tests because it also fails sometimes when not adding Sentry to Alamofire.
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
           xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
-          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \
           && break ; done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
           chmod +x apply-patch.sh
         shell: bash
 
-      # - name: Download and Apply Patch
-      #   run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
+      - name: Download and Apply Patch
+        run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
 
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
           chmod +x apply-patch.sh
         shell: bash
 
-      - name: Download and Apply Patch
-        run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
+      # - name: Download and Apply Patch
+      #   run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
 
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk
@@ -65,6 +65,7 @@ jobs:
           set -o pipefail && env NSUnbufferedIO=YES \
           xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
+          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \
           && break ; done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,8 +45,8 @@ jobs:
           chmod +x apply-patch.sh
         shell: bash
 
-      # - name: Download and Apply Patch
-      #   run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
+      - name: Download and Apply Patch
+        run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
 
       - name: Install Firewalk
         run: brew install alamofire/alamofire/firewalk
@@ -59,11 +59,13 @@ jobs:
 
       - name: Run tests
         # Run the tests twice in case they are flaky.
-        # We skip one test because it also fails sometimes when not adding Sentry to Alamofire.
+        # We skip two tests because it also fails sometimes when not adding Sentry to Alamofire.
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.0,name=iPhone 13 Pro" \
+          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \ 
+          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \
           && break ; done
 


### PR DESCRIPTION
Some tests of Alamofire are flaky even when not adding Sentry to it. Therefore, we disable these tests to make the test suite more stable.

Fixes GH-1565

#skip-changelog