### PR TITLE
ref: Cleaning SentryHub getIntegration

### DIFF
--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -234,9 +234,9 @@ SENTRY_NO_INIT
 - (void)bindClient:(SentryClient *_Nullable)client;
 
 /**
- * Checks if integration is activated for bound client and returns it.
+ * Checks if integration is activated.
  */
-- (id _Nullable)getIntegration:(NSString *)integrationName;
+- (BOOL)hasIntegration:(NSString *)integrationName;
 
 /**
  * Checks if a specific Integration (`integrationClass`) has been installed.

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -147,7 +147,7 @@ SentryCrashIntegration ()
     // We need to make sure to set always the scope to KSCrash so we have it in
     // case of a crash
     NSString *integrationName = NSStringFromClass(SentryCrashIntegration.class);
-    if (nil != [SentrySDK.currentHub getIntegration:integrationName]) {
+    if ([SentrySDK.currentHub hasIntegration:integrationName]) {
 
         [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
             [SentryCrashIntegration enrichScope:outerScope crashWrapper:self.crashAdapter];

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -523,13 +523,10 @@ SentryHub ()
     return NO;
 }
 
-- (nullable id)getIntegration:(NSString *)integrationName
+- (BOOL)hasIntegration:(NSString *)integrationName
 {
     NSArray *integrations = _client.options.integrations;
-    if (![integrations containsObject:integrationName]) {
-        return nil;
-    }
-    return [integrations objectAtIndex:[integrations indexOfObject:integrationName]];
+    return [integrations containsObject:integrationName];
 }
 
 - (void)setUser:(nullable SentryUser *)user


### PR DESCRIPTION
Cleaning up `getIntegration` code from SentryHub

_#skip-changelog_ 