### PR TITLE
ref: Add SwizzleWrapper

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */; };
 		7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */; };
 		7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */; };
+		7B34721728086A9D0041F047 /* SentrySwizzleWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B34721628086A9D0041F047 /* SentrySwizzleWrapperTests.swift */; };
 		7B3B473025D6CBFC00D01640 /* SentryNSError.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B3B472F25D6CBFC00D01640 /* SentryNSError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B3B473825D6CC7E00D01640 /* SentryNSError.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B3B473725D6CC7E00D01640 /* SentryNSError.m */; };
 		7B3B473E25D6CEA500D01640 /* SentryNSErrorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B3B473D25D6CEA500D01640 /* SentryNSErrorTests.swift */; };
@@ -438,6 +439,8 @@
 		7BC3936825B1AB3E004F03D3 /* SentryLevelMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC3936725B1AB3E004F03D3 /* SentryLevelMapper.h */; };
 		7BC3936E25B1AB72004F03D3 /* SentryLevelMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC3936D25B1AB72004F03D3 /* SentryLevelMapper.m */; };
 		7BC3937425B1ACB7004F03D3 /* SentryLevelMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC3937325B1ACB7004F03D3 /* SentryLevelMapperTests.swift */; };
+		7BC63F0828081242009D9E37 /* SentrySwizzleWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BC63F0728081242009D9E37 /* SentrySwizzleWrapper.h */; };
+		7BC63F0A28081288009D9E37 /* SentrySwizzleWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BC63F0928081288009D9E37 /* SentrySwizzleWrapper.m */; };
 		7BC6EBF4255C044A0059822A /* SentryEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC6EBF3255C044A0059822A /* SentryEventTests.swift */; };
 		7BC6EBF8255C05060059822A /* TestData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC6EBF7255C05060059822A /* TestData.swift */; };
 		7BC6EC04255C235F0059822A /* SentryFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC6EC03255C235F0059822A /* SentryFrameTests.swift */; };
@@ -937,6 +940,7 @@
 		7B3398622459C14000BD9C96 /* SentryEnvelopeRateLimit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeRateLimit.h; path = include/SentryEnvelopeRateLimit.h; sourceTree = "<group>"; };
 		7B3398642459C15200BD9C96 /* SentryEnvelopeRateLimit.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeRateLimit.m; sourceTree = "<group>"; };
 		7B3398662459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnvelopeRateLimitTests.swift; sourceTree = "<group>"; };
+		7B34721628086A9D0041F047 /* SentrySwizzleWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySwizzleWrapperTests.swift; sourceTree = "<group>"; };
 		7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryClient+TestInit.h"; sourceTree = "<group>"; };
 		7B3B472F25D6CBFC00D01640 /* SentryNSError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryNSError.h; path = Public/SentryNSError.h; sourceTree = "<group>"; };
 		7B3B473725D6CC7E00D01640 /* SentryNSError.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryNSError.m; sourceTree = "<group>"; };
@@ -1106,6 +1110,8 @@
 		7BC3936725B1AB3E004F03D3 /* SentryLevelMapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryLevelMapper.h; path = include/SentryLevelMapper.h; sourceTree = "<group>"; };
 		7BC3936D25B1AB72004F03D3 /* SentryLevelMapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLevelMapper.m; sourceTree = "<group>"; };
 		7BC3937325B1ACB7004F03D3 /* SentryLevelMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLevelMapperTests.swift; sourceTree = "<group>"; };
+		7BC63F0728081242009D9E37 /* SentrySwizzleWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySwizzleWrapper.h; path = include/SentrySwizzleWrapper.h; sourceTree = "<group>"; };
+		7BC63F0928081288009D9E37 /* SentrySwizzleWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySwizzleWrapper.m; sourceTree = "<group>"; };
 		7BC6EBF3255C044A0059822A /* SentryEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEventTests.swift; sourceTree = "<group>"; };
 		7BC6EBF7255C05060059822A /* TestData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestData.swift; sourceTree = "<group>"; };
 		7BC6EC03255C235F0059822A /* SentryFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFrameTests.swift; sourceTree = "<group>"; };
@@ -1610,6 +1616,8 @@
 				15E0A8EC240F2CB000F044E3 /* SentrySerialization.m */,
 				639889B91EDED18400EA7442 /* SentrySwizzle.h */,
 				639889BA1EDED18400EA7442 /* SentrySwizzle.m */,
