### PR TITLE
fix: Sauce labs iPhone 13 pro iOS version

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -21,7 +21,7 @@ suites:
   - name: "iPhone-Pro"
     devices:
       - name: "iPhone 13 Pro.*"
-        platformVersion: "15.5"
+        platformVersion: "15.6"
         
   - name: "iOS-14"
     devices:


### PR DESCRIPTION
iPhone 13 pro iOS version 15.5 is no longer available in Saucelabs.


_#skip-changelog_ 