### PR TITLE
fix: pull `environment` from where its currently written at profile serialization time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Add span finish flag (#2059)
 - SentryUser.userId should be nullable (#2071)
 - Send time zone name, not abbreviation (#2091)
+- Send `environment` set from `SentryOptions` or `configureScope` with profiling data (#2095)
+
+### Fixes
+
 - Use a prime number for the profiler's sampling rate to reduce the potential for [lock-step](https://stackoverflow.com/a/45471031) issues (#2055).
 - Improve App Hangs detection (#2100)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,14 @@
 - Added extra logs when creating automatic transactions and spans (#2087)
 
 ### Fixes
+
 - Fix Swift 5.5 compatibility (#2060)
 - Add span finish flag (#2059)
 - SentryUser.userId should be nullable (#2071)
 - Send time zone name, not abbreviation (#2091)
-- Send `environment` set from `SentryOptions` or `configureScope` with profiling data (#2095)
-
-### Fixes
-
 - Use a prime number for the profiler's sampling rate to reduce the potential for [lock-step](https://stackoverflow.com/a/45471031) issues (#2055).
 - Improve App Hangs detection (#2100)
+- Send `environment` set from `SentryOptions` or `configureScope` with profiling data (#2095)
 
 ## 7.23.0
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -28,6 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.profilesSampleRate = 1.0
             options.attachScreenshot = true
             options.attachViewHierarchy = true
+            options.environment = "test-app"
 
             let isBenchmarking = ProcessInfo.processInfo.arguments.contains("--io.sentry.test.benchmarking")
             options.enableAutoPerformanceTracking = !isBenchmarking

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -69,6 +69,7 @@ SentryClient ()
 @end
 
 NSString *const DropSessionLogMessage = @"Session has no release name. Won't send it.";
+NSString *const kSentryDefaultEnvironment = @"production";
 
 @implementation SentryClient
 
@@ -536,7 +537,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     // With scope applied, before running callbacks run:
     if (nil == event.environment) {
         // We default to environment 'production' if nothing was set
-        event.environment = @"production";
+        event.environment = kSentryDefaultEnvironment;
     }
 
     // Need to do this after the scope is applied cause this sets the user if there is any

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -3,7 +3,7 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryBacktrace.hpp"
-#import "SentryClient.h"
+#    import "SentryClient.h"
 #    import "SentryDebugImageProvider.h"
 #    import "SentryDebugMeta.h"
 #    import "SentryDefines.h"
@@ -12,12 +12,12 @@
 #    import "SentryEnvelopeItemType.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryHexAddressFormatter.h"
-#import "SentryHub.h"
+#    import "SentryHub.h"
 #    import "SentryId.h"
 #    import "SentryLog.h"
 #    import "SentryProfilingLogging.hpp"
 #    import "SentrySamplingProfiler.hpp"
-#import "SentryScope+Private.h"
+#    import "SentryScope+Private.h"
 #    import "SentryScreenFrames.h"
 #    import "SentrySerialization.h"
 #    import "SentryTime.h"
@@ -222,7 +222,8 @@ isSimulatorBuild()
     }
 }
 
-- (SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction hub:(SentryHub *)hub
+- (SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction
+                                                    hub:(SentryHub *)hub
                                               frameInfo:(SentryScreenFrames *)frameInfo
 {
     NSMutableDictionary<NSString *, id> *profile = nil;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -3,7 +3,7 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryBacktrace.hpp"
-#    import "SentryClient.h"
+#    import "SentryClient+Private.h"
 #    import "SentryDebugImageProvider.h"
 #    import "SentryDebugMeta.h"
 #    import "SentryDefines.h"
@@ -258,7 +258,7 @@ isSimulatorBuild()
     profile[@"device_is_emulator"] = @(isSimulatorBuild());
     profile[@"device_physical_memory_bytes"] =
         [@(NSProcessInfo.processInfo.physicalMemory) stringValue];
-    profile[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment ?: @"production";
+    profile[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment ?: kSentryDefaultEnvironment;
     profile[@"platform"] = transaction.platform;
     profile[@"transaction_id"] = transaction.eventId.sentryIdString;
     profile[@"trace_id"] = transaction.trace.context.traceId.sentryIdString;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -3,6 +3,7 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryBacktrace.hpp"
+#import "SentryClient.h"
 #    import "SentryDebugImageProvider.h"
 #    import "SentryDebugMeta.h"
 #    import "SentryDefines.h"
@@ -11,10 +12,12 @@
 #    import "SentryEnvelopeItemType.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryHexAddressFormatter.h"
+#import "SentryHub.h"
 #    import "SentryId.h"
 #    import "SentryLog.h"
 #    import "SentryProfilingLogging.hpp"
 #    import "SentrySamplingProfiler.hpp"
+#import "SentryScope+Private.h"
 #    import "SentryScreenFrames.h"
 #    import "SentrySerialization.h"
 #    import "SentryTime.h"
@@ -219,7 +222,7 @@ isSimulatorBuild()
     }
 }
 
-- (SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction
+- (SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction hub:(SentryHub *)hub
                                               frameInfo:(SentryScreenFrames *)frameInfo
 {
     NSMutableDictionary<NSString *, id> *profile = nil;
@@ -254,7 +257,7 @@ isSimulatorBuild()
     profile[@"device_is_emulator"] = @(isSimulatorBuild());
     profile[@"device_physical_memory_bytes"] =
         [@(NSProcessInfo.processInfo.physicalMemory) stringValue];
-    profile[@"environment"] = transaction.environment ?: @"production";
+    profile[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment ?: @"production";
     profile[@"platform"] = transaction.platform;
     profile[@"transaction_id"] = transaction.eventId.sentryIdString;
     profile[@"trace_id"] = transaction.trace.context.traceId.sentryIdString;

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -517,7 +517,8 @@ static NSLock *profilerLock;
     if (_profilesSamplerDecision.decision == kSentrySampleDecisionYes) {
         [profilerLock lock];
         if (profiler != nil) {
-            SentryEnvelopeItem *profile = [profiler buildEnvelopeItemForTransaction:transaction hub:_hub
+            SentryEnvelopeItem *profile = [profiler buildEnvelopeItemForTransaction:transaction
+                                                                                hub:_hub
                                                                           frameInfo:frameInfo];
             if (profile != nil) {
                 [additionalEnvelopeItems addObject:profile];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -517,7 +517,7 @@ static NSLock *profilerLock;
     if (_profilesSamplerDecision.decision == kSentrySampleDecisionYes) {
         [profilerLock lock];
         if (profiler != nil) {
-            SentryEnvelopeItem *profile = [profiler buildEnvelopeItemForTransaction:transaction
+            SentryEnvelopeItem *profile = [profiler buildEnvelopeItemForTransaction:transaction hub:_hub
                                                                           frameInfo:frameInfo];
             if (profile != nil) {
                 [additionalEnvelopeItems addObject:profile];

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -7,6 +7,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
+
 @protocol SentryClientAttachmentProcessor <NSObject>
 
 - (nullable NSArray<SentryAttachment *> *)processAttachments:

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -42,7 +42,8 @@ SENTRY_EXTERN_C_END
 /**
  * Builds an envelope item using the currently accumulated profile data.
  */
-- (nullable SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction hub:(SentryHub *)hub
+- (nullable SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction
+                                                             hub:(SentryHub *)hub
                                                        frameInfo:
                                                            (nullable SentryScreenFrames *)frameInfo;
 

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -5,6 +5,7 @@
 
 #    import "SentryCompiler.h"
 
+@class SentryHub;
 @class SentryScreenFrames;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -41,7 +42,7 @@ SENTRY_EXTERN_C_END
 /**
  * Builds an envelope item using the currently accumulated profile data.
  */
-- (nullable SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction
+- (nullable SentryEnvelopeItem *)buildEnvelopeItemForTransaction:(SentryTransaction *)transaction hub:(SentryHub *)hub
                                                        frameInfo:
                                                            (nullable SentryScreenFrames *)frameInfo;
 

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -10,6 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryScope (Private)
 
+@property (atomic, copy, readonly, nullable) NSString *environmentString;
+
 @property (atomic, strong, readonly) NSArray<SentryAttachment *> *attachments;
 
 @property (atomic, strong) SentryUser *_Nullable userObject;

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -756,17 +756,6 @@ class SentryHubTests: XCTestCase {
     private func assertNoEnvelopesCaptured() {
         XCTAssertEqual(0, fixture.client.captureEnvelopeInvocations.count)
     }
-    
-    func testSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
-        options(fixture.options)
-        
-        let hub = fixture.getSut()
-        Dynamic(hub).tracesSampler.random = fixture.random
-        
-        let span = hub.startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation)
-        
-        XCTAssertEqual(expected, span.context.sampled)
-    }
 }
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1,6 +1,8 @@
 import Sentry
 import XCTest
 
+// swiftlint:disable file_length
+
 class SentryHubTests: XCTestCase {
     
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentryHubTests")
@@ -1032,3 +1034,5 @@ extension SentryHubTests {
     }
 }
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+
+// swiftlint:enable file_length

--- a/Tests/SentryTests/SentryScopeTests.m
+++ b/Tests/SentryTests/SentryScopeTests.m
@@ -1,4 +1,5 @@
 #import "SentryBreadcrumb.h"
+#import "SentryClient+Private.h"
 #import "SentryScope+Private.h"
 #import "SentryScope.h"
 #import "SentryUser.h"
@@ -148,7 +149,7 @@
 - (void)testEnvironmentSerializes
 {
     SentryScope *scope = [[SentryScope alloc] init];
-    NSString *expectedEnvironment = @"production";
+    NSString *expectedEnvironment = kSentryDefaultEnvironment;
     [scope setEnvironment:expectedEnvironment];
     XCTAssertEqualObjects([[scope serialize] objectForKey:@"environment"], expectedEnvironment);
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/team-profiling/issues/54