### PR TITLE
fix: Updated Sauce Labs config file to a valid iOS version

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -16,7 +16,7 @@ suites:
   - name: "iOS-15"
     devices:
       - name: "iPhone.*"
-        platformVersion: "15.2"
+        platformVersion: "15.4"
         
   - name: "iOS-14"
     devices:


### PR DESCRIPTION
## :scroll: Description

Updated Sauce Labs config file since they removed iOS 15.2 in favor of iOS 15.4.

_#skip-changelog_