### PR TITLE
fix: Respect existing baggage header instead of overwriting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Remove Sentry keys from cached HTTP request headers (#1975)
 - Collect samples for idle threads in iOS profiler (#1978)
+- Respect existing baggage header instead of overwriting it (#1995)
 
 ## 7.21.0
 

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
+                            <stackView opaque="NO" contentMode="scaleAspectFit" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="480-5y-FtF">
                                 <rect key="frame" x="8" y="242.5" width="398" height="465.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="VbH-LD-DBn">
@@ -193,7 +193,7 @@
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="L2a-LY-eQ7">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="L2a-LY-eQ7">
                                                 <rect key="frame" x="8" y="52.5" width="382" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
@@ -201,7 +201,7 @@
                                                     <action selector="dsnChanged:" destination="BYZ-38-t0r" eventType="editingChanged" id="PSj-ja-pxV"/>
                                                 </connections>
                                             </textField>
-                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
                                                 <rect key="frame" x="8" y="86.5" width="382" height="30"/>
                                                 <state key="normal" title="Reset DSN"/>
                                                 <connections>

--- a/Sources/Sentry/SentryBaggage.m
+++ b/Sources/Sentry/SentryBaggage.m
@@ -32,9 +32,16 @@
 
 - (NSString *)toHTTPHeader
 {
-    NSMutableDictionary *information =
-        @{ @"sentry-trace_id" : _traceId.sentryIdString, @"sentry-public_key" : _publicKey }
-            .mutableCopy;
+    return [self toHTTPHeaderWithOriginalBaggage:nil];
+}
+
+- (NSString *)toHTTPHeaderWithOriginalBaggage:(NSDictionary *_Nullable)originalBaggage
+{
+    NSMutableDictionary *information
+        = originalBaggage.mutableCopy ?: [[NSMutableDictionary alloc] init];
+
+    [information setValue:_traceId.sentryIdString forKey:@"sentry-trace_id"];
+    [information setValue:_publicKey forKey:@"sentry-public_key"];
 
     if (_releaseName != nil)
         [information setValue:_releaseName forKey:@"sentry-release"];

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -296,8 +296,13 @@ SentryNetworkTracker ()
         // because it could contain a completely unrelated trace id from a previous request.
         NSMutableDictionary *existingHeaders = headers.mutableCopy;
         [existingHeaders removeObjectForKey:SENTRY_TRACE_HEADER];
-        existingHeaders[SENTRY_BAGGAGE_HEADER] =
+
+        NSString *newBaggageHeader =
             [self removeSentryTraceIdFromBaggage:headers[SENTRY_BAGGAGE_HEADER]];
+        if (newBaggageHeader.length > 0) {
+            existingHeaders[SENTRY_BAGGAGE_HEADER] =
+                [self removeSentryTraceIdFromBaggage:headers[SENTRY_BAGGAGE_HEADER]];
+        }
         return [existingHeaders copy];
     }
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -275,7 +275,7 @@ SentryNetworkTracker ()
     return kSentrySpanStatusUndefined;
 }
 
-- (NSString *)removeSentryTraceIdFromBaggage:(NSString *)baggage
+- (NSString *)removeSentryKeysFromBaggage:(NSString *)baggage
 {
     NSMutableDictionary *original = [SentrySerialization decodeBaggage:baggage].mutableCopy;
     NSDictionary *filtered =
@@ -302,10 +302,9 @@ SentryNetworkTracker ()
         [existingHeaders removeObjectForKey:SENTRY_TRACE_HEADER];
 
         NSString *newBaggageHeader =
-            [self removeSentryTraceIdFromBaggage:headers[SENTRY_BAGGAGE_HEADER]];
+            [self removeSentryKeysFromBaggage:headers[SENTRY_BAGGAGE_HEADER]];
         if (newBaggageHeader.length > 0) {
-            existingHeaders[SENTRY_BAGGAGE_HEADER] =
-                [self removeSentryTraceIdFromBaggage:headers[SENTRY_BAGGAGE_HEADER]];
+            existingHeaders[SENTRY_BAGGAGE_HEADER] = newBaggageHeader;
         }
         return [existingHeaders copy];
     }

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -278,8 +278,12 @@ SentryNetworkTracker ()
 - (NSString *)removeSentryTraceIdFromBaggage:(NSString *)baggage
 {
     NSMutableDictionary *original = [SentrySerialization decodeBaggage:baggage].mutableCopy;
-    [original removeObjectForKey:@"sentry-trace_id"];
-    return [SentrySerialization baggageEncodedDictionary:original];
+    NSDictionary *filtered =
+        [original dictionaryWithValuesForKeys:
+                      [original.allKeys
+                          filteredArrayUsingPredicate:
+                              [NSPredicate predicateWithFormat:@"NOT SELF BEGINSWITH 'sentry-'"]]];
+    return [SentrySerialization baggageEncodedDictionary:filtered];
 }
 
 - (nullable NSDictionary *)addTraceHeader:(nullable NSDictionary *)headers

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -305,6 +305,8 @@ SentryNetworkTracker ()
             [self removeSentryKeysFromBaggage:headers[SENTRY_BAGGAGE_HEADER]];
         if (newBaggageHeader.length > 0) {
             existingHeaders[SENTRY_BAGGAGE_HEADER] = newBaggageHeader;
+        } else {
+            [existingHeaders removeObjectForKey:SENTRY_BAGGAGE_HEADER];
         }
         return [existingHeaders copy];
     }

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -277,8 +277,7 @@ SentryNetworkTracker ()
 
 - (NSString *)removeSentryTraceIdFromBaggage:(NSString *)baggage
 {
-    NSMutableDictionary *original =
-        [SentrySerialization baggageDecodedDictionary:baggage].mutableCopy;
+    NSMutableDictionary *original = [SentrySerialization decodeBaggage:baggage].mutableCopy;
     [original removeObjectForKey:@"sentry-trace_id"];
     return [SentrySerialization baggageEncodedDictionary:original];
 }
@@ -308,8 +307,8 @@ SentryNetworkTracker ()
     SentryTracer *tracer = [SentryTracer getTracer:span];
     if (tracer != nil) {
         result[SENTRY_BAGGAGE_HEADER] = [[tracer.traceContext toBaggage]
-            toHTTPHeaderWithOriginalBaggage:
-                [SentrySerialization baggageDecodedDictionary:headers[SENTRY_BAGGAGE_HEADER]]];
+            toHTTPHeaderWithOriginalBaggage:[SentrySerialization
+                                                decodeBaggage:headers[SENTRY_BAGGAGE_HEADER]]];
     }
 
     return [[NSDictionary alloc] initWithDictionary:result];

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -137,6 +137,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSDictionary<NSString *, NSString *> *)decodeBaggage:(NSString *)baggage
 {
+    if (baggage == nil || baggage.length == 0) {
+        return @{};
+    }
+
     NSMutableDictionary *decoded = [[NSMutableDictionary alloc] init];
 
     NSArray<NSString *> *properties = [baggage componentsSeparatedByString:@","];

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -135,6 +135,25 @@ NS_ASSUME_NONNULL_BEGIN
     }] componentsJoinedByString:@","];
 }
 
