### PR TITLE
feat: Add option to choose Crash Report and offline Event directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add option to choose Crash Report and offline Event directory (#1954)
+
 ## 7.20.0
 
 ### Features

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -335,6 +335,13 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) NSTimeInterval appHangTimeoutInterval;
 
+/**
+ * The cache directory path for caching offline events.
+ * If this property is nil the SDK uses the default user cache directory in the OS.
+ * If this path does not exists the SDK tries to create it with intermediate directories.
+ */
+@property (nonatomic, strong) NSString *cacheDirectoryPath;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -100,7 +100,13 @@ SentryCrashIntegration ()
             canSendReports = YES;
         }
 
-        [installation install];
+        NSString *reportPath = self.options.cacheDirectoryPath;
+        if (reportPath == nil) {
+            reportPath = [NSSearchPathForDirectoriesInDomains(
+                NSCachesDirectory, NSUserDomainMask, YES) firstObject];
+        }
+
+        [installation installWithReportPath:reportPath];
 
         // We need to send the crashed event together with the crashed session in the same envelope
         // to have proper statistics in release health. To achieve this we need both synchronously

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -40,13 +40,17 @@ SentryFileManager ()
     self = [super init];
     if (self) {
         self.currentDateProvider = currentDateProvider;
-
         NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSString *cachePath
-            = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)
-                  .firstObject;
 
-        self.sentryPath = [cachePath stringByAppendingPathComponent:@"io.sentry"];
+        if (options.cacheDirectoryPath) {
+            self.sentryPath = options.cacheDirectoryPath;
+        } else {
+            self.sentryPath
+                = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES)
+                      .firstObject;
+        }
+
+        self.sentryPath = [self.sentryPath stringByAppendingPathComponent:@"io.sentry"];
         self.sentryPath =
             [self.sentryPath stringByAppendingPathComponent:[options.parsedDsn getHash]];
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -304,6 +304,10 @@ SentryOptions ()
         _sdkInfo = [[SentrySdkInfo alloc] initWithDict:options orDefaults:_sdkInfo];
     }
 
