### PR TITLE
feat: Attach view hierarchy to events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Report App Memory Usage (#2027)
 - Include app permissions with event (#1984)
 - Add culture context to event (#2036)
+- Attach view hierarchy to events (#2044)
 
 ## 7.23.0
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -27,6 +27,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.enableCoreDataTracking = true
             options.profilesSampleRate = 1.0
             options.attachScreenshot = true
+            options.attachViewHierarchy = true
 
             let isBenchmarking = ProcessInfo.processInfo.arguments.contains("--io.sentry.test.benchmarking")
             options.enableAutoPerformanceTracking = !isBenchmarking

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
 		0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */; };
 		0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */; };
+		0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */; };
+		0A9BF4EB28A127120068D266 /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4EA28A127120068D266 /* SentryViewHierarchyTests.swift */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
 		15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15360CD12432779F00112302 /* SentrySessionTracker.h */; };
@@ -734,6 +736,8 @@
 		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
 		0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyIntegration.m; sourceTree = "<group>"; };
 		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
+		0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryViewHierarchy.swift; sourceTree = "<group>"; };
+		0A9BF4EA28A127120068D266 /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
 		0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPermissionsObserver.m; sourceTree = "<group>"; };
 		0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryPermissionsObserver.h; path = include/SentryPermissionsObserver.h; sourceTree = "<group>"; };
 		0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryPermissionsObserver.swift; sourceTree = "<group>"; };
@@ -1474,6 +1478,15 @@
 				0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */,
 			);
 			name = ViewHierarchy;
+			sourceTree = "<group>";
+		};
+		0A9BF4E528A123070068D266 /* ViewHierarchy */ = {
+			isa = PBXGroup;
+			children = (
+				0A9BF4EA28A127120068D266 /* SentryViewHierarchyTests.swift */,
+				0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */,
+			);
+			path = ViewHierarchy;
 			sourceTree = "<group>";
 		};
 		630436001EBCB87500C4D3FA /* Networking */ = {
@@ -2235,6 +2248,7 @@
 			children = (
 				D808FB85281AB2EF009A2A33 /* UIEvents */,
 				D8AB40D92806EBDC00E5E9F7 /* Screenshot */,
+				0A9BF4E528A123070068D266 /* ViewHierarchy */,
 				7B2A70D627D5F06C008B0D15 /* ANR */,
 				7BE0DC3C272AE9C2004FA8B7 /* Breadcrumbs */,
 				7BE0DC3D272AE9CB004FA8B7 /* OutOfMemory */,
@@ -3389,6 +3403,7 @@
 				7B30B68026527C3C006B2752 /* SentryFramesTrackerTests.swift in Sources */,
 				7BC3937425B1ACB7004F03D3 /* SentryLevelMapperTests.swift in Sources */,
 				63FE720E20DA66EC00CDBAE8 /* SentryCrashCString_Tests.m in Sources */,
+				0A9BF4EB28A127120068D266 /* SentryViewHierarchyTests.swift in Sources */,
 				631501BB1EE6F30B00512C5B /* SentrySwizzleTests.m in Sources */,
 				15D0AC882459EE4D006541C2 /* SentryNSURLRequestTests.swift in Sources */,
 				7BE3C78724472E9800A38442 /* TestRequestManager.swift in Sources */,
@@ -3465,6 +3480,7 @@
 				7B58816727FC5D790098B121 /* SentryDiscardReasonMapperTests.swift in Sources */,
 				63FE720320DA66EC00CDBAE8 /* SentryCrashCPU_Tests.m in Sources */,
 				63FE721020DA66EC00CDBAE8 /* SentryCrashCachedData_Tests.m in Sources */,
+				0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */,
 				7BC6EC10255C3F560059822A /* SentryMechanismTests.swift in Sources */,
 				63FE721B20DA66EC00CDBAE8 /* Container+DeepSearch_Tests.m in Sources */,
 				8EA05EED267C2AB200C82B30 /* SentryNetworkTrackerTests.swift in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
 		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
+		0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */; };
+		0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
 		15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15360CD12432779F00112302 /* SentrySessionTracker.h */; };
