### PR TITLE
test: Make message for waitForExistence required

### DIFF
--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -22,24 +22,24 @@ class LaunchUITests: XCTestCase {
 
     func testBreadcrumbData() {
         let breadcrumbLabel = app.staticTexts["breadcrumbLabel"]
-        XCTAssertTrue(breadcrumbLabel.waitForExistence(), "Breadcrumb label not found.")
+        breadcrumbLabel.waitForExistence("Breadcrumb label not found.")
         XCTAssertEqual(breadcrumbLabel.label, "{ category: ui.lifecycle, parentViewController: UINavigationController, beingPresented: false, window_isKeyWindow: true, is_window_rootViewController: false }")
       }
 
     func testLoremIpsum() {
         app.buttons["loremIpsumButton"].tap()
-        XCTAssertTrue(app.textViews.firstMatch.waitForExistence(), "Lorem Ipsum not loaded.")
+        app.textViews.firstMatch.waitForExistence("Lorem Ipsum not loaded.")
     }
     
     func testNavigationTransaction() {
         app.buttons["testNavigationTransactionButton"].tap()
-        XCTAssertTrue(app.images.firstMatch.waitForExistence(), "Navigation transaction not loaded.")
+        app.images.firstMatch.waitForExistence("Navigation transaction not loaded.")
         assertApp()
     }
     
     func testShowNib() {
         app.buttons["showNibButton"].tap()
-        XCTAssertTrue(app.buttons["lonelyButton"].waitForExistence(), "Nib ViewController not loaded.")
+        app.buttons["lonelyButton"].waitForExistence("Nib ViewController not loaded.")
         assertApp()
     }
     
@@ -57,7 +57,7 @@ class LaunchUITests: XCTestCase {
     
     func testShowTableView() {
         app.buttons["showTableViewButton"].tap()
-        XCTAssertTrue(app.navigationBars.buttons.element(boundBy: 0).waitForExistence(), "TableView not loaded.")
+        app.navigationBars.buttons.element(boundBy: 0).waitForExistence("TableView not loaded.")
         assertApp()
     }
     
@@ -65,7 +65,7 @@ class LaunchUITests: XCTestCase {
         app.buttons["showSplitViewButton"].tap()
         
         let app = XCUIApplication()
-        XCTAssertTrue(app.navigationBars["iOS_Swift.SecondarySplitView"].buttons["Root ViewController"].waitForExistence(), "SplitView not loaded.")
+        app.navigationBars["iOS_Swift.SecondarySplitView"].buttons["Root ViewController"].waitForExistence("SplitView not loaded.")
         
         // This validation is currently not working on iOS 10.
         if #available(iOS 11.0, *) {
@@ -74,12 +74,12 @@ class LaunchUITests: XCTestCase {
     }
         
     private func waitForExistenseOfMainScreen() {
-        XCTAssertTrue(app.buttons["captureMessageButton"].waitForExistence(), "Home Screen doesn't exist.")
+        app.buttons["captureMessageButton"].waitForExistence( "Home Screen doesn't exist.")
     }
     
     private func checkSlowAndFrozenFrames() {
         let frameStatsLabel = app.staticTexts["framesStatsLabel"]
-        XCTAssertTrue(frameStatsLabel.waitForExistence(), "Frame statistics message not found.")
+        frameStatsLabel.waitForExistence("Frame statistics message not found.")
         
         let frameStatsAsStringArray = frameStatsLabel.label.components(separatedBy: CharacterSet.decimalDigits.inverted)
         let frameStats = frameStatsAsStringArray.filter { $0 != "" }.map { Int($0) }
@@ -99,7 +99,7 @@ class LaunchUITests: XCTestCase {
     private func assertApp() {
         let confirmation = app.staticTexts["ASSERT_MESSAGE"]
         let errorMessage = app.staticTexts["ASSERT_ERROR"]
-        XCTAssertTrue(confirmation.waitForExistence(), "Assertion Message Not Found")
+        confirmation.waitForExistence("Assertion Message Not Found")
         
         XCTAssertTrue(confirmation.label == "ASSERT: SUCCESS", errorMessage.label)
     }
@@ -108,8 +108,7 @@ class LaunchUITests: XCTestCase {
 
 extension XCUIElement {
 
-    @discardableResult
-    func waitForExistence() -> Bool {
-        self.waitForExistence(timeout: TimeInterval(10))
+    func waitForExistence(_ message: String) {
+        XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
     }
 }

--- a/Samples/tvOS-Swift/tvOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/tvOS-Swift/tvOS-SwiftUITests/LaunchUITests.swift
@@ -17,14 +17,13 @@ class LaunchUITests: XCTestCase {
     }
 
     func testLaunch() throws {
-        XCTAssertTrue(app.buttons["captureMessageButton"].waitForExistence(), "Home Screen doesn't exist.")
+        app.buttons["captureMessageButton"].waitForExistence("Home Screen doesn't exist.")
     }
 }
 
 extension XCUIElement {
 
-    @discardableResult
-    func waitForExistence() -> Bool {
-        self.waitForExistence(timeout: TimeInterval(10))
+    func waitForExistence(_ message: String) {
+        XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
     }
 }


### PR DESCRIPTION
Add parameter message to waitForExistence to make it required
to use an assertion message so we know what is wrong when
waitForExistence times out.

#skip-changelog