### PR TITLE
feat: Include unfinished spans in transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Include unfinished spans in transactions (#1592)
 - build: Disable NSAssertions for Release Builds (#1545)
 
 ## 7.7.0

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -99,16 +99,16 @@ SentrySpan ()
 
 - (void)finish
 {
-    self.timestamp = [SentryCurrentDate date];
-    if (self.transaction != nil) {
-        [self.transaction spanFinished:self];
-    }
+    [self finishWithStatus:kSentrySpanStatusOk];
 }
 
 - (void)finishWithStatus:(SentrySpanStatus)status
 {
     self.context.status = status;
-    [self finish];
+    self.timestamp = [SentryCurrentDate date];
+    if (self.transaction != nil) {
+        [self.transaction spanFinished:self];
+    }
 }
 
 - (SentryTraceHeader *)toTraceHeader

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -236,12 +236,12 @@ class SentryTracerTests: XCTestCase {
     }
     
     func testFinish_WithUnfinishedChildren() {
+        CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider.sharedInstance())
         let sut = fixture.getSut(waitForChildren: false)
         let child1 = sut.startChild(operation: fixture.transactionOperation)
         let child2 = sut.startChild(operation: fixture.transactionOperation)
         let child3 = sut.startChild(operation: fixture.transactionOperation)
         child2.finish()
-        fixture.currentDateProvider.setDate(date: Date(timeIntervalSinceNow: 0.1))
         sut.finish()
         
         XCTAssertTrue(child1.isFinished)

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -235,6 +235,28 @@ class SentryTracerTests: XCTestCase {
         assertAppStartMeasurementNotPutOnTransaction()
     }
     
+    func testFinish_WithUnfinishedChildren() {
+        let sut = fixture.getSut(waitForChildren: false)
+        let child1 = sut.startChild(operation: fixture.transactionOperation)
+        let child2 = sut.startChild(operation: fixture.transactionOperation)
+        let child3 = sut.startChild(operation: fixture.transactionOperation)
+        child2.finish()
+        fixture.currentDateProvider.setDate(date: Date(timeIntervalSinceNow: 0.1))
+        sut.finish()
+        
+        XCTAssertTrue(child1.isFinished)
+        XCTAssertEqual(child1.context.status, .deadlineExceeded)
+        XCTAssertEqual(sut.timestamp, child1.timestamp)
+        
+        XCTAssertTrue(child2.isFinished)
+        XCTAssertEqual(child2.context.status, .ok)
+        XCTAssertNotEqual(sut.timestamp, child2.timestamp)
+        
+        XCTAssertTrue(child3.isFinished)
+        XCTAssertEqual(child3.context.status, .deadlineExceeded)
+        XCTAssertEqual(sut.timestamp, child3.timestamp)
+    }
+    
     // Although we only run this test above the below specified versions, we expect the
     // implementation to be thread safe
     @available(tvOS 10.0, *)

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -55,6 +55,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(span.startTimestamp, TestData.timestamp)
         XCTAssertEqual(span.timestamp, TestData.timestamp)
         XCTAssertTrue(span.isFinished)
+        XCTAssertEqual(span.context.status, .ok)
         
         let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
         XCTAssertEqual(lastEvent.transaction, fixture.someTransaction)
@@ -65,11 +66,11 @@ class SentrySpanTests: XCTestCase {
     
     func testFinishWithStatus() {
         let span = fixture.getSut()
-        span.finish(status: .ok)
+        span.finish(status: .cancelled)
         
         XCTAssertEqual(span.startTimestamp, TestData.timestamp)
         XCTAssertEqual(span.timestamp, TestData.timestamp)
-        XCTAssertEqual(span.context.status, .ok)
+        XCTAssertEqual(span.context.status, .cancelled)
         XCTAssertTrue(span.isFinished)
     }
     
@@ -89,20 +90,6 @@ class SentrySpanTests: XCTestCase {
         
         XCTAssertEqual(serializedChild["span_id"] as? String, childSpan.context.spanId.sentrySpanIdString)
         XCTAssertEqual(serializedChild["parent_span_id"] as? String, span.context.spanId.sentrySpanIdString)
-    }
-    
-    func testFinishWithUnfinishedSpanDropsSpan() {
-        let client = TestClient(options: fixture.options)!
-        let span = fixture.getSut(client: client)
-        span.startChild(operation: fixture.someOperation)
-        
-        span.finish()
-        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
-        let serializedData = lastEvent.serialize()
-        
-        let spans = serializedData["spans"] as! [Any]
-        
-        XCTAssertEqual(spans.count, 0)
     }
     
     func testStartChildWithNameOperation() {


### PR DESCRIPTION
## :scroll: Description

Instead of removing unfinished spans from the transaction in order to avoid the transaction to be discarded, we close all unfinished spans with `deadline_exceeded` status.

## :bulb: Motivation and Context

closes #1303 

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
