### PR TITLE
feat: Reimplemented recursiveDescription so we're not using private API

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
 		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
 		0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */; };
+		0A6EEADD28A657970076B469 /* UIViewRecursiveDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */; };
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
 		0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */; };
 		0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */; };
@@ -738,6 +739,7 @@
 		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
 		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
 		0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
+		0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewRecursiveDescriptionTests.swift; sourceTree = "<group>"; };
 		0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyIntegration.m; sourceTree = "<group>"; };
 		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
 		0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryViewHierarchy.swift; sourceTree = "<group>"; };
@@ -2232,6 +2234,7 @@
 			isa = PBXGroup;
 			children = (
 				7B6438A626A70DDB000D0F65 /* UIViewControllerSentryTests.swift */,
+				0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -3458,6 +3461,7 @@
 				63FE721F20DA66EC00CDBAE8 /* SentryCrashSignalInfo_Tests.m in Sources */,
 				63FE721420DA66EC00CDBAE8 /* SentryCrashMemory_Tests.m in Sources */,
 				63FE720520DA66EC00CDBAE8 /* FileBasedTestCase.m in Sources */,
+				0A6EEADD28A657970076B469 /* UIViewRecursiveDescriptionTests.swift in Sources */,
 				63EED6C32237989300E02400 /* SentryOptionsTest.m in Sources */,
 				7BBD18B22451804C00427C76 /* SentryRetryAfterHeaderParserTests.swift in Sources */,
 				7BD337E424A356180050DB6E /* SentryCrashIntegrationTests.swift in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */; };
 		0A9BF4EB28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
+		0ACBA10128A6406400D711F7 /* UIView+Sentry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ACBA10028A6406400D711F7 /* UIView+Sentry.m */; };
+		0ACBA10328A6407200D711F7 /* UIView+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ACBA10228A6407200D711F7 /* UIView+Sentry.h */; };
 		15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CCE2432777400112302 /* SentrySessionTracker.m */; };
 		15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 15360CD12432779F00112302 /* SentrySessionTracker.h */; };
 		15360CD62432832400112302 /* SentryAutoSessionTrackingIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 15360CD52432832400112302 /* SentryAutoSessionTrackingIntegration.m */; };
@@ -743,6 +745,8 @@
 		0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPermissionsObserver.m; sourceTree = "<group>"; };
 		0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryPermissionsObserver.h; path = include/SentryPermissionsObserver.h; sourceTree = "<group>"; };
 		0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryPermissionsObserver.swift; sourceTree = "<group>"; };
+		0ACBA10028A6406400D711F7 /* UIView+Sentry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIView+Sentry.m"; sourceTree = "<group>"; };
+		0ACBA10228A6407200D711F7 /* UIView+Sentry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "UIView+Sentry.h"; path = "include/UIView+Sentry.h"; sourceTree = "<group>"; };
 		15360CCE2432777400112302 /* SentrySessionTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySessionTracker.m; sourceTree = "<group>"; };
 		15360CD12432779F00112302 /* SentrySessionTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentrySessionTracker.h; path = include/SentrySessionTracker.h; sourceTree = "<group>"; };
 		15360CD52432832400112302 /* SentryAutoSessionTrackingIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAutoSessionTrackingIntegration.m; sourceTree = "<group>"; };
@@ -1599,6 +1603,8 @@
 				7B6438A926A70F24000D0F65 /* UIViewController+Sentry.m */,
 				0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */,
 				0A2D8D9428997845008720F6 /* NSLocale+Sentry.m */,
+				0ACBA10228A6407200D711F7 /* UIView+Sentry.h */,
+				0ACBA10028A6406400D711F7 /* UIView+Sentry.m */,
 			);
 			name = Categories;
 			sourceTree = "<group>";
@@ -2955,6 +2961,7 @@
 				7B7A30C624B48321005A4C6E /* SentryCrashWrapper.h in Headers */,
 				63FE717120DA4C1100CDBAE8 /* SentryCrashSystemCapabilities.h in Headers */,
 				7BE1E33224F7E3B6009D3AD0 /* SentryMigrateSessionInit.h in Headers */,
+				0ACBA10328A6407200D711F7 /* UIView+Sentry.h in Headers */,
 				632F43501F581D5400A18A36 /* SentryCrashExceptionApplication.h in Headers */,
 				7B85DC1E24EFAFCD007D01D2 /* SentryClient+Private.h in Headers */,
 				7BD4BD4327EB29BA0071F4FF /* SentryClientReport.h in Headers */,
@@ -3375,6 +3382,7 @@
 				63FE710520DA4C1000CDBAE8 /* SentryCrashLogger.c in Sources */,
 				0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */,
 				63FE70E920DA4C1000CDBAE8 /* SentryCrashMonitor_User.c in Sources */,
+				0ACBA10128A6406400D711F7 /* UIView+Sentry.m in Sources */,
 				639FCF991EBC7B9700778193 /* SentryEvent.m in Sources */,
 				632F43521F581D5400A18A36 /* SentryCrashExceptionApplication.m in Sources */,
 				0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */,

