### PR TITLE
Fix reporting wrong OOM when starting SDK twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix reporting wrong OOM when starting SDK twice (#1878)
 - Fix JSON conversion error message (#1856)
 - Transaction tag and data serialization (#1826)
 

--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -4,6 +4,7 @@
 #import <SentryCrashWrapper.h>
 #import <SentryOptions.h>
 #import <SentryOutOfMemoryLogic.h>
+#import <SentrySDK+Private.h>
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -86,6 +87,12 @@ SentryOutOfMemoryLogic ()
     }
 
     if (previousAppState.isANROngoing) {
+        return NO;
+    }
+
+    // When calling SentrySDK.start twice we would wrongly report an OOM. We can only
+    // report an OOM when the SDK is started the first time.
+    if (SentrySDK.startInvocations != 1) {
         return NO;
     }
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -24,11 +24,13 @@ static SentryHub *_Nullable currentHub;
 static BOOL crashedLastRunCalled;
 static SentryAppStartMeasurement *sentrySDKappStartMeasurement;
 static NSObject *sentrySDKappStartMeasurementLock;
+static NSUInteger startInvocations;
 
 + (void)initialize
 {
     if (self == [SentrySDK class]) {
         sentrySDKappStartMeasurementLock = [[NSObject alloc] init];
+        startInvocations = 0;
     }
 }
 
@@ -100,6 +102,22 @@ static NSObject *sentrySDKappStartMeasurementLock;
     }
 }
 
+/**
+ * Not public, only for internal use.
+ */
++ (NSUInteger)startInvocations
+{
+    return startInvocations;
+}
+
+/**
+ * Only needed for testing.
+ */
++ (void)setStartInvocations:(NSUInteger)value
+{
+    startInvocations = value;
+}
+
 + (void)startWithOptions:(NSDictionary<NSString *, id> *)optionsDict
 {
     NSError *error = nil;
@@ -116,6 +134,8 @@ static NSObject *sentrySDKappStartMeasurementLock;
 
 + (void)startWithOptionsObject:(SentryOptions *)options
 {
+    startInvocations++;
+
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
     SentryClient *newClient = [[SentryClient alloc] initWithOptions:options];
     // The Hub needs to be initialized with a client so that closing a session

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -18,6 +18,8 @@ SentrySDK (Private)
 
 + (nullable SentryAppStartMeasurement *)getAppStartMeasurement;
 
+@property (nonatomic, class) NSUInteger startInvocations;
+
 + (SentryHub *)currentHub;
 
 @property (nonatomic, nullable, readonly, class) SentryOptions *options;

--- a/Tests/SentryTests/ClearTestState.swift
+++ b/Tests/SentryTests/ClearTestState.swift
@@ -5,6 +5,7 @@ func clearTestState() {
     SentrySDK.close()
     SentrySDK.setCurrentHub(nil)
     SentrySDK.crashedLastRunCalled = false
+    SentrySDK.startInvocations = 0
     
     PrivateSentrySDKOnly.onAppStartMeasurementAvailable = nil
     PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false

--- a/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
@@ -50,6 +50,7 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         fixture = Fixture()
         sut = fixture.getSut()
+        SentrySDK.startInvocations = 1
     }
     
     override func tearDown() {
@@ -159,6 +160,15 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         
         sut.start()
         
+        assertNoOOMSent()
+    }
+    
+    func testSDKStartedTwice_NoOOM() {
+        sut.start()
+        goToForeground()
+
+        SentrySDK.startInvocations = 2
+        sut.start()
         assertNoOOMSent()
     }
     

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -127,6 +127,7 @@ class SentryCrashIntegrationTests: XCTestCase {
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func testEndSessionAsCrashed_WhenOOM_WithCurrentSession() {
         givenOOMAppState()
+        SentrySDK.startInvocations = 1
         
         let expectedCrashedSession = givenCrashedSession()
         

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -503,6 +503,16 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(SentrySDK.getAppStartMeasurement(), appStartMeasurement)
     }
     
+    func testSDKStartInvocations() {
+        XCTAssertEqual(0, SentrySDK.startInvocations)
+        
+        SentrySDK.start { options in
+            options.dsn = SentrySDKTests.dsnAsString
+        }
+        
+        XCTAssertEqual(1, SentrySDK.startInvocations)
+    }
+    
     func testIsEnabled() {
         XCTAssertFalse(SentrySDK.isEnabled)
         


### PR DESCRIPTION


## :scroll: Description

When calling SentrySDK.start twice, we wrongly reported an OOM. This is
fixed now by only reporting an OOM when the user starts the SDK the first
time.

## :bulb: Motivation and Context

Fixes GH-1877, and maybe https://github.com/getsentry/sentry-cocoa/issues/1852 and https://github.com/getsentry/sentry-react-native/issues/1830

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
