### PR TITLE
ci: Use Xcode 13.2.1 for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         
         # We can't use Xcode 10.3 because our tests contain a reference to MacCatalyst,
         # which is only available since iOS 13 / Xcode 11.
-        xcode: ["13.0", "12.5.1", "11.7"]
+        xcode: ["13.2.1", "12.5.1", "11.7"]
 
         test-destination-os: ["latest"]
 


### PR DESCRIPTION
 Use Xcode 13.2.1 for unit tests instead of 13.0.

#skip-changelog