### PR TITLE
test: Increase timeout for testDefaultMaxEnvelopesConcurrent

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -201,7 +201,7 @@ class SentryFileManagerTests: XCTestCase {
         }
         fixture.queue.activate()
         
-        wait(for: [envelopeStoredExpectation], timeout: 2)
+        wait(for: [envelopeStoredExpectation], timeout: 10)
 
         let events = sut.getAllEnvelopes()
         XCTAssertEqual(fixture.maxCacheItems, events.count)


### PR DESCRIPTION
This test sometimes fails with timeout exceeded in CI. Let's increase the timeout.

#skip-changelog