+    if ([options[@"cacheDirectoryPath"] isKindOfClass:[NSString class]]) {
+        self.cacheDirectoryPath = options[@"cacheDirectoryPath"];
+    }
+
     if (nil != error && nil != *error) {
         return NO;
     } else {

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.h
@@ -48,7 +48,7 @@
 /** Install this installation. Call this instead of -[SentryCrash install] to
  * install with everything needed for your particular backend.
  */
-- (void)install;
+- (void)installWithReportPath:(NSString *)reportPath;
 
 /** Convenience method to call -[SentryCrash sendAllReportsWithCompletion:].
  * This method will set the SentryCrash sink and then send all outstanding

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -288,13 +288,13 @@ SentryCrashInstallation ()
     }
 }
 
-- (void)install
+- (void)installWithReportPath:(NSString *)reportPath
 {
     SentryCrash *handler = [SentryCrash sharedInstance];
     @synchronized(handler) {
         g_crashHandlerData = self.crashHandlerData;
         handler.onCrash = crashCallback;
-        [handler install];
+        [handler installWithReportPath:reportPath];
     }
 }
 

--- a/Sources/SentryCrash/Recording/SentryCrash.h
+++ b/Sources/SentryCrash/Recording/SentryCrash.h
@@ -55,9 +55,6 @@ static NSString *const SENTRYCRASH_REPORT_SCREENSHOT_ITEM = @"screenshots";
 
 #pragma mark - Configuration -
 
-/** Init SentryCrash instance with custom base path. */
-- (id)initWithBasePath:(NSString *)basePath;
-
 /** A dictionary containing any info you'd like to appear in crash reports. Must
  * contain only JSON-safe data: NSString for keys, and NSDictionary, NSArray,
  * NSString, NSDate, and NSNumber for values.
@@ -208,6 +205,16 @@ static NSString *const SENTRYCRASH_REPORT_SCREENSHOT_ITEM = @"screenshots";
  * @return YES if the reporter successfully installed.
  */
 - (BOOL)install;
+
+/** Install the crash reporter.
+ * The reporter will record crashes, but will not send any crash reports unless
+ * sink is set.
+ *
+ *@param reportPath A path to store crash reports.
+ *
+ * @return YES if the reporter successfully installed.
+ */
+- (BOOL)installWithReportPath:(NSString *)reportPath;
 
 /** Send all outstanding crash reports to the current sink.
  * It will only attempt to send the most recent 5 reports. All others will be

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -505,6 +505,16 @@ class SentryFileManagerTests: XCTestCase {
         try "garbage".write(to: URL(fileURLWithPath: sut.timezoneOffsetFilePath), atomically: true, encoding: .utf8)
         XCTAssertNil(sut.readTimezoneOffset())
     }
+    
+    func testPathFromOptions() throws {
+        var altCache = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first ?? ""
+        altCache += "/altReportPath"
+        fixture.options.cacheDirectoryPath = altCache
+        
+        let sut = try fixture.getSut()
+        
+        XCTAssertTrue(sut.sentryPath.hasPrefix(altCache))
+    }
 
     private func givenMaximumEnvelopes() {
         fixture.eventIds.forEach { id in

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -12,7 +12,10 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     override func setUp() {
         super.setUp()
         sut = SentryCrashInstallationReporter(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: []))
-        sut.install()
+        
+        let cacheDir = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first
+        
+        sut.install(withReportPath: cacheDir)
         // Works only if SentryCrash is installed
         sentrycrash_deleteAllReports()
     }

--- a/Tests/SentryTests/SentryCrash/SentryCrashTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashTests.m
@@ -23,8 +23,7 @@
 {
     [self initReport:12 withScreenshots:1];
 
-    SentryCrash *sentryCrash = [[SentryCrash alloc]
-        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+    SentryCrash *sentryCrash = [[SentryCrash alloc] init];
     NSArray *files = [sentryCrash getScreenshotPaths:12];
 
     XCTAssertEqual(files.count, 1);
@@ -37,8 +36,7 @@
 {
     [self initReport:12 withScreenshots:2];
 
-    SentryCrash *sentryCrash = [[SentryCrash alloc]
-        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+    SentryCrash *sentryCrash = [[SentryCrash alloc] init];
     NSArray *files = [sentryCrash getScreenshotPaths:12];
     XCTAssertEqual(files.count, 2);
 }
@@ -47,16 +45,14 @@
 {
     [self initReport:12 withScreenshots:0];
 
-    SentryCrash *sentryCrash = [[SentryCrash alloc]
-        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
+    SentryCrash *sentryCrash = [[SentryCrash alloc] init];
     NSArray *files = [sentryCrash getScreenshotPaths:12];
     XCTAssertEqual(files.count, 0);
 }
 
 - (void)test_getScreenshots_NoDirectory
 {
-    SentryCrash *sentryCrash = [[SentryCrash alloc]
-        initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"ReportsFake"]];
+    SentryCrash *sentryCrash = [[SentryCrash alloc] init];
     NSArray *files = [sentryCrash getScreenshotPaths:12];
     XCTAssertEqual(files.count, 0);
 }

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -93,6 +93,15 @@
     XCTAssertEqualObjects(options.dist, @"hhh");
 }
 
+- (void)testCacheDirectoryPath
+{
+    SentryOptions *options = [self getValidOptions:@{}];
+    XCTAssertNil(options.cacheDirectoryPath);
+
+    options = [self getValidOptions:@{ @"cacheDirectoryPath" : @"/somePath/" }];
+    XCTAssertEqualObjects(options.cacheDirectoryPath, @"/somePath/");
+}
+
 - (void)testValidDebug
 {
     [self testDebugWith:@YES expected:YES];
@@ -488,7 +497,9 @@
         @"experimentalEnableTraceSampling" : [NSNull null],
         @"enableSwizzling" : [NSNull null],
         @"enableIOTracking" : [NSNull null],
-        @"sdk" : [NSNull null]
+        @"sdk" : [NSNull null],
+        @"cacheDirectoryPath" : [NSNull null]
+
     }
                                                 didFailWithError:nil];
 
@@ -540,6 +551,7 @@
 #endif
     XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name);
     XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version);
+    XCTAssertNil(options.cacheDirectoryPath);
 }
 
 - (void)testSetValidDsn


### PR DESCRIPTION
## :scroll: Description

Added option to choose where crash report and offline events will be stored instead of the default cache directory.

## :bulb: Motivation and Context

close #1051

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes
