### PR TITLE
ci: upload sample app symbols for saucelabs runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - 'test-server/**'
       - 'Samples/**'
       - '.github/workflows/build.yml'
+      - 'fastlane/**'
 
 jobs:
   # We had issues that the release build was broken on master.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'Tests/**'
       - 'scripts/**'
       - '.github/workflows/integration-tests.yml'
+      - 'fastlane/**'
 
 jobs:
 

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'Sources/**'
       - 'Tests/**'
       - '.github/workflows/saucelabs-UI-tests.yml'
+      - 'fastlane/**'
 
 jobs:
   build-ui-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - 'test-server/**'
       - 'Samples/**'
       - '.github/workflows/test.yml'
+      - 'fastlane/**'
 
 jobs:
   unit-tests:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -7,6 +7,7 @@ on:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'
       - '.github/workflows/testflight.yml'
+      - 'fastlane/**'
 
 jobs:
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,6 +126,12 @@ platform :ios do
       skip_archive: true
     )
 
+    sentry_upload_dsym(
+      auth_token: 'b0a3f3b1fd384bbcaacbe1e6faf1b2e0850e35b35b834500872c91a72bef20e6',
+      org_slug: 'sentry-sdks',
+      project_slug: 'sentry-cocoa',
+      dsym_path: 'DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM.zip'
+    )
   end
 
   desc "Upload iOS-Swift to TestFlight and symbols to Sentry"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,11 +126,14 @@ platform :ios do
       skip_archive: true
     )
 
+    # TODO: don't merge, debug only
+    sh 'find . -name "*.dSYM*"
+
     sentry_upload_dsym(
       auth_token: 'b0a3f3b1fd384bbcaacbe1e6faf1b2e0850e35b35b834500872c91a72bef20e6',
       org_slug: 'sentry-sdks',
       project_slug: 'sentry-cocoa',
-      dsym_path: 'DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM.zip'
+      dsym_path: 'DerivedData/Build/Products/Release-iphoneos/iOS-Swift.app.dSYM.zip'
     )
   end
 


### PR DESCRIPTION
We send some transactions from the iOS-Swift sample app during the benchmark UI test runs, but the frames are not symbolicated. Upload the debug symbols produced when building the app for upload to Sauce Labs.

#skip-changelog