### PR TITLE
fix: remove webkit/optimization check

### DIFF
--- a/Sources/Sentry/include/SentryCompiler.h
+++ b/Sources/Sentry/include/SentryCompiler.h
@@ -102,10 +102,6 @@
 
 #endif /* COMPILER(GCC) */
 
-#if COMPILER(GCC_COMPATIBLE) && !defined(DEBUG) && !defined(__OPTIMIZE__) && !defined(RELEASE_WITHOUT_OPTIMIZATIONS)
-#error "Building release without compiler optimizations: WebKit will be slow. Set -DRELEASE_WITHOUT_OPTIMIZATIONS if this is intended."
-#endif
-
 /* COMPILER(MINGW) - MinGW GCC */
 
 #if defined(__MINGW32__)


### PR DESCRIPTION
This check was breaking a customer's build, as reported in https://github.com/getsentry/sentry-cocoa/issues/1913#issuecomment-1165562212. We aren't sure why, but we don't really need the check, so we'll remove it for now.

#skip-changelog