### PR TITLE
ci: Don't run benchmarks on release

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - release/**
 
   pull_request:
     paths:


### PR DESCRIPTION
Running the benchmarks can take 1 or 2 hours.
This slows down releasing a lot. Disable them for
releases, as we already benchmark on master and
every night at midnight UTC.

#skip-changelog