### PR TITLE
fix: Collect samples for idle threads in iOS profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Remove Sentry keys from cached HTTP request headers (#1975)
+- Collect samples for idle threads in iOS profiler (#1978)
 
 ## 7.21.0
 

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -107,9 +107,6 @@ namespace profiling {
     {
         const auto pair = ThreadHandle::allExcludingCurrent();
         for (const auto &thread : pair.first) {
-            if (thread->isIdle()) {
-                continue;
-            }
             Backtrace bt;
             auto metadata = cache->metadataForThread(*thread);
             if (metadata.threadID == 0) {

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -114,19 +114,19 @@ namespace profiling {
             } else {
                 bt.threadMetadata = std::move(metadata);
             }
-
+            
             // This one is probably safe to call while the thread is suspended, but
             // being conservative here in case the platform time functions take any
             // locks that we're not aware of.
             bt.absoluteTimestamp = getAbsoluteTime();
-
+            
             if (thread->isIdle()) {
                 // Avoid collecting stacks for idle threads as an optimization, we
                 // instead just use an empty backtrace to represent it.
                 f(bt);
                 continue;
             }
-
+            
             // This function calls `pthread_from_mach_thread_np`, which takes a lock,
             // so we must read the value before suspending the thread to avoid risking
             // a deadlock. See the comment below.

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -114,23 +114,15 @@ namespace profiling {
             } else {
                 bt.threadMetadata = std::move(metadata);
             }
-            
-            // This one is probably safe to call while the thread is suspended, but
-            // being conservative here in case the platform time functions take any
-            // locks that we're not aware of.
-            bt.absoluteTimestamp = getAbsoluteTime();
-            
-            if (thread->isIdle()) {
-                // Avoid collecting stacks for idle threads as an optimization, we
-                // instead just use an empty backtrace to represent it.
-                f(bt);
-                continue;
-            }
-            
             // This function calls `pthread_from_mach_thread_np`, which takes a lock,
             // so we must read the value before suspending the thread to avoid risking
             // a deadlock. See the comment below.
             const auto stackBounds = thread->stackBounds();
+
+            // This one is probably safe to call while the thread is suspended, but
+            // being conservative here in case the platform time functions take any
+            // locks that we're not aware of.
+            bt.absoluteTimestamp = getAbsoluteTime();
 
             // ############################################
             // DEADLOCK WARNING: It is not safe to call any functions that acquire a

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -114,15 +114,23 @@ namespace profiling {
             } else {
                 bt.threadMetadata = std::move(metadata);
             }
-            // This function calls `pthread_from_mach_thread_np`, which takes a lock,
-            // so we must read the value before suspending the thread to avoid risking
-            // a deadlock. See the comment below.
-            const auto stackBounds = thread->stackBounds();
-
+            
             // This one is probably safe to call while the thread is suspended, but
             // being conservative here in case the platform time functions take any
             // locks that we're not aware of.
             bt.absoluteTimestamp = getAbsoluteTime();
+            
+            if (thread->isIdle()) {
+                // Avoid collecting stacks for idle threads as an optimization, we
+                // instead just use an empty backtrace to represent it.
+                f(bt);
+                continue;
+            }
+            
+            // This function calls `pthread_from_mach_thread_np`, which takes a lock,
+            // so we must read the value before suspending the thread to avoid risking
+            // a deadlock. See the comment below.
+            const auto stackBounds = thread->stackBounds();
 
             // ############################################
             // DEADLOCK WARNING: It is not safe to call any functions that acquire a

--- a/Tests/SentryTests/Profiling/SentryBacktraceTests.mm
+++ b/Tests/SentryTests/Profiling/SentryBacktraceTests.mm
@@ -109,7 +109,7 @@ indexOfSymbol(const std::uintptr_t *addresses, unsigned long depth, const char *
 }
 
 void *
-threadEntry(__unused void *ptr)
+threadEntry(void *ptr)
 {
     if (pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, nullptr) != 0) {
         return nullptr;

--- a/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
@@ -25,8 +25,18 @@ using namespace sentry::profiling;
 {
     const auto cache = std::make_shared<ThreadMetadataCache>();
     const std::uint32_t samplingRateHz = 300;
+    
+    pthread_t idleThread;
+    XCTAssertEqual(pthread_create(&idleThread, nullptr, idleThreadEntry, nullptr), 0);
+    int numIdleSamples = 0;
+    
     const auto profiler
-        = std::make_shared<SamplingProfiler>([](__unused auto backtrace) {}, samplingRateHz);
+        = std::make_shared<SamplingProfiler>([&](auto &backtrace) {
+            const auto thread = backtrace.threadMetadata.threadID;
+            if (thread == pthread_mach_thread_np(idleThread)) {
+                numIdleSamples++;
+            }
+        }, samplingRateHz);
     XCTAssertFalse(profiler->isSampling());
 
     std::uint64_t start = 0;
@@ -42,6 +52,21 @@ using namespace sentry::profiling;
     XCTAssertGreaterThan(start, static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(std::chrono::duration_cast<std::chrono::seconds>(duration).count(), 0);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
+    XCTAssertGreaterThan(numIdleSamples, 0);
+}
+
+static void *idleThreadEntry(__unused void *ptr)
+{
+    // Wait on a condition variable that will never be signaled to make the thread idle.
+    pthread_cond_t cv;
+    pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+    if (pthread_cond_init(&cv, NULL) != 0) {
+        return nullptr;
+    }
+    if (pthread_cond_wait(&cv, &mutex) != 0) {
+        return nullptr;
+    }
+    return nullptr;
 }
 
 @end

--- a/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
@@ -25,18 +25,19 @@ using namespace sentry::profiling;
 {
     const auto cache = std::make_shared<ThreadMetadataCache>();
     const std::uint32_t samplingRateHz = 300;
-    
+
     pthread_t idleThread;
     XCTAssertEqual(pthread_create(&idleThread, nullptr, idleThreadEntry, nullptr), 0);
     int numIdleSamples = 0;
-    
-    const auto profiler
-        = std::make_shared<SamplingProfiler>([&](auto &backtrace) {
+
+    const auto profiler = std::make_shared<SamplingProfiler>(
+        [&](auto &backtrace) {
             const auto thread = backtrace.threadMetadata.threadID;
             if (thread == pthread_mach_thread_np(idleThread)) {
                 numIdleSamples++;
             }
-        }, samplingRateHz);
+        },
+        samplingRateHz);
     XCTAssertFalse(profiler->isSampling());
 
     std::uint64_t start = 0;
@@ -55,7 +56,8 @@ using namespace sentry::profiling;
     XCTAssertGreaterThan(numIdleSamples, 0);
 }
 
-static void *idleThreadEntry(__unused void *ptr)
+static void *
+idleThreadEntry(__unused void *ptr)
 {
     // Wait on a condition variable that will never be signaled to make the thread idle.
     pthread_cond_t cv;


### PR DESCRIPTION
## :scroll: Description

Remove the check that skips collecting a sample for an idle thread.

## :bulb: Motivation and Context

We were seeing an issue where we found function frames in profiles that were taking way longer than they should, because of missing samples in between: 

![image](https://user-images.githubusercontent.com/353158/179316716-4e1dcae6-175c-4334-89f1-709dda126f40.png)

That's because we were intentionally skipping collecting samples when the thread was idle (which is frequently the case). Not collecting a sample when the thread is idle means that we will have irregular sample timestamps, which cause an incorrect calculation of the function durations.

## :green_heart: How did you test it?

Log sample timestamps and ensure that we're consistently able to collect timestamps every ~10ms for a profiler that is intended to sample at 100hz, even when the thread is idling.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
