### PR TITLE
fix: Wrongly sampling transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
+### Important notice
+
+This release contains a fix for the sampling of transactions. The SDK applied both sample rates for events and transactions when capturing transactions. Previously, when setting sampleRate to 0.0, the SDK would discard all transactions.
+This is fixed now by ignoring the sampleRate for transactions. If you use custom values for sampleRate and traceSampleRate or traceSampler, this change will have an impact on you.
+
+- fix: Wrongly sampling transactions (#1716)
 - feat: Add flag for UIViewControllerTracking (#1711)
+
 ## 7.12.0-beta.0
 
 ### Various fixes & improvements

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -111,8 +111,8 @@ NS_SWIFT_NAME(Options)
 
 /**
  * Indicates the percentage of events being sent to Sentry. Setting this to 0 discards all
- * events, 1.0 or NIL sends all events, 0.01 collects 1% of all events. The default is 1. The value needs
- * to be >= 0.0 and <= 1.0. When setting a value out of range  the SDK sets it to the default
+ * events, 1.0 or NIL sends all events, 0.01 collects 1% of all events. The default is 1. The value
+ * needs to be >= 0.0 and <= 1.0. When setting a value out of range  the SDK sets it to the default
  * of 1.0.
  */
 @property (nullable, nonatomic, copy) NSNumber *sampleRate;

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -110,8 +110,8 @@ NS_SWIFT_NAME(Options)
 + (NSArray<NSString *> *)defaultIntegrations;
 
 /**
- * Indicates the percentage of events being sent to Sentry. Setting this to 0 or NIL discards all
- * events, 1.0 sends all events, 0.01 collects 1% of all events. The default is 1. The value needs
+ * Indicates the percentage of events being sent to Sentry. Setting this to 0 discards all
+ * events, 1.0 or NIL sends all events, 0.01 collects 1% of all events. The default is 1. The value needs
  * to be >= 0.0 and <= 1.0. When setting a value out of range  the SDK sets it to the default
  * of 1.0.
  */

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -406,9 +406,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return nil;
     }
 
+    BOOL eventIsNotATransaction
+        = event.type == nil || ![event.type isEqualToString:SentryEnvelopeItemTypeTransaction];
+
     // Transactions have their own sampleRate
-    if (![event isKindOfClass:[SentryTransaction class]] &&
-        [self isSampled:self.options.sampleRate]) {
+    if (eventIsNotATransaction && [self isSampled:self.options.sampleRate]) {
         [SentryLog logWithMessage:@"Event got sampled, will not send the event"
                          andLevel:kSentryLevelDebug];
         return nil;
@@ -441,9 +443,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     [self setSdk:event];
 
-    // We don't want to attach debug meta and stacktraces for transactions
-    BOOL eventIsNotATransaction
-        = event.type == nil || ![event.type isEqualToString:SentryEnvelopeItemTypeTransaction];
+    // We don't want to attach debug meta and stacktraces for transactions;
     if (eventIsNotATransaction) {
         BOOL shouldAttachStacktrace = alwaysAttachStacktrace || self.options.attachStacktrace
             || (nil != event.exceptions && [event.exceptions count] > 0);

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -5,6 +5,7 @@
 #import "SentryCrashStackEntryMapper.h"
 #import "SentryDebugImageProvider.h"
 #import "SentryDefaultCurrentDateProvider.h"
+#import "SentryDependencyContainer.h"
 #import "SentryDsn.h"
 #import "SentryEnvelope.h"
 #import "SentryEnvelopeItemType.h"
@@ -25,6 +26,7 @@
 #import "SentryOptions+Private.h"
 #import "SentryOptions.h"
 #import "SentryOutOfMemoryTracker.h"
+#import "SentryRandom.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"
 #import "SentryScope.h"
@@ -52,6 +54,7 @@ SentryClient ()
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 @property (nonatomic, strong) SentryThreadInspector *threadInspector;
+@property (nonatomic, strong) id<SentryRandom> random;
 
 @end
 
@@ -93,6 +96,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
         self.transport = [SentryTransportFactory initTransport:self.options
                                              sentryFileManager:self.fileManager];
+
+        self.random = [SentryDependencyContainer sharedInstance].random;
     }
     return self;
 }
@@ -102,12 +107,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                       transport:(id<SentryTransport>)transport
                     fileManager:(SentryFileManager *)fileManager
                 threadInspector:(SentryThreadInspector *)threadInspector
+                         random:(id<SentryRandom>)random
 {
     self = [self initWithOptions:options];
 
     self.transport = transport;
     self.fileManager = fileManager;
     self.threadInspector = threadInspector;
+    self.random = random;
 
     return self;
 }
@@ -378,19 +385,6 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     [self.fileManager storeEnvelope:envelope];
 }
 
-/**
- * returns BOOL chance of YES is defined by sampleRate.
- * if sample rate isn't within 0.0 - 1.0 it returns YES (like if sampleRate
- * is 1.0)
- */
-- (BOOL)checkSampleRate:(NSNumber *)sampleRate
-{
-    if (nil == sampleRate || ![self.options isValidSampleRate:sampleRate]) {
-        return YES;
-    }
-    return ([sampleRate floatValue] >= ((double)arc4random() / 0x100000000));
-}
-
 - (SentryEvent *_Nullable)prepareEvent:(SentryEvent *)event
                              withScope:(SentryScope *)scope
                 alwaysAttachStacktrace:(BOOL)alwaysAttachStacktrace
@@ -412,7 +406,9 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return nil;
     }
 
