### PR TITLE
Set max app start duration to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Set max app start duration to 60s (#1899)
+
 ## 7.17.0
 
 ### Features

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -17,7 +17,11 @@
 
 static NSDate *runtimeInit = nil;
 
-static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 5.0;
+/**
+ * The watchdog usually kicks in after an app hanging 10 to 20 seconds. As the app could hang in
+ * multiple stages during the launch we pick a higher threshold.
+ */
+static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 60.0;
 
 @interface
 SentryAppStartTracker ()

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -134,6 +134,13 @@ class SentryAppStartTrackerTests: XCTestCase {
         assertNoAppStartUp()
     }
     
+    func testAppLaunches_OSAlmostPrewarmedProcess_AppStartUp() {
+        let processStartTime = fixture.currentDate.date().addingTimeInterval(-59)
+        startApp(processStartTimeStamp: processStartTime)
+        
+        assertValidStart(type: .cold, expectedDuration: 59.4)
+    }
+    
     func testAppLaunchesBackgroundTask_NoAppStartUp() {
         sut = fixture.sut
         sut.start()
@@ -283,7 +290,7 @@ class SentryAppStartTrackerTests: XCTestCase {
         SentrySDK.setAppStartMeasurement(nil)
     }
 
-    private func assertValidStart(type: SentryAppStartType) {
+    private func assertValidStart(type: SentryAppStartType, expectedDuration: TimeInterval? = nil) {
         guard let appStartMeasurement = SentrySDK.getAppStartMeasurement() else {
             XCTFail("AppStartMeasurement must not be nil")
             return
@@ -291,7 +298,7 @@ class SentryAppStartTrackerTests: XCTestCase {
         
         XCTAssertEqual(type.rawValue, appStartMeasurement.type.rawValue)
 
-        let expectedAppStartDuration = fixture.appStartDuration
+        let expectedAppStartDuration = expectedDuration ?? fixture.appStartDuration
         let actualAppStartDuration = appStartMeasurement.duration
         XCTAssertEqual(expectedAppStartDuration, actualAppStartDuration, accuracy: 0.000_1)
 


### PR DESCRIPTION


## :scroll: Description

The max app start duration was 5 seconds, which is too short. This
is fixed now by setting it to 60s.

## :bulb: Motivation and Context

I noticed that while investigating https://github.com/getsentry/sentry-cocoa/issues/1897

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
