### PR TITLE
test: Fix flaky SentryClientTests

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		7B56D73524616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B56D73424616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift */; };
 		7B59398224AB47650003AAD2 /* SentrySessionTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B59398124AB47650003AAD2 /* SentrySessionTrackerTests.swift */; };
 		7B59398424AB481B0003AAD2 /* TestNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B59398324AB481B0003AAD2 /* TestNotificationCenter.swift */; };
+		7B5AB65D27E48E5200F1D1BA /* TestThreadInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5AB65C27E48E5200F1D1BA /* TestThreadInspector.swift */; };
 		7B5B94332657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5B94322657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift */; };
 		7B5B94352657AD21002E474B /* SentryFramesTrackingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5B94342657AD21002E474B /* SentryFramesTrackingIntegrationTests.swift */; };
 		7B610D602512390E00B0B5D9 /* SentrySDK+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B610D5E2512390E00B0B5D9 /* SentrySDK+Private.h */; };
@@ -888,6 +889,7 @@
 		7B56D73424616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryConcurrentRateLimitsDictionaryTests.swift; sourceTree = "<group>"; };
 		7B59398124AB47650003AAD2 /* SentrySessionTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySessionTrackerTests.swift; sourceTree = "<group>"; };
 		7B59398324AB481B0003AAD2 /* TestNotificationCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestNotificationCenter.swift; sourceTree = "<group>"; };
+		7B5AB65C27E48E5200F1D1BA /* TestThreadInspector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestThreadInspector.swift; sourceTree = "<group>"; };
 		7B5B94322657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAppStartTrackingIntegrationTests.swift; sourceTree = "<group>"; };
 		7B5B94342657AD21002E474B /* SentryFramesTrackingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFramesTrackingIntegrationTests.swift; sourceTree = "<group>"; };
 		7B610D5E2512390E00B0B5D9 /* SentrySDK+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySDK+Private.h"; path = "include/SentrySDK+Private.h"; sourceTree = "<group>"; };
@@ -1856,6 +1858,7 @@
 				7BA61CC5247CFC5F00C130A8 /* SentryCrashDefaultBinaryImageProviderTests.swift */,
 				7BA61CCE247EB59500C130A8 /* SentryCrashUUIDConversionTests.swift */,
 				7BA61CCB247D14E600C130A8 /* SentryThreadInspectorTests.swift */,
+				7B5AB65C27E48E5200F1D1BA /* TestThreadInspector.swift */,
 				7B7D872F248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift */,
 				7B140899248791660035403D /* SentryCrashStackEntryMapperTests.swift */,
 				7B6D98EA24C6E84F005502FA /* SentryCrashInstallationReporterTests.swift */,
@@ -2963,6 +2966,7 @@
 				7BEF4957270C4B9D00F8F30E /* SentryUIViewControllerSwizzlingTests.swift in Sources */,
 				630436161EC0AD3100C4D3FA /* SentryNSDataCompressionTests.m in Sources */,
 				63FE722420DA66EC00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m in Sources */,
+				7B5AB65D27E48E5200F1D1BA /* TestThreadInspector.swift in Sources */,
 				7BF9EF742722A85B00B5BBEF /* SentryClassRegistrator.m in Sources */,
 				63B819141EC352A7002FDF4C /* SentryInterfacesTests.m in Sources */,
 				7B14089A248791660035403D /* SentryCrashStackEntryMapperTests.swift in Sources */,

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -99,8 +99,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 /** Internal constructor for testing */
 - (instancetype)initWithOptions:(SentryOptions *)options
