### PR TITLE
fix: remove duplicate init of sentry SDK

### DIFF
--- a/Samples/TrendingMovies/TrendingMovies/AppDelegate.swift
+++ b/Samples/TrendingMovies/TrendingMovies/AppDelegate.swift
@@ -28,18 +28,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         print("[TrendingMovies] didFinishLaunchingWithOptions")
         Tracer.setUp(finishedLaunching: true)
-        
-        SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
-            options.debug = true
-            options.sessionTrackingIntervalMillis = 5_000
-            // Sampling 100% - In Production you probably want to adjust this
-            options.tracesSampleRate = 1.0
-            options.enableFileIOTracking = true
-            options.enableCoreDataTracking = true
-            options.enableProfiling = true
-            options.attachScreenshot = true
-        }
 
         window = UIWindow(frame: UIScreen.main.bounds)
         let tabBarController = createTabBarController(items: [

--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -29,9 +29,14 @@ extension Tracer {
 
         SentrySDK.start { options in
             options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
-            options.environment = "integration-tests"
-            options.enableProfiling = true
             options.debug = true
+            options.sessionTrackingIntervalMillis = 5_000
+            // Sampling 100% - In Production you probably want to adjust this
+            options.tracesSampleRate = 1.0
+            options.enableFileIOTracking = true
+            options.enableCoreDataTracking = true
+            options.enableProfiling = true
+            options.attachScreenshot = true
         }
 
         SentrySDK.configureScope { scope in


### PR DESCRIPTION
Noticed there was a second location that initializes Sentry in Trending Movies. Removed the dupe and merged options from both.

#skip-changelog