### PR TITLE
ci: skip steps that have cached results

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -118,8 +118,7 @@ jobs:
         id: cache_gems
         with:
           path: vendor/bundle
-          key: >-
-            ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
+          key: home-assistant-integration-gems-${{ runner.os }}-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
 
       - name: Install Gems
         if: steps.cache_gems.outputs.cache-hit != 'true'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,7 +122,9 @@ jobs:
 
       - name: Install Gems
         if: steps.cache_gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3 --path vendor/bundle
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle install --jobs 4 --retry 3
 
       - name: Install Pods Release
         if: steps.cache_pods.outputs.cache-hit != 'true'
@@ -130,7 +132,9 @@ jobs:
 
       - name: Run tests
       # Run the tests twice in case they are flaky.
-        run: for i in {1..2}; do bundle exec fastlane test && break ; done
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          for i in {1..2}; do bundle exec fastlane test && break ; done
 
   # We borrow the tests of VLC iOS under the GPLv2 (or later) and the MPLv2: https://github.com/videolan/vlc-ios
   # The following steps checkout VLC and apply a github patch to the project. The patch adds

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Install Gems
         if: steps.cache_gems.outputs.cache-hit != 'true'
-        run: bundle install --jobs 4 --retry 3
+        run: bundle install --jobs 4 --retry 3 --path vendor/bundle
 
       - name: Install Pods Release
         if: steps.cache_pods.outputs.cache-hit != 'true'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -128,7 +128,9 @@ jobs:
 
       - name: Install Pods Release
         if: steps.cache_pods.outputs.cache-hit != 'true'
-        run: bundle exec pod install --repo-update
+        run: |
+          bundle config set --local path 'vendor/bundle'
+          bundle exec pod install --repo-update
 
       - name: Run tests
       # Run the tests twice in case they are flaky.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -110,7 +110,7 @@ jobs:
             Tools/MaterialDesignIcons.ttf
             Tools/MaterialDesignIcons.json
           key: >-
-            ${{ runner.os }}-pods-xcode-13.2
+            home-assistant-tests-${{ runner.os }}-pods-xcode-13.2
             ${{ hashFiles('**/Gemfile.lock', '**/Podfile.lock', 'Tools/BuildMaterialDesignIconsFont.sh') }}
 
       - uses: actions/cache@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -102,23 +102,23 @@ jobs:
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-homekit
 
       - uses: actions/cache@v3
-        name: "Cache: Pods"
-        id: cache_pods
-        with:
-          path: |
-            Pods
-            Tools/MaterialDesignIcons.ttf
-            Tools/MaterialDesignIcons.json
-          key: >-
-            home-assistant-tests-${{ runner.os }}-pods-xcode-13.2
-            ${{ hashFiles('**/Gemfile.lock', '**/Podfile.lock', 'Tools/BuildMaterialDesignIconsFont.sh') }}
-
-      - uses: actions/cache@v3
         name: "Cache: Gems"
         id: cache_gems
         with:
           path: vendor/bundle
           key: home-assistant-integration-gems-${{ runner.os }}-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
+
+      - uses: actions/cache@v3
+        name: "Cache: Pods"
+        id: cache_pods
+        if: steps.cache_gems.outputs.cache-hit == 'true'
+        with:
+          path: |
+            Pods
+            Podfile
+            Podfile.lock
+            Tools/**
+          key: home-assistant-tests-pods-${{ runner.os }}-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('Podfile', '**/Podfile.lock', 'Tools/**') }}
 
       - name: Install Gems
         if: steps.cache_gems.outputs.cache-hit != 'true'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,9 +122,11 @@ jobs:
             ${{ runner.os }}-gems-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
 
       - name: Install Gems
+        if: steps.cache_gems.outputs.cache-hit != 'true'
         run: bundle install --jobs 4 --retry 3
 
       - name: Install Pods Release
+        if: steps.cache_pods.outputs.cache-hit != 'true'
         run: bundle exec pod install --repo-update
 
       - name: Run tests
@@ -162,12 +164,14 @@ jobs:
 
       - uses: actions/cache@v3
         name: "Cache: Pods"
+        id: cache-pods
         with:
           path: Pods
           key: >-
             ${{ runner.os }}-pods-${{ hashFiles('**/Podfile.lock') }}
 
       - name: Install Pods
+        if: steps.cache_pods.outputs.cache-hit != 'true'
         run: pod install
 
       - name: Run UI Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
+    name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}} - runs on ${{ matrix.runs-on }}
     runs-on: ${{matrix.runs-on}}
     timeout-minutes: 20
     

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
       # xcode-test.sh
       - name: Cache for Test Server
         id: test_server_cache
-        if: ${{ matrix.runs-on == 'macos-11' }}
+        if: ${{ matrix.runs-on }} == 'macos-11'
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on == 'macos-11' }}
+        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on }} == 'macos-11'
         run: swift build
         working-directory: test-server
 
       - name: Run Test Server in Background
-        if: ${{ matrix.runs-on == 'macos-11' }}
+        if: ${{ matrix.runs-on }} == 'macos-11'
         run: swift run &
         working-directory: test-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
       # xcode-test.sh
       - name: Cache for Test Server
         id: test_server_cache
-        if: ${{ matrix.runs-on }} == 'macos-11'
+        if: matrix.runs-on == 'macos-11'
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on }} == 'macos-11'
+        if: steps.cache_test_server.outputs.cache-hit != 'true' && matrix.runs-on == 'macos-11'
         run: swift build
         working-directory: test-server
 
       - name: Run Test Server in Background
