### PR TITLE
Don't track OOMs for simulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Fixes
 
+- Don't track OOMs for simulators (#1970)
 - Properly sanitize the event context and SDK information (#1943)
 - Don't send error 429 as `network_error` (#1957)
 - Sanitize Span data (#1963)

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -5,6 +5,7 @@
 #import <Foundation/Foundation.h>
 #import <SentryCrashCachedData.h>
 #import <SentryCrashDebug.h>
+#import <SentryCrashMonitor_System.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,6 +32,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isBeingTraced
 {
     return sentrycrashdebug_isBeingTraced();
+}
+
+- (BOOL)isSimulatorBuild
+{
+    return sentrycrash_isSimulatorBuild();
 }
 
 - (BOOL)isApplicationInForeground

--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -48,6 +48,10 @@ SentryOutOfMemoryLogic ()
         return NO;
     }
 
+    if (self.crashAdapter.isSimulatorBuild) {
+        return NO;
+    }
+
     // If the release name is different we assume it's an upgrade
     if (![currentAppState.releaseName isEqualToString:previousAppState.releaseName]) {
         return NO;

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -16,6 +16,8 @@ SENTRY_NO_INIT
 
 - (BOOL)isBeingTraced;
 
+- (BOOL)isSimulatorBuild;
+
 - (BOOL)isApplicationInForeground;
 
 - (void)installAsyncHooks;

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
@@ -37,6 +37,8 @@ extern "C" {
  */
 SentryCrashMonitorAPI *sentrycrashcm_system_getAPI(void);
 
+bool sentrycrash_isSimulatorBuild(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -351,6 +351,12 @@ isSimulatorBuild()
 #endif
 }
 
+bool
+sentrycrash_isSimulatorBuild(void)
+{
+    return isSimulatorBuild();
+}
+
 /** The file path for the bundle’s App Store receipt.
  *
  * @return App Store receipt for iOS 7+, nil otherwise.

--- a/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
@@ -130,6 +130,19 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
         assertNoOOMSent()
     }
     
+    func testIsSimulatorBuild_NoOOM() {
+        fixture.crashWrapper.internalIsSimulatorBuild = true
+        sut.start()
+        
+        goToForeground()
+        goToBackground()
+        terminateApp()
+        
+        sut.start()
+        
+        assertNoOOMSent()
+    }
+    
     func testTerminatedNormally_NoOOM() {
         sut.start()
         goToForeground()
@@ -274,7 +287,6 @@ class SentryOutOfMemoryTrackerTests: XCTestCase {
     
     private func terminateApp() {
         TestNotificationCenter.willTerminate()
-        sut.stop()
     }
     
     private func assertOOMEventSent() {

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
@@ -17,6 +17,8 @@ SENTRY_NO_INIT
 
 @property (nonatomic, assign) BOOL internalIsBeingTraced;
 
+@property (nonatomic, assign) BOOL internalIsSimulatorBuild;
+
 @property (nonatomic, assign) BOOL internalIsApplicationInForeground;
 
 @property (nonatomic, assign) BOOL installAsyncHooksCalled;

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
@@ -10,6 +10,7 @@
     instance.internalActiveDurationSinceLastCrash = NO;
     instance.internalActiveDurationSinceLastCrash = 0;
     instance.internalIsBeingTraced = NO;
+    instance.internalIsSimulatorBuild = NO;
     instance.internalIsApplicationInForeground = YES;
     instance.installAsyncHooksCalled = NO;
     instance.closeCalled = NO;
@@ -29,6 +30,11 @@
 - (BOOL)isBeingTraced
 {
     return self.internalIsBeingTraced;
+}
+
+- (BOOL)isSimulatorBuild
+{
+    return self.internalIsSimulatorBuild;
 }
 
 - (BOOL)isApplicationInForeground


### PR DESCRIPTION
## :scroll: Description

Stop reporting OOMs for simulator builds, as the watchdog doesn't kill simulators
when they are hungry for memory.

## :bulb: Motivation and Context

Saw the isSimulatorBuild code in SentryCrashMonitor_System and thought it makes sense for OOMs.

## :green_heart: How did you test it?
Unit tests and real device.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
