### PR TITLE
feat: include "partial" app permissions

### DIFF
--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -111,6 +111,7 @@ typedef NS_ENUM(NSUInteger, SentryLevel) {
 typedef NS_ENUM(NSInteger, SentryPermissionStatus) {
     kSentryPermissionStatusUnknown = 0,
     kSentryPermissionStatusGranted,
+    kSentryPermissionStatusPartial,
     kSentryPermissionStatusDenied
 };
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -699,6 +699,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return @"granted";
         break;
 
+    case kSentryPermissionStatusPartial:
+        return @"partial";
+        break;
+
     case kSentryPermissionStatusDenied:
         return @"not_granted";
         break;

--- a/Sources/Sentry/SentryPermissionsObserver.m
+++ b/Sources/Sentry/SentryPermissionsObserver.m
@@ -84,11 +84,15 @@ SentryPermissionsObserver () <CLLocationManagerDelegate>
     case MPMediaLibraryAuthorizationStatusNotDetermined:
         self.mediaLibraryPermissionStatus = kSentryPermissionStatusUnknown;
         break;
+
     case MPMediaLibraryAuthorizationStatusDenied:
         self.mediaLibraryPermissionStatus = kSentryPermissionStatusDenied;
         break;
-    case MPMediaLibraryAuthorizationStatusRestricted: // The app may access some of the content in
-                                                      // the user's media library.
+
+    case MPMediaLibraryAuthorizationStatusRestricted:
+        self.mediaLibraryPermissionStatus = kSentryPermissionStatusPartial;
+        break;
+
     case MPMediaLibraryAuthorizationStatusAuthorized:
         self.mediaLibraryPermissionStatus = kSentryPermissionStatusGranted;
         break;
@@ -104,12 +108,16 @@ SentryPermissionsObserver () <CLLocationManagerDelegate>
     case PHAuthorizationStatusNotDetermined:
         self.photoLibraryPermissionStatus = kSentryPermissionStatusUnknown;
         break;
+
     case PHAuthorizationStatusDenied:
-    case PHAuthorizationStatusRestricted: // The app isn’t authorized to access the photo library,
-                                          // and the user can’t grant such permission.
+    case PHAuthorizationStatusRestricted:
         self.photoLibraryPermissionStatus = kSentryPermissionStatusDenied;
         break;
+
     case PHAuthorizationStatusLimited:
+        self.photoLibraryPermissionStatus = kSentryPermissionStatusPartial;
+        break;
+
     case PHAuthorizationStatusAuthorized:
         self.photoLibraryPermissionStatus = kSentryPermissionStatusGranted;
         break;
@@ -128,13 +136,16 @@ SentryPermissionsObserver () <CLLocationManagerDelegate>
         break;
 
     case UNAuthorizationStatusAuthorized:
-    case UNAuthorizationStatusProvisional:
         self.pushPermissionStatus = kSentryPermissionStatusGranted;
+        break;
+
+    case UNAuthorizationStatusProvisional:
+        self.pushPermissionStatus = kSentryPermissionStatusPartial;
         break;
 
 #    if TARGET_OS_IOS
     case UNAuthorizationStatusEphemeral:
-        self.pushPermissionStatus = kSentryPermissionStatusGranted;
+        self.pushPermissionStatus = kSentryPermissionStatusPartial;
         break;
 #    endif
     }
@@ -159,7 +170,7 @@ SentryPermissionsObserver () <CLLocationManagerDelegate>
 
 #if !TARGET_OS_OSX
     case kCLAuthorizationStatusAuthorizedWhenInUse:
-        self.locationPermissionStatus = kSentryPermissionStatusGranted;
+        self.locationPermissionStatus = kSentryPermissionStatusPartial;
         break;
 #endif
     }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -543,8 +543,8 @@ class SentryClientTest: XCTestCase {
     func testCaptureCrash_Permissions() {
         fixture.permissionsObserver.internalLocationPermissionStatus = SentryPermissionStatus.granted
         fixture.permissionsObserver.internalPushPermissionStatus = SentryPermissionStatus.granted
-        fixture.permissionsObserver.internalMediaLibraryPermissionStatus = SentryPermissionStatus.granted
-        fixture.permissionsObserver.internalPhotoLibraryPermissionStatus = SentryPermissionStatus.granted
+        fixture.permissionsObserver.internalMediaLibraryPermissionStatus = SentryPermissionStatus.denied
+        fixture.permissionsObserver.internalPhotoLibraryPermissionStatus = SentryPermissionStatus.partial
 
         let event = TestData.event
         event.threads = nil
@@ -556,8 +556,8 @@ class SentryClientTest: XCTestCase {
             let permissions = actual.context?["app"]?["permissions"] as? [String: String]
             XCTAssertEqual(permissions?["push_notifications"], "granted")
             XCTAssertEqual(permissions?["location_access"], "granted")
-            XCTAssertEqual(permissions?["media_library"], "granted")
-            XCTAssertEqual(permissions?["photo_library"], "granted")
+            XCTAssertEqual(permissions?["media_library"], "not_granted")
+            XCTAssertEqual(permissions?["photo_library"], "partial")
         }
     }
 


### PR DESCRIPTION
## :scroll: Description

While reading https://github.com/getsentry/team-mobile/issues/6 I noticed that the spec supports "partial" app permissions. This is great, and the SDK now uses this as well.

#skip-changelog, as this is part of the same release that includes #1984.

## :bulb: Motivation and Context

This is a follow-up of https://github.com/getsentry/sentry-cocoa/pull/1984. See https://github.com/getsentry/team-mobile/issues/6.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
