### PR TITLE
ref: remove integrations shouldBeDisabled duplication

### DIFF
--- a/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
+++ b/Samples/watchOS-Swift/watchOS-Swift.xcodeproj/xcshareddata/xcschemes/watchOS-Swift WatchKit App.xcscheme
@@ -54,8 +54,10 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/watchOS-Swift WatchKit App">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -63,7 +65,7 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -71,8 +73,10 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable
-         runnableDebuggingMode = "0">
+      <RemoteRunnable
+         runnableDebuggingMode = "2"
+         BundleIdentifier = "com.apple.Carousel"
+         RemotePath = "/watchOS-Swift WatchKit App">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
@@ -80,7 +84,16 @@
             BlueprintName = "watchOS-Swift WatchKit App"
             ReferencedContainer = "container:watchOS-Swift.xcodeproj">
          </BuildableReference>
-      </BuildableProductRunnable>
+      </RemoteRunnable>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7B82C48224C98A93002CA6D1"
+            BuildableName = "watchOS-Swift WatchKit App.app"
+            BlueprintName = "watchOS-Swift WatchKit App"
+            ReferencedContainer = "container:watchOS-Swift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		0A1C3592287D7107007D01E3 /* SentryMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C3591287D7107007D01E3 /* SentryMetaTests.swift */; };
 		0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */; };
 		0A2D8D5D289815EB008720F6 /* SentryBaseIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */; };
+		0A2D8D8728992260008720F6 /* SentryBaseIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D8628992260008720F6 /* SentryBaseIntegrationTests.swift */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
 		15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15360CD12432779F00112302 /* SentrySessionTracker.h */; };
 		15360CD62432832400112302 /* SentryAutoSessionTrackingIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CD52432832400112302 /* SentryAutoSessionTrackingIntegration.m */; };
@@ -717,6 +718,7 @@
 		0A1C3591287D7107007D01E3 /* SentryMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetaTests.swift; sourceTree = "<group>"; };
 		0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBaseIntegration.m; sourceTree = "<group>"; };
 		0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBaseIntegration.h; path = include/SentryBaseIntegration.h; sourceTree = "<group>"; };
+		0A2D8D8628992260008720F6 /* SentryBaseIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBaseIntegrationTests.swift; sourceTree = "<group>"; };
 		15360CCE2432777400112302 /* SentrySessionTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySessionTracker.m; sourceTree = "<group>"; };
 		15360CD12432779F00112302 /* SentrySessionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentrySessionTracker.h; path = include/SentrySessionTracker.h; sourceTree = "<group>"; };
 		15360CD52432832400112302 /* SentryAutoSessionTrackingIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAutoSessionTrackingIntegration.m; sourceTree = "<group>"; };
@@ -2207,6 +2209,7 @@
 				7BE0DC3F272AE9F0004FA8B7 /* Session */,
 				7BE0DC3E272AE9DC004FA8B7 /* SentryCrash */,
 				7B59398324AB481B0003AAD2 /* TestNotificationCenter.swift */,
+				0A2D8D8628992260008720F6 /* SentryBaseIntegrationTests.swift */,
 			);
 			path = Integrations;
 			sourceTree = "<group>";
@@ -3482,6 +3485,7 @@
 				7BDB03BF25136A7D00BAE198 /* TestSentryDispatchQueueWrapper.swift in Sources */,
 				7B6438A726A70DDB000D0F65 /* UIViewControllerSentryTests.swift in Sources */,
 				15E0A8F0240F638200F044E3 /* SentrySerializationNilTests.m in Sources */,
+				0A2D8D8728992260008720F6 /* SentryBaseIntegrationTests.swift in Sources */,
 				7B6D135C27F4605D00331ED2 /* TestEnvelopeRateLimitDelegate.swift in Sources */,
 				7B2A70D827D5F080008B0D15 /* SentryANRTrackerTests.swift in Sources */,
 				63FE722120DA66EC00CDBAE8 /* SentryCrashDynamicLinker_Tests.m in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		03F84D3827DD4191008FE43F /* SentryBacktrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03F84D3127DD4191008FE43F /* SentryBacktrace.cpp */; };
 		03F9D37C2819A65C00602916 /* SentryProfilerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03F9D37B2819A65C00602916 /* SentryProfilerTests.mm */; };
 		0A1C3592287D7107007D01E3 /* SentryMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C3591287D7107007D01E3 /* SentryMetaTests.swift */; };
+		0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */; };
+		0A2D8D5D289815EB008720F6 /* SentryBaseIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
 		15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15360CD12432779F00112302 /* SentrySessionTracker.h */; };
 		15360CD62432832400112302 /* SentryAutoSessionTrackingIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CD52432832400112302 /* SentryAutoSessionTrackingIntegration.m */; };
@@ -713,6 +715,8 @@
 		03F84D3127DD4191008FE43F /* SentryBacktrace.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SentryBacktrace.cpp; path = Sources/Sentry/SentryBacktrace.cpp; sourceTree = SOURCE_ROOT; };
 		03F9D37B2819A65C00602916 /* SentryProfilerTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfilerTests.mm; sourceTree = "<group>"; };
 		0A1C3591287D7107007D01E3 /* SentryMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetaTests.swift; sourceTree = "<group>"; };
+		0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBaseIntegration.m; sourceTree = "<group>"; };
+		0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBaseIntegration.h; path = include/SentryBaseIntegration.h; sourceTree = "<group>"; };
 		15360CCE2432777400112302 /* SentrySessionTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySessionTracker.m; sourceTree = "<group>"; };
 		15360CD12432779F00112302 /* SentrySessionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentrySessionTracker.h; path = include/SentrySessionTracker.h; sourceTree = "<group>"; };
 		15360CD52432832400112302 /* SentryAutoSessionTrackingIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAutoSessionTrackingIntegration.m; sourceTree = "<group>"; };
@@ -1669,6 +1673,8 @@
 				7D7F0A5E23DF3D2C00A4629C /* SentryGlobalEventProcessor.h */,
 				7DAC588E23D8B2E0001CF26B /* SentryGlobalEventProcessor.m */,
 				7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */,
+				0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */,
+				0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */,
 			);
 			name = Integrations;
 			sourceTree = "<group>";
@@ -2790,6 +2796,7 @@
 				7D7F0A5F23DF3D2C00A4629C /* SentryGlobalEventProcessor.h in Headers */,
 				7B82D54524E2A05500EE670F /* SentryId.h in Headers */,
 				D867063D27C3BC2400048851 /* SentryCoreDataTrackingIntegration.h in Headers */,
+				0A2D8D5D289815EB008720F6 /* SentryBaseIntegration.h in Headers */,
 				63FE716520DA4C1100CDBAE8 /* SentryCrashMemory.h in Headers */,
 				7B6D125F265F778500C9BE4B /* PrivateSentrySDKOnly.h in Headers */,
 				63FE713F20DA4C1100CDBAE8 /* SentryCrashStackCursor_SelfThread.h in Headers */,
@@ -3304,6 +3311,7 @@
 				63FE713520DA4C1100CDBAE8 /* SentryCrashMemory.c in Sources */,
 				63FE714520DA4C1100CDBAE8 /* SentryCrashObjC.c in Sources */,
 				63FE710520DA4C1000CDBAE8 /* SentryCrashLogger.c in Sources */,
+				0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */,
 				63FE70E920DA4C1000CDBAE8 /* SentryCrashMonitor_User.c in Sources */,
 				639FCF991EBC7B9700778193 /* SentryEvent.m in Sources */,
 				632F43521F581D5400A18A36 /* SentryCrashExceptionApplication.m in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -38,10 +38,10 @@
 		03F84D3827DD4191008FE43F /* SentryBacktrace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 03F84D3127DD4191008FE43F /* SentryBacktrace.cpp */; };
 		03F9D37C2819A65C00602916 /* SentryProfilerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 03F9D37B2819A65C00602916 /* SentryProfilerTests.mm */; };
 		0A1C3592287D7107007D01E3 /* SentryMetaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1C3591287D7107007D01E3 /* SentryMetaTests.swift */; };
