### PR TITLE
build: Format code only on specific files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,5 +20,6 @@ repos:
         name: Clang Format
         entry: make
         language: system
+        types_or: ["objective-c", "objective-c++", "c", "c++", "swift" ]
         args:
           - "format"


### PR DESCRIPTION
Run pre commit hook format only when specific files are modified.

#skip-changelog