### PR TITLE
test: Change make test to use Test configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ format:
 
 test:
 	@echo "--> Running all tests"
-	xcodebuild -workspace Sentry.xcworkspace -scheme Sentry -configuration Debug GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES -destination "platform=macOS" test | rbenv exec bundle exec xcpretty -t
+	xcodebuild -workspace Sentry.xcworkspace -scheme Sentry -configuration Test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES -destination "platform=macOS" test | rbenv exec bundle exec xcpretty -t
 .PHONY: test
 
 run-test-server:


### PR DESCRIPTION
Updating MakeFile test command to use `Test` configuration.

Solves #1595 

_#skip-changelog_