### PR TITLE
ci: disable automatic transactions in profile generator

### DIFF
--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -37,7 +37,9 @@ extension Tracer {
             options.enableCoreDataTracking = true
             options.profilesSampleRate = 1.0
             options.attachScreenshot = true
-            options.enableUserInteractionTracing = true
+            options.enableUserInteractionTracing = false
+            options.enableUIViewControllerTracking = false
+
         }
 
         SentrySDK.configureScope { scope in


### PR DESCRIPTION
This might be corrupting the profiles that we expect to be sent from the profile generation UI test.

#skip-changelog