-                   transport:(id<SentryTransport>)transport
-                 fileManager:(SentryFileManager *)fileManager
+                      transport:(id<SentryTransport>)transport
+                    fileManager:(SentryFileManager *)fileManager
                 threadInspector:(SentryThreadInspector *)threadInspector
 {
     self = [self initWithOptions:options];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -99,13 +99,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 /** Internal constructor for testing */
 - (instancetype)initWithOptions:(SentryOptions *)options
-                   andTransport:(id<SentryTransport>)transport
-                 andFileManager:(SentryFileManager *)fileManager
+                   transport:(id<SentryTransport>)transport
+                 fileManager:(SentryFileManager *)fileManager
+                threadInspector:(SentryThreadInspector *)threadInspector
 {
     self = [self initWithOptions:options];
 
     self.transport = transport;
     self.fileManager = fileManager;
+    self.threadInspector = threadInspector;
 
     return self;
 }

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -1,7 +1,7 @@
 #import "SentryTransport.h"
 #import <Sentry/Sentry.h>
 
-@class SentryCrashWrapper;
+@class SentryCrashWrapper, SentryThreadInspector;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,8 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 SentryClient (TestInit)
 
 - (instancetype)initWithOptions:(SentryOptions *)options
-                   andTransport:(id<SentryTransport>)transport
-                 andFileManager:(SentryFileManager *)fileManager;
+                   transport:(id<SentryTransport>)transport
+                 fileManager:(SentryFileManager *)fileManager
+                threadInspector:(SentryThreadInspector *)threadInspector;
 
 @end
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -10,8 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 SentryClient (TestInit)
 
 - (instancetype)initWithOptions:(SentryOptions *)options
-                   transport:(id<SentryTransport>)transport
-                 fileManager:(SentryFileManager *)fileManager
+                      transport:(id<SentryTransport>)transport
+                    fileManager:(SentryFileManager *)fileManager
                 threadInspector:(SentryThreadInspector *)threadInspector;
 
 @end

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -11,7 +11,7 @@ class SentryClientTest: XCTestCase {
         let transport = TestTransport()
         
         let debugImageBuilder = SentryDebugImageProvider()
-        let threadInspector = TestThreadInspector()
+        let threadInspector = TestThreadInspector.instance
         
         let session: SentrySession
         let event: Event

--- a/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
+++ b/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
@@ -2,12 +2,12 @@ import Foundation
 
 class TestThreadInspector: SentryThreadInspector {
     
-    init() {
+    static var instance: TestThreadInspector {
         // We need something to pass to the super initializer, because the empty initializer has been marked unavailable.
         let inAppLogic = SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])
         let crashStackEntryMapper = SentryCrashStackEntryMapper(inAppLogic: inAppLogic)
         let stacktraceBuilder = SentryStacktraceBuilder(crashStackEntryMapper: crashStackEntryMapper)
-        super.init(stacktraceBuilder: stacktraceBuilder, andMachineContextWrapper: SentryCrashDefaultMachineContextWrapper())
+        return TestThreadInspector(stacktraceBuilder: stacktraceBuilder, andMachineContextWrapper: SentryCrashDefaultMachineContextWrapper())
     }
     
     override func getCurrentThreads() -> [Sentry.Thread] {

--- a/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
+++ b/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+class TestThreadInspector: SentryThreadInspector {
+    
+    init() {
+        // We need something to pass to the super initializer, because the empty initializer has been marked unavailable.
+        let inAppLogic = SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])
+        let crashStackEntryMapper = SentryCrashStackEntryMapper(inAppLogic: inAppLogic)
+        let stacktraceBuilder = SentryStacktraceBuilder(crashStackEntryMapper: crashStackEntryMapper)
+        super.init(stacktraceBuilder: stacktraceBuilder, andMachineContextWrapper: SentryCrashDefaultMachineContextWrapper())
+    }
+    
+    override func getCurrentThreads() -> [Sentry.Thread] {
+        return [TestData.thread]
+    }
+
+}


### PR DESCRIPTION
The SentryClientTests used SentryThreadInspector for asserting that SentryClient
appropriately calls the SentryThreadInspector, and it also validated the thread's
stacktraces. The assertion also compared the number of threads, which can easily
change between the call to SentryClient and the assertion later on. As
SentryThreadInspectorTests test the functionality of SentryThreadInspector, we can
instead use a test implementation in SentryClientTests to make the tests deterministic.

Fixes GH-1706

#skip-changelog