++ (NSDictionary<NSString *, NSString *> *)baggageDecodedDictionary:(NSString *)baggage
+{
+    NSMutableDictionary *decoded = [[NSMutableDictionary alloc] init];
+
+    NSArray<NSString *> *properties = [baggage componentsSeparatedByString:@","];
+
+    for (NSString *property in properties) {
+        NSArray<NSString *> *parts = [property componentsSeparatedByString:@"="];
+        if (parts.count != 2) {
+            continue;
+        }
+        NSString *key = parts[0];
+        NSString *value = [parts[1] stringByRemovingPercentEncoding];
+        decoded[key] = value;
+    }
+
+    return decoded.copy;
+}
+
 + (SentryEnvelope *_Nullable)envelopeWithData:(NSData *)data
 {
     SentryEnvelopeHeader *envelopeHeader = nil;

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -135,7 +135,7 @@ NS_ASSUME_NONNULL_BEGIN
     }] componentsJoinedByString:@","];
 }
 
-+ (NSDictionary<NSString *, NSString *> *)baggageDecodedDictionary:(NSString *)baggage
++ (NSDictionary<NSString *, NSString *> *)decodeBaggage:(NSString *)baggage
 {
     NSMutableDictionary *decoded = [[NSMutableDictionary alloc] init];
 

--- a/Sources/Sentry/include/SentryBaggage.h
+++ b/Sources/Sentry/include/SentryBaggage.h
@@ -57,6 +57,7 @@ static NSString *const SENTRY_BAGGAGE_HEADER = @"baggage";
                      sampleRate:(nullable NSString *)sampleRate;
 
 - (NSString *)toHTTPHeader;
+- (NSString *)toHTTPHeaderWithOriginalBaggage:(NSDictionary *_Nullable)originalBaggage;
 
 @end
 

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -16,7 +16,7 @@ static int const SENTRY_BAGGAGE_MAX_SIZE = 8192;
 + (NSData *_Nullable)dataWithSession:(SentrySession *)session
                                error:(NSError *_Nullable *_Nullable)error;
 
-+ (NSDictionary<NSString *, NSString *> *)baggageDecodedDictionary:(NSString *)baggage;
++ (NSDictionary<NSString *, NSString *> *)decodeBaggage:(NSString *)baggage;
 + (NSString *)baggageEncodedDictionary:(NSDictionary *)dictionary;
 
 + (SentrySession *_Nullable)sessionWithData:(NSData *)sessionData;

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -16,6 +16,7 @@ static int const SENTRY_BAGGAGE_MAX_SIZE = 8192;
 + (NSData *_Nullable)dataWithSession:(SentrySession *)session
                                error:(NSError *_Nullable *_Nullable)error;
 
++ (NSDictionary<NSString *, NSString *> *)baggageDecodedDictionary:(NSString *)baggage;
 + (NSString *)baggageEncodedDictionary:(NSDictionary *)dictionary;
 
 + (SentrySession *_Nullable)sessionWithData:(NSData *)sessionData;

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -254,12 +254,27 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["key": "value%"]), "key=value%25")
         XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["key": "value-_"]), "key=value-_")
         XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["key": "value\n\r"]), "key=value%0A%0D")
