### PR TITLE
ref: Move SentryHub to SentrySDK+Private

### DIFF
--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -4,7 +4,7 @@
 
 @protocol SentrySpan;
 
-@class SentryHub, SentryOptions, SentryEvent, SentryBreadcrumb, SentryScope, SentryUser, SentryId,
+@class SentryOptions, SentryEvent, SentryBreadcrumb, SentryScope, SentryUser, SentryId,
     SentryUserFeedback, SentryTransactionContext;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -1,6 +1,6 @@
 #import "SentrySDK.h"
 
-@class SentryId, SentryAppStartMeasurement, SentryEnvelope;
+@class SentryHub, SentryId, SentryAppStartMeasurement, SentryEnvelope;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
SentrySDK doesn't use the SentryHub, only SentrySDK+Private does.

#skip-changelog