-    if (NO == [self checkSampleRate:self.options.sampleRate]) {
+    // Transactions have their own sampleRate
+    if (![event isKindOfClass:[SentryTransaction class]] &&
+        [self isSampled:self.options.sampleRate]) {
         [SentryLog logWithMessage:@"Event got sampled, will not send the event"
                          andLevel:kSentryLevelDebug];
         return nil;
@@ -503,6 +499,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     return event;
+}
+
+- (BOOL)isSampled:(NSNumber *)sampleRate
+{
+    if (nil == sampleRate) {
+        return NO;
+    }
+
+    return [self.random nextNumber] <= sampleRate.doubleValue ? NO : YES;
 }
 
 - (BOOL)isDisabled

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -75,4 +75,14 @@ static NSObject *sentryDependencyContainerLock;
     }
 }
 
+- (id<SentryRandom>)random
+{
+    @synchronized(sentryDependencyContainerLock) {
+        if (_random == nil) {
+            _random = [[SentryRandom alloc] init];
+        }
+        return _random;
+    }
+}
+
 @end

--- a/Sources/Sentry/SentryTracesSampler.m
+++ b/Sources/Sentry/SentryTracesSampler.m
@@ -1,4 +1,5 @@
 #import "SentryTracesSampler.h"
+#import "SentryDependencyContainer.h"
 #import "SentryOptions.h"
 #import "SentrySamplingContext.h"
 #import "SentryTransactionContext.h"
@@ -21,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithOptions:(SentryOptions *)options
 {
-    return [self initWithOptions:options random:[[SentryRandom alloc] init]];
+    return [self initWithOptions:options random:[SentryDependencyContainer sharedInstance].random];
 }
 
 - (SentrySampleDecision)sample:(SentrySamplingContext *)context

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentryRandom.h"
 #import <Foundation/Foundation.h>
 
 @class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper;
@@ -18,6 +19,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryAppStateManager *appStateManager;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryThreadWrapper *threadWrapper;
+@property (nonatomic, strong) id<SentryRandom> random;
 
 @end
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -1,3 +1,4 @@
+#import "SentryRandom.h"
 #import "SentryTransport.h"
 #import <Sentry/Sentry.h>
 
@@ -12,7 +13,8 @@ SentryClient (TestInit)
 - (instancetype)initWithOptions:(SentryOptions *)options
                       transport:(id<SentryTransport>)transport
                     fileManager:(SentryFileManager *)fileManager
