### PR TITLE
fix: Avoid race condition in SentryCrash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This is fixed now by ignoring the sampleRate for transactions. If you use custom
 
 ### Various fixes & improvements
 
+- fix: Avoid race condition in SentryCrash (#1735)
 - fix: Wrongly sampling transactions (#1716)
 - feat: Add flag for UIViewControllerTracking (#1711)
 - feat: Add more info to touch event breadcrumbs (#1724)

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -97,7 +97,9 @@ __cxa_throw(void *thrown_exception, std::type_info *tinfo, void (*dest)(void *))
 static void
 CPPExceptionTerminate(void)
 {
-    sentrycrashmc_suspendEnvironment();
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+    sentrycrashmc_suspendEnvironment(&threads, &numThreads);
     SentryCrashLOG_DEBUG("Trapped c++ exception");
     const char *name = NULL;
     std::type_info *tinfo = __cxxabiv1::__cxa_current_exception_type();
@@ -163,7 +165,7 @@ CPPExceptionTerminate(void)
         SentryCrashLOG_DEBUG("Detected NSException. Letting the current "
                              "NSException handler deal with it.");
     }
-    sentrycrashmc_resumeEnvironment();
+    sentrycrashmc_resumeEnvironment(threads, numThreads);
 
     SentryCrashLOG_DEBUG("Calling original terminate handler.");
     g_originalTerminateHandler();

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Deadlock.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Deadlock.m
@@ -102,7 +102,9 @@ static NSTimeInterval g_watchdogInterval = 0;
 
 - (void)handleDeadlock
 {
-    sentrycrashmc_suspendEnvironment();
+    thread_act_array_t threads = NULL;
+    mach_msg_type_number_t numThreads = 0;
+    sentrycrashmc_suspendEnvironment(&threads, &numThreads);
     sentrycrashcm_notifyFatalExceptionCaptured(false);
 
     SentryCrashMC_NEW_CONTEXT(machineContext);
@@ -122,7 +124,7 @@ static NSTimeInterval g_watchdogInterval = 0;
     crashContext->stackCursor = &stackCursor;
 
     sentrycrashcm_handleException(crashContext);
-    sentrycrashmc_resumeEnvironment();
+    sentrycrashmc_resumeEnvironment(threads, numThreads);
     sentrycrash_async_backtrace_decref(stackCursor.async_caller);
 
     SentryCrashLOG_DEBUG(@"Calling abort()");

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -276,7 +276,9 @@ handleExceptions(void *const userData)
     SentryCrashLOG_DEBUG("Trapped mach exception code 0x%x, subcode 0x%x", exceptionMessage.code[0],
         exceptionMessage.code[1]);
     if (g_isEnabled) {
-        sentrycrashmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        sentrycrashmc_suspendEnvironment(&threads, &numThreads);
         g_isHandlingCrash = true;
         sentrycrashcm_notifyFatalExceptionCaptured(true);
 
@@ -339,7 +341,7 @@ handleExceptions(void *const userData)
 
         SentryCrashLOG_DEBUG("Crash handling complete. Restoring original handlers.");
         g_isHandlingCrash = false;
-        sentrycrashmc_resumeEnvironment();
+        sentrycrashmc_resumeEnvironment(threads, numThreads);
         sentrycrash_async_backtrace_decref(g_stackCursor.async_caller);
     }
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -61,7 +61,9 @@ handleException(NSException *exception, BOOL currentSnapshotUserReported)
 {
     SentryCrashLOG_DEBUG(@"Trapped exception %@", exception);
     if (g_isEnabled) {
-        sentrycrashmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        sentrycrashmc_suspendEnvironment(&threads, &numThreads);
         sentrycrashcm_notifyFatalExceptionCaptured(false);
 
         SentryCrashLOG_DEBUG(@"Filling out context.");
@@ -100,7 +102,7 @@ handleException(NSException *exception, BOOL currentSnapshotUserReported)
 
         free(callstack);
         if (currentSnapshotUserReported) {
-            sentrycrashmc_resumeEnvironment();
+            sentrycrashmc_resumeEnvironment(threads, numThreads);
         }
         if (g_previousUncaughtExceptionHandler != NULL) {
             SentryCrashLOG_DEBUG(@"Calling original exception handler.");

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -83,7 +83,9 @@ handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
 {
     SentryCrashLOG_DEBUG("Trapped signal %d", sigNum);
     if (g_isEnabled) {
-        sentrycrashmc_suspendEnvironment();
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
+        sentrycrashmc_suspendEnvironment(&threads, &numThreads);
         sentrycrashcm_notifyFatalExceptionCaptured(false);
 
         SentryCrashLOG_DEBUG("Filling out context.");
@@ -104,7 +106,7 @@ handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
         crashContext->stackCursor = &g_stackCursor;
 
         sentrycrashcm_handleException(crashContext);
-        sentrycrashmc_resumeEnvironment();
+        sentrycrashmc_resumeEnvironment(threads, numThreads);
         sentrycrash_async_backtrace_decref(g_stackCursor.async_caller);
     }
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
@@ -46,8 +46,10 @@ sentrycrashcm_reportUserException(const char *name, const char *reason, const ch
         SentryCrashLOG_WARN("User-reported exception monitor is not installed. "
                             "Exception has not been recorded.");
     } else {
+        thread_act_array_t threads = NULL;
+        mach_msg_type_number_t numThreads = 0;
         if (logAllThreads) {
-            sentrycrashmc_suspendEnvironment();
+            sentrycrashmc_suspendEnvironment(&threads, &numThreads);
         }
         if (terminateProgram) {
             sentrycrashcm_notifyFatalExceptionCaptured(false);
@@ -78,7 +80,7 @@ sentrycrashcm_reportUserException(const char *name, const char *reason, const ch
         sentrycrash_async_backtrace_decref(stackCursor.async_caller);
 
         if (logAllThreads) {
-            sentrycrashmc_resumeEnvironment();
+            sentrycrashmc_resumeEnvironment(threads, numThreads);
         }
         if (terminateProgram) {
             abort();

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -172,8 +172,8 @@ isThreadInList(thread_t thread, SentryCrashThread *list, int listCount)
 #endif
 
 void
-sentrycrashmc_suspendEnvironment(__unused thread_act_array_t *suspendedThreads,
-    __unused mach_msg_type_number_t *numSuspendedThreads)
+sentrycrashmc_suspendEnvironment(
+    thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads)
 {
 #if SentryCrashCRASH_HAS_THREADS_API
     SentryCrashLOG_DEBUG("Suspending environment.");

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -212,7 +212,7 @@ sentrycrashmc_resumeEnvironment(
     const thread_t thisThread = (thread_t)sentrycrashthread_self();
 
     if (threads == NULL || numThreads == 0) {
-        SentryCrashLOG_ERROR("we should call ksmc_suspendEnvironment() first");
+        SentryCrashLOG_ERROR("we should call sentrycrashmc_suspendEnvironment() first");
         return;
     }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -172,23 +172,22 @@ isThreadInList(thread_t thread, SentryCrashThread *list, int listCount)
 #endif
 
 void
-sentrycrashmc_suspendEnvironment()
+sentrycrashmc_suspendEnvironment(__unused thread_act_array_t *suspendedThreads,
+    __unused mach_msg_type_number_t *numSuspendedThreads)
 {
 #if SentryCrashCRASH_HAS_THREADS_API
     SentryCrashLOG_DEBUG("Suspending environment.");
     kern_return_t kr;
     const task_t thisTask = mach_task_self();
     const thread_t thisThread = (thread_t)sentrycrashthread_self();
-    thread_act_array_t threads;
-    mach_msg_type_number_t numThreads;
 
-    if ((kr = task_threads(thisTask, &threads, &numThreads)) != KERN_SUCCESS) {
+    if ((kr = task_threads(thisTask, suspendedThreads, numSuspendedThreads)) != KERN_SUCCESS) {
         SentryCrashLOG_ERROR("task_threads: %s", mach_error_string(kr));
         return;
     }
 
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        thread_t thread = threads[i];
+    for (mach_msg_type_number_t i = 0; i < *numSuspendedThreads; i++) {
+        thread_t thread = (*suspendedThreads)[i];
         if (thread != thisThread
             && !isThreadInList(thread, g_reservedThreads, g_reservedThreadsCount)) {
             if ((kr = thread_suspend(thread)) != KERN_SUCCESS) {
@@ -198,28 +197,22 @@ sentrycrashmc_suspendEnvironment()
         }
     }
 
-    for (mach_msg_type_number_t i = 0; i < numThreads; i++) {
-        mach_port_deallocate(thisTask, threads[i]);
-    }
-    vm_deallocate(thisTask, (vm_address_t)threads, sizeof(thread_t) * numThreads);
-
     SentryCrashLOG_DEBUG("Suspend complete.");
 #endif
 }
 
 void
-sentrycrashmc_resumeEnvironment()
+sentrycrashmc_resumeEnvironment(
+    __unused thread_act_array_t threads, __unused mach_msg_type_number_t numThreads)
 {
 #if SentryCrashCRASH_HAS_THREADS_API
     SentryCrashLOG_DEBUG("Resuming environment.");
     kern_return_t kr;
     const task_t thisTask = mach_task_self();
     const thread_t thisThread = (thread_t)sentrycrashthread_self();
-    thread_act_array_t threads;
-    mach_msg_type_number_t numThreads;
 
-    if ((kr = task_threads(thisTask, &threads, &numThreads)) != KERN_SUCCESS) {
-        SentryCrashLOG_ERROR("task_threads: %s", mach_error_string(kr));
+    if (threads == NULL || numThreads == 0) {
+        SentryCrashLOG_ERROR("we should call ksmc_suspendEnvironment() first");
         return;
     }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -32,15 +32,17 @@ extern "C" {
 #endif
 
 #include "SentryCrashThread.h"
+#include <mach/mach.h>
 #include <stdbool.h>
 
 /** Suspend the runtime environment.
  */
-void sentrycrashmc_suspendEnvironment(void);
+void sentrycrashmc_suspendEnvironment(
+    thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads);
 
 /** Resume the runtime environment.
  */
-void sentrycrashmc_resumeEnvironment(void);
+void sentrycrashmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads);
 
 /** Create a new machine context on the stack.
  * This macro creates a storage object on the stack, as well as a pointer of

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_Tests.m
@@ -42,10 +42,16 @@
 
 - (void)testSuspendResumeThreads
 {
-    sentrycrashmc_suspendEnvironment();
-    sentrycrashmc_suspendEnvironment();
-    sentrycrashmc_resumeEnvironment();
-    sentrycrashmc_resumeEnvironment();
+    thread_act_array_t threads1 = NULL;
+    mach_msg_type_number_t numThreads1 = 0;
+    sentrycrashmc_suspendEnvironment(&threads1, &numThreads1);
+
+    thread_act_array_t threads2 = NULL;
+    mach_msg_type_number_t numThreads2 = 0;
+    sentrycrashmc_suspendEnvironment(&threads2, &numThreads2);
+
+    sentrycrashmc_resumeEnvironment(threads2, numThreads2);
+    sentrycrashmc_resumeEnvironment(threads1, numThreads1);
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description

Apply patch https://github.com/kstenerud/KSCrash/pull/351 that was based on https://github.com/kstenerud/KSCrash/pull/321 
to SentryCrash to avoid a race condition when suspending and resuming the
environment.

## :bulb: Motivation and Context

Came up while investigating https://github.com/getsentry/sentry-cocoa/issues/1533.

## :green_heart: How did you test it?
Just applied the patch which didn't contain any tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
