### PR TITLE
feat: Collect queue label information for profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Add profile data category for rate limiting (#1799)
 - Allow setting SDK info with Options initWithDict (#1793)
+- Collect queue label information for profiles (#1787)
 - Remove ViewController name match for swizzling (#1802)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Features
 
+- Collect queue label information for profiles (#1828)
+
+### Features
+
 - Allow partial SDK info override (#1816)
 
 ### Fixes
@@ -16,7 +20,6 @@
 
 - Add profile data category for rate limiting (#1799)
 - Allow setting SDK info with Options initWithDict (#1793)
-- Collect queue label information for profiles (#1787)
 - Remove ViewController name match for swizzling (#1802)
 
 ### Fixes

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -169,7 +169,7 @@ namespace profiling {
                     // There's no cached metadata, so we should try to read it.
                     const auto queue = reinterpret_cast<dispatch_queue_t *>(queueAddress);
                     const auto queueLabel = dispatch_queue_get_label(*queue);
-                    std::strncat(newQueueLabel, queueLabel, sizeof(newQueueLabel) - 1);
+                    strlcpy(newQueueLabel, queueLabel, sizeof(newQueueLabel));
                 }
 
                 thread->resume();

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -138,6 +138,12 @@ namespace profiling {
                 continue;
             }
 
+            // Retrieving queue metadata *must* be done after suspending the thread,
+            // because otherwise the queue could be deallocated in the middle of us
+            // trying to read from it. This doesn't use any of the pthread APIs, only
+            // thread_info, so the above comment about the deadlock does not apply here.
+            bt.queueMetadata = cache->metadataForQueue(thread->dispatchQueueAddress());
+
             bool reachedEndOfStack = false;
             std::uintptr_t addresses[kMaxBacktraceDepth];
             const auto depth = backtrace(*thread, *pair.second, addresses, stackBounds,

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -152,7 +152,7 @@ namespace profiling {
             std::uintptr_t addresses[kMaxBacktraceDepth];
             const auto depth = backtrace(*thread, *pair.second, addresses, stackBounds,
                 &reachedEndOfStack, kMaxBacktraceDepth, 0);
-            
+
             // Retrieving queue metadata *must* be done after suspending the thread,
             // because otherwise the queue could be deallocated in the middle of us
             // trying to read from it. This doesn't use any of the pthread APIs, only
@@ -161,7 +161,7 @@ namespace profiling {
             if (queueAddress != 0) {
                 // This operation is read-only and does not result in any heap allocations.
                 auto cachedMetadata = cache->metadataForQueue(queueAddress);
-                
+
                 // Copy the queue label onto the stack to avoid a heap allocation.
                 char newQueueLabel[256];
                 *newQueueLabel = '\0';
@@ -171,9 +171,9 @@ namespace profiling {
                     const auto queueLabel = dispatch_queue_get_label(*queue);
                     std::strncat(newQueueLabel, queueLabel, sizeof(newQueueLabel) - 1);
                 }
-                
+
                 thread->resume();
-                
+
                 if (cachedMetadata.address == 0) {
                     cachedMetadata.address = queueAddress;
                     // These cause heap allocations but it's safe now since the thread has
@@ -185,7 +185,7 @@ namespace profiling {
             } else {
                 thread->resume();
             }
-            
+
             // ############################################
             // END DEADLOCK WARNING
             // ############################################

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -178,7 +178,7 @@ namespace profiling {
                     cachedMetadata.address = queueAddress;
                     // These cause heap allocations but it's safe now since the thread has
                     // been resumed above.
-                    cachedMetadata.label = std::string(newQueueLabel);
+                    cachedMetadata.label = std::make_shared<std::string>(newQueueLabel);
                     cache->setQueueMetadata(cachedMetadata);
                 }
                 bt.queueMetadata = std::move(cachedMetadata);

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -163,7 +163,7 @@ namespace profiling {
                 auto cachedMetadata = cache->metadataForQueue(queueAddress);
                 
                 // Copy the queue label onto the stack to avoid a heap allocation.
-                char newQueueLabel[128];
+                char newQueueLabel[256];
                 *newQueueLabel = '\0';
                 if (cachedMetadata.address == 0) {
                     // There's no cached metadata, so we should try to read it.

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -151,7 +151,8 @@ isSimulatorBuild()
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                     threadMetadata[threadID] = metadata;
                 }
-                if (queueAddress != nil && queueMetadata[queueAddress] == nil && backtrace.queueMetadata.label != nullptr) {
+                if (queueAddress != nil && queueMetadata[queueAddress] == nil
+                    && backtrace.queueMetadata.label != nullptr) {
                     queueMetadata[queueAddress] = @{
                         @"label" :
                             [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()]

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -151,10 +151,10 @@ isSimulatorBuild()
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                     threadMetadata[threadID] = metadata;
                 }
-                if (queueAddress != nil && queueMetadata[queueAddress] == nil) {
+                if (queueAddress != nil && queueMetadata[queueAddress] == nil && backtrace.queueMetadata.label != nullptr) {
                     queueMetadata[queueAddress] = @{
                         @"label" :
-                            [NSString stringWithUTF8String:backtrace.queueMetadata.label.c_str()]
+                            [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()]
                     };
                 }
 #    if defined(DEBUG)

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -123,19 +123,25 @@ isSimulatorBuild()
         const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
         const auto samples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
         const auto threadMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
+        const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
         sampledProfile[@"samples"] = samples;
         sampledProfile[@"thread_metadata"] = threadMetadata;
+        sampledProfile[@"queue_metadata"] = queueMetadata;
         _profile[@"sampled_profile"] = sampledProfile;
         _startTimestamp = getAbsoluteTime();
 
         __weak const auto weakSelf = self;
         _profiler = std::make_shared<SamplingProfiler>(
-            [weakSelf, sampledProfile, threadMetadata, samples](auto &backtrace) {
+            [weakSelf, sampledProfile, threadMetadata, queueMetadata, samples](auto &backtrace) {
                 const auto strongSelf = weakSelf;
                 if (strongSelf == nil) {
                     return;
                 }
                 const auto threadID = [@(backtrace.threadMetadata.threadID) stringValue];
+                NSString *queueAddress = nil;
+                if (backtrace.queueMetadata.address != 0) {
+                    queueAddress = sentry_formatHexAddress(@(backtrace.queueMetadata.address));
+                }
                 if (threadMetadata[threadID] == nil) {
                     const auto metadata = [NSMutableDictionary<NSString *, id> dictionary];
                     if (!backtrace.threadMetadata.name.empty()) {
@@ -144,6 +150,12 @@ isSimulatorBuild()
                     }
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                     threadMetadata[threadID] = metadata;
+                }
+                if (queueAddress != nil && queueMetadata[queueAddress] == nil) {
+                    queueMetadata[queueAddress] = @{
+                        @"label" :
+                            [NSString stringWithUTF8String:backtrace.queueMetadata.label.c_str()]
+                    };
                 }
 #    if defined(DEBUG)
                 const auto symbols
@@ -166,6 +178,9 @@ isSimulatorBuild()
                     [@(getDurationNs(strongSelf->_startTimestamp, backtrace.absoluteTimestamp))
                         stringValue];
                 sample[@"thread_id"] = threadID;
+                if (queueAddress != nil) {
+                    sample[@"queue_address"] = queueAddress;
+                }
                 [samples addObject:sample];
             },
             100 /** Sample 100 times per second */);

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -10,6 +10,13 @@
 #    include <mach/mach.h>
 #    include <pthread.h>
 
+/**
+ * SentryCrashMemory.h uses the restrict keyword, which is valid in C99 but
+ * invalid in C++; we can use __restrict as an alternative.
+ * */
+#    define restrict __restrict
+#    include "SentryCrashMemory.h"
+
 namespace sentry {
 namespace profiling {
 
@@ -115,6 +122,29 @@ namespace profiling {
             return std::string(name);
         }
         return {};
+    }
+
+    std::uint64_t
+    ThreadHandle::dispatchQueueAddress() const noexcept
+    {
+        if (handle_ == THREAD_NULL) {
+            return {};
+        }
+        integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = { 0 };
+        thread_info_t info = infoBuffer;
+        mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
+        const auto rv = thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count);
+        const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
+        // MACH_SEND_INVALID_DEST is returned when the thread no longer exists
+        if (rv != MACH_SEND_INVALID_DEST && SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS
+            && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+            const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
+            if (queuePtr != nullptr && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))
+                && idInfo->thread_handle != 0 && *queuePtr != nullptr) {
+                return idInfo->dispatch_qaddr;
+            }
+        }
+        return 0;
     }
 
     int

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -133,11 +133,8 @@ namespace profiling {
         integer_t infoBuffer[THREAD_IDENTIFIER_INFO_COUNT] = { 0 };
         thread_info_t info = infoBuffer;
         mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
-        const auto rv = thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count);
         const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
-        // MACH_SEND_INVALID_DEST is returned when the thread no longer exists
-        if (rv != MACH_SEND_INVALID_DEST && SENTRY_PROF_LOG_KERN_RETURN(rv) == KERN_SUCCESS
-            && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+        if (thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count) == KERN_SUCCESS && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
             const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
             if (queuePtr != nullptr && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))
                 && idInfo->thread_handle != 0 && *queuePtr != nullptr) {

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -134,7 +134,8 @@ namespace profiling {
         thread_info_t info = infoBuffer;
         mach_msg_type_number_t count = THREAD_IDENTIFIER_INFO_COUNT;
         const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
-        if (thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count) == KERN_SUCCESS && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+        if (thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count) == KERN_SUCCESS
+            && sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
             const auto queuePtr = reinterpret_cast<dispatch_queue_t *>(idInfo->dispatch_qaddr);
             if (queuePtr != nullptr && sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))
                 && idInfo->thread_handle != 0 && *queuePtr != nullptr) {

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -75,7 +75,9 @@ namespace profiling {
         }
     }
 
-    void ThreadMetadataCache::setQueueMetadata(QueueMetadata metadata) {
+    void
+    ThreadMetadataCache::setQueueMetadata(QueueMetadata metadata)
+    {
         queueMetadataCache_.push_back(std::move(metadata));
     }
 

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -6,7 +6,6 @@
 #    include "SentryThreadHandle.hpp"
 
 #    include <algorithm>
-#    include <dispatch/dispatch.h>
 #    include <string>
 #    include <vector>
 
@@ -62,7 +61,7 @@ namespace profiling {
     }
 
     QueueMetadata
-    ThreadMetadataCache::metadataForQueue(std::uint64_t address)
+    ThreadMetadataCache::metadataForQueue(std::uint64_t address) const
     {
         if (address == 0) {
             return {};
@@ -70,13 +69,14 @@ namespace profiling {
         const auto it = std::find_if(queueMetadataCache_.cbegin(), queueMetadataCache_.cend(),
             [address](const QueueMetadata &metadata) { return metadata.address == address; });
         if (it == queueMetadataCache_.cend()) {
-            const auto queue = reinterpret_cast<dispatch_queue_t *>(address);
-            QueueMetadata metadata = { address, std::string(dispatch_queue_get_label(*queue)) };
-            queueMetadataCache_.push_back(metadata);
-            return metadata;
+            return { 0, {} };
         } else {
             return (*it);
         }
+    }
+
+    void ThreadMetadataCache::setQueueMetadata(QueueMetadata metadata) {
+        queueMetadataCache_.push_back(std::move(metadata));
     }
 
 } // namespace profiling

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -6,6 +6,7 @@
 #    include "SentryThreadHandle.hpp"
 
 #    include <algorithm>
+#    include <dispatch/dispatch.h>
 #    include <string>
 #    include <vector>
 
@@ -28,9 +29,9 @@ namespace profiling {
     ThreadMetadataCache::metadataForThread(const ThreadHandle &thread)
     {
         const auto handle = thread.nativeHandle();
-        const auto it = std::find_if(cache_.cbegin(), cache_.cend(),
+        const auto it = std::find_if(threadMetadataCache_.cbegin(), threadMetadataCache_.cend(),
             [handle](const ThreadHandleMetadataPair &pair) { return pair.handle == handle; });
-        if (it == cache_.cend()) {
+        if (it == threadMetadataCache_.cend()) {
             ThreadMetadata metadata;
             metadata.threadID = ThreadHandle::tidFromNativeHandle(handle);
             metadata.priority = thread.priority();
@@ -43,7 +44,7 @@ namespace profiling {
                     // Don't collect backtraces for Sentry-owned threads.
                     metadata.priority = 0;
                     metadata.threadID = 0;
-                    cache_.push_back({ handle, metadata });
+                    threadMetadataCache_.push_back({ handle, metadata });
                     return metadata;
                 }
                 if (threadName.size() > kMaxThreadNameLength) {
@@ -53,10 +54,28 @@ namespace profiling {
                 metadata.name = threadName;
             }
 
-            cache_.push_back({ handle, metadata });
+            threadMetadataCache_.push_back({ handle, metadata });
             return metadata;
         } else {
             return (*it).metadata;
+        }
+    }
+
+    QueueMetadata
+    ThreadMetadataCache::metadataForQueue(std::uint64_t address)
+    {
+        if (address == 0) {
+            return {};
+        }
+        const auto it = std::find_if(queueMetadataCache_.cbegin(), queueMetadataCache_.cend(),
+            [address](const QueueMetadata &metadata) { return metadata.address == address; });
+        if (it == queueMetadataCache_.cend()) {
+            const auto queue = reinterpret_cast<dispatch_queue_t *>(address);
+            QueueMetadata metadata = { address, std::string(dispatch_queue_get_label(*queue)) };
+            queueMetadataCache_.push_back(metadata);
+            return metadata;
+        } else {
+            return (*it);
         }
     }
 

--- a/Sources/Sentry/include/SentryBacktrace.hpp
+++ b/Sources/Sentry/include/SentryBacktrace.hpp
@@ -21,6 +21,7 @@ namespace profiling {
 
     struct Backtrace {
         ThreadMetadata threadMetadata;
+        QueueMetadata queueMetadata;
         std::uint64_t absoluteTimestamp;
         std::vector<std::uintptr_t> addresses;
     };

--- a/Sources/Sentry/include/SentryThreadHandle.hpp
+++ b/Sources/Sentry/include/SentryThreadHandle.hpp
@@ -7,6 +7,7 @@
 #    include "SentryStackBounds.hpp"
 
 #    include <chrono>
+#    include <cstdint>
 #    include <mach/mach.h>
 #    include <memory>
 #    include <pthread.h>
@@ -95,6 +96,17 @@ namespace profiling {
          * @warning This function is not async-signal safe!
          */
         std::string name() const noexcept;
+
+        /**
+         * @return The address of the dispatch queue currently associated with
+         * the thread, or 0 if there is no valid queue. This function checks if
+         * the memory at the returned address is readable, but there is no guarantee
+         * that the queue will continue to stay valid by the time you deference it,
+         * as queue deallocation can happen concurrently.
+         *
+         * @warning This function is not async-signal safe!
+         */
+        std::uint64_t dispatchQueueAddress() const noexcept;
 
         /**
          * @return The priority of the specified thread, or -1 if the thread priority

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -42,12 +42,18 @@ namespace profiling {
 
         /**
          * Returns the metadata for the queue at the specified address.
-         * @param address The address of the queue to retrieve metadata from.
-         * @note This function assumes that the queue address is valid. If the address
-         * is invalid, the behavior is non-deterministic and will probably crash.
-         * @return @c QueueMetadata for the queue at the specified address.
+         * @param address The address of the queue.
+         * @return @c QueueMetadata for the queue at the specified address if a cached
+         * entry exists, or an empty @c QueueMetadata with the address set to 0 if it
+         * does not exist.
          */
-        QueueMetadata metadataForQueue(std::uint64_t address);
+        QueueMetadata metadataForQueue(std::uint64_t address) const;
+        
+        /**
+         * Stores metadata for the queue at the address specified in `metadata.address`
+         * @param metadata The metadata to associate with the queue.
+         */
+        void setQueueMetadata(QueueMetadata metadata);
 
         ThreadMetadataCache() = default;
         ThreadMetadataCache(const ThreadMetadataCache &) = delete;

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -20,7 +20,9 @@ namespace profiling {
 
     struct QueueMetadata {
         std::uint64_t address;
-        std::string label;
+        // std::string always heap allocates a string buffer, since this data structure
+        // might be created while its unsafe to allocate, we wrap it in a pointer.
+        std::shared_ptr<std::string> label;
     };
 
     /**

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -6,6 +6,7 @@
 
 #    include "SentryThreadHandle.hpp"
 
+#    include <cstdint>
 #    include <memory>
 #    include <string>
 
@@ -17,9 +18,14 @@ namespace profiling {
         int priority;
     };
 
+    struct QueueMetadata {
+        std::uint64_t address;
+        std::string label;
+    };
+
     /**
-     * Caches thread metadata (name, priority, etc.) for reuse while profiling, since querying that
-     * metadata from the thread every time can be expensive.
+     * Caches thread and queue metadata (name, priority, etc.) for reuse while profiling,
+     * since querying that metadata every time can be expensive.
      *
      * @note This class is not thread-safe.
      */
@@ -34,6 +40,15 @@ namespace profiling {
          */
         ThreadMetadata metadataForThread(const ThreadHandle &thread);
 
+        /**
+         * Returns the metadata for the queue at the specified address.
+         * @param address The address of the queue to retrieve metadata from.
+         * @note This function assumes that the queue address is valid. If the address
+         * is invalid, the behavior is non-deterministic and will probably crash.
+         * @return @c QueueMetadata for the queue at the specified address.
+         */
+        QueueMetadata metadataForQueue(std::uint64_t address);
+
         ThreadMetadataCache() = default;
         ThreadMetadataCache(const ThreadMetadataCache &) = delete;
         ThreadMetadataCache &operator=(const ThreadMetadataCache &) = delete;
@@ -43,7 +58,8 @@ namespace profiling {
             ThreadHandle::NativeHandle handle;
             ThreadMetadata metadata;
         };
-        std::vector<const ThreadHandleMetadataPair> cache_;
+        std::vector<const ThreadHandleMetadataPair> threadMetadataCache_;
+        std::vector<const QueueMetadata> queueMetadataCache_;
     };
 
 } // namespace profiling

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -48,7 +48,7 @@ namespace profiling {
          * does not exist.
          */
         QueueMetadata metadataForQueue(std::uint64_t address) const;
-        
+
         /**
          * Stores metadata for the queue at the address specified in `metadata.address`
          * @param metadata The metadata to associate with the queue.

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -111,8 +111,8 @@ threadSpin(void *name)
     const auto cache = std::make_shared<ThreadMetadataCache>();
 
     const auto address = reinterpret_cast<std::uint64_t>(&queue);
-    cache->setQueueMetadata({ address, label });
-    XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
+    cache->setQueueMetadata({ address, std::make_shared<std::string>(label) });
+    XCTAssertTrue(*cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
 }
 
 - (void)testNonexistentQueueAddressReturnsNoMetadata
@@ -121,7 +121,7 @@ threadSpin(void *name)
     const auto metadata = cache->metadataForQueue(0);
 
     XCTAssertEqual(metadata.address, static_cast<unsigned long long>(0));
-    XCTAssertEqual(metadata.label, "");
+    XCTAssertEqual(metadata.label, nullptr);
 }
 
 @end

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -111,7 +111,7 @@ threadSpin(void *name)
     const auto cache = std::make_shared<ThreadMetadataCache>();
 
     const auto address = reinterpret_cast<std::uint64_t>(&queue);
-    cache->setQueueMetadata({address, label});
+    cache->setQueueMetadata({ address, label });
     XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
 }
 

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -35,7 +35,7 @@ threadSpin(void *name)
 
 @implementation SentryThreadMetadataCacheTests
 
-- (void)testRetrievesMetadata
+- (void)testRetrievesThreadMetadata
 {
     pthread_t thread;
     char name[] = "SentryThreadMetadataCacheTests";
@@ -60,7 +60,7 @@ threadSpin(void *name)
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
 }
 
-- (void)testReturnsCachedMetadata
+- (void)testReturnsCachedThreadMetadata
 {
     pthread_t thread;
     char name[] = "SentryThreadMetadataCacheTests";
@@ -102,6 +102,24 @@ threadSpin(void *name)
 
     XCTAssertEqual(pthread_cancel(thread), 0);
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
+}
+
+- (void)testRetrievesQueueMetadata
+{
+    const auto label = "io.sentry.SentryThreadMetadataCacheTests.testQueue";
+    const auto queue = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
+    const auto cache = std::make_shared<ThreadMetadataCache>();
+
+    XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
+}
+
+- (void)testNullQueueAddressReturnsNoMetadata
+{
+    const auto cache = std::make_shared<ThreadMetadataCache>();
+    const auto metadata = cache->metadataForQueue(0);
+
+    XCTAssertEqual(metadata.address, static_cast<unsigned long long>(0));
+    XCTAssertEqual(metadata.label, "");
 }
 
 @end

--- a/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryTests/Profiling/SentryThreadMetadataCacheTests.mm
@@ -110,10 +110,12 @@ threadSpin(void *name)
     const auto queue = dispatch_queue_create(label, DISPATCH_QUEUE_SERIAL);
     const auto cache = std::make_shared<ThreadMetadataCache>();
 
+    const auto address = reinterpret_cast<std::uint64_t>(&queue);
+    cache->setQueueMetadata({address, label});
     XCTAssertTrue(cache->metadataForQueue(reinterpret_cast<std::uint64_t>(&queue)).label == label);
 }
 
-- (void)testNullQueueAddressReturnsNoMetadata
+- (void)testNonexistentQueueAddressReturnsNoMetadata
 {
     const auto cache = std::make_shared<ThreadMetadataCache>();
     const auto metadata = cache->metadataForQueue(0);


### PR DESCRIPTION
## :scroll: Description

We previously avoided collecting queue names because the `dispatch_qaddr` field (see diff) would point to a queue that was no longer valid by the time we read the field, causing a crash. I found a note in some Apple code that explains what was happening here: https://github.com/WebKit/WebKit/blob/09225dc168d445890bb0e2a5fa8bc19aef8556f2/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm#L119

The queue had been deallocated by the time we were reading the field. In order to avoid this race condition, in this PR, we suspend the thread before trying to read the field from the queue. Suspending the thread *should* prevent the dispatch queue from deallocated, assuming the deallocation happens on the thread that the queue is currently assigned to. I am not yet 100% confident in this behavior but we will have to try this in production (**for opt-in profiling beta customers only, this doesn't impact anything else**) and see if this works.

This is an example profiling output that contains the queue metadata:
[example_output.txt](https://github.com/getsentry/sentry-cocoa/files/8587061/example_output.txt)

Each sample has a `queue_address` key that can be used to look up the corresponding queue label from the top level `queue_metadata` object.

## Take 2

I previously implemented this in https://github.com/getsentry/sentry-cocoa/pull/1787 but there was a bug that caused a deadlock (which caused CI to hang). The deadlock happened because the allocator takes a lock, and we were suspending a thread that was holding that lock and then trying to take the same lock to allocate a new `std::string` for the queue label. 

I've refactored the code to avoid all heap allocations while the thread is suspended.

## :bulb: Motivation and Context

Since most threads on iOS do not have names, having labels for the queues that are running on the threads is crucial for good developer UX in profiling.

## :green_heart: How did you test it?

Added new tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
