### PR TITLE
feat: Provide private access to SentryOptions for hybrid SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Read free_memory when the event is captured, not only at SDK startup (#1962)
+- Provide private access to SentryOptions for hybrid SDKs (#1991)
 
 ### Fixes
 

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -1,5 +1,7 @@
 #import "PrivateSentrySDKOnly.h"
+#import "SentryClient.h"
 #import "SentryDebugImageProvider.h"
+#import "SentryHub+Private.h"
 #import "SentryInstallation.h"
 #import "SentryMeta.h"
 #import "SentrySDK+Private.h"
@@ -44,6 +46,15 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 + (NSString *)installationID
 {
     return [SentryInstallation id];
+}
+
++ (SentryOptions *)options
+{
+    SentryOptions *options = [[SentrySDK currentHub] client].options;
+    if (options != nil) {
+        return options;
+    }
+    return [[SentryOptions alloc] init];
 }
 
 + (SentryOnAppStartMeasurementAvailable)onAppStartMeasurementAvailable

--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -2,7 +2,8 @@
 
 #import "SentryDefines.h"
 
-@class SentryEnvelope, SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames;
+@class SentryEnvelope, SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames,
+    SentryOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -52,6 +53,8 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 @property (class, nullable, nonatomic, readonly) SentryAppStartMeasurement *appStartMeasurement;
 
 @property (class, nonatomic, readonly, copy) NSString *installationID;
+
+@property (class, nonatomic, readonly, copy) SentryOptions *options;
 
 /**
  * If enabled, the SDK won't send the app start measurement with the first transaction. Instead, if

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryHub (Private)
 
+- (SentryClient *_Nullable)client;
+
 - (void)captureCrashEvent:(SentryEvent *)event;
 
 - (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope;

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -62,6 +62,21 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true
         XCTAssertTrue(PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode)
     }
+
+    func testOptions() {
+        let options = Options()
+        options.dsn = TestConstants.dsnAsString(username: "SentryFramesTrackingIntegrationTests")
+        let client = TestClient(options: options)
+        SentrySDK.setCurrentHub(TestHub(client: client, andScope: nil))
+
+        XCTAssertEqual(PrivateSentrySDKOnly.options, options)
+    }
+
+    func testDefaultOptions() {
+        XCTAssertNotNil(PrivateSentrySDKOnly.options)
+        XCTAssertNil(PrivateSentrySDKOnly.options.dsn)
+        XCTAssertEqual(PrivateSentrySDKOnly.options.enabled, true)
+    }
     
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     


### PR DESCRIPTION
## :scroll: Description

Hybrid SDKs can now access the options of the current client, or will get an empty SentryOptions object back if no hub/client was set. 

## :bulb: Motivation and Context

Requested by @marandaneto. Closes #1665.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps

@marandaneto and @brustolin can you please have a look?