### PR TITLE
ci: Set ui-tests Environment

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -176,6 +176,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
+
+      - run: git apply ./scripts/set-device-tests-environment.patch
       
       - run: fastlane build_ios_swift_ui_test
         env:

--- a/scripts/set-device-tests-environment.patch
+++ b/scripts/set-device-tests-environment.patch
@@ -1,0 +1,12 @@
+diff --git a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+index 3b5406d8..2d4481f5 100644
+--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
++++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+@@ -23,6 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
+             // Sampling 100% - In Production you probably want to adjust this
+             options.tracesSampleRate = 1.0
+             options.sessionTrackingIntervalMillis = 5_000
++            options.environment = "device-tests"
+         }
+         
+         return true


### PR DESCRIPTION
Set ui-tests environment to Sentry of iOS-Swift init so we can inspect
transactions from ui-tests in Sentry.

#skip-changelog