### PR TITLE
fix: Crash in SentrySubClassFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Crash in SentrySubClassFinder (#1635)
 - fix: Set timestamp in init of event (#1629)
 - fix: Load invalid CrashState json (#1625)
 - feat: Auto I/O spans for NSData (#1557)

--- a/Sources/Sentry/SentryDefaultObjCRuntimeWrapper.m
+++ b/Sources/Sentry/SentryDefaultObjCRuntimeWrapper.m
@@ -9,4 +9,9 @@
     return objc_getClassList(buffer, bufferCount);
 }
 
+- (Class)getSuperclass:(Class)cls
+{
+    return class_getSuperclass(cls);
+}
+
 @end

--- a/Sources/Sentry/SentryDefaultObjCRuntimeWrapper.m
+++ b/Sources/Sentry/SentryDefaultObjCRuntimeWrapper.m
@@ -9,9 +9,9 @@
     return objc_getClassList(buffer, bufferCount);
 }
 
-- (Class)getSuperclass:(Class)cls
+- (void)countIterateClasses
 {
-    return class_getSuperclass(cls);
+    // Do nothing
 }
 
 @end

--- a/Sources/Sentry/SentryObjCRuntimeWrapper.h
+++ b/Sources/Sentry/SentryObjCRuntimeWrapper.h
@@ -4,4 +4,6 @@
 
 - (int)getClassList:(__unsafe_unretained Class *)buffer bufferCount:(int)bufferCount;
 
+- (Class)getSuperclass:(Class)cls;
+
 @end

--- a/Sources/Sentry/SentryObjCRuntimeWrapper.h
+++ b/Sources/Sentry/SentryObjCRuntimeWrapper.h
@@ -4,6 +4,6 @@
 
 - (int)getClassList:(__unsafe_unretained Class *)buffer bufferCount:(int)bufferCount;
 
-- (Class)getSuperclass:(Class)cls;
+- (void)countIterateClasses;
 
 @end

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -49,6 +49,14 @@ SentrySubClassFinder ()
             [SentryLog logWithMessage:msg andLevel:kSentryLevelError];
             return;
         }
+        
+        // Only for testing. We want to know in tests if the code iterated over the classes, because
+        // iterating in edge cases could lead to crashses. Ideally, we would wrap
+        // class_getSuperclass in the SentryObjCRuntimeWrapper and count its invocations. As
+        // class_getSuperclass is called in a tight loop doing so would slow down the code
+        // significantly. This is pragmatic workaround to find out in tests if the code iterated
+        // over the classes.
+        [self.objcRuntimeWrapper countIterateClasses];
 
         // Storing the actual classes in an NSArray would call initializer of the class, which we
         // must avoid as we are on a background thread here and dealing with UIViewControllers,
@@ -74,7 +82,7 @@ SentrySubClassFinder ()
             // are doing something we shouldn't do. It's safer to use a regular while loop to check
             // if superClass is valid.
             while (superClass && superClass != parentClass) {
-                superClass = [self.objcRuntimeWrapper getSuperclass:superClass];
+                superClass = class_getSuperclass(superClass);
             }
 
             if (superClass) {

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -27,46 +27,38 @@ SentrySubClassFinder ()
 - (void)actOnSubclassesOf:(Class)parentClass block:(void (^)(Class))block
 {
     [self.dispatchQueue dispatchAsyncWithBlock:^{
-        int numClasses = [self.objcRuntimeWrapper getClassList:NULL bufferCount:0];
+        Class *classes = NULL;
+        int numClasses = -1;
+        int retriesForGettingClasses = 1;
 
-        if (numClasses <= 0) {
+        // The number of classes may change between the two invocations of class_getSuperclass. If
+        // this or any other error happens, we retry once. We don't want to retry this in a loop
+        // because of the danger of an endless loop.
+        for (int i = 0; numClasses == -1 && i <= retriesForGettingClasses; i++) {
+            numClasses = [self getClassList:&classes];
+
+            if (numClasses < 0) {
+                free(classes);
+                classes = NULL;
+            }
+        }
+
+        if (numClasses < 0) {
             NSString *msg =
-                [NSString stringWithFormat:@"No classes found when retrieving class list for %@.",
-                          parentClass];
+                [NSString stringWithFormat:@"Not able to get subclasses for %@", parentClass];
             [SentryLog logWithMessage:msg andLevel:kSentryLevelError];
             return;
         }
 
-        int memSize = sizeof(Class) * numClasses;
-        Class *classes = (__unsafe_unretained Class *)malloc(memSize);
-
-        if (classes == NULL && memSize) {
-            NSString *msg = [NSString
-                stringWithFormat:@"Couldn't allocate memory for retrieving class list for %@",
-                parentClass];
-            [SentryLog logWithMessage:msg andLevel:kSentryLevelError];
-            return;
-        }
-
-        // Don't assign the result getClassList again to numClasses because if a class is registered
-        // in the meantime our buffer would not be big enough and we would crash when iterating over
-        // the classes below.
-        int secondNumClasses = [self.objcRuntimeWrapper getClassList:classes
-                                                         bufferCount:numClasses];
-
-        // Only set the numClasses to secondNumClasses in the very unlikely case the number of
-        // classes decreased. If the number of classes increased, which can happen, we only iterate
-        // over the inital number of classes. We don't want to retry the whole process and are fine
-        // with possibly skipping a few newly added classes as they could anyway be added later in
-        // the lifetime of the app.
-        if (secondNumClasses < numClasses) {
-            numClasses = secondNumClasses;
-        }
-
-        // Storing the actual classes in an NSArray would call initialize of the class, which we
+        // Storing the actual classes in an NSArray would call initializer of the class, which we
         // must avoid as we are on a background thread here and dealing with UIViewControllers,
         // which assume they are running on the main thread. Therefore, we store the indexes instead
         // so we can search for the subclasses on a background thread.
+        // We can't use NSObject:isSubclassOfClass as not all classes in the runtime in classes
+        // inherit from NSObject and a call to isSubclassOfClass would call the initializer of the
+        // class, which we can't allow because of the problem with UIViewControllers mentioned
+        // above.
+
         NSMutableArray<NSNumber *> *indexesToSwizzle = [NSMutableArray new];
         for (NSInteger i = 0; i < numClasses; i++) {
             Class superClass = classes[i];
@@ -82,10 +74,10 @@ SentrySubClassFinder ()
             // are doing something we shouldn't do. It's safer to use a regular while loop to check
             // if superClass is valid.
             while (superClass && superClass != parentClass) {
-                superClass = class_getSuperclass(superClass);
+                superClass = [self.objcRuntimeWrapper getSuperclass:superClass];
             }
 
-            if (superClass != nil) {
+            if (superClass) {
                 [indexesToSwizzle addObject:@(i)];
             }
         }
@@ -98,6 +90,41 @@ SentrySubClassFinder ()
             free(classes);
         }];
     }];
+}
+
+- (int)getClassList:(Class **)classes
+{
+    int numClasses = [self.objcRuntimeWrapper getClassList:NULL bufferCount:0];
+
+    if (numClasses <= 0) {
+        return -1;
+    }
+
+    int memSize = sizeof(Class) * numClasses;
+    *classes = (__unsafe_unretained Class *)malloc(memSize);
+
+    if (classes == NULL && memSize) {
+        [SentryLog logWithMessage:@"Couldn't allocate memory when retrieving class list."
+                         andLevel:kSentryLevelError];
+        return -1;
+    }
+
+    // Don't assign the result getClassList again to numClasses because if a class is registered
+    // in the meantime our buffer would not be big enough and we would crash when iterating over
+    // the classes.
+    int secondNumClasses = [self.objcRuntimeWrapper getClassList:*classes bufferCount:numClasses];
+
+    // When the number of classes changes between the invocation of class_getSuperclass, we run the
+    // risk of accessing bad memory when iterating over all classes, also see
+    // https://github.com/getsentry/sentry-cocoa/issues/1634
+    if (secondNumClasses != numClasses) {
+        [SentryLog logWithMessage:@"Can't find subclasses, because the number of classes changed "
+                                  @"between invocations of class_getSuperclass."
+                         andLevel:kSentryLevelDebug];
+        return -1;
+    }
+
+    return numClasses;
 }
 
 @end

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -29,12 +29,12 @@ SentrySubClassFinder ()
     [self.dispatchQueue dispatchAsyncWithBlock:^{
         Class *classes = NULL;
         int numClasses = -1;
-        int retriesForGettingClasses = 1;
+        int attemptsForGettingClasses = 2;
 
         // The number of classes may change between the two invocations of class_getSuperclass. If
         // this or any other error happens, we retry once. We don't want to retry this in a loop
         // because of the danger of an endless loop.
-        for (int i = 0; numClasses == -1 && i <= retriesForGettingClasses; i++) {
+        for (int i = 0; numClasses == -1 && i < attemptsForGettingClasses; i++) {
             numClasses = [self getClassList:&classes];
 
             if (numClasses < 0) {

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -49,7 +49,7 @@ SentrySubClassFinder ()
             [SentryLog logWithMessage:msg andLevel:kSentryLevelError];
             return;
         }
-        
+
         // Only for testing. We want to know in tests if the code iterated over the classes, because
         // iterating in edge cases could lead to crashses. Ideally, we would wrap
         // class_getSuperclass in the SentryObjCRuntimeWrapper and count its invocations. As

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.h
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.h
@@ -10,6 +10,6 @@
 
 @property (nullable, nonatomic, copy) int (^numClasses)(int);
 
-@property (nonatomic, assign) NSUInteger getSuperclassInvocations;
+@property (nonatomic, assign) NSUInteger iterateClassesInvocations;
 
 @end

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.h
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.h
@@ -10,4 +10,6 @@
 
 @property (nullable, nonatomic, copy) int (^numClasses)(int);
 
+@property (nonatomic, assign) NSUInteger getSuperclassInvocations;
+
 @end

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
@@ -35,10 +35,9 @@ SentryTestObjCRuntimeWrapper ()
     return numClasses;
 }
 
-- (Class)getSuperclass:(Class)cls
+- (void)countIterateClasses
 {
-    self.getSuperclassInvocations++;
-    return [self.objcRuntimeWrapper getSuperclass:cls];
+    self.iterateClassesInvocations++;
 }
 
 @end

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
@@ -35,4 +35,10 @@ SentryTestObjCRuntimeWrapper ()
     return numClasses;
 }
 
+- (Class)getSuperclass:(Class)cls
+{
+    self.getSuperclassInvocations++;
+    return [self.objcRuntimeWrapper getSuperclass:cls];
+}
+
 @end

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -29,9 +29,21 @@ class SentrySubClassFinderTests: XCTestCase {
         testActOnSubclassesOf(Child2.self, expected: [])
     }
     
-    func testActOnSubclassesOfChild2_WhenNewClassRegistered_ReturnsChildren() {
+    func testActOnSubclassesOfChild2_WhenNewClassesRegistered_ReturnNoChildren() {
         fixture.runtimeWrapper.beforeGetClassList = {
             SentryClassRegistrator.registerClass(SentryId().sentryIdString)
+        }
+        testActOnSubclassesOf(Child1.self, expected: [])
+        XCTAssertEqual(0, fixture.runtimeWrapper.getSuperclassInvocations)
+    }
+    
+    func testActOnSubclassesOfChild2_WhenNewClassOnlyOnceRegistered_ReturnsChildren() {
+        var invocations = 0
+        fixture.runtimeWrapper.beforeGetClassList = {
+            if invocations == 1 {
+                SentryClassRegistrator.registerClass(SentryId().sentryIdString)
+            }
+            invocations += 1
         }
         testActOnSubclassesOf(Child1.self, expected: [GrandChild2.self, GrandChild1.self])
     }
@@ -54,6 +66,17 @@ class SentrySubClassFinderTests: XCTestCase {
         }
         
         testActOnSubclassesOf(Child1.self, expected: [GrandChild2.self, GrandChild1.self])
+    }
+    
+    func testActOnSubclasses_ClassListKeepsReturnsOneLess_ReturnsNoChildren() {
+        var invocations = -1
+        fixture.runtimeWrapper.numClasses = { numClasses in
+            invocations += 1
+            return numClasses - Int32(invocations)
+        }
+        
+        testActOnSubclassesOf(Child1.self, expected: [])
+        XCTAssertEqual(0, fixture.runtimeWrapper.getSuperclassInvocations)
     }
     
     func testActOnSubclasses_NoClassesFound_ReturnsNoChildren() {

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -34,7 +34,7 @@ class SentrySubClassFinderTests: XCTestCase {
             SentryClassRegistrator.registerClass(SentryId().sentryIdString)
         }
         testActOnSubclassesOf(Child1.self, expected: [])
-        XCTAssertEqual(0, fixture.runtimeWrapper.getSuperclassInvocations)
+        XCTAssertEqual(0, fixture.runtimeWrapper.iterateClassesInvocations)
     }
     
     func testActOnSubclassesOfChild2_WhenNewClassOnlyOnceRegistered_ReturnsChildren() {
@@ -76,7 +76,7 @@ class SentrySubClassFinderTests: XCTestCase {
         }
         
         testActOnSubclassesOf(Child1.self, expected: [])
-        XCTAssertEqual(0, fixture.runtimeWrapper.getSuperclassInvocations)
+        XCTAssertEqual(0, fixture.runtimeWrapper.iterateClassesInvocations)
     }
     
     func testActOnSubclasses_NoClassesFound_ReturnsNoChildren() {


### PR DESCRIPTION
## :scroll: Description

When trying to find all subclasses of a given class, the code potentially
tried to access bad memory, leading to EXC_BAD_ACCESS. With this
PR, we don't iterate over all classes loaded by objc_getClassList when
the number of classes returned changes between its two invocations.
Instead, when the number changes, the code now throws away the
allocated memory and retries once.

## :bulb: Motivation and Context

This more defensive approach is worth a shot to fix GH-1634.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
