### PR TITLE
test: Increase timeout for SentryFileManagerTests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
 
         test-destination-os: ["latest"]
 
+        a: [1,2,3,4,5]
+
         # Test on iOS 12.4
         include:
           - runs-on: macos-10.15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,8 +31,6 @@ jobs:
 
         test-destination-os: ["latest"]
 
-        a: [1,2,3,4,5]
-
         # Test on iOS 12.4
         include:
           - runs-on: macos-10.15

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -199,7 +199,7 @@ class SentryFileManagerTests: XCTestCase {
         }
         fixture.queue.activate()
         
-        wait(for: [envelopeStoredExpectation], timeout: 5)
+        wait(for: [envelopeStoredExpectation], timeout: 10)
 
         let events = sut.getAllEnvelopes()
         XCTAssertEqual(fixture.maxCacheItems, events.count)

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -193,13 +193,13 @@ class SentryFileManagerTests: XCTestCase {
         envelopeStoredExpectation.expectedFulfillmentCount = envelopeCount
         for _ in 0..<envelopeCount {
             fixture.queue.async {
-                self.sut.store(TestConstants.envelope)
                 envelopeStoredExpectation.fulfill()
+                self.sut.store(TestConstants.envelope)
             }
         }
         fixture.queue.activate()
         
-        wait(for: [envelopeStoredExpectation], timeout: 10)
+        wait(for: [envelopeStoredExpectation], timeout: 2)
 
         let events = sut.getAllEnvelopes()
         XCTAssertEqual(fixture.maxCacheItems, events.count)

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -199,7 +199,7 @@ class SentryFileManagerTests: XCTestCase {
         }
         fixture.queue.activate()
         
-        wait(for: [envelopeStoredExpectation], timeout: 2)
+        wait(for: [envelopeStoredExpectation], timeout: 5)
 
         let events = sut.getAllEnvelopes()
         XCTAssertEqual(fixture.maxCacheItems, events.count)

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -188,13 +188,15 @@ class SentryFileManagerTests: XCTestCase {
     }
 
     func testDefaultMaxEnvelopesConcurrent() {
-        let envelopeCount = fixture.maxCacheItems * 10
+        let parallelTaskAmount = 5
         let envelopeStoredExpectation = expectation(description: "Envelope stored")
-        envelopeStoredExpectation.expectedFulfillmentCount = envelopeCount
-        for _ in 0..<envelopeCount {
+        envelopeStoredExpectation.expectedFulfillmentCount = parallelTaskAmount
+        for _ in 0..<parallelTaskAmount {
             fixture.queue.async {
+                for _ in 0..<self.fixture.maxCacheItems {
+                    self.sut.store(TestConstants.envelope)
+                }
                 envelopeStoredExpectation.fulfill()
-                self.sut.store(TestConstants.envelope)
             }
         }
         fixture.queue.activate()


### PR DESCRIPTION
Increase timeout for testDefaultMaxEnvelopesConcurrent because
the CI failed a few times due to timeout exceeded

Related to https://github.com/getsentry/sentry-cocoa/pull/1745

#skip-changelog