### PR TITLE
feat: Enhance the UIViewController breadcrumbs with more data

### DIFF
--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -194,7 +194,15 @@ SentryBreadcrumbTracker ()
                 crumb.type = @"navigation";
                 NSString *viewControllerName = [SentryUIViewControllerSanitizer
                     sanitizeViewControllerName:[NSString stringWithFormat:@"%@", self]];
-                crumb.data = @ { @"screen" : viewControllerName };
+
+                NSMutableDictionary *data = @ { @"screen" : viewControllerName }.mutableCopy;
+
+                NSString *title = [SentryUIViewControllerSanitizer extractTitle: self];
+                if ([title length] != 0) {
+                    data[@"title"] = title;
+                }
+
+                crumb.data = data;
 
                 // Adding crumb via the SDK calls SentryBeforeBreadcrumbCallback
                 [SentrySDK addBreadcrumb:crumb];

--- a/Sources/Sentry/SentryUIViewControllerSanitizer.m
+++ b/Sources/Sentry/SentryUIViewControllerSanitizer.m
@@ -31,4 +31,12 @@
     return description;
 }
 
++ (NSString *)extractTitle:(UIViewController *)controller
+{
+    if ([controller.navigationItem.title length] != 0) {
+        return controller.navigationItem.title;
+    }
+    return controller.title;
+}
+
 @end

--- a/Sources/Sentry/include/SentryUIViewControllerSanitizer.h
+++ b/Sources/Sentry/include/SentryUIViewControllerSanitizer.h
@@ -1,5 +1,6 @@
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @return The view controller sanitized class name.
  */
 + (NSString *)sanitizeViewControllerName:(id)controller;
++ (NSString *)extractTitle:(UIViewController *)controller;
 
 @end
 


### PR DESCRIPTION
## :scroll: Description

We're adding more UIViewController information in the `viewDidAppear` breadcrumbs.

- title
- accessibility identifier
- presentation mode

## :bulb: Motivation and Context

Closes #1727

## :green_heart: How did you test it?

By running the iOS-Swift sample app.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
