### PR TITLE
Implement description for SentryBreadcrumb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Implement description for SentryBreadcrumb (#1880)
+
 ## 7.16.1
 
 ### Fixes

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -79,4 +79,9 @@
     return hash;
 }
 
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %p, %@>", [self class], self, [self serialize]];
+}
+
 @end

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -88,4 +88,13 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(fixture.message, actual["message"] as? String)
         XCTAssertEqual(["some": ["data": "data", "date": fixture.dateAs8601String]], actual["data"] as? Dictionary)
     }
+    
+    func testDescription() {
+        let crumb = fixture.breadcrumb
+        let actual = crumb.description
+        
+        let serialaziedString = NSString(format: "<SentryBreadcrumb: %p, %@>", crumb, crumb.serialize())
+        
+        XCTAssertEqual(serialaziedString, actual as NSString)
+    }
 }


### PR DESCRIPTION


## :scroll: Description

Implement the description method for SentryBreadcrumb so that when adding
breadcrumbs you see in the log what the breadcrumb contains.

## :bulb: Motivation and Context

Came up while investigating APM for SwiftUI.

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
