### PR TITLE
docs: Clarify sendDefaultPii

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -167,9 +167,12 @@ NS_SWIFT_NAME(Options)
  * When enabled, the SDK sends personal identifiable along with events. The default is
  * <code>NO</code>.
  *
- * @discussion When the user of an event doesn't contain an IP address, the SDK sets it to
- * <code>{{auto}}</code> to instruct the server to use the connection IP address as the user
- * address.
+ * @discussion When the user of an event doesn't contain an IP address, and this flag is
+ * <code>YES</code>, the SDK sets it to <code>{{auto}}</code> to instruct the server to use the
+ * connection IP address as the user address. Due to backward compatibility concerns, Sentry set the
+ * IP address to <code>{{auto}}</code> out of the box for Cocoa. If you want to stop Sentry from
+ * using the connections IP address, you have to enable Prevent Storing of IP Addresses in your
+ * project settings in Sentry.
  */
 @property (nonatomic, assign) BOOL sendDefaultPii;
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -456,6 +456,9 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     // User can't be nil as setUserIdIfNoUserSet sets it.
     if (self.options.sendDefaultPii && nil == event.user.ipAddress) {
         // Let Sentry infer the IP address from the connection.
+        // Due to backward compatibility concerns, Sentry servers set the IP address to {{auto}} out
+        // of the box for only Cocoa and JavaScript, which makes this toggle currently somewhat
+        // useless. Still, we keep it for future compatibility reasons.
         event.user.ipAddress = @"{{auto}}";
     }
 


### PR DESCRIPTION
Explain the special casing of the Apple SDK for setting the ip_address
to {{auto}} on Sentry and how to disable the collection of users
IP addresses.

Fixes GH-1673

#skip-changelog