### PR TITLE
fix: enableProfiling option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: enableProfiling option via initWithDict (#1743)
+
 ## 7.12.0
 
 ### Important notice

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -268,6 +268,11 @@ SentryOptions ()
     [self setBool:options[@"enableCoreDataTracking"]
             block:^(BOOL value) { self->_enableCoreDataTracking = value; }];
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+    [self setBool:options[@"enableProfiling"]
+            block:^(BOOL value) { self->_enableProfiling = value; }];
+#endif
+
     if (nil != error && nil != *error) {
         return NO;
     } else {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -630,6 +630,13 @@
     [self testBooleanField:@"enableSwizzling"];
 }
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+- (void)testEnableProfiling
+{
+    [self testBooleanField:@"enableProfiling" defaultValue:NO];
+}
+#endif
+
 - (void)testTracesSampleRate
 {
     SentryOptions *options = [self getValidOptions:@{ @"tracesSampleRate" : @0.1 }];


### PR DESCRIPTION


## :scroll: Description

The SentryOptions missed setting enableProfiling via initWithDict.

## :bulb: Motivation and Context

Came across this when doing https://github.com/getsentry/sentry-cocoa/pull/1742

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
