### PR TITLE
test: Fixing UI Test

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Tools/UIAssert.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/UIAssert.swift
@@ -97,6 +97,6 @@ class UIAssert {
         }
         
         UIAssert.isEqual(missing.count, 0, "Following spans not found: \(missing.joined(separator: ", "))")
-        UIAssert.isEqual(numberOfSpans, expectingSpans, "Transaction did not complete. Expecting \(expectingSpans) spans, got \(children.count)")
+        UIAssert.isEqual(numberOfSpans, expectingSpans, "Transaction did not complete. Expecting \(expectingSpans) spans, got \(numberOfSpans)")
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/TraceTestViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/TraceTestViewController.swift
@@ -7,6 +7,7 @@ class TraceTestViewController: UIViewController {
     @IBOutlet weak var imageView: UIImageView!
     var spanObserver: SpanObserver?
     var lifeCycleSteps = ["loadView"]
+    var addSpan = true
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,10 +41,12 @@ class TraceTestViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         appendLifeCycleStep("viewDidAppear")
+        addSpan = false
     }
     override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
         appendLifeCycleStep("viewWillLayoutSubviews")
+        appendLifeCycleStep("layoutSubViews")
     }
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
@@ -51,7 +54,7 @@ class TraceTestViewController: UIViewController {
     }
     
     func appendLifeCycleStep(_ name: String) {
-        if spanObserver?.span.isFinished == false {
+        if addSpan {
             lifeCycleSteps.append(name)
         }
     }
@@ -72,6 +75,6 @@ class TraceTestViewController: UIViewController {
         
         UIAssert.isEqual(child.tags["http.status_code"], "200", "Could not read status_code tag value")
                 
-        UIAssert.checkForViewControllerLifeCycle(span, expectingSpans: 12, viewController: "TraceTestViewController", stepsToCheck: lifeCycleSteps)
+        UIAssert.checkForViewControllerLifeCycle(span, expectingSpans: lifeCycleSteps.count, viewController: "TraceTestViewController", stepsToCheck: lifeCycleSteps)
     }
 }

--- a/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
+++ b/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
@@ -54,10 +54,8 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/watchOS-Swift WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -65,7 +63,7 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -73,10 +71,8 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <RemoteRunnable
-         runnableDebuggingMode = "2"
-         BundleIdentifier = "com.apple.Carousel"
-         RemotePath = "/watchOS-Swift WatchKit App">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -84,16 +80,7 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </RemoteRunnable>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
-            BuildableName = "watchOS-Swift WatchKit App.app"
-            BlueprintName = "watchOS-Swift WatchKit App"
-            ReferencedContainer = "container:watchOS-Swift.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">


### PR DESCRIPTION
Some UI tests are flaky. Mainly the ones that verify the information on the transaction.

In order to minimize this flakiness, this PR reproduce in a parallel manner, what happens automatically in the SDK, this way we can compare this two results.

_#skip-changelog_