### PR TITLE
Improvements for code formatting

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,6 +5,8 @@ excluded:
   - DependencyManagerTests
   - Sources/SentryCrash
   - vendor
+  - test-server/.build/
+
 only_rules:
   #- attributes
   - class_delegate_protocol

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ lint:
 # Format all h,c,cpp and m files
 format:
 	@find . -type f \( -name "*.h" -or -name "*.hpp" -or -name "*.c" -or -name "*.cpp" -or -name "*.m" -or -name "*.mm" \) -and \
-		! \( -path "**.build/*" -or -path "**/libs/**" \) \
+		! \( -path "**.build/*" -or -path "**Build/*" -or -path "**/Carthage/Checkouts/*"  -or -path "**/libs/**" \) \
 		| xargs clang-format -i -style=file
 
-	swiftlint autocorrect
+	swiftlint --fix
 .PHONY: format
 
 test:


### PR DESCRIPTION
Ignore more paths for clang-format and swiftlint. Use swiftlint --fix
over deprecated autocorrect.

#skip-changelog