### PR TITLE
Revert "feat: Collect queue label information for profiles (#1787)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ Features:
 
 - Add profile data category for rate limiting (#1799)
 - Allow setting SDK info with Options initWithDict (#1793)
-- Collect queue label information for profiles (#1787)
 - Remove ViewController name match for swizzling (#1802)
 
 Fixes: 

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -138,12 +138,6 @@ namespace profiling {
                 continue;
             }
 
-            // Retrieving queue metadata *must* be done after suspending the thread,
-            // because otherwise the queue could be deallocated in the middle of us
-            // trying to read from it. This doesn't use any of the pthread APIs, only
-            // thread_info, so the above comment about the deadlock does not apply here.
-            bt.queueMetadata = cache->metadataForQueue(thread->dispatchQueueAddress());
-
             bool reachedEndOfStack = false;
             std::uintptr_t addresses[kMaxBacktraceDepth];
             const auto depth = backtrace(*thread, *pair.second, addresses, stackBounds,

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -123,25 +123,19 @@ isSimulatorBuild()
         const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
         const auto samples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
         const auto threadMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
-        const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
         sampledProfile[@"samples"] = samples;
         sampledProfile[@"thread_metadata"] = threadMetadata;
-        sampledProfile[@"queue_metadata"] = queueMetadata;
         _profile[@"sampled_profile"] = sampledProfile;
         _startTimestamp = getAbsoluteTime();
 
         __weak const auto weakSelf = self;
         _profiler = std::make_shared<SamplingProfiler>(
-            [weakSelf, sampledProfile, threadMetadata, queueMetadata, samples](auto &backtrace) {
+            [weakSelf, sampledProfile, threadMetadata, samples](auto &backtrace) {
                 const auto strongSelf = weakSelf;
                 if (strongSelf == nil) {
                     return;
                 }
                 const auto threadID = [@(backtrace.threadMetadata.threadID) stringValue];
-                NSString *queueAddress = nil;
-                if (backtrace.queueMetadata.address != 0) {
-                    queueAddress = sentry_formatHexAddress(@(backtrace.queueMetadata.address));
-                }
                 if (threadMetadata[threadID] == nil) {
                     const auto metadata = [NSMutableDictionary<NSString *, id> dictionary];
                     if (!backtrace.threadMetadata.name.empty()) {
@@ -150,12 +144,6 @@ isSimulatorBuild()
                     }
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                     threadMetadata[threadID] = metadata;
-                }
-                if (queueAddress != nil && queueMetadata[queueAddress] == nil) {
-                    queueMetadata[queueAddress] = @{
-                        @"label" :
-                            [NSString stringWithUTF8String:backtrace.queueMetadata.label.c_str()]
-                    };
                 }
 #    if defined(DEBUG)
                 const auto symbols
@@ -178,9 +166,6 @@ isSimulatorBuild()
                     [@(getDurationNs(strongSelf->_startTimestamp, backtrace.absoluteTimestamp))
                         stringValue];
                 sample[@"thread_id"] = threadID;
-                if (queueAddress != nil) {
-                    sample[@"queue_address"] = queueAddress;
-                }
                 [samples addObject:sample];
             },
             100 /** Sample 100 times per second */);

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -10,13 +10,6 @@
 #    include <mach/mach.h>
 #    include <pthread.h>
 
-/**
- * SentryCrashMemory.h uses the restrict keyword, which is valid in C99 but
- * invalid in C++; we can use __restrict as an alternative.
- * */
-#    define restrict __restrict
-#    include "SentryCrashMemory.h"
-
 namespace sentry {
 namespace profiling {
 
@@ -122,29 +115,6 @@ namespace profiling {
             return std::string(name);
         }
         return {};
-    }
-
-    std::uint64_t
-    ThreadHandle::dispatchQueueAddress() const noexcept
-    {
-        if (handle_ == THREAD_NULL) {
-            return {};
-        }
-        integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = { 0 };
-        thread_info_t info = infoBuffer;
-        mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
-        const auto rv = thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count);
-        const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
-        // MACH_SEND_INVALID_DEST is returned when the thread no longer exists
-        if (rv != MACH_SEND_INVALID_DEST && SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS
-            && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
-            const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
-            if (queuePtr != nullptr && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))
-                && idInfo->thread_handle != 0 && *queuePtr != nullptr) {
-                return idInfo->dispatch_qaddr;
-            }
-        }
-        return 0;
     }
 
     int

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -6,7 +6,6 @@
 #    include "SentryThreadHandle.hpp"
 
 #    include <algorithm>
-#    include <dispatch/dispatch.h>
 #    include <string>
 #    include <vector>
 
@@ -29,9 +28,9 @@ namespace profiling {
     ThreadMetadataCache::metadataForThread(const ThreadHandle &thread)
     {
         const auto handle = thread.nativeHandle();
-        const auto it = std::find_if(threadMetadataCache_.cbegin(), threadMetadataCache_.cend(),
+        const auto it = std::find_if(cache_.cbegin(), cache_.cend(),
             [handle](const ThreadHandleMetadataPair &pair) { return pair.handle == handle; });
-        if (it == threadMetadataCache_.cend()) {
+        if (it == cache_.cend()) {
             ThreadMetadata metadata;
             metadata.threadID = ThreadHandle::tidFromNativeHandle(handle);
             metadata.priority = thread.priority();
@@ -44,7 +43,7 @@ namespace profiling {
                     // Don't collect backtraces for Sentry-owned threads.
                     metadata.priority = 0;
                     metadata.threadID = 0;
-                    threadMetadataCache_.push_back({ handle, metadata });
+                    cache_.push_back({ handle, metadata });
                     return metadata;
                 }
                 if (threadName.size() > kMaxThreadNameLength) {
@@ -54,28 +53,10 @@ namespace profiling {
                 metadata.name = threadName;
             }
 
-            threadMetadataCache_.push_back({ handle, metadata });
+            cache_.push_back({ handle, metadata });
             return metadata;
         } else {
             return (*it).metadata;
-        }
-    }
-
-    QueueMetadata
-    ThreadMetadataCache::metadataForQueue(std::uint64_t address)
-    {
-        if (address == 0) {
-            return {};
-        }
-        const auto it = std::find_if(queueMetadataCache_.cbegin(), queueMetadataCache_.cend(),
-            [address](const QueueMetadata &metadata) { return metadata.address == address; });
-        if (it == queueMetadataCache_.cend()) {
-            const auto queue = reinterpret_cast<dispatch_queue_t *>(address);
-            QueueMetadata metadata = { address, std::string(dispatch_queue_get_label(*queue)) };
-            queueMetadataCache_.push_back(metadata);
-            return metadata;
-        } else {
-            return (*it);
         }
     }
 

--- a/Sources/Sentry/include/SentryBacktrace.hpp
+++ b/Sources/Sentry/include/SentryBacktrace.hpp
@@ -21,7 +21,6 @@ namespace profiling {
 
     struct Backtrace {
         ThreadMetadata threadMetadata;
-        QueueMetadata queueMetadata;
         std::uint64_t absoluteTimestamp;
         std::vector<std::uintptr_t> addresses;
     };

--- a/Sources/Sentry/include/SentryThreadHandle.hpp
+++ b/Sources/Sentry/include/SentryThreadHandle.hpp
@@ -7,7 +7,6 @@
 #    include "SentryStackBounds.hpp"
 
 #    include <chrono>
-#    include <cstdint>
 #    include <mach/mach.h>
 #    include <memory>
 #    include <pthread.h>
@@ -96,17 +95,6 @@ namespace profiling {
          * @warning This function is not async-signal safe!
          */
         std::string name() const noexcept;
-
-        /**
-         * @return The address of the dispatch queue currently associated with
-         * the thread, or 0 if there is no valid queue. This function checks if
-         * the memory at the returned address is readable, but there is no guarantee
-         * that the queue will continue to stay valid by the time you deference it,
-         * as queue deallocation can happen concurrently.
-         *
-         * @warning This function is not async-signal safe!
-         */
-        std::uint64_t dispatchQueueAddress() const noexcept;
 
         /**
          * @return The priority of the specified thread, or -1 if the thread priority

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -6,7 +6,6 @@
 
 #    include "SentryThreadHandle.hpp"
 
-#    include <cstdint>
 #    include <memory>
 #    include <string>
 
@@ -18,14 +17,9 @@ namespace profiling {
         int priority;
     };
 
-    struct QueueMetadata {
-        std::uint64_t address;
-        std::string label;
-    };
-
     /**
-     * Caches thread and queue metadata (name, priority, etc.) for reuse while profiling,
-     * since querying that metadata every time can be expensive.
+     * Caches thread metadata (name, priority, etc.) for reuse while profiling, since querying that
+     * metadata from the thread every time can be expensive.
      *
      * @note This class is not thread-safe.
      */
@@ -40,15 +34,6 @@ namespace profiling {
          */
         ThreadMetadata metadataForThread(const ThreadHandle &thread);
 
-        /**
-         * Returns the metadata for the queue at the specified address.
-         * @param address The address of the queue to retrieve metadata from.
-         * @note This function assumes that the queue address is valid. If the address
-         * is invalid, the behavior is non-deterministic and will probably crash.
-         * @return @c QueueMetadata for the queue at the specified address.
-         */
-        QueueMetadata metadataForQueue(std::uint64_t address);
-
         ThreadMetadataCache() = default;
         ThreadMetadataCache(const ThreadMetadataCache &) = delete;
         ThreadMetadataCache &operator=(const ThreadMetadataCache &) = delete;
@@ -58,8 +43,7 @@ namespace profiling {
             ThreadHandle::NativeHandle handle;
             ThreadMetadata metadata;
         };
-        std::vector<const ThreadHandleMetadataPair> threadMetadataCache_;
-        std::vector<const QueueMetadata> queueMetadataCache_;
+        std::vector<const ThreadHandleMetadataPair> cache_;
     };
 
 } // namespace profiling

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -35,7 +35,7 @@ threadSpin(void *name)
 
 @implementation SentryThreadMetadataCacheTests
 
-- (void)testRetrievesThreadMetadata
+- (void)testRetrievesMetadata
 {
     pthread_t thread;
     char name[] = "SentryThreadMetadataCacheTests";
@@ -60,7 +60,7 @@ threadSpin(void *name)
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
 }
 
-- (void)testReturnsCachedThreadMetadata
+- (void)testReturnsCachedMetadata
 {
     pthread_t thread;
     char name[] = "SentryThreadMetadataCacheTests";
@@ -102,24 +102,6 @@ threadSpin(void *name)
 
     XCTAssertEqual(pthread_cancel(thread), 0);
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
-}
-
-- (void)testRetrievesQueueMetadata
-{
-    const auto label = "io.sentry.SentryThreadMetadataCacheTests.testQueue";
-    const auto queue = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
-    const auto cache = std::make_shared<ThreadMetadataCache>();
-
-    XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
-}
-
-- (void)testNullQueueAddressReturnsNoMetadata
-{
-    const auto cache = std::make_shared<ThreadMetadataCache>();
-    const auto metadata = cache->metadataForQueue(0);
-
-    XCTAssertEqual(metadata.address, static_cast<unsigned long long>(0));
-    XCTAssertEqual(metadata.label, "");
 }
 
 @end


### PR DESCRIPTION
This reverts commit 46cefbd20568701b2a017f2b969f081c6e3e8b22.

## :scroll: Description

This is causing CI to time out, for example: https://github.com/getsentry/sentry-cocoa/runs/6323480788?check_suite_focus=true

## :bulb: Motivation and Context

Unblock others while I work on a fix.

## :green_heart: How did you test it?

I reverted the change in another PR and CI passed.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
