### PR TITLE
ref: Mark options.sdkInfo as deprecated

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -1,6 +1,7 @@
 #import "PrivateSentrySDKOnly.h"
 #import "SentryDebugImageProvider.h"
 #import "SentryInstallation.h"
+#import "SentryMeta.h"
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import <Foundation/Foundation.h>
@@ -64,6 +65,16 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 + (void)setAppStartMeasurementHybridSDKMode:(BOOL)appStartMeasurementHybridSDKMode
 {
     _appStartMeasurementHybridSDKMode = appStartMeasurementHybridSDKMode;
+}
+
++ (void)setSdkName:(NSString *)sdkName
+{
+    SentryMeta.sdkName = sdkName;
+}
+
++ (void)setSdkVersionString:(NSString *)versionString
+{
+    SentryMeta.versionString = versionString;
 }
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -41,6 +41,12 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (NSArray<SentryDebugMeta *> *)getDebugImages;
 
+/**
+ * Override SDK information.
+ */
++ (void)setSdkName:(NSString *)sdkName;
++ (void)setSdkVersionString:(NSString *)versionString;
+
 @property (class, nullable, nonatomic, copy)
     SentryOnAppStartMeasurementAvailable onAppStartMeasurementAvailable;
 

--- a/Sources/Sentry/Public/SentryEnvelope.h
+++ b/Sources/Sentry/Public/SentryEnvelope.h
@@ -28,21 +28,6 @@ SENTRY_NO_INIT
  * @param traceContext Current trace state.
  */
 - (instancetype)initWithId:(nullable SentryId *)eventId
-              traceContext:(nullable SentryTraceContext *)traceContext;
-
-/**
- * Initializes an SentryEnvelopeHeader object with the specified eventId, skdInfo and traceContext.
- *
- * It is recommended to use initWithId:traceContext: because it sets the sdkInfo for you.
- *
- * @param eventId The identifier of the event. Can be nil if no event in the envelope or attachment
- * related to event.
- * @param sdkInfo sdkInfo Describes the Sentry SDK. Can be nil for backwards compatibility. New
- * instances should always provide a version.
- * @param traceContext Current trace state.
- */
-- (instancetype)initWithId:(nullable SentryId *)eventId
-                   sdkInfo:(nullable SentrySdkInfo *)sdkInfo
               traceContext:(nullable SentryTraceContext *)traceContext NS_DESIGNATED_INITIALIZER;
 
 /**

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -154,7 +154,8 @@ NS_SWIFT_NAME(Options)
 /**
  * Describes the Sentry SDK and its configuration used to capture and transmit an event.
  */
