### PR TITLE
fix: test server cache step id

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       # macos-10.15. For now, disable the tests on iOS 12 requiring the test server in
       # xcode-test.sh
       - name: Cache for Test Server
-        id: test_server_cache
+        id: cache_test_server
         if: matrix.runs-on == 'macos-11'
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Fix for a copypasta/typo from #2045, that resulted in a cached test-server binary still being rebuilt unnecessarily.

#skip-changelog