+		0A2690B72885C2E000E4432D /* TestSentryPermissionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */; };
 		0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */; };
 		0A2D8D5D289815EB008720F6 /* SentryBaseIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */; };
 		0A2D8D8728992260008720F6 /* SentryBaseIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D8628992260008720F6 /* SentryBaseIntegrationTests.swift */; };
-		0A2690B72885C2E000E4432D /* TestSentryPermissionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */; };
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
@@ -1683,8 +1683,8 @@
 				7D7F0A5E23DF3D2C00A4629C /* SentryGlobalEventProcessor.h */,
 				7DAC588E23D8B2E0001CF26B /* SentryGlobalEventProcessor.m */,
 				7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */,
-				0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */,
 				0A2D8D5C289815EB008720F6 /* SentryBaseIntegration.h */,
+				0A2D8D5A289815C0008720F6 /* SentryBaseIntegration.m */,
 			);
 			name = Integrations;
 			sourceTree = "<group>";

--- a/Sources/Sentry/Public/SentryIntegrationProtocol.h
+++ b/Sources/Sentry/Public/SentryIntegrationProtocol.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Installs the integration and returns YES if successful.
  */
-- (void)installWithOptions:(SentryOptions *)options;
+- (BOOL)installWithOptions:(SentryOptions *)options;
 
 /**
  * Uninstalls the integration.

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -32,23 +32,10 @@ SentryANRTrackingIntegration ()
 
 @implementation SentryANRTrackingIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
-    if (![self shouldBeEnabled:@[
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableAppHangTracking
-                                                     optionName:@"enableAppHangTracking"],
-            [[SentryOptionWithDescription alloc]
-                initWithOption:(options.appHangTimeoutInterval > 0)
-                           log:@"Not going to enable App Hanging integration because "
-                               @"appHangTimeoutInterval is 0."],
-            [[SentryOptionWithDescription alloc]
-                initWithOption:(![SentryDependencyContainer.sharedInstance
-                                       .crashWrapper isBeingTraced])
-                           log:@"Not going to enable App Hanging integration because the debugger "
-                               @"is attached."],
-        ]]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     self.tracker =
@@ -56,6 +43,13 @@ SentryANRTrackingIntegration ()
 
     [self.tracker addListener:self];
     self.options = options;
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableAppHangTracking;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -49,7 +49,7 @@ SentryANRTrackingIntegration ()
 
 - (SentryIntegrationOption)integrationOptions
 {
-    return kIntegrationOptionEnableAppHangTracking;
+    return kIntegrationOptionEnableAppHangTracking | kIntegrationOptionDebuggerNotAttached;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -25,7 +25,13 @@ SentryAppStartTrackingIntegration ()
 - (void)installWithOptions:(SentryOptions *)options
 {
 #if SENTRY_HAS_UIKIT
-    if (![self shouldBeEnabled:options]) {
+    if (![self shouldBeEnabled:@[
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableAutoPerformanceTracking
+                    optionName:@"enableAutoPerformanceTracking"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
+                                                     optionName:@"isTracingEnabled"],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
@@ -51,7 +57,7 @@ SentryAppStartTrackingIntegration ()
 }
 
 #if SENTRY_HAS_UIKIT
-- (BOOL)shouldBeEnabled:(SentryOptions *)options
+- (BOOL)shouldBeEnabled:(NSArray *)options;
 {
     // If the cocoa SDK is being used by a hybrid SDK,
     // we install App start tracking and let the hybrid SDK decide what to do.
@@ -59,22 +65,7 @@ SentryAppStartTrackingIntegration ()
         return YES;
     }
 
-    if (!options.enableAutoPerformanceTracking) {
-        [SentryLog logWithMessage:
-                       @"enableAutoPerformanceTracking disabled. Will not track app start up time."
-                         andLevel:kSentryLevelDebug];
-        return NO;
-    }
-
-    if (!options.isTracingEnabled) {
-        [SentryLog
-            logWithMessage:
-                @"No tracesSampleRate and tracesSampler set. Will not track app start up time."
-                  andLevel:kSentryLevelDebug];
-        return NO;
-    }
-
-    return YES;
+    return [super shouldBeEnabled:options];
 }
 #endif
 

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -2,7 +2,6 @@
 #import "SentryAppStartTracker.h"
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryLog.h"
-#import "SentryOptions+Private.h"
 #import <Foundation/Foundation.h>
 #import <PrivateSentrySDKOnly.h>
 #import <SentryAppStateManager.h>

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -57,7 +57,7 @@ SentryAppStartTrackingIntegration ()
 }
 
 #if SENTRY_HAS_UIKIT
-- (BOOL)shouldBeEnabled:(NSArray *)options;
+- (BOOL)shouldBeEnabled:(NSArray *)options
 {
     // If the cocoa SDK is being used by a hybrid SDK,
     // we install App start tracking and let the hybrid SDK decide what to do.

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -4,7 +4,6 @@
 #import "SentryDependencyContainer.h"
 #import "SentryFileManager.h"
 #import "SentryLog.h"
-#import "SentryOptions+Private.h"
 #import "SentryOptions.h"
 #import "SentrySystemEventBreadcrumbs.h"
 

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -22,10 +22,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 - (void)installWithOptions:(nonnull SentryOptions *)options
 {
-    if (!options.enableAutoBreadcrumbTracking) {
-        [SentryLog logWithMessage:@"Not going to enable BreadcrumbTracking because "
-                                  @"enableAutoBreadcrumbTracking is disabled."
-                         andLevel:kSentryLevelDebug];
+    if (![self isEnabled:options.enableAutoBreadcrumbTracking]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -20,11 +20,10 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 @implementation SentryAutoBreadcrumbTrackingIntegration
 
-- (void)installWithOptions:(nonnull SentryOptions *)options
+- (BOOL)installWithOptions:(nonnull SentryOptions *)options
 {
-    if (![self isEnabled:options.enableAutoBreadcrumbTracking]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     [self installWithOptions:options
@@ -36,6 +35,13 @@ SentryAutoBreadcrumbTrackingIntegration ()
                                                               .fileManager
                                    andCurrentDateProvider:[SentryDefaultCurrentDateProvider
                                                               sharedInstance]]];
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableAutoBreadcrumbTracking;
 }
 
 /**

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -17,11 +17,10 @@ SentryAutoSessionTrackingIntegration ()
 
 @implementation SentryAutoSessionTrackingIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
-    if (![self isEnabled:options.enableAutoSessionTracking]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     SentrySessionTracker *tracker = [[SentrySessionTracker alloc]
@@ -29,6 +28,13 @@ SentryAutoSessionTrackingIntegration ()
         currentDateProvider:[SentryDefaultCurrentDateProvider sharedInstance]];
     [tracker start];
     self.tracker = tracker;
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableAutoSessionTracking;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -19,7 +19,7 @@ SentryAutoSessionTrackingIntegration ()
 
 - (void)installWithOptions:(SentryOptions *)options
 {
-    if (!options.enableAutoSessionTracking) {
+    if (![self isEnabled:options.enableAutoSessionTracking]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -1,7 +1,6 @@
 #import "SentryAutoSessionTrackingIntegration.h"
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryLog.h"
-#import "SentryOptions+Private.h"
 #import "SentryOptions.h"
 #import "SentrySDK.h"
 #import "SentrySessionTracker.h"

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -35,6 +35,10 @@ NS_ASSUME_NONNULL_BEGIN
 {
     SentryIntegrationOption integrationOptions = [self integrationOptions];
 
+    if (integrationOptions & kIntegrationOptionNone) {
+        return YES;
+    }
+
     if ((integrationOptions & kIntegrationOptionEnableAutoSessionTracking)
         && !options.enableAutoSessionTracking) {
         [self logWithOptionName:@"enableAutoSessionTracking"];
@@ -82,11 +86,6 @@ NS_ASSUME_NONNULL_BEGIN
             [self logWithReason:@"because appHangTimeoutInterval is 0"];
             return NO;
         }
-
-        if ([SentryDependencyContainer.sharedInstance.crashWrapper isBeingTraced]) {
-            [self logWithReason:@"because the debugger is attached"];
-            return NO;
-        }
     }
 
     if ((integrationOptions & kIntegrationOptionEnableNetworkTracking)
@@ -126,6 +125,12 @@ NS_ASSUME_NONNULL_BEGIN
 
     if ((integrationOptions & kIntegrationOptionIsTracingEnabled) && !options.isTracingEnabled) {
         [self logWithOptionName:@"isTracingEnabled"];
+        return NO;
+    }
+
+    if ((integrationOptions & kIntegrationOptionDebuggerNotAttached) &&
+        [SentryDependencyContainer.sharedInstance.crashWrapper isBeingTraced]) {
+        [self logWithReason:@"because the debugger is attached"];
         return NO;
     }
 

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -41,16 +41,10 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
-    if (integrationOptions & kIntegrationOptionEnableOutOfMemoryTracking) {
-        if (!options.enableOutOfMemoryTracking) {
-            [self logWithOptionName:@"enableOutOfMemoryTracking"];
-            return NO;
-        }
-
-        if (NSProcessInfo.processInfo.environment[@"XCTestConfigurationFilePath"] != nil) {
-            [self logWithReason:@"because unit tests are running"];
-            return NO;
-        }
+    if ((integrationOptions & kIntegrationOptionEnableOutOfMemoryTracking)
+        && !options.enableOutOfMemoryTracking) {
+        [self logWithOptionName:@"enableOutOfMemoryTracking"];
+        return NO;
     }
 
     if ((integrationOptions & kIntegrationOptionEnableAutoPerformanceTracking)

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -59,6 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+#if SENTRY_HAS_UIKIT
     if ((integrationOptions & kIntegrationOptionEnableUIViewControllerTracking)
         && !options.enableUIViewControllerTracking) {
         [self logWithOptionName:@"enableUIViewControllerTracking"];
@@ -75,6 +76,7 @@ NS_ASSUME_NONNULL_BEGIN
         [self logWithOptionName:@"enableUserInteractionTracing"];
         return NO;
     }
+#endif
 
     if (integrationOptions & kIntegrationOptionEnableAppHangTracking) {
         if (!options.enableAppHangTracking) {

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -1,0 +1,74 @@
+#import "SentryBaseIntegration.h"
+#import "SentryLog.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation SentryOptionWithDescription
+- (instancetype)initWithOption:(BOOL)option log:(NSString *)log
+{
+    if (self = [super init]) {
+        self.option = option;
+        self.log = log;
+    }
+    return self;
+}
+- (instancetype)initWithOption:(BOOL)option optionName:(NSString *)optionName
+{
+    if (self = [super init]) {
+        self.option = option;
+        self.optionName = optionName;
+    }
+    return self;
+}
+@end
+
+@implementation SentryBaseIntegration
+
+- (NSString *)integrationName
+{
+    return NSStringFromClass([self classForCoder]);
+}
+
+- (BOOL)isEnabled:(BOOL)option
+{
+    return [self shouldBeEnabled:@[ @(option) ]];
+}
+
+- (BOOL)shouldBeEnabled:(NSArray *)options
+{
+    for (id option in options) {
+        if ([option isKindOfClass:[NSNumber class]]) {
+            NSNumber *castedOption = option;
+            if (![castedOption boolValue]) {
+                [SentryLog logWithMessage:[NSString stringWithFormat:@"Not going to enable %@",
+                                                    [self integrationName]]
+                                 andLevel:kSentryLevelDebug];
+                return NO;
+            }
+        }
+
+        if ([option isKindOfClass:[SentryOptionWithDescription class]]) {
+            SentryOptionWithDescription *castedOption = option;
+            if (!castedOption.option) {
+                if (castedOption.optionName != nil) {
+                    [SentryLog
+                        logWithMessage:
+                            [NSString
+                                stringWithFormat:@"Not going to enable %@ because %@ is disabled",
+                                [self integrationName], castedOption.optionName]
+                              andLevel:kSentryLevelDebug];
+                } else {
+                    [SentryLog logWithMessage:castedOption.log andLevel:kSentryLevelDebug];
+                }
+                return NO;
+            }
+        }
+    }
+
+    return YES;
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -16,11 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)installWithOptions:(SentryOptions *)options
 {
-    if (![self shouldBeEnabledWithOptions:options]) {
-        return NO;
-    }
-
-    return YES;
+    return [self shouldBeEnabledWithOptions:options];
 }
 
 - (void)logWithOptionName:(NSString *)optionName

--- a/Sources/Sentry/SentryCoreDataTrackingIntegration.m
+++ b/Sources/Sentry/SentryCoreDataTrackingIntegration.m
@@ -17,47 +17,23 @@ SentryCoreDataTrackingIntegration ()
 
 - (void)installWithOptions:(SentryOptions *)options
 {
-    if ([self shouldBeDisabled:options]) {
+    if (![self shouldBeEnabled:@[
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableAutoPerformanceTracking
+                    optionName:@"enableAutoPerformanceTracking"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
+                                                     optionName:@"enableSwizzling"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
+                                                     optionName:@"isTracingEnabled"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableCoreDataTracking
+                                                     optionName:@"enableCoreDataTracking"],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
 
     self.tracker = [[SentryCoreDataTracker alloc] init];
     [SentryCoreDataSwizzling.sharedInstance startWithMiddleware:self.tracker];
-}
-
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
-{
-    if (!options.enableAutoPerformanceTracking) {
-        [SentryLog logWithMessage:@"Not going to enable CoreData tracking because "
-                                  @"enableAutoPerformanceTracking is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableSwizzling) {
-        [SentryLog logWithMessage:
-                       @"Not going to enable CoreData tracking because enableSwizzling is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.isTracingEnabled) {
-        [SentryLog
-            logWithMessage:@"Not going to enable CoreData tracking because tracing is disabled."
-                  andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableCoreDataTracking) {
-        [SentryLog
-            logWithMessage:
-                @"Not going to enable CoreData tracking because enableCoreDataTracking is disabled."
-                  andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryCoreDataTrackingIntegration.m
+++ b/Sources/Sentry/SentryCoreDataTrackingIntegration.m
@@ -3,7 +3,6 @@
 #import "SentryCoreDataTracker.h"
 #import "SentryLog.h"
 #import "SentryNSDataSwizzling.h"
-#import "SentryOptions+Private.h"
 #import "SentryOptions.h"
 
 @interface

--- a/Sources/Sentry/SentryCoreDataTrackingIntegration.m
+++ b/Sources/Sentry/SentryCoreDataTrackingIntegration.m
@@ -15,25 +15,22 @@ SentryCoreDataTrackingIntegration ()
 
 @implementation SentryCoreDataTrackingIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
-    if (![self shouldBeEnabled:@[
-            [[SentryOptionWithDescription alloc]
-                initWithOption:options.enableAutoPerformanceTracking
-                    optionName:@"enableAutoPerformanceTracking"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
-                                                     optionName:@"enableSwizzling"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
-                                                     optionName:@"isTracingEnabled"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableCoreDataTracking
-                                                     optionName:@"enableCoreDataTracking"],
-        ]]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     self.tracker = [[SentryCoreDataTracker alloc] init];
     [SentryCoreDataSwizzling.sharedInstance startWithMiddleware:self.tracker];
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableAutoPerformanceTracking | kIntegrationOptionEnableSwizzling
+        | kIntegrationOptionIsTracingEnabled | kIntegrationOptionEnableCoreDataTracking;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -60,7 +60,7 @@ SentryCrashIntegration ()
     return self;
 }
 
-- (void)installWithOptions:(nonnull SentryOptions *)options
+- (BOOL)installWithOptions:(nonnull SentryOptions *)options
 {
     self.options = options;
 
@@ -84,6 +84,8 @@ SentryCrashIntegration ()
     }
 
     [self configureScope];
+
+    return YES;
 }
 
 - (void)startCrashHandler

--- a/Sources/Sentry/SentryFileIOTrackingIntegration.m
+++ b/Sources/Sentry/SentryFileIOTrackingIntegration.m
@@ -1,7 +1,6 @@
 #import "SentryFileIOTrackingIntegration.h"
 #import "SentryLog.h"
 #import "SentryNSDataSwizzling.h"
-#import "SentryOptions+Private.h"
 #import "SentryOptions.h"
 
 @implementation SentryFileIOTrackingIntegration

--- a/Sources/Sentry/SentryFileIOTrackingIntegration.m
+++ b/Sources/Sentry/SentryFileIOTrackingIntegration.m
@@ -6,24 +6,21 @@
 
 @implementation SentryFileIOTrackingIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
-    if (![self shouldBeEnabled:@[
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
-                                                     optionName:@"enableSwizzling"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
-                                                     optionName:@"isTracingEnabled"],
-            [[SentryOptionWithDescription alloc]
-                initWithOption:options.enableAutoPerformanceTracking
-                    optionName:@"enableAutoPerformanceTracking"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableFileIOTracking
-                                                     optionName:@"enableFileIOTracking"],
-        ]]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     [SentryNSDataSwizzling start];
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableSwizzling | kIntegrationOptionIsTracingEnabled
+        | kIntegrationOptionEnableAutoPerformanceTracking | kIntegrationOptionEnableFileIOTracking;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryFileIOTrackingIntegration.m
+++ b/Sources/Sentry/SentryFileIOTrackingIntegration.m
@@ -8,45 +8,22 @@
 
 - (void)installWithOptions:(SentryOptions *)options
 {
-    if ([self shouldBeDisabled:options]) {
+    if (![self shouldBeEnabled:@[
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
+                                                     optionName:@"enableSwizzling"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
+                                                     optionName:@"isTracingEnabled"],
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableAutoPerformanceTracking
+                    optionName:@"enableAutoPerformanceTracking"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableFileIOTracking
+                                                     optionName:@"enableFileIOTracking"],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
 
     [SentryNSDataSwizzling start];
-}
-
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
-{
-    if (!options.enableSwizzling) {
-        [SentryLog logWithMessage:
-                       @"Not going to enable FileIOTracking because enableSwizzling is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.isTracingEnabled) {
-        [SentryLog logWithMessage:@"Not going to enable FileIOTracking because tracing is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableAutoPerformanceTracking) {
-        [SentryLog logWithMessage:@"Not going to enable FileIOTracking because "
-                                  @"enableAutoPerformanceTracking is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableFileIOTracking) {
-        [SentryLog
-            logWithMessage:
-                @"Not going to enable FileIOTracking because enableFileIOTracking is disabled."
-                  andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -2,7 +2,6 @@
 #import "PrivateSentrySDKOnly.h"
 #import "SentryFramesTracker.h"
 #import "SentryLog.h"
-#import "SentryOptions+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -20,7 +20,13 @@ SentryFramesTrackingIntegration ()
 - (void)installWithOptions:(SentryOptions *)options
 {
 #if SENTRY_HAS_UIKIT
-    if ([self shouldBeDisabled:options]) {
+    if (![self shouldBeEnabled:@[
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableAutoPerformanceTracking
+                    optionName:@"enableAutoPerformanceTracking"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
+                                                     optionName:@"isTracingEnabled"],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
@@ -37,31 +43,15 @@ SentryFramesTrackingIntegration ()
 }
 
 #if SENTRY_HAS_UIKIT
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
+- (BOOL)shouldBeEnabled:(NSArray<NSNumber *> *)options
 {
     // If the cocoa SDK is being used by a hybrid SDK,
     // we let the hybrid SDK decide whether to track frames or not.
     if (PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode) {
-        return NO;
-    }
-
-    if (!options.enableAutoPerformanceTracking) {
-        [SentryLog
-            logWithMessage:
-                @"enableAutoPerformanceTracking disabled. Will not track slow and frozen frames."
-                  andLevel:kSentryLevelDebug];
         return YES;
     }
 
-    if (!options.isTracingEnabled) {
-        [SentryLog
-            logWithMessage:
-                @"No tracesSampleRate and tracesSampler set. Will not track slow and frozen frames."
-                  andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
+    return [super shouldBeEnabled:options];
 }
 #endif
 

--- a/Sources/Sentry/SentryNetworkTrackingIntegration.m
+++ b/Sources/Sentry/SentryNetworkTrackingIntegration.m
@@ -2,7 +2,6 @@
 #import "SentryLog.h"
 #import "SentryNSURLSessionTaskSearch.h"
 #import "SentryNetworkTracker.h"
-#import "SentryOptions+Private.h"
 #import "SentryOptions.h"
 #import "SentrySwizzle.h"
 #import <objc/runtime.h>

--- a/Sources/Sentry/SentryNetworkTrackingIntegration.m
+++ b/Sources/Sentry/SentryNetworkTrackingIntegration.m
@@ -9,14 +9,14 @@
 
 @implementation SentryNetworkTrackingIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
     if (!options.enableSwizzling) {
         [SentryLog logWithMessage:
                        @"Not going to enable NetworkTracking because enableSwizzling is disabled."
                          andLevel:kSentryLevelDebug];
         [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+        return NO;
     }
 
     BOOL shouldEnableNetworkTracking = YES;
@@ -54,8 +54,9 @@
 
     if (shouldEnableNetworkTracking || options.enableNetworkBreadcrumbs) {
         [SentryNetworkTrackingIntegration swizzleURLSessionTask];
+        return YES;
     } else {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
+        return NO;
     }
 }
 

--- a/Sources/Sentry/SentryNetworkTrackingIntegration.m
+++ b/Sources/Sentry/SentryNetworkTrackingIntegration.m
@@ -17,29 +17,7 @@
         return NO;
     }
 
-    BOOL shouldEnableNetworkTracking = YES;
-
-    if (!options.isTracingEnabled) {
-        [SentryLog logWithMessage:
-                       @"Not going to enable NetworkTracking because isTracingEnabled is disabled."
-                         andLevel:kSentryLevelDebug];
-        shouldEnableNetworkTracking = NO;
-    }
-
-    if (shouldEnableNetworkTracking && !options.enableAutoPerformanceTracking) {
-        [SentryLog logWithMessage:@"Not going to enable NetworkTracking because "
-                                  @"enableAutoPerformanceTracking is disabled."
-                         andLevel:kSentryLevelDebug];
-        shouldEnableNetworkTracking = NO;
-    }
-
-    if (shouldEnableNetworkTracking && !options.enableNetworkTracking) {
-        [SentryLog
-            logWithMessage:
-                @"Not going to enable NetworkTracking because enableNetworkTracking is disabled."
-                  andLevel:kSentryLevelDebug];
-        shouldEnableNetworkTracking = NO;
-    }
+    BOOL shouldEnableNetworkTracking = [super shouldBeEnabledWithOptions:options];
 
     if (shouldEnableNetworkTracking) {
         [SentryNetworkTracker.sharedInstance enableNetworkTracking];
@@ -56,6 +34,12 @@
     } else {
         return NO;
     }
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionIsTracingEnabled | kIntegrationOptionEnableAutoPerformanceTracking
+        | kIntegrationOptionEnableNetworkTracking;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryNetworkTrackingIntegration.m
+++ b/Sources/Sentry/SentryNetworkTrackingIntegration.m
@@ -15,7 +15,6 @@
         [SentryLog logWithMessage:
                        @"Not going to enable NetworkTracking because enableSwizzling is disabled."
                          andLevel:kSentryLevelDebug];
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
         return NO;
     }
 

--- a/Sources/Sentry/SentryNetworkTrackingIntegration.m
+++ b/Sources/Sentry/SentryNetworkTrackingIntegration.m
@@ -11,9 +11,7 @@
 - (BOOL)installWithOptions:(SentryOptions *)options
 {
     if (!options.enableSwizzling) {
-        [SentryLog logWithMessage:
-                       @"Not going to enable NetworkTracking because enableSwizzling is disabled."
-                         andLevel:kSentryLevelDebug];
+        [self logWithOptionName:@"enableSwizzling"];
         return NO;
     }
 

--- a/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
+++ b/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
@@ -22,14 +22,28 @@ SentryOutOfMemoryTrackingIntegration ()
 
 @property (nonatomic, strong) SentryOutOfMemoryTracker *tracker;
 @property (nonatomic, strong) SentryANRTracker *anrTracker;
+@property (nullable, nonatomic, copy) NSString *testConfigurationFilePath;
 @property (nonatomic, strong) SentryAppStateManager *appStateManager;
 
 @end
 
 @implementation SentryOutOfMemoryTrackingIntegration
 
+- (instancetype)init
+{
+    if (self = [super init]) {
+        self.testConfigurationFilePath
+            = NSProcessInfo.processInfo.environment[@"XCTestConfigurationFilePath"];
+    }
+    return self;
+}
+
 - (BOOL)installWithOptions:(SentryOptions *)options
 {
+    if (self.testConfigurationFilePath) {
+        return NO;
+    }
+
     if (![super installWithOptions:options]) {
         return NO;
     }

--- a/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
+++ b/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
@@ -40,7 +40,12 @@ SentryOutOfMemoryTrackingIntegration ()
 
 - (void)installWithOptions:(SentryOptions *)options
 {
-    if ([self shouldBeDisabled:options]) {
+    if (![self shouldBeEnabled:@[
+            @(options.enableOutOfMemoryTracking),
+            [[SentryOptionWithDescription alloc]
+                initWithOption:self.testConfigurationFilePath == nil
+                           log:@"Won't track OOMs, because detected that unit tests are running."],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
@@ -72,23 +77,6 @@ SentryOutOfMemoryTrackingIntegration ()
     [self.anrTracker addListener:self];
 
     self.appStateManager = appStateManager;
-}
-
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
-{
-    if (!options.enableOutOfMemoryTracking) {
-        return YES;
-    }
-
-    // The testConfigurationFilePath is not nil when running unit tests. This doesn't work for UI
-    // tests though.
-    if (self.testConfigurationFilePath) {
-        [SentryLog logWithMessage:@"Won't track OOMs, because detected that unit tests are running."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -19,7 +19,20 @@ SentryPerformanceTrackingIntegration ()
 
 - (void)installWithOptions:(SentryOptions *)options
 {
-    if ([self shouldBeDisabled:options]) {
+    if (![self shouldBeEnabled:@[
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableAutoPerformanceTracking
+                    optionName:@"enableAutoPerformanceTracking"],
+#if SENTRY_HAS_UIKIT
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableUIViewControllerTracking
+                    optionName:@"enableUIViewControllerTracking"],
+#endif
+            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
+                                                     optionName:@"isTracingEnabled"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
+                                                     optionName:@"enableSwizzling"],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
@@ -47,41 +60,6 @@ SentryPerformanceTrackingIntegration ()
                               @"start] does nothing."
                      andLevel:kSentryLevelDebug];
 #endif
-}
-
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
-{
-    if (!options.enableAutoPerformanceTracking) {
-        [SentryLog logWithMessage:@"enableAutoPerformanceTracking disabled. Will not start "
-                                  @"SentryPerformanceTrackingIntegration."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-#if SENTRY_HAS_UIKIT
-    if (!options.enableUIViewControllerTracking) {
-        [SentryLog logWithMessage:@"enableUIViewControllerTracking disabled. Will not start "
-                                  @"SentryPerformanceTrackingIntegration."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-#endif
-
-    if (!options.isTracingEnabled) {
-        [SentryLog logWithMessage:@"No tracesSampleRate and tracesSampler set. Will not start "
-                                  @"SentryPerformanceTrackingIntegration."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableSwizzling) {
-        [SentryLog logWithMessage:@"enableSwizzling disabled. Will not start "
-                                  @"SentryPerformanceTrackingIntegration."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
 }
 
 @end

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -2,7 +2,6 @@
 #import "SentryDefaultObjCRuntimeWrapper.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryLog.h"
-#import "SentryOptions+Private.h"
 #import "SentrySubClassFinder.h"
 #import "SentryUIViewControllerSwizzling.h"
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -8,6 +8,7 @@
 #import "SentryHub+Private.h"
 #import "SentryLog.h"
 #import "SentryMeta.h"
+#import "SentryOptions+Private.h"
 #import "SentryScope.h"
 
 @interface
@@ -361,6 +362,8 @@ static NSUInteger startInvocations;
                                                 integrationName]
                              andLevel:kSentryLevelDebug];
             [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
+        } else {
+            [[SentrySDK.currentHub getClient].options removeEnabledIntegration:integrationName];
         }
     }
 }

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -355,11 +355,13 @@ static NSUInteger startInvocations;
             continue;
         }
         id<SentryIntegrationProtocol> integrationInstance = [[integrationClass alloc] init];
-        [integrationInstance installWithOptions:options];
-        [SentryLog
-            logWithMessage:[NSString stringWithFormat:@"Integration installed: %@", integrationName]
-                  andLevel:kSentryLevelDebug];
-        [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
+        BOOL shouldInstall = [integrationInstance installWithOptions:options];
+        if (shouldInstall) {
+            [SentryLog logWithMessage:[NSString stringWithFormat:@"Integration installed: %@",
+                                                integrationName]
+                             andLevel:kSentryLevelDebug];
+            [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
+        }
     }
 }
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -363,7 +363,7 @@ static NSUInteger startInvocations;
                              andLevel:kSentryLevelDebug];
             [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
         } else {
-            [[SentrySDK.currentHub getClient].options removeEnabledIntegration:integrationName];
+            [options removeEnabledIntegration:integrationName];
         }
     }
 }

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -42,17 +42,23 @@ saveScreenShot(const char *path)
 
 @implementation SentryScreenshotIntegration
 
-- (void)installWithOptions:(nonnull SentryOptions *)options
+- (BOOL)installWithOptions:(nonnull SentryOptions *)options
 {
-    if (![self isEnabled:options.attachScreenshot]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     SentryClient *client = [SentrySDK.currentHub getClient];
     client.attachmentProcessor = self;
 
     sentrycrash_setSaveScreenshots(&saveScreenShot);
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionAttachScreenshot;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -44,7 +44,7 @@ saveScreenShot(const char *path)
 
 - (void)installWithOptions:(nonnull SentryOptions *)options
 {
-    if ([self shouldBeDisabled:options]) {
+    if (![self isEnabled:options.attachScreenshot]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
@@ -86,16 +86,6 @@ saveScreenShot(const char *path)
     }
 
     return result;
-}
-
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
-{
-    if (!options.attachScreenshot) {
-        [SentryLog logWithMessage:@"Screenshot integration disabled." andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
 }
 
 @end

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -7,7 +7,6 @@
 #import "SentryEvent.h"
 #import "SentryHub+Private.h"
 #import "SentryLog.h"
-#import "SentryOptions+Private.h"
 #import "SentrySDK+Private.h"
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryUIEventTrackingIntegration.m
+++ b/Sources/Sentry/SentryUIEventTrackingIntegration.m
@@ -19,7 +19,17 @@ SentryUIEventTrackingIntegration ()
 
 - (void)installWithOptions:(SentryOptions *)options
 {
-    if ([self shouldBeDisabled:options]) {
+    if (![self shouldBeEnabled:@[
+            [[SentryOptionWithDescription alloc]
+                initWithOption:options.enableAutoPerformanceTracking
+                    optionName:@"enableAutoPerformanceTracking"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
+                                                     optionName:@"enableSwizzling"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
+                                                     optionName:@"isTracingEnabled"],
+            [[SentryOptionWithDescription alloc] initWithOption:options.enableUserInteractionTracing
+                                                     optionName:@"enableUserInteractionTracing"],
+        ]]) {
         [options removeEnabledIntegration:NSStringFromClass([self class])];
         return;
     }
@@ -31,39 +41,6 @@ SentryUIEventTrackingIntegration ()
                    idleTimeout:options.idleTimeout];
 
     [self.uiEventTracker start];
-}
-
-- (BOOL)shouldBeDisabled:(SentryOptions *)options
-{
-    if (!options.enableAutoPerformanceTracking) {
-        [SentryLog logWithMessage:@"Not going to enable User Interaction tracking because "
-                                  @"enableAutoPerformanceTracking is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableSwizzling) {
-        [SentryLog logWithMessage:@"Not going to enable User Interaction tracking because "
-                                  @"enableSwizzling is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.isTracingEnabled) {
-        [SentryLog logWithMessage:
-                       @"Not going to enable User Interaction tracking because tracing is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    if (!options.enableUserInteractionTracing) {
-        [SentryLog logWithMessage:@"Not going to enable User Interaction tracking because "
-                                  @"enableUserInteractionTracing is disabled."
-                         andLevel:kSentryLevelDebug];
-        return YES;
-    }
-
-    return NO;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryUIEventTrackingIntegration.m
+++ b/Sources/Sentry/SentryUIEventTrackingIntegration.m
@@ -17,21 +17,10 @@ SentryUIEventTrackingIntegration ()
 
 @implementation SentryUIEventTrackingIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
-    if (![self shouldBeEnabled:@[
-            [[SentryOptionWithDescription alloc]
-                initWithOption:options.enableAutoPerformanceTracking
-                    optionName:@"enableAutoPerformanceTracking"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableSwizzling
-                                                     optionName:@"enableSwizzling"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.isTracingEnabled
-                                                     optionName:@"isTracingEnabled"],
-            [[SentryOptionWithDescription alloc] initWithOption:options.enableUserInteractionTracing
-                                                     optionName:@"enableUserInteractionTracing"],
-        ]]) {
-        [options removeEnabledIntegration:NSStringFromClass([self class])];
-        return;
+    if (![super installWithOptions:options]) {
+        return NO;
     }
 
     SentryDependencyContainer *dependencies = [SentryDependencyContainer sharedInstance];
@@ -41,6 +30,14 @@ SentryUIEventTrackingIntegration ()
                    idleTimeout:options.idleTimeout];
 
     [self.uiEventTracker start];
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableAutoPerformanceTracking | kIntegrationOptionEnableSwizzling
+        | kIntegrationOptionIsTracingEnabled | kIntegrationOptionEnableUserInteractionTracing;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/include/SentryANRTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryANRTrackingIntegration.h
@@ -1,11 +1,12 @@
 #import "SentryANRTracker.h"
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryANRTrackingIntegration
-    : NSObject <SentryIntegrationProtocol, SentryANRTrackerDelegate>
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentryAppStartTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAppStartTrackingIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
@@ -6,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Tracks cold and warm app start time for iOS, tvOS, and Mac Catalyst.
  */
