### PR TITLE
test: Increase wait timeout for ANR tests

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -7,7 +7,7 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
     private var fixture: Fixture!
     private var anrDetectedExpectation: XCTestExpectation!
     private var anrStoppedExpectation: XCTestExpectation!
-    private let waitTimeout: TimeInterval = 0.3
+    private let waitTimeout: TimeInterval = 1.0
     
     private class Fixture {
         let timeoutInterval: TimeInterval = 5


### PR DESCRIPTION
The SentryANRTrackerTests sometimes fail because the test expectation
times out. Increase the timeout from 0.3 to 1.0 seconds if the CI is
busy and the test slows down.

#skip-changelog