+				7BC63F0728081242009D9E37 /* SentrySwizzleWrapper.h */,
+				7BC63F0928081288009D9E37 /* SentrySwizzleWrapper.m */,
 				632F434E1F581D5400A18A36 /* SentryCrashExceptionApplication.h */,
 				632F434F1F581D5400A18A36 /* SentryCrashExceptionApplication.m */,
 				7BE3C7662445C0CA00A38442 /* SentryCurrentDate.h */,
@@ -2181,6 +2189,7 @@
 				7BD4E8E727FD95900086C410 /* SentryMigrateSessionInitTests.m */,
 				7BD4E8E527FD84480086C410 /* TestFileManagerDelegate.swift */,
 				631501BA1EE6F30B00512C5B /* SentrySwizzleTests.m */,
+				7B34721628086A9D0041F047 /* SentrySwizzleWrapperTests.swift */,
 				7BE3C7742445C82300A38442 /* SentryCurrentDateTests.swift */,
 				7BE3C7762445E50A00A38442 /* TestCurrentDateProvider.swift */,
 				7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */,
@@ -2808,6 +2817,7 @@
 				15360CF02433A16D00112302 /* SentryInstallation.h in Headers */,
 				63FE714720DA4C1100CDBAE8 /* SentryCrashMachineContext.h in Headers */,
 				7BA61CAB247BA98100C130A8 /* SentryDebugImageProvider.h in Headers */,
+				7BC63F0828081242009D9E37 /* SentrySwizzleWrapper.h in Headers */,
 				638DC9A01EBC6B6400A66E41 /* SentryRequestOperation.h in Headers */,
 				7B7A599526B692540060A676 /* SentryScreenFrames.h in Headers */,
 				6344DDB01EC308E400D9160D /* SentryCrashInstallationReporter.h in Headers */,
@@ -3050,6 +3060,7 @@
 				7DB3A687238EA75E00A2D442 /* SentryHttpTransport.m in Sources */,
 				63FE70D520DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.m in Sources */,
 				7B0A54282521C22C00A71716 /* SentryFrameRemover.m in Sources */,
+				7BC63F0A28081288009D9E37 /* SentrySwizzleWrapper.m in Sources */,
 				7B6C5EDC264E8DA80010D138 /* SentryFramesTrackingIntegration.m in Sources */,
 				63295AF71EF3C7DB002D4490 /* NSDictionary+SentrySanitize.m in Sources */,
 				7B8ECBFC26498958005FE2EF /* SentryAppStateManager.m in Sources */,
@@ -3285,6 +3296,7 @@
 				7BD4BD4B27EB2DC20071F4FF /* SentryDiscardedEventTests.swift in Sources */,
 				63FE721A20DA66EC00CDBAE8 /* SentryCrashSysCtl_Tests.m in Sources */,
 				7B88F30424BC8E6500ADF90A /* SentrySerializationTests.swift in Sources */,
+				7B34721728086A9D0041F047 /* SentrySwizzleWrapperTests.swift in Sources */,
 				8EC4CF5025C3A0070093DEE9 /* SentrySpanContextTests.swift in Sources */,
 				7BE0DC2F272ABAF6004FA8B7 /* SentryAutoBreadcrumbTrackingIntegrationTests.swift in Sources */,
 				7BA1C51F2716DDB3005D75A4 /* Invocations.swift in Sources */,

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -1,5 +1,6 @@
 #import "SentryAutoBreadcrumbTrackingIntegration.h"
 #import "SentryBreadcrumbTracker.h"
+#import "SentryDependencyContainer.h"
 #import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -16,8 +17,11 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 - (void)installWithOptions:(nonnull SentryOptions *)options
 {
+
     [self installWithOptions:options
-             breadcrumbTracker:[[SentryBreadcrumbTracker alloc] init]
+             breadcrumbTracker:[[SentryBreadcrumbTracker alloc]
+                                   initWithSwizzleWrapper:[SentryDependencyContainer sharedInstance]
+                                                              .swizzleWrapper]
         systemEventBreadcrumbs:[[SentrySystemEventBreadcrumbs alloc] init]];
 }
 

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -7,6 +7,7 @@
 #import "SentrySDK+Private.h"
 #import "SentryScope.h"
 #import "SentrySwizzle.h"