-        if: ${{ matrix.runs-on }} == 'macos-11'
+        if: matrix.runs-on == 'macos-11'
         run: swift run &
         working-directory: test-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
       # xcode-test.sh
       - name: Cache for Test Server
         id: test_server_cache
-        if: ${{ matrix.runs-on }} == 'macos-11'
+        if: ${{ matrix.runs-on }} == macos-11
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on }} == 'macos-11'
+        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on }} == macos-11
         run: swift build
         working-directory: test-server
 
       - name: Run Test Server in Background
-        if: ${{ matrix.runs-on }} == 'macos-11'
+        if: ${{ matrix.runs-on }} == macos-11
         run: swift run &
         working-directory: test-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   unit-tests:
-    name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}} - runs on ${{ matrix.runs-on }}
+    name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
     runs-on: ${{matrix.runs-on}}
     timeout-minutes: 20
     
@@ -61,19 +61,19 @@ jobs:
       # xcode-test.sh
       - name: Cache for Test Server
         id: test_server_cache
-        if: ${{ matrix.runs-on }} == macos-11
+        if: ${{ matrix.runs-on == 'macos-11' }}
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on }} == macos-11
+        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on == 'macos-11' }}
         run: swift build
         working-directory: test-server
 
       - name: Run Test Server in Background
-        if: ${{ matrix.runs-on }} == macos-11
+        if: ${{ matrix.runs-on == 'macos-11' }}
         run: swift run &
         working-directory: test-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
       # xcode-test.sh
       - name: Cache for Test Server
         id: test_server_cache
-        if: ${{ matrix.runs-on == 'macos-11'}}  
+        if: ${{ matrix.runs-on == 'macos-11'}}
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true'
+        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on == 'macos-11'}}
         run: swift build
         working-directory: test-server
 
       - name: Run Test Server in Background
-        if: ${{ matrix.runs-on == 'macos-11'}}  
+        if: ${{ matrix.runs-on == 'macos-11'}}
         run: swift run &
         working-directory: test-server
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
 
       - name: Build Test Server
         if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on == 'macos-11'}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,17 +60,21 @@ jobs:
       # macos-10.15. For now, disable the tests on iOS 12 requiring the test server in
       # xcode-test.sh
       - name: Cache for Test Server
+        id: test_server_cache
         if: ${{ matrix.runs-on == 'macos-11'}}  
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
+      - name: Build Test Server
+        if: steps.cache_test_server.outputs.cache-hit != 'true'
+        run: swift build
+        working-directory: test-server
+
       - name: Run Test Server in Background
         if: ${{ matrix.runs-on == 'macos-11'}}  
-        run: | 
-          swift build
-          swift run &
+        run: swift run &
         working-directory: test-server
 
       # Select Xcode after starting server, because the server needs Xcode 13
@@ -140,11 +144,13 @@ jobs:
 
       - name: Cache for Test Server
         uses: actions/cache@v3
+        id: cache_test_server
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
       - run: swift build
+        if: steps.cache_test_server.outputs.cache-hit != 'true'
         working-directory: test-server
 
       - name: Run Test Server in Background

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,19 +61,19 @@ jobs:
       # xcode-test.sh
       - name: Cache for Test Server
         id: test_server_cache
-        if: ${{ matrix.runs-on == 'macos-11'}}
+        if: ${{ matrix.runs-on }} == 'macos-11'
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on == 'macos-11'}}
+        if: steps.cache_test_server.outputs.cache-hit != 'true' && ${{ matrix.runs-on }} == 'macos-11'
         run: swift build
         working-directory: test-server
 
       - name: Run Test Server in Background
-        if: ${{ matrix.runs-on == 'macos-11'}}
+        if: ${{ matrix.runs-on }} == 'macos-11'
         run: swift run &
         working-directory: test-server
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -336,9 +336,6 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign, readonly) BOOL isProfilingEnabled;
 
-/** A code change to force a re-run of all CI jobs, to test that the job step caching works. */
-@property (nonatomic, assign, readonly) BOOL DONOTMERGE;
-
 /**
  * DEPRECATED: Use `profilesSampleRate` instead. Setting `enableProfiling` to YES is the equivalent
  * of setting `profilesSampleRate` to `1.0`. If `profilesSampleRate` is set, it will take precedence

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -336,6 +336,9 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign, readonly) BOOL isProfilingEnabled;
 
+/** A code change to force a re-run of all CI jobs, to test that the job step caching works. */
+@property (nonatomic, assign, readonly) BOOL DONOTMERGE;
+
 /**
  * DEPRECATED: Use `profilesSampleRate` instead. Setting `enableProfiling` to YES is the equivalent
  * of setting `profilesSampleRate` to `1.0`. If `profilesSampleRate` is set, it will take precedence


### PR DESCRIPTION
We have some jobs that attempt to cache results of some steps, but never actual skip the job if there's a cache hit. Here's how much time we save by skipping the work:

- integration tests
    - home assistant
        - gem install: 30s
        - pod install: 75s
    - vlc pods: 60s
- unit tests
    - test-server build: 120s (x 11 platforms/variants)

= 24.75 minutes per PR (with a full test suite run)

Also `test-server` is not supposed to run on non-macOS-11 jobs, but the condition to skip it was malformed so it would still run. This didn't seem to break on master, but broke on this branch without changing the condition. In any case, the new form works, so I think we should stick with it.

#skip-changelog

