### PR TITLE
feat: Attach view hierarchy for crashes

### DIFF
--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -37,6 +37,7 @@ extension Tracer {
             options.enableCoreDataTracking = true
             options.profilesSampleRate = 1.0
             options.attachScreenshot = true
+            options.attachViewHierarchy = true
             options.enableUserInteractionTracing = true
         }
 

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -22,6 +22,7 @@ AppDelegate ()
         options.tracesSampleRate = @1.0;
         options.enableFileIOTracking = YES;
         options.attachScreenshot = YES;
+        options.attachViewHierarchy = YES;
         options.enableUserInteractionTracing = YES;
     }];
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -46,11 +46,12 @@
 		0A2D8D9828997887008720F6 /* NSLocale+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */; };
 		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
 		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
+		0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */; };
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
 		0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */; };
 		0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */; };
 		0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */; };
-		0A9BF4EB28A127120068D266 /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4EA28A127120068D266 /* SentryViewHierarchyTests.swift */; };
+		0A9BF4EB28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
 		15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15360CD12432779F00112302 /* SentrySessionTracker.h */; };
@@ -734,10 +735,11 @@
 		0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSLocale+Sentry.h"; path = "include/NSLocale+Sentry.h"; sourceTree = "<group>"; };
 		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
 		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
+		0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
 		0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyIntegration.m; sourceTree = "<group>"; };
 		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
 		0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryViewHierarchy.swift; sourceTree = "<group>"; };
-		0A9BF4EA28A127120068D266 /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
+		0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyIntegrationTests.swift; sourceTree = "<group>"; };
 		0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPermissionsObserver.m; sourceTree = "<group>"; };
 		0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryPermissionsObserver.h; path = include/SentryPermissionsObserver.h; sourceTree = "<group>"; };
 		0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryPermissionsObserver.swift; sourceTree = "<group>"; };
