### PR TITLE
ref: Fix spelling of adapter

### DIFF
--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -21,12 +21,12 @@ SentryOutOfMemoryLogic ()
 @implementation SentryOutOfMemoryLogic
 
 - (instancetype)initWithOptions:(SentryOptions *)options
-                   crashAdapter:(SentryCrashWrapper *)crashAdatper
+                   crashAdapter:(SentryCrashWrapper *)crashAdapter
                 appStateManager:(SentryAppStateManager *)appStateManager
 {
     if (self = [super init]) {
         self.options = options;
-        self.crashAdapter = crashAdatper;
+        self.crashAdapter = crashAdapter;
         self.appStateManager = appStateManager;
     }
     return self;

--- a/Sources/Sentry/include/SentryOutOfMemoryLogic.h
+++ b/Sources/Sentry/include/SentryOutOfMemoryLogic.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 - (instancetype)initWithOptions:(SentryOptions *)options
-                   crashAdapter:(SentryCrashWrapper *)crashAdatper
+                   crashAdapter:(SentryCrashWrapper *)crashAdapter
                 appStateManager:(SentryAppStateManager *)appStateManager;
 
 - (BOOL)isOOM;


### PR DESCRIPTION
## :scroll: Description

Just a spelling mistake I noticed

## :bulb: Motivation and Context

Correct spelling! :)

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