@@ -730,6 +732,8 @@
 		0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSLocale+Sentry.h"; path = "include/NSLocale+Sentry.h"; sourceTree = "<group>"; };
 		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
 		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
+		0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyIntegration.m; sourceTree = "<group>"; };
+		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
 		0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPermissionsObserver.m; sourceTree = "<group>"; };
 		0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryPermissionsObserver.h; path = include/SentryPermissionsObserver.h; sourceTree = "<group>"; };
 		0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryPermissionsObserver.swift; sourceTree = "<group>"; };
@@ -1463,6 +1467,15 @@
 			path = Profiling;
 			sourceTree = "<group>";
 		};
+		0A9BF4E028A114690068D266 /* ViewHierarchy */ = {
+			isa = PBXGroup;
+			children = (
+				0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */,
+				0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */,
+			);
+			name = ViewHierarchy;
+			sourceTree = "<group>";
+		};
 		630436001EBCB87500C4D3FA /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -1690,6 +1703,7 @@
 				7BE0DC36272AE80A004FA8B7 /* Session */,
 				7BE0DC35272AE7BF004FA8B7 /* SentryCrash */,
 				D85596EF280580BE0041FF8B /* Screenshot */,
+				0A9BF4E028A114690068D266 /* ViewHierarchy */,
 				7D7F0A5E23DF3D2C00A4629C /* SentryGlobalEventProcessor.h */,
 				7DAC588E23D8B2E0001CF26B /* SentryGlobalEventProcessor.m */,
 				7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */,
@@ -2789,6 +2803,7 @@
 			files = (
 				03BCC38E27E2A377003232C7 /* SentryProfilingConditionals.h in Headers */,
 				8E133FA625E72EB400ABD0BF /* SentrySamplingContext.h in Headers */,
+				0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */,
 				8E4E7C7425DAAB49006AB9E2 /* SentrySpanProtocol.h in Headers */,
 				8EC4CF4A25C38DAA0093DEE9 /* SentrySpanStatus.h in Headers */,
 				8ECC673D25C23996000E2BF6 /* SentrySpanId.h in Headers */,
@@ -3232,6 +3247,7 @@
 				A2475E1B25FB63D7007D9080 /* SentryHook.c in Sources */,
 				63FE70D720DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.c in Sources */,
 				7B96572226830D2400C66E25 /* SentryScopeSyncC.c in Sources */,
+				0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */,
 				7BBD188B244841FB00427C76 /* SentryHttpDateParser.m in Sources */,
 				8E4E7C8225DAB2A5006AB9E2 /* SentryTracer.m in Sources */,
 				15E0A8E5240C457D00F044E3 /* SentryEnvelope.m in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		0A2690B72885C2E000E4432D /* TestSentryPermissionsObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */; };
 		0A2D8D9628997845008720F6 /* NSLocale+Sentry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D9428997845008720F6 /* NSLocale+Sentry.m */; };
 		0A2D8D9828997887008720F6 /* NSLocale+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */; };
+		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
+		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
@@ -720,6 +722,8 @@
 		0A1C3591287D7107007D01E3 /* SentryMetaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetaTests.swift; sourceTree = "<group>"; };
 		0A2D8D9428997845008720F6 /* NSLocale+Sentry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+Sentry.m"; sourceTree = "<group>"; };
 		0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSLocale+Sentry.h"; path = "include/NSLocale+Sentry.h"; sourceTree = "<group>"; };
+		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
+		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
 		0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPermissionsObserver.m; sourceTree = "<group>"; };
 		0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryPermissionsObserver.h; path = include/SentryPermissionsObserver.h; sourceTree = "<group>"; };
 		0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryPermissionsObserver.swift; sourceTree = "<group>"; };
@@ -2630,6 +2634,8 @@
 				D85852B827EDDC5900C6D8AE /* SentryUIApplication.m */,
 				D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */,
 				D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */,
