### PR TITLE
build: Remove trailing-whitespace

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
       - id: check-yaml
       - id: detect-private-key
       - id: end-of-file-fixer
-      - id: trailing-whitespace
       - id: no-commit-to-branch
         args: ["-b master"]
 


### PR DESCRIPTION
Remove trailing-whitespace of pre-commit hook cause
it causes some formatting issues in combination with Xcode.

#skip-changelog