### PR TITLE
fix: Always tracks App start for Hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- fix: Always tracks App start for Hybrid SDKs
 - feat: Send SDK integrations (#1647)
 - fix: Don't track OOMs for unit tests (#1651)
 - fix: Add verification for vendor UUID in OOM logic (#1648)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- fix: Always tracks App start for Hybrid SDKs
+- fix: Always tracks App start for Hybrid SDKs (#1662) 
 - feat: Send SDK integrations (#1647)
 - fix: Don't track OOMs for unit tests (#1651)
 - fix: Add verification for vendor UUID in OOM logic (#1648)

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -136,12 +136,12 @@ SentryAppStartTracker ()
 
     // With only running this once we know that the process is a new one when the following code is
     // executed.
-#if TEST
+#    if TEST
     block();
-#else
+#    else
     static dispatch_once_t once;
     [self.dispatchQueue dispatchOnce:&once block:block];
-#endif
+#    endif
 }
 
 /**

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -136,6 +136,7 @@ SentryAppStartTracker ()
 
     // With only running this once we know that the process is a new one when the following code is
     // executed.
+// We need to make sure the block runs on each test instead of only once
 #    if TEST
     block();
 #    else

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -136,8 +136,12 @@ SentryAppStartTracker ()
 
     // With only running this once we know that the process is a new one when the following code is
     // executed.
+#if TEST
+    block();
+#else
     static dispatch_once_t once;
     [self.dispatchQueue dispatchOnce:&once block:block];
+#endif
 }
 
 /**

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -4,6 +4,7 @@
 #import "SentryLog.h"
 #import "SentryOptions+Private.h"
 #import <Foundation/Foundation.h>
+#import <PrivateSentrySDKOnly.h>
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
 #import <SentryCrashAdapter.h>
@@ -59,6 +60,12 @@ SentryAppStartTrackingIntegration ()
 #if SENTRY_HAS_UIKIT
 - (BOOL)shouldBeEnabled:(SentryOptions *)options
 {
+    // If the cocoa SDK is being used by a hybrid SDK,
+    // we install App start tracking and let the hybrid SDK decide what to do.
+    if (PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode) {
+        return YES;
+    }
+
     if (!options.enableAutoPerformanceTracking) {
         [SentryLog
             logWithMessage:@"AutoUIPerformanceTracking disabled. Will not track app start up time."

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -51,6 +51,19 @@ class SentryAppStartTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(SentrySDK.getAppStartMeasurement())
     }
     
+    func testHybridSDKModeEnabled_DoesUpdatesAppState() {
+        PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true
+        
+        let options = fixture.options
+        options.tracesSampleRate = 0.0
+        options.tracesSampler = nil
+        sut.install(with: options)
+        
+        TestNotificationCenter.uiWindowDidBecomeVisible()
+        
+        XCTAssertNotNil(SentrySDK.getAppStartMeasurement())
+    }
+    
     func testOnlyAppStartMeasuringEnabled_DoesNotUpdatesAppState() {
         let options = fixture.options
         options.tracesSampleRate = 0.0

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -29,6 +29,8 @@ class SentryAppStartTrackingIntegrationTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         fixture.fileManager.deleteAppState()
+        PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false
+        SentrySDK.setAppStartMeasurement(nil)
         sut.stop()
     }
     
@@ -67,6 +69,7 @@ class SentryAppStartTrackingIntegrationTests: XCTestCase {
     func testOnlyAppStartMeasuringEnabled_DoesNotUpdatesAppState() {
         let options = fixture.options
         options.tracesSampleRate = 0.0
+        options.tracesSampler = nil
         sut.install(with: options)
         
         TestNotificationCenter.uiWindowDidBecomeVisible()


### PR DESCRIPTION
## :scroll: Description

When used by a hybrid SDK, Cocoa SDK should track app start.

## :bulb: Motivation and Context

closes #1657

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