-@interface SentryAppStartTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryAppStartTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 - (void)stop;
 

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -5,7 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * This automatically adds breadcrumbs for different user actions.
  */
-@interface SentryAutoBreadcrumbTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryAutoBreadcrumbTrackingIntegration
+    : SentryBaseIntegration <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
@@ -6,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Automatically tracks session start and end.
  */
-@interface SentryAutoSessionTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryAutoSessionTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 - (void)stop;
 

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -26,6 +26,8 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
 
 - (NSString *)integrationName;
 - (BOOL)installWithOptions:(SentryOptions *)options;
+- (void)logWithOptionName:(NSString *)optionName;
+- (void)logWithReason:(NSString *)reason;
 - (BOOL)shouldBeEnabledWithOptions:(SentryOptions *)options;
 - (SentryIntegrationOption)integrationOptions;
 

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -1,0 +1,23 @@
+#import "SentryOptions.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryOptionWithDescription : NSObject
+@property (nonatomic) BOOL option;
+@property (strong, nonatomic, nullable) NSString *log;
+@property (strong, nonatomic, nullable) NSString *optionName;
+- (instancetype)initWithOption:(BOOL)option log:(NSString *)log;
+- (instancetype)initWithOption:(BOOL)option optionName:(NSString *)optionName;
+@end
+
+@interface SentryBaseIntegration : NSObject
+
+- (NSString *)integrationName;
+
+- (BOOL)isEnabled:(BOOL)option;
+- (BOOL)shouldBeEnabled:(NSArray *)options;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -19,6 +19,7 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
     kIntegrationOptionEnableSwizzling = 1 << 11,
     kIntegrationOptionEnableAutoBreadcrumbTracking = 1 << 12,
     kIntegrationOptionIsTracingEnabled = 1 << 13,
