### PR TITLE
ref: Change SplitViewSecondaryController

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
-    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -14,27 +12,27 @@
             <objects>
                 <viewController title="Sentry Test App (Swift)" id="BYZ-38-t0r" customClass="ViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
-                                <rect key="frame" x="8" y="278" width="398" height="394.33333333333326"/>
+                                <rect key="frame" x="8" y="125" width="584" height="394.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="VbH-LD-DBn">
-                                        <rect key="frame" x="0.0" y="0.0" width="398" height="270"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="584" height="270"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="hHG-as-TfH">
-                                                <rect key="frame" x="0.0" y="0.0" width="180.33333333333334" height="270"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="264.5" height="270"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QJW-l9-sD6">
-                                                        <rect key="frame" x="0.0" y="0.0" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="264.5" height="30"/>
                                                         <state key="normal" title="add Breadcrumb"/>
                                                         <connections>
                                                             <action selector="addBreadcrumb:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QZb-n6-c67"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Ls3-eR-jlU">
-                                                        <rect key="frame" x="0.0" y="30" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="30" width="264.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="captureMessageButton"/>
                                                         <state key="normal" title="Message"/>
                                                         <connections>
@@ -42,49 +40,49 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KU1-qd-h5w">
-                                                        <rect key="frame" x="0.0" y="60" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="60" width="264.5" height="30"/>
                                                         <state key="normal" title="User Feedback"/>
                                                         <connections>
                                                             <action selector="captureUserFeedback:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ek5-6c-HRz"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WZK-C2-hjR">
-                                                        <rect key="frame" x="0.0" y="90" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="90" width="264.5" height="30"/>
                                                         <state key="normal" title="Error"/>
                                                         <connections>
                                                             <action selector="captureError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="XSc-zg-aee"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D9Z-XG-OJP">
-                                                        <rect key="frame" x="0.0" y="120" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="120" width="264.5" height="30"/>
                                                         <state key="normal" title="NSException"/>
                                                         <connections>
                                                             <action selector="captureNSException:" destination="BYZ-38-t0r" eventType="touchUpInside" id="BT7-dZ-MrB"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UQw-od-fYk" userLabel="fatalError">
-                                                        <rect key="frame" x="0.0" y="150" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="150" width="264.5" height="30"/>
                                                         <state key="normal" title="fatalError"/>
                                                         <connections>
                                                             <action selector="captureFatalError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Uyy-8e-VRa"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lgF-Uq-3Bb">
-                                                        <rect key="frame" x="0.0" y="180" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="180" width="264.5" height="30"/>
                                                         <state key="normal" title="crash"/>
                                                         <connections>
                                                             <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="imm-ZO-4Af"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0Au-jS-aRl">
-                                                        <rect key="frame" x="0.0" y="210" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="210" width="264.5" height="30"/>
                                                         <state key="normal" title="OOM crash"/>
                                                         <connections>
                                                             <action selector="oomCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Oju-om-O6e"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xur-X2-ih4">
-                                                        <rect key="frame" x="0.0" y="240" width="180.33333333333334" height="30"/>
+                                                        <rect key="frame" x="0.0" y="240" width="264.5" height="30"/>
                                                         <state key="normal" title="async crash"/>
                                                         <connections>
                                                             <action selector="asyncCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mqi-sE-R7d"/>
@@ -93,31 +91,31 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="1a2-Yg-Az9">
-                                                <rect key="frame" x="180.33333333333337" y="0.0" width="217.66666666666663" height="270"/>
+                                                <rect key="frame" x="264.5" y="0.0" width="319.5" height="270"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yi7-GN-26l">
-                                                        <rect key="frame" x="0.0" y="0.0" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="319.5" height="30"/>
                                                         <state key="normal" title="ANR fully blocking"/>
                                                         <connections>
                                                             <action selector="anrFullyBlocking:" destination="BYZ-38-t0r" eventType="touchUpInside" id="dJy-Fs-khK"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TSF-10-5ts">
-                                                        <rect key="frame" x="0.0" y="30" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="30" width="319.5" height="30"/>
                                                         <state key="normal" title="ANR filling run loop"/>
                                                         <connections>
                                                             <action selector="anrFillingRunLoop:" destination="BYZ-38-t0r" eventType="touchUpInside" id="13D-io-hVz"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cdR-H3-8fr">
-                                                        <rect key="frame" x="0.0" y="60" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="60" width="319.5" height="30"/>
                                                         <state key="normal" title="Capture Transaction"/>
                                                         <connections>
                                                             <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kff-pT-Uf4"/>
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jwi-v3-e8T">
-                                                        <rect key="frame" x="0.0" y="90" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="90" width="319.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="loremIpsumButton"/>
                                                         <state key="normal" title="Lorem Ipsum"/>
                                                         <connections>
@@ -125,7 +123,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8CV-WC-ffq">
-                                                        <rect key="frame" x="0.0" y="120" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="120" width="319.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="testNavigationTransactionButton"/>
                                                         <state key="normal" title="Image"/>
                                                         <connections>
@@ -133,7 +131,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LvU-yx-01i">
-                                                        <rect key="frame" x="0.0" y="150" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="150" width="319.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="showNibButton"/>
                                                         <state key="normal" title="Show Nib"/>
                                                         <connections>
@@ -141,7 +139,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RjO-LN-eHj">
-                                                        <rect key="frame" x="0.0" y="180" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="180" width="319.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="showTableViewButton"/>
                                                         <state key="normal" title="TableView"/>
                                                         <connections>
@@ -149,7 +147,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ok0-hq-2kK">
-                                                        <rect key="frame" x="0.0" y="210" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="210" width="319.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="showSplitViewButton"/>
                                                         <state key="normal" title="SplitView"/>
                                                         <connections>
