### PR TITLE
fix: disable automatic user interaction tracing when benchmarking

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -27,7 +27,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.enableCoreDataTracking = true
             options.enableProfiling = true
             options.attachScreenshot = true
-            options.enableUserInteractionTracing = true
+
+            // the benchmark test starts and stops a custom transaction using a UIButton, and automatic user interaction tracing stops the transaction that begins with that button press after the idle timeout elapses, stopping the profiler (only one profiler runs regardless of the number of concurrent transactions)
+            if !ProcessInfo.processInfo.arguments.contains("--io.sentry.test.benchmarking") {
+                options.enableUserInteractionTracing = true
+            }
         }
         
         return true

--- a/Samples/iOS-Swift/iOS-SwiftUITests/SDKPerformanceBenchmarkTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/SDKPerformanceBenchmarkTests.swift
@@ -14,7 +14,7 @@ class SDKPerformanceBenchmarkTests: XCTestCase {
         var results = [Double]()
         for _ in 0..<5 {
             let app = XCUIApplication()
-
+            app.launchArguments.append("--io.sentry.test.benchmarking")
             app.launch()
             app.buttons["Performance scenarios"].tap()
 


### PR DESCRIPTION
This was causing the profiler to stop too early, throwing off the benchmark numbers.

#skip-changelog