### PR TITLE
fix: Don't send error 429 as network_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Properly sanitize the event context and SDK information (#1943)
+- Don't send error 429 as `network_error` (#1957)
 
 ## 7.20.0
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -225,7 +225,7 @@ SentryHttpTransport ()
                addRequest:request
         completionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
             // If the response is not nil we had an internet connection.
-            if (error) {
+            if (error && response.statusCode != 429) {
                 [_self recordLostEventFor:envelope.items];
             }
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -298,11 +298,14 @@ class SentryHttpTransportTests: XCTestCase {
     }
 
     func testSendEventWithRateLimitResponse() {
+        fixture.requestManager.nextError = NSError(domain: "something", code: 12)
+
         let response = givenRateLimitResponse(forCategory: SentryEnvelopeItemTypeSession)
 
         sendEvent()
 
         assertRateLimitUpdated(response: response)
+        assertClientReportStoredInMemory()
     }
 
     func testSendEnvelopeWithRetryAfterResponse() {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -292,6 +292,9 @@ class SentryHttpTransportTests: XCTestCase {
         sendEvent()
 
         assertRateLimitUpdated(response: response)
+
+        let dict = Dynamic(sut).discardedEvents.asDictionary as? [String: SentryDiscardedEvent]
+        XCTAssertEqual(dict?.count, 0)
     }
 
     func testSendEventWithRateLimitResponse() {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -287,14 +287,14 @@ class SentryHttpTransportTests: XCTestCase {
     }
 
     func testSendEventWithRetryAfterResponse() {
+        fixture.requestManager.nextError = NSError(domain: "something", code: 12)
+        
         let response = givenRetryAfterResponse()
 
         sendEvent()
 
         assertRateLimitUpdated(response: response)
-
-        let dict = Dynamic(sut).discardedEvents.asDictionary as? [String: SentryDiscardedEvent]
-        XCTAssertEqual(dict?.count, 0)
+        assertClientReportNotStoredInMemory()
     }
 
     func testSendEventWithRateLimitResponse() {


### PR DESCRIPTION
## :scroll: Description

The docs state that errors with status code 429 should not be sent as network_error. The SDK didn't follow this rule yet.

## :bulb: Motivation and Context

Fixes #1753

## :green_heart: How did you test it?

Unit test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