@@ -157,7 +155,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cTC-V8-T1j">
-                                                        <rect key="frame" x="0.0" y="240" width="217.66666666666666" height="30"/>
+                                                        <rect key="frame" x="0.0" y="240" width="319.5" height="30"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="useCoreData"/>
                                                         <state key="normal" title="Core Data"/>
                                                         <connections>
@@ -169,16 +167,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UrL-kT-AJU">
-                                        <rect key="frame" x="0.0" y="270" width="398" height="124.33333333333331"/>
+                                        <rect key="frame" x="0.0" y="270" width="584" height="124.5"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DSN  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m3h-wb-Xfa">
-                                                <rect key="frame" x="8" y="32" width="382" height="20.333333333333329"/>
+                                                <rect key="frame" x="8" y="32" width="568" height="20.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="L2a-LY-eQ7">
-                                                <rect key="frame" x="8" y="52.333333333333371" width="382" height="34"/>
+                                                <rect key="frame" x="8" y="52.5" width="568" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
@@ -186,7 +184,7 @@
                                                 </connections>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
-                                                <rect key="frame" x="8" y="86.333333333333371" width="382" height="30"/>
+                                                <rect key="frame" x="8" y="86.5" width="568" height="30"/>
                                                 <state key="normal" title="Reset DSN"/>
                                                 <connections>
                                                     <action selector="resetDSN:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mc6-d3-jaa"/>
@@ -222,11 +220,11 @@
             <objects>
                 <viewController id="cay-7M-Gvd" customClass="TraceTestViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="i9I-wJ-Z2B">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="oQQ-QQ-VWP">
-                                <rect key="frame" x="87" y="108" width="240" height="240"/>
+                                <rect key="frame" x="180" y="64" width="240" height="240"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="240" id="iMc-sb-nxg"/>
                                     <constraint firstAttribute="width" constant="240" id="uUA-q8-18d"/>
@@ -270,11 +268,11 @@
             <objects>
                 <viewController id="ikl-rF-hao" customClass="SplitRootViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="146-N0-BiP">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is Split Root ViewController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5bi-2z-fqb">
-                                <rect key="frame" x="85.666666666666686" y="438.66666666666669" width="243" height="20.666666666666686"/>
+                                <rect key="frame" x="178.5" y="307.5" width="243" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -317,12 +315,12 @@
             </objects>
             <point key="canvasLocation" x="396" y="1371"/>
         </scene>
-        <!--Split View Secondary Controller-->
+        <!--Secondary Split View Controller-->
         <scene sceneID="qwb-vD-6AF">
             <objects>
-                <viewController id="g8o-dT-S6v" customClass="SplitViewSecondaryController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="g8o-dT-S6v" customClass="SecondarySplitViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BKf-tT-kLA">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="842"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="puK-Su-Cjb"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -337,18 +335,18 @@
             <objects>
                 <viewController id="2jd-n4-Ihk" customClass="LoremIpsumViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="hTi-ne-s8a">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-yg-zgj">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem title="Hello" id="7le-ZX-hzV"/>
                                 </items>
                             </navigationBar>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" delaysContentTouches="NO" editable="NO" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sla-j3-cfX">
-                                <rect key="frame" x="20" y="70" width="374" height="826"/>
+                                <rect key="frame" x="20" y="70" width="560" height="530"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/SplitViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/SplitViewController.swift
@@ -30,11 +30,11 @@ class SplitRootViewController: UIViewController {
     }
     
     @IBAction func showSecondary() {
-            splitViewController?.showDetailViewController(SplitViewSecondaryController(), sender: nil)
+            splitViewController?.showDetailViewController(SecondarySplitViewController(), sender: nil)
     }
 }
 
-class SplitViewSecondaryController: UIViewController {
+class SecondarySplitViewController: UIViewController {
     
     var spanObserver: SpanObserver?
     var assertView: AssertView!

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -52,7 +52,9 @@ class LaunchUITests: XCTestCase {
     
     func testSplitView() {
         app.buttons["showSplitViewButton"].tap()
-        XCTAssertTrue(app.navigationBars["iOS_Swift.SplitViewSecondary"].buttons["Root ViewController"].waitForExistence(), "SplitView not loaded.")
+        
+        let app = XCUIApplication()
+        XCTAssertTrue(app.navigationBars["iOS_Swift.SecondarySplitView"].buttons["Root ViewController"].waitForExistence(), "SplitView not loaded.")
         
         // This validation is currently not working on iOS 10.
         if #available(iOS 11.0, *) {

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -119,7 +119,6 @@ SentryUIViewControllerPerformanceTracker ()
                                         measureSpanWithDescription:@"viewWillAppear"
                                                          operation:
                                                              SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                                      parentSpanId:spanId
                                                            inBlock:callbackToOrigin];
 
                                     SentrySpanId *viewAppearingId = [self.tracker
@@ -193,7 +192,6 @@ SentryUIViewControllerPerformanceTracker ()
                      [self.tracker
                          measureSpanWithDescription:lifecycleMethod
                                           operation:SENTRY_VIEWCONTROLLER_RENDERING_OPERATION
-                                       parentSpanId:spanId
                                             inBlock:callbackToOrigin];
                  }];
 


### PR DESCRIPTION
## :scroll: Description

Renamed SplitViewSecondaryController in samples to SecondarySplitViewController.
Removed a `SentryUIViewControllerPerformanceTracker` transaction stack redundancy.

## :bulb: Motivation and Context

Only view controller which name contains `viewcontroller` are swizzled. Because of that, SplitViewSecondaryController transactions are not being created.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Check in Sentry.io

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

_#skip-changelog_
