### PR TITLE
feat: Transaction name source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add culture context to event (#2036)
 - Attach view hierarchy to events (#2044)
 - Clean up SentryOptions: added `enableCrashHandler` and deprecated `integrations` (#2049)
+- Integrations send the [transaction name source](https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations) (#2076)
 
 ### Fixes
 - Fix Swift 5.5 compatibility (#2060)

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
 		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
 		0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */; };
+		0A56DA5F28ABA01B00C400D5 /* SentryTransactionContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */; };
 		0A6EEADD28A657970076B469 /* UIViewRecursiveDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */; };
 		0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */; };
 		0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */; };
@@ -739,6 +740,7 @@
 		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
 		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
 		0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
+		0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryTransactionContext+Private.h"; path = "include/SentryTransactionContext+Private.h"; sourceTree = "<group>"; };
 		0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewRecursiveDescriptionTests.swift; sourceTree = "<group>"; };
 		0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyIntegration.m; sourceTree = "<group>"; };
 		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
@@ -2717,6 +2719,7 @@
 				7B6C5ED0264E5D6C0010D138 /* SentryTransaction+Private.h */,
 				8ECC673B25C23996000E2BF6 /* SentryTransactionContext.h */,
 				8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */,
+				0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */,
 				8EC4CF4725C38CAF0093DEE9 /* SentrySpanStatus.h */,
 				8E133FA525E72EB400ABD0BF /* SentrySamplingContext.h */,
 				8E133FA025E72DEF00ABD0BF /* SentrySamplingContext.m */,
@@ -2931,6 +2934,7 @@
 				6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */,
 				7BF9EF7C2722B90E00B5BBEF /* SentryDefaultObjCRuntimeWrapper.h in Headers */,
 				63FE718720DA4C1100CDBAE8 /* SentryCrashReportVersion.h in Headers */,
+				0A56DA5F28ABA01B00C400D5 /* SentryTransactionContext+Private.h in Headers */,
 				8E7C98312693E1CC00E6336C /* SentryTraceHeader.h in Headers */,
 				7BBD18912449BE9000427C76 /* SentryDefaultRateLimits.h in Headers */,
 				7B8713AE26415ADF006D6004 /* SentryAppStartTrackingIntegration.h in Headers */,

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -128,3 +128,15 @@ static NSString *_Nonnull const SentryLevelNames[] = {
 };
 
 static NSUInteger const defaultMaxBreadcrumbs = 100;
+
+/**
+ * Transaction name source
+ */
+typedef NS_ENUM(NSInteger, SentryTransactionNameSource) {
+    kSentryTransactionNameSourceCustom = 0,
+    kSentryTransactionNameSourceUrl,
+    kSentryTransactionNameSourceRoute,
+    kSentryTransactionNameSourceView,
+    kSentryTransactionNameSourceComponent,
+    kSentryTransactionNameSourceTask
+};

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -79,7 +79,7 @@ NS_SWIFT_NAME(Event)
  * The current transaction (state) on the crash.
  *
  * This property is deprecated and will be removed in a future version of the SDK.
- * Use SentryTransaction.transactionContext.name
+ * Use SentryTransaction.trace.transactionContext.name
  */
 @property (nonatomic, copy) NSString *_Nullable transaction;
 

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -77,9 +77,6 @@ NS_SWIFT_NAME(Event)
 
 /**
  * The current transaction (state) on the crash.
- *
- * This property is deprecated and will be removed in a future version of the SDK.
- * Use SentryTransaction.trace.transactionContext.name
  */
 @property (nonatomic, copy) NSString *_Nullable transaction;
 

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -76,7 +76,10 @@ NS_SWIFT_NAME(Event)
 @property (nonatomic, copy) NSString *_Nullable environment;
 
 /**
- * The current transaction (state) on the crash
+ * The current transaction (state) on the crash.
+ *
+ * This property is deprecated and will be removed in a future version of the SDK.
+ * Use SentryTransaction.transactionContext.name
  */
 @property (nonatomic, copy) NSString *_Nullable transaction;
 

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -76,7 +76,7 @@ NS_SWIFT_NAME(Event)
 @property (nonatomic, copy) NSString *_Nullable environment;
 
 /**
- * The current transaction (state) on the crash.
+ * The current transaction (state) on the crash
  */
 @property (nonatomic, copy) NSString *_Nullable transaction;
 

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -66,9 +66,9 @@ SENTRY_NO_INIT
  *
  * @return The created transaction.
  */
-- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                 operation:(NSString *)operation
-    NS_SWIFT_NAME(startTransaction(name:operation:));
+//- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+//                                 operation:(NSString *)operation
+//    NS_SWIFT_NAME(startTransaction(name:operation:));
 
 /**
  * Creates a transaction, binds it to the hub and returns the instance.
@@ -79,10 +79,10 @@ SENTRY_NO_INIT
  *
  * @return The created transaction.
  */
-- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                 operation:(NSString *)operation
-                               bindToScope:(BOOL)bindToScope
-    NS_SWIFT_NAME(startTransaction(name:operation:bindToScope:));
+//- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+//                                 operation:(NSString *)operation
+//                               bindToScope:(BOOL)bindToScope
+//    NS_SWIFT_NAME(startTransaction(name:operation:bindToScope:));
 
 /**
  * Creates a transaction, binds it to the hub and returns the instance.

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -66,9 +66,9 @@ SENTRY_NO_INIT
  *
  * @return The created transaction.
  */
