### PR TITLE
Unset scope span when finishing idle transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Unset scope span when finishing idle transaction (#1902)
 - Set max app start duration to 60s (#1899)
 
 ## 7.17.0

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -403,6 +403,12 @@ static NSLock *profilerLock;
     if (_hub == nil)
         return;
 
+    [_hub.scope useSpan:^(id<SentrySpan> _Nullable span) {
+        if (span == self) {
+            [self->_hub.scope setSpan:nil];
+        }
+    }];
+
     @synchronized(_children) {
         if (self.idleTimeout > 0.0 && _children.count == 0) {
             return;
@@ -422,12 +428,6 @@ static NSLock *profilerLock;
             [self trimEndTimestamp];
         }
     }
-
-    [_hub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-        if (span == self) {
-            [self->_hub.scope setSpan:nil];
-        }
-    }];
 
     SentryTransaction *transaction = [self toTransaction];
     NSMutableArray<SentryEnvelopeItem *> *additionalEnvelopeItems = [NSMutableArray array];

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -142,6 +142,16 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(0, fixture.hub.capturedEventsWithScopes.count)
     }
     
+    func testIdleTimeout_NoChildren_SpanOnScopeUnset() {
+        let sut = fixture.getSut(idleTimeout: fixture.idleTimeout, dispatchQueueWrapper: fixture.dispatchQueue)
+        
+        fixture.hub.scope.span = sut
+        
+        fixture.dispatchQueue.invokeLastDispatchAfter()
+        
+        XCTAssertNil(fixture.hub.scope.span)
+    }
+    
     func testIdleTimeout_InvokesDispatchAfterWithCorrectWhen() {
         _ = fixture.getSut(idleTimeout: fixture.idleTimeout, dispatchQueueWrapper: fixture.dispatchQueue)
         
@@ -453,6 +463,25 @@ class SentryTracerTests: XCTestCase {
         XCTAssertNil(sut.finishCallback)
         
         wait(for: [callbackExpectation], timeout: 0.1)
+    }
+    
+    func testFinish_SetScopeSpanToNil() {
+        let sut = fixture.getSut()
+        fixture.hub.scope.span = sut
+        
+        sut.finish()
+        
+        XCTAssertNil(fixture.hub.scope.span)
+    }
+    
+    func testFinish_DifferentSpanOnScope_DoesNotSetScopeSpanToNil() {
+        let sut = fixture.getSut()
+        let sutOnScope = fixture.getSut()
+        fixture.hub.scope.span = sutOnScope
+        
+        sut.finish()
+        
+        XCTAssertTrue(sutOnScope === fixture.hub.scope.span)
     }
     
     // Although we only run this test above the below specified versions, we expect the


### PR DESCRIPTION

## :scroll: Description

Set scope span to nil when finishing an idle transaction without children.


## :bulb: Motivation and Context

Came up when investigating https://github.com/getsentry/sentry-cocoa/issues/1897

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
