### PR TITLE
ref: Make getDebugImages static for private SDKs

### DIFF
--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -39,7 +39,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * Returns the current list of debug images. Be aware that the SentryDebugMeta is actually
  * describing a debug image. This class should be renamed to SentryDebugImage in a future version.
  */
-- (NSArray<SentryDebugMeta *> *)getDebugImages;
++ (NSArray<SentryDebugMeta *> *)getDebugImages;
 
 @property (class, nullable, nonatomic, copy)
     SentryOnAppStartMeasurementAvailable onAppStartMeasurementAvailable;

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -3,6 +3,7 @@
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
 #import <SentryCrashWrapper.h>
+#import <SentryDebugImageProvider.h>
 #import <SentryDefaultCurrentDateProvider.h>
 #import <SentryDependencyContainer.h>
 #import <SentryHub.h>
@@ -117,6 +118,16 @@ static NSObject *sentryDependencyContainerLock;
             _swizzleWrapper = SentrySwizzleWrapper.sharedInstance;
         }
         return _swizzleWrapper;
+    }
+}
+
+- (SentryDebugImageProvider *)debugImageProvider
+{
+    @synchronized(sentryDependencyContainerLock) {
+        if (_debugImageProvider == nil) {
+            _debugImageProvider = [[SentryDebugImageProvider alloc] init];
+        }
+        return _debugImageProvider;
     }
 }
 

--- a/Sources/Sentry/SentryHybridSKdsOnly.m
+++ b/Sources/Sentry/SentryHybridSKdsOnly.m
@@ -4,14 +4,8 @@
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import <Foundation/Foundation.h>
+#import <SentryDependencyContainer.h>
 #import <SentryFramesTracker.h>
-
-@interface
-PrivateSentrySDKOnly ()
-
-@property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
-
-@end
 
 @implementation PrivateSentrySDKOnly
 
@@ -20,14 +14,6 @@ static BOOL _appStartMeasurementHybridSDKMode = NO;
 #if SENTRY_HAS_UIKIT
 static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 #endif
-
-- (instancetype)init
-{
-    if (self = [super init]) {
-        _debugImageProvider = [[SentryDebugImageProvider alloc] init];
-    }
-    return self;
-}
 
 + (void)storeEnvelope:(SentryEnvelope *)envelope
 {
@@ -44,9 +30,9 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [SentrySerialization envelopeWithData:data];
 }
 
-- (NSArray<SentryDebugMeta *> *)getDebugImages
++ (NSArray<SentryDebugMeta *> *)getDebugImages
 {
-    return [self.debugImageProvider getDebugImages];
+    return [[SentryDependencyContainer sharedInstance].debugImageProvider getDebugImages];
 }
 
 + (nullable SentryAppStartMeasurement *)appStartMeasurement

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -2,7 +2,8 @@
 #import "SentryRandom.h"
 #import <Foundation/Foundation.h>
 
-@class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper;
+@class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper,
+    SentryDebugImageProvider;
 
 #if SENTRY_HAS_UIKIT
 @class SentryScreenshot, SentryUIApplication;
@@ -25,6 +26,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryThreadWrapper *threadWrapper;
 @property (nonatomic, strong) id<SentryRandom> random;
 @property (nonatomic, strong) SentrySwizzleWrapper *swizzleWrapper;
+@property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 
 #if SENTRY_HAS_UIKIT
 @property (nonatomic, strong) SentryScreenshot *screenshot;

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -35,8 +35,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     }
     
     func testGetDebugImages() {
-        let sut = PrivateSentrySDKOnly()
-        let images = sut.getDebugImages()
+        let images = PrivateSentrySDKOnly.getDebugImages()
         
         // Only make sure we get some images. The actual tests are in
         // SentryDebugImageProviderTests


### PR DESCRIPTION
Other methods in PrivateSentrySDKOnly are static. `getDebugImages` not being static makes no sense. 
See https://github.com/getsentry/sentry-dart/pull/823/files#r845811128

#skip-changelog