### PR TITLE
feat: Allow setting SDK info with Options initWithDict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - fix: Parsing of output from backtrace_symbols() (#1782)
+- feat: Allow setting SDK info (name & version) with Options initWithDict (#1793)
 
 ## 7.14.0
 
@@ -61,7 +62,7 @@ If you are using profiling and self-hosted Sentry, this version requires Sentry 
 
 ## 7.10.0
 
-- fix: Always tracks App start for Hybrid SDKs (#1662) 
+- fix: Always tracks App start for Hybrid SDKs (#1662)
 - feat: Send SDK integrations (#1647)
 - fix: Don't track OOMs for unit tests (#1651)
 - fix: Add verification for vendor UUID in OOM logic (#1648)

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -280,6 +280,12 @@ SentryOptions ()
     [self setBool:options[@"sendClientReports"]
             block:^(BOOL value) { self->_sendClientReports = value; }];
 
+    // SentrySdkInfo already expects a dictionary with {"sdk": {"name": ..., "value": ...}}
+    // so we're passing the whole options object.
+    if ([options[@"sdk"] isKindOfClass:[NSDictionary class]]) {
+        _sdkInfo = [[SentrySdkInfo alloc] initWithDict:options];
+    }
+
     if (nil != error && nil != *error) {
         return NO;
     } else {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -503,7 +503,8 @@
         @"urlSessionDelegate" : [NSNull null],
         @"experimentalEnableTraceSampling" : [NSNull null],
         @"enableSwizzling" : [NSNull null],
-        @"enableIOTracking" : [NSNull null]
+        @"enableIOTracking" : [NSNull null],
+        @"sdk" : [NSNull null]
     }
                                                 didFailWithError:nil];
 
@@ -551,6 +552,8 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     XCTAssertEqual(NO, options.enableProfiling);
 #endif
+    XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name);
+    XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version);
 }
 
 - (void)testSetValidDsn
@@ -593,6 +596,20 @@
 
     XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name);
     XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version);
+}
+
+- (void)testSetCustomSdkInfo
+{
+    NSDictionary *dict = @{ @"name" : @"custom.sdk", @"version" : @"1.2.3-alpha.0" };
+
+    NSError *error = nil;
+    SentryOptions *options =
+        [[SentryOptions alloc] initWithDict:@{ @"sdk" : dict, @"dsn" : @"https://a:b@c.d/1" }
+                           didFailWithError:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqual(dict[@"name"], options.sdkInfo.name);
+    XCTAssertEqual(dict[@"version"], options.sdkInfo.version);
 }
 
 - (void)testMaxAttachmentSize


### PR DESCRIPTION
## :scroll: Description

Enables users to override the SDK info

## :bulb: Motivation and Context

This allows other SDKs that use sentry-cocoa internally to identify the events. Enables https://github.com/getsentry/sentry-unity/issues/616

## :green_heart: How did you test it?

Added a test case

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes
