### PR TITLE
fix: sanitize span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Properly sanitize the event context and SDK information (#1943)
 - Don't send error 429 as `network_error` (#1957)
+- Sanitize SentrySpan data and tags (#1963)
 
 ## 7.20.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Properly sanitize the event context and SDK information (#1943)
 - Don't send error 429 as `network_error` (#1957)
-- Sanitize SentrySpan data and tags (#1963)
+- Sanitize Span data (#1963)
 
 ## 7.20.0
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -139,7 +139,7 @@ SentrySpan ()
         if (_tags.count > 0) {
             NSMutableDictionary *tags = _context.tags.mutableCopy;
             [tags addEntriesFromDictionary:_tags.copy];
-            mutableDictionary[@"tags"] = [tags sentry_sanitize];
+            mutableDictionary[@"tags"] = tags;
         }
     }
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -1,5 +1,6 @@
 #import "SentrySpan.h"
 #import "NSDate+SentryExtras.h"
+#import "NSDictionary+SentrySanitize.h"
 #import "SentryCurrentDate.h"
 #import "SentryNoOpSpan.h"
 #import "SentryTraceHeader.h"
@@ -130,7 +131,7 @@ SentrySpan ()
 
     @synchronized(_data) {
         if (_data.count > 0) {
-            mutableDictionary[@"data"] = _data.copy;
+            mutableDictionary[@"data"] = [_data.copy sentry_sanitize];
         }
     }
 
@@ -138,7 +139,7 @@ SentrySpan ()
         if (_tags.count > 0) {
             NSMutableDictionary *tags = _context.tags.mutableCopy;
             [tags addEntriesFromDictionary:_tags.copy];
-            mutableDictionary[@"tags"] = tags;
+            mutableDictionary[@"tags"] = [tags sentry_sanitize];
         }
     }
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -697,7 +697,7 @@ static NSLock *profilerLock;
                 [mutableDictionary[@"tags"] isKindOfClass:NSDictionary.class]) {
                 [tags addEntriesFromDictionary:mutableDictionary[@"tags"]];
             }
-            mutableDictionary[@"tags"] = [tags sentry_sanitize];
+            mutableDictionary[@"tags"] = tags;
         }
     }
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -1,4 +1,5 @@
 #import "SentryTracer.h"
+#import "NSDictionary+SentrySanitize.h"
 #import "PrivateSentrySDKOnly.h"
 #import "SentryAppStartMeasurement.h"
 #import "SentryClient.h"
@@ -685,7 +686,7 @@ static NSLock *profilerLock;
                 [mutableDictionary[@"data"] isKindOfClass:NSDictionary.class]) {
                 [data addEntriesFromDictionary:mutableDictionary[@"data"]];
             }
-            mutableDictionary[@"data"] = data;
+            mutableDictionary[@"data"] = [data sentry_sanitize];
         }
     }
 
@@ -696,7 +697,7 @@ static NSLock *profilerLock;
                 [mutableDictionary[@"tags"] isKindOfClass:NSDictionary.class]) {
                 [tags addEntriesFromDictionary:mutableDictionary[@"tags"]];
             }
-            mutableDictionary[@"tags"] = tags;
+            mutableDictionary[@"tags"] = [tags sentry_sanitize];
         }
     }
 

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -166,6 +166,16 @@ class SentrySpanTests: XCTestCase {
         let serialization = span.serialize()
         XCTAssertEqual((serialization["data"] as! Dictionary)["date"], "1970-01-01T00:00:10.000Z")
     }
+
+    func testSanitizeDataSpan() {
+        let span = SentrySpan(transaction: fixture.getSut() as! SentryTracer, context: SpanContext(operation: "test"))
+
+        span.setExtra(value: Date(timeIntervalSince1970: 10), key: "date")
+        span.finish()
+
+        let serialization = span.serialize()
+        XCTAssertEqual((serialization["data"] as! Dictionary)["date"], "1970-01-01T00:00:10.000Z")
+    }
     
     func testSerialization_WithNoDataAndTag() {
         let span = fixture.getSut()

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -156,6 +156,16 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual((serialization["data"] as! Dictionary)[fixture.extraKey], fixture.extraValue)
         XCTAssertEqual((serialization["tags"] as! Dictionary)[fixture.extraKey], fixture.extraValue)
     }
+
+    func testSanitizeData() {
+        let span = fixture.getSut()
+
+        span.setExtra(value: Date(timeIntervalSince1970: 10), key: "date")
+        span.finish()
+
+        let serialization = span.serialize()
+        XCTAssertEqual((serialization["data"] as! Dictionary)["date"], "1970-01-01T00:00:10.000Z")
+    }
     
     func testSerialization_WithNoDataAndTag() {
         let span = fixture.getSut()


### PR DESCRIPTION
## :scroll: Description

Sanitize span data when serializing.

## :bulb: Motivation and Context

Closes #1307

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
