### PR TITLE
ci: Add GH actions to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,8 @@ updates:
   - dependency-name: fastlane
     versions:
     - 2.179.0
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
So we can avoid manual PRs like https://github.com/getsentry/sentry-cocoa/pull/1845 and https://github.com/getsentry/sentry-cocoa/pull/1846

#skip-changelog