### PR TITLE
feat: Use the macho format for debug information in Profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Collect queue label information for profiles (#1828)
+- Use the macho format for debug information in Profiling (#1830)
 
 ### Features
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -205,7 +205,14 @@ isSimulatorBuild()
     const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
     const auto debugMeta = [_debugImageProvider getDebugImages];
     for (SentryDebugMeta *debugImage in debugMeta) {
-        [debugImages addObject:[debugImage serialize]];
+        const auto debugImageDict = [NSMutableDictionary<NSString *, id> dictionary];
+        debugImageDict[@"type"] = @"macho";
+        debugImageDict[@"debug_id"] = debugImage.uuid;
+        debugImageDict[@"code_file"] = debugImage.name;
+        debugImageDict[@"image_addr"] = debugImage.imageAddress;
+        debugImageDict[@"image_size"] = debugImage.imageSize;
+        debugImageDict[@"image_vmaddr"] = debugImage.imageVmAddress;
+        [debugImages addObject:debugImageDict];
     }
     if (debugImages.count > 0) {
         profile[@"debug_meta"] = @{ @"images" : debugImages };

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -799,14 +799,30 @@ class SentryHubTests: XCTestCase {
         XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: profile["profile_id"] as! String))
         XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: profile["trace_id"] as! String))
         
-        XCTAssertFalse(((profile["debug_meta"] as! [String: Any])["images"] as! [Any]).isEmpty)
+        let images = (profile["debug_meta"] as! [String: Any])["images"] as! [[String: Any]]
+        XCTAssertFalse(images.isEmpty)
+        let firstImage = images[0]
+        XCTAssertFalse((firstImage["code_file"] as! String).isEmpty)
+        XCTAssertFalse((firstImage["debug_id"] as! String).isEmpty)
+        XCTAssertFalse((firstImage["image_addr"] as! String).isEmpty)
+        XCTAssertGreaterThan((firstImage["image_size"] as! Int), 0)
+        XCTAssertEqual(firstImage["type"] as! String, "macho")
+        
         let sampledProfile = profile["sampled_profile"] as! [String: Any]
+        let threadMetadata = sampledProfile["thread_metadata"] as! [String: Any]
+        let queueMetadata = sampledProfile["queue_metadata"] as! [String: Any]
+        
+        XCTAssertFalse(threadMetadata.isEmpty)
+        XCTAssertGreaterThan((threadMetadata.first?.value as! [String: Any])["priority"] as! Int, 0)
+        XCTAssertFalse(queueMetadata.isEmpty)
+        XCTAssertFalse(((queueMetadata.first?.value as! [String: Any])["label"] as! String).isEmpty)
+        
         let samples = sampledProfile["samples"] as! [[String: Any]]
         XCTAssertFalse(samples.isEmpty)
-        
         let frames = samples[0]["frames"] as! [[String: Any]]
         XCTAssertFalse(frames.isEmpty)
         XCTAssertFalse((frames[0]["instruction_addr"] as! String).isEmpty)
+        XCTAssertFalse((frames[0]["function"] as! String).isEmpty)
     }
     
     private func testSampler(expected: SentrySampleDecision, options: (Options) -> Void) {


### PR DESCRIPTION
## :scroll: Description

Calling `-[SentryDebugMeta serialize]` encodes the data in the older "apple" format: https://github.com/getsentry/relay/blob/master/relay-general/src/protocol/debugmeta.rs#L107

This switches it over to the new "macho" format that symbolicator supports: https://github.com/getsentry/relay/blob/master/relay-general/src/protocol/debugmeta.rs#L309

This **only impacts Profiling**. A more extensive change would change the implementation of `-serialize` so that all debug_meta (including for crashes) use the new format, but this change would require more testing.

## :bulb: Motivation and Context

* Move to a newer, more supported format
* This may help us address some issues where symbolicator isn't returning the correct file name / line number information for symbolicated frames

## :green_heart: How did you test it?

* Updated unit tests
* Test that the Profiling backend can ingest the new format

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [X] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
