### PR TITLE
chore: Bump MacOS Pod version

### DIFF
--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
                      :tag => s.version.to_s }
 
   s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.10"
+  s.osx.deployment_target = "10.15"
   s.tvos.deployment_target = "9.0"
   s.watchos.deployment_target = "2.0"
   s.module_name  = "Sentry"


### PR DESCRIPTION
The SDK minimum MacOS versions is 10.15, but cocoa pod config files says we support 10.10.
Bumping MacOS version in cocoa pods config file.

_#skip-changelog_ 