### PR TITLE
ci: upload dSYMs for all jobs that run on real devices

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
+      - name: Install SentryCli
+        run: brew install getsentry/tools/sentry-cli
       - run: git apply ./scripts/set-device-tests-environment.patch
       - name: Cache iOS-Swift App and dSYM build products
         id: ios-swift-cache

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -41,7 +41,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/PerformanceBenchmarks-Runner.app
           key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/PerformanceBenchmarks/**') }}
-      - run: fastlane build_ios_swift
+      - run: fastlane build_ios_swift_for_tests
         if: steps.ios-swift-cache.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -23,7 +23,6 @@ jobs:
     name: Build app and test runner
     runs-on: macos-11
     steps:
-      - run: echo "Hi mom!"
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
       - name: Install SentryCli

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -23,6 +23,7 @@ jobs:
     name: Build app and test runner
     runs-on: macos-11
     steps:
+      - run: echo "Hi mom!"
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
       - name: Install SentryCli

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -26,7 +26,23 @@ jobs:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
       - run: git apply ./scripts/set-device-tests-environment.patch
-      - run: fastlane build_ios_benchmark_test
+      - name: Cache iOS-Swift App and dSYM build products
+        id: ios-swift-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}
+      - name: Cache iOS-Swift UI Test Runner App build product
+        id: ios-swift-benchmark-runner-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/PerformanceBenchmarks-Runner.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/PerformanceBenchmarks/**') }}
+      - run: fastlane build_ios_swift
+        if: steps.ios-swift-cache.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -35,6 +51,20 @@ jobs:
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
+      - run: fastlane build_ios_benchmark_test
+        if: steps.ios-swift-benchmark-runner-cache.outputs.cache-hit != 'true'
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+          FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
+          MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
+      - name: Upload dSYMs
+        if: steps.ios-swift-cache.outputs.cache-hit != 'true'
+        run: |
+          sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project sentry-cocoa DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
       - name: Archiving DerivedData
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -19,6 +19,7 @@ jobs:
     name: Build app and test runner
     runs-on: macos-12
     steps:
+      - run: echo "Hi mom!"
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh 13.4.1
       - name: Install SentryCli

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -32,7 +32,33 @@ jobs:
       - name: Install Carthage deps
         if: steps.trendingmovies-carthage-cache.outputs.cache-hit != 'true'
         run: cd Samples/TrendingMovies && carthage update --use-xcframeworks
+      - name: Cache TrendingMovies App and dSYM build products
+        id: cache-trending-movies-app
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app
+            DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app.dSYM
+          key: trendingmovies-app-cache-key-${{ hashFiles('Samples/TrendingMovies/TrendingMovies/**') }}
+      - name: Cache ProfileDataGenerator UI Test Runner App build product
+        id: cache-profiledatagenerator-test-runner-app
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/ProfileDataGeneratorUITest-Runner.app
+          key: profiledatagenerator-test-runner-app-cache-key-${{ hashFiles('Samples/TrendingMovies/ProfileDataGeneratorUITest/**') }}
+      - run: fastlane build_trending_movies
+        if: steps.cache-trending-movies-app.outputs.cache-hit != 'true'
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+          FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
+          MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - run: fastlane build_profile_data_generator_ui_test
+        if: steps.cache-profiledatagenerator-test-runner-app.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -19,7 +19,6 @@ jobs:
     name: Build app and test runner
     runs-on: macos-12
     steps:
-      - run: echo "Hi mom!"
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh 13.4.1
       - name: Install SentryCli

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -38,14 +38,14 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
-          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-uitest-runner-cache
         uses: actions/cache@v3
         with:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
-          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-SwiftUITests/**') }}
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-SwiftUITests/**') }}-Xcode-${{ matrix.xcode }}
       - run: fastlane build_ios_swift_for_tests
         if: steps.ios-swift-cache.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -25,6 +25,7 @@ jobs:
         xcode: ["13.2", "12.5.1"]
 
     steps:
+      - run: echo "Hi mom!"
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
       - name: Install SentryCli

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -28,8 +28,23 @@ jobs:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
       - run: git apply ./scripts/set-device-tests-environment.patch
-      
-      - run: fastlane build_ios_swift_ui_test
+      - name: Cache iOS-Swift App and dSYM build products
+        id: ios-swift-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}
+      - name: Cache iOS-Swift UI Test Runner App build product
+        id: ios-swift-uitest-runner-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-SwiftUITests/**') }}
+      - run: fastlane build_ios_swift
+        if: steps.ios-swift-cache.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
@@ -38,7 +53,20 @@ jobs:
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
-      
+      - run: fastlane build_ios_swift_ui_tests
+        if: steps.ios-swift-uitest-runner-cache.outputs.cache-hit != 'true'
+        env:
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY: ${{ secrets.APP_STORE_CONNECT_KEY }}
+          FASTLANE_KEYCHAIN_PASSWORD: ${{ secrets.FASTLANE_KEYCHAIN_PASSWORD }}
+          MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
+      - name: Upload dSYMs
+        if: steps.ios-swift-cache.outputs.cache-hit != 'true'
+        run: |
+          sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project sentry-cocoa DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
       - name: Archiving DerivedData
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -53,7 +53,7 @@ jobs:
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.MATCH_GIT_PRIVATE_KEY }}
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
-      - run: fastlane build_ios_swift_ui_tests
+      - run: fastlane build_ios_swift_ui_test
         if: steps.ios-swift-uitest-runner-cache.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -43,7 +43,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
           key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-SwiftUITests/**') }}
-      - run: fastlane build_ios_swift
+      - run: fastlane build_ios_swift_for_tests
         if: steps.ios-swift-cache.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -25,7 +25,6 @@ jobs:
         xcode: ["13.2", "12.5.1"]
 
     steps:
-      - run: echo "Hi mom!"
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
       - name: Install SentryCli

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
+      - name: Install SentryCli
+        run: brew install getsentry/tools/sentry-cli
       - run: git apply ./scripts/set-device-tests-environment.patch
       - name: Cache iOS-Swift App and dSYM build products
         id: ios-swift-cache

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.6)
+    activesupport (6.1.6.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,7 +17,7 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.618.0)
+    aws-partitions (1.619.0)
     aws-sdk-core (3.132.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -155,7 +155,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-sentry (1.12.1)
+    fastlane-plugin-sentry (1.12.2)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -203,7 +203,7 @@ GEM
     http-cookie (1.0.5)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.10.0)
+    i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.1)
     json (2.6.2)
@@ -261,7 +261,7 @@ GEM
       tty-cursor (~> 0.7)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf (0.1.4)
@@ -295,4 +295,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.3.17
+   2.3.15

--- a/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/ProfileDataGeneratorUITest.xcscheme
+++ b/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/ProfileDataGeneratorUITest.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "847EA5422852F7CD00F65FE4"
+               BuildableName = "ProfileDataGeneratorUITest.xctest"
+               BlueprintName = "ProfileDataGeneratorUITest"
+               ReferencedContainer = "container:TrendingMovies.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUITests.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUITests.xcscheme
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1340"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B64386726A6C544000D0F65"
+               BuildableName = "iOS-SwiftUITests.xctest"
+               BlueprintName = "iOS-SwiftUITests"
+               ReferencedContainer = "container:iOS-Swift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,6 +73,28 @@ platform :ios do
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end
 
+  lane :build_ios_swift do
+
+    setup_ci(
+      force: true
+    )
+
+    sync_code_signing(
+      type: "development",
+      readonly: true,
+      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"]
+    )
+
+    build_app(
+      workspace: "Sentry.xcworkspace",
+      scheme: "iOS-Swift",
+      derived_data_path: "DerivedData",
+      skip_archive: true
+    )
+
+    delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
+  end
+
   lane :build_ios_swift_ui_test do
 
     setup_ci(
@@ -87,7 +109,7 @@ platform :ios do
 
     build_app(
       workspace: "Sentry.xcworkspace",
-      scheme: "iOS-Swift",
+      scheme: "iOS-SwiftUITests",
       xcargs: "build-for-testing",
       derived_data_path: "DerivedData",
       skip_archive: true
@@ -134,8 +156,30 @@ platform :ios do
 
     build_app(
       workspace: "Sentry.xcworkspace",
-      scheme: "TrendingMovies",
+      scheme: "ProfileDataGeneratorUITest",
       xcargs: "build-for-testing",
+      derived_data_path: "DerivedData",
+      skip_archive: true,
+    )
+
+    delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
+  end
+
+  lane :build_trending_movies do
+
+    setup_ci(
+      force: true
+    )
+
+    sync_code_signing(
+      type: "development",
+      readonly: true,
+      app_identifier: ["io.sentry.sample.TrendingMovies"]
+    )
+
+    build_app(
+      workspace: "Sentry.xcworkspace",
+      scheme: "TrendingMovies",
       derived_data_path: "DerivedData",
       skip_archive: true,
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -107,13 +107,8 @@ platform :ios do
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-SwiftUITests.xctrunner"]
     )
 
-    build_app(
-      workspace: "Sentry.xcworkspace",
-      scheme: "iOS-SwiftUITests",
-      xcargs: "build-for-testing",
-      derived_data_path: "DerivedData",
-      skip_archive: true
-    )
+    # don't use gym here because it always appends a "build" command which fails, since this is a test target not configured for running
+    sh "set -o pipefail && xcodebuild -workspace ../Sentry.xcworkspace -scheme iOS-SwiftUITests -derivedDataPath ../DerivedData -destination 'generic/platform=iOS' build-for-testing | xcpretty"
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end
@@ -155,7 +150,7 @@ platform :ios do
     )
 
     # don't use gym here because it always appends a "build" command which fails, since this is a test target not configured for running
-    sh "xcodebuild -workspace ../Sentry.xcworkspace -scheme ProfileDataGeneratorUITest -derivedDataPath ../DerivedData -destination 'generic/platform=iOS' build-for-testing"
+    sh "set -o pipefail && xcodebuild -workspace ../Sentry.xcworkspace -scheme ProfileDataGeneratorUITest -derivedDataPath ../DerivedData -destination 'generic/platform=iOS' build-for-testing | xcpretty"
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,7 +73,7 @@ platform :ios do
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end
 
-  lane :build_ios_swift do
+  lane :build_ios_swift_for_tests do
 
     setup_ci(
       force: true

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -154,13 +154,8 @@ platform :ios do
       app_identifier: ["io.sentry.sample.TrendingMovies", "io.sentry.sample.movies.ProfileDataGeneratorUITest.xctrunner"]
     )
 
-    build_app(
-      workspace: "Sentry.xcworkspace",
-      scheme: "ProfileDataGeneratorUITest",
-      xcargs: "build-for-testing",
-      derived_data_path: "DerivedData",
-      skip_archive: true,
-    )
+    # don't use gym here because it always appends a "build" command which fails, since this is a test target not configured for running
+    sh "xcodebuild -workspace ../Sentry.xcworkspace -scheme ProfileDataGeneratorUITest -derivedDataPath ../DerivedData -destination 'generic/platform=iOS' build-for-testing"
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end


### PR DESCRIPTION
We have "unknown" symbols for some sample app profiling flamegraphs. To try to fix this we will make sure all sample apps' dSYMs are uploaded when running jobs that send profiling information when running on a real device.

Because this could incur lots of new symbol uploads since the jobs run frequently, also cache all the build products involved for each:
- the app itself
- the app's dSYM
- the test runner app

This way only when the sources have changed is a new dSYM uploaded.

Caching the compilations also helps speed up CI workflows in general:
- UI tests:
    - ~2.5 minutes x2 (two different xcode versions each build a version)
- benchmarks: ~2.5 min
- test profile data generation: ~6.5 minutes

For a grand total of ~14 minutes of compute per full CI run.

#skip-changelog