### PR TITLE
Hub uses its scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow partial SDK info override (#1816)
 
+### Fixes
+
+- Hub uses its scope (#1821)
+
 ## 7.15.0
 
 ### Features

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -253,7 +253,7 @@ SentryHub ()
 
 - (SentryId *)captureEvent:(SentryEvent *)event
 {
-    return [self captureEvent:event withScope:[[SentryScope alloc] init]];
+    return [self captureEvent:event withScope:self.scope];
 }
 
 - (SentryId *)captureEvent:(SentryEvent *)event withScope:(SentryScope *)scope
@@ -344,7 +344,7 @@ SentryHub ()
 
 - (SentryId *)captureMessage:(NSString *)message
 {
-    return [self captureMessage:message withScope:[[SentryScope alloc] init]];
+    return [self captureMessage:message withScope:self.scope];
 }
 
 - (SentryId *)captureMessage:(NSString *)message withScope:(SentryScope *)scope
@@ -358,7 +358,7 @@ SentryHub ()
 
 - (SentryId *)captureError:(NSError *)error
 {
-    return [self captureError:error withScope:[[SentryScope alloc] init]];
+    return [self captureError:error withScope:self.scope];
 }
 
 - (SentryId *)captureError:(NSError *)error withScope:(SentryScope *)scope
@@ -377,7 +377,7 @@ SentryHub ()
 
 - (SentryId *)captureException:(NSException *)exception
 {
-    return [self captureException:exception withScope:[[SentryScope alloc] init]];
+    return [self captureException:exception withScope:self.scope];
 }
 
 - (SentryId *)captureException:(NSException *)exception withScope:(SentryScope *)scope

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -202,12 +202,12 @@ class SentryHubTests: XCTestCase {
     }
     
     func testCaptureEventWithoutScope() {
-        fixture.getSut().capture(event: fixture.event)
+        fixture.getSut(fixture.options, fixture.scope).capture(event: fixture.event)
         
         XCTAssertEqual(1, fixture.client.captureEventWithScopeInvocations.count)
         if let eventArguments = fixture.client.captureEventWithScopeInvocations.first {
             XCTAssertEqual(fixture.event.eventId, eventArguments.event.eventId)
-            XCTAssertEqual(Scope(), eventArguments.scope)
+            XCTAssertEqual(fixture.scope, eventArguments.scope)
         }
     }
     
@@ -377,12 +377,12 @@ class SentryHubTests: XCTestCase {
     }
     
     func testCaptureMessageWithoutScope() {
-        fixture.getSut().capture(message: fixture.message)
+        fixture.getSut(fixture.options, fixture.scope).capture(message: fixture.message)
         
         XCTAssertEqual(1, fixture.client.captureMessageWithScopeInvocations.count)
         if let messageArguments = fixture.client.captureMessageWithScopeInvocations.first {
             XCTAssertEqual(fixture.message, messageArguments.message)
-            XCTAssertEqual(Scope(), messageArguments.scope)
+            XCTAssertEqual(fixture.scope, messageArguments.scope)
         }
     }
     
@@ -416,12 +416,12 @@ class SentryHubTests: XCTestCase {
     }
     
     func testCatpureErrorWithoutScope() {
-        fixture.getSut().capture(error: fixture.error).assertIsNotEmpty()
+        fixture.getSut(fixture.options, fixture.scope).capture(error: fixture.error).assertIsNotEmpty()
         
         XCTAssertEqual(1, fixture.client.captureErrorWithScopeInvocations.count)
         if let errorArguments = fixture.client.captureErrorWithScopeInvocations.first {
             XCTAssertEqual(fixture.error, errorArguments.error as NSError)
-            XCTAssertEqual(Scope(), errorArguments.scope)
+            XCTAssertEqual(fixture.scope, errorArguments.scope)
         }
     }
     
@@ -436,12 +436,12 @@ class SentryHubTests: XCTestCase {
     }
     
     func testCatpureExceptionWithoutScope() {
-        fixture.getSut().capture(exception: fixture.exception).assertIsNotEmpty()
+        fixture.getSut(fixture.options, fixture.scope).capture(exception: fixture.exception).assertIsNotEmpty()
         
         XCTAssertEqual(1, fixture.client.captureExceptionWithScopeInvocations.count)
         if let errorArguments = fixture.client.captureExceptionWithScopeInvocations.first {
             XCTAssertEqual(fixture.exception, errorArguments.exception)
-            XCTAssertEqual(Scope(), errorArguments.scope)
+            XCTAssertEqual(fixture.scope, errorArguments.scope)
         }
     }
     


### PR DESCRIPTION


## :scroll: Description

When calling capture without the scope parameter, the hub created a new
empty scope. Instead, the hub should use its scope when calling such
methods.

## :bulb: Motivation and Context

Came up when interacting with the hub directly in https://github.com/getsentry/sentry-cocoa/pull/1815. It is annoying to pass in the scope of the hub when calling `hub.captureEvent` to make the hub use its scope.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
