### PR TITLE
ci: fix ui thread starvation in benchmarks

### DIFF
--- a/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
+++ b/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
@@ -84,23 +84,11 @@ static BOOL checkedAssertions = NO;
         [app launch];
         [app.buttons[@"Performance scenarios"] tap];
 
-        XCUIElement *startButton = app.buttons[@"Start test"];
-        if (![startButton waitForExistenceWithTimeout:5.0]) {
-            XCTFail(@"Couldn't find benchmark retrieval button.");
-        }
-        [startButton tap];
-
-        // after hitting the start button, the test app will do CPU intensive work until hitting the
+        // after navigating to the test, the test app will do CPU intensive work until hitting the
         // stop button. wait 15 seconds so that work can be done while the profiler does its thing,
         // and the benchmarking observation in the test app will record how much CPU time is used by
         // everything
         sleep(15);
-
-        XCUIElement *stopButton = app.buttons[@"Stop test"];
-        if (![stopButton waitForExistenceWithTimeout:5.0]) {
-            XCTFail(@"Couldn't find benchmark retrieval button.");
-        }
-        [stopButton tap];
 
         XCUIElement *textField = app.textFields[@"io.sentry.benchmark.value-marshaling-text-field"];
         if (![textField waitForExistenceWithTimeout:5.0]) {

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/PerformanceViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/PerformanceViewController.swift
@@ -2,55 +2,30 @@ import Sentry
 import UIKit
 
 class PerformanceViewController: UIViewController {
-    private let startTestButton = UIButton(type: .custom)
-    private let stopTestButton = UIButton(type: .custom)
     private let valueTextField = UITextField(frame: .zero)
 
     override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
         super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
 
-        startTestButton.addTarget(self, action: #selector(startTest), for: .touchUpInside)
-        startTestButton.setTitle("Start test", for: .normal)
-
-        stopTestButton.addTarget(self, action: #selector(stopTest), for: .touchUpInside)
-        stopTestButton.setTitle("Stop test", for: .normal)
-
-        let buttons = [
-            startTestButton,
-            stopTestButton
-        ]
-        buttons.forEach {
-            $0.setTitleColor(.black, for: .normal)
-        }
         valueTextField.accessibilityLabel = "io.sentry.benchmark.value-marshaling-text-field"
-        let stack = UIStackView(arrangedSubviews: buttons + [valueTextField])
-        stack.axis = .vertical
-        stack.alignment = .center
-        stack.distribution = .fillProportionally
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(stack)
+        valueTextField.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(valueTextField)
         NSLayoutConstraint.activate([
-            stack.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            stack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            stack.bottomAnchor.constraint(lessThanOrEqualTo: view.bottomAnchor),
-            stack.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+            valueTextField.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            valueTextField.widthAnchor.constraint(equalTo: view.widthAnchor, constant: -20)
         ])
-
-        if #available(iOS 11.0, *) {
-            NSLayoutConstraint.activate([
-                stack.topAnchor.constraint(greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                stack.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor)
-            ])
-        }
+        valueTextField.isHidden = true
 
         view.backgroundColor = .white
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        startTest()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -68,8 +43,10 @@ class PerformanceViewController: UIViewController {
     private let iterations = 5_000_000
     private let range = 1..<Double.greatestFiniteMagnitude
     private var transaction: Span?
+}
 
-    private func doWork(withNumber a: Double) -> Double {
+private extension PerformanceViewController {
+    func doWork(withNumber a: Double) -> Double {
         var b: Double
         if arc4random() % 2 == 0 {
             b = fmod(a, Double.random(in: range))
@@ -89,16 +66,20 @@ class PerformanceViewController: UIViewController {
         }
     }
 
-    @objc func startTest() {
+    func startTest() {
         SentrySDK.configureScope {
             $0.setTag(value: "performance-benchmark", key: "uitest-type")
         }
         transaction = SentrySDK.startTransaction(name: "io.sentry.benchmark.transaction", operation: "crunch-numbers")
         timer = Timer.scheduledTimer(timeInterval: interval, target: self, selector: #selector(doRandomWork), userInfo: nil, repeats: true)
         SentryBenchmarking.startBenchmark()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
+            self.stopTest()
+        }
     }
 
-    @objc func stopTest() {
+    func stopTest() {
         defer {
             timer?.invalidate()
             transaction?.finish()
@@ -110,6 +91,8 @@ class PerformanceViewController: UIViewController {
             valueTextField.text = "nil"
             return
         }
+
+        valueTextField.isHidden = false
         valueTextField.text = "\(value)"
 
         SentrySDK.configureScope {


### PR DESCRIPTION
Maxing out CPU with a hot while loop also prevented the test runner app from
being able to query the accessibility system to hit the stop button. This causes
lots of retries and eventual failures or timeouts in other areas, and the tests
to run a long time in general.

Instead of having a button press stop the benchmark and contending for time on
the main run loop, just remove the start/stop buttons and start when the view
controller appears, and set a 15 second delay to stop the benchmarks. Then the
test runner queries the text field for results as usual. Removing the steps needed 
to press the start and stop buttons also saves time.

#skip-changelog