--- a/Sources/Sentry/NSData+Sentry.m
+++ b/Sources/Sentry/NSData+Sentry.m
@@ -3,7 +3,7 @@
 @implementation
 NSData (Sentry)
 
-- (NSData *)nullTerminated
+- (NSData *)sentry_nullTerminated
 {
     if (self == nil) {
         return nil;

--- a/Sources/Sentry/NSLocale+Sentry.m
+++ b/Sources/Sentry/NSLocale+Sentry.m
@@ -3,7 +3,7 @@
 @implementation
 NSLocale (Sentry)
 
-- (BOOL)timeIs24HourFormat
+- (BOOL)sentry_timeIs24HourFormat
 {
     NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
     [formatter setDateStyle:NSDateFormatterNoStyle];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -742,7 +742,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
             }
 #endif
                       culture[@"locale"] = self.locale.localeIdentifier;
-                      culture[@"is_24_hour_format"] = @(self.locale.timeIs24HourFormat);
+                      culture[@"is_24_hour_format"] = @(self.locale.sentry_timeIs24HourFormat);
                       culture[@"timezone"] = self.timezone.name;
                   }];
 }

--- a/Sources/Sentry/SentryCrashScopeObserver.m
+++ b/Sources/Sentry/SentryCrashScopeObserver.m
@@ -162,7 +162,7 @@ SentryCrashScopeObserver ()
     }
 
     // C strings need to be null terminated
-    return [json nullTerminated];
+    return [json sentry_nullTerminated];
 }
 
 @end

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -249,7 +249,8 @@ SentryUIViewControllerSwizzling ()
 
 - (void)swizzleRootViewControllerAndDescendant:(UIViewController *)rootViewController
 {
-    NSArray<UIViewController *> *allViewControllers = rootViewController.descendantViewControllers;
+    NSArray<UIViewController *> *allViewControllers
+        = rootViewController.sentry_descendantViewControllers;
 
     for (UIViewController *viewController in allViewControllers) {
         Class viewControllerClass = [viewController class];

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -1,14 +1,10 @@
 #import "SentryViewHierarchy.h"
 #import "SentryDependencyContainer.h"
 #import "SentryUIApplication.h"
+#import "UIView+Sentry.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
-
-@interface
-UIView (Debugging)
-- (id)recursiveDescription;
-@end
 
 @implementation SentryViewHierarchy
 
@@ -27,10 +23,10 @@ UIView (Debugging)
         // In the case of a crash we can't dispatch work to be executed anymore,
         // so we'll run this on the wrong thread.
         if ([NSThread isMainThread] || preventMoveToMainThread) {
-            [result addObject:[window recursiveDescription]];
+            [result addObject:[window sentry_recursiveViewHierarchyDescription]];
         } else {
-            dispatch_sync(
-                dispatch_get_main_queue(), ^{ [result addObject:[window recursiveDescription]]; });
+            dispatch_sync(dispatch_get_main_queue(),
+                ^{ [result addObject:[window sentry_recursiveViewHierarchyDescription]]; });
         }
     }];
 

--- a/Sources/Sentry/UIView+Sentry.m
+++ b/Sources/Sentry/UIView+Sentry.m
@@ -1,0 +1,34 @@
+#import "UIView+Sentry.h"
+
+#if SENTRY_HAS_UIKIT
+
+@implementation
+UIView (Sentry)
+
+- (NSString *)sentry_recursiveViewHierarchyDescription
+{
+    NSMutableString *mutableString = @"".mutableCopy;
+
+    [self sentry_recursiveViewHierarchyDescriptionWithLevel:0 into:mutableString];
+
+    return mutableString.copy;
+}
+
+- (void)sentry_recursiveViewHierarchyDescriptionWithLevel:(NSInteger)level
+                                                     into:(NSMutableString *)mutableString
+{
+    for (int i = 0; i < level; i++) {
+        [mutableString appendString:@"   | "];
+    }
+
+    [mutableString appendString:[self description]];
+    [mutableString appendString:@"\n"];
+
+    for (UIView *subview in self.subviews) {
+        [subview sentry_recursiveViewHierarchyDescriptionWithLevel:level + 1 into:mutableString];
+    }
+}
+
+@end
+
+#endif

--- a/Sources/Sentry/UIViewController+Sentry.m
+++ b/Sources/Sentry/UIViewController+Sentry.m
@@ -5,7 +5,7 @@
 @implementation
 UIViewController (Sentry)
 
