### PR TITLE
ci: udpate testflight job steps

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,25 +16,18 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
-      - uses: ruby/setup-ruby@v1
-
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
-
-      - name: Setup fastlane
-        run: bundle install   
 
       # We upload a new version to TestFlight on every commit on Master
       # So we need to bump the bundle version each time
       - name: Bump Bundle Version
         env: 
           FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
-        run: bundle exec fastlane bump_bundle_version
-        shell: sh
+        run: fastlane bump_bundle_version
 
       - name: Remove preview version suffixes
-        run: bundle exec fastlane remove_preview_version_suffixes
-        shell: sh
+        run: fastlane remove_preview_version_suffixes
 
       - name: Run Fastlane
         env:
@@ -48,9 +41,8 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
-          bundle exec fastlane build_ios_swift
-          bundle exec fastlane ios_swift_to_testflight
-        shell: sh
+          fastlane build_ios_swift
+          fastlane ios_swift_to_testflight
 
       - name: Archiving
         uses: actions/upload-artifact@v3

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# For available Xcode versions on Github Action, see 
-# https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
-# Although https://github.com/actions/virtual-environments/tree/main/images/macos has readmes on
-# macOS-10.14 and macOS-10.13 only macOS-10.15 and macOS-11 are working. When using macOS-10.14 or
-# macOS-10.13 GitHub Actions never find a runner and the job keeps hanging until it times out.
+# For available Xcode versions see:
+# - https://github.com/actions/virtual-environments/blob/6a2f3acb8890efd4b6ba9344d5f73af25e7a2bcf/images/macos/macos-10.15-Readme.md?plain=1#L254-L266
+# - https://github.com/actions/virtual-environments/blob/6a2f3acb8890efd4b6ba9344d5f73af25e7a2bcf/images/macos/macos-11-Readme.md?plain=1#L248-L253
 
 set -euo pipefail
 


### PR DESCRIPTION
I noticed a few redundancies in the workflow that should be taken care of by default in the github action macos image.

#skip-changelog