### PR TITLE
chore: Update SentryOptions screenshot comment

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -200,6 +200,8 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableUIViewControllerTracking;
 
 /**
+ * This feature is EXPERIMENTAL.
+ *
  * Automatically attaches a screenshot when capturing an error or exception.
  *
  * Default value is <code>NO</code>


### PR DESCRIPTION
Adding "Experimental Feature" to the screenshot option because we don't have enough feedback on this feature to turn it on by default yet.

_#skip-changelog_ 