-- (NSArray<UIViewController *> *)descendantViewControllers
+- (NSArray<UIViewController *> *)sentry_descendantViewControllers
 {
 
     // The implementation of UIViewController makes sure a parent can't be a child of his child.

--- a/Sources/Sentry/include/NSData+Sentry.h
+++ b/Sources/Sentry/include/NSData+Sentry.h
@@ -9,7 +9,7 @@ NSData (Sentry)
  * Adds a null character to the end of the byte array. This helps when strings should be null
  * terminated.
  */
-- (nullable NSData *)nullTerminated;
+- (nullable NSData *)sentry_nullTerminated;
 
 @end
 

--- a/Sources/Sentry/include/NSLocale+Sentry.h
+++ b/Sources/Sentry/include/NSLocale+Sentry.h
@@ -3,6 +3,6 @@
 @interface
 NSLocale (Sentry)
 
-- (BOOL)timeIs24HourFormat;
+- (BOOL)sentry_timeIs24HourFormat;
 
 @end

--- a/Sources/Sentry/include/UIView+Sentry.h
+++ b/Sources/Sentry/include/UIView+Sentry.h
@@ -1,0 +1,17 @@
+#import "SentryDefines.h"
+
+#if SENTRY_HAS_UIKIT
+#    import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface
+UIView (Sentry)
+
+- (NSString *)sentry_recursiveViewHierarchyDescription;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Sources/Sentry/include/UIViewController+Sentry.h
+++ b/Sources/Sentry/include/UIViewController+Sentry.h
@@ -12,7 +12,8 @@ UIViewController (Sentry)
  * An array of view controllers that are descendants, meaning children, grandchildren, ... , of the
  * current view controller.
  */
-@property (nonatomic, readonly, strong) NSArray<UIViewController *> *descendantViewControllers;
+@property (nonatomic, readonly, strong)
+    NSArray<UIViewController *> *sentry_descendantViewControllers;
 
 @end
 

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -164,7 +164,7 @@ getBasePath()
         if (userInfo != nil) {
             userInfoJSON = [[SentryCrashJSONCodec encode:userInfo
                                                  options:SentryCrashJSONEncodeOptionSorted
-                                                   error:&error] nullTerminated];
+                                                   error:&error] sentry_nullTerminated];
             if (error != NULL) {
                 SentryCrashLOG_ERROR(@"Could not serialize user info: %@", error);
                 return;

--- a/Tests/SentryTests/Categories/UIViewControllerSentryTests.swift
+++ b/Tests/SentryTests/Categories/UIViewControllerSentryTests.swift
@@ -6,7 +6,7 @@ class UIViewControllerSentryTests: XCTestCase {
     func testOnlyOneViewController() {
         let viewController = UIViewController()
         
-        XCTAssertEqual([viewController], viewController.descendantViewControllers)
+        XCTAssertEqual([viewController], viewController.sentry_descendantViewControllers)
     }
     
     func testTwoChildViewController() {
@@ -18,7 +18,7 @@ class UIViewControllerSentryTests: XCTestCase {
         let child2 = UIViewController()
         root.addChild(child2)
         
-        XCTAssertEqual(Set([root, child2, child1]), Set(root.descendantViewControllers))
+        XCTAssertEqual(Set([root, child2, child1]), Set(root.sentry_descendantViewControllers))
     }
     
     func testGrandChildViewController() {
@@ -33,7 +33,7 @@ class UIViewControllerSentryTests: XCTestCase {
         let grandChild2 = UIViewController()
         child.addChild(grandChild2)
         
-        XCTAssertEqual(Set([root, child, grandChild2, grandChild1]), Set(root.descendantViewControllers))
+        XCTAssertEqual(Set([root, child, grandChild2, grandChild1]), Set(root.sentry_descendantViewControllers))
     }
 }
 

--- a/Tests/SentryTests/Categories/UIViewRecursiveDescriptionTests.swift
+++ b/Tests/SentryTests/Categories/UIViewRecursiveDescriptionTests.swift
@@ -1,0 +1,30 @@
+@testable import Sentry
+import XCTest
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+class UIViewRecursiveDescriptionTests: XCTestCase {
+    func testSimpleView() {
+        let view = UIView()
+        let description = view.sentry_recursiveViewHierarchyDescription()
+        XCTAssertEqual(description, view.description + "\n")
+    }
+
+    func testViewHierarchy() {
+        let view = UIView()
+        let subview = UIView()
+        let button = UIButton(frame: .init(x: 0, y: 0, width: 100, height: 100))
+        subview.addSubview(button)
+        view.addSubview(subview)
+
+        let description = view.sentry_recursiveViewHierarchyDescription()
+
+        let expected = [
+            view.description,
+            "   | " + subview.description,
+            "   |    | " + button.description
+        ]
+
+        XCTAssertEqual(description, expected.joined(separator: "\n") + "\n")
+    }
+}
+#endif

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -162,6 +162,7 @@
 #import "TestSentryCrashWrapper.h"
 #import "TestSentrySpan.h"
 #import "TestUrlSession.h"
+#import "UIView+Sentry.h"
 #import "UIViewController+Sentry.h"
 #import "URLSessionTaskMock.h"
 


### PR DESCRIPTION
## :scroll: Description

Follow up of #2044 and #2063. Reimplemented `recursiveDescription` so we're not using private API. Output is equal to Apple's version. Bonus: we now have the basis to make tweaks to the output for when we want to standardize across platforms.

#skip-changelog.

## :bulb: Motivation and Context

Don't use private API.

## :green_heart: How did you test it?

Verified same output, and same tests still succeed.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
