### PR TITLE
Fix getting class data mask in SentryCrash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- fix: Parsing of output from backtrace_symbols() (#1782)
+### Fixes 
+
+- Fix getting class data mask in SentryCrash (#1788)
+- Fix parsing of output from backtrace_symbols() (#1782)
 
 ## 7.14.0
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.c
@@ -261,7 +261,7 @@ getIsaPointer(const void *const objectOrClassPtr)
 static inline struct class_rw_t *
 getClassRW(const struct class_t *const class)
 {
-    uintptr_t ptr = class->data_NEVER_USE & (~WORD_MASK);
+    uintptr_t ptr = class->data_NEVER_USE & FAST_DATA_MASK;
     return (struct class_rw_t *)ptr;
 }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -136,10 +136,12 @@ enum {
 #    define WORD_SHIFT 3UL
 #    define WORD_MASK 7UL
 #    define WORD_BITS 64
+#    define FAST_DATA_MASK 0x00007ffffffffff8UL
 #else
 #    define WORD_SHIFT 2UL
 #    define WORD_MASK 3UL
 #    define WORD_BITS 32
+#    define FAST_DATA_MASK 0xfffffffcUL
 #endif
 
 // ======================================================================


### PR DESCRIPTION

## :scroll: Description

Running SentryCrashObjC_Tests locally leads to a crash. This is
fixed now by using the FAST_DATA_MASK pointed out in
https://opensource.apple.com/source/objc4/objc4-680/runtime/objc-runtime-new.h.auto.html
and also used in a patch for KSCrash https://github.com/kstenerud/KSCrash/pull/429. 

Thanks, @Rui4u, for the PR to KSCrash.

## :bulb: Motivation and Context

We want to be able to run our tests locally.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