+    kIntegrationOptionDebuggerNotAttached = 1 << 14,
 };
 
 @interface SentryBaseIntegration : NSObject

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -3,20 +3,30 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryOptionWithDescription : NSObject
-@property (nonatomic) BOOL option;
-@property (strong, nonatomic, nullable) NSString *log;
-@property (strong, nonatomic, nullable) NSString *optionName;
-- (instancetype)initWithOption:(BOOL)option log:(NSString *)log;
-- (instancetype)initWithOption:(BOOL)option optionName:(NSString *)optionName;
-@end
+typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
+    kIntegrationOptionNone = 0,
+    kIntegrationOptionEnableAutoSessionTracking = 1 << 0,
+    kIntegrationOptionEnableOutOfMemoryTracking = 1 << 1,
+    kIntegrationOptionEnableAutoPerformanceTracking = 1 << 2,
+    kIntegrationOptionEnableUIViewControllerTracking = 1 << 3,
+    kIntegrationOptionAttachScreenshot = 1 << 4,
+    kIntegrationOptionEnableUserInteractionTracing = 1 << 5,
+    kIntegrationOptionEnableAppHangTracking = 1 << 6,
+    kIntegrationOptionEnableNetworkTracking = 1 << 7,
+    kIntegrationOptionEnableFileIOTracking = 1 << 8,
+    kIntegrationOptionEnableNetworkBreadcrumbs = 1 << 9,
+    kIntegrationOptionEnableCoreDataTracking = 1 << 10,
+    kIntegrationOptionEnableSwizzling = 1 << 11,
+    kIntegrationOptionEnableAutoBreadcrumbTracking = 1 << 12,
+    kIntegrationOptionIsTracingEnabled = 1 << 13,
+};
 
 @interface SentryBaseIntegration : NSObject
 
 - (NSString *)integrationName;