-//- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-//                                 operation:(NSString *)operation
-//    NS_SWIFT_NAME(startTransaction(name:operation:));
+- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                 operation:(NSString *)operation
+    NS_SWIFT_NAME(startTransaction(name:operation:));
 
 /**
  * Creates a transaction, binds it to the hub and returns the instance.
@@ -79,10 +79,10 @@ SENTRY_NO_INIT
  *
  * @return The created transaction.
  */
-//- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-//                                 operation:(NSString *)operation
-//                               bindToScope:(BOOL)bindToScope
-//    NS_SWIFT_NAME(startTransaction(name:operation:bindToScope:));
+- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope
+    NS_SWIFT_NAME(startTransaction(name:operation:bindToScope:));
 
 /**
  * Creates a transaction, binds it to the hub and returns the instance.

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -1,6 +1,18 @@
 #import "SentrySampleDecision.h"
 #import "SentrySpanContext.h"
 
+/**
+ * Transaction name source
+ */
+typedef NS_ENUM(NSInteger, SentryTransactionNameSource) {
+    kSentryTransactionNameSourceCustom = 0,
+    kSentryTransactionNameSourceUrl,
+    kSentryTransactionNameSourceRoute,
+    kSentryTransactionNameSourceView,
+    kSentryTransactionNameSourceComponent,
+    kSentryTransactionNameSourceTask
+};
+
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentrySpanId;
@@ -13,6 +25,7 @@ SENTRY_NO_INIT
  * Transaction name
  */
 @property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly) SentryTransactionNameSource nameSource;
 
 /**
  * Parent sampled
@@ -32,7 +45,7 @@ SENTRY_NO_INIT
  *
  * @return SentryTransactionContext
  */
-- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation;
+//- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation;
 
 /**
  * Init a SentryTransactionContext with given name and set other fields by default
@@ -43,9 +56,9 @@ SENTRY_NO_INIT
  *
  * @return SentryTransactionContext
  */
-- (instancetype)initWithName:(NSString *)name
-                   operation:(NSString *)operation
-                     sampled:(SentrySampleDecision)sampled;
+//- (instancetype)initWithName:(NSString *)name
+//                   operation:(NSString *)operation
+//                     sampled:(SentrySampleDecision)sampled;
 
 /**
  * Init a SentryTransactionContext with given name, traceId, SpanId, parentSpanId and whether the
@@ -60,12 +73,12 @@ SENTRY_NO_INIT
  *
  * @return SentryTransactionContext
  */
-- (instancetype)initWithName:(NSString *)name
-                   operation:(NSString *)operation
-                     traceId:(SentryId *)traceId
-                      spanId:(SentrySpanId *)spanId
-                parentSpanId:(nullable SentrySpanId *)parentSpanId
-               parentSampled:(SentrySampleDecision)parentSampled;
+//- (instancetype)initWithName:(NSString *)name
+//                   operation:(NSString *)operation
+//                     traceId:(SentryId *)traceId
+//                      spanId:(SentrySpanId *)spanId
+//                parentSpanId:(nullable SentrySpanId *)parentSpanId
+//               parentSampled:(SentrySampleDecision)parentSampled;
 
 @end
 

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -1,18 +1,6 @@
 #import "SentrySampleDecision.h"
 #import "SentrySpanContext.h"
 
-/**
- * Transaction name source
- */
-typedef NS_ENUM(NSInteger, SentryTransactionNameSource) {
-    kSentryTransactionNameSourceCustom = 0,
-    kSentryTransactionNameSourceUrl,
-    kSentryTransactionNameSourceRoute,
-    kSentryTransactionNameSourceView,
-    kSentryTransactionNameSourceComponent,
-    kSentryTransactionNameSourceTask
-};
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentrySpanId;

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -45,7 +45,7 @@ SENTRY_NO_INIT
  *
  * @return SentryTransactionContext
  */
-//- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation;
+- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation;
 
 /**
  * Init a SentryTransactionContext with given name and set other fields by default
@@ -56,9 +56,9 @@ SENTRY_NO_INIT
  *
  * @return SentryTransactionContext
  */
-//- (instancetype)initWithName:(NSString *)name
-//                   operation:(NSString *)operation
-//                     sampled:(SentrySampleDecision)sampled;
+- (instancetype)initWithName:(NSString *)name
+                   operation:(NSString *)operation
+                     sampled:(SentrySampleDecision)sampled;
 
 /**
  * Init a SentryTransactionContext with given name, traceId, SpanId, parentSpanId and whether the
@@ -73,12 +73,12 @@ SENTRY_NO_INIT
  *
  * @return SentryTransactionContext
  */
-//- (instancetype)initWithName:(NSString *)name
-//                   operation:(NSString *)operation
-//                     traceId:(SentryId *)traceId
-//                      spanId:(SentrySpanId *)spanId
-//                parentSpanId:(nullable SentrySpanId *)parentSpanId
-//               parentSampled:(SentrySampleDecision)parentSampled;
+- (instancetype)initWithName:(NSString *)name
+                   operation:(NSString *)operation
+                     traceId:(SentryId *)traceId
+                      spanId:(SentrySpanId *)spanId
+                parentSpanId:(nullable SentrySpanId *)parentSpanId
+               parentSampled:(SentrySampleDecision)parentSampled;
 
 @end
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -18,7 +18,7 @@
 #import "SentryTracer.h"
 #import "SentryTracesSampler.h"
 #import "SentryTransaction.h"
