### PR TITLE
Detect prewarmed starts with env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Remove WebKit optimization check (#1921)
+- Detect prewarmed starts with env variable (#1927)
 
 ## 7.18.1
 

--- a/Tests/SentryTests/ClearTestState.swift
+++ b/Tests/SentryTests/ClearTestState.swift
@@ -22,4 +22,7 @@ func clearTestState() {
     SentryDependencyContainer.reset()
     Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()
     SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
+    
+    setenv("ActivePrewarm", "0", 1)
+    SentryAppStartTracker.load()
 }


### PR DESCRIPTION
Stop reporting pre-warmed app starts based on the ActivePrewarm
env variable. Increase the SENTRY_APP_START_MAX_DURATION
to 180.

## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

This is a preparation for fixing GH-1897. First, we want to stop reporting wrong app start data. After that, we can open a PR to start reporting pre-warmed app starts.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
GH-1897, which means reporting pre-warmed app starts.