-
-- (BOOL)isEnabled:(BOOL)option;
-- (BOOL)shouldBeEnabled:(NSArray *)options;
+- (BOOL)installWithOptions:(SentryOptions *)options;
+- (BOOL)shouldBeEnabledWithOptions:(SentryOptions *)options;
+- (SentryIntegrationOption)integrationOptions;
 
 @end
 

--- a/Sources/Sentry/include/SentryCoreDataTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryCoreDataTrackingIntegration.h
@@ -1,8 +1,9 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryCoreDataTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryCoreDataTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryFileIOTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryFileIOTrackingIntegration.h
@@ -1,8 +1,9 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryFileIOTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryFileIOTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryFramesTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryFramesTrackingIntegration.h
@@ -1,9 +1,10 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryFramesTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryFramesTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 - (void)stop;
 

--- a/Sources/Sentry/include/SentryNetworkTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryNetworkTrackingIntegration.h
@@ -1,8 +1,9 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryNetworkTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryNetworkTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryOutOfMemoryTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryOutOfMemoryTrackingIntegration.h
@@ -1,11 +1,12 @@
 #import "SentryANRTracker.h"
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryOutOfMemoryTrackingIntegration
-    : NSObject <SentryIntegrationProtocol, SentryANRTrackerDelegate>
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentryPerformanceTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryPerformanceTrackingIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
@@ -10,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  * enableAutoPerformanceTracking to NO
  * in SentryOptions during SentrySDK initialization.
  */