-#import "SentryTransactionContext.h"
+#import "SentryTransactionContext+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -297,19 +297,21 @@ SentryHub ()
 
 - (id<SentrySpan>)startTransactionWithName:(NSString *)name operation:(NSString *)operation
 {
-    return [self
-        startTransactionWithContext:[[SentryTransactionContext alloc] initWithName:name
-                                                                         operation:operation]];
+    return [self startTransactionWithContext:[[SentryTransactionContext alloc]
+                                                 initWithName:name
+                                                   nameSource:kSentryTransactionNameSourceCustom
+                                                    operation:operation]];
 }
 
 - (id<SentrySpan>)startTransactionWithName:(NSString *)name
                                  operation:(NSString *)operation
                                bindToScope:(BOOL)bindToScope
 {
-    return
-        [self startTransactionWithContext:[[SentryTransactionContext alloc] initWithName:name
-                                                                               operation:operation]
-                              bindToScope:bindToScope];
+    return [self startTransactionWithContext:[[SentryTransactionContext alloc]
+                                                 initWithName:name
+                                                   nameSource:kSentryTransactionNameSourceCustom
+                                                    operation:operation]
+                                 bindToScope:bindToScope];
 }
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -304,6 +304,16 @@ SentryHub ()
 }
 
 - (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation
+{
+    return [self
+        startTransactionWithContext:[[SentryTransactionContext alloc] initWithName:name
+                                                                        nameSource:source
+                                                                         operation:operation]];
+}
+
+- (id<SentrySpan>)startTransactionWithName:(NSString *)name
                                  operation:(NSString *)operation
                                bindToScope:(BOOL)bindToScope
 {
@@ -312,6 +322,18 @@ SentryHub ()
                                                    nameSource:kSentryTransactionNameSourceCustom
                                                     operation:operation]
                                  bindToScope:bindToScope];
+}
+
+- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope
+{
+    return
+        [self startTransactionWithContext:[[SentryTransactionContext alloc] initWithName:name
+                                                                              nameSource:source
+                                                                               operation:operation]
+                              bindToScope:bindToScope];
 }
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -7,7 +7,7 @@
 #import "SentrySpanId.h"
 #import "SentrySpanProtocol.h"
 #import "SentryTracer.h"
