### PR TITLE
feat: Add a new enableAutoBreadcrumbTracking option

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -335,6 +335,11 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) NSTimeInterval appHangTimeoutInterval;
 
+/**
+ * When enabled, the SDK adds breadcrumbs for various system events. Default value is YES.
+ */
+@property (nonatomic, assign) BOOL enableAutoBreadcrumbTracking;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -3,6 +3,9 @@
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryDependencyContainer.h"
 #import "SentryFileManager.h"
+#import "SentryLog.h"
+#import "SentryOptions+Private.h"
+#import "SentryOptions.h"
 #import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,6 +22,13 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 - (void)installWithOptions:(nonnull SentryOptions *)options
 {
+    if (!options.enableAutoBreadcrumbTracking) {
+        [SentryLog logWithMessage:@"Not going to enable BreadcrumbTracking because "
+                                  @"enableAutoBreadcrumbTracking is disabled."
+                         andLevel:kSentryLevelDebug];
+        [options removeEnabledIntegration:NSStringFromClass([self class])];
+        return;
+    }
 
     [self installWithOptions:options
              breadcrumbTracker:[[SentryBreadcrumbTracker alloc]

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -61,6 +61,7 @@ SentryOptions ()
 #endif
         self.enableAppHangTracking = NO;
         self.appHangTimeoutInterval = 2.0;
+        self.enableAutoBreadcrumbTracking = YES;
 
         self.enableNetworkTracking = YES;
         self.enableFileIOTracking = NO;
@@ -246,7 +247,6 @@ SentryOptions ()
     if ([options[@"idleTimeout"] isKindOfClass:[NSNumber class]]) {
         self.idleTimeout = [options[@"idleTimeout"] doubleValue];
     }
-
 #endif
 
     [self setBool:options[@"enableAppHangTracking"]
@@ -297,6 +297,9 @@ SentryOptions ()
 
     [self setBool:options[@"sendClientReports"]
             block:^(BOOL value) { self->_sendClientReports = value; }];
+
+    [self setBool:options[@"enableAutoBreadcrumbTracking"]
+            block:^(BOOL value) { self->_enableAutoBreadcrumbTracking = value; }];
 
     // SentrySdkInfo already expects a dictionary with {"sdk": {"name": ..., "value": ...}}
     // so we're passing the whole options object.

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,5 +1,4 @@
 #import "SentryIntegrationProtocol.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -480,6 +480,7 @@
         @"enableAppHangTracking" : [NSNull null],
         @"appHangTimeoutInterval" : [NSNull null],
         @"enableNetworkTracking" : [NSNull null],
+        @"enableAutoBreadcrumbTracking" : [NSNull null],
         @"tracesSampleRate" : [NSNull null],
         @"tracesSampler" : [NSNull null],
         @"inAppIncludes" : [NSNull null],
@@ -535,6 +536,7 @@
     XCTAssertNil(options.urlSessionDelegate);
     XCTAssertEqual(YES, options.enableSwizzling);
     XCTAssertEqual(NO, options.enableFileIOTracking);
+    XCTAssertEqual(YES, options.enableAutoBreadcrumbTracking);
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     XCTAssertEqual(NO, options.enableProfiling);
 #endif


### PR DESCRIPTION
## :scroll: Description

We're unifying the options, so breadcrumb tracking is also enabled via a boolean option `enableAutoBreadcrumbTracking`.

## :bulb: Motivation and Context

We're unifying the options, so breadcrumb tracking is also enabled via a boolean option. Closes #427.

## :green_heart: How did you test it?

WIP

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
