### PR TITLE
ref: Handle systemInfo empty in CrashIntegration

### DIFF
--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -204,7 +204,7 @@ SentryCrashIntegration ()
 
     NSDictionary *systemInfo = [crashWrapper systemInfo];
 
-    // This only applies if SentryCrashIntegration is not installed
+    // SystemInfo should only be nil when SentryCrash has not been installed
     if (systemInfo != nil && systemInfo.count != 0) {
         [osData setValue:systemInfo[@"osVersion"] forKey:@"build"];
         [osData setValue:systemInfo[@"kernelVersion"] forKey:@"kernel_version"];
@@ -213,7 +213,7 @@ SentryCrashIntegration ()
 
     [scope setContextValue:osData forKey:@"os"];
 
-    // This only applies if SentryCrashIntegration is not installed
+    // SystemInfo should only be nil when SentryCrash has not been installed
     if (systemInfo == nil || systemInfo.count == 0) {
         return;
     }

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -55,6 +55,14 @@ NS_ASSUME_NONNULL_BEGIN
     sentrycrashccd_close();
 }
 
+- (NSDictionary *)systemInfo
+{
+    static NSDictionary *sharedInfo = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ sharedInfo = SentryCrash.sharedInstance.systemInfo; });
+    return sharedInfo;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryCrashIntegration.h
+++ b/Sources/Sentry/include/SentryCrashIntegration.h
@@ -3,13 +3,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryScope;
+@class SentryScope, SentryCrashWrapper;
 
 static NSString *const SentryDeviceContextFreeMemoryKey = @"free_memory";
 
 @interface SentryCrashIntegration : NSObject <SentryIntegrationProtocol>
 
-+ (void)enrichScope:(SentryScope *)scope;
++ (void)enrichScope:(SentryScope *)scope crashWrapper:(SentryCrashWrapper *)crashWrapper;
 
 @end
 

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -26,6 +26,8 @@ SENTRY_NO_INIT
  */
 - (void)close;
 
+- (NSDictionary *)systemInfo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -109,7 +109,7 @@ class SentryCrashIntegrationTests: XCTestCase {
         // We don't worry about the actual values
         // This is an edge case where the user doesn't use the
         // SentryCrashIntegration. Just make sure to not crash.
-        XCTAssertTrue(scope.contextDictionary.count > 0)
+        XCTAssertFalse(scope.contextDictionary.allValues.isEmpty)
     }
     
     func testEndSessionAsCrashed_WithCurrentSession() {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -38,7 +38,11 @@ class SentryCrashIntegrationTests: XCTestCase {
         }
         
         func getSut() -> SentryCrashIntegration {
-            return SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: dispatchQueueWrapper)
+            return getSut(crashWrapper: sentryCrash)
+        }
+        
+        func getSut(crashWrapper: SentryCrashWrapper) -> SentryCrashIntegration {
+            return SentryCrashIntegration(crashAdapter: crashWrapper, andDispatchQueueWrapper: dispatchQueueWrapper)
         }
         
         var sutWithoutCrash: SentryCrashIntegration {
@@ -96,6 +100,16 @@ class SentryCrashIntegrationTests: XCTestCase {
         let context = userInfo["context"] as? [String: Any]
         
         assertContext(context: context)
+    }
+    
+    func testSystemInfoIsEmpty() {
+        let scope = Scope()
+        SentryCrashIntegration.enrichScope(scope, crashWrapper: TestSentryCrashWrapper.sharedInstance())
+        
+        // We don't worry about the actual values
+        // This is an edge case where the user doesn't use the
+        // SentryCrashIntegration. Just make sure to not crash.
+        XCTAssertTrue(scope.contextDictionary.count > 0)
     }
     
     func testEndSessionAsCrashed_WithCurrentSession() {
@@ -202,7 +216,7 @@ class SentryCrashIntegrationTests: XCTestCase {
     }
     
     func testUninstall_DoesNotUpdateLocale_OnLocaleDidChangeNotification() {
-        let (sut, hub) = givenSutWithGlobalHub()
+        let (sut, hub) = givenSutWithGlobalHubAndCrashWrapper()
 
         sut.install(with: Options())
 
@@ -217,7 +231,7 @@ class SentryCrashIntegrationTests: XCTestCase {
     }
     
     func testOSCorrectlySetToScopeContext() {
-        let (sut, hub) = givenSutWithGlobalHub()
+        let (sut, hub) = givenSutWithGlobalHubAndCrashWrapper()
         
         sut.install(with: Options())
         
@@ -239,7 +253,7 @@ class SentryCrashIntegrationTests: XCTestCase {
     }
     
     func testLocaleChanged_DifferentLocale_SetsCurrentLocale() {
-        let (sut, hub) = givenSutWithGlobalHub()
+        let (sut, hub) = givenSutWithGlobalHubAndCrashWrapper()
         
         sut.install(with: Options())
         
@@ -274,6 +288,14 @@ class SentryCrashIntegrationTests: XCTestCase {
     
     private func givenSutWithGlobalHub() -> (SentryCrashIntegration, SentryHub) {
         let sut = fixture.getSut()
+        let hub = fixture.hub
+        SentrySDK.setCurrentHub(hub)
+
+        return (sut, hub)
+    }
+    
+    private func givenSutWithGlobalHubAndCrashWrapper() -> (SentryCrashIntegration, SentryHub) {
+        let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         let hub = fixture.hub
         SentrySDK.setCurrentHub(hub)
 

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
@@ -1,4 +1,5 @@
 #import "TestSentryCrashWrapper.h"
+#import "SentryCrash.h"
 #import <Foundation/Foundation.h>
 
 @implementation TestSentryCrashWrapper
@@ -43,6 +44,11 @@
 - (void)close
 {
     self.closeCalled = YES;
+}
+
+- (NSDictionary *)systemInfo
+{
+    return @{};
 }
 
 @end

--- a/Tests/SentryTests/TestUtils/SentryTestObserver.m
+++ b/Tests/SentryTests/TestUtils/SentryTestObserver.m
@@ -2,6 +2,7 @@
 #import "SentryBreadcrumb.h"
 #import "SentryClient.h"
 #import "SentryCrashIntegration.h"
+#import "SentryCrashWrapper.h"
 #import "SentryCurrentDate.h"
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryHub.h"
@@ -48,7 +49,8 @@ SentryTestObserver ()
         [SentrySDK startWithOptionsObject:options];
 
         self.scope = [[SentryScope alloc] init];
-        [SentryCrashIntegration enrichScope:self.scope];
+        [SentryCrashIntegration enrichScope:self.scope
+                               crashWrapper:[SentryCrashWrapper sharedInstance]];
 
         self.options = options;
     }


### PR DESCRIPTION

## :scroll: Description

Handle edge case when systemInfo is empty in SentryCrashIntegration.

#skip-changelog

## :bulb: Motivation and Context

I actually wanted to fix GH-1104, because I thought I can do it in an hour as I had to use a workaround in https://github.com/getsentry/sentry-cocoa/pull/1815 to get the scope data, see https://github.com/getsentry/sentry-cocoa/blob/b1ce7c5cd4cbb16a0c97ca417b0891831b779b84/Tests/SentryTests/TestUtils/SentryTestObserver.m#L50-L51

I stopped working on fishing GH-1104 as it turns out not to be a quick fix. I didn't want to throw away some of the refactorings though.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