-#import "SentryTransactionContext.h"
+#import "SentryTransactionContext+Private.h"
 #import "SentryUIEventTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -51,7 +51,9 @@ SentryPerformanceTracker () <SentryTracerDelegate>
         newSpan = [activeSpan startChildWithOperation:operation description:name];
     } else {
         SentryTransactionContext *context =
-            [[SentryTransactionContext alloc] initWithName:name operation:operation];
+            [[SentryTransactionContext alloc] initWithName:name
+                                                nameSource:kSentryTransactionNameSourceComponent
+                                                 operation:operation];
 
         [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> span) {
             BOOL bindToScope = true;

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -51,9 +51,7 @@ SentryPerformanceTracker () <SentryTracerDelegate>
         newSpan = [activeSpan startChildWithOperation:operation description:name];
     } else {
         SentryTransactionContext *context =
-            [[SentryTransactionContext alloc] initWithName:name
-                                                nameSource:kSentryTransactionNameSourceComponent
-                                                 operation:operation];
+            [[SentryTransactionContext alloc] initWithName:name operation:operation];
 
         [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> span) {
             BOOL bindToScope = true;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -259,7 +259,7 @@ isSimulatorBuild()
     profile[@"transaction_id"] = transaction.eventId.sentryIdString;
     profile[@"trace_id"] = transaction.trace.context.traceId.sentryIdString;
     profile[@"profile_id"] = [[SentryId alloc] init].sentryIdString;
-    profile[@"transaction_name"] = transaction.transactionContext.name;
+    profile[@"transaction_name"] = transaction.trace.transactionContext.name;
     profile[@"duration_ns"] = [@(getDurationNs(_startTimestamp, getAbsoluteTime())) stringValue];
 
     const auto bundle = NSBundle.mainBundle;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -19,6 +19,7 @@
 #    import "SentrySerialization.h"
 #    import "SentryTime.h"
 #    import "SentryTransaction.h"
+#    import "SentryTransactionContext.h"
 
 #    if defined(DEBUG)
 #        include <execinfo.h>
@@ -258,7 +259,7 @@ isSimulatorBuild()
     profile[@"transaction_id"] = transaction.eventId.sentryIdString;
     profile[@"trace_id"] = transaction.trace.context.traceId.sentryIdString;
     profile[@"profile_id"] = [[SentryId alloc] init].sentryIdString;
-    profile[@"transaction_name"] = transaction.transaction;
+    profile[@"transaction_name"] = transaction.transactionContext.name;
     profile[@"duration_ns"] = [@(getDurationNs(_startTimestamp, getAbsoluteTime())) stringValue];
 
     const auto bundle = NSBundle.mainBundle;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -259,7 +259,7 @@ isSimulatorBuild()
     profile[@"transaction_id"] = transaction.eventId.sentryIdString;
     profile[@"trace_id"] = transaction.trace.context.traceId.sentryIdString;
     profile[@"profile_id"] = [[SentryId alloc] init].sentryIdString;
-    profile[@"transaction_name"] = transaction.trace.transactionContext.name;
+    profile[@"transaction_name"] = transaction.transaction;
     profile[@"duration_ns"] = [@(getDurationNs(_startTimestamp, getAbsoluteTime())) stringValue];
 
     const auto bundle = NSBundle.mainBundle;

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -184,14 +184,37 @@ static NSUInteger startInvocations;
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name operation:(NSString *)operation
 {
-    return [SentrySDK.currentHub startTransactionWithName:name operation:operation];
+    return [self startTransactionWithName:name
+                               nameSource:kSentryTransactionNameSourceCustom
+                                operation:operation];
+}
+
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation
+{
+    return [SentrySDK.currentHub startTransactionWithName:name
+                                               nameSource:source
+                                                operation:operation];
 }
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name
                                  operation:(NSString *)operation
                                bindToScope:(BOOL)bindToScope
 {
+    return [self startTransactionWithName:name
+                               nameSource:kSentryTransactionNameSourceCustom
+                                operation:operation
+                              bindToScope:bindToScope];
+}
+
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope
+{
     return [SentrySDK.currentHub startTransactionWithName:name
+                                               nameSource:source
                                                 operation:operation
                                               bindToScope:bindToScope];
 }

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -9,6 +9,7 @@
 #import "SentrySession.h"
 #import "SentrySpan.h"
 #import "SentryTracer.h"
+#import "SentryTransactionContext.h"
 #import "SentryUser.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -531,7 +532,7 @@ SentryScope ()
         if (span != nil) {
             if (![event.type isEqualToString:SentryEnvelopeItemTypeTransaction] &&
                 [span isKindOfClass:[SentryTracer class]]) {
-                event.transaction = [(SentryTracer *)span name];
+                event.transaction = [[(SentryTracer *)span transactionContext] name];
             }
             newContext[@"trace"] = [span.context serialize];
         }

--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -91,17 +91,21 @@ SentrySpanContext () {
 
     // Since we guard for 'undecided', we'll
     // either send it if it's 'true' or 'false'.
-    if (self.sampled != kSentrySampleDecisionUndecided)
+    if (self.sampled != kSentrySampleDecisionUndecided) {
         [mutabledictionary setValue:SentrySampleDecisionNames[self.sampled] forKey:@"sampled"];
+    }
 
-    if (self.spanDescription != nil)
+    if (self.spanDescription != nil) {
         [mutabledictionary setValue:self.spanDescription forKey:@"description"];
+    }
 
-    if (self.parentSpanId != nil)
+    if (self.parentSpanId != nil) {
         [mutabledictionary setValue:self.parentSpanId.sentrySpanIdString forKey:@"parent_span_id"];
+    }
 
-    if (self.status != kSentrySpanStatusUndefined)
+    if (self.status != kSentrySpanStatusUndefined) {
         [mutabledictionary setValue:SentrySpanStatusNames[self.status] forKey:@"status"];
+    }
 
     return mutabledictionary;
 }

--- a/Sources/Sentry/SentryTraceContext.m
+++ b/Sources/Sentry/SentryTraceContext.m
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
                        publicKey:options.parsedDsn.url.user
                      releaseName:options.releaseName
                      environment:options.environment
-                     transaction:tracer.name
+                     transaction:tracer.transactionContext.name
                      userSegment:userSegment
                       sampleRate:sampleRate];
 }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -565,8 +565,7 @@ static NSLock *profilerLock;
     }
 
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
-    transaction.transaction = self.transactionContext.name;
-    transaction.nameSource = self.transactionContext.nameSource;
+    transaction.transactionContext = self.transactionContext;
     [self addMeasurements:transaction appStartMeasurement:appStartMeasurement];
     return transaction;
 }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -565,6 +565,7 @@ static NSLock *profilerLock;
     }
 
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
+    transaction.transaction = self.transactionContext.name;
     transaction.transactionContext = self.transactionContext;
     [self addMeasurements:transaction appStartMeasurement:appStartMeasurement];
     return transaction;

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -145,7 +145,7 @@ static NSLock *profilerLock;
 {
     if (self = [super init]) {
         self.rootSpan = [[SentrySpan alloc] initWithTransaction:self context:transactionContext];
-        self.name = transactionContext.name;
+        self.transactionContext = transactionContext;
         _children = [[NSMutableArray alloc] init];
         self.hub = hub;
         self.isWaitingForChildren = NO;
@@ -565,7 +565,8 @@ static NSLock *profilerLock;
     }
 
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
-    transaction.transaction = self.name;
+    transaction.transaction = self.transactionContext.name;
+    transaction.nameSource = self.transactionContext.nameSource;
     [self addMeasurements:transaction appStartMeasurement:appStartMeasurement];
     return transaction;
 }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -566,7 +566,6 @@ static NSLock *profilerLock;
 
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
     transaction.transaction = self.transactionContext.name;
-    transaction.transactionContext = self.transactionContext;
     [self addMeasurements:transaction appStartMeasurement:appStartMeasurement];
     return transaction;
 }

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -1,6 +1,7 @@
 #import "SentryTransaction.h"
 #import "NSDictionary+SentrySanitize.h"
 #import "SentryEnvelopeItemType.h"
+#import "SentryTransactionContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,6 +37,8 @@ SentryTransaction ()
 {
     NSMutableDictionary<NSString *, id> *serializedData =
         [[NSMutableDictionary alloc] initWithDictionary:[super serialize]];
+
+    [serializedData setValue:self.transactionContext.name forKey:@"transaction"];
 
     NSMutableArray *serializedSpans = [[NSMutableArray alloc] init];
     for (id<SentrySpan> span in self.spans) {
@@ -84,7 +87,7 @@ SentryTransaction ()
     }
 
     serializedData[@"transaction_info"] =
-        @{ @"source" : [self stringForNameSource:self.nameSource] };
+        @{ @"source" : [self stringForNameSource:self.transactionContext.nameSource] };
 
     return serializedData;
 }

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -83,7 +83,28 @@ SentryTransaction ()
         serializedData[@"measurements"] = [self.measurements.copy sentry_sanitize];
     }
 
