### PR TITLE
fix: Set SentryEvent timestamp to be the time the event was created

### DIFF
--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
         self.eventId = [[SentryId alloc] init];
         self.level = level;
         self.platform = @"cocoa";
+        self.timestamp = [SentryCurrentDate date];
     }
     return self;
 }

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -1,7 +1,19 @@
 import XCTest
+import Sentry
 
 class SentryEventTests: XCTestCase {
 
+    func testInitWithLevel() {
+        let dateProvider = TestCurrentDateProvider()
+        CurrentDate.setCurrentDateProvider(dateProvider)
+        
+        let event = Event(level: .debug)
+        
+        XCTAssertEqual(event.platform, "cocoa")
+        XCTAssertEqual(event.level, .debug)
+        XCTAssertEqual(event.timestamp, dateProvider.date())
+    }
+    
     func testSerialize() {
         let event = TestData.event
         let actual = event.serialize()


### PR DESCRIPTION
## :scroll: Description

Setting SentryEvent timestamp at initialization.

## :bulb: Motivation and Context

Solve #1034

## :green_heart: How did you test it?

Unit Tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