+#import "SentrySwizzleWrapper.h"
 #import "SentryUIViewControllerSanitizer.h"
 
 #if SENTRY_HAS_UIKIT
@@ -15,7 +16,27 @@
 #    import <Cocoa/Cocoa.h>
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
+static NSString *const SentryBreadcrumbTrackerSwizzleSendAction
+    = @"SentryBreadcrumbTrackerSwizzleSendAction";
+
+@interface
+SentryBreadcrumbTracker ()
+
+@property (nonatomic, strong) SentrySwizzleWrapper *swizzleWrapper;
+
+@end
+
 @implementation SentryBreadcrumbTracker
+
+- (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper
+{
+    if (self = [super init]) {
+        self.swizzleWrapper = swizzleWrapper;
+    }
+    return self;
+}
 
 - (void)start
 {
@@ -31,10 +52,9 @@
 
 - (void)stop
 {
-    // This is a noop because the notifications are registered via blocks and monkey patching
-    // which are both super hard to clean up.
-    // Either way, all these are guarded by checking the client of the current hub, which
-    // we remove when uninstalling the SDK.
+    // All breadcrumbs are guarded by checking the client of the current hub, which we remove when
+    // uninstalling the SDK. Therefore, we don't clean up everything.
+    [self.swizzleWrapper removeSwizzleSendActionForKey:SentryBreadcrumbTrackerSwizzleSendAction];
 }
 
 - (void)trackApplicationUIKitNotifications
@@ -124,34 +144,28 @@
 {
 #if SENTRY_HAS_UIKIT
 
-    // SentrySwizzleInstanceMethod declaration shadows a local variable. The swizzling is working
-    // fine and we accept this warning.
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wshadow"
-
-    static const void *swizzleSendActionKey = &swizzleSendActionKey;
-    SEL selector = NSSelectorFromString(@"sendAction:to:from:forEvent:");
-    SentrySwizzleInstanceMethod(UIApplication.class, selector, SentrySWReturnType(BOOL),
-        SentrySWArguments(SEL action, id target, id sender, UIEvent * event), SentrySWReplacement({
-            if (nil != [SentrySDK.currentHub getClient]) {
-                NSDictionary *data = nil;
-                for (UITouch *touch in event.allTouches) {
-                    if (touch.phase == UITouchPhaseCancelled || touch.phase == UITouchPhaseEnded) {
-                        data = [SentryBreadcrumbTracker extractDataFromView:touch.view];
-                    }
-                }
-
-                SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo
-                                                                         category:@"touch"];
-                crumb.type = @"user";
-                crumb.message = [NSString stringWithFormat:@"%s", sel_getName(action)];
-                crumb.data = data;
-                [SentrySDK addBreadcrumb:crumb];
+    [self.swizzleWrapper
+        swizzleSendAction:^(NSString *action, UIEvent *event) {
+            if ([SentrySDK.currentHub getClient] == nil) {
+                return;
             }
-            return SentrySWCallOriginal(action, target, sender, event);
-        }),
-        SentrySwizzleModeOncePerClassAndSuperclasses, swizzleSendActionKey);
-#    pragma clang diagnostic pop
+
+            NSDictionary *data = nil;
+            for (UITouch *touch in event.allTouches) {
+                if (touch.phase == UITouchPhaseCancelled || touch.phase == UITouchPhaseEnded) {
+                    data = [SentryBreadcrumbTracker extractDataFromView:touch.view];
+                }
+            }
+
+            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo
+                                                                     category:@"touch"];
+            crumb.type = @"user";
+            crumb.message = action;
+            crumb.data = data;
+            [SentrySDK addBreadcrumb:crumb];
+        }
+                   forKey:SentryBreadcrumbTrackerSwizzleSendAction];
+
 #else
     [SentryLog logWithMessage:@"NO UIKit -> [SentryBreadcrumbTracker "
                               @"swizzleSendAction] does nothing."
@@ -223,3 +237,5 @@
 #endif
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -54,7 +54,9 @@ SentryBreadcrumbTracker ()
 {
     // All breadcrumbs are guarded by checking the client of the current hub, which we remove when
     // uninstalling the SDK. Therefore, we don't clean up everything.
+#if SENTRY_HAS_UIKIT
     [self.swizzleWrapper removeSwizzleSendActionForKey:SentryBreadcrumbTrackerSwizzleSendAction];
+#endif
 }
 
 - (void)trackApplicationUIKitNotifications

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -90,7 +90,7 @@ static NSObject *sentryDependencyContainerLock;
 {
     @synchronized(sentryDependencyContainerLock) {
         if (_swizzleWrapper == nil) {
-            _swizzleWrapper = [[SentrySwizzleWrapper alloc] init];
+            _swizzleWrapper = SentrySwizzleWrapper.sharedInstance;
         }
         return _swizzleWrapper;
     }

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -6,6 +6,7 @@
 #import <SentryDependencyContainer.h>
 #import <SentryHub.h>
 #import <SentrySDK+Private.h>
+#import <SentrySwizzleWrapper.h>
 #import <SentrySysctl.h>
 #import <SentryThreadWrapper.h>
 
@@ -82,6 +83,16 @@ static NSObject *sentryDependencyContainerLock;
             _random = [[SentryRandom alloc] init];
         }
         return _random;
+    }
+}
+
+- (SentrySwizzleWrapper *)swizzleWrapper
+{
+    @synchronized(sentryDependencyContainerLock) {
+        if (_swizzleWrapper == nil) {
+            _swizzleWrapper = [[SentrySwizzleWrapper alloc] init];
+        }
+        return _swizzleWrapper;
     }
 }
 

--- a/Sources/Sentry/SentrySwizzleWrapper.m
+++ b/Sources/Sentry/SentrySwizzleWrapper.m
@@ -4,13 +4,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-#if SENTRY_HAS_UIKIT
-
 @interface
 SentrySwizzleWrapper ()
 
+#if SENTRY_HAS_UIKIT
 @property (nonatomic, strong)
     NSMutableDictionary<NSString *, SentrySwizzleSendActionCallback> *swizzleSendActionCallbacks;
+#endif
 
 @end
 
@@ -19,11 +19,14 @@ SentrySwizzleWrapper ()
 - (instancetype)init
 {
     if (self = [super init]) {
+#if SENTRY_HAS_UIKIT
         self.swizzleSendActionCallbacks = [NSMutableDictionary new];
+#endif
     }
     return self;
 }
 
+#if SENTRY_HAS_UIKIT
 - (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key
 {
     // We need to make a copy of the block to avoid ARC of autoreleasing it.
@@ -62,13 +65,14 @@ SentrySwizzleWrapper ()
         callback([NSString stringWithFormat:@"%s", sel_getName(action)], event);
     }
 }
+#endif
 
 - (void)removeAllCallbacks
 {
+#if SENTRY_HAS_UIKIT
     [self.swizzleSendActionCallbacks removeAllObjects];
+#endif
 }
 @end
-
-#endif
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentrySwizzleWrapper.m
+++ b/Sources/Sentry/SentrySwizzleWrapper.m
@@ -1,0 +1,74 @@
+#import "SentrySwizzleWrapper.h"
+#import "SentrySwizzle.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if SENTRY_HAS_UIKIT
+
+@interface
+SentrySwizzleWrapper ()
+
+@property (nonatomic, strong)
+    NSMutableDictionary<NSString *, SentrySwizzleSendActionCallback> *swizzleSendActionCallbacks;
+
+@end
+
+@implementation SentrySwizzleWrapper
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        self.swizzleSendActionCallbacks = [NSMutableDictionary new];
+    }
+    return self;
+}
+
+- (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key
+{
+    // We need to make a copy of the block to avoid ARC of autoreleasing it.
+    self.swizzleSendActionCallbacks[key] = [callback copy];
+
+    if (self.swizzleSendActionCallbacks.count != 1) {
+        return;
+    }
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wshadow"
+
+    __block SentrySwizzleWrapper *_self = self;
+    static const void *swizzleSendActionKey = &swizzleSendActionKey;
+    SEL selector = NSSelectorFromString(@"sendAction:to:from:forEvent:");
+    SentrySwizzleInstanceMethod(UIApplication.class, selector, SentrySWReturnType(BOOL),
+        SentrySWArguments(SEL action, id target, id sender, UIEvent * event), SentrySWReplacement({
+            [_self sendActionCalled:action event:event];
+            return SentrySWCallOriginal(action, target, sender, event);
+        }),
+        SentrySwizzleModeOncePerClassAndSuperclasses, swizzleSendActionKey);
+#    pragma clang diagnostic pop
+}
+
+- (void)removeSwizzleSendActionForKey:(NSString *)key
+{
+    [self.swizzleSendActionCallbacks removeObjectForKey:key];
+}
+
+/**
+ * For testing.
+ */
+- (void)sendActionCalled:(SEL)action event:(UIEvent *)event
+{
+    for (SentrySwizzleSendActionCallback callback in self.swizzleSendActionCallbacks.allValues) {
+        callback([NSString stringWithFormat:@"%s", sel_getName(action)], event);
+    }
+}
+
+- (void)removeAllCallbacks
+{
+    [self.swizzleSendActionCallbacks removeAllObjects];
+}
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryBreadcrumbTracker.h
+++ b/Sources/Sentry/include/SentryBreadcrumbTracker.h
@@ -1,9 +1,18 @@
-#import <Foundation/Foundation.h>
+#import "SentryDefines.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SentrySwizzleWrapper;
 
 @interface SentryBreadcrumbTracker : NSObject
+SENTRY_NO_INIT
+
+- (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper;
 
 - (void)start;
 - (void)startSwizzle;
 - (void)stop;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -2,7 +2,7 @@
 #import "SentryRandom.h"
 #import <Foundation/Foundation.h>
 
-@class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper;
+@class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,6 +20,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryThreadWrapper *threadWrapper;
 @property (nonatomic, strong) id<SentryRandom> random;
+@property (nonatomic, strong) SentrySwizzleWrapper *swizzleWrapper;
 
 @end
 

--- a/Sources/Sentry/include/SentrySwizzleWrapper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapper.h
@@ -1,0 +1,29 @@
+#import "SentryDefines.h"
+
+#if SENTRY_HAS_UIKIT
+#    import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef void (^SentrySwizzleSendActionCallback)(NSString *actionName, UIEvent *event);
+
+/**
+ * A wrapper around swizzling for testability and to only swizzle once when multiple implementations
+ * need to be called for the same swizzled method.
+ */
+@interface SentrySwizzleWrapper : NSObject
+
+- (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key;
+
+- (void)removeSwizzleSendActionForKey:(NSString *)key;
+
+/**
+ * For testing purposes.
+ */
+- (void)removeAllCallbacks;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Sources/Sentry/include/SentrySwizzleWrapper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapper.h
@@ -15,6 +15,9 @@ typedef void (^SentrySwizzleSendActionCallback)(NSString *actionName, UIEvent *e
  * need to be called for the same swizzled method.
  */
 @interface SentrySwizzleWrapper : NSObject
+SENTRY_NO_INIT
+
+@property (class, readonly, nonatomic) SentrySwizzleWrapper *sharedInstance;
 
 #if SENTRY_HAS_UIKIT
 - (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key;

--- a/Sources/Sentry/include/SentrySwizzleWrapper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapper.h
@@ -2,10 +2,13 @@
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if SENTRY_HAS_UIKIT
 typedef void (^SentrySwizzleSendActionCallback)(NSString *actionName, UIEvent *event);
+#endif
 
 /**
  * A wrapper around swizzling for testability and to only swizzle once when multiple implementations
@@ -13,9 +16,11 @@ typedef void (^SentrySwizzleSendActionCallback)(NSString *actionName, UIEvent *e
  */
 @interface SentrySwizzleWrapper : NSObject
 
+#if SENTRY_HAS_UIKIT
 - (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key;
 
 - (void)removeSwizzleSendActionForKey:(NSString *)key;
+#endif
 
 /**
  * For testing purposes.
@@ -25,5 +30,3 @@ typedef void (^SentrySwizzleSendActionCallback)(NSString *actionName, UIEvent *e
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif

--- a/Tests/SentryTests/ClearTestState.swift
+++ b/Tests/SentryTests/ClearTestState.swift
@@ -20,4 +20,5 @@ func clearTestState() {
     
     SentryDependencyContainer.reset()
     Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()
+    SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
 }

--- a/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+class SentrySwizzleWrapperTests: XCTestCase {
+    
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    
+    private class Fixture {
+        let actionName = #selector(someMethod).description
+        let event = UIEvent()
+    }
+    
+    private var fixture: Fixture!
+    private var sut: SentrySwizzleWrapper!
+    
+    @objc
+    func someMethod() {
+        // Empty on purpose
+    }
+    
+    override func setUp() {
+        super.setUp()
+        
+        fixture = Fixture()
+        sut = SentrySwizzleWrapper()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        sut.removeAllCallbacks()
+    }
+    
+    func testSendAction_RegisterCallbacks_CallbacksCalled() {
+        let firstExcpectation = expectation(description: "first")
+        sut.swizzleSendAction({ actualAction, actualEvent in
+            XCTAssertEqual(self.fixture.actionName, actualAction)
+            XCTAssertEqual(self.fixture.event, actualEvent)
+            firstExcpectation.fulfill()
+        }, forKey: "first")
+        
+        let secondExcpectation = expectation(description: "second")
+        sut.swizzleSendAction({ actualAction, actualEvent in
+            XCTAssertEqual(self.fixture.actionName, actualAction)
+            XCTAssertEqual(self.fixture.event, actualEvent)
+            secondExcpectation.fulfill()
+        }, forKey: "second")
+        
+        sendActionCalled()
+        
+        wait(for: [firstExcpectation, secondExcpectation], timeout: 0.1)
+    }
+    
+    func testSendAction_RegisterCallbackForSameKey_LastCallbackCalled() {
+        let firstExcpectation = expectation(description: "first")
+        firstExcpectation.isInverted = true
+        sut.swizzleSendAction({ _, _ in
+            firstExcpectation.fulfill()
+        }, forKey: "first")
+        
+        let secondExcpectation = expectation(description: "second")
+        sut.swizzleSendAction({ actualAction, actualEvent in
+            XCTAssertEqual(self.fixture.actionName, actualAction)
+            XCTAssertEqual(self.fixture.event, actualEvent)
+            secondExcpectation.fulfill()
+        }, forKey: "first")
+        
+        sendActionCalled()
+        
+        wait(for: [firstExcpectation, secondExcpectation], timeout: 0.1)
+    }
+    
+    func testSendAction_RemoveCallback_CallbackNotCalled() {
+        let firstExcpectation = expectation(description: "first")
+        firstExcpectation.isInverted = true
+        sut.swizzleSendAction({ _, _ in
+            firstExcpectation.fulfill()
+        }, forKey: "first")
+        
+        sut.removeSwizzleSendAction(forKey: "first")
+        
+        sendActionCalled()
+        
+        wait(for: [firstExcpectation], timeout: 0.1)
+    }
+    
+    func testSendAction_AfterCallingReset_CallbackNotCalled() {
+        let neverExcpectation = expectation(description: "never")
+        neverExcpectation.isInverted = true
+        sut.swizzleSendAction({ _, _ in
+            neverExcpectation.fulfill()
+        }, forKey: "never")
+        
+        sut.removeAllCallbacks()
+        
+        sendActionCalled()
+        
+        wait(for: [neverExcpectation], timeout: 0.1)
+    }
+    
+    private func sendActionCalled() {
+        Dynamic(sut).sendActionCalled(#selector(someMethod), event: self.fixture.event)
+    }
+
+#endif
+    
+}

--- a/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
@@ -21,12 +21,12 @@ class SentrySwizzleWrapperTests: XCTestCase {
         super.setUp()
         
         fixture = Fixture()
-        sut = SentrySwizzleWrapper()
+        sut = SentrySwizzleWrapper.sharedInstance
     }
     
     override func tearDown() {
         super.tearDown()
-        sut.removeAllCallbacks()
+        clearTestState()
     }
     
     func testSendAction_RegisterCallbacks_CallbacksCalled() {
@@ -97,7 +97,7 @@ class SentrySwizzleWrapperTests: XCTestCase {
     }
     
     private func sendActionCalled() {
-        Dynamic(sut).sendActionCalled(#selector(someMethod), event: self.fixture.event)
+        Dynamic(SentrySwizzleWrapper.self).sendActionCalled(#selector(someMethod), event: self.fixture.event)
     }
 
 #endif

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
     
     private class Fixture {
-        let tracker = SentryTestBreadcrumbTracker()
+        let tracker = SentryTestBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper())
         
         var sut: SentryAutoBreadcrumbTrackingIntegration {
             return SentryAutoBreadcrumbTrackingIntegration()

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
     
     private class Fixture {
-        let tracker = SentryTestBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper())
+        let tracker = SentryTestBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper.sharedInstance)
         
         var sut: SentryAutoBreadcrumbTrackingIntegration {
             return SentryAutoBreadcrumbTrackingIntegration()
@@ -16,6 +16,11 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
     override func setUp() {
         super.setUp()
         fixture = Fixture()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+        clearTestState()
     }
 
     func testInstallWithSwizzleEnabled_StartSwizzleCalled() {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -20,8 +20,20 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
     
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     
+    func testStopRemovesSwizzleSendAction() {
+        let swizzleWrapper = SentrySwizzleWrapper()
+        let sut = SentryBreadcrumbTracker(swizzleWrapper: swizzleWrapper)
+        
+        sut.start()
+        sut.startSwizzle()
+        sut.stop()
+        
+        let dict = Dynamic(swizzleWrapper).swizzleSendActionCallbacks.asDictionary
+        XCTAssertEqual(0, dict?.count)
+    }
+    
     func testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb() {
-        let sut = SentryBreadcrumbTracker()
+        let sut = SentryBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper())
         sut.start()
         sut.startSwizzle()
         

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -21,19 +21,19 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     
     func testStopRemovesSwizzleSendAction() {
-        let swizzleWrapper = SentrySwizzleWrapper()
+        let swizzleWrapper = SentrySwizzleWrapper.sharedInstance
         let sut = SentryBreadcrumbTracker(swizzleWrapper: swizzleWrapper)
         
         sut.start()
         sut.startSwizzle()
         sut.stop()
         
-        let dict = Dynamic(swizzleWrapper).swizzleSendActionCallbacks.asDictionary
+        let dict = Dynamic(swizzleWrapper).swizzleSendActionCallbacks().asDictionary
         XCTAssertEqual(0, dict?.count)
     }
     
     func testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb() {
-        let sut = SentryBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper())
+        let sut = SentryBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper.sharedInstance)
         sut.start()
         sut.startSwizzle()
         

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -128,6 +128,7 @@
 #import "SentryStacktrace.h"
 #import "SentryStacktraceBuilder.h"
 #import "SentrySubClassFinder.h"
+#import "SentrySwizzleWrapper.h"
 #import "SentrySysctl.h"
 #import "SentrySystemEventBreadcrumbs.h"
 #import "SentryTestIntegration.h"


### PR DESCRIPTION

## :scroll: Description

Add a wrapper around swizzling sendAction:to:from:forEvent:
for testability and to only swizzle once when multiple implementations
need to be called for the same swizzled method.

#skip-changelog

## :bulb: Motivation and Context

This PR is preparation for transactions for UI events.

## :green_heart: How did you test it?
Unit tests and simulator

Crumb before
https://sentry.io/organizations/sentry-sdks/issues/2895893229/events/f797f149447e4a7ebe8c68a0c2ac4f63/?project=5428557
<img width="911" alt="Screen Shot 2022-04-19 at 10 56 32" src="https://user-images.githubusercontent.com/2443292/163968270-4ad455fc-8a98-4dba-8da6-f887de2575f4.png">

Crumb after
https://sentry.io/organizations/sentry-sdks/issues/2895893229/events/794156d2586e4abca8d598ea63f20548/?project=5428557
<img width="915" alt="Screen Shot 2022-04-19 at 10 56 49" src="https://user-images.githubusercontent.com/2443292/163968328-b92dc889-9209-44ff-82b4-ebffdf3b715a.png">


## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
