### PR TITLE
ci: Fix Simulator UI Tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,7 +153,7 @@ jobs:
         shell: sh
 
   ui-tests-swift-ui:
-    name: UI Tests for ${{matrix.device}}
+    name: UI Tests for SwiftUI on ${{matrix.device}}
     runs-on: macos-11
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,10 +165,8 @@ jobs:
           - xcode: "12.5.1"
             device: "iPhone 8 (14.5)"
 
-          - xcode: "11.7"
-            device: "iPhone 8 (13.7)"
+        # Our SwiftUI requires iOS 14 or higher
             
-
     steps:
       - uses: actions/checkout@v2
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
@@ -177,7 +175,6 @@ jobs:
       - name: Run Fastlane
         run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"${{matrix.device}}" && break ; done
         shell: sh
-
 
   # macos-11 doesn't have a simulator for iOS 12
   ui-tests-swift-ui-ios-12:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,11 +157,20 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        device: ["iPhone 8 (15.2)", "iPhone 8 (14.5)", "iPhone 8 (13.7)"]
+        include:
+          - xcode: "13.2.1"
+            device: "iPhone 8 (15.2)"
+
+          - xcode: "12.5.1"
+            device: "iPhone 8 (14.5)"
+
+          - xcode: "11.7"
+            device: "iPhone 8 (13.7)"
+            
 
     steps:
       - uses: actions/checkout@v2
-      - run: ./scripts/ci-select-xcode.sh 13.2
+      - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,7 +156,8 @@ jobs:
     name: UI Tests for ${{matrix.device}}
     runs-on: macos-11
     strategy:
-      matrix:
+      fail-fast: false
+      matrix:  
         include:
           - xcode: "13.2.1"
             device: "iPhone 8 (15.2)"


### PR DESCRIPTION
GitHub Actions were always falling back to the default simultor iOS
15.2, because it can't find the requested simulators. This is fixed now
by selecting the matching Xcode version.

Fixes GH-1638

#skip-changelog