+        XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["key": ""]), "key=")
         
         let largeValue = String(repeating: "a", count: 8_188)
         
         XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["key": largeValue]), "key=\(largeValue)")
         XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["AKey": "something", "BKey": largeValue]), "AKey=something")
         XCTAssertEqual(SentrySerialization.baggageEncodedDictionary(["AKey": "something", "BKey": largeValue, "CKey": "Other Value"]), "AKey=something,CKey=Other%20Value")
+    }
+
+    func testBaggageStringToDictionaryDecoded() {
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value"), ["key": "value"])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key2=value2,key=value"), ["key": "value", "key2": "value2"])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%26"), ["key": "value&"])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%3D"), ["key": "value="])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%20"), ["key": "value "])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%25"), ["key": "value%"])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value-_"), ["key": "value-_"])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%0A%0D"), ["key": "value\n\r"])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary(""), [:])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key"), [:])
+        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key="), ["key": ""])
     }
     
     private func serializeEnvelope(envelope: SentryEnvelope) -> Data {

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -264,17 +264,17 @@ class SentrySerializationTests: XCTestCase {
     }
 
     func testBaggageStringToDictionaryDecoded() {
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value"), ["key": "value"])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key2=value2,key=value"), ["key": "value", "key2": "value2"])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%26"), ["key": "value&"])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%3D"), ["key": "value="])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%20"), ["key": "value "])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%25"), ["key": "value%"])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value-_"), ["key": "value-_"])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key=value%0A%0D"), ["key": "value\n\r"])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary(""), [:])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key"), [:])
-        XCTAssertEqual(SentrySerialization.baggageDecodedDictionary("key="), ["key": ""])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value"), ["key": "value"])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key2=value2,key=value"), ["key": "value", "key2": "value2"])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value%26"), ["key": "value&"])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value%3D"), ["key": "value="])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value%20"), ["key": "value "])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value%25"), ["key": "value%"])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value-_"), ["key": "value-_"])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key=value%0A%0D"), ["key": "value\n\r"])
+        XCTAssertEqual(SentrySerialization.decodeBaggage(""), [:])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key"), [:])
+        XCTAssertEqual(SentrySerialization.decodeBaggage("key="), ["key": ""])
     }
     
     private func serializeEnvelope(envelope: SentryEnvelope) -> Data {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -455,13 +455,28 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(headers?.count, 2)
         XCTAssertNotNil(headers?["baggage"])
         XCTAssertNotNil(headers?["sentry-trace"])
+
+        let decodedBaggage = SentrySerialization.baggageDecodedDictionary(headers?["baggage"] ?? "")
+        XCTAssertEqual(decodedBaggage.count, 4)
+    }
+
+    func test_AddTraceHeader_AppendOriginalBaggage() {
+        let sut = fixture.getSut()
+        SentrySDK.currentHub().scope.span = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
+        let headers = sut.addTraceHeader(["baggage": "key1=value"])
+        XCTAssertEqual(headers?.count, 2)
+        XCTAssertNotNil(headers?["baggage"])
+        XCTAssertNotNil(headers?["sentry-trace"])
+
+        let decodedBaggage = SentrySerialization.baggageDecodedDictionary(headers?["baggage"] ?? "")
+        XCTAssertEqual(decodedBaggage.count, 5)
     }
 
     func test_RemoveExistingTraceHeader_WhenNoSpan() {
         let sut = fixture.getSut()
-        let headers = sut.addTraceHeader(["a": "a", "baggage": "baggage", "sentry-trace": "sentry-trace"])
-        XCTAssertEqual(headers?.count, 1)
-        XCTAssertNil(headers?["baggage"])
+        let headers = sut.addTraceHeader(["a": "a", "baggage": "key=value,sentry-trace_id=sentry-trace_id", "sentry-trace": "sentry-trace"])
+        XCTAssertEqual(headers?.count, 2)
+        XCTAssertEqual(headers?["baggage"], "key=value")
         XCTAssertNil(headers?["sentry-trace"])
     }
     

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -479,6 +479,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(headers?["baggage"], "key=value")
         XCTAssertNil(headers?["sentry-trace"])
     }
