### PR TITLE
fix: Possible endless loop for onCrashedLastRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is fixed now by ignoring the sampleRate for transactions. If you use custom
 
 ### Various fixes & improvements
 
+- fix: Possible endless loop for onCrashedLastRun (#1734)
 - fix: Wrongly sampling transactions (#1716)
 - feat: Add flag for UIViewControllerTracking (#1711)
 - feat: Add more info to touch event breadcrumbs (#1724)

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -494,8 +494,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     if (isCrashEvent && nil != self.options.onCrashedLastRun && !SentrySDK.crashedLastRunCalled) {
         // We only want to call the callback once. It can occur that multiple crash events are
         // about to be sent.
-        self.options.onCrashedLastRun(event);
         SentrySDK.crashedLastRunCalled = YES;
+        self.options.onCrashedLastRun(event);
     }
 
     return event;

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -892,7 +892,7 @@ class SentryClientTest: XCTestCase {
         let event = TestData.event
         let expectation = expectation(description: "onCrashedLastRun called")
         
-        var captureCrash: (()-> Void)?
+        var captureCrash: (() -> Void)?
         
         let client = fixture.getSut(configureOptions: { options in
             options.onCrashedLastRun = { crashEvent in

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -888,6 +888,26 @@ class SentryClientTest: XCTestCase {
         client.captureCrash(TestData.event, with: fixture.scope)
     }
     
+    func testOnCrashedLastRun_CallingCaptureCrash_OnlyInvokeCallbackOnce() {
+        let event = TestData.event
+        let expectation = expectation(description: "onCrashedLastRun called")
+        
+        var captureCrash: (()-> Void)?
+        
+        let client = fixture.getSut(configureOptions: { options in
+            options.onCrashedLastRun = { crashEvent in
+                expectation.fulfill()
+                XCTAssertEqual(event.eventId, crashEvent.eventId)
+                captureCrash!()
+            }
+        })
+        captureCrash = { client.captureCrash(event, with: self.fixture.scope) }
+        
+        client.captureCrash(event, with: fixture.scope)
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+    
     func testCaptureTransactionEvent_sendTraceState() {
         let transaction = fixture.transaction
         let client = fixture.getSut()

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -890,13 +890,13 @@ class SentryClientTest: XCTestCase {
     
     func testOnCrashedLastRun_CallingCaptureCrash_OnlyInvokeCallbackOnce() {
         let event = TestData.event
-        let expectation = expectation(description: "onCrashedLastRun called")
+        let callbackExpectation = expectation(description: "onCrashedLastRun called")
         
         var captureCrash: (() -> Void)?
         
         let client = fixture.getSut(configureOptions: { options in
             options.onCrashedLastRun = { crashEvent in
-                expectation.fulfill()
+                callbackExpectation.fulfill()
                 XCTAssertEqual(event.eventId, crashEvent.eventId)
                 captureCrash!()
             }
@@ -905,7 +905,7 @@ class SentryClientTest: XCTestCase {
         
         client.captureCrash(event, with: fixture.scope)
         
-        wait(for: [expectation], timeout: 0.1)
+        wait(for: [callbackExpectation], timeout: 0.1)
     }
     
     func testCaptureTransactionEvent_sendTraceState() {


### PR DESCRIPTION


## :scroll: Description

Calling captureCrash inside the onCrashedLastRun callback leads to an
endless loop. As captureCrash is not public, the chances are low that this
ever happens. Nevertheless, we can easily fix this by setting the BOOL for
crashedLastRunCalled before executing the callback.

## :bulb: Motivation and Context

I spotted this while answering a question for onCrashedLastRun.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