-                threadInspector:(SentryThreadInspector *)threadInspector;
+                threadInspector:(SentryThreadInspector *)threadInspector
+                         random:(id<SentryRandom>)random;
 
 @end
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -24,7 +24,7 @@ class SentryClientTest: XCTestCase {
         let random = TestRandom(value: 1.0)
         
         let trace = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
-        let transaction : Transaction
+        let transaction: Transaction
         
         init() {
             session = SentrySession(releaseName: "release")
@@ -625,7 +625,7 @@ class SentryClientTest: XCTestCase {
             options.sampleRate = sampleRate
         }).capture(event: TestData.event)
         
-        if (isSampled) {
+        if isSampled {
             eventId.assertIsEmpty()
             assertNothingSent()
         } else {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -21,6 +21,10 @@ class SentryClientTest: XCTestCase {
         
         let user: User
         let fileManager: SentryFileManager
+        let random = TestRandom(value: 1.0)
+        
+        let trace = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
+        let transaction : Transaction
         
         init() {
             session = SentrySession(releaseName: "release")
@@ -38,6 +42,8 @@ class SentryClientTest: XCTestCase {
             let options = Options()
             options.dsn = SentryClientTest.dsn
             fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: TestCurrentDateProvider())
+            
+            transaction = Transaction(trace: trace, children: [])
         }
 
         func getSut(configureOptions: (Options) -> Void = { _ in }) -> Client {
@@ -48,7 +54,7 @@ class SentryClientTest: XCTestCase {
                 ])
                 configureOptions(options)
 
-                client = Client(options: options, transport: transport, fileManager: fileManager, threadInspector: threadInspector)
+                client = Client(options: options, transport: transport, fileManager: fileManager, threadInspector: threadInspector, random: random)
             } catch {
                 XCTFail("Options could not be created")
             }
@@ -596,6 +602,53 @@ class SentryClientTest: XCTestCase {
         assertNothingSent()
     }
     
+    func testSampleRateNil_EventNotSampled() {
+        testSampleRate(sampleRate: nil, randomValue: 0, isSampled: false)
+    }
+    
+    func testSampleRateBiggerRandom_EventNotSampled() {
+        testSampleRate(sampleRate: 0.5, randomValue: 0.49, isSampled: false)
+    }
+    
+    func testSampleRateEqualsRandom_EventNotSampled() {
+        testSampleRate(sampleRate: 0.5, randomValue: 0.5, isSampled: false)
+    }
+    
+    func testSampleRateSmallerRandom_EventSampled() {
+        testSampleRate(sampleRate: 0.50, randomValue: 0.51, isSampled: true)
+    }
+    
+    private func testSampleRate( sampleRate: NSNumber?, randomValue: Double, isSampled: Bool) {
+        fixture.random.value = randomValue
+        
+        let eventId = fixture.getSut(configureOptions: { options in
+            options.sampleRate = sampleRate
+        }).capture(event: TestData.event)
+        
+        if (isSampled) {
+            eventId.assertIsEmpty()
+            assertNothingSent()
+        } else {
+            eventId.assertIsNotEmpty()
+            assertLastSentEvent { actual in
+                XCTAssertEqual(eventId, actual.eventId)
+            }
+        }
+    }
+    
+    func testSampleRateDoesNotImpactTransactions() {
+        fixture.random.value = 0.51
+        
+        let eventId = fixture.getSut(configureOptions: { options in
+            options.sampleRate = 0.00
+        }).capture(event: fixture.transaction)
+        
+        eventId.assertIsNotEmpty()
+        assertLastSentEvent { actual in
+            XCTAssertEqual(eventId, actual.eventId)
+        }
+    }
+    
     func testNoDsn_UserFeedbackNotSent() {
         let sut = fixture.getSutWithNoDsn()
         sut.capture(userFeedback: UserFeedback(eventId: SentryId()))
@@ -836,8 +889,7 @@ class SentryClientTest: XCTestCase {
     }
     
     func testCaptureTransactionEvent_sendTraceState() {
-        let trace = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
-        let transaction = Transaction(trace: trace, children: [])
+        let transaction = fixture.transaction
         let client = fixture.getSut()
         client.options.experimentalEnableTraceSampling = true
         client.capture(event: transaction)
@@ -846,8 +898,7 @@ class SentryClientTest: XCTestCase {
     }
     
     func testCaptureTransactionEvent_dontSendTraceState() {
-        let trace = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
-        let transaction = Transaction(trace: trace, children: [])
+        let transaction = fixture.transaction
         let client = fixture.getSut()
         client.capture(event: transaction)
         
@@ -858,7 +909,7 @@ class SentryClientTest: XCTestCase {
         let event = Event(level: SentryLevel.warning)
         event.message = fixture.message
         let scope = Scope()
-        scope.span = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
+        scope.span = fixture.trace
         
         let client = fixture.getSut()
         client.options.experimentalEnableTraceSampling = true


### PR DESCRIPTION


## :scroll: Description

The SDK applied both sample rates for events and transactions when capturing transactions.
Previously, when setting sampleRate to 0.0, the SDK would sample all transactions. This is
fixed now by ignoring the sampleRate for transactions.

I had to refactor the code a bit to make it testable.

## :bulb: Motivation and Context

Came up when investigating https://github.com/getsentry/sentry-cocoa/issues/1655.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
