### PR TITLE
fix: Changelog to move #1782 to the Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: Parsing of output from backtrace_symbols() (#1782)
+
 ## 7.14.0
 
 - fix: User feedback crash (#1766)
@@ -7,7 +11,6 @@
 - fix: Remove authenticated pointer stripping for iOS backtraces (#1757)
 - perf: Filter binary images on Sentry Crash (#1767)
 - fix: NSURL warning during SDK initialization (#1764)
-- fix: Parsing of output from backtrace_symbols() (#1782)
 
 ## 7.13.0
 


### PR DESCRIPTION
## :scroll: Description

I merged my PR after the 7.14.0 release had been cut, so this item went in the wrong section.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps


#skip-changelog