### PR TITLE
feat: Add flag for UIViewControllerTracking

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -184,6 +184,14 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) BOOL enableAutoPerformanceTracking;
 
+#if SENTRY_HAS_UIKIT
+/**
+ * When enabled, the SDK tracks performance for UIViewController subclasses. The default is
+ * <code>YES</code>.
+ */
+@property (nonatomic, assign) BOOL enableUIViewControllerTracking;
+#endif
+
 /**
  * When enabled, the SDK adds breadcrumbs for HTTP requests and tracks performance for HTTP
  * requests if auto performance tracking and enableSwizzling are enabled. The default is

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -52,6 +52,9 @@ SentryOptions ()
         self.maxAttachmentSize = 20 * 1024 * 1024;
         self.sendDefaultPii = NO;
         self.enableAutoPerformanceTracking = YES;
+#if SENTRY_HAS_UIKIT
+        self.enableUIViewControllerTracking = YES;
+#endif
         self.enableNetworkTracking = YES;
         self.enableFileIOTracking = NO;
         self.enableNetworkBreadcrumbs = YES;
@@ -219,6 +222,11 @@ SentryOptions ()
 
     [self setBool:options[@"enableAutoPerformanceTracking"]
             block:^(BOOL value) { self->_enableAutoPerformanceTracking = value; }];
+
+#if SENTRY_HAS_UIKIT
+    [self setBool:options[@"enableUIViewControllerTracking"]
+            block:^(BOOL value) { self->_enableUIViewControllerTracking = value; }];
+#endif
 
     [self setBool:options[@"enableNetworkTracking"]
             block:^(BOOL value) { self->_enableNetworkTracking = value; }];

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -58,6 +58,15 @@ SentryPerformanceTrackingIntegration ()
         return YES;
     }
 
+#if SENTRY_HAS_UIKIT
+    if (!options.enableUIViewControllerTracking) {
+        [SentryLog logWithMessage:@"enableUIViewControllerTracking disabled. Will not start "
+                                  @"SentryPerformanceTrackingIntegration."
+                         andLevel:kSentryLevelDebug];
+        return YES;
+    }
+#endif
+
     if (!options.isTracingEnabled) {
         [SentryLog logWithMessage:@"No tracesSampleRate and tracesSampler set. Will not start "
                                   @"SentryPerformanceTrackingIntegration."

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
@@ -43,15 +43,27 @@ class SentryPerformanceTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(Dynamic(sut).swizzling.asObject)
     }
     
-    func test_AutoPerformanceDisabled_RemovesEnabledIntegration() {
+    func testAutoPerformanceDisabled_DisablesIntegration() {
         let options = Options()
         options.enableAutoPerformanceTracking = false
         
+        disablesIntegration(options)
+    }
+    
+    func testUIViewControllerDisabled_DisablesIntegration() {
+        let options = Options()
+        options.enableUIViewControllerTracking = false
+        
+        disablesIntegration(options)
+    }
+    
+    private func disablesIntegration(_ options: Options) {
         let sut = SentryPerformanceTrackingIntegration()
         sut.install(with: options)
         
         let expexted = Options.defaultIntegrations().filter { !$0.contains("PerformanceTracking") }
         assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertNil(Dynamic(sut).swizzling.asObject)
     }
     
 #endif

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -486,6 +486,9 @@
         @"maxAttachmentSize" : [NSNull null],
         @"sendDefaultPii" : [NSNull null],
         @"enableAutoPerformanceTracking" : [NSNull null],
+#if SENTRY_HAS_UIKIT
+        @"enableUIViewControllerTracking" : [NSNull null],
+#endif
         @"enableNetworkTracking" : [NSNull null],
         @"tracesSampleRate" : [NSNull null],
         @"tracesSampler" : [NSNull null],
@@ -526,6 +529,9 @@
     XCTAssertEqual(20 * 1024 * 1024, options.maxAttachmentSize);
     XCTAssertEqual(NO, options.sendDefaultPii);
     XCTAssertTrue(options.enableAutoPerformanceTracking);
+#if SENTRY_HAS_UIKIT
+    XCTAssertTrue(options.enableUIViewControllerTracking);
+#endif
     XCTAssertEqual(YES, options.enableNetworkTracking);
     XCTAssertNil(options.tracesSampleRate);
     XCTAssertNil(options.tracesSampler);
@@ -603,6 +609,13 @@
 {
     [self testBooleanField:@"enableAutoPerformanceTracking"];
 }
+
+#if SENTRY_HAS_UIKIT
+- (void)testEnableUIViewControllerTracking
+{
+    [self testBooleanField:@"enableUIViewControllerTracking"];
+}
+#endif
 
 - (void)testEnableNetworkTracking
 {


### PR DESCRIPTION




## :scroll: Description

Add a flag enableUIViewControllerTracking to allow disabling of
tracking APM for UIViewControllers.

## :bulb: Motivation and Context

Fixes GH-1594

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
