### PR TITLE
Use pod_target_xcconfig for Podspec

### DIFF
--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.frameworks = 'Foundation'
   s.libraries = 'z', 'c++'
-  s.xcconfig = {
+  s.pod_target_xcconfig = {
       'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
       'CLANG_CXX_LIBRARY' => 'libc++'


### PR DESCRIPTION
## :scroll: Description

Update Podspec syntax that was deprecated with Cocoapods 0.38 in 2015, which fixes the pod’s settings overwriting settings of an app target using the pod.

## :bulb: Motivation and Context

#1652 added `CLANG_CXX_LANGUAGE_STANDARD = c++14` to the list of xcconfig flags, which causes every app using the pod to use that C++ language standard, even if the app target itself specifies a different standard. Using the newer Podspec syntax fixes this issue.

Relevant documentation/discussion:
https://blog.cocoapods.org/CocoaPods-0.38/#split-of-xcconfig
https://github.com/CocoaPods/CocoaPods/issues/3813#issuecomment-128445627
