### PR TITLE
ci: Set fixed saucectl version

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           name: DerivedData-Xcode-${{matrix.xcode}}
 
-      - run: npm install -g saucectl
+      - run: npm install -g saucectl@0.93.0
 
       # As SauceLabs is a bit flaky we retry 5 times
       - name: Run Tests in SauceLab

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - master
-      - ci/saucectl-version
 
   pull_request:
     paths:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - master
+      - ci/saucectl-version
 
   pull_request:
     paths:


### PR DESCRIPTION
Running CI with 0.94.0 fails. Let's pin saucectl to 0.93.0 to make it
work again.

#skip-changelog