### PR TITLE
fix: Add more descriptive deprecation message for enableProfiling

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -346,7 +346,7 @@ NS_SWIFT_NAME(Options)
  * feature is not supported on watchOS or tvOS.
  */
 @property (nonatomic, assign) BOOL enableProfiling DEPRECATED_MSG_ATTRIBUTE(
-    "This property will be removed in a future version of the SDK");
+    "Use profilesSampleRate or profilesSampler instead. This property will be removed in a future version of the SDK");
 #endif
 
 /**

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -346,7 +346,8 @@ NS_SWIFT_NAME(Options)
  * feature is not supported on watchOS or tvOS.
  */
 @property (nonatomic, assign) BOOL enableProfiling DEPRECATED_MSG_ATTRIBUTE(
-    "Use profilesSampleRate or profilesSampler instead. This property will be removed in a future version of the SDK");
+    "Use profilesSampleRate or profilesSampler instead. This property will be removed in a future "
+    "version of the SDK");
 #endif
 
 /**


### PR DESCRIPTION
## :scroll: Description

Update the message to tell users what the new API is.

_#skip-changelog_

## :bulb: Motivation and Context

The old API was marked as deprecated but without information on what the replacement was.

## :green_heart: How did you test it?

Build

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [X] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
