### PR TITLE
fix: Remove logging that could occur while a thread is suspended

### DIFF
--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -240,7 +240,7 @@ namespace profiling {
         if (handle_ == THREAD_NULL) {
             return false;
         }
-        return SENTRY_PROF_LOG_KERN_RETURN(thread_suspend(handle_)) == KERN_SUCCESS;
+        return thread_suspend(handle_) == KERN_SUCCESS;
     }
 
     bool
@@ -249,7 +249,7 @@ namespace profiling {
         if (handle_ == THREAD_NULL) {
             return false;
         }
-        return SENTRY_PROF_LOG_KERN_RETURN(thread_resume(handle_)) == KERN_SUCCESS;
+        return thread_resume(handle_) == KERN_SUCCESS;
     }
 
     bool


### PR DESCRIPTION
## :scroll: Description

Remove some logging that could happen when threads fail to be suspended or resumed.

## :bulb: Motivation and Context

`SENTRY_PROF_LOG_KERN_RETURN` will result in a call to a logger that may perform a heap allocation, which is dangerous for the reasons documented here: https://github.com/getsentry/sentry-cocoa/blob/91cf82a906ef359eb1f2ecafa8599104bb357eca/Sources/Sentry/SentryBacktrace.cpp#L127

This is an unlikely scenario - if the `thread_suspend` call fails and we log an error, the thread is likely not suspended - but the logs are low value enough that it's better not to take the risk.

## :green_heart: How did you test it?

This is preventing a hard-to-reproduce scenario so there's no way to easily unit test it, but we check that all existing tests pass.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
