### PR TITLE
ci: use `setup_ci` instead of our custom keychain setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,7 @@ on:
       - 'test-server/**'
       - 'Samples/**'
       - '.github/workflows/build.yml'
+      - 'fastlane/**'
 
 jobs:
   # We had issues that the release build was broken on master.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'Tests/**'
       - 'scripts/**'
       - '.github/workflows/integration-tests.yml'
+      - 'fastlane/**'
 
 jobs:
 

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'Sources/**'
       - 'Tests/**'
       - '.github/workflows/saucelabs-UI-tests.yml'
+      - 'fastlane/**'
 
 jobs:
   build-ui-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - 'test-server/**'
       - 'Samples/**'
       - '.github/workflows/test.yml'
+      - 'fastlane/**'
 
 jobs:
   unit-tests:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -7,6 +7,7 @@ on:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'
       - '.github/workflows/testflight.yml'
+      - 'fastlane/**'
 
 jobs:
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,50 +1,17 @@
 default_platform(:ios)
 
 platform :ios do
-  # Defined in Appfile
-  app_identifier = CredentialsManager::AppfileConfig.try_fetch_value(:app_identifier)
-  team_id = CredentialsManager::AppfileConfig.try_fetch_value(:team_id)
-
-  desc "Run match for local development"
-  lane :match_local do
-    match(
-      type: "development", 
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-SwiftUITests.xctrunner"]
-    )
-    match(
-      type: "appstore", 
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-SwiftUITests.xctrunner"]
-    )
-  end
-
-  ci_keychain_name = "ios-swift.keychain"
-  ci_keychain_password = ENV["FASTLANE_KEYCHAIN_PASSWORD"]
-
-  lane :match_ci do
-    # CI can hang when Xcode is trying to sign the app because
-    # a modal window pops up to access the signing key's keychain. This modal
-    # lets the action hang. A workaround is to create a local keychain and
-    # store the signing keys in there.
-    # https://github.com/actions/virtual-environments/issues/1820#issuecomment-719549887
-    # Doing this with Fastlane makes it easier to debug issues locally.
-    sh("security delete-keychain #{ci_keychain_name} || true") # Delete the keychain if it already exists
-    sh("security create-keychain -p '#{ci_keychain_password}'  #{ci_keychain_name}")
-    sh("security set-keychain-settings -lut 21600 #{ci_keychain_name}")
-    sh("security unlock-keychain -p '#{ci_keychain_password}' #{ci_keychain_name}")
-    sh("security list-keychain -d user -s #{ci_keychain_name}")
-  end
-
-  ioSwiftInfoPlistPath = "./Samples/iOS-Swift/iOS-Swift/Info.plist"
-  ioSwiftClipInfoPlistPath = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
+  ios_swift_infoplist_path = "./Samples/iOS-Swift/iOS-Swift/Info.plist"
+  ios_swift_clip_infoplist_path = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
 
   lane :bump_bundle_version do
     set_info_plist_value(
-      path: ioSwiftInfoPlistPath, 
+      path: ios_swift_infoplist_path,
       key: "CFBundleVersion", 
       value: ENV["FASTLANE_BUNDLE_VERSION"]
     )
     set_info_plist_value(
-      path: ioSwiftClipInfoPlistPath, 
+      path: ios_swift_clip_infoplist_path,
       key: "CFBundleVersion", 
       value: ENV["FASTLANE_BUNDLE_VERSION"]
     )
@@ -60,12 +27,12 @@ platform :ios do
     version = version.split("-", -1)[0]
 
     set_info_plist_value(
-      path: ioSwiftInfoPlistPath, 
+      path: ios_swift_infoplist_path,
       key: "CFBundleShortVersionString", 
       value: version
     )
     set_info_plist_value(
-      path: ioSwiftClipInfoPlistPath, 
+      path: ios_swift_clip_infoplist_path,
       key: "CFBundleShortVersionString", 
       value: version
     )
@@ -86,39 +53,37 @@ platform :ios do
   desc "Build iOS-Swift with Release"
   lane :build_ios_swift do
     
-    match_ci
+    setup_ci
 
     sync_code_signing(
-      type: "appstore", 
-      keychain_name: ci_keychain_name,
-      keychain_password: ci_keychain_password,
+      type: "appstore",
       readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift",  "io.sentry.sample.iOS-Swift.Clip"]
     )
 
-		build_app(
+    build_app(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
-			include_bitcode: true,
+      include_bitcode: true,
       include_symbols: false,
       export_method: "app-store",
       archive_path: "iOS-Swift"
     )
   end
-
+  
   lane :build_ios_swift_ui_test do
 
-    match_ci
+    setup_ci(
+      force: true
+    )
 
     sync_code_signing(
       type: "development",
-      keychain_name: ci_keychain_name,
-      keychain_password: ci_keychain_password,
       readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-SwiftUITests.xctrunner"]
     )
 
-		build_app(
+    build_app(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
       xcargs: "build-for-testing",
@@ -140,7 +105,6 @@ platform :ios do
     testflight
 
     download_dsyms(
-      app_identifier: app_identifier,
       wait_for_dsym_processing: true,
       build_number: ENV["FASTLANE_BUNDLE_VERSION"]
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,6 +69,8 @@ platform :ios do
       export_method: "app-store",
       archive_path: "iOS-Swift"
     )
+
+    delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end
   
   lane :build_ios_swift_ui_test do
@@ -91,6 +93,7 @@ platform :ios do
       skip_archive: true
     )
 
+    delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end
 
   desc "Upload iOS-Swift to TestFlight and symbols to Sentry"


### PR DESCRIPTION
Replace our custom keychain logic with Fastlane's [`setup_ci`](https://docs.fastlane.tools/actions/setup_ci/). These changes allow running the lanes locally and succeeding in the codesign steps, for testing before pushing to CI.

Also:
- Lets the values from Appfile be automatically fetched instead of explicitly extracting with CredentialsManager.
- Fix some typos, casing and indentation.

#skip-changelog