### PR TITLE
Allow SentryTrace to have a specific end timestamp set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Include app permissions with event (#1984)
 - Add culture context to event (#2036)
 
+### Fixes
+
+- Don't override already-set timestamp when finishing Trace (#2056)
+
 ## 7.23.0
 
 ### Features

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -275,6 +275,23 @@ class SentryTracerTests: XCTestCase {
         
         assertOneTransactionCaptured(sut)
     }
+
+    func testSetSpecificTimestamp_NotOverriddenOnTrace() {
+        let sut = fixture.getSut(idleTimeout: 5.0, dispatchQueueWrapper: fixture.dispatchQueue)
+        let child1 = sut.startChild(operation: fixture.transactionOperation)
+        advanceTime(bySeconds: 1.0)
+        child1.finish()
+
+        advanceTime(bySeconds: 1.0)
+        let customTimestamp = fixture.currentDateProvider.date()
+        sut.timestamp = customTimestamp
+        XCTAssertFalse(sut.isFinished)
+        advanceTime(bySeconds: 1.0)
+        sut.finish()
+
+        XCTAssertTrue(sut.isFinished)
+        XCTAssertEqual(sut.timestamp, customTimestamp)
+    }
     
     func testIdleTimeout_TimesOut_TrimsEndTimestamp() {
         let sut = fixture.getSut(idleTimeout: fixture.idleTimeout, dispatchQueueWrapper: fixture.dispatchQueue)


### PR DESCRIPTION
## :scroll: Description

This PR extends the custom timestamp functionality that was recently added to `SentrySpan`s (#1993) to `SentryTrace`s. This is accomplished by ensuring the root span does not have a `timestamp` _and_ that its status is anything but `kSentrySpanStatusUndefined` since setting the trace's `timestamp` is a pass through to the `rootSpan.timestamp` but does not "finish" `rootSpan`. Further, setting a trace's `timestamp` will prevent duration truncation to the last of the child subspans, the assumption being that if the developer set a desired value then they probably know what they want.

Question: there are some cases in `SentryNetworkTracker` that appear like they could end up with a `context.status == kSentrySpanStatusUndefined` but I'm not sure how realistic those may be. There are plenty of HTTP status codes that are not covered by `-[SentryNetworkTracker spanStatusForHttpResponseStatusCode:]` so maybe there needs to be a different signal that `rootSpan` is not finished?

## :bulb: Motivation and Context

Recently-ish (#1993) Sentry spans gained the ability to have a specific `timestamp` value set and it not be overwritten by calling `finish`. This however did not extend to the `SentryTrace` type. Traces generally could benefit from this change too as the developer may want to say a trace ended at a specific time (ex: completing spans and traces on a thread separate from instrumented code).

https://github.com/getsentry/sentry-cocoa/pull/1993

## :green_heart: How did you test it?
Added a unit test and integrated with our application to verify that transactions were sent to Sentry as expected

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
