### PR TITLE
ci: Set timeout to 20 minutes for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
     runs-on: ${{matrix.runs-on}}
+    timeout-minutes: 20
     strategy:      
       fail-fast: false
       matrix:


### PR DESCRIPTION
We had an issue with hanging tests, reverted https://github.com/getsentry/sentry-cocoa/pull/1808.
The default of GH actions is 360 minutes. This PR reduces the time-out to 20 minutes for unit tests, 
so they don't hang for 6 hours.

#skip-changelog