### PR TITLE
Add profile data category for rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Features: 
 
+- Add profile data category for rate limiting (#1799)
 - Allow setting SDK info with Options initWithDict (#1793)
 
 Fixes: 

--- a/Sources/Sentry/Public/SentryEnvelopeItemType.h
+++ b/Sources/Sentry/Public/SentryEnvelopeItemType.h
@@ -4,3 +4,4 @@ static NSString *const SentryEnvelopeItemTypeUserFeedback = @"user_report";
 static NSString *const SentryEnvelopeItemTypeTransaction = @"transaction";
 static NSString *const SentryEnvelopeItemTypeAttachment = @"attachment";
 static NSString *const SentryEnvelopeItemTypeClientReport = @"client_report";
+static NSString *const SentryEnvelopeItemTypeProfile = @"profile";

--- a/Sources/Sentry/SentryDataCategoryMapper.m
+++ b/Sources/Sentry/SentryDataCategoryMapper.m
@@ -34,6 +34,9 @@ SentryDataCategoryMapper ()
     if ([itemType isEqualToString:SentryEnvelopeItemTypeAttachment]) {
         category = kSentryDataCategoryAttachment;
     }
+    if ([itemType isEqualToString:SentryEnvelopeItemTypeProfile]) {
+        category = kSentryDataCategoryProfile;
+    }
     return category;
 }
 
@@ -61,6 +64,9 @@ SentryDataCategoryMapper ()
     }
     if (value == kSentryDataCategoryUserFeedback) {
         category = kSentryDataCategoryUserFeedback;
+    }
+    if (value == kSentryDataCategoryProfile) {
+        category = kSentryDataCategoryProfile;
     }
     if (value == kSentryDataCategoryUnknown) {
         category = kSentryDataCategoryUnknown;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -8,6 +8,7 @@
 #    import "SentryDefines.h"
 #    import "SentryDependencyContainer.h"
 #    import "SentryEnvelope.h"
+#    import "SentryEnvelopeItemType.h"
 #    import "SentryHexAddressFormatter.h"
 #    import "SentryId.h"
 #    import "SentryLog.h"
@@ -16,7 +17,6 @@
 #    import "SentrySerialization.h"
 #    import "SentryTime.h"
 #    import "SentryTransaction.h"
-#    import "SentryEnvelopeItemType.h"
 
 #    if defined(DEBUG)
 #        include <execinfo.h>

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -16,6 +16,7 @@
 #    import "SentrySerialization.h"
 #    import "SentryTime.h"
 #    import "SentryTransaction.h"
+#    import "SentryEnvelopeItemType.h"
 
 #    if defined(DEBUG)
 #        include <execinfo.h>
@@ -228,7 +229,7 @@ isSimulatorBuild()
         return nil;
     }
 
-    const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:@"profile"
+    const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
                                                                 length:JSONData.length];
     return [[SentryEnvelopeItem alloc] initWithHeader:header data:JSONData];
 }

--- a/Sources/Sentry/SentryRateLimitParser.m
+++ b/Sources/Sentry/SentryRateLimitParser.m
@@ -79,6 +79,9 @@ SentryRateLimitParser ()
     if ([category isEqualToString:SentryDataCategoryNames[kSentryDataCategoryAttachment]]) {
         result = kSentryDataCategoryAttachment;
     }
+    if ([category isEqualToString:SentryDataCategoryNames[kSentryDataCategoryProfile]]) {
+        result = kSentryDataCategoryProfile;
+    }
 
     // UserFeedback is not listed for rate limits
     // https://develop.sentry.dev/sdk/rate-limiting/#definitions

--- a/Sources/Sentry/include/SentryDataCategory.h
+++ b/Sources/Sentry/include/SentryDataCategory.h
@@ -13,7 +13,8 @@ typedef NS_ENUM(NSUInteger, SentryDataCategory) {
     kSentryDataCategoryTransaction = 4,
     kSentryDataCategoryAttachment = 5,
     kSentryDataCategoryUserFeedback = 6,
-    kSentryDataCategoryUnknown = 7
+    kSentryDataCategoryProfile = 7,
+    kSentryDataCategoryUnknown = 8
 };
 
 static NSString *_Nonnull const SentryDataCategoryNames[] = {
@@ -24,5 +25,6 @@ static NSString *_Nonnull const SentryDataCategoryNames[] = {
     @"transaction",
     @"attachment",
     @"user_report",
+    @"profile",
     @"unkown",
 };

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
@@ -109,10 +109,11 @@ class SentryRateLimitsParserTests: XCTestCase {
             SentryDataCategory.session.asNSNumber: date,
             SentryDataCategory.transaction.asNSNumber: date,
             SentryDataCategory.attachment.asNSNumber: date,
+            SentryDataCategory.profile.asNSNumber: date,
             SentryDataCategory.all.asNSNumber: date
         ]
         
-        let actual = sut.parse("1:default;foobar;error;session;transaction;attachment:organization,1::key")
+        let actual = sut.parse("1:default;foobar;error;session;transaction;attachment;profile:organization,1::key")
         
         XCTAssertEqual(expected, actual)
     }

--- a/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
@@ -13,6 +13,7 @@ class SentryDataCategoryMapperTests: XCTestCase {
         XCTAssertEqual(SentryDataCategory.session, mapEnvelopeItemType(itemType: "session"))
         XCTAssertEqual(SentryDataCategory.transaction, mapEnvelopeItemType(itemType: "transaction"))
         XCTAssertEqual(SentryDataCategory.attachment, mapEnvelopeItemType(itemType: "attachment"))
+        XCTAssertEqual(SentryDataCategory.profile, mapEnvelopeItemType(itemType: "profile"))
         XCTAssertEqual(SentryDataCategory.default, mapEnvelopeItemType(itemType: "unkown item type"))
     }
 
@@ -24,7 +25,8 @@ class SentryDataCategoryMapperTests: XCTestCase {
         XCTAssertEqual(.transaction, DataCategoryMapper.mapInteger(toCategory: 4))
         XCTAssertEqual(.attachment, DataCategoryMapper.mapInteger(toCategory: 5))
         XCTAssertEqual(.userFeedback, DataCategoryMapper.mapInteger(toCategory: 6))
-        XCTAssertEqual(.unknown, DataCategoryMapper.mapInteger(toCategory: 7))
+        XCTAssertEqual(.profile, DataCategoryMapper.mapInteger(toCategory: 7))
+        XCTAssertEqual(.unknown, DataCategoryMapper.mapInteger(toCategory: 8))
     }
     
     func testMapStringToCategory() {
@@ -35,6 +37,7 @@ class SentryDataCategoryMapperTests: XCTestCase {
         XCTAssertEqual(.transaction, DataCategoryMapper.mapString(toCategory: "transaction"))
         XCTAssertEqual(.attachment, DataCategoryMapper.mapString(toCategory: "attachment"))
         XCTAssertEqual(.userFeedback, DataCategoryMapper.mapString(toCategory: "user_report"))
+        XCTAssertEqual(.profile, DataCategoryMapper.mapString(toCategory: "profile"))
         XCTAssertEqual(.unknown, DataCategoryMapper.mapString(toCategory: "unkown"))
     }
 


### PR DESCRIPTION




## :scroll: Description

Add profile data category for rate limiting to support rate limiting for
profile envelope items.

## :bulb: Motivation and Context

Fixes GH-1798

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