+    serializedData[@"transaction_info"] =
+        @{ @"source" : [self stringForNameSource:self.nameSource] };
+
     return serializedData;
+}
+
+- (NSString *)stringForNameSource:(SentryTransactionNameSource)source
+{
+    switch (source) {
+    case kSentryTransactionNameSourceCustom:
+        return @"custom";
+    case kSentryTransactionNameSourceUrl:
+        return @"url";
+    case kSentryTransactionNameSourceRoute:
+        return @"route";
+    case kSentryTransactionNameSourceView:
+        return @"view";
+    case kSentryTransactionNameSourceComponent:
+        return @"component";
+    case kSentryTransactionNameSourceTask:
+        return @"task";
+    }
 }
 @end
 

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -38,8 +38,6 @@ SentryTransaction ()
     NSMutableDictionary<NSString *, id> *serializedData =
         [[NSMutableDictionary alloc] initWithDictionary:[super serialize]];
 
-    [serializedData setValue:self.transactionContext.name forKey:@"transaction"];
-
     NSMutableArray *serializedSpans = [[NSMutableArray alloc] init];
     for (id<SentrySpan> span in self.spans) {
         [serializedSpans addObject:[span serialize]];
@@ -86,8 +84,12 @@ SentryTransaction ()
         serializedData[@"measurements"] = [self.measurements.copy sentry_sanitize];
     }
 
-    serializedData[@"transaction_info"] =
-        @{ @"source" : [self stringForNameSource:self.transactionContext.nameSource] };
+    if (self.trace) {
+        [serializedData setValue:self.trace.transactionContext.name forKey:@"transaction"];
+
+        serializedData[@"transaction_info"] =
+            @{ @"source" : [self stringForNameSource:self.trace.transactionContext.nameSource] };
+    }
 
     return serializedData;
 }

--- a/Sources/Sentry/SentryTransactionContext.m
+++ b/Sources/Sentry/SentryTransactionContext.m
@@ -4,27 +4,63 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryTransactionContext
 
-- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation
+//- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation
+//{
+//    return [self initWithName:name nameSource:kSentryTransactionNameSourceCustom
+//    operation:operation];
+//}
+
+- (instancetype)initWithName:(NSString *)name
+                  nameSource:(SentryTransactionNameSource)source
+                   operation:(NSString *)operation
 {
     if (self = [super initWithOperation:operation]) {
         _name = [NSString stringWithString:name];
+        _nameSource = source;
         self.parentSampled = false;
     }
     return self;
 }
 
+//- (instancetype)initWithName:(NSString *)name
+//                   operation:(NSString *)operation
+//                     sampled:(SentrySampleDecision)sampled
+//{
+//    return [self initWithName:name nameSource:kSentryTransactionNameSourceCustom
+//    operation:operation sampled:sampled];
+//}
+
 - (instancetype)initWithName:(NSString *)name
+                  nameSource:(SentryTransactionNameSource)source
                    operation:(NSString *)operation
                      sampled:(SentrySampleDecision)sampled
 {
     if (self = [super initWithOperation:operation sampled:sampled]) {
         _name = [NSString stringWithString:name];
+        _nameSource = source;
         self.parentSampled = false;
     }
     return self;
 }
 
+//- (instancetype)initWithName:(NSString *)name
+//                   operation:(nonnull NSString *)operation
+//                     traceId:(SentryId *)traceId
+//                      spanId:(SentrySpanId *)spanId
+//                parentSpanId:(nullable SentrySpanId *)parentSpanId
+//               parentSampled:(SentrySampleDecision)parentSampled
+//{
+//    return [self initWithName:name
+//                   nameSource:kSentryTransactionNameSourceCustom
+//                    operation:operation
+//                      traceId:traceId
+//                       spanId:spanId
+//                 parentSpanId:parentSpanId
+//                parentSampled:parentSampled];
+//}
+
 - (instancetype)initWithName:(NSString *)name
+                  nameSource:(SentryTransactionNameSource)source
                    operation:(nonnull NSString *)operation
                      traceId:(SentryId *)traceId
                       spanId:(SentrySpanId *)spanId
@@ -37,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
                             operation:operation
                               sampled:false]) {
         _name = [NSString stringWithString:name];
+        _nameSource = source;
         self.parentSampled = parentSampled;
     }
     return self;

--- a/Sources/Sentry/SentryTransactionContext.m
+++ b/Sources/Sentry/SentryTransactionContext.m
@@ -4,11 +4,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryTransactionContext
 
-//- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation
-//{
-//    return [self initWithName:name nameSource:kSentryTransactionNameSourceCustom
-//    operation:operation];
-//}
+- (instancetype)initWithName:(NSString *)name operation:(NSString *)operation
+{
+    return [self initWithName:name
+                   nameSource:kSentryTransactionNameSourceCustom
+                    operation:operation];
+}
 
 - (instancetype)initWithName:(NSString *)name
                   nameSource:(SentryTransactionNameSource)source
@@ -22,13 +23,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-//- (instancetype)initWithName:(NSString *)name
-//                   operation:(NSString *)operation
-//                     sampled:(SentrySampleDecision)sampled
-//{
-//    return [self initWithName:name nameSource:kSentryTransactionNameSourceCustom
-//    operation:operation sampled:sampled];
-//}
+- (instancetype)initWithName:(NSString *)name
+                   operation:(NSString *)operation
+                     sampled:(SentrySampleDecision)sampled
+{
+    return [self initWithName:name
+                   nameSource:kSentryTransactionNameSourceCustom
+                    operation:operation
+                      sampled:sampled];
+}
 
 - (instancetype)initWithName:(NSString *)name
                   nameSource:(SentryTransactionNameSource)source
