### PR TITLE
feat: Add support for hybrid SDKs to enable frame tracking

### DIFF
--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -59,7 +59,13 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 @property (class, nonatomic, assign) BOOL appStartMeasurementHybridSDKMode;
 
 #if SENTRY_HAS_UIKIT
+/**
+ * Allows hybrid SDKs to enable frame tracking measurements despite other options.
+ */
+@property (class, nonatomic, assign) BOOL framesTrackingMeasurementHybridSDKMode;
+
 @property (class, nonatomic, assign, readonly) BOOL isFramesTrackingRunning;
+
 @property (class, nonatomic, assign, readonly) SentryScreenFrames *currentScreenFrames;
 #endif
 

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -1,4 +1,5 @@
 #import "SentryFramesTrackingIntegration.h"
+#import "PrivateSentrySDKOnly.h"
 #import "SentryFramesTracker.h"
 #import "SentryLog.h"
 #import "SentryOptions+Private.h"
@@ -38,6 +39,12 @@ SentryFramesTrackingIntegration ()
 #if SENTRY_HAS_UIKIT
 - (BOOL)shouldBeDisabled:(SentryOptions *)options
 {
+    // If the cocoa SDK is being used by a hybrid SDK,
+    // we let the hybrid SDK decide whether to track frames or not.
+    if (PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode) {
+        return NO;
+    }
+
     if (!options.enableAutoPerformanceTracking) {
         [SentryLog logWithMessage:
                        @"AutoUIPerformanceTracking disabled. Will not track slow and frozen frames."

--- a/Sources/Sentry/SentryHybridSKdsOnly.m
+++ b/Sources/Sentry/SentryHybridSKdsOnly.m
@@ -17,7 +17,9 @@ PrivateSentrySDKOnly ()
 
 static SentryOnAppStartMeasurementAvailable _onAppStartMeasurmentAvailable;
 static BOOL _appStartMeasurementHybridSDKMode = NO;
+#if SENTRY_HAS_UIKIT
 static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
+#endif
 
 - (instancetype)init
 {

--- a/Sources/Sentry/SentryHybridSKdsOnly.m
+++ b/Sources/Sentry/SentryHybridSKdsOnly.m
@@ -17,6 +17,7 @@ PrivateSentrySDKOnly ()
 
 static SentryOnAppStartMeasurementAvailable _onAppStartMeasurmentAvailable;
 static BOOL _appStartMeasurementHybridSDKMode = NO;
+static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 - (instancetype)init
 {
@@ -78,6 +79,16 @@ static BOOL _appStartMeasurementHybridSDKMode = NO;
 }
 
 #if SENTRY_HAS_UIKIT
+
++ (BOOL)framesTrackingMeasurementHybridSDKMode
+{
+    return _framesTrackingMeasurementHybridSDKMode;
+}
+
++ (void)setFramesTrackingMeasurementHybridSDKMode:(BOOL)framesTrackingMeasurementHybridSDKMode
+{
+    _framesTrackingMeasurementHybridSDKMode = framesTrackingMeasurementHybridSDKMode;
+}
 
 + (BOOL)isFramesTrackingRunning
 {

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -66,7 +66,6 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
         PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = true
         
         let options = fixture.options
-        options.tracesSampleRate = 0.1
         options.enableAutoPerformanceTracking = false
         sut.install(with: options)
         

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -24,6 +24,11 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
         sut = fixture.sut
     }
     
+    override func tearDown() {
+        PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = false
+        super.tearDown()
+    }
+    
     func testTracesSampleRateSet_MeasuresFrames() {
         let options = fixture.options
         options.tracesSampleRate = 0.1
@@ -55,6 +60,17 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
         sut.install(with: options)
         
         XCTAssertNil(Dynamic(sut).tracker.asObject)
+    }
+    
+    func test_HybridSDKEnables_MeasureFrames() {
+        PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = true
+        
+        let options = fixture.options
+        options.tracesSampleRate = 0.1
+        options.enableAutoPerformanceTracking = false
+        sut.install(with: options)
+        
+        XCTAssertNotNil(Dynamic(sut).tracker.asObject)
     }
     
     func testUninstall() {


### PR DESCRIPTION
## :scroll: Description

Added support for hybrid SDKs to enable frame tracking using `PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode` flag.

## :bulb: Motivation and Context

Closes #1685 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

_#skip-changelog_ 
