### PR TITLE
fix: Crash in profiling logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Properly sanitize the event context and SDK information (#1943)
 - Don't send error 429 as `network_error` (#1957)
 - Deprecate not needed option `sdkInfo` (#1960)
+- Crash in profiling logger (#1964)
 
 ## 7.20.0
 

--- a/Sources/Sentry/SentryProfilingLogging.mm
+++ b/Sources/Sentry/SentryProfilingLogging.mm
@@ -33,9 +33,10 @@ namespace profiling {
         }
         va_list args;
         va_start(args, fmt);
-        va_end(args);
         const auto fmtStr = [[NSString alloc] initWithUTF8String:fmt];
-        [SentryLog logWithMessage:[[NSString alloc] initWithFormat:fmtStr arguments:args]
+        const auto msgStr = [[NSString alloc] initWithFormat:fmtStr arguments:args];
+        va_end(args);
+        [SentryLog logWithMessage:msgStr
                          andLevel:sentryLevelFromLogLevel(level)];
     }
 

--- a/Sources/Sentry/SentryProfilingLogging.mm
+++ b/Sources/Sentry/SentryProfilingLogging.mm
@@ -36,8 +36,7 @@ namespace profiling {
         const auto fmtStr = [[NSString alloc] initWithUTF8String:fmt];
         const auto msgStr = [[NSString alloc] initWithFormat:fmtStr arguments:args];
         va_end(args);
-        [SentryLog logWithMessage:msgStr
-                         andLevel:sentryLevelFromLogLevel(level)];
+        [SentryLog logWithMessage:msgStr andLevel:sentryLevelFromLogLevel(level)];
     }
 
 } // namespace profiling


### PR DESCRIPTION
## :scroll: Description

Call `va_end` *after* creating the `NSString *`, otherwise this is undefined behavior and can crash.

## :bulb: Motivation and Context

Customer reported a crash:

![image](https://user-images.githubusercontent.com/353158/178593745-8f82f16f-412c-4684-a2a8-8b59c1bd8a2e.png)

## :green_heart: How did you test it?

Manually verified that logging still works, we will deploy the fix and ask the customer to check whether this resolves their issue.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
