### PR TITLE
ci: Disable OOM for UI tests

### DIFF
--- a/scripts/set-device-tests-environment.patch
+++ b/scripts/set-device-tests-environment.patch
@@ -1,12 +1,14 @@
 diff --git a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
-index 25b92eed..ccd2590d 100644
+index 25b92eed..8934d90b 100644
 --- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
 +++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
-@@ -26,6 +26,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
+@@ -26,6 +26,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
              options.enableFileIOTracking = true
              options.enableCoreDataTracking = true
              options.enableProfiling = true
 +            options.environment = "device-tests"
++            // The UI tests generate false OOMs
++            options.enableOutOfMemoryTracking = false
          }
          
          return true


### PR DESCRIPTION
The UI tests generate false OOMs and spam Sentry.

#skip-changelog