### PR TITLE
fix: Log empty samples instead of collecting stacks for idle threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add sampling configuration for profiling (#2004)
 
+### Fixes
+
+- Log empty samples instead of collecting stacks for idle threads (#2013)
+
 ## 7.22.0
 
 ### Features

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -1,114 +1,114 @@
-//import XCTest
-//
-//class LaunchUITests: XCTestCase {
-//
-//    private let app: XCUIApplication = XCUIApplication()
-//
-//    override func setUp() {
-//        super.setUp()
-//        
-//        continueAfterFailure = false
-//        XCUIDevice.shared.orientation = .portrait
-//        app.launch()
-//        
-//        waitForExistenseOfMainScreen()
-//        checkSlowAndFrozenFrames()
-//    }
-//    
-//    override func tearDown() {
-//        app.terminate()
-//        super.tearDown()
-//    }
-//
-//    func testBreadcrumbData() {
-//        let breadcrumbLabel = app.staticTexts["breadcrumbLabel"]
-//        breadcrumbLabel.waitForExistence("Breadcrumb label not found.")
-//        XCTAssertEqual(breadcrumbLabel.label, "{ category: ui.lifecycle, parentViewController: UINavigationController, beingPresented: false, window_isKeyWindow: true, is_window_rootViewController: false }")
-//      }
-//
-//    func testLoremIpsum() {
-//        app.buttons["loremIpsumButton"].tap()
-//        app.textViews.firstMatch.waitForExistence("Lorem Ipsum not loaded.")
-//    }
-//    
-//    func testNavigationTransaction() {
-//        app.buttons["testNavigationTransactionButton"].tap()
-//        app.images.firstMatch.waitForExistence("Navigation transaction not loaded.")
-//        assertApp()
-//    }
-//    
-//    func testShowNib() {
-//        app.buttons["showNibButton"].tap()
-//        app.buttons["lonelyButton"].waitForExistence("Nib ViewController not loaded.")
-//        assertApp()
-//    }
-//    
-//    func testUiClickTransaction() {
-//        app.buttons["uiClickTransactionButton"].tap()
-//    }
-//    
-//    func testCaptureError() {
-//        app.buttons["Error"].tap()
-//    }
-//    
-//    func testCaptureException() {
-//        app.buttons["NSException"].tap()
-//    }
-//    
-//    func testShowTableView() {
-//        app.buttons["showTableViewButton"].tap()
-//        app.navigationBars.buttons.element(boundBy: 0).waitForExistence("TableView not loaded.")
-//        assertApp()
-//    }
-//    
-//    func testSplitView() {
-//        app.buttons["showSplitViewButton"].tap()
-//        
-//        let app = XCUIApplication()
-//        app.navigationBars["iOS_Swift.SecondarySplitView"].buttons["Root ViewController"].waitForExistence("SplitView not loaded.")
-//        
-//        // This validation is currently not working on iOS 10.
-//        if #available(iOS 11.0, *) {
-//            assertApp()
-//        }
-//    }
-//        
-//    private func waitForExistenseOfMainScreen() {
-//        app.buttons["captureMessageButton"].waitForExistence( "Home Screen doesn't exist.")
-//    }
-//    
-//    private func checkSlowAndFrozenFrames() {
-//        let frameStatsLabel = app.staticTexts["framesStatsLabel"]
-//        frameStatsLabel.waitForExistence("Frame statistics message not found.")
-//        
-//        let frameStatsAsStringArray = frameStatsLabel.label.components(separatedBy: CharacterSet.decimalDigits.inverted)
-//        let frameStats = frameStatsAsStringArray.filter { $0 != "" }.map { Int($0) }
-//        
-//        XCTAssertEqual(3, frameStats.count)
-//        guard let totalFrames = frameStats[0] else { XCTFail("No total frames found."); return }
-//        guard let slowFrames = frameStats[1] else { XCTFail("No slow frames found."); return }
-//        guard let frozenFrames = frameStats[1] else { XCTFail("No frozen frames found."); return }
-//
-//        let slowFramesPercentage = Double(slowFrames) / Double(totalFrames)
-//        XCTAssertTrue(0.5 > slowFramesPercentage, "Too many slow frames.")
-//        
-//        let frozenFramesPercentage = Double(frozenFrames) / Double(totalFrames)
-//        XCTAssertTrue(0.5 > frozenFramesPercentage, "Too many frozen frames.")
-//    }
-//    
-//    private func assertApp() {
-//        let confirmation = app.staticTexts["ASSERT_MESSAGE"]
-//        let errorMessage = app.staticTexts["ASSERT_ERROR"]
-//        confirmation.waitForExistence("Assertion Message Not Found")
-//        
-//        XCTAssertTrue(confirmation.label == "ASSERT: SUCCESS", errorMessage.label)
-//    }
-//    
-//}
-//
-//extension XCUIElement {
-//
-//    func waitForExistence(_ message: String) {
-//        XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
-//    }
-//}
+import XCTest
+
+class LaunchUITests: XCTestCase {
+
+    private let app: XCUIApplication = XCUIApplication()
+
+    override func setUp() {
+        super.setUp()
+        
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        app.launch()
+        
+        waitForExistenseOfMainScreen()
+        checkSlowAndFrozenFrames()
+    }
+    
+    override func tearDown() {
+        app.terminate()
+        super.tearDown()
+    }
+
+    func testBreadcrumbData() {
+        let breadcrumbLabel = app.staticTexts["breadcrumbLabel"]
+        breadcrumbLabel.waitForExistence("Breadcrumb label not found.")
+        XCTAssertEqual(breadcrumbLabel.label, "{ category: ui.lifecycle, parentViewController: UINavigationController, beingPresented: false, window_isKeyWindow: true, is_window_rootViewController: false }")
+      }
+
+    func testLoremIpsum() {
+        app.buttons["loremIpsumButton"].tap()
+        app.textViews.firstMatch.waitForExistence("Lorem Ipsum not loaded.")
+    }
+    
+    func testNavigationTransaction() {
+        app.buttons["testNavigationTransactionButton"].tap()
+        app.images.firstMatch.waitForExistence("Navigation transaction not loaded.")
+        assertApp()
+    }
+    
+    func testShowNib() {
+        app.buttons["showNibButton"].tap()
+        app.buttons["lonelyButton"].waitForExistence("Nib ViewController not loaded.")
+        assertApp()
+    }
+    
+    func testUiClickTransaction() {
+        app.buttons["uiClickTransactionButton"].tap()
+    }
+    
+    func testCaptureError() {
+        app.buttons["Error"].tap()
+    }
+    
+    func testCaptureException() {
+        app.buttons["NSException"].tap()
+    }
+    
+    func testShowTableView() {
+        app.buttons["showTableViewButton"].tap()
+        app.navigationBars.buttons.element(boundBy: 0).waitForExistence("TableView not loaded.")
+        assertApp()
+    }
+    
+    func testSplitView() {
+        app.buttons["showSplitViewButton"].tap()
+        
+        let app = XCUIApplication()
+        app.navigationBars["iOS_Swift.SecondarySplitView"].buttons["Root ViewController"].waitForExistence("SplitView not loaded.")
+        
+        // This validation is currently not working on iOS 10.
+        if #available(iOS 11.0, *) {
+            assertApp()
+        }
+    }
+        
+    private func waitForExistenseOfMainScreen() {
+        app.buttons["captureMessageButton"].waitForExistence( "Home Screen doesn't exist.")
+    }
+    
+    private func checkSlowAndFrozenFrames() {
+        let frameStatsLabel = app.staticTexts["framesStatsLabel"]
+        frameStatsLabel.waitForExistence("Frame statistics message not found.")
+        
+        let frameStatsAsStringArray = frameStatsLabel.label.components(separatedBy: CharacterSet.decimalDigits.inverted)
+        let frameStats = frameStatsAsStringArray.filter { $0 != "" }.map { Int($0) }
+        
+        XCTAssertEqual(3, frameStats.count)
+        guard let totalFrames = frameStats[0] else { XCTFail("No total frames found."); return }
+        guard let slowFrames = frameStats[1] else { XCTFail("No slow frames found."); return }
+        guard let frozenFrames = frameStats[1] else { XCTFail("No frozen frames found."); return }
+
+        let slowFramesPercentage = Double(slowFrames) / Double(totalFrames)
+        XCTAssertTrue(0.5 > slowFramesPercentage, "Too many slow frames.")
+        
+        let frozenFramesPercentage = Double(frozenFrames) / Double(totalFrames)
+        XCTAssertTrue(0.5 > frozenFramesPercentage, "Too many frozen frames.")
+    }
+    
+    private func assertApp() {
+        let confirmation = app.staticTexts["ASSERT_MESSAGE"]
+        let errorMessage = app.staticTexts["ASSERT_ERROR"]
+        confirmation.waitForExistence("Assertion Message Not Found")
+        
+        XCTAssertTrue(confirmation.label == "ASSERT: SUCCESS", errorMessage.label)
+    }
+    
+}
+
+extension XCUIElement {
+
+    func waitForExistence(_ message: String) {
+        XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
+    }
+}

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -116,6 +116,7 @@ namespace profiling {
             // Log an empty stack for an idle thread, we don't need to walk the stack.
             if (thread->isIdle()) {
                 bt.threadMetadata.threadID = thread->tid();
+                bt.threadMetadata.priority = -1;
                 f(bt);
                 continue;
             }

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -108,23 +108,25 @@ namespace profiling {
         const auto pair = ThreadHandle::allExcludingCurrent();
         for (const auto &thread : pair.first) {
             Backtrace bt;
+            // This one is probably safe to call while the thread is suspended, but
+            // being conservative here in case the platform time functions take any
+            // locks that we're not aware of.
+            bt.absoluteTimestamp = getAbsoluteTime();
+            
+            // Log an empty stack for an idle thread, we don't need to walk the stack.
+            if (thread->isIdle()) {
+                bt.threadMetadata.threadID = thread->tid();
+                f(bt);
+                continue;
+            }
+            
             auto metadata = cache->metadataForThread(*thread);
             if (metadata.threadID == 0) {
                 continue;
             } else {
                 bt.threadMetadata = std::move(metadata);
             }
-            // This one is probably safe to call while the thread is suspended, but
-            // being conservative here in case the platform time functions take any
-            // locks that we're not aware of.
-            bt.absoluteTimestamp = getAbsoluteTime();
-
-            // Log an empty stack for an idle thread, we don't need to walk the stack.
-            if (thread->isIdle()) {
-                f(bt);
-                continue;
-            }
-
+            
             // This function calls `pthread_from_mach_thread_np`, which takes a lock,
             // so we must read the value before suspending the thread to avoid risking
             // a deadlock. See the comment below.

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -112,21 +112,21 @@ namespace profiling {
             // being conservative here in case the platform time functions take any
             // locks that we're not aware of.
             bt.absoluteTimestamp = getAbsoluteTime();
-            
+
             // Log an empty stack for an idle thread, we don't need to walk the stack.
             if (thread->isIdle()) {
                 bt.threadMetadata.threadID = thread->tid();
                 f(bt);
                 continue;
             }
-            
+
             auto metadata = cache->metadataForThread(*thread);
             if (metadata.threadID == 0) {
                 continue;
             } else {
                 bt.threadMetadata = std::move(metadata);
             }
-            
+
             // This function calls `pthread_from_mach_thread_np`, which takes a lock,
             // so we must read the value before suspending the thread to avoid risking
             // a deadlock. See the comment below.

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -118,19 +118,17 @@ namespace profiling {
             // being conservative here in case the platform time functions take any
             // locks that we're not aware of.
             bt.absoluteTimestamp = getAbsoluteTime();
-            
+
             // Log an empty stack for an idle thread, we don't need to walk the stack.
             if (thread->isIdle()) {
                 f(bt);
                 continue;
             }
-            
+
             // This function calls `pthread_from_mach_thread_np`, which takes a lock,
             // so we must read the value before suspending the thread to avoid risking
             // a deadlock. See the comment below.
             const auto stackBounds = thread->stackBounds();
-
-            
 
             // ############################################
             // DEADLOCK WARNING: It is not safe to call any functions that acquire a

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -870,7 +870,7 @@ class SentryHubTests: XCTestCase {
         let queueMetadata = sampledProfile["queue_metadata"] as! [String: Any]
         
         XCTAssertFalse(threadMetadata.isEmpty)
-        XCTAssertGreaterThan(threadMetadata.first?.value["priority"] as! Int, 0)
+        XCTAssertFalse(threadMetadata.values.compactMap { $0["priority"] }.filter { ($0 as! Int) > 0 }.isEmpty)
         XCTAssertFalse(threadMetadata.values.filter { $0["is_main_thread"] as? Bool == true }.isEmpty)
         XCTAssertFalse(queueMetadata.isEmpty)
         XCTAssertFalse(((queueMetadata.first?.value as! [String: Any])["label"] as! String).isEmpty)


### PR DESCRIPTION
## :scroll: Description

* Fix test breakage in https://github.com/getsentry/sentry-cocoa/issues/2000
* Revert https://github.com/getsentry/sentry-cocoa/pull/2003
* Replace stacks for idle threads with an empty sample so that it doesn't render in the profile

## :bulb: Motivation and Context

Collecting stacks for idle threads produces this kind of data, where we have a stack that just shows the thread waiting on a function like `mach_msg_trap`. Instead of collecting these stacks, we can just log an empty sample, which will prevent it from rendering in the flamegraph.

<img width="1295" alt="CleanShot 2022-07-27 at 16 57 00@2x" src="https://user-images.githubusercontent.com/353158/181392120-0041e46b-a905-4f58-8661-c8b9253405ac.png">

This also fixes a bug in iOS 12 where we would repeatedly fail to suspend an idle thread, which broke some tests (https://github.com/getsentry/sentry-cocoa/issues/2000). With this new implementation we won't attempt to suspend an idle thread.

## :green_heart: How did you test it?

* Run existing tests for `SentrySamplingProfiler`
* Re-enable `LaunchUITests` and verify that they pass

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