+				0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */,
+				0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -2793,6 +2799,7 @@
 				7B6C5F8126034354007F7DFF /* SentryOutOfMemoryLogic.h in Headers */,
 				63FE708520DA4C1000CDBAE8 /* SentryCrashReportFilter.h in Headers */,
 				D8ACE3CD2762187D00F5A213 /* SentryNSDataSwizzling.h in Headers */,
+				0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */,
 				8EAE980C261E9F530073B6B3 /* SentryUIViewControllerPerformanceTracker.h in Headers */,
 				63FE717D20DA4C1100CDBAE8 /* SentryCrashCachedData.h in Headers */,
 				7BBC826D25DFCFDE005F1ED8 /* SentryInAppLogic.h in Headers */,
@@ -3283,6 +3290,7 @@
 				8E25C95325F836D000DC215B /* SentryRandom.m in Sources */,
 				7BC85231245812EC005A70F0 /* SentryFileContents.m in Sources */,
 				03F84D3527DD4191008FE43F /* SentryThreadHandle.cpp in Sources */,
+				0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */,
 				8EA1ED0B2668F8C400E62B98 /* SentryUIViewControllerSwizzling.m in Sources */,
 				7B98D7CF25FB650F00C5A389 /* SentryOutOfMemoryTrackingIntegration.m in Sources */,
 				8E5D38DD261D4A3E000D363D /* SentryPerformanceTrackingIntegration.m in Sources */,

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -202,8 +202,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachScreenshot;
 
 /**
- * Automatically attaches a textual representation of the view hierarchy when capturing an error or
- * exception.
+ * Automatically attaches a textual representation of the view hierarchy when capturing an event.
  *
  * Default value is <code>NO</code>
  */

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -209,7 +209,8 @@ NS_SWIFT_NAME(Options)
 /**
  * This feature is EXPERIMENTAL.
  *
- * Automatically attaches a textual representation of the view hierarchy when capturing an error event.
+ * Automatically attaches a textual representation of the view hierarchy when capturing an error
+ * event.
  *
  * Default value is <code>NO</code>
  */

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -207,7 +207,9 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachScreenshot;
 
 /**
- * Automatically attaches a textual representation of the view hierarchy when capturing an event.
+ * This feature is EXPERIMENTAL.
+ *
+ * Automatically attaches a textual representation of the view hierarchy when capturing an error event.
  *
  * Default value is <code>NO</code>
  */

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -202,6 +202,14 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachScreenshot;
 
 /**
+ * Automatically attaches a textual representation of the view hierarchy when capturing an error or
+ * exception.
+ *
+ * Default value is <code>NO</code>
+ */
+@property (nonatomic, assign) BOOL attachViewHierarchy;
+
+/**
  * This feature is EXPERIMENTAL.
  *
  * When enabled, the SDK creates transactions for UI events like buttons clicks, switch toggles,

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -134,6 +134,12 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+    if ((integrationOptions & kIntegrationOptionAttachViewHierarchy)
+        && !options.attachViewHierarchy) {
+        [self logWithOptionName:@"attachViewHierarchy"];
+        return NO;
+    }
+
     return YES;
 }
 

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -134,11 +134,13 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+#if SENTRY_HAS_UIKIT
     if ((integrationOptions & kIntegrationOptionAttachViewHierarchy)
         && !options.attachViewHierarchy) {
         [self logWithOptionName:@"attachViewHierarchy"];
         return NO;
     }
+#endif
 
     return YES;
 }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -42,6 +42,7 @@
 #import "SentryTransportFactory.h"
 #import "SentryUser.h"
 #import "SentryUserFeedback.h"
+#import "SentryViewHierarchy.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -521,6 +522,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     [self applyPermissionsToEvent:event];
     [self applyCultureContextToEvent:event];
 
+    [SentryViewHierarchy fetchViewHierarchy];
+
     // With scope applied, before running callbacks run:
     if (nil == event.environment) {
         // We default to environment 'production' if nothing was set
@@ -560,6 +563,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     return event;
+}
+
+- (void)viewHierachy
+{
+    NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
 }
 
 - (BOOL)isSampled:(NSNumber *)sampleRate

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -16,6 +16,7 @@
 #import <SentrySwizzleWrapper.h>
 #import <SentrySysctl.h>
 #import <SentryThreadWrapper.h>
+#import <SentryViewHierarchy.h>
 
 @implementation SentryDependencyContainer
 
@@ -129,6 +130,18 @@ static NSObject *sentryDependencyContainerLock;
         }
     }
     return _screenshot;
+}
+
+- (SentryViewHierarchy *)viewHierarchy
+{
+    if (_viewHierarchy == nil) {
+        @synchronized(sentryDependencyContainerLock) {
+            if (_viewHierarchy == nil) {
+                _viewHierarchy = [[SentryViewHierarchy alloc] init];
+            }
+        }
+    }
+    return _viewHierarchy;
 }
 
 - (SentryUIApplication *)application

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -26,7 +26,7 @@ SentryOptions ()
         @"SentryCrashIntegration",
 #if SENTRY_HAS_UIKIT
         @"SentryANRTrackingIntegration", @"SentryScreenshotIntegration",
-        @"SentryUIEventTrackingIntegration",
+        @"SentryUIEventTrackingIntegration", @"SentryViewHierarchyIntegration",
 #endif
         @"SentryFramesTrackingIntegration", @"SentryAutoBreadcrumbTrackingIntegration",
         @"SentryAutoSessionTrackingIntegration", @"SentryAppStartTrackingIntegration",

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -59,6 +59,7 @@ SentryOptions ()
 #if SENTRY_HAS_UIKIT
         self.enableUIViewControllerTracking = YES;
         self.attachScreenshot = NO;
+        self.attachViewHierarchy = NO;
         self.enableUserInteractionTracing = NO;
         self.idleTimeout = 3.0;
 #endif
@@ -243,6 +244,9 @@ SentryOptions ()
 
     [self setBool:options[@"attachScreenshot"]
             block:^(BOOL value) { self->_attachScreenshot = value; }];
+
+    [self setBool:options[@"attachViewHierarchy"]
+            block:^(BOOL value) { self->_attachViewHierarchy = value; }];
 
     [self setBool:options[@"enableUserInteractionTracing"]
             block:^(BOOL value) { self->_enableUserInteractionTracing = value; }];

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -71,8 +71,9 @@ saveScreenShot(const char *path)
 
     // We don't take screenshots if there is no exception/error.
     // We dont take screenshots if the event is a crash event.
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent)
+    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent) {
         return attachments;
+    }
 
     NSArray *screenshot = [SentryDependencyContainer.sharedInstance.screenshot appScreenshots];
 

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -1,12 +1,9 @@
 #import "SentryScreenshotIntegration.h"
 #import "SentryAttachment.h"
-#import "SentryClient+Private.h"
 #import "SentryCrashC.h"
 #import "SentryDependencyContainer.h"
 #import "SentryEvent+Private.h"
-#import "SentryEvent.h"
 #import "SentryHub+Private.h"
-#import "SentryLog.h"
 #import "SentrySDK+Private.h"
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -48,7 +48,7 @@ saveScreenShot(const char *path)
     }
 
     SentryClient *client = [SentrySDK.currentHub getClient];
-    client.attachmentProcessor = self;
+    [client addAttachmentProcessor:self];
 
     sentrycrash_setSaveScreenshots(&saveScreenShot);
 
@@ -63,6 +63,9 @@ saveScreenShot(const char *path)
 - (void)uninstall
 {
     sentrycrash_setSaveScreenshots(NULL);
+
+    SentryClient *client = [SentrySDK.currentHub getClient];
+    [client removeAttachmentProcessor:self];
 }
 
 - (NSArray<SentryAttachment *> *)processAttachments:(NSArray<SentryAttachment *> *)attachments

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -19,7 +19,12 @@ UIView (Debugging)
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:[windows count]];
 
     [windows enumerateObjectsUsingBlock:^(UIWindow *window, NSUInteger idx, BOOL *stop) {
-        [result addObject:[window recursiveDescription]];
+        if ([NSThread isMainThread]) {
+            [result addObject:[window recursiveDescription]];
+        } else {
+            dispatch_sync(
+                dispatch_get_main_queue(), ^{ [result addObject:[window recursiveDescription]]; });
+        }
     }];
 
     return result;

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -12,14 +12,17 @@ UIView (Debugging)
 
 @implementation SentryViewHierarchy
 
-+ (void)fetchViewHierarchy
++ (NSArray<NSString *> *)fetchViewHierarchy
 {
     NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
 
-    for (UIWindow *window in windows) {
-        NSString *description = [window recursiveDescription];
-        NSLog(@"%@", description);
-    }
+    NSMutableArray *result = [NSMutableArray arrayWithCapacity:[windows count]];
+
+    [windows enumerateObjectsUsingBlock:^(UIWindow *window, NSUInteger idx, BOOL *stop) {
+        [result addObject:[window recursiveDescription]];
+    }];
+
+    return result;
 }
 
 @end

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -12,7 +12,7 @@ UIView (Debugging)
 
 @implementation SentryViewHierarchy
 
-+ (NSArray<NSString *> *)fetchViewHierarchy
+- (NSArray<NSString *> *)fetchViewHierarchy
 {
     NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
 

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -1,0 +1,27 @@
+#import "SentryViewHierarchy.h"
+#import "SentryDependencyContainer.h"
+#import "SentryUIApplication.h"
+
+#if SENTRY_HAS_UIKIT
+#    import <UIKit/UIKit.h>
+
+@interface
+UIView (Debugging)
+- (id)recursiveDescription;
+@end
+
+@implementation SentryViewHierarchy
+
++ (void)fetchViewHierarchy
+{
+    NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
+
+    for (UIWindow *window in windows) {
+        NSString *description = [window recursiveDescription];
+        NSLog(@"%@", description);
+    }
+}
+
+@end
+
+#endif

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -1,0 +1,60 @@
+#import "SentryViewHierarchyIntegration.h"
+#import "SentryAttachment.h"
+#import "SentryClient+Private.h"
+#import "SentryCrashC.h"
+#import "SentryDependencyContainer.h"
+#import "SentryEvent+Private.h"
+#import "SentryEvent.h"
+#import "SentryHub+Private.h"
+#import "SentryLog.h"
+#import "SentrySDK+Private.h"
+#import "SentryViewHierarchy.h"
+
+#if SENTRY_HAS_UIKIT
+
+@implementation SentryViewHierarchyIntegration
+
+- (BOOL)installWithOptions:(nonnull SentryOptions *)options
+{
+    if (![super installWithOptions:options]) {
+        return NO;
+    }
+
+    SentryClient *client = [SentrySDK.currentHub getClient];
+    [client addAttachmentProcessor:self];
+
+    return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionAttachViewHierarchy;
+}
+
+- (void)uninstall
+{
+    SentryClient *client = [SentrySDK.currentHub getClient];
+    [client removeAttachmentProcessor:self];
+}
+
+- (NSArray<SentryAttachment *> *)processAttachments:(NSArray<SentryAttachment *> *)attachments
+                                           forEvent:(nonnull SentryEvent *)event
+{
+
+    NSArray *decriptions = [SentryViewHierarchy fetchViewHierarchy];
+    NSMutableArray *result =
+        [NSMutableArray arrayWithCapacity:attachments.count + decriptions.count];
+    [result addObjectsFromArray:attachments];
+
+    [decriptions enumerateObjectsUsingBlock:^(NSString *decription, NSUInteger idx, BOOL *stop) {
+        SentryAttachment *attachment = [[SentryAttachment alloc]
+            initWithData:[decription dataUsingEncoding:NSUTF8StringEncoding]
+                filename:[NSString stringWithFormat:@"view-hierarchy-%lu.txt", (unsigned long)idx]];
+        [result addObject:attachment];
+    }];
+
+    return result;
+}
+
+@end
+#endif

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -1,12 +1,7 @@
 #import "SentryViewHierarchyIntegration.h"
 #import "SentryAttachment.h"
-#import "SentryClient+Private.h"
-#import "SentryCrashC.h"
 #import "SentryDependencyContainer.h"
-#import "SentryEvent+Private.h"
-#import "SentryEvent.h"
 #import "SentryHub+Private.h"
-#import "SentryLog.h"
 #import "SentrySDK+Private.h"
 #import "SentryViewHierarchy.h"
 
@@ -41,7 +36,8 @@
                                            forEvent:(nonnull SentryEvent *)event
 {
 
-    NSArray *decriptions = [SentryViewHierarchy fetchViewHierarchy];
+    NSArray *decriptions =
+        [SentryDependencyContainer.sharedInstance.viewHierarchy fetchViewHierarchy];
     NSMutableArray *result =
         [NSMutableArray arrayWithCapacity:attachments.count + decriptions.count];
     [result addObjectsFromArray:attachments];

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -1,6 +1,7 @@
 #import "SentryViewHierarchyIntegration.h"
 #import "SentryAttachment.h"
 #import "SentryDependencyContainer.h"
+#import "SentryEvent+Private.h"
 #import "SentryHub+Private.h"
 #import "SentrySDK+Private.h"
 #import "SentryViewHierarchy.h"
@@ -35,6 +36,11 @@
 - (NSArray<SentryAttachment *> *)processAttachments:(NSArray<SentryAttachment *> *)attachments
                                            forEvent:(nonnull SentryEvent *)event
 {
+    // We don't attach the view hierarchy if there is no exception/error.
+    // We dont attach the view hierarchy if the event is a crash event.
+    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent) {
+        return attachments;
+    }
 
     NSArray *decriptions =
         [SentryDependencyContainer.sharedInstance.viewHierarchy fetchViewHierarchy];

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -20,6 +20,7 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
     kIntegrationOptionEnableAutoBreadcrumbTracking = 1 << 12,
     kIntegrationOptionIsTracingEnabled = 1 << 13,
     kIntegrationOptionDebuggerNotAttached = 1 << 14,
+    kIntegrationOptionAttachViewHierarchy = 1 << 15,
 };
 
 @interface SentryBaseIntegration : NSObject

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -18,7 +18,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryClient (Private)
 
-@property (nonatomic, weak) id<SentryClientAttachmentProcessor> attachmentProcessor;
+@property (nonatomic, strong)
+    NSMutableArray<id<SentryClientAttachmentProcessor>> *attachmentProcessors;
 @property (nonatomic, strong) SentryThreadInspector *threadInspector;
 
 - (SentryFileManager *)fileManager;
@@ -48,6 +49,9 @@ SentryClient (Private)
 - (void)storeEnvelope:(SentryEnvelope *)envelope;
 
 - (void)recordLostEvent:(SentryDataCategory)category reason:(SentryDiscardReason)reason;
+
+- (void)addAttachmentProcessor:(id<SentryClientAttachmentProcessor>)attachmentProcessor;
+- (void)removeAttachmentProcessor:(id<SentryClientAttachmentProcessor>)attachmentProcessor;
 
 @end
 

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -4,7 +4,7 @@
 #import <Foundation/Foundation.h>
 
 @class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper,
-    SentryDispatchQueueWrapper, SentryDebugImageProvider, SentryANRTracker;
+    SentryDispatchQueueWrapper, SentryDebugImageProvider, SentryANRTracker, SentryViewHierarchy;
 
 #if SENTRY_HAS_UIKIT
 @class SentryScreenshot, SentryUIApplication;
@@ -34,6 +34,7 @@ SENTRY_NO_INIT
 
 #if SENTRY_HAS_UIKIT
 @property (nonatomic, strong) SentryScreenshot *screenshot;
+@property (nonatomic, strong) SentryViewHierarchy *viewHierarchy;
 @property (nonatomic, strong) SentryUIApplication *application;
 #endif
 

--- a/Sources/Sentry/include/SentryViewHierarchy.h
+++ b/Sources/Sentry/include/SentryViewHierarchy.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryViewHierarchy : NSObject
 
-+ (void)fetchViewHierarchy;
++ (NSArray<NSString *> *)fetchViewHierarchy;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryViewHierarchy.h
+++ b/Sources/Sentry/include/SentryViewHierarchy.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryViewHierarchy : NSObject
 
-+ (NSArray<NSString *> *)fetchViewHierarchy;
+- (NSArray<NSString *> *)fetchViewHierarchy;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryViewHierarchy.h
+++ b/Sources/Sentry/include/SentryViewHierarchy.h
@@ -1,0 +1,14 @@
+#import "SentryDefines.h"
+#import <Foundation/Foundation.h>
+
+#if SENTRY_HAS_UIKIT
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryViewHierarchy : NSObject
+
++ (void)fetchViewHierarchy;
+@end
+
+NS_ASSUME_NONNULL_END
+#endif

--- a/Sources/Sentry/include/SentryViewHierarchyIntegration.h
+++ b/Sources/Sentry/include/SentryViewHierarchyIntegration.h
@@ -1,0 +1,16 @@
+#import "SentryBaseIntegration.h"
+#import "SentryClient+Private.h"
+#import "SentryIntegrationProtocol.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+#if SENTRY_HAS_UIKIT
+
+@interface SentryViewHierarchyIntegration
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentryClientAttachmentProcessor>
+
+@end
+
+#endif
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -35,21 +35,21 @@ class SentryScreenshotIntegrationTests: XCTestCase {
 
     func test_attachScreenshot_disabled() {
         SentrySDK.start { $0.attachScreenshot = false }
-        XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessor)
+        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
         XCTAssertFalse(sentrycrash_hasSaveScreenshotCallback())
     }
     
     func test_attachScreenshot_enabled() {
         SentrySDK.start { $0.attachScreenshot = true }
-        XCTAssertNotNil(SentrySDK.currentHub().getClient()?.attachmentProcessor)
+        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
         XCTAssertTrue(sentrycrash_hasSaveScreenshotCallback())
     }
     
-    func test_unistall() {
+    func test_uninstall() {
         SentrySDK.start { $0.attachScreenshot = true }
         SentrySDK.close()
         
-        XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessor)
+        XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
         XCTAssertFalse(sentrycrash_hasSaveScreenshotCallback())
     }
     

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
@@ -1,0 +1,72 @@
+import Sentry
+import XCTest
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+class SentryViewHierarchyTests: XCTestCase {
+
+    private class Fixture {
+        let viewHierarchy: TestSentryViewHierarchy
+
+        init() {
+            let testViewHierarchy = TestSentryViewHierarchy()
+            testViewHierarchy.result = ["view hierarchy"]
+            viewHierarchy = testViewHierarchy
+        }
+
+        func getSut() -> SentryViewHierarchyIntegration {
+            let result = SentryViewHierarchyIntegration()
+            return result
+        }
+    }
+
+    private var fixture: Fixture!
+
+    override func setUp() {
+        super.setUp()
+        fixture = Fixture()
+
+        SentryDependencyContainer.sharedInstance().viewHierarchy = fixture.viewHierarchy
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        clearTestState()
+    }
+
+    func test_attachViewHierarchy_disabled() {
+        SentrySDK.start { $0.attachViewHierarchy = false }
+        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
+    }
+
+    func test_attachViewHierarchy_enabled() {
+        SentrySDK.start { $0.attachViewHierarchy = true }
+        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
+    }
+
+    func test_uninstall() {
+        SentrySDK.start { $0.attachViewHierarchy = true }
+        SentrySDK.close()
+        XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
+    }
+
+    func test_attachments() {
+        let sut = fixture.getSut()
+        let event = Event(error: NSError(domain: "", code: -1))
+        fixture.viewHierarchy.result = ["view hierarchy for window zero", "view hierarchy for window one"]
+
+        let newAttachmentList = sut.processAttachments([], for: event) ?? []
+
+        XCTAssertEqual(newAttachmentList.count, 2)
+        XCTAssertEqual(newAttachmentList[0].filename, "view-hierarchy-0.txt")
+        XCTAssertEqual(newAttachmentList[1].filename, "view-hierarchy-1.txt")
+
+        XCTAssertEqual(newAttachmentList[0].contentType, "application/octet-stream")
+        XCTAssertEqual(newAttachmentList[1].contentType, "application/octet-stream")
+
+        XCTAssertEqual(newAttachmentList[0].data?.count, "view hierarchy for window zero".lengthOfBytes(using: .utf8))
+        XCTAssertEqual(newAttachmentList[1].data?.count, "view hierarchy for window one".lengthOfBytes(using: .utf8))
+
+    }
+
+}
+#endif

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
@@ -49,6 +49,37 @@ class SentryViewHierarchyTests: XCTestCase {
         XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
     }
 
+    func test_noViewHierarchy_attachment() {
+        let sut = fixture.getSut()
+        let event = Event()
+
+        let newAttachmentList = sut.processAttachments([], for: event)
+
+        XCTAssertEqual(newAttachmentList?.count, 0)
+    }
+
+    func test_noViewHierarchy_CrashEvent() {
+        let sut = fixture.getSut()
+        let event = Event(error: NSError(domain: "", code: -1))
+        event.isCrashEvent = true
+
+        let newAttachmentList = sut.processAttachments([], for: event)
+
+        XCTAssertEqual(newAttachmentList?.count, 0)
+    }
+
+    func test_noViewHierarchy_keepAttachment() {
+        let sut = fixture.getSut()
+        let event = Event()
+
+        let attachment = Attachment(data: Data(), filename: "Some Attachment")
+
+        let newAttachmentList = sut.processAttachments([attachment], for: event)
+
+        XCTAssertEqual(newAttachmentList?.count, 1)
+        XCTAssertEqual(newAttachmentList?.first, attachment)
+    }
+
     func test_attachments() {
         let sut = fixture.getSut()
         let event = Event(error: NSError(domain: "", code: -1))

--- a/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchy.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchy.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+class TestSentryViewHierarchy: SentryViewHierarchy {
+
+    var result: [String] = []
+
+    override func fetch() -> [String] {
+        return result
+    }
+}
+#endif

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -264,7 +264,7 @@ class SentryClientTest: XCTestCase {
             return result
         }
         
-        sut.attachmentProcessor = processor
+        sut.add(processor)
         sut.capture(event: event)
         
         let sendedAttachments = fixture.transportAdapter.sendEventWithTraceStateInvocations.first?.attachments ?? []
@@ -285,7 +285,7 @@ class SentryClientTest: XCTestCase {
             return result
         }
         
-        sut.attachmentProcessor = processor
+        sut.add(processor)
         sut.captureError(error, with: fixture.session, with: Scope())
         
         let sentAttachments = fixture.transportAdapter.sentEventsWithSessionTraceState.first?.attachments ?? []
@@ -305,7 +305,7 @@ class SentryClientTest: XCTestCase {
             return result
         }
         
-        sut.attachmentProcessor = processor
+        sut.add(processor)
         sut.captureError(error, with: SentrySession(releaseName: ""), with: Scope())
         
         let sendedAttachments = fixture.transportAdapter.sendEventWithTraceStateInvocations.first?.attachments ?? []

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -156,6 +156,8 @@
 #import "SentryUIViewControllerSwizzling+Test.h"
 #import "SentryUIViewControllerSwizzling.h"
 #import "SentryUserFeedback.h"
+#import "SentryViewHierarchy.h"
+#import "SentryViewHierarchyIntegration.h"
 #import "TestNSURLRequestBuilder.h"
 #import "TestSentryCrashWrapper.h"
 #import "TestSentrySpan.h"


### PR DESCRIPTION
## :scroll: Description

All errors and exceptions can now get the full window's view hierarchy added as attachments. This is controlled by a new option `attachViewHierarchy` which I defaulted to false.

![Screen Shot 2022-08-08 at 13 25 33](https://user-images.githubusercontent.com/229384/183407602-22afbac2-a225-4279-9bb8-54bc5074d371.png)

![Screen Shot 2022-08-08 at 13 26 09](https://user-images.githubusercontent.com/229384/183407671-30e00268-7e43-4248-9eb3-973c53bde30e.png)

## :bulb: Motivation and Context

Closes #1772

## :green_heart: How did you test it?

Manual, and unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