-@interface SentryPerformanceTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryPerformanceTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 @end
 

--- a/Sources/Sentry/include/SentryScreenshotIntegration.h
+++ b/Sources/Sentry/include/SentryScreenshotIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryBaseIntegration.h"
 #import "SentryClient+Private.h"
 #import "SentryIntegrationProtocol.h"
 #import "SentryScreenshot.h"
@@ -7,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT
 
 @interface SentryScreenshotIntegration
-    : NSObject <SentryIntegrationProtocol, SentryClientAttachmentProcessor>
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentryClientAttachmentProcessor>
 
 @end
 

--- a/Sources/Sentry/include/SentryUIEventTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryUIEventTrackingIntegration.h
@@ -1,9 +1,10 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT
-@interface SentryUIEventTrackingIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryUIEventTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 @end
 #endif

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -42,27 +42,25 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertNotNil(Dynamic(sut).tracker.asAnyObject)
     }
     
-    func test_enableAppHangsTracking_Disabled_RemovesEnabledIntegration() {
+    func test_enableAppHangsTracking_Disabled() {
         let options = Options()
         options.enableAppHangTracking = false
         
         sut = SentryANRTrackingIntegration()
-        sut.install(with: options)
-        
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("ANRTracking") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        let result = sut.install(with: options)
+
+        XCTAssertFalse(result)
     }
     
-    func test_appHangsTimeoutInterval_Zero_RemovesEnabledIntegration() {
+    func test_appHangsTimeoutInterval_Zero() {
         let options = Options()
         options.enableAppHangTracking = true
         options.appHangTimeoutInterval = 0
         
         sut = SentryANRTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("ANRTracking") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
     
     func testANRDetected_EventCaptured() {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -43,15 +43,14 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(0, fixture.tracker.startSwizzleInvocations.count)
     }
 
-    func test_enableAutoBreadcrumbTracking_Disabled_RemovesEnabledIntegration() {
+    func test_enableAutoBreadcrumbTracking_Disabled() {
         let options = Options()
         options.enableAutoBreadcrumbTracking = false
 
         let sut = SentryAutoBreadcrumbTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
 
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("SentryAutoBreadcrumbTrackingIntegration") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
 }
 

--- a/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryIntegrationTests.swift
@@ -95,10 +95,9 @@ class SentryOutOfMemoryIntegrationTests: XCTestCase {
         options.enableOutOfMemoryTracking = false
         
         let sut = SentryOutOfMemoryTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("OutOfMemory") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
     
     private func givenInitializedTracker(isBeingTraced: Bool = false) {

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -87,13 +87,12 @@ class SentryAppStartTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(SentrySDK.getAppStartMeasurement())
     }
     
-    func test_PerformanceTrackingDisabled_RemovesEnabledIntegration() {
+    func test_PerformanceTrackingDisabled() {
         let options = fixture.options
         options.enableAutoPerformanceTracking = false
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("AppStart") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
     
 }

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -83,14 +83,13 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(fixture.displayLink.selector)
     }
     
-    func test_FramesTrackingDisabled_RemovesEnabledIntegration() {
+    func test_FramesTracking_Disabled() {
         let options = Options()
         options.enableAutoPerformanceTracking = false
         
-        fixture.sut.install(with: options)
+        let result = fixture.sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("FramesTracking") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
 }
 #endif

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIoTrackingUnitTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIoTrackingUnitTests.swift
@@ -3,13 +3,12 @@ import XCTest
 
 class SentryFileIoTrackingUnitTests: XCTestCase {
 
-    func test_FileIOTrackingDisabled_RemovesEnabledIntegration() {
+    func test_FileIOTracking_Disabled() {
         let options = Options()
         options.enableFileIOTracking = false
         let sut = SentryFileIOTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("FileIO") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
 }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -259,10 +259,9 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
     
     private func assertRemovedIntegration(_ options: Options) {
         let sut = SentryNetworkTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("NetworkTracking") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
 }
 

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
@@ -43,14 +43,14 @@ class SentryPerformanceTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(Dynamic(sut).swizzling.asObject)
     }
     
-    func testAutoPerformanceDisabled_DisablesIntegration() {
+    func testAutoPerformanceDisabled() {
         let options = Options()
         options.enableAutoPerformanceTracking = false
         
         disablesIntegration(options)
     }
     
-    func testUIViewControllerDisabled_DisablesIntegration() {
+    func testUIViewControllerDisabled() {
         let options = Options()
         options.enableUIViewControllerTracking = false
         
@@ -59,10 +59,9 @@ class SentryPerformanceTrackingIntegrationTests: XCTestCase {
     
     private func disablesIntegration(_ options: Options) {
         let sut = SentryPerformanceTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("PerformanceTracking") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
         XCTAssertNil(Dynamic(sut).swizzling.asObject)
     }
     

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -1,6 +1,12 @@
 import Sentry
 import XCTest
 
+class MyTestIntegration: SentryBaseIntegration {
+    override func integrationOptions() -> SentryIntegrationOption {
+        return .integrationOptionAttachScreenshot
+    }
+}
+
 class SentryBaseIntegrationTests: XCTestCase {
     var logOutput: TestLogOutput!
 
@@ -24,42 +30,19 @@ class SentryBaseIntegrationTests: XCTestCase {
         XCTAssertEqual(sut.integrationName(), "SentryBaseIntegration")
     }
 
-    func testIsEnabled_True() {
+    func testInstall() {
         let sut = SentryBaseIntegration()
-        XCTAssertEqual(sut.isEnabled(true), true)
-        XCTAssertEqual([], logOutput.loggedMessages)
+        let result = sut.install(with: .init())
+        XCTAssertTrue(result)
     }
 
-    func testIsEnabled_False() {
-        let sut = SentryBaseIntegration()
-        XCTAssertEqual(sut.isEnabled(false), false)
-        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryBaseIntegration"], logOutput.loggedMessages)
-    }
-
-    func testShouldBeEnabled_Bools_True() {
-        let sut = SentryBaseIntegration()
-        XCTAssertEqual(sut.shouldBeEnabled([true, true]), true)
-        XCTAssertEqual([], logOutput.loggedMessages)
-    }
-
-    func testShouldBeEnabled_Bools_False() {
-        let sut = SentryBaseIntegration()
-        XCTAssertEqual(sut.shouldBeEnabled([true, false]), false)
-        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryBaseIntegration"], logOutput.loggedMessages)
-    }
-
-    func testShouldBeEnabled_SentryOptionWithDescription_True() {
-        let sut = SentryBaseIntegration()
-        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: true, log: "Log me")]), true)
-        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: true, optionName: "optionName")]), true)
-        XCTAssertEqual([], logOutput.loggedMessages)
-    }
-
-    func testShouldBeEnabled_SentryOptionWithDescription_False() {
-        let sut = SentryBaseIntegration()
-        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: false, log: "Log me")]), false)
-        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: false, optionName: "optionName")]), false)
-        XCTAssertEqual(["Sentry - debug:: Log me", "Sentry - debug:: Not going to enable SentryBaseIntegration because optionName is disabled"], logOutput.loggedMessages)
+    func testInstall_FailingIntegrationOption() {
+        let sut = MyTestIntegration()
+        let options = Options()
+        options.attachScreenshot = false
+        let result = sut.install(with: options)
+        XCTAssertFalse(result)
+        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryTests.MyTestIntegration because attachScreenshot is disabled."], logOutput.loggedMessages)
     }
 
     class TestLogOutput: SentryLogOutput {

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -1,0 +1,71 @@
+import Sentry
+import XCTest
+
+class SentryBaseIntegrationTests: XCTestCase {
+    var logOutput: TestLogOutput!
+
+    override func setUp() {
+        super.setUp()
+        SentryLog.configure(true, diagnosticLevel: SentryLevel.debug)
+
+        logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        // Set back to default
+        SentryLog.configure(true, diagnosticLevel: SentryLevel.error)
+        SentryLog.setLogOutput(nil)
+    }
+
+    func testIntegrationName() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.integrationName(), "SentryBaseIntegration")
+    }
+
+    func testIsEnabled_True() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.isEnabled(true), true)
+        XCTAssertEqual([], logOutput.loggedMessages)
+    }
+
+    func testIsEnabled_False() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.isEnabled(false), false)
+        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryBaseIntegration"], logOutput.loggedMessages)
+    }
+
+    func testShouldBeEnabled_Bools_True() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.shouldBeEnabled([true, true]), true)
+        XCTAssertEqual([], logOutput.loggedMessages)
+    }
+
+    func testShouldBeEnabled_Bools_False() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.shouldBeEnabled([true, false]), false)
+        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryBaseIntegration"], logOutput.loggedMessages)
+    }
+
+    func testShouldBeEnabled_SentryOptionWithDescription_True() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: true, log: "Log me")]), true)
+        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: true, optionName: "optionName")]), true)
+        XCTAssertEqual([], logOutput.loggedMessages)
+    }
+
+    func testShouldBeEnabled_SentryOptionWithDescription_False() {
+        let sut = SentryBaseIntegration()
+        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: false, log: "Log me")]), false)
+        XCTAssertEqual(sut.shouldBeEnabled([SentryOptionWithDescription(option: false, optionName: "optionName")]), false)
+        XCTAssertEqual(["Sentry - debug:: Log me", "Sentry - debug:: Not going to enable SentryBaseIntegration because optionName is disabled"], logOutput.loggedMessages)
+    }
+
+    class TestLogOutput: SentryLogOutput {
+        var loggedMessages: [String] = []
+        override func log(_ message: String) {
+            loggedMessages.append(message)
+        }
+    }
+}

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class MyTestIntegration: SentryBaseIntegration {
     override func integrationOptions() -> SentryIntegrationOption {
-        return .integrationOptionAttachScreenshot
+        return .integrationOptionEnableAutoSessionTracking
     }
 }
 
