### PR TITLE
feat: Collect queue label information for profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: Parsing of output from backtrace_symbols() (#1782)
+- feat: Collect queue label information for profiles (#1787)
 
 ## 7.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ## Unreleased
 
-- fix: Parsing of output from backtrace_symbols() (#1782)
-- feat: Collect queue label information for profiles (#1787)
 Features: 
 
 - Allow setting SDK info with Options initWithDict (#1793)
+- Collect queue label information for profiles (#1787)
 
 Fixes: 
 

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -137,6 +137,12 @@ namespace profiling {
             if (!thread->suspend()) {
                 continue;
             }
+            
+            // Retrieving queue metadata *must* be done after suspending the thread,
+            // because otherwise the queue could be deallocated in the middle of us
+            // trying to read from it. This doesn't use any of the pthread APIs, only
+            // thread_info, so the above comment about the deadlock does not apply here.
+            bt.queueMetadata = cache->metadataForQueue(thread->dispatchQueueAddress());
 
             bool reachedEndOfStack = false;
             std::uintptr_t addresses[kMaxBacktraceDepth];

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -137,7 +137,7 @@ namespace profiling {
             if (!thread->suspend()) {
                 continue;
             }
-            
+
             // Retrieving queue metadata *must* be done after suspending the thread,
             // because otherwise the queue could be deallocated in the middle of us
             // trying to read from it. This doesn't use any of the pthread APIs, only

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -151,7 +151,10 @@ isSimulatorBuild()
                     threadMetadata[threadID] = metadata;
                 }
                 if (queueAddress != nil && queueMetadata[queueAddress] == nil) {
-                    queueMetadata[queueAddress] = @{@"label": [NSString stringWithUTF8String:backtrace.queueMetadata.label.c_str()]};
+                    queueMetadata[queueAddress] = @{
+                        @"label" :
+                            [NSString stringWithUTF8String:backtrace.queueMetadata.label.c_str()]
+                    };
                 }
 #    if defined(DEBUG)
                 const auto symbols

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -122,19 +122,25 @@ isSimulatorBuild()
         const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
         const auto samples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
         const auto threadMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
+        const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
         sampledProfile[@"samples"] = samples;
         sampledProfile[@"thread_metadata"] = threadMetadata;
+        sampledProfile[@"queue_metadata"] = queueMetadata;
         _profile[@"sampled_profile"] = sampledProfile;
         _startTimestamp = getAbsoluteTime();
 
         __weak const auto weakSelf = self;
         _profiler = std::make_shared<SamplingProfiler>(
-            [weakSelf, sampledProfile, threadMetadata, samples](auto &backtrace) {
+            [weakSelf, sampledProfile, threadMetadata, queueMetadata, samples](auto &backtrace) {
                 const auto strongSelf = weakSelf;
                 if (strongSelf == nil) {
                     return;
                 }
                 const auto threadID = [@(backtrace.threadMetadata.threadID) stringValue];
+                NSString *queueAddress = nil;
+                if (backtrace.queueMetadata.address != 0) {
+                    queueAddress = sentry_formatHexAddress(@(backtrace.queueMetadata.address));
+                }
                 if (threadMetadata[threadID] == nil) {
                     const auto metadata = [NSMutableDictionary<NSString *, id> dictionary];
                     if (!backtrace.threadMetadata.name.empty()) {
@@ -143,6 +149,9 @@ isSimulatorBuild()
                     }
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                     threadMetadata[threadID] = metadata;
+                }
+                if (queueAddress != nil && queueMetadata[queueAddress] == nil) {
+                    queueMetadata[queueAddress] = @{@"label": [NSString stringWithUTF8String:backtrace.queueMetadata.label.c_str()]};
                 }
 #    if defined(DEBUG)
                 const auto symbols
@@ -165,6 +174,9 @@ isSimulatorBuild()
                     [@(getDurationNs(strongSelf->_startTimestamp, backtrace.absoluteTimestamp))
                         stringValue];
                 sample[@"thread_id"] = threadID;
+                if (queueAddress != nil) {
+                    sample[@"queue_address"] = queueAddress;
+                }
                 [samples addObject:sample];
             },
             100 /** Sample 100 times per second */);

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -124,7 +124,7 @@ namespace profiling {
         return {};
     }
 
-    uint64_t ThreadHandle::dispatchQueueAddress() const noexcept {
+    std::uint64_t ThreadHandle::dispatchQueueAddress() const noexcept {
         if (handle_ == THREAD_NULL) {
             return {};
         }

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -10,6 +10,13 @@
 #    include <mach/mach.h>
 #    include <pthread.h>
 
+/**
+ * SentryCrashMemory.h uses the restrict keyword, which is valid in C99 but
+ * invalid in C++; we can use __restrict as an alternative.
+ * */
+#define restrict __restrict
+#include "SentryCrashMemory.h"
+
 namespace sentry {
 namespace profiling {
 
@@ -115,6 +122,26 @@ namespace profiling {
             return std::string(name);
         }
         return {};
+    }
+
+    uint64_t ThreadHandle::dispatchQueueAddress() const noexcept {
+        if (handle_ == THREAD_NULL) {
+            return {};
+        }
+        integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = {0};
+        thread_info_t info = infoBuffer;
+        mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
+        const auto rv = thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count);
+        const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
+        // MACH_SEND_INVALID_DEST is returned when the thread no longer exists
+        if ((rv != MACH_SEND_INVALID_DEST) && (SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS) && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+            const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
+            if (queuePtr != nullptr
+                && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr)) && idInfo->thread_handle != 0 && *queuePtr != nullptr) {
+                return idInfo->dispatch_qaddr;
+            }
+        }
+        return 0;
     }
 
     int

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -14,8 +14,8 @@
  * SentryCrashMemory.h uses the restrict keyword, which is valid in C99 but
  * invalid in C++; we can use __restrict as an alternative.
  * */
-#define restrict __restrict
-#include "SentryCrashMemory.h"
+#    define restrict __restrict
+#    include "SentryCrashMemory.h"
 
 namespace sentry {
 namespace profiling {
@@ -124,20 +124,23 @@ namespace profiling {
         return {};
     }
 
-    std::uint64_t ThreadHandle::dispatchQueueAddress() const noexcept {
+    std::uint64_t
+    ThreadHandle::dispatchQueueAddress() const noexcept
+    {
         if (handle_ == THREAD_NULL) {
             return {};
         }
-        integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = {0};
+        integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = { 0 };
         thread_info_t info = infoBuffer;
         mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
         const auto rv = thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count);
         const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
         // MACH_SEND_INVALID_DEST is returned when the thread no longer exists
-        if ((rv != MACH_SEND_INVALID_DEST) && (SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS) && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+        if ((rv != MACH_SEND_INVALID_DEST) && (SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS)
+            && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
             const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
-            if (queuePtr != nullptr
-                && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr)) && idInfo->thread_handle != 0 && *queuePtr != nullptr) {
+            if (queuePtr != nullptr && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))
+                && idInfo->thread_handle != 0 && *queuePtr != nullptr) {
                 return idInfo->dispatch_qaddr;
             }
         }

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -136,7 +136,7 @@ namespace profiling {
         const auto rv = thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count);
         const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
         // MACH_SEND_INVALID_DEST is returned when the thread no longer exists
-        if ((rv != MACH_SEND_INVALID_DEST) && (SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS)
+        if (rv != MACH_SEND_INVALID_DEST && SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS
             && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
             const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
             if (queuePtr != nullptr && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -62,6 +62,9 @@ namespace profiling {
     }
 
     QueueMetadata ThreadMetadataCache::metadataForQueue(std::uint64_t address) {
+        if (address == 0) {
+            return {};
+        }
         const auto it = std::find_if(queueMetadataCache_.cbegin(), queueMetadataCache_.cend(),
             [address](const QueueMetadata &metadata) { return metadata.address == address; });
         if (it == queueMetadataCache_.cend()) {

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -6,9 +6,9 @@
 #    include "SentryThreadHandle.hpp"
 
 #    include <algorithm>
+#    include <dispatch/dispatch.h>
 #    include <string>
 #    include <vector>
-# include <dispatch/dispatch.h>
 
 namespace {
 
@@ -61,7 +61,9 @@ namespace profiling {
         }
     }
 
-    QueueMetadata ThreadMetadataCache::metadataForQueue(std::uint64_t address) {
+    QueueMetadata
+    ThreadMetadataCache::metadataForQueue(std::uint64_t address)
+    {
         if (address == 0) {
             return {};
         }

--- a/Sources/Sentry/include/SentryBacktrace.hpp
+++ b/Sources/Sentry/include/SentryBacktrace.hpp
@@ -21,6 +21,7 @@ namespace profiling {
 
     struct Backtrace {
         ThreadMetadata threadMetadata;
+        QueueMetadata queueMetadata;
         std::uint64_t absoluteTimestamp;
         std::vector<std::uintptr_t> addresses;
     };

--- a/Sources/Sentry/include/SentryThreadHandle.hpp
+++ b/Sources/Sentry/include/SentryThreadHandle.hpp
@@ -95,6 +95,17 @@ namespace profiling {
          * @warning This function is not async-signal safe!
          */
         std::string name() const noexcept;
+        
+        /**
+         * @return The address of the dispatch queue currently associated with
+         * the thread, or 0 if there is no valid queue. This function checks if
+         * the memory at the returned address is readable, but there is no guarantee
+         * that the queue will continue to stay valid by the time you deference it,
+         * as queue deallocation can happen concurrently.
+         *
+         * @warning This function is not async-signal safe!
+         */
+        uint64_t dispatchQueueAddress() const noexcept;
 
         /**
          * @return The priority of the specified thread, or -1 if the thread priority

--- a/Sources/Sentry/include/SentryThreadHandle.hpp
+++ b/Sources/Sentry/include/SentryThreadHandle.hpp
@@ -96,7 +96,7 @@ namespace profiling {
          * @warning This function is not async-signal safe!
          */
         std::string name() const noexcept;
-        
+
         /**
          * @return The address of the dispatch queue currently associated with
          * the thread, or 0 if there is no valid queue. This function checks if

--- a/Sources/Sentry/include/SentryThreadHandle.hpp
+++ b/Sources/Sentry/include/SentryThreadHandle.hpp
@@ -7,6 +7,7 @@
 #    include "SentryStackBounds.hpp"
 
 #    include <chrono>
+#    include <cstdint>
 #    include <mach/mach.h>
 #    include <memory>
 #    include <pthread.h>
@@ -105,7 +106,7 @@ namespace profiling {
          *
          * @warning This function is not async-signal safe!
          */
-        uint64_t dispatchQueueAddress() const noexcept;
+        std::uint64_t dispatchQueueAddress() const noexcept;
 
         /**
          * @return The priority of the specified thread, or -1 if the thread priority

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -6,6 +6,7 @@
 
 #    include "SentryThreadHandle.hpp"
 
+#    include <cstdint>
 #    include <memory>
 #    include <string>
 
@@ -17,9 +18,14 @@ namespace profiling {
         int priority;
     };
 
+    struct QueueMetadata {
+        std::uint64_t address;
+        std::string label;
+    };
+
     /**
-     * Caches thread metadata (name, priority, etc.) for reuse while profiling, since querying that
-     * metadata from the thread every time can be expensive.
+     * Caches thread and queue metadata (name, priority, etc.) for reuse while profiling,
+     * since querying that metadata every time can be expensive.
      *
      * @note This class is not thread-safe.
      */
@@ -33,6 +39,15 @@ namespace profiling {
          * for this thread.
          */
         ThreadMetadata metadataForThread(const ThreadHandle &thread);
+        
+        /**
+         * Returns the metadata for the queue at the specified address.
+         * @param address The address of the queue to retrieve metadata from.
+         * @note This function assumes that the queue address is valid. If the address
+         * is invalid, the behavior is non-deterministic and will probably crash.
+         * @return @c QueueMetadata for the queue at the specified address.
+         */
+        QueueMetadata metadataForQueue(std::uint64_t address);
 
         ThreadMetadataCache() = default;
         ThreadMetadataCache(const ThreadMetadataCache &) = delete;
@@ -43,7 +58,8 @@ namespace profiling {
             ThreadHandle::NativeHandle handle;
             ThreadMetadata metadata;
         };
-        std::vector<const ThreadHandleMetadataPair> cache_;
+        std::vector<const ThreadHandleMetadataPair> threadMetadataCache_;
+        std::vector<const QueueMetadata> queueMetadataCache_;
     };
 
 } // namespace profiling

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -39,7 +39,7 @@ namespace profiling {
          * for this thread.
          */
         ThreadMetadata metadataForThread(const ThreadHandle &thread);
-        
+
         /**
          * Returns the metadata for the queue at the specified address.
          * @param address The address of the queue to retrieve metadata from.

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -104,18 +104,20 @@ threadSpin(void *name)
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
 }
 
-- (void)testRetrievesQueueMetadata {
+- (void)testRetrievesQueueMetadata
+{
     const auto label = "io.sentry.SentryThreadMetadataCacheTests.testQueue";
     const auto queue = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
     const auto cache = std::make_shared<ThreadMetadataCache>();
-    
+
     XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
 }
 
-- (void)testNullQueueAddressReturnsNoMetadata {
+- (void)testNullQueueAddressReturnsNoMetadata
+{
     const auto cache = std::make_shared<ThreadMetadataCache>();
     const auto metadata = cache->metadataForQueue(0);
-    
+
     XCTAssertEqual(metadata.address, static_cast<unsigned long long>(0));
     XCTAssertEqual(metadata.label, "");
 }

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -35,7 +35,7 @@ threadSpin(void *name)
 
 @implementation SentryThreadMetadataCacheTests
 
-- (void)testRetrievesMetadata
+- (void)testRetrievesThreadMetadata
 {
     pthread_t thread;
     char name[] = "SentryThreadMetadataCacheTests";
@@ -60,7 +60,7 @@ threadSpin(void *name)
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
 }
 
-- (void)testReturnsCachedMetadata
+- (void)testReturnsCachedThreadMetadata
 {
     pthread_t thread;
     char name[] = "SentryThreadMetadataCacheTests";
@@ -102,6 +102,14 @@ threadSpin(void *name)
 
     XCTAssertEqual(pthread_cancel(thread), 0);
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
+}
+
+- (void)testRetrievesQueueMetadata {
+    const auto label = "io.sentry.SentryThreadMetadataCacheTests.testQueue";
+    const auto queue = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
+    const auto cache = std::make_shared<ThreadMetadataCache>();
+    
+    XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
 }
 
 @end

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -112,6 +112,14 @@ threadSpin(void *name)
     XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
 }
 
+- (void)testNullQueueAddressReturnsNoMetadata {
+    const auto cache = std::make_shared<ThreadMetadataCache>();
+    const auto metadata = cache->metadataForQueue(0);
+    
+    XCTAssertEqual(metadata.address, static_cast<unsigned long long>(0));
+    XCTAssertEqual(metadata.label, "");
+}
+
 @end
 
 #endif


### PR DESCRIPTION
## :scroll: Description

We previously avoided collecting queue names because the `dispatch_qaddr` field (see diff) would point to a queue that was no longer valid by the time we read the field, causing a crash. I found a note in some Apple code that explains what was happening here: https://github.com/WebKit/WebKit/blob/09225dc168d445890bb0e2a5fa8bc19aef8556f2/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm#L119

The queue had been deallocated by the time we were reading the field. In order to avoid this race condition, in this PR, we suspend the thread before trying to read the field from the queue. Suspending the thread *should* prevent the dispatch queue from deallocated, assuming the deallocation happens on the thread that the queue is currently assigned to. I am not yet 100% confident in this behavior but we will have to try this in production (**for opt-in profiling beta customers only, this doesn't impact anything else**) and see if this works.

This is an example profiling output that contains the queue metadata:
[example_output.txt](https://github.com/getsentry/sentry-cocoa/files/8587061/example_output.txt)

Each sample has a `queue_address` key that can be used to look up the corresponding queue label from the top level `queue_metadata` object.

## :bulb: Motivation and Context

Since most threads on iOS do not have names, having labels for the queues that are running on the threads is crucial for good developer UX in profiling.

## :green_heart: How did you test it?

Added new tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
