### PR TITLE
fix: use prime sample rate to reduce profiler lock-step potential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Fixes
 
-- Use a prime number for the profiler's sampling rate to reduce the potention for [lock-step](https://stackoverflow.com/a/45471031) issues (#2055).
+- Use a prime number for the profiler's sampling rate to reduce the potential for [lock-step](https://stackoverflow.com/a/45471031) issues (#2055).
 
 ## 7.23.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Include app permissions with event (#1984)
 - Add culture context to event (#2036)
 
+### Fixes
+
+- Use a prime number for the profiler's sampling rate to reduce the potention for [lock-step](https://stackoverflow.com/a/45471031) issues (#2055).
+
 ## 7.23.0
 
 ### Features

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -204,7 +204,7 @@ isSimulatorBuild()
                 }
                 [samples addObject:sample];
             },
-            100 /** Sample 100 times per second */);
+            101 /** Sample 101 times per second */);
         _profiler->startSampling();
     }
 }

--- a/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
@@ -24,7 +24,7 @@ using namespace sentry::profiling;
 - (void)testProfiling
 {
     const auto cache = std::make_shared<ThreadMetadataCache>();
-    const std::uint32_t samplingRateHz = 300;
+    const std::uint32_t samplingRateHz = 301;
 
     pthread_t idleThread;
     XCTAssertEqual(pthread_create(&idleThread, nullptr, idleThreadEntry, nullptr), 0);


### PR DESCRIPTION
## :scroll: Description

We simply change the profiler's internal sampling rate from 100 to 101 (a prime number).

## :bulb: Motivation and Context

This reduces the potential for [lock-step](https://stackoverflow.com/a/45471031) problems. With a composite number, it's possible for repeated subroutines with durations that are divisors of the sample rate to occur in phase with the sampler's starting and/or stopping, which can produce misleading results.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
~- [ ] I added tests to verify the changes~
~- [ ] I updated the docs if needed~
~- [ ] Review from the native team if needed~
- [x] No breaking changes

## :crystal_ball: Next steps
