### PR TITLE
Apply patch for SentryCrashCachedData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Unreleased
 
-- fix: Parsing of output from backtrace_symbols() (#1782)
+### Fixes 
+
+- Apply patch for SentryCrashCachedData (#1799)
+- Fix parsing of output from backtrace_symbols() (#1782)
 
 ## 7.14.0
 

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -148,17 +148,10 @@ SentryCrashIntegration ()
 - (void)uninstall
 {
     if (nil != installation) {
-        // Its not really possible to uninstall SentryCrash. Best we can do is to deactivate
-        // all the monitors and clear the `onCrash` callback installed on the global handler.
-        SentryCrash *handler = [SentryCrash sharedInstance];
-        @synchronized(handler) {
-            [handler setMonitoring:SentryCrashMonitorTypeNone];
-            handler.onCrash = NULL;
-        }
+        [self.crashAdapter close];
         installationToken = 0;
     }
-    [self.crashAdapter deactivateAsyncHooks];
-
+    
     [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -4,6 +4,7 @@
 #import "SentryHook.h"
 #import <Foundation/Foundation.h>
 #import <SentryCrashDebug.h>
+#import <SentryCrashCachedData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -42,9 +43,16 @@ NS_ASSUME_NONNULL_BEGIN
     sentrycrash_install_async_hooks();
 }
 
-- (void)deactivateAsyncHooks
+- (void)close
 {
+    SentryCrash *handler = [SentryCrash sharedInstance];
+    @synchronized(handler) {
+        [handler setMonitoring:SentryCrashMonitorTypeNone];
+        handler.onCrash = NULL;
+    }
+    
     sentrycrash_deactivate_async_hooks();
+    sentrycrashccd_close();
 }
 
 @end

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -20,7 +20,10 @@ SENTRY_NO_INIT
 
 - (void)installAsyncHooks;
 
-- (void)deactivateAsyncHooks;
+/**
+ * It's not really possible to close SentryCrash. Best we can do is to deactivate all the monitors, clear the `onCrash` callback installed on the global handler, and a few more minor things.
+ */
+- (void)close;
 
 @end
 

--- a/Sources/SentryCrash/Recording/SentryCrash.h
+++ b/Sources/SentryCrash/Recording/SentryCrash.h
@@ -106,6 +106,16 @@ typedef enum {
  */
 @property (nonatomic, readwrite, assign) double deadlockWatchdogInterval;
 
+/** If YES, attempt to fetch dispatch queue names for each running thread.
+ *
+ * WARNING: There is a chance that this will crash on a sentrycrashccd_getQueueName() call!
+ *
+ * Enable at your own risk.
+ *
+ * Default: NO
+ */
+@property (nonatomic, readwrite, assign) BOOL searchQueueNames;
+
 /** If YES, introspect memory contents during a crash.
  * Any Objective-C objects or C strings near the stack pointer or referenced by
  * cpu registers or exceptions will be recorded in the crash report, along with

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -96,6 +96,7 @@ getBasePath()
 @synthesize deleteBehaviorAfterSendAll = _deleteBehaviorAfterSendAll;
 @synthesize monitoring = _monitoring;
 @synthesize deadlockWatchdogInterval = _deadlockWatchdogInterval;
+@synthesize searchQueueNames = _searchQueueNames;
 @synthesize onCrash = _onCrash;
 @synthesize bundleName = _bundleName;
 @synthesize basePath = _basePath;
@@ -142,6 +143,7 @@ getBasePath()
         self.introspectMemory = YES;
         self.catchZombies = NO;
         self.maxReportCount = 5;
+        self.searchQueueNames = NO;
         self.monitoring = SentryCrashMonitorTypeProductionSafeMinimal;
     }
     return self;
@@ -185,6 +187,12 @@ getBasePath()
 {
     _deadlockWatchdogInterval = deadlockWatchdogInterval;
     sentrycrash_setDeadlockWatchdogInterval(deadlockWatchdogInterval);
+}
+
+- (void)setSearchQueueNames:(BOOL)searchQueueNames
+{
+    _searchQueueNames = searchQueueNames;
+    sentrycrash_setSearchQueueNames(searchQueueNames);
 }
 
 - (void)setOnCrash:(SentryCrashReportWriteCallback)onCrash

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -176,6 +176,12 @@ sentrycrash_setDeadlockWatchdogInterval(double deadlockWatchdogInterval)
 }
 
 void
+sentrycrash_setSearchQueueNames(bool searchQueueNames)
+{
+    sentrycrashccd_setSearchQueueNames(searchQueueNames);
+}
+
+void
 sentrycrash_setIntrospectMemory(bool introspectMemory)
 {
     sentrycrashreport_setIntrospectMemory(introspectMemory);

--- a/Sources/SentryCrash/Recording/SentryCrashC.h
+++ b/Sources/SentryCrash/Recording/SentryCrashC.h
@@ -85,6 +85,16 @@ void sentrycrash_setUserInfoJSON(const char *const userInfoJSON);
  */
 void sentrycrash_setDeadlockWatchdogInterval(double deadlockWatchdogInterval);
 
+/** If true, attempt to fetch dispatch queue names for each running thread.
+ *
+ * WARNING: There is a chance that this will crash on a sentrycrashccd_getQueueName() call!
+ *
+ * Enable at your own risk.
+ *
+ * Default: false
+ */
+void sentrycrash_setSearchQueueNames(bool searchQueueNames);
+
 /** If true, introspect memory contents during a crash.
  * Any Objective-C objects or C strings near the stack pointer or referenced by
  * cpu registers or exceptions will be recorded in the crash report, along with

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.h
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.h
@@ -28,9 +28,12 @@
 #include "SentryCrashThread.h"
 
 void sentrycrashccd_init(int pollingIntervalInSeconds);
+void sentrycrashccd_close(void);
 
 void sentrycrashccd_freeze(void);
 void sentrycrashccd_unfreeze(void);
+
+void sentrycrashccd_setSearchQueueNames(bool searchQueueNames);
 
 SentryCrashThread *sentrycrashccd_getAllThreads(int *threadCount);
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
@@ -53,3 +53,68 @@ sentrycrashthread_getThreadName(const SentryCrashThread thread, char *const buff
     const pthread_t pthread = pthread_from_mach_thread_np((thread_t)thread);
     return pthread_getname_np(pthread, buffer, (unsigned)bufLength) == 0;
 }
+
+bool
+sentrycrashthread_getQueueName(const SentryCrashThread thread, char *const buffer, int bufLength)
+{
+    // WARNING: This implementation is no longer async-safe!
+
+    integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = { 0 };
+    thread_info_t info = infoBuffer;
+    mach_msg_type_number_t inOutSize = THREAD_IDENTIFIER_INFO_COUNT;
+    kern_return_t kr = 0;
+
+    kr = thread_info((thread_t)thread, THREAD_IDENTIFIER_INFO, info, &inOutSize);
+    if (kr != KERN_SUCCESS) {
+        SentryCrashLOG_TRACE(
+            "Error getting thread_info with flavor THREAD_IDENTIFIER_INFO from mach thread : %s",
+            mach_error_string(kr));
+        return false;
+    }
+
+    thread_identifier_info_t idInfo = (thread_identifier_info_t)info;
+    if (!sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+        SentryCrashLOG_DEBUG("Thread %p has an invalid thread identifier info %p", thread, idInfo);
+        return false;
+    }
+    dispatch_queue_t *dispatch_queue_ptr = (dispatch_queue_t *)idInfo->dispatch_qaddr;
+    if (!sentrycrashmem_isMemoryReadable(dispatch_queue_ptr, sizeof(*dispatch_queue_ptr))) {
+        SentryCrashLOG_DEBUG(
+            "Thread %p has an invalid dispatch queue pointer %p", thread, dispatch_queue_ptr);
+        return false;
+    }
+    // thread_handle shouldn't be 0 also, because
+    // identifier_info->dispatch_qaddr =  identifier_info->thread_handle +
+    // get_dispatchqueue_offset_from_proc(thread->task->bsd_info);
+    if (dispatch_queue_ptr == NULL || idInfo->thread_handle == 0 || *dispatch_queue_ptr == NULL) {
+        SentryCrashLOG_TRACE("This thread doesn't have a dispatch queue attached : %p", thread);
+        return false;
+    }
+
+    dispatch_queue_t dispatch_queue = *dispatch_queue_ptr;
+    const char *queue_name = dispatch_queue_get_label(dispatch_queue);
+    if (queue_name == NULL) {
+        SentryCrashLOG_TRACE("Error while getting dispatch queue name : %p", dispatch_queue);
+        return false;
+    }
+    SentryCrashLOG_TRACE("Dispatch queue name: %s", queue_name);
+    int length = (int)strlen(queue_name);
+
+    // Queue label must be a null terminated string.
+    int iLabel;
+    for (iLabel = 0; iLabel < length + 1; iLabel++) {
+        if (queue_name[iLabel] < ' ' || queue_name[iLabel] > '~') {
+            break;
+        }
+    }
+    if (queue_name[iLabel] != 0) {
+        // Found a non-null, invalid char.
+        SentryCrashLOG_TRACE("Queue label contains invalid chars");
+        return false;
+    }
+    bufLength = MIN(length, bufLength - 1); // just strlen, without null-terminator
+    strncpy(buffer, queue_name, bufLength);
+    buffer[bufLength] = 0; // terminate string
+    SentryCrashLOG_TRACE("Queue label = %s", buffer);
+    return true;
+}

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.h
@@ -50,6 +50,20 @@ typedef uintptr_t SentryCrashThread;
 bool sentrycrashthread_getThreadName(
     const SentryCrashThread thread, char *const buffer, int bufLength);
 
+/** Get the name of a thread's dispatch queue. Internally, a queue name will
+ * never be more than 64 characters long.
+ *
+ * @param thread The thread whose queue name to get.
+ *
+ * @oaram buffer Buffer to hold the name.
+ *
+ * @param bufLength The length of the buffer.
+ *
+ * @return true if a name or label was found.
+ */
+bool sentrycrashthread_getQueueName(
+    const SentryCrashThread thread, char *const buffer, int bufLength);
+
 /* Get the current mach thread ID.
  * mach_thread_self() receives a send right for the thread port which needs to
  * be deallocated to balance the reference count. This function takes care of

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -191,14 +191,14 @@ class SentryCrashIntegrationTests: XCTestCase {
         XCTAssertFalse(fixture.sentryCrash.installAsyncHooksCalled)
     }
 
-    func testUninstall_CallsDeactivateAsyncHooks() {
+    func testUninstall_CallsClose() {
         let sut = fixture.getSut()
 
         sut.install(with: Options())
 
         sut.uninstall()
 
-        XCTAssertTrue(fixture.sentryCrash.deactivateAsyncHooksCalled)
+        XCTAssertTrue(fixture.sentryCrash.closeCalled)
     }
     
     func testUninstall_DoesNotUpdateLocale_OnLocaleDidChangeNotification() {

--- a/Tests/SentryTests/SentryCrash/SentryCrashCachedData_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashCachedData_Tests.m
@@ -34,6 +34,8 @@
 
 - (void)testGetThreadName
 {
+    sentrycrashccd_close();
+    
     NSString *expectedName = @"This is a test thread";
     TestThread *thread = [TestThread new];
     thread.name = expectedName;

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
@@ -21,7 +21,7 @@ SENTRY_NO_INIT
 
 @property (nonatomic, assign) BOOL installAsyncHooksCalled;
 
-@property (nonatomic, assign) BOOL deactivateAsyncHooksCalled;
+@property (nonatomic, assign) BOOL closeCalled;
 
 @end
 

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
@@ -11,7 +11,7 @@
     instance.internalIsBeingTraced = NO;
     instance.internalIsApplicationInForeground = YES;
     instance.installAsyncHooksCalled = NO;
-    instance.deactivateAsyncHooksCalled = NO;
+    instance.closeCalled = NO;
     return instance;
 }
 
@@ -40,9 +40,9 @@
     self.installAsyncHooksCalled = YES;
 }
 
-- (void)deactivateAsyncHooks
+- (void)close
 {
-    self.deactivateAsyncHooksCalled = YES;
+    self.closeCalled = YES;
 }
 
 @end


### PR DESCRIPTION


## :scroll: Description

Apply the [latest changes of KSCrash](https://github.com/kstenerud/KSCrash/commits/master/Source/KSCrash/Recording/KSCrashCachedData.c) to SentryCrashCachedData:
- https://github.com/kstenerud/KSCrash/commit/277555f9d86d4a3b13e689ba4102969d31c343f4
- https://github.com/kstenerud/KSCrash/commit/e0fc2c5d8867731fd2d936ab86793faa695092a0

## :bulb: Motivation and Context

While investigating https://github.com/getsentry/sentry-cocoa/issues/1756, the tests sometimes failed in
https://github.com/getsentry/sentry-cocoa/blob/31f75f31afe1d8c6d51ad179b7cee5854c62ccfd/Sources/SentryCrash/Recording/SentryCrashCachedData.c#L103
Therefore, I applied the latest changes from KSCrash.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
