### PR TITLE
chore: Xcode project reorgs

### DIFF
--- a/Samples/README.md
+++ b/Samples/README.md
@@ -1,0 +1,5 @@
+# Samples
+
+Sample applications used as test hosts and manual acceptance testing.
+
+Most subdirectories contain an xcodeproj per platform/version, with one or more targets describing variants of applications targeting it, and including the Sentry SDK via a subproject reference. Each sample xcodeproj is included in the top level Sentry.xcworkspace.

--- a/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
+++ b/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
@@ -54,8 +54,10 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/watchOS-Swift WatchKit App">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -63,7 +65,7 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,8 +73,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/watchOS-Swift WatchKit App">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -80,7 +84,16 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
+            BuildableName = "watchOS-Swift WatchKit App.app"
+            BlueprintName = "watchOS-Swift WatchKit App"
+            ReferencedContainer = "container:watchOS-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1,3 +1,4 @@
+
 // !$*UTF8*$!
 {
 	archiveVersion = 1;
@@ -1230,23 +1231,8 @@
 		7D5C4419237C2E1F00DAB0A3 /* SentryHub.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryHub.m; sourceTree = "<group>"; };
 		7D65260B237F649E00113EA2 /* SentryScope.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryScope.m; sourceTree = "<group>"; };
 		7D7F0A5E23DF3D2C00A4629C /* SentryGlobalEventProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryGlobalEventProcessor.h; path = include/SentryGlobalEventProcessor.h; sourceTree = "<group>"; };
-		7D826E342390838C00EED93D /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
-		7D826E352390838C00EED93D /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
-		7D826E362390838D00EED93D /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		7D826E372390838D00EED93D /* Gemfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile; sourceTree = "<group>"; };
-		7D826E382390838D00EED93D /* Sentry.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sentry.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		7D826E392390838D00EED93D /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
-		7D826E3A2390838D00EED93D /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
 		7D826E3E2390840E00EED93D /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		7D826E3F2390840E00EED93D /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
-		7D826E41239084F000EED93D /* release.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = release.yml; sourceTree = "<group>"; };
-		7D826E42239084F000EED93D /* CODEOWNERS */ = {isa = PBXFileReference; lastKnownFileType = text; path = CODEOWNERS; sourceTree = "<group>"; };
-		7D826E43239084F000EED93D /* ISSUE_TEMPLATE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ISSUE_TEMPLATE.md; sourceTree = "<group>"; };
-		7D826E44239084F100EED93D /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
-		7D826E45239084F100EED93D /* .craft.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .craft.yml; sourceTree = "<group>"; };
-		7D826E47239084F100EED93D /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
-		7D826E4C239084F100EED93D /* .oclint */ = {isa = PBXFileReference; lastKnownFileType = text; path = .oclint; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.yaml; };
-		7D826E4D239084F100EED93D /* .gitmodules */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitmodules; sourceTree = "<group>"; };
 		7D9B079F23D1E89800C5FC8E /* SentryMeta.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryMeta.h; path = include/SentryMeta.h; sourceTree = "<group>"; };
 		7DAC588E23D8B2E0001CF26B /* SentryGlobalEventProcessor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryGlobalEventProcessor.m; sourceTree = "<group>"; };
 		7DB3A684238EA75E00A2D442 /* SentryHttpTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryHttpTransport.m; sourceTree = "<group>"; };
@@ -1256,7 +1242,29 @@
 		7DC830FF239826280043DD9A /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = Public/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
 		7DC831082398283C0043DD9A /* SentryCrashIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashIntegration.h; path = include/SentryCrashIntegration.h; sourceTree = "<group>"; };
 		7DC831092398283C0043DD9A /* SentryCrashIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashIntegration.m; sourceTree = "<group>"; };
+		844A34C3282B278500C6D1DF /* .github */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .github; sourceTree = "<group>"; };
 		844DA7F6282435CD00E6B62E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		844DA80328246D5000E6B62E /* .oclint */ = {isa = PBXFileReference; lastKnownFileType = text; path = .oclint; sourceTree = "<group>"; };