-@property (nonatomic, readonly, strong) SentrySdkInfo *sdkInfo;
+@property (nonatomic, readonly, strong) SentrySdkInfo *sdkInfo DEPRECATED_MSG_ATTRIBUTE(
+    "This property will be removed in a future version of the SDK");
 
 /**
  * The maximum size for each attachment in bytes. Default is 20 MiB / 20 * 1024 * 1024 bytes.

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -363,8 +363,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithSession:session];
-    SentryEnvelopeHeader *envelopeHeader =
-        [[SentryEnvelopeHeader alloc] initWithId:nil sdkInfo:self.options.sdkInfo traceContext:nil];
+    SentryEnvelopeHeader *envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:nil
+                                                                       traceContext:nil];
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader
                                                            singleItem:item];
     [self captureEnvelope:envelope];
@@ -591,8 +591,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     event.sdk = @{
-        @"name" : self.options.sdkInfo.name,
-        @"version" : self.options.sdkInfo.version,
+        @"name" : SentryMeta.sdkName,
+        @"version" : SentryMeta.versionString,
         @"integrations" : integrations
     };
 }

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -20,37 +20,17 @@ NS_ASSUME_NONNULL_BEGIN
 // id can be null if no event in the envelope or attachment related to event
 - (instancetype)initWithId:(SentryId *_Nullable)eventId
 {
-    SentrySdkInfo *sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
-                                                      andVersion:SentryMeta.versionString];
-    self = [self initWithId:eventId andSdkInfo:sdkInfo];
-
+    self = [self initWithId:eventId traceContext:nil];
     return self;
-}
-
-- (instancetype)initWithId:(SentryId *_Nullable)eventId andSdkInfo:(SentrySdkInfo *_Nullable)sdkInfo
-{
-    return [self initWithId:eventId sdkInfo:sdkInfo traceContext:nil];
 }
 
 - (instancetype)initWithId:(nullable SentryId *)eventId
               traceContext:(nullable SentryTraceContext *)traceContext
 {
-    SentrySdkInfo *sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
-                                                      andVersion:SentryMeta.versionString];
-
-    self = [self initWithId:eventId sdkInfo:sdkInfo traceContext:traceContext];
-
-    return self;
-}
-
-- (instancetype)initWithId:(nullable SentryId *)eventId
-                   sdkInfo:(nullable SentrySdkInfo *)sdkInfo
-              traceContext:(nullable SentryTraceContext *)traceContext
-{
-
     if (self = [super init]) {
         _eventId = eventId;
-        _sdkInfo = sdkInfo;
+        _sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
+                                            andVersion:SentryMeta.versionString];
         _traceContext = traceContext;
     }
 

--- a/Sources/Sentry/SentryMeta.m
+++ b/Sources/Sentry/SentryMeta.m
@@ -5,17 +5,27 @@
 // Don't remove the static keyword. If you do the compiler adds the constant name to the global
 // symbol table and it might clash with other constants. When keeping the static keyword the
 // compiler replaces all occurrences with the value.
-static NSString *const versionString = @"7.20.0";
-static NSString *const sdkName = @"sentry.cocoa";
+static NSString *versionString = @"7.20.0";
+static NSString *sdkName = @"sentry.cocoa";
 
 + (NSString *)versionString
 {
     return versionString;
 }
 
++ (void)setVersionString:(NSString *)value
+{
+    versionString = value;
+}
+
 + (NSString *)sdkName
 {
     return sdkName;
+}
+
++ (void)setSdkName:(NSString *)value
+{
+    sdkName = value;
 }
 
 @end

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -303,8 +303,13 @@ SentryOptions ()
 
     // SentrySdkInfo already expects a dictionary with {"sdk": {"name": ..., "value": ...}}
     // so we're passing the whole options object.
+    // Note: we should remove this code once the hybrid SDKs move over to the new
+    // PrivateSentrySDKOnly setter function.
     if ([options[@"sdk"] isKindOfClass:[NSDictionary class]]) {
-        _sdkInfo = [[SentrySdkInfo alloc] initWithDict:options orDefaults:_sdkInfo];
+        SentrySdkInfo *sdkInfo = [[SentrySdkInfo alloc] initWithDict:options orDefaults:_sdkInfo];
+        SentryMeta.versionString = sdkInfo.version;
+        SentryMeta.sdkName = sdkInfo.name;
+        _sdkInfo = sdkInfo;
     }
 
     if (nil != error && nil != *error) {

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -179,7 +179,6 @@ NS_ASSUME_NONNULL_BEGIN
                 }
 
                 envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:eventId
-                                                                  sdkInfo:sdkInfo
                                                              traceContext:traceContext];
             }
             break;

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -58,10 +58,8 @@ SentryTransportAdapter ()
                                                                attachments:attachments];
     [items addObjectsFromArray:additionalEnvelopeItems];
 
-    SentryEnvelopeHeader *envelopeHeader =
-        [[SentryEnvelopeHeader alloc] initWithId:event.eventId
-                                         sdkInfo:self.options.sdkInfo
-                                    traceContext:traceContext];
+    SentryEnvelopeHeader *envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:event.eventId
+                                                                       traceContext:traceContext];
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader items:items];
 
     [self sendEnvelope:envelope];
@@ -76,10 +74,8 @@ SentryTransportAdapter ()
                                                                attachments:attachments];
     [items addObject:[[SentryEnvelopeItem alloc] initWithSession:session]];
 
-    SentryEnvelopeHeader *envelopeHeader =
-        [[SentryEnvelopeHeader alloc] initWithId:event.eventId
-                                         sdkInfo:self.options.sdkInfo
-                                    traceContext:traceContext];
+    SentryEnvelopeHeader *envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:event.eventId
+                                                                       traceContext:traceContext];
 
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader items:items];
 
@@ -90,9 +86,7 @@ SentryTransportAdapter ()
 {
     SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithUserFeedback:userFeedback];
     SentryEnvelopeHeader *envelopeHeader =
-        [[SentryEnvelopeHeader alloc] initWithId:userFeedback.eventId
-                                         sdkInfo:self.options.sdkInfo
-                                    traceContext:nil];
+        [[SentryEnvelopeHeader alloc] initWithId:userFeedback.eventId traceContext:nil];
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader
                                                            singleItem:item];
     [self sendEnvelope:envelope];

--- a/Sources/Sentry/include/SentryMeta.h
+++ b/Sources/Sentry/include/SentryMeta.h
@@ -7,12 +7,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Return a version string e.g: 1.2.3 (3)
  */
-@property (nonatomic, class, readonly, copy) NSString *versionString;
+@property (nonatomic, class, copy) NSString *versionString;
 
 /**
  * Return a string sentry-cocoa
  */
