### PR TITLE
ref: Remove not working log in SentryNSURLRequest

### DIFF
--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -93,7 +93,7 @@ SentryNSURLRequest ()
         [self setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
         self.HTTPBody = [data sentry_gzippedWithCompressionLevel:-1 error:error];
     }
-    
+
     return self;
 }
 

--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -93,16 +93,7 @@ SentryNSURLRequest ()
         [self setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
         self.HTTPBody = [data sentry_gzippedWithCompressionLevel:-1 error:error];
     }
-
-    // TODO: When the SDK inits, Client is created, then hub, then hub assigned
-    // to SentrySDK. That means there's no hub set yet on SentrySDK when this
-    // code runs (hub init closes pending sessions)
-    if ([SentrySDK.currentHub getClient].options.debug == YES) {
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"Envelope request with data: %@",
-                                            [[NSString alloc] initWithData:data
-                                                                  encoding:NSUTF8StringEncoding]]
-                         andLevel:kSentryLevelDebug];
-    }
+    
     return self;
 }
 


### PR DESCRIPTION
The log message is always nil and logging the JSON of an envelope
is very verbose when having attachments. You can get the contents
of an envelope by looking at the stored file on disk instead.

#skip-changelog