### PR TITLE
chore: Configure the root of the project to use four spaces for indentation

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1583,7 +1583,9 @@
 				63AA75921EB8AEDB00D153DE /* Tests */,
 				7D826E3C2390840E00EED93D /* Utils */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		6327C5D41EB8A783004E799B /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
Just like the sample folder already did, now the top level Sentry folder also uses 4 spaces for indentation.

#skip-changelog