### PR TITLE
fix: SentryANRTrackerTests flaky test

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -7,7 +7,7 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
     private var fixture: Fixture!
     private var anrDetectedExpectation: XCTestExpectation!
     private var anrStoppedExpectation: XCTestExpectation!
-    private let waitTimeout: TimeInterval = 0.1
+    private let waitTimeout: TimeInterval = 0.3
     
     private class Fixture {
         let timeoutInterval: TimeInterval = 5


### PR DESCRIPTION
This never fail in the local machine, even repeating it 1000 times. But it fails regularly with CI.
I believe 0.1 second to wait all expectations to be fulfilled may be not enough time in some situations and environments.

close #1948 

_#skip-changelog_