### PR TITLE
feat: Remove ViewController name match for swizzling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features: 
 
 - Allow setting SDK info with Options initWithDict (#1793)
+- Remove ViewController name match for swizzling (#1802)
 
 Fixes: 
 

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -48,9 +48,9 @@ SentrySubClassFinder ()
         // NSObject and a call to isSubclassOfClass would call the initializer of the class, which
         // we can't allow because of the problem with UIViewControllers mentioned above.
         //
-        //Turn out the approach to search all the view controllers inside the app binary image is
-        //fast and we don't need to include this restriction that will cause confusion.
-        //In a project with 1000 classes (a big project), it took only ~3ms to check all classes.
+        // Turn out the approach to search all the view controllers inside the app binary image is
+        // fast and we don't need to include this restriction that will cause confusion.
+        // In a project with 1000 classes (a big project), it took only ~3ms to check all classes.
         NSMutableArray<NSString *> *classesToSwizzle = [NSMutableArray new];
         for (int i = 0; i < count; i++) {
             NSString *className = [NSString stringWithUTF8String:classes[i]];

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -47,6 +47,10 @@ SentrySubClassFinder ()
         // NSObject:isSubclassOfClass as not all classes in the runtime in classes inherit from
         // NSObject and a call to isSubclassOfClass would call the initializer of the class, which
         // we can't allow because of the problem with UIViewControllers mentioned above.
+        //
+        //Turn out the approach to search all the view controllers inside the app binary image is
+        //fast and we don't need to include this restriction that will cause confusion.
+        //In a project with 1000 classes (a big project), it took only ~3ms to check all classes.
         NSMutableArray<NSString *> *classesToSwizzle = [NSMutableArray new];
         for (int i = 0; i < count; i++) {
             NSString *className = [NSString stringWithUTF8String:classes[i]];

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -61,8 +61,12 @@ SentrySubClassFinder ()
             for (NSString *className in classesToSwizzle) {
                 block(NSClassFromString(className));
             }
-            
-            [SentryLog logWithMessage:[NSString stringWithFormat:@"This are the UIViewControllers that generates automatic transactions: %@", [classesToSwizzle componentsJoinedByString:@", "] ] andLevel:kSentryLevelDebug];
+
+            [SentryLog
+                logWithMessage:[NSString stringWithFormat:@"This are the UIViewControllers that "
+                                                          @"generates automatic transactions: %@",
+                                         [classesToSwizzle componentsJoinedByString:@", "]]
+                      andLevel:kSentryLevelDebug];
         }];
     }];
 }

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -50,20 +50,19 @@ SentrySubClassFinder ()
         NSMutableArray<NSString *> *classesToSwizzle = [NSMutableArray new];
         for (int i = 0; i < count; i++) {
             NSString *className = [NSString stringWithUTF8String:classes[i]];
-            if ([className containsString:@"ViewController"]) {
-                Class class = NSClassFromString(className);
-                if ([self isClass:class subClassOf:viewControllerClass]) {
-                    [classesToSwizzle addObject:className];
-                }
+            Class class = NSClassFromString(className);
+            if ([self isClass:class subClassOf:viewControllerClass]) {
+                [classesToSwizzle addObject:className];
             }
         }
 
         free(classes);
-
         [self.dispatchQueue dispatchOnMainQueue:^{
             for (NSString *className in classesToSwizzle) {
                 block(NSClassFromString(className));
             }
+            
+            [SentryLog logWithMessage:[NSString stringWithFormat:@"This are the UIViewControllers that generates automatic transactions: %@", [classesToSwizzle componentsJoinedByString:@", "] ] andLevel:kSentryLevelDebug];
         }];
     }];
 }

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -16,7 +16,7 @@ class SentrySubClassFinderTests: XCTestCase {
         let testClassesNames = [NSStringFromClass(FirstViewController.self),
                                 NSStringFromClass(SecondViewController.self),
                                 NSStringFromClass(ViewControllerNumberThree.self),
-                                NSStringFromClass(VCWrongNaming.self),
+                                NSStringFromClass(VCAnyNaming.self),
                                 NSStringFromClass(FakeViewController.self)]
         init() {
             if let name = class_getImageName(FirstViewController.self) {
@@ -39,7 +39,7 @@ class SentrySubClassFinderTests: XCTestCase {
     }
     
     func testActOnSubclassesOfViewController() {
-        testActOnSubclassesOfViewController(expected: [FirstViewController.self, SecondViewController.self, ViewControllerNumberThree.self])
+        testActOnSubclassesOfViewController(expected: [FirstViewController.self, SecondViewController.self, ViewControllerNumberThree.self, VCAnyNaming.self])
     }
     
     func testActOnSubclassesOfViewController_NoViewController() {
@@ -51,12 +51,7 @@ class SentrySubClassFinderTests: XCTestCase {
         fixture.runtimeWrapper.classesNames = { _ in [NSStringFromClass(FakeViewController.self)] }
         testActOnSubclassesOfViewController(expected: [])
     }
-    
-    func testActOnSubclassesOfViewController_IgnoreWrongNaming() {
-        fixture.runtimeWrapper.classesNames = { _ in [NSStringFromClass(VCWrongNaming.self)] }
-        testActOnSubclassesOfViewController(expected: [])
-    }
-    
+     
     func testActOnSubclassesOfViewController_WrongImage_NoViewController() {
         fixture.runtimeWrapper.classesNames = nil
         testActOnSubclassesOfViewController(expected: [], imageName: "OtherImage")
@@ -108,6 +103,6 @@ class SentrySubClassFinderTests: XCTestCase {
 class FirstViewController: UIViewController {}
 class SecondViewController: UIViewController {}
 class ViewControllerNumberThree: UIViewController {}
-class VCWrongNaming: UIViewController {}
+class VCAnyNaming: UIViewController {}
 class FakeViewController {}
 #endif


### PR DESCRIPTION
## :scroll: Description

Removed the name checking for view controller when swizzling.

## :bulb: Motivation and Context

Turn out the approach to search all the view controllers inside the app binary image is fast and we don't need to include this restriction that will cause confusion.

In a project with 1000 classes (a big project), it took only ~3ms to check all classes. 

## :green_heart: How did you test it?

Profiling for performance and unit tests to know if the method that searches view controllers is picking the right ones.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
