### PR TITLE
tests: Reenable testDefaultMaxEnvelopesConcurrent

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -185,10 +185,7 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(expected, fixture.delegate.envelopeItemsDeleted.invocations)
     }
 
-    /**
-     * Disabled because flaky. Fix with https://github.com/getsentry/sentry-cocoa/issues/2017.
-     */
-    func tesDefaultMaxEnvelopesConcurrent() {
+    func testDefaultMaxEnvelopesConcurrent() {
         let parallelTaskAmount = 5
         let queue = DispatchQueue(label: "testDefaultMaxEnvelopesConcurrent", qos: .userInitiated, attributes: [.concurrent, .initiallyInactive])
         


### PR DESCRIPTION
Closes #2017
#skip-changelog