### PR TITLE
fix: SentryUser.userId should be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,10 @@
 - Attach view hierarchy to events (#2044)
 - Clean up SentryOptions: added `enableCrashHandler` and deprecated `integrations` (#2049)
 
-### Fix
-
-- Add span finish flag (#2059)
-
 ### Fixes
 - Fix Swift 5.5 compatibility (#2060)
+- Add span finish flag (#2059)
+- SentryUser.userId should be nullable (#2071)
 
 ## 7.23.0
 

--- a/Sources/Sentry/Public/SentryUser.h
+++ b/Sources/Sentry/Public/SentryUser.h
@@ -9,7 +9,7 @@ NS_SWIFT_NAME(User)
 /**
  * Optional: Id of the user
  */
-@property (atomic, copy) NSString *userId;
+@property (atomic, copy) NSString *_Nullable userId;
 
 /**
  * Optional: Email of the user
@@ -39,7 +39,6 @@ NS_SWIFT_NAME(User)
 - (instancetype)initWithUserId:(NSString *)userId;
 
 - (instancetype)init;
-+ (instancetype)new NS_UNAVAILABLE;
 
 - (BOOL)isEqual:(id _Nullable)other;
 

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -54,10 +54,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isEqual:(id _Nullable)other
 {
     @synchronized(self) {
-        if (other == self)
+        if (other == self) {
             return YES;
-        if (!other || ![[other class] isEqual:[self class]])
+        }
+        if (!other || ![[other class] isEqual:[self class]]) {
             return NO;
+        }
 
         return [self isEqualToUser:other];
     }
@@ -69,30 +71,38 @@ NS_ASSUME_NONNULL_BEGIN
         // We need to get some local copies of the properties, because they could be modified during
         // the if statements
 
-        if (self == user)
+        if (self == user) {
             return YES;
-        if (user == nil)
+        }
+        if (user == nil) {
             return NO;
+        }
 
         NSString *otherUserId = user.userId;
-        if (self.userId != otherUserId && ![self.userId isEqualToString:otherUserId])
+        if (self.userId != otherUserId && ![self.userId isEqualToString:otherUserId]) {
             return NO;
+        }
 
         NSString *otherEmail = user.email;
-        if (self.email != otherEmail && ![self.email isEqualToString:otherEmail])
+        if (self.email != otherEmail && ![self.email isEqualToString:otherEmail]) {
             return NO;
+        }
 
         NSString *otherUsername = user.username;
-        if (self.username != otherUsername && ![self.username isEqualToString:otherUsername])
+        if (self.username != otherUsername && ![self.username isEqualToString:otherUsername]) {
             return NO;
+        }
 
         NSString *otherIpAdress = user.ipAddress;
-        if (self.ipAddress != otherIpAdress && ![self.ipAddress isEqualToString:otherIpAdress])
+        if (self.ipAddress != otherIpAdress && ![self.ipAddress isEqualToString:otherIpAdress]) {
             return NO;
+        }
 
         NSDictionary<NSString *, id> *otherUserData = user.data;
-        if (self.data != otherUserData && ![self.data isEqualToDictionary:otherUserData])
+        if (self.data != otherUserData && ![self.data isEqualToDictionary:otherUserData]) {
             return NO;
+        }
+
         return YES;
     }
 }

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -27,6 +27,13 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(user.userId, actual["id"] as? String)
         XCTAssertEqual(1, actual.count)
     }
+
+    func testSerializationWithoutId() {
+        let user = User()
+        let actual = user.serialize()
+
+        XCTAssertNil(actual["id"] as? String)
+    }
     
     func testHash() {
         XCTAssertEqual(TestData.user.hash(), TestData.user.hash())


### PR DESCRIPTION
## :scroll: Description

`SentryUser.userId` should be nullable to align with the docs / specs.

## :bulb: Motivation and Context

Fixes #2035

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
