### PR TITLE
test: Enable file IO for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'Sources/**'
       - 'Tests/**'
+      - 'scripts/**'
 
 jobs:
 

--- a/scripts/add-sentry-to-alamofire.patch
+++ b/scripts/add-sentry-to-alamofire.patch
@@ -1,8 +1,8 @@
 diff --git a/Alamofire.xcodeproj/project.pbxproj b/Alamofire.xcodeproj/project.pbxproj
-index f3e5d1a..2b3096d 100644
+index 3882645..56fea58 100644
 --- a/Alamofire.xcodeproj/project.pbxproj
 +++ b/Alamofire.xcodeproj/project.pbxproj
-@@ -402,6 +402,7 @@
+@@ -409,6 +409,7 @@
  		4CFB030E1D7D2FA20056F249 /* utf8_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F41D7D2FA20056F249 /* utf8_string.txt */; };
  		4CFB030F1D7D2FA20056F249 /* utf8_string.txt in Resources */ = {isa = PBXBuildFile; fileRef = 4CFB02F41D7D2FA20056F249 /* utf8_string.txt */; };
  		4DD67C251A5C590000ED2280 /* Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = F897FF4019AA800700AB5182 /* Alamofire.swift */; };
@@ -10,7 +10,7 @@ index f3e5d1a..2b3096d 100644
  		8035DB621BAB492500466CB3 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */; };
  		E4202FD01B667AA100C997FB /* ParameterEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE2724E1AF88FB500F1D59A /* ParameterEncoding.swift */; };
  		E4202FD21B667AA100C997FB /* ResponseSerialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDE2C451AF89FF300BABAE5 /* ResponseSerialization.swift */; };
-@@ -621,6 +622,7 @@
+@@ -623,6 +624,7 @@
  			isa = PBXFrameworksBuildPhase;
  			buildActionMask = 2147483647;
  			files = (
@@ -18,7 +18,7 @@ index f3e5d1a..2b3096d 100644
  			);
  			runOnlyForDeploymentPostprocessing = 0;
  		};
-@@ -951,6 +953,13 @@
+@@ -962,6 +964,13 @@
  			path = String;
  			sourceTree = "<group>";
  		};
@@ -32,7 +32,7 @@ index f3e5d1a..2b3096d 100644
  		B39E2F821C1A72E5002DA1A9 /* Varying Encoding Types and Extensions */ = {
  			isa = PBXGroup;
  			children = (
-@@ -973,6 +982,7 @@
+@@ -984,6 +993,7 @@
  				F8111E3519A95C8B0040E7D1 /* Source */,
  				F8111E3F19A95C8B0040E7D1 /* Tests */,
  				F8111E3419A95C8B0040E7D1 /* Products */,
@@ -40,7 +40,7 @@ index f3e5d1a..2b3096d 100644
  			);
  			indentWidth = 4;
  			sourceTree = "<group>";
-@@ -1141,6 +1151,8 @@
+@@ -1152,6 +1162,8 @@
  			dependencies = (
  			);
  			name = "Alamofire macOS";
@@ -49,7 +49,7 @@ index f3e5d1a..2b3096d 100644
  			productName = AlamofireOSX;
  			productReference = 4DD67C0B1A5C55C900ED2280 /* Alamofire.framework */;
  			productType = "com.apple.product-type.framework";
-@@ -1177,6 +1189,9 @@
+@@ -1188,6 +1200,9 @@
  			dependencies = (
  			);
  			name = "Alamofire iOS";
@@ -59,7 +59,7 @@ index f3e5d1a..2b3096d 100644
  			productName = Alamofire;
  			productReference = F8111E3319A95C8B0040E7D1 /* Alamofire.framework */;
  			productType = "com.apple.product-type.framework";
-@@ -1270,6 +1285,9 @@
+@@ -1281,6 +1296,9 @@
  				Base,
  			);
  			mainGroup = F8111E2919A95C8B0040E7D1;
@@ -69,7 +69,7 @@ index f3e5d1a..2b3096d 100644
  			productRefGroup = F8111E3419A95C8B0040E7D1 /* Products */;
  			projectDirPath = "";
  			projectRoot = "";
-@@ -2361,6 +2379,25 @@
+@@ -2379,6 +2397,25 @@
  			defaultConfigurationName = Release;
  		};
  /* End XCConfigurationList section */
@@ -96,10 +96,10 @@ index f3e5d1a..2b3096d 100644
  	rootObject = F8111E2A19A95C8B0040E7D1 /* Project object */;
  }
 diff --git a/Tests/BaseTestCase.swift b/Tests/BaseTestCase.swift
