### PR TITLE
chore: Compile iOS13-Swift sample

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,7 @@ jobs:
         beforeXcode: ['']
         scheme:
           - macOS-Swift
+          - iOS13-Swift
         # other sample projects are built in ui-tests
 
         # WatchOS needs Sentry as a XCFramework  


### PR DESCRIPTION
Try to compile `iOS13-Swift` sample during CI to ensure all required files were added.

close #1938

_#skip-changelog_