### PR TITLE
feat: Extra logging when creating transactions and spans

### DIFF
--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -29,12 +29,25 @@
         fetchSpan = [span startChildWithOperation:SENTRY_COREDATA_FETCH_OPERATION
                                       description:[self descriptionFromRequest:request]];
     }];
+
+    [SentryLog
+        logWithMessage:
+            [NSString stringWithFormat:@"SentryCoreDataTracker automatically "
+                                       @"created a new span with description: %@, operation: %@",
+                      fetchSpan.description, SENTRY_COREDATA_FETCH_OPERATION]
+              andLevel:kSentryLevelDebug];
+
     NSArray *result = original(request, error);
 
     [fetchSpan setDataValue:[NSNumber numberWithInteger:result.count] forKey:@"read_count"];
 
     [fetchSpan
         finishWithStatus:error != nil ? kSentrySpanStatusInternalError : kSentrySpanStatusOk];
+
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"SentryCoreDataTracker automatically "
+                                                         @"finished span with status: %@",
+                                        error == nil ? @"ok" : @"error"]
+                     andLevel:kSentryLevelDebug];
 
     return result;
 }
@@ -54,6 +67,14 @@
                                           description:[self descriptionForOperations:operations
                                                                            inContext:context]];
 
+            [SentryLog
+                logWithMessage:
+                    [NSString
+                        stringWithFormat:@"SentryCoreDataTracker automatically "
+                                         @"created a new span with description: %@, operation: %@",
+                        fetchSpan.description, SENTRY_COREDATA_FETCH_OPERATION]
+                      andLevel:kSentryLevelDebug];
+
             [fetchSpan setDataValue:operations forKey:@"operations"];
         }];
     }
@@ -62,6 +83,11 @@
 
     [fetchSpan
         finishWithStatus:*error != nil ? kSentrySpanStatusInternalError : kSentrySpanStatusOk];
+
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"SentryCoreDataTracker automatically "
+                                                         @"finished span with status: %@",
+                                        *error == nil ? @"ok" : @"error"]
+                     andLevel:kSentryLevelDebug];
 
     return result;
 }

--- a/Sources/Sentry/SentryNSDataTracker.m
+++ b/Sources/Sentry/SentryNSDataTracker.m
@@ -168,6 +168,13 @@ SentryNSDataTracker ()
         return nil;
     }
 
+    [SentryLog
+        logWithMessage:
+            [NSString stringWithFormat:@"SentryNSDataTracker automatically "
+                                       @"created a new span with description: %@, operation: %@",
+                      ioSpan.description, operation]
+              andLevel:kSentryLevelDebug];
+
     [ioSpan setDataValue:path forKey:@"file.path"];
 
     return ioSpan;
@@ -213,6 +220,11 @@ SentryNSDataTracker ()
 {
     [span setDataValue:[NSNumber numberWithUnsignedInteger:data.length] forKey:@"file.size"];
     [span finish];
+
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"SentryNSDataTracker automatically "
+                                                         @"finshed span %@",
+                                        span.description]
+                     andLevel:kSentryLevelDebug];
 }
 
 - (BOOL)ignoreFile:(NSString *)path

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -111,8 +111,19 @@ SentryNetworkTracker ()
 
         // We only create a span if there is a transaction in the scope,
         // otherwise we have nothing else to do here.
-        if (netSpan == nil)
+        if (netSpan == nil) {
+            [SentryLog
+                logWithMessage:@"No transaction bound to scope. Won't track network operation."
+                      andLevel:kSentryLevelDebug];
+
             return;
+        }
+
+        [SentryLog
+            logWithMessage:[NSString stringWithFormat:@"SentryNetworkTracker automatically "
+                                                      @"created HTTP span for sessionTask: %@",
+                                     netSpan.description]
+                  andLevel:kSentryLevelDebug];
 
         objc_setAssociatedObject(sessionTask, &SENTRY_NETWORK_REQUEST_TRACKER_SPAN, netSpan,
             OBJC_ASSOCIATION_RETAIN_NONATOMIC);
@@ -135,13 +146,15 @@ SentryNetworkTracker ()
 
     NSURL *url = [[sessionTask currentRequest] URL];
 
-    if (url == nil)
+    if (url == nil) {
         return;
+    }
 
     // Don't measure requests to Sentry's backend
     NSURL *apiUrl = [NSURL URLWithString:SentrySDK.options.dsn];
-    if ([url.host isEqualToString:apiUrl.host] && [url.path containsString:apiUrl.path])
+    if ([url.host isEqualToString:apiUrl.host] && [url.path containsString:apiUrl.path]) {
         return;
+    }
 
     id<SentrySpan> netSpan;
     @synchronized(sessionTask) {
@@ -175,7 +188,8 @@ SentryNetworkTracker ()
     [netSpan setDataValue:@"fetch" forKey:@"type"];
 
     [netSpan finishWithStatus:[self statusForSessionTask:sessionTask state:newState]];
-    [SentryLog logWithMessage:@"Finished HTTP span for sessionTask" andLevel:kSentryLevelDebug];
+    [SentryLog logWithMessage:@"SentryNetworkTracker finished HTTP span for sessionTask"
+                     andLevel:kSentryLevelDebug];
 }
 
 - (void)addBreadcrumbForSessionTask:(NSURLSessionTask *)sessionTask

--- a/Sources/Sentry/SentryUIEventTracker.m
+++ b/Sources/Sentry/SentryUIEventTracker.m
@@ -1,5 +1,6 @@
 #import "SentrySwizzleWrapper.h"
 #import <SentryHub+Private.h>
+#import <SentryLog.h>
 #import <SentrySDK+Private.h>
 #import <SentrySDK.h>
 #import <SentryScope.h>
@@ -84,6 +85,12 @@ SentryUIEventTracker ()
 
             [currentActiveTransaction finish];
 
+            [SentryLog
+                logWithMessage:[NSString
+                                   stringWithFormat:@"SentryUIEventTracker finished transaction %@",
+                                   currentActiveTransaction.transactionContext.name]
+                      andLevel:kSentryLevelDebug];
+
             NSString *operation = [self getOperation:sender];
 
             SentryTransactionContext *context =
@@ -106,6 +113,13 @@ SentryUIEventTracker ()
                                                 customSamplingContext:@{}
                                                           idleTimeout:self.idleTimeout
                                                  dispatchQueueWrapper:self.dispatchQueueWrapper];
+
+                [SentryLog
+                    logWithMessage:[NSString stringWithFormat:@"SentryUIEventTracker automatically "
+                                                              @"created a new transaction with "
+                                                              @"name: %@, bindToScope: %@",
+                                             transactionName, bindToScope ? @"YES" : @"NO"]
+                          andLevel:kSentryLevelDebug];
             }];
 
             if ([[sender class] isSubclassOfClass:[UIView class]]) {


### PR DESCRIPTION
## :scroll: Description

Added logs when starting or finishing automatic transactions or spans.

## :bulb: Motivation and Context

Closes #2050.

## :green_heart: How did you test it?

Manually by running the sample app with debug logs on. Not sure if we really need to add unit tests for logs?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
