### PR TITLE
fix: Save main thread Id during SentryCrashDefaultMachineContextWrapper +load

### DIFF
--- a/Sources/Sentry/SentryCrashDefaultMachineContextWrapper.m
+++ b/Sources/Sentry/SentryCrashDefaultMachineContextWrapper.m
@@ -20,7 +20,7 @@ SentryCrashThread mainThreadID;
 
 @implementation SentryCrashDefaultMachineContextWrapper
 
-+ (void)initialize
++ (void)load
 {
     mainThreadID = pthread_mach_thread_np(pthread_self());
 }


### PR DESCRIPTION
We were using `+initialize` method from `SentryCrashDefaultMachineContextWrapper` to save the main thread id. `+initialize` is called with the first message sent to the class, and this can occur in any thread.

'+load' is called when the library is load and this always occurs on the main thread, therefore a much safer place to save main thread id.


_#skip-changelog_ 


