### PR TITLE
test: fix UI test naming and runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ on:
       - 'Sources/**'
       - 'test-server/**'
       - 'Samples/**'
-      - '.github/workflows/**'
+      - '.github/workflows/build.yml'
 
 jobs:
   # We had issues that the release build was broken on master.

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -6,6 +6,7 @@ on:
       - 'Tests/**'
       - 'test-server/**'
       - 'Samples/**'
+      - '.github/workflows/format-code.yml'
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
       - 'Tests/**'
       - 'test-server/**'
       - 'Samples/**'
+      - '.github/workflows/lint.yml'
 
   pull_request:
     paths:
@@ -15,6 +16,7 @@ on:
       - 'Tests/**'
       - 'test-server/**'
       - 'Samples/**'
+      - '.github/workflows/lint.yml'
 
 jobs:
   swift-lint:

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'Sources/**'
       - 'Tests/**'
+      - '.github/workflows/saucelabs-UI-tests.yml'
 
 jobs:
   build-ui-tests:

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -3,7 +3,7 @@ on:
   # Schedule the UI tests so we can see in Sentry how the duration of transactions
   # changes over time.
   schedule:
-    - cron: '* */4 * * *'
+    - cron: '0 */4 * * *'
   push:
     branches:
       - master

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -46,7 +46,7 @@ jobs:
 
 
   run-ui-tests-with-sauce:
-    name: Run UITests iOS ${{ matrix.iOS }} on Sauce Labs
+    name: Run UI Tests for iOS ${{ matrix.iOS }} on Sauce Labs
     runs-on: ubuntu-latest
     needs: build-ui-tests
     strategy:      

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -3,7 +3,7 @@ on:
   # Schedule the UI tests so we can see in Sentry how the duration of transactions
   # changes over time.
   schedule:
-    - cron: '* 0 * * *'
+    - cron: '0 0 * * *'
   push:
     branches:
       - master

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -59,7 +59,7 @@ jobs:
           - xcode: "13.2"
             iOS: 14
 
-          - xcode "13.2"
+          - xcode: "13.2"
             iOS: 13
 
           # iOS 12 has a failing test that we need to fix https://github.com/getsentry/sentry-cocoa/issues/1566

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -3,7 +3,7 @@ on:
   # Schedule the UI tests so we can see in Sentry how the duration of transactions
   # changes over time.
   schedule:
-    - cron: '0 * * * *'
+    - cron: '* 0 * * *'
   push:
     branches:
       - master

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -3,7 +3,7 @@ on:
   # Schedule the UI tests so we can see in Sentry how the duration of transactions
   # changes over time.
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 * * * *'
   push:
     branches:
       - master

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -1,4 +1,4 @@
-name: UI Tests
+name: Sauce Labs UI Tests
 on:
   # Schedule the UI tests so we can see in Sentry how the duration of transactions
   # changes over time.
@@ -45,8 +45,8 @@ jobs:
             **/Debug-iphoneos/iOS-SwiftUITests-Runner.app
 
 
-  run-ui-tests:
-    name: Run UITests iOS ${{ matrix.iOS }}
+  run-ui-tests-with-sauce:
+    name: Run UITests iOS ${{ matrix.iOS }} on Sauce Labs
     runs-on: ubuntu-latest
     needs: build-ui-tests
     strategy:      
@@ -75,7 +75,7 @@ jobs:
 
       - run: npm install -g saucectl@0.93.0
 
-      # As SauceLabs is a bit flaky we retry 5 times
+      # As Sauce Labs is a bit flaky we retry 5 times
       - name: Run Tests in SauceLab
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -59,7 +59,9 @@ jobs:
           - xcode: "13.2"
             iOS: 14
 
-          # iOS 13 has a failing test that we need to fix https://github.com/getsentry/sentry-cocoa/issues/1564
+          - xcode "13.2"
+            iOS: 13
+
           # iOS 12 has a failing test that we need to fix https://github.com/getsentry/sentry-cocoa/issues/1566
           # iOS 11 keeps timing out and we don't know how to fix it.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
       - 'Tests/**'
       - 'test-server/**'
       - 'Samples/**'
-      - '.github/workflows/**'
+      - '.github/workflows/test.yml'
 
 jobs:
   unit-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,6 +190,9 @@ jobs:
 
           - xcode: "12.5.1"
             device: "iPhone 8 (14.5)"
+
+          - xcode: "12.5.1"
+            device: "iPhone 8 (13.7)"
             
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -197,7 +197,7 @@ jobs:
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swift_ui device:"${{matrix.device}}" && break ; done
+        run: for i in {1..2}; do fastlane ui_tests_ios_swiftui device:"${{matrix.device}}" && break ; done
         shell: sh
 
   # macos-11 doesn't have a simulator for iOS 12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,24 +162,24 @@ jobs:
 
 
   ui-tests:
