### PR TITLE
feat: allow partial sdk info override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Allow partial SDK info override (#1816)
+
 ## 7.15.0
 
 ### Features

--- a/Sources/Sentry/Public/SentrySdkInfo.h
+++ b/Sources/Sentry/Public/SentrySdkInfo.h
@@ -33,6 +33,9 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithDict:(NSDictionary *)dict;
 
+- (instancetype)initWithDict:(NSDictionary *)dict
+                  orDefaults:(SentrySdkInfo *)info;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -283,7 +283,7 @@ SentryOptions ()
     // SentrySdkInfo already expects a dictionary with {"sdk": {"name": ..., "value": ...}}
     // so we're passing the whole options object.
     if ([options[@"sdk"] isKindOfClass:[NSDictionary class]]) {
-        _sdkInfo = [[SentrySdkInfo alloc] initWithDict:options];
+        _sdkInfo = [[SentrySdkInfo alloc] initWithDict:options orDefaults:_sdkInfo];
     }
 
     if (nil != error && nil != *error) {

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -44,6 +44,25 @@ NS_ASSUME_NONNULL_BEGIN
     return [self initWithName:name andVersion:version];
 }
 
+- (instancetype)initWithDict:(NSDictionary *)dict orDefaults:(SentrySdkInfo *)info;
+{
+    NSString *name = info.name;
+    NSString *version = info.version;
+
+    if (nil != dict[@"sdk"] && [dict[@"sdk"] isKindOfClass:[NSDictionary class]]) {
+        NSDictionary<NSString *, id> *sdkInfoDict = dict[@"sdk"];
+        if ([sdkInfoDict[@"name"] isKindOfClass:[NSString class]]) {
+            name = sdkInfoDict[@"name"];
+        }
+
+        if ([sdkInfoDict[@"version"] isKindOfClass:[NSString class]]) {
+            version = sdkInfoDict[@"version"];
+        }
+    }
+
+    return [self initWithName:name andVersion:version];
+}
+
 - (NSDictionary<NSString *, id> *)serialize
 {
     return @{ @"sdk" : @ { @"name" : self.name, @"version" : self.version } };

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -612,6 +612,34 @@
     XCTAssertEqual(dict[@"version"], options.sdkInfo.version);
 }
 
+- (void)testSetCustomSdkName
+{
+    NSDictionary *dict = @{ @"name" : @"custom.sdk" };
+
+    NSError *error = nil;
+    SentryOptions *options =
+        [[SentryOptions alloc] initWithDict:@{ @"sdk" : dict, @"dsn" : @"https://a:b@c.d/1" }
+                           didFailWithError:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqual(dict[@"name"], options.sdkInfo.name);
+    XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version); // default version
+}
+
+- (void)testSetCustomSdkVersion
+{
+    NSDictionary *dict = @{ @"version" : @"1.2.3-alpha.0" };
+
+    NSError *error = nil;
+    SentryOptions *options =
+        [[SentryOptions alloc] initWithDict:@{ @"sdk" : dict, @"dsn" : @"https://a:b@c.d/1" }
+                           didFailWithError:&error];
+
+    XCTAssertNil(error);
+    XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name); // default name
+    XCTAssertEqual(dict[@"version"], options.sdkInfo.version);
+}
+
 - (void)testMaxAttachmentSize
 {
     NSNumber *maxAttachmentSize = @21;


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

Turns out we want to keep the sentry-cocoa SDK version when overriding the name while integrated in the sentry-unity SDK. This PR enables doing that. No bread

## :green_heart: How did you test it?

new unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