@@ -39,10 +39,10 @@ class SentryBaseIntegrationTests: XCTestCase {
     func testInstall_FailingIntegrationOption() {
         let sut = MyTestIntegration()
         let options = Options()
-        options.attachScreenshot = false
+        options.enableAutoSessionTracking = false
         let result = sut.install(with: options)
         XCTAssertFalse(result)
-        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryTests.MyTestIntegration because attachScreenshot is disabled."], logOutput.loggedMessages)
+        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryTests.MyTestIntegration because enableAutoSessionTracking is disabled."], logOutput.loggedMessages)
     }
 
     class TestLogOutput: SentryLogOutput {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryTestIntegration.m
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryTestIntegration.m
@@ -4,9 +4,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryTestIntegration
 
-- (void)installWithOptions:(SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
     self.options = options;
+    return YES;
 }
 
 @end

--- a/Tests/SentryTests/Integrations/Session/SentryAutoSessionTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentryAutoSessionTrackingIntegrationTests.swift
@@ -9,14 +9,13 @@ class SentryAutoSessionTrackingIntegrationTests: XCTestCase {
         XCTAssertNotNil(Dynamic(sut).tracker.asAnyObject)
     }
     
-    func test_AutoSessionTrackingDisabled_RemovesEnabledIntegration() {
+    func test_AutoSessionTracking_Disabled() {
         let options = Options()
         options.enableAutoSessionTracking = false
         
         let sut = SentryAutoSessionTrackingIntegration()
-        sut.install(with: options)
+        let result = sut.install(with: options)
         
-        let expexted = Options.defaultIntegrations().filter { !$0.contains("AutoSession") }
-        assertArrayEquals(expected: expexted, actual: Array(options.enabledIntegrations))
+        XCTAssertFalse(result)
     }
 }

--- a/Tests/SentryTests/Protocol/SentryDebugMetaEquality.swift
+++ b/Tests/SentryTests/Protocol/SentryDebugMetaEquality.swift
@@ -5,8 +5,7 @@ extension DebugMeta {
         if  let other = object as? DebugMeta {
             return  uuid == other.uuid &&
                 type == other.type &&
-                name == other.name  &&
-                imageSize == other.imageSize &&
+                name == other.name && imageSize == other.imageSize &&
                 imageAddress == other.imageAddress &&
                 imageVmAddress == other.imageVmAddress
         } else {

--- a/Tests/SentryTests/Protocol/SentryThreadEquality.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadEquality.swift
@@ -6,8 +6,7 @@ extension Sentry.Thread {
             return  threadId == other.threadId &&
                 name == other.name &&
                 stacktrace == other.stacktrace &&
-                crashed == other.crashed  &&
-                current == other.current
+                crashed == other.crashed && current == other.current
         } else {
             return false
         }

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -106,8 +106,13 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(SentryLevel.debug, options?.diagnosticLevel)
         XCTAssertEqual(true, options?.attachStacktrace)
         XCTAssertEqual(true, options?.enableAutoSessionTracking)
-        
-        assertIntegrationsInstalled(integrations: options?.integrations ?? [])
+
+        assertIntegrationsInstalled(integrations: [
+            "SentryCrashIntegration",
+            "SentryAutoBreadcrumbTrackingIntegration",
+            "SentryAutoSessionTrackingIntegration",
+            "SentryNetworkTrackingIntegration"
+        ])
     }
     
     func testStartWithConfigureOptions_NoDsn() throws {
@@ -527,7 +532,7 @@ class SentrySDKTests: XCTestCase {
     private func assertIntegrationsInstalled(integrations: [String]) {
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {
-                XCTAssertTrue(SentrySDK.currentHub().isIntegrationInstalled(integrationClass))
+                XCTAssertTrue(SentrySDK.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")
             } else {
                 XCTFail("Integration \(integration) not installed.")
             }


### PR DESCRIPTION
## :scroll: Description

There is a lot of duplication in all the integration, in the `shouldBeDisabled` code. They all check a bunch of options, and the logging logic is all the same. They all need to remove the integration from the installed options as well. Now, everything is simplified with a base class, and we only have to give an array of integration options.

#skip-changelog

## :bulb: Motivation and Context

Closes #1696 

## :green_heart: How did you test it?

Added tests for `SentryBaseIntegration`. Made sure all the existing integration unit tests still pass. Ran the sample app and made sure all the integrations work as expected.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