+		844DA80428246D5000E6B62E /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
+		844DA80528246D5000E6B62E /* Sentry.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Sentry.podspec; sourceTree = "<group>"; };
+		844DA80628246D5000E6B62E /* .craft.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .craft.yml; sourceTree = "<group>"; };
+		844DA80728246D5000E6B62E /* Gemfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Gemfile; sourceTree = "<group>"; };
+		844DA80828246D5000E6B62E /* .gitmodules */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitmodules; sourceTree = "<group>"; };
+		844DA80928246D5000E6B62E /* dangerfile.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = dangerfile.js; sourceTree = "<group>"; };
+		844DA80A28246D5000E6B62E /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		844DA80B28246D5000E6B62E /* Brewfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = Brewfile; sourceTree = "<group>"; };
+		844DA80C28246D5000E6B62E /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
+		844DA80D28246D5000E6B62E /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		844DA80E28246D5000E6B62E /* LICENSE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = LICENSE.md; sourceTree = "<group>"; };
+		844DA80F28246D5000E6B62E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		844DA81028246D5000E6B62E /* CONTRIBUTING.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CONTRIBUTING.md; sourceTree = "<group>"; };
+		844DA81628246D5000E6B62E /* .gitignore */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitignore; sourceTree = "<group>"; };
+		844DA81B28246D9300E6B62E /* Brewfile.lock.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = Brewfile.lock.json; sourceTree = "<group>"; };
+		844DA81C28246D9300E6B62E /* Gemfile.lock */ = {isa = PBXFileReference; lastKnownFileType = text; path = Gemfile.lock; sourceTree = "<group>"; };
+		844DA81D28246DAE00E6B62E /* develop-docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "develop-docs"; sourceTree = "<group>"; };
+		844DA81E28246DB900E6B62E /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = "<group>"; };
+		844DA81F28246DE300E6B62E /* scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = scripts; sourceTree = "<group>"; };
+		844DA82028246E0600E6B62E /* test-server */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = "test-server"; sourceTree = "<group>"; };
 		861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSArray+SentrySanitize.h"; path = "include/NSArray+SentrySanitize.h"; sourceTree = "<group>"; };
 		861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SentrySanitize.m"; sourceTree = "<group>"; };
 		8E0551DF26A7A63C00400526 /* TestProtocolClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProtocolClient.swift; sourceTree = "<group>"; };
@@ -1518,24 +1526,33 @@
 		6327C5C91EB8A783004E799B = {
 			isa = PBXGroup;
 			children = (
-				7D826E40239084F000EED93D /* .github */,
+				844A34C3282B278500C6D1DF /* .github */,
+				844DA81628246D5000E6B62E /* .gitignore */,
+				844DA80828246D5000E6B62E /* .gitmodules */,
+				844DA80328246D5000E6B62E /* .oclint */,
+				844DA80B28246D5000E6B62E /* Brewfile */,
+				844DA81D28246DAE00E6B62E /* develop-docs */,
+				844DA81E28246DB900E6B62E /* fastlane */,
+				844DA80728246D5000E6B62E /* Gemfile */,
+				844DA80428246D5000E6B62E /* Makefile */,
+				844DA81F28246DE300E6B62E /* scripts */,
+				844DA82028246E0600E6B62E /* test-server */,
+				844DA80928246D5000E6B62E /* dangerfile.js */,
+				844DA81B28246D9300E6B62E /* Brewfile.lock.json */,
+				844DA81C28246D9300E6B62E /* Gemfile.lock */,
+				844DA80C28246D5000E6B62E /* CHANGELOG.md */,
+				844DA81028246D5000E6B62E /* CONTRIBUTING.md */,
+				844DA80E28246D5000E6B62E /* LICENSE.md */,
+				844DA80F28246D5000E6B62E /* README.md */,
+				844DA80528246D5000E6B62E /* Sentry.podspec */,
+				844DA80D28246D5000E6B62E /* Package.swift */,
+				844DA80628246D5000E6B62E /* .craft.yml */,
+				844DA80A28246D5000E6B62E /* .swiftlint.yml */,
+				6304360C1EC05CEF00C4D3FA /* Frameworks */,
+				6327C5D41EB8A783004E799B /* Products */,
 				63AA756E1EB8AEDB00D153DE /* Sources */,
 				63AA75921EB8AEDB00D153DE /* Tests */,
-				6327C5D41EB8A783004E799B /* Products */,
-				6304360C1EC05CEF00C4D3FA /* Frameworks */,
 				7D826E3C2390840E00EED93D /* Utils */,
