### PR TITLE
fix: Restore Swift 5.5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Include app permissions with event (#1984)
 - Add culture context to event (#2036)
 
+### Fixes
+- Fix Swift 5.5 compatibility (#2060)
+
 ## 7.23.0
 
 ### Features

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -714,12 +714,21 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     [self modifyContext:event
                     key:@"culture"
                   block:^(NSMutableDictionary *culture) {
-                      if (@available(iOS 10, macOS 10.12, watchOS 3, tvOS 10, macCatalyst 13, *)) {
+#if TARGET_OS_MACCATALYST
+                      if (@available(macCatalyst 13, *)) {
                           culture[@"calendar"] = [self.locale
                               localizedStringForCalendarIdentifier:self.locale.calendarIdentifier];
                           culture[@"display_name"] = [self.locale
                               localizedStringForLocaleIdentifier:self.locale.localeIdentifier];
                       }
+#else
+            if (@available(iOS 10, macOS 10.12, watchOS 3, tvOS 10, *)) {
+                culture[@"calendar"] = [self.locale
+                    localizedStringForCalendarIdentifier:self.locale.calendarIdentifier];
+                culture[@"display_name"] =
+                    [self.locale localizedStringForLocaleIdentifier:self.locale.localeIdentifier];
+            }
+#endif
                       culture[@"locale"] = self.locale.localeIdentifier;
                       culture[@"is_24_hour_format"] = @(self.locale.timeIs24HourFormat);
                       culture[@"timezone"] = self.timezone.name;

--- a/Sources/Sentry/SentrySamplingProfiler.cpp
+++ b/Sources/Sentry/SentrySamplingProfiler.cpp
@@ -10,6 +10,7 @@
 #    include <mach/clock.h>
 #    include <mach/clock_reply.h>
 #    include <mach/clock_types.h>
+#    include <malloc/_malloc.h>
 #    include <pthread.h>
 
 namespace sentry {

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -76,7 +76,7 @@ SentryUIViewControllerSwizzling ()
                   @"notification.";
             [SentryLog logWithMessage:message andLevel:kSentryLevelDebug];
 
-            if (@available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *)) {
+            if (@available(iOS 13.0, tvOS 13.0, *)) {
                 [NSNotificationCenter.defaultCenter
                     addObserver:self
                        selector:@selector(swizzleRootViewControllerFromSceneDelegateNotification:)
@@ -172,7 +172,7 @@ SentryUIViewControllerSwizzling ()
  */
 - (void)swizzleRootViewControllerFromSceneDelegateNotification:(NSNotification *)notification
 {
-    if (@available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *)) {
+    if (@available(iOS 13.0, tvOS 13.0, *)) {
         if (![notification.name isEqualToString:UISceneWillConnectNotification])
             return;
 


### PR DESCRIPTION
## :scroll: Description

Currently our SDK doesn't compile using Swift 5.5 because of 2 errors:

- Unrecognized platform name macCatalyst
- Missing include <malloc/_malloc.h>

In the case that the macCatalyst check is for the same version as for the iOS check, we can drop that check: "You don't have to guard Catalyst separately from iOS if they're the same version". We do have one place where we check for a different version, so that is a bit of an ugly fix now.

## :bulb: Motivation and Context

Closes #2057

## :green_heart: How did you test it?

Everything still builds and tests complete.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
