### PR TITLE
fix: NSURL warning during SDK initialization.

### DIFF
--- a/Sources/Sentry/SentryNSURLSessionTaskSearch.m
+++ b/Sources/Sentry/SentryNSURLSessionTaskSearch.m
@@ -43,7 +43,7 @@ https://github.com/AFNetworking/AFNetworking/blob/4eaec5b586ddd897ebeda896e332a6
     // thats why the URL parameter is a empty url that points nowhere.
     // AFNetwork uses nil as parameter, but according to documentation this a nonnull parameter,
     // and when bridged to swift, the nil parameters causes an exception.
-    NSURLSessionDataTask *localDataTask = [session dataTaskWithURL:[NSURL new]];
+    NSURLSessionDataTask *localDataTask = [session dataTaskWithURL:[NSURL URLWithString:@""]];
 
     Class currentClass = [localDataTask class];
     NSMutableArray *result = [[NSMutableArray alloc] init];


### PR DESCRIPTION
We have a warning when the `SentryNetworkTrackingIntegration` because there is a NSURL initialisation without a url.

We don't really use the NSURL we just need an instance to be able to initialise a NSURLSessionDataTask that we also don't use but only retrieve the class type, so using an empty string is fine to fix the warning problem.


