### PR TITLE
perf: Reduce the number of binary image in an event

### DIFF
--- a/Sources/Sentry/Public/SentryDebugImageProvider.h
+++ b/Sources/Sentry/Public/SentryDebugImageProvider.h
@@ -1,7 +1,7 @@
 #import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
-@class SentryDebugMeta;
+@class SentryDebugMeta, SentryThread;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,6 +11,13 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryDebugImageProvider : NSObject
 
 - (instancetype)init;
+
+/**
+ * Returns a list of debug images that are being referenced in the given threads.
+ *
+ * @param threads A list of SentryThread that may or may not contains a stacktrace.
+ */
+- (NSArray<SentryDebugMeta *> *)getDebugImagesForThreads:(NSArray<SentryThread *> *)threads;
 
 /**
  * Returns the current list of debug images. Be aware that the SentryDebugMeta is actually

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -469,14 +469,17 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         BOOL shouldAttachStacktrace = alwaysAttachStacktrace || self.options.attachStacktrace
             || (nil != event.exceptions && [event.exceptions count] > 0);
 
-        BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);
-        if (!isCrashEvent && shouldAttachStacktrace && debugMetaNotAttached) {
-            event.debugMeta = [self.debugImageProvider getDebugImages];
-        }
-
         BOOL threadsNotAttached = !(nil != event.threads && event.threads.count > 0);
         if (!isCrashEvent && shouldAttachStacktrace && threadsNotAttached) {
             event.threads = [self.threadInspector getCurrentThreads];
+        }
+
+        BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);
+        if (!isCrashEvent && shouldAttachStacktrace && debugMetaNotAttached) {
+            if (event.threads == nil)
+                event.debugMeta = [self.debugImageProvider getDebugImages];
+            else
+                event.debugMeta = [self.debugImageProvider getDebugImagesForThreads:event.threads];
         }
     }
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -475,7 +475,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         }
 
         BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);
-        if (!isCrashEvent && shouldAttachStacktrace && debugMetaNotAttached && event.threads != nil) {
+        if (!isCrashEvent && shouldAttachStacktrace && debugMetaNotAttached
+            && event.threads != nil) {
             event.debugMeta = [self.debugImageProvider getDebugImagesForThreads:event.threads];
         }
     }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -475,11 +475,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         }
 
         BOOL debugMetaNotAttached = !(nil != event.debugMeta && event.debugMeta.count > 0);
-        if (!isCrashEvent && shouldAttachStacktrace && debugMetaNotAttached) {
-            if (event.threads == nil)
-                event.debugMeta = [self.debugImageProvider getDebugImages];
-            else
-                event.debugMeta = [self.debugImageProvider getDebugImagesForThreads:event.threads];
+        if (!isCrashEvent && shouldAttachStacktrace && debugMetaNotAttached && event.threads != nil) {
+            event.debugMeta = [self.debugImageProvider getDebugImagesForThreads:event.threads];
         }
     }
 

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -45,8 +45,8 @@ SentryDebugImageProvider ()
 
     for (SentryThread *thread in threads) {
         for (SentryFrame *frame in thread.stacktrace.frames) {
-            if (frame.imageAddress && ![imageNames containsObject:frame.imageAddress]) {
-                [imageNames addObject:frame.imageAddress];
+            if (frame.imageAddress && ![imageAdresses containsObject:frame.imageAddress]) {
+                [imageAdresses addObject:frame.imageAddress];
             }
         }
     }
@@ -56,7 +56,7 @@ SentryDebugImageProvider ()
     NSArray<SentryDebugMeta *> *binaryImages = [self getDebugImages];
 
     for (SentryDebugMeta *sourceImage in binaryImages) {
-        if ([imageNames containsObject:sourceImage.imageAddress]) {
+        if ([imageAdresses containsObject:sourceImage.imageAddress]) {
             [result addObject:sourceImage];
         }
     }

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -41,7 +41,7 @@ SentryDebugImageProvider ()
 
 - (NSArray<SentryDebugMeta *> *)getDebugImagesForThreads:(NSArray<SentryThread *> *)threads
 {
-    NSMutableSet<NSString *> *imageNames = [[NSMutableSet alloc] init];
+    NSMutableSet<NSString *> *imageAdresses = [[NSMutableSet alloc] init];
 
     for (SentryThread *thread in threads) {
         for (SentryFrame *frame in thread.stacktrace.frames) {

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -3,8 +3,11 @@
 #import "SentryCrashDynamicLinker.h"
 #import "SentryCrashUUIDConversion.h"
 #import "SentryDebugMeta.h"
+#import "SentryFrame.h"
 #import "SentryHexAddressFormatter.h"
 #import "SentryLog.h"
+#import "SentryStackTrace.h"
+#import "SentryThread.h"
 #import <Foundation/Foundation.h>
 
 @interface
@@ -34,6 +37,31 @@ SentryDebugImageProvider ()
         self.binaryImageProvider = binaryImageProvider;
     }
     return self;
+}
+
+- (NSArray<SentryDebugMeta *> *)getDebugImagesForThreads:(NSArray<SentryThread *> *)threads
+{
+    NSMutableSet<NSString *> *imageNames = [[NSMutableSet alloc] init];
+
+    for (SentryThread *thread in threads) {
+        for (SentryFrame *frame in thread.stacktrace.frames) {
+            if (frame.imageAddress && ![imageNames containsObject:frame.imageAddress]) {
+                [imageNames addObject:frame.imageAddress];
+            }
+        }
+    }
+
+    NSMutableArray<SentryDebugMeta *> *result = [NSMutableArray new];
+
+    NSArray<SentryDebugMeta *> *binaryImages = [self getDebugImages];
+
+    for (SentryDebugMeta *sourceImage in binaryImages) {
+        if ([imageNames containsObject:sourceImage.imageAddress]) {
+            [result addObject:sourceImage];
+        }
+    }
+
+    return result;
 }
 
 - (NSArray<SentryDebugMeta *> *)getDebugImages

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -126,7 +126,7 @@ class SentryClientTest: XCTestCase {
             XCTAssertEqual(SentryLevel.info, actual.level)
             XCTAssertEqual(fixture.message, actual.message)
 
-            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidDebugMeta(actual: actual.debugMeta, forThreads: actual.threads)
             assertValidThreads(actual: actual.threads)
         }
     }
@@ -200,7 +200,7 @@ class SentryClientTest: XCTestCase {
         fixture.getSut().capture(event: event, scope: fixture.scope)
         
         assertLastSentEventWithAttachment { actual in
-            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
             assertValidThreads(actual: actual.threads)
         }
     }
@@ -315,7 +315,7 @@ class SentryClientTest: XCTestCase {
         sut.capture(event: event)
         
         assertLastSentEvent { actual in
-            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
             XCTAssertEqual(event.threads, actual.threads)
         }
     }
@@ -331,7 +331,7 @@ class SentryClientTest: XCTestCase {
         assertLastSentEvent { actual in
             XCTAssertEqual(event.level, actual.level)
             XCTAssertEqual(event.message, actual.message)
-            assertValidDebugMeta(actual: actual.debugMeta)
+            assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
             assertValidThreads(actual: actual.threads)
         }
     }
@@ -1160,7 +1160,7 @@ class SentryClientTest: XCTestCase {
         XCTAssertEqual(error.domain, mechanism.meta?.error?.domain)
         XCTAssertEqual(error.code, mechanism.meta?.error?.code)
         
-        assertValidDebugMeta(actual: event.debugMeta)
+        assertValidDebugMeta(actual: event.debugMeta, forThreads: event.threads)
         assertValidThreads(actual: event.threads)
     }
     
@@ -1168,7 +1168,7 @@ class SentryClientTest: XCTestCase {
         XCTAssertEqual(SentryLevel.error, event.level)
         XCTAssertEqual(exception.reason, event.exceptions!.first!.value)
         XCTAssertEqual(exception.name.rawValue, event.exceptions!.first!.type)
-        assertValidDebugMeta(actual: event.debugMeta)
+        assertValidDebugMeta(actual: event.debugMeta, forThreads: event.threads)
         assertValidThreads(actual: event.threads)
     }
     
@@ -1186,8 +1186,8 @@ class SentryClientTest: XCTestCase {
         }
     }
     
-    private func assertValidDebugMeta(actual: [DebugMeta]?) {
-        let debugMetas = fixture.debugImageBuilder.getDebugImages()
+    private func assertValidDebugMeta(actual: [DebugMeta]?, forThreads threads: [Sentry.Thread]?) {
+        let debugMetas = fixture.debugImageBuilder.getDebugImages(for: threads ?? [])
         
         XCTAssertEqual(debugMetas, actual ?? [])
     }


### PR DESCRIPTION
## :scroll: Description

Instead of sending every binary image for each Event, we filter only those that are referenced in the event threads.

## :bulb: Motivation and Context

close #1676 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

_#skip-changelog_
