### PR TITLE
ci: Update available GH actions Xcode link

### DIFF
--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # For available Xcode versions see:
-# - https://github.com/actions/virtual-environments/blob/6a2f3acb8890efd4b6ba9344d5f73af25e7a2bcf/images/macos/macos-10.15-Readme.md?plain=1#L254-L266
-# - https://github.com/actions/virtual-environments/blob/6a2f3acb8890efd4b6ba9344d5f73af25e7a2bcf/images/macos/macos-11-Readme.md?plain=1#L248-L253
+# - https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode
+# - https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
 
 set -euo pipefail
 
@@ -10,4 +10,3 @@ set -euo pipefail
 XCODE_VERSION="${1:-13.2.1}"
 
 sudo xcode-select -s /Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer
-


### PR DESCRIPTION
The current links point to a fixed commit. When GH adds new Xcode
versions we don't see them as the commit points to the past.
This is fixed by pointing to the latest version in the readme.

#skip-changelog