### PR TITLE
Fix crash in dirContentsCount() when dir == NULL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - feat: Send SDK integrations (#1647)
 - fix: Don't track OOMs for unit tests (#1651)
 - fix: Add verification for vendor UUID in OOM logic (#1648)
+- fix crash in dirContentsCount() when dir == NULL (#1658)
 
 ## 7.9.0
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -96,7 +96,7 @@ dirContents(const char *path, char ***entries, int *count)
     }
     dir = opendir(path);
     if (dir == NULL) {
-        SentryCrashLOG_ERROR("Error reading directory %s: %s", strerror(errno));
+        SentryCrashLOG_ERROR("Error reading directory %s: %s", path, strerror(errno));
         goto done;
     }
 
@@ -144,7 +144,7 @@ deletePathContents(const char *path, bool deleteTopLevelPathAlso)
 {
     struct stat statStruct = { 0 };
     if (stat(path, &statStruct) != 0) {
-        SentryCrashLOG_ERROR("Could not stat %s: %s", strerror(errno));
+        SentryCrashLOG_ERROR("Could not stat %s: %s", path, strerror(errno));
         return false;
     }
     if (S_ISDIR(statStruct.st_mode)) {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -73,7 +73,7 @@ dirContentsCount(const char *path)
     int count = 0;
     DIR *dir = opendir(path);
     if (dir == NULL) {
-        SentryCrashLOG_ERROR("Error reading directory %s: %s", strerror(errno));
+        SentryCrashLOG_ERROR("Error reading directory %s: %s", path, strerror(errno));
         return 0;
     }
 


### PR DESCRIPTION
The format for the log specifies two string arguments but only one is supplied potentially causing a crash

## :scroll: Description

Assume the `path` variable was unintentionally omitted when logging the error. Adding it back to prevent a possible crash.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixes a crashing problem.

<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Made change in local project.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