+
+    func test_RemoveExistingTraceHeader_WhenNoSpan_NoEmptyBaggage() {
+        let sut = fixture.getSut()
+        let headers = sut.addTraceHeader(["a": "a", "baggage": "sentry-trace_id=sentry-trace_id,sentry-release=abc", "sentry-trace": "sentry-trace"])
+        XCTAssertEqual(headers?.count, 1)
+        XCTAssertNil(headers?["baggage"])
+        XCTAssertNil(headers?["sentry-trace"])
+    }
     
     func test_AddTraceHeader_NoTransaction() {
         let sut = fixture.getSut()

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -474,7 +474,7 @@ class SentryNetworkTrackerTests: XCTestCase {
 
     func test_RemoveExistingTraceHeader_WhenNoSpan() {
         let sut = fixture.getSut()
-        let headers = sut.addTraceHeader(["a": "a", "baggage": "key=value,sentry-trace_id=sentry-trace_id", "sentry-trace": "sentry-trace"])
+        let headers = sut.addTraceHeader(["a": "a", "baggage": "key=value,sentry-trace_id=sentry-trace_id,sentry-release=abc", "sentry-trace": "sentry-trace"])
         XCTAssertEqual(headers?.count, 2)
         XCTAssertEqual(headers?["baggage"], "key=value")
         XCTAssertNil(headers?["sentry-trace"])

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -456,7 +456,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNotNil(headers?["baggage"])
         XCTAssertNotNil(headers?["sentry-trace"])
 
-        let decodedBaggage = SentrySerialization.baggageDecodedDictionary(headers?["baggage"] ?? "")
+        let decodedBaggage = SentrySerialization.decodeBaggage(headers?["baggage"] ?? "")
         XCTAssertEqual(decodedBaggage.count, 4)
     }
 
@@ -468,7 +468,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNotNil(headers?["baggage"])
         XCTAssertNotNil(headers?["sentry-trace"])
 
-        let decodedBaggage = SentrySerialization.baggageDecodedDictionary(headers?["baggage"] ?? "")
+        let decodedBaggage = SentrySerialization.decodeBaggage(headers?["baggage"] ?? "")
         XCTAssertEqual(decodedBaggage.count, 5)
     }
 

--- a/Tests/SentryTests/Transaction/SentryBaggageTests.swift
+++ b/Tests/SentryTests/Transaction/SentryBaggageTests.swift
@@ -9,6 +9,12 @@ class SentryBaggageTests: XCTestCase {
         
         XCTAssertEqual(header, "sentry-environment=teste,sentry-public_key=publicKey,sentry-release=release%20name,sentry-sample_rate=0.49,sentry-trace_id=00000000000000000000000000000000,sentry-user_segment=test%20user")
     }
+
+    func test_baggageToHeader_AppendToOriginal() {
+        let header = SentryBaggage(trace: SentryId.empty, publicKey: "publicKey", releaseName: "release name", environment: "teste", userSegment: "test user", sampleRate: "0.49").toHTTPHeader(withOriginalBaggage: ["a": "a", "sentry-trace_id": "to-be-overwritten"])
+
+        XCTAssertEqual(header, "a=a,sentry-environment=teste,sentry-public_key=publicKey,sentry-release=release%20name,sentry-sample_rate=0.49,sentry-trace_id=00000000000000000000000000000000,sentry-user_segment=test%20user")
+    }
     
     func test_baggageToHeader_onlyTrace_ignoreNils() {
         let header = SentryBaggage(trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil, userSegment: nil, sampleRate: nil).toHTTPHeader()


### PR DESCRIPTION
## :scroll: Description

`SentryNetworkTracker` adds a baggage header with some sentry keys and values, but it does so by completely overwriting any possibly existing baggage header. And when we remove the baggage header when `SentrySDK.currentHub.scope.span` is `nil`, we also do that by removing the entire baggage header instead of only the `sentry-trace_id` key that we actually need to remove.

Now we respect the existing baggage header, if it's there, by modifying it.

## :bulb: Motivation and Context

Closes #1911

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
