### PR TITLE
fix: Remove duplicate changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 - feat: Add Client Reports (#1733)
 - fix: enableProfiling option via initWithDict (#1743)
-- fix: Remove authenticated pointer stripping for iOS backtraces (#1757)
 
 ## 7.12.0
 


### PR DESCRIPTION
## :scroll: Description

Remove a changelog entry that was duplicated between 7.13.0 and Unreleased. The actual change is unreleased.

_#skip-changelog_

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
