### PR TITLE
fix: Handle failure to read thread priority gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,10 @@
 
 - Add sampling configuration for profiling (#2004)
 
-### Fixed
-
-- Handle failure to read thread priority gracefully (#2015)
 ### Fixes
 
 - Remove logging that could occur while a thread is suspended (#2014)
+- Handle failure to read thread priority gracefully (#2015)
 
 ## 7.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add sampling configuration for profiling (#2004)
 
+### Fixed
+
+- Handle failure to read thread priority gracefully (#2015)
+
 ## 7.22.0
 
 ### Features

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -156,19 +156,16 @@ isSimulatorBuild()
                 NSMutableDictionary<NSString *, id> *metadata = threadMetadata[threadID];
                 if (metadata == nil) {
                     metadata = [NSMutableDictionary<NSString *, id> dictionary];
-                    if (!backtrace.threadMetadata.name.empty()) {
-                        metadata[@"name"] =
-                            [NSString stringWithUTF8String:backtrace.threadMetadata.name.c_str()];
-                    }
-                    if (backtrace.threadMetadata.priority != -1) {
-                        metadata[@"priority"] = @(backtrace.threadMetadata.priority);
-                    }
                     if (backtrace.threadMetadata.threadID == mainThreadID) {
                         metadata[@"is_main_thread"] = @YES;
                     }
                     threadMetadata[threadID] = metadata;
-                } else if (backtrace.threadMetadata.priority != -1
-                    && metadata[@"priority"] == nil) {
+                }
+                if (!backtrace.threadMetadata.name.empty() && metadata[@"name"] == nil) {
+                    metadata[@"name"] =
+                        [NSString stringWithUTF8String:backtrace.threadMetadata.name.c_str()];
+                }
+                if (backtrace.threadMetadata.priority != -1 && metadata[@"priority"] == nil) {
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                 }
                 if (queueAddress != nil && queueMetadata[queueAddress] == nil

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -131,7 +131,8 @@ isSimulatorBuild()
         _profile = [NSMutableDictionary<NSString *, id> dictionary];
         const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
         const auto samples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-        const auto threadMetadata = [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
+        const auto threadMetadata =
+            [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
         const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
         sampledProfile[@"samples"] = samples;
         sampledProfile[@"thread_metadata"] = threadMetadata;
@@ -166,7 +167,8 @@ isSimulatorBuild()
                         metadata[@"is_main_thread"] = @YES;
                     }
                     threadMetadata[threadID] = metadata;
-                } else if (backtrace.threadMetadata.priority != -1 && metadata[@"priority"] == nil) {
+                } else if (backtrace.threadMetadata.priority != -1
+                    && metadata[@"priority"] == nil) {
                     metadata[@"priority"] = @(backtrace.threadMetadata.priority);
                 }
                 if (queueAddress != nil && queueMetadata[queueAddress] == nil

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -36,23 +36,25 @@ namespace profiling {
             metadata.priority = thread.priority();
 
             // If getting the priority fails (via pthread_getschedparam()), that
-            // means the rest of this is probably going to fail too.
-            if (metadata.priority != -1) {
-                auto threadName = thread.name();
-                if (isSentryOwnedThreadName(threadName)) {
-                    // Don't collect backtraces for Sentry-owned threads.
-                    metadata.priority = 0;
-                    metadata.threadID = 0;
-                    threadMetadataCache_.push_back({ handle, metadata });
-                    return metadata;
-                }
-                if (threadName.size() > kMaxThreadNameLength) {
-                    threadName.resize(kMaxThreadNameLength);
-                }
-
-                metadata.name = threadName;
+            // means the rest of this is probably going to fail too. We also don't
+            // want to cache this result.
+            if (metadata.priority == -1) {
+                return metadata;
+            }
+            
+            auto threadName = thread.name();
+            if (isSentryOwnedThreadName(threadName)) {
+                // Don't collect backtraces for Sentry-owned threads.
+                metadata.priority = 0;
+                metadata.threadID = 0;
+                threadMetadataCache_.push_back({ handle, metadata });
+                return metadata;
+            }
+            if (threadName.size() > kMaxThreadNameLength) {
+                threadName.resize(kMaxThreadNameLength);
             }
 
+            metadata.name = threadName;
             threadMetadataCache_.push_back({ handle, metadata });
             return metadata;
         } else {

--- a/Sources/Sentry/SentryThreadMetadataCache.cpp
+++ b/Sources/Sentry/SentryThreadMetadataCache.cpp
@@ -41,7 +41,7 @@ namespace profiling {
             if (metadata.priority == -1) {
                 return metadata;
             }
-            
+
             auto threadName = thread.name();
             if (isSentryOwnedThreadName(threadName)) {
                 // Don't collect backtraces for Sentry-owned threads.


### PR DESCRIPTION
## :scroll: Description

Handle this failure gracefully and only log a thread priority if reading it was successful.

## :bulb: Motivation and Context

Reading the thread priority can return `-1` in failure cases and we don't want to store this in the profile payload if we're not able to read a legitimate value. This also fixes a flake with the `testStartTransaction_ProfilingDataIsValid` test which checked for a valid priority and failed about 20% of the time on macOS.

## :green_heart: How did you test it?

Verify that `testStartTransaction_ProfilingDataIsValid` no longer flakes on macOS.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [X] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [X] No breaking changes

## :crystal_ball: Next steps