@@ -1483,7 +1485,7 @@
 		0A9BF4E528A123070068D266 /* ViewHierarchy */ = {
 			isa = PBXGroup;
 			children = (
-				0A9BF4EA28A127120068D266 /* SentryViewHierarchyTests.swift */,
+				0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */,
 				0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */,
 			);
 			path = ViewHierarchy;
@@ -2738,6 +2740,7 @@
 			children = (
 				D81FDF10280EA0080045E0E4 /* SentryScreenShotTests.swift */,
 				D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */,
+				0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -3403,7 +3406,7 @@
 				7B30B68026527C3C006B2752 /* SentryFramesTrackerTests.swift in Sources */,
 				7BC3937425B1ACB7004F03D3 /* SentryLevelMapperTests.swift in Sources */,
 				63FE720E20DA66EC00CDBAE8 /* SentryCrashCString_Tests.m in Sources */,
-				0A9BF4EB28A127120068D266 /* SentryViewHierarchyTests.swift in Sources */,
+				0A9BF4EB28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift in Sources */,
 				631501BB1EE6F30B00512C5B /* SentrySwizzleTests.m in Sources */,
 				15D0AC882459EE4D006541C2 /* SentryNSURLRequestTests.swift in Sources */,
 				7BE3C78724472E9800A38442 /* TestRequestManager.swift in Sources */,
@@ -3429,6 +3432,7 @@
 				7BAF3DC8243DB90E008A5414 /* TestTransport.swift in Sources */,
 				7B0A54562523178700A71716 /* SentryScopeSwiftTests.swift in Sources */,
 				7B5B94332657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift in Sources */,
+				0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */,
 				D8FFE50C2703DBB400607131 /* SwizzlingCallTests.swift in Sources */,
 				D8B76B0828081461000A58C4 /* TestSentryScreenShot.swift in Sources */,
 				7BE2C7F8257000A4003B66C7 /* SentryTestIntegration.m in Sources */,

--- a/Sources/Sentry/SentryCrashReportSink.m
+++ b/Sources/Sentry/SentryCrashReportSink.m
@@ -37,8 +37,8 @@ SentryCrashReportSink ()
     [sentReports addObject:report];
     SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
 
-    if (report[SENTRYCRASH_REPORT_SCREENSHOT_ITEM]) {
-        for (NSString *ssPath in report[SENTRYCRASH_REPORT_SCREENSHOT_ITEM]) {
+    if (report[SENTRYCRASH_REPORT_ATTACHMENTS_ITEM]) {
+        for (NSString *ssPath in report[SENTRYCRASH_REPORT_ATTACHMENTS_ITEM]) {
             [scope addAttachment:[[SentryAttachment alloc] initWithPath:ssPath]];
         }
     }

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -12,27 +12,6 @@ void
 saveScreenShot(const char *path)
 {
     NSString *reportPath = [NSString stringWithUTF8String:path];
-    NSError *error = nil;
-
-    if (![NSFileManager.defaultManager fileExistsAtPath:reportPath]) {
-        [NSFileManager.defaultManager createDirectoryAtPath:reportPath
-                                withIntermediateDirectories:YES
-                                                 attributes:nil
-                                                      error:&error];
-        if (error != nil)
-            return;
-    } else {
-        // We first delete any screenshot that could be from an old crash report
-        NSArray *oldFiles = [NSFileManager.defaultManager contentsOfDirectoryAtPath:reportPath
-                                                                              error:&error];
-
-        if (!error) {
-            [oldFiles enumerateObjectsUsingBlock:^(NSString *obj, NSUInteger idx, BOOL *stop) {
-                [NSFileManager.defaultManager removeItemAtPath:obj error:nil];
-            }];
-        }
-    }
-
     [SentryDependencyContainer.sharedInstance.screenshot saveScreenShots:reportPath];
 }
 

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -30,6 +30,18 @@ UIView (Debugging)
     return result;
 }
 
+- (void)saveViewHierarchy:(NSString *)path
+{
+    [[self fetchViewHierarchy]
+        enumerateObjectsUsingBlock:^(NSString *description, NSUInteger idx, BOOL *stop) {
+            NSString *fileName =
+                [NSString stringWithFormat:@"view-hierarchy-%lu.txt", (unsigned long)idx];
+            NSString *filePath = [path stringByAppendingPathComponent:fileName];
+            NSData *data = [description dataUsingEncoding:NSUTF8StringEncoding];
+            [data writeToFile:filePath atomically:YES];
+        }];
+}
+
 @end
 
 #endif

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -24,6 +24,8 @@ UIView (Debugging)
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:[windows count]];
 
     [windows enumerateObjectsUsingBlock:^(UIWindow *window, NSUInteger idx, BOOL *stop) {
+        // In the case of a crash we can't dispatch work to be executed anymore,
+        // so we'll run this on the wrong thread.
         if ([NSThread isMainThread] || preventMoveToMainThread) {
             [result addObject:[window recursiveDescription]];
         } else {
@@ -37,18 +39,14 @@ UIView (Debugging)
 
 - (void)saveViewHierarchy:(NSString *)path
 {
-    NSArray<NSString *> *descriptions = [self fetchViewHierarchyPreventMoveToMainThread:YES];
-
-    if ([descriptions count]) {
-        [descriptions
-            enumerateObjectsUsingBlock:^(NSString *description, NSUInteger idx, BOOL *stop) {
-                NSString *fileName =
-                    [NSString stringWithFormat:@"view-hierarchy-%lu.txt", (unsigned long)idx];
-                NSString *filePath = [path stringByAppendingPathComponent:fileName];
-                NSData *data = [description dataUsingEncoding:NSUTF8StringEncoding];
-                [data writeToFile:filePath atomically:YES];
-            }];
-    }
+    [[self fetchViewHierarchyPreventMoveToMainThread:YES]
+        enumerateObjectsUsingBlock:^(NSString *description, NSUInteger idx, BOOL *stop) {
+            NSString *fileName =
+                [NSString stringWithFormat:@"view-hierarchy-%lu.txt", (unsigned long)idx];
+            NSString *filePath = [path stringByAppendingPathComponent:fileName];
+            NSData *data = [description dataUsingEncoding:NSUTF8StringEncoding];
+            [data writeToFile:filePath atomically:YES];
+        }];
 }
 
 @end

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -1,5 +1,6 @@
 #import "SentryViewHierarchyIntegration.h"
 #import "SentryAttachment.h"
+#import "SentryCrashC.h"
 #import "SentryDependencyContainer.h"
 #import "SentryEvent+Private.h"
 #import "SentryHub+Private.h"
@@ -7,6 +8,13 @@
 #import "SentryViewHierarchy.h"
 
 #if SENTRY_HAS_UIKIT
+
+void
+saveViewHierarchy(const char *path)
+{
+    NSString *reportPath = [NSString stringWithUTF8String:path];
+    [SentryDependencyContainer.sharedInstance.viewHierarchy saveViewHierarchy:reportPath];
+}
 
 @implementation SentryViewHierarchyIntegration
 
@@ -18,6 +26,8 @@
 
     SentryClient *client = [SentrySDK.currentHub getClient];
     [client addAttachmentProcessor:self];
+
+    sentrycrash_setSaveViewHierarchy(&saveViewHierarchy);
 
     return YES;
 }

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -39,6 +39,8 @@ saveViewHierarchy(const char *path)
 
 - (void)uninstall
 {
+    sentrycrash_setSaveViewHierarchy(NULL);
+
     SentryClient *client = [SentrySDK.currentHub getClient];
     [client removeAttachmentProcessor:self];
 }

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -63,7 +63,8 @@ saveViewHierarchy(const char *path)
     [decriptions enumerateObjectsUsingBlock:^(NSString *decription, NSUInteger idx, BOOL *stop) {
         SentryAttachment *attachment = [[SentryAttachment alloc]
             initWithData:[decription dataUsingEncoding:NSUTF8StringEncoding]
-                filename:[NSString stringWithFormat:@"view-hierarchy-%lu.txt", (unsigned long)idx]];
+                filename:[NSString stringWithFormat:@"view-hierarchy-%lu.txt", (unsigned long)idx]
+             contentType:@"text/plain"];
         [result addObject:attachment];
     }];
 

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -4,10 +4,10 @@
 #import <Foundation/Foundation.h>
 
 @class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper,
-    SentryDispatchQueueWrapper, SentryDebugImageProvider, SentryANRTracker, SentryViewHierarchy;
+    SentryDispatchQueueWrapper, SentryDebugImageProvider, SentryANRTracker;
 
 #if SENTRY_HAS_UIKIT
-@class SentryScreenshot, SentryUIApplication;
+@class SentryScreenshot, SentryUIApplication, SentryViewHierarchy;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/SentryViewHierarchy.h
+++ b/Sources/Sentry/include/SentryViewHierarchy.h
@@ -8,6 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryViewHierarchy : NSObject
 
 - (NSArray<NSString *> *)fetchViewHierarchy;
+
+- (void)saveViewHierarchy:(NSString *)path;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SentryCrash/Recording/SentryCrash.h
+++ b/Sources/SentryCrash/Recording/SentryCrash.h
@@ -43,7 +43,7 @@ typedef enum {
     SentryCrashCDeleteAlways
 } SentryCrashCDeleteBehavior;
 
-static NSString *const SENTRYCRASH_REPORT_SCREENSHOT_ITEM = @"screenshots";
+static NSString *const SENTRYCRASH_REPORT_ATTACHMENTS_ITEM = @"attachments";
 
 /**
  * Reports any crashes that occur in the application.

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -480,7 +480,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
     NSArray *attachments = [self getAttachmentPaths:reportID];
     if (attachments.count > 0) {
-        crashReport[SENTRYCRASH_REPORT_SCREENSHOT_ITEM] = attachments;
+        crashReport[SENTRYCRASH_REPORT_ATTACHMENTS_ITEM] = attachments;
     }
 
     [self doctorReport:crashReport];

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -401,7 +401,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return nil;
 }
 
-- (NSArray<NSString *> *)getAttachmentsPaths:(int64_t)reportID
+- (NSArray<NSString *> *)getAttachmentPaths:(int64_t)reportID
 {
     char report_attachments_path[SentryCrashCRS_MAX_PATH_LENGTH];
     sentrycrashcrs_getAttachmentsPath_forReportId(reportID, report_attachments_path);
@@ -478,7 +478,7 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
         return nil;
     }
 
-    NSArray *attachments = [self getAttachmentsPaths:reportID];
+    NSArray *attachments = [self getAttachmentPaths:reportID];
     if (attachments.count > 0) {
         crashReport[SENTRYCRASH_REPORT_SCREENSHOT_ITEM] = attachments;
     }

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -401,11 +401,11 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     return nil;
 }
 
-- (NSArray<NSString *> *)getScreenshotPaths:(int64_t)reportID
+- (NSArray<NSString *> *)getAttachmentsPaths:(int64_t)reportID
 {
-    char report_screenshot_path[SentryCrashCRS_MAX_PATH_LENGTH];
-    sentrycrashcrs_getScreenshotPath_forReportId(reportID, report_screenshot_path);
-    NSString *path = [NSString stringWithUTF8String:report_screenshot_path];
+    char report_attachments_path[SentryCrashCRS_MAX_PATH_LENGTH];
+    sentrycrashcrs_getAttachmentsPath_forReportId(reportID, report_attachments_path);
+    NSString *path = [NSString stringWithUTF8String:report_attachments_path];
 
     BOOL isDir = false;
     if (![NSFileManager.defaultManager fileExistsAtPath:path isDirectory:&isDir] || !isDir)
@@ -478,9 +478,9 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
         return nil;
     }
 
-    NSArray *screenShots = [self getScreenshotPaths:reportID];
-    if (screenShots.count > 0) {
-        crashReport[SENTRYCRASH_REPORT_SCREENSHOT_ITEM] = screenShots;
+    NSArray *attachments = [self getAttachmentsPaths:reportID];
+    if (attachments.count > 0) {
+        crashReport[SENTRYCRASH_REPORT_SCREENSHOT_ITEM] = attachments;
     }
 
     [self doctorReport:crashReport];

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -330,3 +330,9 @@ sentrycrash_hasSaveScreenshotCallback()
 {
     return g_saveScreenShot != NULL;
 }
+
+bool
+sentrycrash_hasSaveViewHierarchyCallback()
+{
+    return g_saveViewHierarchy != NULL;
+}

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -108,7 +108,8 @@ onCrash(struct SentryCrash_MonitorContext *monitorContext)
         sentrycrashreport_writeStandardReport(monitorContext, crashReportFilePath);
     }
 
-    // Report is saved to disk, now we try to take screenshots.
+    // Report is saved to disk, now we try to take screenshots
+    // and view hierarchies.
     // Depending on the state of the crash this may not work
     // because we gonna call into non async-signal safe code
     // but since the app is already in a crash state we don't

--- a/Sources/SentryCrash/Recording/SentryCrashC.h
+++ b/Sources/SentryCrash/Recording/SentryCrashC.h
@@ -232,6 +232,12 @@ void sentrycrash_deleteReportWithID(int64_t reportID);
  */
 bool sentrycrash_hasSaveScreenshotCallback(void);
 
+/**
+ * For testing purpose.
+ * Indicates that a callback was registered for view hierarchy.
+ */
+bool sentrycrash_hasSaveViewHierarchyCallback(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/SentryCrash/Recording/SentryCrashC.h
+++ b/Sources/SentryCrash/Recording/SentryCrashC.h
@@ -123,6 +123,14 @@ void sentrycrash_setMaxReportCount(int maxReportCount);
  */
 void sentrycrash_setSaveScreenshots(void (*callback)(const char *));
 
+/**
+ * Set the callback to be called at the end of a crash to make the app save the view hierarchy
+ * descriptions;
+ *
+ * @param callback function pointer that will be called with a give path.
+ */
+void sentrycrash_setSaveViewHierarchy(void (*callback)(const char *));
+
 /** Report a custom, user defined exception.
  * This can be useful when dealing with scripting languages.
  *

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.c
@@ -234,16 +234,16 @@ sentrycrashcrs_readReport(int64_t reportID)
 }
 
 void
-sentrycrashcrs_getScreenshotPath_forReportId(int64_t reportID, char *pathBuffer)
+sentrycrashcrs_getAttachmentsPath_forReportId(int64_t reportID, char *pathBuffer)
 {
-    snprintf(pathBuffer, SentryCrashCRS_MAX_PATH_LENGTH, "%s/%s-report-%016llx-screenshots",
+    snprintf(pathBuffer, SentryCrashCRS_MAX_PATH_LENGTH, "%s/%s-report-%016llx-attachments",
         g_reportsPath, g_appName, reportID);
 }
 
 void
-sentrycrashcrs_getScreenshotsPath_forReport(const char *reportPath, char *pathBuffer)
+sentrycrashcrs_getAttachmentsPath_forReport(const char *reportPath, char *pathBuffer)
 {
-    sentrycrashcrs_getScreenshotPath_forReportId(getReportIDFromFilePath(reportPath), pathBuffer);
+    sentrycrashcrs_getAttachmentsPath_forReportId(getReportIDFromFilePath(reportPath), pathBuffer);
 }
 
 int64_t

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.h
@@ -82,20 +82,19 @@ void sentrycrashcrs_getCrashReportPathById(int64_t reportId, char *pathBuffer);
  */
 char *sentrycrashcrs_readReport(int64_t reportID);
 
-/** Gets a report screenshots directory for given report id.
+/** Gets a report attachments directory for given report id.
  *
  * @param reportID The report's ID.
  * @param pathBuffer A buffer to store the path.
  */
-void sentrycrashcrs_getScreenshotPath_forReportId(int64_t reportID, char *pathBuffer);
+void sentrycrashcrs_getAttachmentsPath_forReportId(int64_t reportID, char *pathBuffer);
 
-/** Gets a report screenshots directory for given report path;
+/** Gets a report attachments directory for given report path;
  *
  * @param reportPath The path of the report.
  * @param pathBuffer A buffer to store the path.
  */
-
-void sentrycrashcrs_getScreenshotsPath_forReport(const char *reportPath, char *pathBuffer);
+void sentrycrashcrs_getAttachmentsPath_forReport(const char *reportPath, char *pathBuffer);
 
 /** Add a custom report to the store.
  *

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -2,7 +2,7 @@ import Sentry
 import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-class SentryViewHierarchyTests: XCTestCase {
+class SentryViewHierarchyIntegrationTests: XCTestCase {
 
     private class Fixture {
         let viewHierarchy: TestSentryViewHierarchy

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
@@ -91,8 +91,8 @@ class SentryViewHierarchyTests: XCTestCase {
         XCTAssertEqual(newAttachmentList[0].filename, "view-hierarchy-0.txt")
         XCTAssertEqual(newAttachmentList[1].filename, "view-hierarchy-1.txt")
 
-        XCTAssertEqual(newAttachmentList[0].contentType, "application/octet-stream")
-        XCTAssertEqual(newAttachmentList[1].contentType, "application/octet-stream")
+        XCTAssertEqual(newAttachmentList[0].contentType, "text/plain")
+        XCTAssertEqual(newAttachmentList[1].contentType, "text/plain")
 
         XCTAssertEqual(newAttachmentList[0].data?.count, "view hierarchy for window zero".lengthOfBytes(using: .utf8))
         XCTAssertEqual(newAttachmentList[1].data?.count, "view hierarchy for window one".lengthOfBytes(using: .utf8))

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyTests.swift
@@ -36,17 +36,20 @@ class SentryViewHierarchyTests: XCTestCase {
     func test_attachViewHierarchy_disabled() {
         SentrySDK.start { $0.attachViewHierarchy = false }
         XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
+        XCTAssertFalse(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
     func test_attachViewHierarchy_enabled() {
         SentrySDK.start { $0.attachViewHierarchy = true }
         XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
+        XCTAssertTrue(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
     func test_uninstall() {
         SentrySDK.start { $0.attachViewHierarchy = true }
         SentrySDK.close()
         XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
+        XCTAssertFalse(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
     func test_noViewHierarchy_attachment() {

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTest.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTest.swift
@@ -8,7 +8,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
         let reportSink = SentryCrashReportSink(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: []))
         let expect = expectation(description: "Callback Called")
         
-        let report = ["screenshots": ["file.png"]]
+        let report = ["attachments": ["file.png"]]
         
         reportSink.filterReports([report]) { _, _, _ in
             self.assertCrashEventWithScope { _, scope in

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -231,7 +231,7 @@
 
     XCTAssertEqualObjects([NSString stringWithUTF8String:screenshotsPath],
         [self.tempPath stringByAppendingPathComponent:
-                           @"/ReportPath/AppName-report-00000013b0ac358d-screenshots"]);
+                           @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
 }
 
 - (void)test_ScreenshotsPath_forReport
@@ -249,7 +249,7 @@
 
     XCTAssertEqualObjects([NSString stringWithUTF8String:screenshotPath],
         [self.tempPath stringByAppendingPathComponent:
-                           @"/ReportPath/AppName-report-00000013b0ac358d-screenshots"]);
+                           @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
 }
 
 - (void)test_initializeIDs

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -220,21 +220,21 @@
     [self expectReports:@[ @(reportID) ] areStrings:@[ reportContents ]];
 }
 
-- (void)test_ScreenshotsPath_forReportId
+- (void)test_AttachmentsPath_forReportId
 {
     self.appName = @"AppName";
     [self prepareReportStoreWithPathEnd:@"/ReportPath"];
     uint64_t reportId = 84568454541;
 
-    char screenshotsPath[SentryCrashCRS_MAX_PATH_LENGTH];
-    sentrycrashcrs_getAttachmentsPath_forReportId(reportId, screenshotsPath);
+    char attachmentsPath[SentryCrashCRS_MAX_PATH_LENGTH];
+    sentrycrashcrs_getAttachmentsPath_forReportId(reportId, attachmentsPath);
 
-    XCTAssertEqualObjects([NSString stringWithUTF8String:screenshotsPath],
+    XCTAssertEqualObjects([NSString stringWithUTF8String:attachmentsPath],
         [self.tempPath stringByAppendingPathComponent:
                            @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
 }
 
-- (void)test_ScreenshotsPath_forReport
+- (void)test_AttachmentsPath_forReport
 {
     self.appName = @"AppName";
     [self prepareReportStoreWithPathEnd:@"/ReportPath"];
@@ -244,10 +244,10 @@
     char reportPath[SentryCrashCRS_MAX_PATH_LENGTH];
     sentrycrashcrs_getCrashReportPathById(reportId, reportPath);
 
-    char screenshotPath[SentryCrashCRS_MAX_PATH_LENGTH];
-    sentrycrashcrs_getAttachmentsPath_forReport(reportPath, screenshotPath);
+    char attachmentsPath[SentryCrashCRS_MAX_PATH_LENGTH];
+    sentrycrashcrs_getAttachmentsPath_forReport(reportPath, attachmentsPath);
 
-    XCTAssertEqualObjects([NSString stringWithUTF8String:screenshotPath],
+    XCTAssertEqualObjects([NSString stringWithUTF8String:attachmentsPath],
         [self.tempPath stringByAppendingPathComponent:
                            @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
 }

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -227,7 +227,7 @@
     uint64_t reportId = 84568454541;
 
     char screenshotsPath[SentryCrashCRS_MAX_PATH_LENGTH];
-    sentrycrashcrs_getScreenshotPath_forReportId(reportId, screenshotsPath);
+    sentrycrashcrs_getAttachmentsPath_forReportId(reportId, screenshotsPath);
 
     XCTAssertEqualObjects([NSString stringWithUTF8String:screenshotsPath],
         [self.tempPath stringByAppendingPathComponent:
@@ -245,7 +245,7 @@
     sentrycrashcrs_getCrashReportPathById(reportId, reportPath);
 
     char screenshotPath[SentryCrashCRS_MAX_PATH_LENGTH];
-    sentrycrashcrs_getScreenshotsPath_forReport(reportPath, screenshotPath);
+    sentrycrashcrs_getAttachmentsPath_forReport(reportPath, screenshotPath);
 
     XCTAssertEqualObjects([NSString stringWithUTF8String:screenshotPath],
         [self.tempPath stringByAppendingPathComponent:

--- a/Tests/SentryTests/SentryCrash/SentryCrashTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashTests.m
@@ -7,7 +7,7 @@
 @end
 
 @interface SentryCrash (private)
-- (NSArray *)getScreenshotPaths:(int64_t)reportID;
+- (NSArray *)getAttachmentPaths:(int64_t)reportID;
 @end
 
 @implementation SentryCrashTests
@@ -25,12 +25,12 @@
 
     SentryCrash *sentryCrash = [[SentryCrash alloc]
         initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
-    NSArray *files = [sentryCrash getScreenshotPaths:12];
+    NSArray *files = [sentryCrash getAttachmentPaths:12];
 
     XCTAssertEqual(files.count, 1);
     XCTAssertEqualObjects(files.firstObject,
         [self.tempPath stringByAppendingPathComponent:
-                           @"Reports/AppName-report-000000000000000c-screenshots/0.png"]);
+                           @"Reports/AppName-report-000000000000000c-attachments/0.png"]);
 }
 
 - (void)test_getScreenshots_TwoFiles
@@ -39,7 +39,7 @@
 
     SentryCrash *sentryCrash = [[SentryCrash alloc]
         initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
-    NSArray *files = [sentryCrash getScreenshotPaths:12];
+    NSArray *files = [sentryCrash getAttachmentPaths:12];
     XCTAssertEqual(files.count, 2);
 }
 
@@ -49,7 +49,7 @@
 
     SentryCrash *sentryCrash = [[SentryCrash alloc]
         initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"Reports"]];
-    NSArray *files = [sentryCrash getScreenshotPaths:12];
+    NSArray *files = [sentryCrash getAttachmentPaths:12];
     XCTAssertEqual(files.count, 0);
 }
 
@@ -57,7 +57,7 @@
 {
     SentryCrash *sentryCrash = [[SentryCrash alloc]
         initWithBasePath:[self.tempPath stringByAppendingPathComponent:@"ReportsFake"]];
-    NSArray *files = [sentryCrash getScreenshotPaths:12];
+    NSArray *files = [sentryCrash getAttachmentPaths:12];
     XCTAssertEqual(files.count, 0);
 }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashTests.m
@@ -67,7 +67,7 @@
     sentrycrashcrs_initialize("AppName", reportStorePath.UTF8String);
 
     char reportPathBuffer[500];
-    sentrycrashcrs_getScreenshotPath_forReportId(12, reportPathBuffer);
+    sentrycrashcrs_getAttachmentsPath_forReportId(12, reportPathBuffer);
     NSString *ssDir = [NSString stringWithUTF8String:reportPathBuffer];
     [NSFileManager.defaultManager createDirectoryAtPath:ssDir
                             withIntermediateDirectories:true

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+class SentryViewHierarchyTests: XCTestCase {
+    private class Fixture {
+
+        let uiApplication = TestSentryUIApplication()
+
+        var sut: SentryViewHierarchy {
+            return SentryViewHierarchy()
+        }
+    }
+
+    private var fixture: Fixture!
+
+    override func setUp() {
+        super.setUp()
+        fixture = Fixture()
+        SentryDependencyContainer.sharedInstance().application = fixture.uiApplication
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        clearTestState()
+    }
+
+    func test_Draw_Each_Window() {
+        let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+        let secondWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+
+        fixture.uiApplication.windows = [firstWindow, secondWindow]
+
+        let descriptions = self.fixture.sut.fetch()
+
+        XCTAssertEqual(descriptions.count, 2)
+    }
+
+    func test_Draw_ViewHierarchy() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+
+        fixture.uiApplication.windows = [window]
+
+        let descriptions = self.fixture.sut.fetch()
+
+        XCTAssertTrue(descriptions[0].starts(with: "<UIWindow: "))
+    }
+
+    class TestSentryUIApplication: SentryUIApplication {
+        private var _windows: [UIWindow]?
+
+        override var windows: [UIWindow]? {
+            get {
+                return _windows
+            }
+            set {
+                _windows = newValue
+            }
+        }
+    }
+}
+#endif

--- a/scripts/set-device-tests-environment.patch
+++ b/scripts/set-device-tests-environment.patch
@@ -12,3 +12,4 @@ index 25b92eed..8934d90b 100644
              options.enableCoreDataTracking = true
              options.profilesSampleRate = 1.0
              options.attachScreenshot = true
+             options.attachViewHierarchy = true


### PR DESCRIPTION
## :scroll: Description

Follow up of #2044. We now also create view hierarchy attachments for crashes, just like the screenshots integration. Streamlined the code to deal with a common "attachments" folder.

#skip-changelog

## :bulb: Motivation and Context

Feature parity with the screenshots feature.

## :green_heart: How did you test it?

Manually by crashing the sample app, and with added unit tests (mirroring the tests from screenshots).

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