-index fe54ffc..d85da5e 100644
+index 1eeafe7..f5f3dea 100644
 --- a/Tests/BaseTestCase.swift
 +++ b/Tests/BaseTestCase.swift
-@@ -25,8 +25,39 @@
+@@ -25,8 +25,37 @@
  import Alamofire
  import Foundation
  import XCTest
@@ -117,11 +117,9 @@ index fe54ffc..d85da5e 100644
 +        if (!SentryInitialized) {
 +            SentrySDK.start { options in
 +                options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
-+                options.tracesSampler = { _ in
-+                    // Discard all traces.
-+                    return 0
-+                }
-+                
++                options.environment = "integration-tests"
++                options.tracesSampler = 1.0
++                options.enableFileIOTracking = true
 +            }
 +            
 +            SentryInitialized = true

--- a/scripts/add-sentry-to-alamofire.patch
+++ b/scripts/add-sentry-to-alamofire.patch
@@ -118,7 +118,7 @@ index 1eeafe7..f5f3dea 100644
 +            SentrySDK.start { options in
 +                options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
 +                options.environment = "integration-tests"
-+                options.tracesSampler = 1.0
++                options.tracesSampleRate = 1.0
 +                options.enableFileIOTracking = true
 +            }
 +            

--- a/scripts/add-sentry-to-homekit.patch
+++ b/scripts/add-sentry-to-homekit.patch
@@ -12,7 +12,7 @@ index d2d83b14..6756f31b 100644
  pod 'Version'
  pod 'XCGLogger'
 diff --git a/Sources/App/AppDelegate.swift b/Sources/App/AppDelegate.swift
-index 8e0e35f4..0cb45503 100644
+index 8e0e35f4..3d34887d 100644
 --- a/Sources/App/AppDelegate.swift
 +++ b/Sources/App/AppDelegate.swift
 @@ -13,6 +13,7 @@ import SafariServices
@@ -23,13 +23,15 @@ index 8e0e35f4..0cb45503 100644
  
  let keychain = Constants.Keychain
  
-@@ -125,6 +126,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
+@@ -125,6 +126,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
          _ application: UIApplication,
          didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
      ) -> Bool {
 +        SentrySDK.start { options in
 +            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
++            options.environment = "integration-tests"
 +            options.tracesSampleRate = 1.0
++            options.enableFileIOTracking = true
 +        }
 +        
          if NSClassFromString("XCTest") != nil {

--- a/scripts/add-sentry-to-vlc.patch
+++ b/scripts/add-sentry-to-vlc.patch
@@ -12,7 +12,7 @@ index efdc34e6..95a5a944 100644
    pod 'SwiftLint', '~> 0.25.0', :configurations => ['Debug']
  end
 diff --git a/Sources/VLCAppDelegate.m b/Sources/VLCAppDelegate.m
-index 45e05469..cbddbe19 100644
+index 45e05469..0050ffbc 100644
 --- a/Sources/VLCAppDelegate.m
 +++ b/Sources/VLCAppDelegate.m
 @@ -23,6 +23,7 @@
@@ -23,17 +23,16 @@ index 45e05469..cbddbe19 100644
  
  NSString *VLCAppCenterAppID = @"0114ca8e-2652-44ce-588d-2ebd035c3577";
  
-@@ -136,6 +137,14 @@ NSString *VLCAppCenterAppID = @"0114ca8e-2652-44ce-588d-2ebd035c3577";
+@@ -136,6 +137,13 @@ NSString *VLCAppCenterAppID = @"0114ca8e-2652-44ce-588d-2ebd035c3577";
  - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
  {
      [MSACAppCenter start:VLCAppCenterAppID withServices:@[[MSACAnalytics class], [MSACCrashes class]]];
 +    
 +    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
 +        options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
-+        options.tracesSampler = ^NSNumber * (SentrySamplingContext * samplingContext) {
-+            // Discard all traces.
-+            return @0;
-+            };
++        options.environment = @"integration-tests";
++        options.tracesSampler = @0;
++        options.enableFileIOTracking = YES;
 +    }];
  
      self.orientationLock = UIInterfaceOrientationMaskPortrait | UIInterfaceOrientationMaskLandscape;

--- a/scripts/add-sentry-to-vlc.patch
+++ b/scripts/add-sentry-to-vlc.patch
@@ -31,7 +31,7 @@ index 45e05469..0050ffbc 100644
 +    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
 +        options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
 +        options.environment = @"integration-tests";
-+        options.tracesSampler = @0;
++        options.tracesSampleRate = @0;
 +        options.enableFileIOTracking = YES;
 +    }];
  


### PR DESCRIPTION
Enable file IO APM for integration tests and send transactions
to Sentry with an integration-test environment.

#skip-changelog