-@property (nonatomic, class, readonly, copy) NSString *sdkName;
+@property (nonatomic, class, copy) NSString *sdkName;
 
 @end
 

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -91,8 +91,8 @@ class SentrySerializationTests: XCTestCase {
     }
 
     func testSentryEnvelopeSerializer_SdkInfo() {
-        let sdkInfo = SentrySdkInfo(name: "sentry.cocoa", andVersion: "5.0.1")
-        let envelopeHeader = SentryEnvelopeHeader(id: nil, sdkInfo: sdkInfo, traceContext: nil)
+        let sdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, andVersion: SentryMeta.versionString)
+        let envelopeHeader = SentryEnvelopeHeader(id: nil, traceContext: nil)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
 
         assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
@@ -122,15 +122,6 @@ class SentrySerializationTests: XCTestCase {
         }
     }
     
-    func testSentryEnvelopeSerializer_SdkInfoIsNil() {
-        let envelopeHeader = SentryEnvelopeHeader(id: nil, sdkInfo: nil, traceContext: nil)
-        let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertNil(deserializedEnvelope.header.sdkInfo)
-        }
-    }
-
     func testSentryEnvelopeSerializer_ZeroByteItemReturnsEnvelope() {
         let itemData = "{}\n{\"length\":0,\"type\":\"attachment\"}\n".data(using: .utf8)!
         XCTAssertNotNil(SentrySerialization.envelope(with: itemData))

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -135,9 +135,8 @@ class SentryEnvelopeTests: XCTestCase {
     }
     
     func testInitSentryEnvelopeHeader_IdAndSkInfoNil() {
-        let allNil = SentryEnvelopeHeader(id: nil, sdkInfo: nil, traceContext: nil)
+        let allNil = SentryEnvelopeHeader(id: nil, traceContext: nil)
         XCTAssertNil(allNil.eventId)
-        XCTAssertNil(allNil.sdkInfo)
         XCTAssertNil(allNil.traceContext)
     }
     
@@ -146,15 +145,6 @@ class SentryEnvelopeTests: XCTestCase {
         XCTAssertNil(allNil.eventId)
         XCTAssertNotNil(allNil.sdkInfo)
         XCTAssertNil(allNil.traceContext)
-    }
-    
-    func testInitSentryEnvelopeHeader_SetIdAndSdkInfo() {
-        let eventId = SentryId()
-        let sdkInfo = SentrySdkInfo(name: "sdk", andVersion: "1.2.3-alpha.0")
-        
-        let envelopeHeader = SentryEnvelopeHeader(id: eventId, sdkInfo: sdkInfo, traceContext: nil)
-        XCTAssertEqual(eventId, envelopeHeader.eventId)
-        XCTAssertEqual(sdkInfo, envelopeHeader.sdkInfo)
     }
     
     func testInitSentryEnvelopeHeader_SetIdAndTraceState() {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -545,8 +545,12 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     XCTAssertEqual(NO, options.enableProfiling);
 #endif
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name);
     XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version);
+#pragma clang diagnostic pop
 }
 
 - (void)testSetValidDsn
@@ -585,10 +589,12 @@
 
 - (void)testSdkInfo
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentryOptions *options = [[SentryOptions alloc] init];
-
     XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name);
     XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version);
+#pragma clang diagnostic pop
 }
 
 - (void)testSetCustomSdkInfo
@@ -601,8 +607,12 @@
                            didFailWithError:&error];
 
     XCTAssertNil(error);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqual(dict[@"name"], options.sdkInfo.name);
     XCTAssertEqual(dict[@"version"], options.sdkInfo.version);
+#pragma clang diagnostic pop
 }
 
 - (void)testSetCustomSdkName
@@ -615,8 +625,12 @@
                            didFailWithError:&error];
 
     XCTAssertNil(error);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqual(dict[@"name"], options.sdkInfo.name);
     XCTAssertEqual(SentryMeta.versionString, options.sdkInfo.version); // default version
+#pragma clang diagnostic pop
 }
 
 - (void)testSetCustomSdkVersion
@@ -629,8 +643,12 @@
                            didFailWithError:&error];
 
     XCTAssertNil(error);
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqual(SentryMeta.sdkName, options.sdkInfo.name); // default name
     XCTAssertEqual(dict[@"version"], options.sdkInfo.version);
+#pragma clang diagnostic pop
 }
 
 - (void)testMaxAttachmentSize


### PR DESCRIPTION
## :scroll: Description

options.sdkInfo is  deprecated; SentryMeta is now the only source of truth. The values can be overridden by hybrid SDKs via PrivateSentrySDKOnly.

## :bulb: Motivation and Context

Closes #1884

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
