### PR TITLE
fix: JSON conversion error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix JSON conversion error message (#1856)
+
 ## 7.16.0
 
 ### Features

--- a/Sources/Sentry/SentryMessage.m
+++ b/Sources/Sentry/SentryMessage.m
@@ -39,6 +39,11 @@ const NSUInteger MAX_STRING_LENGTH = 8192;
     return serializedData;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p, %@>", [self class], self, [self serialize]];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -256,7 +256,13 @@ class SentryEnvelopeTests: XCTestCase {
         if let data = envelope.items.first?.data {
             let json = String(data: data, encoding: .utf8) ?? ""
 
-            json.assertContains("JSON conversion error for event with message: '\(event.message?.description ?? "")'", "message")
+            // Asserting the description of the message doesn't work properly, because
+            // the serialization adds \n. Therefore, we only check for bits of the
+            // the description. The actual description is tested in the tests for the
+            // SentryMessage
+            json.assertContains("JSON conversion error for event with message: '<SentryMessage: ", "message")
+            json.assertContains("formatted = \(event.message?.formatted ?? "")", "message")
+            
             json.assertContains("warning", "level")
             json.assertContains(event.releaseName ?? "", "releaseName")
             json.assertContains(event.environment ?? "", "environment")

--- a/Tests/SentryTests/Protocol/SentryMessageTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMessageTests.swift
@@ -6,11 +6,17 @@ class SentryMessageTests: XCTestCase {
         let stringMaxCount = 8_192
         let maximumCount: String
         let tooLong: String
+        let message: SentryMessage
         
         init() {
             maximumCount = String(repeating: "a", count: stringMaxCount)
             tooLong = String(repeating: "a", count: stringMaxCount + 1)
+            
+            message = SentryMessage(formatted: "A message my params")
+            message.message = "A message %s %s"
+            message.params = ["my", "params"]
         }
+        
     }
     
     private let fixture = Fixture()
@@ -38,14 +44,34 @@ class SentryMessageTests: XCTestCase {
     }
     
     func testSerialize() {
-        let message = SentryMessage(formatted: "A message my params")
-        message.message = "A message %s %s"
-        message.params = ["my", "params"]
+        let message = fixture.message
         
         let actual = message.serialize()
         
         XCTAssertEqual(message.formatted, actual["formatted"] as? String)
         XCTAssertEqual(message.message, actual["message"] as? String)
         XCTAssertEqual(message.params, actual["params"] as? [String])
+    }
+    
+    func testDescription() {
+        let message = fixture.message
+        
+        let actual = message.description
+        
+        let beginning = String(format: "<SentryMessage: %p, ", message)
+        let expected = "\(beginning){\n    formatted = \"\(message.formatted)\";\n    message = \"\(message.message ?? "")\";\n    params =     (\n        my,\n        params\n    );\n}>"
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func testDescription_WithoutMessageAndParams() {
+        let message = fixture.message
+        message.message = nil
+        message.params = nil
+        
+        let actual = message.description
+        
+        let beginning = String(format: "<SentryMessage: %p, ", message)
+        let expected = "\(beginning){\n    formatted = \"\(message.formatted)\";\n}>"
+        XCTAssertEqual(expected, actual)
     }
 }


### PR DESCRIPTION




## :scroll: Description

When the JSON conversion fails in SentryEnvelope the error message
prints the description of the SentryMessage. As SentryMessage.description
didn't have an implementation the error message was useless. This is fixed
by adding an implementation for description.

## :bulb: Motivation and Context

Fixes GH-1854

## :green_heart: How did you test it?
Unit testgs

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
