### PR TITLE
feat: Clean up SentryOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Report App Memory Usage (#2027)
 - Include app permissions with event (#1984)
 - Add culture context to event (#2036)
-- Clean up SentryOptions (#2049)
+- Clean up SentryOptions: added `enableCrashHandler` and deprecated `integrations` (#2049)
 
 ## 7.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Report App Memory Usage (#2027)
 - Include app permissions with event (#1984)
 - Add culture context to event (#2036)
+- Clean up SentryOptions (#2049)
 
 ## 7.23.0
 

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -38,11 +38,6 @@ SENTRY_NO_INIT
  */
 - (void)endSessionWithTimestamp:(NSDate *)timestamp;
 
-@property (nonatomic, strong)
-    NSMutableArray<NSObject<SentryIntegrationProtocol> *> *installedIntegrations;
-
-@property (nonatomic, strong) NSMutableArray<NSString *> *installedIntegrationNames;
-
 /**
  * Captures a manually created event and sends it to Sentry.
  *

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -41,6 +41,8 @@ SENTRY_NO_INIT
 @property (nonatomic, strong)
     NSMutableArray<NSObject<SentryIntegrationProtocol> *> *installedIntegrations;
 
+@property (nonatomic, strong) NSMutableArray<NSString *> *installedIntegrationNames;
+
 /**
  * Captures a manually created event and sends it to Sentry.
  *

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -107,14 +107,12 @@ NS_SWIFT_NAME(Options)
 /**
  * Array of integrations to install.
  */
-@property (nullable, nonatomic, copy) NSArray<NSString *> *integrations DEPRECATED_MSG_ATTRIBUTE(
-    "This property will be removed in a future version of the SDK");
+@property (nullable, nonatomic, copy) NSArray<NSString *> *integrations;
 
 /**
  * Array of default integrations. Will be used if integrations are nil
  */
-+ (NSArray<NSString *> *)defaultIntegrations DEPRECATED_MSG_ATTRIBUTE(
-    "This property will be removed in a future version of the SDK");
++ (NSArray<NSString *> *)defaultIntegrations;
 
 /**
  * Indicates the percentage of events being sent to Sentry. Setting this to 0 discards all

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -60,6 +60,11 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enabled;
 
 /**
+ * When enabled, the SDK sends crashes to Sentry. Default value is YES.
+ */
+@property (nonatomic, assign) BOOL enableCrashHandler;
+
+/**
  * How many breadcrumbs do you want to keep in memory?
  * Default is 100.
  */
@@ -102,12 +107,14 @@ NS_SWIFT_NAME(Options)
 /**
  * Array of integrations to install.
  */
-@property (nullable, nonatomic, copy) NSArray<NSString *> *integrations;
+@property (nullable, nonatomic, copy) NSArray<NSString *> *integrations DEPRECATED_MSG_ATTRIBUTE(
+    "This property will be removed in a future version of the SDK");
 
 /**
  * Array of default integrations. Will be used if integrations are nil
  */
-+ (NSArray<NSString *> *)defaultIntegrations;
++ (NSArray<NSString *> *)defaultIntegrations DEPRECATED_MSG_ATTRIBUTE(
+    "This property will be removed in a future version of the SDK");
 
 /**
  * Indicates the percentage of events being sent to Sentry. Setting this to 0 discards all

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -134,6 +134,12 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+    if ((integrationOptions & kIntegrationOptionEnableCrashHandler)
+        && !options.enableCrashHandler) {
+        [self logWithOptionName:@"enableCrashHandler"];
+        return NO;
+    }
+
     return YES;
 }
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -17,6 +17,7 @@
 #import "SentryException.h"
 #import "SentryFileManager.h"
 #import "SentryGlobalEventProcessor.h"
+#import "SentryHub+Private.h"
 #import "SentryHub.h"
 #import "SentryId.h"
 #import "SentryInAppLogic.h"

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -17,6 +17,7 @@
 #import "SentryException.h"
 #import "SentryFileManager.h"
 #import "SentryGlobalEventProcessor.h"
+#import "SentryHub.h"
 #import "SentryId.h"
 #import "SentryInAppLogic.h"
 #import "SentryInstallation.h"
@@ -607,7 +608,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     id integrations = event.extra[@"__sentry_sdk_integrations"];
     if (!integrations) {
         integrations = [NSMutableArray new];
-        for (NSString *integration in self.options.enabledIntegrations) {
+        for (NSString *integration in SentrySDK.currentHub.installedIntegrationNames) {
             // Every integration starts with "Sentry" and ends with "Integration". To keep the
             // payload of the event small we remove both.
             NSString *withoutSentry = [integration stringByReplacingOccurrencesOfString:@"Sentry"

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -62,6 +62,10 @@ SentryCrashIntegration ()
 
 - (BOOL)installWithOptions:(nonnull SentryOptions *)options
 {
+    if (![super installWithOptions:options]) {
+        return NO;
+    }
+
     self.options = options;
 
     SentryAppStateManager *appStateManager =
@@ -86,6 +90,11 @@ SentryCrashIntegration ()
     [self configureScope];
 
     return YES;
+}
+
+- (SentryIntegrationOption)integrationOptions
+{
+    return kIntegrationOptionEnableCrashHandler;
 }
 
 - (void)startCrashHandler

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -157,28 +157,24 @@ SentryCrashIntegration ()
 {
     // We need to make sure to set always the scope to KSCrash so we have it in
     // case of a crash
-    NSString *integrationName = NSStringFromClass(SentryCrashIntegration.class);
-    if ([SentrySDK.currentHub hasIntegration:integrationName]) {
+    [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
+        [SentryCrashIntegration enrichScope:outerScope crashWrapper:self.crashAdapter];
 
-        [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
-            [SentryCrashIntegration enrichScope:outerScope crashWrapper:self.crashAdapter];
+        NSMutableDictionary<NSString *, id> *userInfo =
+            [[NSMutableDictionary alloc] initWithDictionary:[outerScope serialize]];
+        // SentryCrashReportConverter.convertReportToEvent needs the release name and
+        // the dist of the SentryOptions in the UserInfo. When SentryCrash records a
+        // crash it writes the UserInfo into SentryCrashField_User of the report.
+        // SentryCrashReportConverter.initWithReport loads the contents of
+        // SentryCrashField_User into self.userContext and convertReportToEvent can map
+        // the release name and dist to the SentryEvent. Fixes GH-581
+        userInfo[@"release"] = self.options.releaseName;
+        userInfo[@"dist"] = self.options.dist;
 
-            NSMutableDictionary<NSString *, id> *userInfo =
-                [[NSMutableDictionary alloc] initWithDictionary:[outerScope serialize]];
-            // SentryCrashReportConverter.convertReportToEvent needs the release name and
-            // the dist of the SentryOptions in the UserInfo. When SentryCrash records a
-            // crash it writes the UserInfo into SentryCrashField_User of the report.
-            // SentryCrashReportConverter.initWithReport loads the contents of
-            // SentryCrashField_User into self.userContext and convertReportToEvent can map
-            // the release name and dist to the SentryEvent. Fixes GH-581
-            userInfo[@"release"] = self.options.releaseName;
-            userInfo[@"dist"] = self.options.dist;
+        [SentryCrash.sharedInstance setUserInfo:userInfo];
 
-            [SentryCrash.sharedInstance setUserInfo:userInfo];
-
-            [outerScope addObserver:self.scopeObserver];
-        }];
-    }
+        [outerScope addObserver:self.scopeObserver];
+    }];
 
     [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(currentLocaleDidChange)

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -46,6 +46,7 @@ SentryHub ()
         _scope = scope;
         _sessionLock = [[NSObject alloc] init];
         _installedIntegrations = [[NSMutableArray alloc] init];
+        _installedIntegrationNames = [[NSMutableArray alloc] init];
         _crashWrapper = [SentryCrashWrapper sharedInstance];
         _tracesSampler = [[SentryTracesSampler alloc] initWithOptions:client.options];
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -525,7 +526,7 @@ SentryHub ()
 
 - (BOOL)hasIntegration:(NSString *)integrationName
 {
-    NSArray *integrations = _client.options.integrations;
+    NSArray *integrations = SentrySDK.currentHub.installedIntegrationNames;
     return [integrations containsObject:integrationName];
 }
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -31,6 +31,9 @@ SentryHub ()
 @property (nonatomic, strong) SentryTracesSampler *tracesSampler;
 @property (nonatomic, strong) SentryProfilesSampler *profilesSampler;
 @property (nonatomic, strong) id<SentryCurrentDateProvider> currentDateProvider;
+@property (nonatomic, strong)
+    NSMutableArray<NSObject<SentryIntegrationProtocol> *> *installedIntegrations;
+@property (nonatomic, strong) NSMutableArray<NSString *> *installedIntegrationNames;
 
 @end
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -516,7 +516,7 @@ SentryHub ()
  */
 - (BOOL)isIntegrationInstalled:(Class)integrationClass
 {
-    for (id<SentryIntegrationProtocol> item in SentrySDK.currentHub.installedIntegrations) {
+    for (id<SentryIntegrationProtocol> item in self.installedIntegrations) {
         if ([item isKindOfClass:integrationClass]) {
             return YES;
         }
@@ -526,8 +526,7 @@ SentryHub ()
 
 - (BOOL)hasIntegration:(NSString *)integrationName
 {
-    NSArray *integrations = SentrySDK.currentHub.installedIntegrationNames;
-    return [integrations containsObject:integrationName];
+    return [self.installedIntegrationNames containsObject:integrationName];
 }
 
 - (void)setUser:(nullable SentryUser *)user

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -214,10 +214,7 @@ SentryOptions ()
     }
 
     if ([options[@"integrations"] isKindOfClass:[NSArray class]]) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         self.integrations = [options[@"integrations"] filteredArrayUsingPredicate:isNSString];
-#pragma clang diagnostic pop
     }
 
     if ([options[@"sampleRate"] isKindOfClass:[NSNumber class]]) {

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -44,10 +44,7 @@ SentryOptions ()
         self.debug = NO;
         self.maxBreadcrumbs = defaultMaxBreadcrumbs;
         self.maxCacheItems = 30;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        self.integrations = SentryOptions.defaultIntegrations;
-#pragma clang diagnostic pop
+        _integrations = SentryOptions.defaultIntegrations;
         _defaultSampleRate = @1;
         self.sampleRate = _defaultSampleRate;
         self.enableAutoSessionTracking = YES;
@@ -125,6 +122,15 @@ SentryOptions ()
         }
     }
     return self;
+}
+
+- (void)setIntegrations:(NSArray<NSString *> *)integrations
+{
+    [SentryLog logWithMessage:
+                   @"Setting `SentryOptions.integrations` is deprecated. Integrations should be "
+                   @"enabled or disabled using their respective `SentryOptions.enable*` property."
+                     andLevel:kSentryLevelWarning];
+    _integrations = integrations;
 }
 
 - (void)setDsn:(NSString *)dsn

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -339,10 +339,7 @@ static NSUInteger startInvocations;
         return;
     }
     SentryOptions *options = [SentrySDK.currentHub getClient].options;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     for (NSString *integrationName in [SentrySDK.currentHub getClient].options.integrations) {
-#pragma clang diagnostic pop
         Class integrationClass = NSClassFromString(integrationName);
         if (nil == integrationClass) {
             NSString *logMessage = [NSString stringWithFormat:@"[SentryHub doInstallIntegrations] "

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -339,7 +339,10 @@ static NSUInteger startInvocations;
         return;
     }
     SentryOptions *options = [SentrySDK.currentHub getClient].options;
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     for (NSString *integrationName in [SentrySDK.currentHub getClient].options.integrations) {
+#pragma clang diagnostic pop
         Class integrationClass = NSClassFromString(integrationName);
         if (nil == integrationClass) {
             NSString *logMessage = [NSString stringWithFormat:@"[SentryHub doInstallIntegrations] "
@@ -362,8 +365,7 @@ static NSUInteger startInvocations;
                                                 integrationName]
                              andLevel:kSentryLevelDebug];
             [SentrySDK.currentHub.installedIntegrations addObject:integrationInstance];
-        } else {
-            [options removeEnabledIntegration:integrationName];
+            [SentrySDK.currentHub.installedIntegrationNames addObject:integrationName];
         }
     }
 }

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -20,6 +20,7 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
     kIntegrationOptionEnableAutoBreadcrumbTracking = 1 << 12,
     kIntegrationOptionIsTracingEnabled = 1 << 13,
     kIntegrationOptionDebuggerNotAttached = 1 << 14,
+    kIntegrationOptionEnableCrashHandler = 1 << 16,
 };
 
 @interface SentryBaseIntegration : NSObject

--- a/Sources/Sentry/include/SentryCrashIntegration.h
+++ b/Sources/Sentry/include/SentryCrashIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
@@ -8,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const SentryDeviceContextFreeMemoryKey = @"free_memory";
 static NSString *const SentryDeviceContextAppMemoryKey = @"app_memory";
 
-@interface SentryCrashIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryCrashIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
 + (void)enrichScope:(SentryScope *)scope crashWrapper:(SentryCrashWrapper *)crashWrapper;
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -8,6 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryHub (Private)
 
+@property (nonatomic, strong)
+    NSMutableArray<NSObject<SentryIntegrationProtocol> *> *installedIntegrations;
+@property (nonatomic, strong) NSMutableArray<NSString *> *installedIntegrationNames;
+
 - (SentryClient *_Nullable)client;
 
 - (void)captureCrashEvent:(SentryEvent *)event;

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -18,10 +18,6 @@ SentryOptions (Private)
 
 - (BOOL)isValidProfilesSampleRate:(NSNumber *)profilesSampleRate;
 
-@property (nonatomic, strong, readonly) NSSet<NSString *> *enabledIntegrations;
-
-- (void)removeEnabledIntegration:(NSString *)integration;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -940,29 +940,16 @@ class SentryClientTest: XCTestCase {
     }
     
     func testSetSDKIntegrations() {
+        SentrySDK.start(options: Options())
+
         let eventId = fixture.getSut().capture(message: fixture.messageAsString)
-        
-        let expected = shortenIntegrations(Options().integrations)
-        
-        eventId.assertIsNotEmpty()
-        assertLastSentEvent { actual in
-            assertArrayEquals(expected: expected, actual: actual.sdk?["integrations"] as? [String])
-        }
-    }
-    
-    func testSetSDKIntegrations_CustomIntegration() {
-        var integrations = Options().integrations
-        integrations?.append("Custom")
-        
-        let eventId = fixture.getSut(configureOptions: { options in
-            options.integrations = integrations
-        }).capture(message: fixture.messageAsString)
-        
-        let expected = shortenIntegrations(integrations)
 
         eventId.assertIsNotEmpty()
         assertLastSentEvent { actual in
-            assertArrayEquals(expected: expected, actual: actual.sdk?["integrations"] as? [String])
+            assertArrayEquals(
+                expected: ["AutoBreadcrumbTracking", "AutoSessionTracking", "Crash", "NetworkTracking"],
+                actual: actual.sdk?["integrations"] as? [String]
+            )
         }
     }
     

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -327,30 +327,6 @@
         @"Default integrations are not set correctly");
 }
 
-- (void)testEnabledIntegrations_SameAsDefault
-{
-    SentryOptions *options = [self getValidOptions:@{}];
-
-    [self assertArrayEquals:[SentryOptions defaultIntegrations]
-                     actual:options.enabledIntegrations.allObjects];
-}
-
-- (void)testEnabledIntegrations_AddCustomAndRemoveIntegration
-{
-    NSMutableArray<NSString *> *integrations = [SentryOptions defaultIntegrations].mutableCopy;
-    [integrations addObject:@"Custom"];
-
-    SentryOptions *options = [self getValidOptions:@{}];
-    options.integrations = integrations;
-
-    NSString *crashIntegration = @"SentryCrashIntegration";
-    NSMutableArray<NSString *> *expected = integrations.mutableCopy;
-    [expected removeObject:crashIntegration];
-
-    [options removeEnabledIntegration:crashIntegration];
-    [self assertArrayEquals:expected actual:options.enabledIntegrations.allObjects];
-}
-
 - (void)testSampleRateWithDict
 {
     NSNumber *sampleRate = @0.1;


### PR DESCRIPTION
## :scroll: Description

- Added a new option `enableCrashHandler`, which controls if `SentryCrashIntegration` is installed or not
- Deprecated `SentryOptions.integrations`, by adding a setter which logs a warning (actually marking it as deprecated with a macro is not possible since our tests no longer compile - no way to silence warnings in Swift files!)
- Removed `SentryOptions.enabledIntegrations`, `SentryOptions.disabledIntegrations` and `SentryOptions.removeEnabledIntegration`
- Added `installedIntegrationNames` to SentryHub, which is used to send the list of installed integrations to Sentry. 

## :bulb: Motivation and Context

Cleaning up SentryOptions and prepare to remove deprecated arrays when v8 comes around. Closes #2043.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
