### PR TITLE
Send time zone name, not abbreviation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix Swift 5.5 compatibility (#2060)
 - Add span finish flag (#2059)
 - SentryUser.userId should be nullable (#2071)
+- Send time zone name, not abbreviation (#2091)
 
 ### Fixes
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -562,7 +562,7 @@ initialize()
         g_systemData.cpuSubType = sentrycrashsysctl_int32ForName("hw.cpusubtype");
         g_systemData.binaryCPUType = header->cputype;
         g_systemData.binaryCPUSubType = header->cpusubtype;
-        g_systemData.timezone = cString([NSTimeZone localTimeZone].abbreviation);
+        g_systemData.timezone = cString([NSTimeZone localTimeZone].name);
         g_systemData.processName = cString([NSProcessInfo processInfo].processName);
         g_systemData.processID = [NSProcessInfo processInfo].processIdentifier;
         g_systemData.parentProcessID = getppid();


### PR DESCRIPTION
## :scroll: Description

I noticed we were sending the localized time zone abbreviation instead of the time zone name.

For example, we should be sending `"America/Los_Angeles"`, not `"PDT"`

## :bulb: Motivation and Context

Fixes #1033 

## :green_heart: How did you test it?

Simple property change, visible on any `NSTimeZone` instance.

In fact, `name` is much more reliable than `abbreviation`, because it's the non-localized IANA identifier that is used as a key when retrieving a time zone.  A time zone will always have a name.  It may or may not have an abbreviation.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