-    name: UI Tests for ${{matrix.target}}
+    name: UI Tests for ${{matrix.target}} on Simulators
     runs-on: macos-11
     strategy:
       matrix:
-        target: ["ios_swiftui", "ios_objc", "tvos_swift" ]
+        target: ["ios_swift", "ios_objc", "tvos_swift" ]
 
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh 
 
-      # GitHub Actions sometimes fail to launch the UI tests. 
-      # Therefore we retry
+      # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
         run: for i in {1..2}; do fastlane ui_tests_${{matrix.target}} && break ; done
         shell: sh
 
+  # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:
-    name: UI Tests for SwiftUI on ${{matrix.device}}
+    name: UI Tests for SwiftUI on ${{matrix.device}} Simulator
     runs-on: macos-11
     strategy:
       fail-fast: false
@@ -190,8 +190,6 @@ jobs:
 
           - xcode: "12.5.1"
             device: "iPhone 8 (14.5)"
-
-        # Our SwiftUI requires iOS 14 or higher
             
     steps:
       - uses: actions/checkout@v3
@@ -199,13 +197,16 @@ jobs:
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"${{matrix.device}}" && break ; done
+        run: for i in {1..2}; do fastlane ui_tests_ios_swift_ui device:"${{matrix.device}}" && break ; done
         shell: sh
 
   # macos-11 doesn't have a simulator for iOS 12
-  ui-tests-swift-ui-ios-12:
-    name: UI Tests for iOS 12
+  ui-tests-swift-ios-12:
+    name: UI Tests on iOS 12 Simulator
     runs-on: macos-10.15
+    strategy:
+      matrix:
+        target: ["ios_swift", "ios_objc", "tvos_swift" ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,9 +190,6 @@ jobs:
 
           - xcode: "12.5.1"
             device: "iPhone 8 (14.5)"
-
-          - xcode: "12.5.1"
-            device: "iPhone 8 (13.7)"
             
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,6 +213,6 @@ jobs:
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"$iPhone 8 (12.4)" && break ; done
+        run: for i in {1..2}; do fastlane ui_tests_${{matrix.target}} device:"$iPhone 8 (12.4)" && break ; done
         shell: sh
 

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/project.pbxproj
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/project.pbxproj
@@ -509,7 +509,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 97JCY7859U;
 				INFOPLIST_FILE = "iOS-ObjectiveCUITests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/project.pbxproj
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/project.pbxproj
@@ -531,7 +531,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 97JCY7859U;
 				INFOPLIST_FILE = "iOS-ObjectiveCUITests/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Samples/tvOS-Swift/tvOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/tvOS-Swift/tvOS-Swift.xcodeproj/project.pbxproj
@@ -479,7 +479,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_TARGET_NAME = "tvOS-Swift";
-				TVOS_DEPLOYMENT_TARGET = 14.5;
 			};
 			name = Debug;
 		};
@@ -499,7 +498,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_TARGET_NAME = "tvOS-Swift";
-				TVOS_DEPLOYMENT_TARGET = 14.5;
 			};
 			name = Release;
 		};

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -36,6 +36,10 @@ To run the unit tests with the thread sanitizer enabled in Xcode click on edit s
 
 You can use the `generate-classes.sh` to generate ViewControllers and other classes to emulate a large project. This is useful, for example, to test the performance of swizzling in a large project without having to check in thousands of lines of code.
 
+## UI Tests
+
+CI runs UI tests on simulators via the `test.yml` workflow, and on devices via `saucelabs-UI-tests.yml`. All are run for each PR, and Sauce Labs tests also run on a nightly cron schedule.
+
 ## Generating Diagrams
 
 The diagrams are created with [PlantUml](http://plantuml.com). The advantage of PlantUml


### PR DESCRIPTION
- made it more explicit which UI tests run on simulators and which run in Sauce Labs
- ensured that the UI tests for `iOS-Swift` and `iOS-SwiftUI` run in the right workflows
- reenabled iOS 13 testing now that #1564 is resolved
- change the cron schedule for the UI tests on saucelabs to run once every day ([0 0 \* \* \*](https://crontab.guru/#0_0_*_*_*)) (it was previously set to [* */4 * * *](https://crontab.guru/#*_*/4_*_*_*), which runs every minute for every fourth hour of the day–360 times per day instead of 1)
- trigger reruns of workflows when they're edited

#skip-changelog