@@ -43,21 +46,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
-//- (instancetype)initWithName:(NSString *)name
-//                   operation:(nonnull NSString *)operation
-//                     traceId:(SentryId *)traceId
-//                      spanId:(SentrySpanId *)spanId
-//                parentSpanId:(nullable SentrySpanId *)parentSpanId
-//               parentSampled:(SentrySampleDecision)parentSampled
-//{
-//    return [self initWithName:name
-//                   nameSource:kSentryTransactionNameSourceCustom
-//                    operation:operation
-//                      traceId:traceId
-//                       spanId:spanId
-//                 parentSpanId:parentSpanId
-//                parentSampled:parentSampled];
-//}
+- (instancetype)initWithName:(NSString *)name
+                   operation:(nonnull NSString *)operation
+                     traceId:(SentryId *)traceId
+                      spanId:(SentrySpanId *)spanId
+                parentSpanId:(nullable SentrySpanId *)parentSpanId
+               parentSampled:(SentrySampleDecision)parentSampled
+{
+    return [self initWithName:name
+                   nameSource:kSentryTransactionNameSourceCustom
+                    operation:operation
+                      traceId:traceId
+                       spanId:spanId
+                 parentSpanId:parentSpanId
+                parentSampled:parentSampled];
+}
 
 - (instancetype)initWithName:(NSString *)name
                   nameSource:(SentryTransactionNameSource)source

--- a/Sources/Sentry/SentryUIEventTracker.m
+++ b/Sources/Sentry/SentryUIEventTracker.m
@@ -75,7 +75,8 @@ SentryUIEventTracker ()
                 currentActiveTransaction = self.activeTransactions.lastObject;
             }
 
