### PR TITLE
fix: Case sensitive header import error

### DIFF
--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -6,7 +6,7 @@
 #import "SentryFrame.h"
 #import "SentryHexAddressFormatter.h"
 #import "SentryLog.h"
-#import "SentryStackTrace.h"
+#import "SentryStacktrace.h"
 #import "SentryThread.h"
 #import <Foundation/Foundation.h>
 

--- a/Sources/Sentry/SentryScreenshot.m
+++ b/Sources/Sentry/SentryScreenshot.m
@@ -1,4 +1,4 @@
-#import "SentryScreenShot.h"
+#import "SentryScreenshot.h"
 #import "SentryDependencyContainer.h"
 #import "SentryUIApplication.h"
 


### PR DESCRIPTION
## :scroll: Description

Fixes the casing of the import in SentryScreenshot.m and SentryDebugImageProvider.m

## :bulb: Motivation and Context

It broke builds on case sensitive file systems.

## :green_heart: How did you test it?

Tested the build in an iOS app

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

