### PR TITLE
fix: Use constant for max thread name size instead of magic number

### DIFF
--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -117,7 +117,7 @@ namespace profiling {
         if (handle == nullptr) {
             return {};
         }
-        char name[128];
+        char name[MAXTHREADNAMESIZE];
         if (SENTRY_PROF_LOG_ERROR_RETURN(pthread_getname_np(handle, name, sizeof(name))) == 0) {
             return std::string(name);
         }


### PR DESCRIPTION
## :scroll: Description

Use a constant for max thread name length instead of a hardcoded `128`

_#skip-changelog_

## :bulb: Motivation and Context

The system already defines a constant for the max allowable length of a thread name, we don't have to pick a number for it.

## :green_heart: How did you test it?

Build

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