-            BOOL sameAction = [currentActiveTransaction.name isEqualToString:transactionName];
+            BOOL sameAction =
+                [currentActiveTransaction.transactionContext.name isEqualToString:transactionName];
             if (sameAction) {
                 [currentActiveTransaction dispatchIdleTimeout];
                 return;

--- a/Sources/Sentry/SentryUIEventTracker.m
+++ b/Sources/Sentry/SentryUIEventTracker.m
@@ -6,7 +6,7 @@
 #import <SentrySpanOperations.h>
 #import <SentrySpanProtocol.h>
 #import <SentryTracer.h>
-#import <SentryTransactionContext.h>
+#import <SentryTransactionContext+Private.h>
 #import <SentryUIEventTracker.h>
 
 #if SENTRY_HAS_UIKIT
@@ -86,7 +86,9 @@ SentryUIEventTracker ()
             NSString *operation = [self getOperation:sender];
 
             SentryTransactionContext *context =
-                [[SentryTransactionContext alloc] initWithName:transactionName operation:operation];
+                [[SentryTransactionContext alloc] initWithName:transactionName
+                                                    nameSource:kSentryTransactionNameSourceComponent
+                                                     operation:operation];
 
             __block SentryTracer *transaction;
             [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -1,5 +1,4 @@
 #import "SentryHub.h"
-#import "SentryTransactionContext+Private.h"
 
 @class SentryEnvelopeItem, SentryId, SentryScope, SentryTransaction, SentryDispatchQueueWrapper,
     SentryTracer;

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -1,4 +1,5 @@
 #import "SentryHub.h"
+#import "SentryTransactionContext+Private.h"
 
 @class SentryEnvelopeItem, SentryId, SentryScope, SentryTransaction, SentryDispatchQueueWrapper,
     SentryTracer;
@@ -21,6 +22,15 @@ SentryHub (Private)
 - (void)setSampleRandomValue:(NSNumber *)value;
 
 - (void)closeCachedSessionWithTimestamp:(NSDate *_Nullable)timestamp;
+
+- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation;
+
+- (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope;
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -1,5 +1,4 @@
 #import "SentrySDK.h"
-#import "SentryTransactionContext+Private.h"
 
 @class SentryHub, SentryId, SentryAppStartMeasurement, SentryEnvelope;
 

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -1,4 +1,5 @@
 #import "SentrySDK.h"
+#import "SentryTransactionContext+Private.h"
 
 @class SentryHub, SentryId, SentryAppStartMeasurement, SentryEnvelope;
 
@@ -35,6 +36,18 @@ SentrySDK (Private)
  * Needed by hybrid SDKs as react-native to synchronously capture an envelope.
  */
 + (void)captureEnvelope:(SentryEnvelope *)envelope;
+
+/**
+ * Start a transaction with a name and a name source.
+ */
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation;
+
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                nameSource:(SentryTransactionNameSource)source
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope;
 
 @end
 

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -20,10 +20,7 @@ static NSTimeInterval const SentryTracerDefaultTimeout = 3.0;
 
 @interface SentryTracer : NSObject <SentrySpan>
 
-/**
- *Span name.
- */
-@property (nonatomic, copy) NSString *name;
+@property (nonatomic, copy) SentryTransactionContext *transactionContext;
 
 /**
  * The context information of the span.

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -20,7 +20,7 @@ static NSTimeInterval const SentryTracerDefaultTimeout = 3.0;
 
 @interface SentryTracer : NSObject <SentrySpan>
 
-@property (nonatomic, copy) SentryTransactionContext *transactionContext;
+@property (nonatomic, strong) SentryTransactionContext *transactionContext;
 
 /**
  * The context information of the span.

--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -12,8 +12,6 @@ SENTRY_NO_INIT
 
 @property (nonatomic, strong) SentryTracer *trace;
 
-@property (nonatomic, strong) SentryTransactionContext *transactionContext;
-
 - (instancetype)initWithTrace:(SentryTracer *)trace children:(NSArray<id<SentrySpan>> *)children;
 
 @end

--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -1,6 +1,7 @@
 #import "SentryEvent.h"
 #import "SentrySpanProtocol.h"
 #import "SentryTracer.h"
+#import "SentryTransactionContext+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,6 +12,7 @@ NS_SWIFT_NAME(Transaction)
 SENTRY_NO_INIT
 
 @property (nonatomic, strong) SentryTracer *trace;
+@property (nonatomic) SentryTransactionNameSource nameSource;
 
 - (instancetype)initWithTrace:(SentryTracer *)trace children:(NSArray<id<SentrySpan>> *)children;
 

--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -4,14 +4,15 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryTracer;
+@class SentryTracer, SentryTransactionContext;
 
 NS_SWIFT_NAME(Transaction)
 @interface SentryTransaction : SentryEvent
 SENTRY_NO_INIT
 
 @property (nonatomic, strong) SentryTracer *trace;
-@property (nonatomic) SentryTransactionNameSource nameSource;
+
+@property (nonatomic, strong) SentryTransactionContext *transactionContext;
 
 - (instancetype)initWithTrace:(SentryTracer *)trace children:(NSArray<id<SentrySpan>> *)children;
 

--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -1,7 +1,6 @@
 #import "SentryEvent.h"
 #import "SentrySpanProtocol.h"
 #import "SentryTracer.h"
-#import "SentryTransactionContext+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -1,0 +1,27 @@
+#import "SentryTransactionContext.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface
+SentryTransactionContext (Private)
+
+- (instancetype)initWithName:(NSString *)name
+                  nameSource:(SentryTransactionNameSource)source
+                   operation:(NSString *)operation;
+
+- (instancetype)initWithName:(NSString *)name
+                  nameSource:(SentryTransactionNameSource)source
+                   operation:(NSString *)operation
+                     sampled:(SentrySampleDecision)sampled;
+
+- (instancetype)initWithName:(NSString *)name
+                  nameSource:(SentryTransactionNameSource)source
+                   operation:(nonnull NSString *)operation
+                     traceId:(SentryId *)traceId
+                      spanId:(SentrySpanId *)spanId
+                parentSpanId:(nullable SentrySpanId *)parentSpanId
+               parentSampled:(SentrySampleDecision)parentSampled;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -51,6 +51,8 @@ class SentryPerformanceTrackerTests: XCTestCase {
         
         XCTAssert(scopeSpan === transaction)
         XCTAssertTrue(transaction.waitForChildren)
+        XCTAssertEqual(transaction.transactionContext.name, fixture.someTransaction)
+        XCTAssertEqual(transaction.transactionContext.nameSource, .component)
     }
     
     func testStartSpan_ScopeAlreadyWithSpan() {
@@ -66,7 +68,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         XCTAssert(scopeSpan === firstTransaction)
     }
     
-    func testStartSpan_ScopeWithUIActionSpan_FinishesSoan() {
+    func testStartSpan_ScopeWithUIActionSpan_FinishesSpan() {
         let sut = fixture.getSut()
         let firstTransaction = SentrySDK.startTransaction(name: fixture.someTransaction, operation: "ui.action", bindToScope: true)
         let spanId = startSpan(tracker: sut)

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -52,7 +52,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         XCTAssert(scopeSpan === transaction)
         XCTAssertTrue(transaction.waitForChildren)
         XCTAssertEqual(transaction.transactionContext.name, fixture.someTransaction)
-        XCTAssertEqual(transaction.transactionContext.nameSource, .component)
+        XCTAssertEqual(transaction.transactionContext.nameSource, .custom)
     }
     
     func testStartSpan_ScopeAlreadyWithSpan() {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -113,6 +113,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             callbackExpectation.fulfill()
         }
         XCTAssertEqual((transactionSpan as! SentryTracer?)!.transactionContext.name, fixture.viewControllerName)
+        XCTAssertEqual((transactionSpan as! SentryTracer?)!.transactionContext.nameSource, .custom)
         XCTAssertFalse(transactionSpan.isFinished)
 
         sut.viewControllerViewDidLoad(viewController) {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -112,7 +112,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             XCTAssertEqual(blockSpan.context.spanDescription, self.loadView)
             callbackExpectation.fulfill()
         }
-        XCTAssertEqual((transactionSpan as! SentryTracer?)!.name, fixture.viewControllerName)
+        XCTAssertEqual((transactionSpan as! SentryTracer?)!.transactionContext.name, fixture.viewControllerName)
         XCTAssertFalse(transactionSpan.isFinished)
 
         sut.viewControllerViewDidLoad(viewController) {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -88,7 +88,7 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         let span = SentrySDK.span
         XCTAssertNotNil(span)
         
-        let transactionName = Dynamic(span).name.asString
+        let transactionName = Dynamic(span).transactionContext.name.asString
         let expectedTransactionName = SentryUIViewControllerSanitizer.sanitizeViewControllerName(controller)
         XCTAssertEqual(expectedTransactionName, transactionName)
     }

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -250,7 +250,7 @@ class SentryUIEventTrackerTests: XCTestCase {
         XCTAssertEqual(1, transactions.count)
         XCTAssertTrue(span === transactions.first)
         
-        XCTAssertEqual(name, span.name)
+        XCTAssertEqual(name, span.transactionContext.name)
         XCTAssertEqual(operation, span.context.operation)
     }
     

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -243,7 +243,7 @@ class SentryUIEventTrackerTests: XCTestCase {
         return try! XCTUnwrap(Dynamic(sut).activeTransactions.asArray as? [SentryTracer])
     }
     
-    private func assertTransaction(name: String, operation: String) {
+    private func assertTransaction(name: String, operation: String, nameSource: SentryTransactionNameSource = .component) {
         let span = try! XCTUnwrap(SentrySDK.span as? SentryTracer)
         
         let transactions = try! XCTUnwrap(Dynamic(sut).activeTransactions.asArray as? [SentryTracer])
@@ -251,6 +251,7 @@ class SentryUIEventTrackerTests: XCTestCase {
         XCTAssertTrue(span === transactions.first)
         
         XCTAssertEqual(name, span.transactionContext.name)
+        XCTAssertEqual(nameSource, span.transactionContext.nameSource)
         XCTAssertEqual(operation, span.context.operation)
     }
     

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackingIntegrationTests.swift
@@ -67,7 +67,7 @@ class SentryUIEventTrackerIntegrationTests: XCTestCase {
         XCTAssertTrue(SentrySwizzleWrapper.hasItens())
     }
     
-    func test_Unistall() {
+    func test_Uninstall() {
         let sut = fixture.getSut()
         sut.install(with: fixture.optionForUIEventTracking())
         XCTAssertNotNil(Dynamic(sut).uiEventTracker as SentryUIEventTracker?)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -215,7 +215,7 @@ class SentryHubTests: XCTestCase {
     func testStartTransactionWithNameOperation() {
         let span = fixture.getSut().startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation)
         let tracer = Dynamic(span)
-        XCTAssertEqual(tracer.name, fixture.transactionName)
+        XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
         XCTAssertEqual(span.context.operation, fixture.transactionOperation)
     }
     
@@ -223,7 +223,7 @@ class SentryHubTests: XCTestCase {
         let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation))
         
         let tracer = Dynamic(span)
-        XCTAssertEqual(tracer.name, fixture.transactionName)
+        XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
         XCTAssertEqual(span.context.operation, fixture.transactionOperation)
     }
     
@@ -239,7 +239,7 @@ class SentryHubTests: XCTestCase {
         let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation), customSamplingContext: ["customKey": "customValue"])
         
         let tracer = Dynamic(span)
-        XCTAssertEqual(tracer.name, fixture.transactionName)
+        XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
         XCTAssertEqual(customSamplingContext?["customKey"] as? String, "customValue")
         XCTAssertEqual(span.context.operation, fixture.transactionOperation)
     }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -220,10 +220,26 @@ class SentryHubTests: XCTestCase {
     }
     
     func testStartTransactionWithContext() {
-        let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation))
+        let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(
+            name: fixture.transactionName,
+            operation: fixture.transactionOperation
+        ))
         
         let tracer = Dynamic(span)
         XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
+        XCTAssertEqual(span.context.operation, fixture.transactionOperation)
+    }
+
+    func testStartTransactionWithNameSource() {
+        let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(
+            name: fixture.transactionName,
+            nameSource: .url,
+            operation: fixture.transactionOperation
+        ))
+
+        let tracer = Dynamic(span)
+        XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
+        XCTAssertEqual(tracer.transactionContext.nameSource, SentryTransactionNameSource.url)
         XCTAssertEqual(span.context.operation, fixture.transactionOperation)
     }
     

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -147,6 +147,7 @@
 #import "SentryTracer.h"
 #import "SentryTransaction+Private.h"
 #import "SentryTransaction.h"
+#import "SentryTransactionContext+Private.h"
 #import "SentryTransport.h"
 #import "SentryTransportAdapter.h"
 #import "SentryTransportFactory.h"

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -13,7 +13,7 @@ class SentryTransactionTests: XCTestCase {
         }
         
         func getContext() -> TransactionContext {
-            return TransactionContext(name: transactionName, operation: transactionOperation)
+            return TransactionContext(name: transactionName, nameSource: .component, operation: transactionOperation)
         }
         
         func getTrace() -> SentryTracer {
@@ -61,7 +61,7 @@ class SentryTransactionTests: XCTestCase {
         let actualMeasurements = actual["measurements"] as? [String: [String: Double]]
         XCTAssertEqual(appStart, actualMeasurements?["app_start_cold"] )
     }
-    
+
     func testSerializeMeasurements_GarbageInMeasurements_GarbageSanitized() {
         let transaction = fixture.getTransaction()
         
@@ -150,5 +150,13 @@ class SentryTransactionTests: XCTestCase {
         // then
         XCTAssertEqual(serializedTransactionExtra, [fixture.testKey: fixture.testValue])
     }
-    
+
+    func testSerialize_TransactionInfo() {
+        let scope = Scope()
+        let transaction = fixture.getTransactionWith(scope: scope)
+        let actual = transaction.serialize()
+
+        let actualTransactionInfo = actual["transaction_info"] as? [String: String]
+        XCTAssertEqual(actualTransactionInfo?["source"], "component")
+    }
 }


### PR DESCRIPTION
## :scroll: Description

Added a new property to the transaction context: the name source. By default this is "custom", but we can set a different one in our integrations. See https://develop.sentry.dev/sdk/event-payloads/transaction/#transaction-annotations.

Users of the SDK can't set a name source, it'll always be "custom" when they start a transaction with a name.

## :bulb: Motivation and Context

Closes #2075.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