-				7D826E392390838D00EED93D /* CHANGELOG.md */,
-				7D826E372390838D00EED93D /* Gemfile */,
-				7D826E352390838C00EED93D /* Gemfile.lock */,
-				7D826E3A2390838D00EED93D /* LICENSE.md */,
-				7D826E342390838C00EED93D /* Makefile */,
-				7D826E362390838D00EED93D /* README.md */,
-				7D826E382390838D00EED93D /* Sentry.podspec */,
-				7D826E45239084F100EED93D /* .craft.yml */,
-				7D826E47239084F100EED93D /* .gitignore */,
-				7D826E4D239084F100EED93D /* .gitmodules */,
-				7D826E4C239084F100EED93D /* .oclint */,
-				7D826E44239084F100EED93D /* .swiftlint.yml */,
 			);
 			sourceTree = "<group>";
 		};
@@ -2492,16 +2509,6 @@
 				7D826E3F2390840E00EED93D /* main.swift */,
 			);
 			path = VersionBump;
-			sourceTree = "<group>";
-		};
-		7D826E40239084F000EED93D /* .github */ = {
-			isa = PBXGroup;
-			children = (
-				7D826E41239084F000EED93D /* release.yml */,
-				7D826E42239084F000EED93D /* CODEOWNERS */,
-				7D826E43239084F000EED93D /* ISSUE_TEMPLATE.md */,
-			);
-			path = .github;
 			sourceTree = "<group>";
 		};
 		8405A517279906EF001B38A1 /* Profiling */ = {

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1,4 +1,3 @@
-
 // !$*UTF8*$!
 {
 	archiveVersion = 1;
@@ -1264,7 +1263,6 @@
 		844DA81D28246DAE00E6B62E /* develop-docs */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "develop-docs"; sourceTree = "<group>"; };
 		844DA81E28246DB900E6B62E /* fastlane */ = {isa = PBXFileReference; lastKnownFileType = folder; path = fastlane; sourceTree = "<group>"; };
 		844DA81F28246DE300E6B62E /* scripts */ = {isa = PBXFileReference; lastKnownFileType = folder; path = scripts; sourceTree = "<group>"; };
-		844DA82028246E0600E6B62E /* test-server */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = "test-server"; sourceTree = "<group>"; };
 		861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSArray+SentrySanitize.h"; path = "include/NSArray+SentrySanitize.h"; sourceTree = "<group>"; };
 		861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SentrySanitize.m"; sourceTree = "<group>"; };
 		8E0551DF26A7A63C00400526 /* TestProtocolClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProtocolClient.swift; sourceTree = "<group>"; };
@@ -1536,7 +1534,6 @@
 				844DA80728246D5000E6B62E /* Gemfile */,
 				844DA80428246D5000E6B62E /* Makefile */,
 				844DA81F28246DE300E6B62E /* scripts */,
-				844DA82028246E0600E6B62E /* test-server */,
 				844DA80928246D5000E6B62E /* dangerfile.js */,
 				844DA81B28246D9300E6B62E /* Brewfile.lock.json */,
 				844DA81C28246D9300E6B62E /* Gemfile.lock */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1242,6 +1242,7 @@
 		7DC831082398283C0043DD9A /* SentryCrashIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashIntegration.h; path = include/SentryCrashIntegration.h; sourceTree = "<group>"; };
 		7DC831092398283C0043DD9A /* SentryCrashIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashIntegration.m; sourceTree = "<group>"; };
 		844A34C3282B278500C6D1DF /* .github */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .github; sourceTree = "<group>"; };
+		844A3563282B3C9F00C6D1DF /* .sauce */ = {isa = PBXFileReference; lastKnownFileType = folder; path = .sauce; sourceTree = "<group>"; };
 		844DA7F6282435CD00E6B62E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		844DA80328246D5000E6B62E /* .oclint */ = {isa = PBXFileReference; lastKnownFileType = text; path = .oclint; sourceTree = "<group>"; };
 		844DA80428246D5000E6B62E /* Makefile */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.make; path = Makefile; sourceTree = "<group>"; };
@@ -1528,6 +1529,7 @@
 				844DA81628246D5000E6B62E /* .gitignore */,
 				844DA80828246D5000E6B62E /* .gitmodules */,
 				844DA80328246D5000E6B62E /* .oclint */,
+				844A3563282B3C9F00C6D1DF /* .sauce */,
 				844DA80B28246D5000E6B62E /* Brewfile */,
 				844DA81D28246DAE00E6B62E /* develop-docs */,
 				844DA81E28246DB900E6B62E /* fastlane */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1256,6 +1256,7 @@
 		7DC830FF239826280043DD9A /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = Public/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
 		7DC831082398283C0043DD9A /* SentryCrashIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashIntegration.h; path = include/SentryCrashIntegration.h; sourceTree = "<group>"; };
 		7DC831092398283C0043DD9A /* SentryCrashIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashIntegration.m; sourceTree = "<group>"; };
+		844DA7F6282435CD00E6B62E /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		861265F72404EC1500C4AFDE /* NSArray+SentrySanitize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSArray+SentrySanitize.h"; path = "include/NSArray+SentrySanitize.h"; sourceTree = "<group>"; };
 		861265F82404EC1500C4AFDE /* NSArray+SentrySanitize.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSArray+SentrySanitize.m"; sourceTree = "<group>"; };
 		8E0551DF26A7A63C00400526 /* TestProtocolClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProtocolClient.swift; sourceTree = "<group>"; };
@@ -1677,6 +1678,7 @@
 		63AA75921EB8AEDB00D153DE /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				844DA7F6282435CD00E6B62E /* README.md */,
 				7B9660B12783500E0014A767 /* ThreadSanitizer.sup */,
 				630C01951EC341D600C52CEF /* Resources */,
 				63AA76AA1EB9D5CD00D153DE /* Configuration */,

--- a/Sentry.xcworkspace/contents.xcworkspacedata
+++ b/Sentry.xcworkspace/contents.xcworkspacedata
@@ -1,27 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
-   <FileRef
-      location = "group:Samples/iOS15-SwiftUI/iOS15-SwiftUI.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Samples/iOS-SwiftUI/iOS-SwiftUI.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Samples/watchOS-Swift/watchOS-Swift.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Samples/tvOS-Swift/tvOS-Swift.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Samples/macOS-Swift/macOS-Swift.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj">
-   </FileRef>
-   <FileRef
-      location = "group:Samples/iOS-Swift/iOS-Swift.xcodeproj">
-   </FileRef>
+   <Group
+      location = "container:"
+      name = "Samples">
+      <FileRef
+         location = "group:Samples/README.md">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/iOS15-SwiftUI/iOS15-SwiftUI.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/iOS-SwiftUI/iOS-SwiftUI.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/watchOS-Swift/watchOS-Swift.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/tvOS-Swift/tvOS-Swift.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/macOS-Swift/macOS-Swift.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj">
+      </FileRef>
+      <FileRef
+         location = "group:Samples/iOS-Swift/iOS-Swift.xcodeproj">
+      </FileRef>
+   </Group>
    <FileRef
       location = "group:Sentry.xcodeproj">
    </FileRef>

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -2,7 +2,8 @@
 
 For test guidelines please checkout the [Contributing Guidelines](../CONTRIBUTING.md).
 
-Integrations tests for generating and sending data to Sentry to test certain features:
+# Integration tests 
+
+For generating and sending data to Sentry.
 
 * [SessionGeneratorTests](./SentryTests/Integrations/SentrySessionGeneratorTests.swift) generates session data to validate release health.
-* [TransactionGeneratorTests](./SentryTests/Performance/TransactionGeneratorTests.swift) generates transactions.


### PR DESCRIPTION
## :scroll: Description

#skip-changelog

- xcode project reorg (see screenshot below):
    - add a few files to the Xcode project navigator for easy editing ~, including `test-server/` which also pulls in its SPM dependencies~ (this broke things in CI)
    - reogranize sample apps under a group to match the file structure
    - convert some included top-level folders containing files not belonging to any targets to folder references
- add a readme to for the sample apps and updates a readme that was out of date

screenshot showing before/after xcodeproj reorg: 
![Screen Shot 2022-05-10 at 2 50 43 PM](https://user-images.githubusercontent.com/3241469/167739399-603c58f4-bc02-43f5-a6e8-5ce6f39406e6.png)

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

I made these changes while diving into the source/project for the first time.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Ensure it passes CI; no code changes, so as long as tests don't break we're good 👍🏻 

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
