### PR TITLE
test: skip tests via Xcode scheme

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -56,7 +56,16 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "SentryClientTest/testCaptureMessage()">
+               </Test>
+               <Test
                   Identifier = "SentrySDKIntegrationTestsBase">
+               </Test>
+               <Test
+                  Identifier = "SentrySessionGeneratorTests/testSendSessions()">
+               </Test>
+               <Test
+                  Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces()">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -49,15 +49,15 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
     }
     
     func test_Install_swizzlingDisabled() {
-        test_DontInstall { $0.enableSwizzling = false }
+        assert_DontInstall { $0.enableSwizzling = false }
     }
     
     func test_Install_autoPerformanceDisabled() {
-        test_DontInstall { $0.enableAutoPerformanceTracking = false }
+        assert_DontInstall { $0.enableAutoPerformanceTracking = false }
     }
     
     func test_Install_coreDataTrackingDisabled() {
-        test_DontInstall { $0.enableCoreDataTracking = false }
+        assert_DontInstall { $0.enableCoreDataTracking = false }
     }
     
     func test_Fetch() {
@@ -112,7 +112,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(transaction.children.count, 0)
     }
     
-    func test_DontInstall(_ confOptions: ((Options) -> Void)) {
+    private func assert_DontInstall(_ confOptions: ((Options) -> Void)) {
         let sut = fixture.getSut()
         confOptions(fixture.options)
         XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.middleware)

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -112,7 +112,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(transaction.children.count, 0)
     }
     
-    private func test_DontInstall(_ confOptions: ((Options) -> Void)) {
+    func test_DontInstall(_ confOptions: ((Options) -> Void)) {
         let sut = fixture.getSut()
         confOptions(fixture.options)
         XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.middleware)

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -45,25 +45,25 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
     }
     
     func testNetworkTrackerDisabled_WhenNetworkTrackingDisabled() {
-        testNetworkTrackerDisabled { options in
+        asserrtNetworkTrackerDisabled { options in
             options.enableNetworkTracking = false
         }
     }
     
     func testNetworkTrackerDisabled_WhenAutoPerformanceTrackingDisabled() {
-        testNetworkTrackerDisabled { options in
+        asserrtNetworkTrackerDisabled { options in
             options.enableAutoPerformanceTracking = false
         }
     }
     
     func testNetworkTrackerDisabled_WhenTracingDisabled() {
-        testNetworkTrackerDisabled { options in
+        asserrtNetworkTrackerDisabled { options in
             options.tracesSampleRate = 0.0
         }
     }
     
     func testNetworkTrackerDisabled_WhenSwizzlingDisabled() {
-        testNetworkTrackerDisabled { options in
+        asserrtNetworkTrackerDisabled { options in
             options.enableSwizzling = false
         }
     }
@@ -229,7 +229,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertEqual("200", networkSpan.tags["http.status_code"])
     }
     
-    func testNetworkTrackerDisabled(configureOptions: (Options) -> Void) {
+    private func asserrtNetworkTrackerDisabled(configureOptions: (Options) -> Void) {
         configureOptions(fixture.options)
         
         startSDK()

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -229,7 +229,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertEqual("200", networkSpan.tags["http.status_code"])
     }
     
-    private func testNetworkTrackerDisabled(configureOptions: (Options) -> Void) {
+    func testNetworkTrackerDisabled(configureOptions: (Options) -> Void) {
         configureOptions(fixture.options)
         
         startSDK()

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -39,22 +39,22 @@ class SentrySubClassFinderTests: XCTestCase {
     }
     
     func testActOnSubclassesOfViewController() {
-        testActOnSubclassesOfViewController(expected: [FirstViewController.self, SecondViewController.self, ViewControllerNumberThree.self, VCAnyNaming.self])
+        assertActOnSubclassesOfViewController(expected: [FirstViewController.self, SecondViewController.self, ViewControllerNumberThree.self, VCAnyNaming.self])
     }
     
     func testActOnSubclassesOfViewController_NoViewController() {
         fixture.runtimeWrapper.classesNames = { _ in [] }
-        testActOnSubclassesOfViewController(expected: [])
+        assertActOnSubclassesOfViewController(expected: [])
     }
     
     func testActOnSubclassesOfViewController_IgnoreFakeViewController() {
         fixture.runtimeWrapper.classesNames = { _ in [NSStringFromClass(FakeViewController.self)] }
-        testActOnSubclassesOfViewController(expected: [])
+        assertActOnSubclassesOfViewController(expected: [])
     }
      
     func testActOnSubclassesOfViewController_WrongImage_NoViewController() {
         fixture.runtimeWrapper.classesNames = nil
-        testActOnSubclassesOfViewController(expected: [], imageName: "OtherImage")
+        assertActOnSubclassesOfViewController(expected: [], imageName: "OtherImage")
     }
   
     func testGettingSublcasses_DoesNotCallInitializer() {
@@ -68,11 +68,11 @@ class SentrySubClassFinderTests: XCTestCase {
         XCTAssertFalse(SentryInitializeForGettingSubclassesCalled.wasCalled())
     }
     
-    func testActOnSubclassesOfViewController(expected: [AnyClass]) {
-        testActOnSubclassesOfViewController(expected: expected, imageName: fixture.imageName)
+    private func assertActOnSubclassesOfViewController(expected: [AnyClass]) {
+        assertActOnSubclassesOfViewController(expected: expected, imageName: fixture.imageName)
     }
     
-    func testActOnSubclassesOfViewController(expected: [AnyClass], imageName: String) {
+    private func assertActOnSubclassesOfViewController(expected: [AnyClass], imageName: String) {
         let expect = expectation(description: "")
         
         if expected.isEmpty {

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -68,11 +68,11 @@ class SentrySubClassFinderTests: XCTestCase {
         XCTAssertFalse(SentryInitializeForGettingSubclassesCalled.wasCalled())
     }
     
-    private func testActOnSubclassesOfViewController(expected: [AnyClass]) {
+    func testActOnSubclassesOfViewController(expected: [AnyClass]) {
         testActOnSubclassesOfViewController(expected: expected, imageName: fixture.imageName)
     }
     
-    private func testActOnSubclassesOfViewController(expected: [AnyClass], imageName: String) {
+    func testActOnSubclassesOfViewController(expected: [AnyClass], imageName: String) {
         let expect = expectation(description: "")
         
         if expected.isEmpty {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -93,7 +93,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         }
     }
 
-    private func testUILifeCycle(finishStatus: SentrySpanStatus, lifecycleEndingMethod: (SentryUIViewControllerPerformanceTracker, UIViewController, SentryPerformanceTracker, XCTestExpectation, Span) -> Void) {
+    func testUILifeCycle(finishStatus: SentrySpanStatus, lifecycleEndingMethod: (SentryUIViewControllerPerformanceTracker, UIViewController, SentryPerformanceTracker, XCTestExpectation, Span) -> Void) {
         let sut = fixture.getSut()
         let viewController = fixture.viewController
         let tracker = fixture.tracker

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -64,7 +64,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     }
     
     func testUILifeCycle_ViewDidAppear() {
-        testUILifeCycle(finishStatus: SentrySpanStatus.ok) { sut, viewController, tracker, callbackExpectation, transactionSpan in
+        assertUILifeCycle(finishStatus: SentrySpanStatus.ok) { sut, viewController, tracker, callbackExpectation, transactionSpan in
             sut.viewControllerViewDidAppear(viewController) {
                 let blockSpan = self.getStack(tracker).last!
                 XCTAssertEqual(blockSpan.context.parentSpanId, transactionSpan.context.spanId)
@@ -83,7 +83,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     func testUILifeCycle_NoViewDidAppear_OnlyViewWillDisappear() {
         // Don't call viewDidAppear on purpose.
 
-        testUILifeCycle(finishStatus: SentrySpanStatus.cancelled) { sut, viewController, tracker, callbackExpectation, transactionSpan in
+        assertUILifeCycle(finishStatus: SentrySpanStatus.cancelled) { sut, viewController, tracker, callbackExpectation, transactionSpan in
             sut.viewControllerViewWillDisappear(viewController) {
                 let blockSpan = self.getStack(tracker).last!
                 XCTAssertEqual(blockSpan.context.parentSpanId, transactionSpan.context.spanId)
@@ -93,7 +93,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         }
     }
 
-    func testUILifeCycle(finishStatus: SentrySpanStatus, lifecycleEndingMethod: (SentryUIViewControllerPerformanceTracker, UIViewController, SentryPerformanceTracker, XCTestExpectation, Span) -> Void) {
+    private func assertUILifeCycle(finishStatus: SentrySpanStatus, lifecycleEndingMethod: (SentryUIViewControllerPerformanceTracker, UIViewController, SentryPerformanceTracker, XCTestExpectation, Span) -> Void) {
         let sut = fixture.getSut()
         let viewController = fixture.viewController
         let tracker = fixture.tracker

--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -62,7 +62,7 @@ class SentrySessionGeneratorTests: XCTestCase {
     /**
      * Disabled on purpose. This test just sends sessions to Sentry, but doesn't verify that they arrive there properly.
      */
-    func tesSendSessions() {
+    func testSendSessions() {
         sendSessions(amount: Sessions(healthy: 10, errored: 10, crashed: 3, oom: 1, abnormal: 1))
     }
     

--- a/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
@@ -88,15 +88,15 @@ class SentryDefaultRateLimitsTests: XCTestCase {
     }
 
     func testRetryAfterHeaderDeltaSeconds() {
-        testRetryHeaderWith1Second(value: "1")
+        assertRetryHeaderWith1Second(value: "1")
     }
     
     func testRetryAfterHeaderHttpDate() {
         let headerValue = HttpDateFormatter.string(from: CurrentDate.date().addingTimeInterval(1))
-        testRetryHeaderWith1Second(value: headerValue)
+        assertRetryHeaderWith1Second(value: headerValue)
     }
     
-    func testRetryHeaderWith1Second(value: String) {
+    private func assertRetryHeaderWith1Second(value: String) {
         let response = TestResponseFactory.createRetryAfterResponse(headerValue: value)
         sut.update(response)
         XCTAssertTrue(sut.isRateLimitActive(SentryDataCategory.default))

--- a/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
@@ -96,7 +96,7 @@ class SentryDefaultRateLimitsTests: XCTestCase {
         testRetryHeaderWith1Second(value: headerValue)
     }
     
-    private func testRetryHeaderWith1Second(value: String) {
+    func testRetryHeaderWith1Second(value: String) {
         let response = TestResponseFactory.createRetryAfterResponse(headerValue: value)
         sut.update(response)
         XCTAssertTrue(sut.isRateLimitActive(SentryDataCategory.default))

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -132,7 +132,7 @@ class SentryClientTest: XCTestCase {
         clearTestState()
     }
     
-    func tesCaptureMessage() {
+    func testCaptureMessage() {
         let eventId = fixture.getSut().capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -803,7 +803,7 @@ class SentryClientTest: XCTestCase {
         testSampleRate(sampleRate: 0.50, randomValue: 0.51, isSampled: true)
     }
     
-    private func testSampleRate( sampleRate: NSNumber?, randomValue: Double, isSampled: Bool) {
+    func testSampleRate( sampleRate: NSNumber?, randomValue: Double, isSampled: Bool) {
         fixture.random.value = randomValue
         
         let eventId = fixture.getSut(configureOptions: { options in

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -788,22 +788,22 @@ class SentryClientTest: XCTestCase {
     }
     
     func testSampleRateNil_EventNotSampled() {
-        testSampleRate(sampleRate: nil, randomValue: 0, isSampled: false)
+        assertSampleRate(sampleRate: nil, randomValue: 0, isSampled: false)
     }
     
     func testSampleRateBiggerRandom_EventNotSampled() {
-        testSampleRate(sampleRate: 0.5, randomValue: 0.49, isSampled: false)
+        assertSampleRate(sampleRate: 0.5, randomValue: 0.49, isSampled: false)
     }
     
     func testSampleRateEqualsRandom_EventNotSampled() {
-        testSampleRate(sampleRate: 0.5, randomValue: 0.5, isSampled: false)
+        assertSampleRate(sampleRate: 0.5, randomValue: 0.5, isSampled: false)
     }
     
     func testSampleRateSmallerRandom_EventSampled() {
-        testSampleRate(sampleRate: 0.50, randomValue: 0.51, isSampled: true)
+        assertSampleRate(sampleRate: 0.50, randomValue: 0.51, isSampled: true)
     }
     
-    func testSampleRate( sampleRate: NSNumber?, randomValue: Double, isSampled: Bool) {
+    private func assertSampleRate( sampleRate: NSNumber?, randomValue: Double, isSampled: Bool) {
         fixture.random.value = randomValue
         
         let eventId = fixture.getSut(configureOptions: { options in

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -68,9 +68,9 @@ class SentryStacktraceBuilderTests: XCTestCase {
     }
     
     /**
-     * Disabled in CI for now, because this test is flaky.
+     * Disabled for now, because this test is flaky.
      */
-    func tesAsyncStacktraces() throws {
+    func testAsyncStacktraces() throws {
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
             options.stitchAsyncCode = true

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -283,38 +283,38 @@ class SentryHubTests: XCTestCase {
     }
     
     func testStartTransactionNotSamplingUsingSampleRate() {
-        testSampler(expected: .no) { options in
+        assertSampler(expected: .no) { options in
             options.tracesSampleRate = 0.49
         }
     }
     
     func testStartTransactionSamplingUsingSampleRate() {
-        testSampler(expected: .yes) { options in
+        assertSampler(expected: .yes) { options in
             options.tracesSampleRate = 0.50
         }
     }
 
     func testStartTransactionSamplingUsingTracesSampler() {
-        testSampler(expected: .yes) { options in
+        assertSampler(expected: .yes) { options in
             options.tracesSampler = { _ in return 0.51 }
         }
     }
     
     func testStartTransaction_WhenSampleRateAndSamplerNil() {
-        testSampler(expected: .no) { options in
+        assertSampler(expected: .no) { options in
             options.tracesSampleRate = nil
             options.tracesSampler = { _ in return nil }
         }
     }
     
     func testStartTransaction_WhenTracesSamplerOutOfRange_TooBig() {
-        testSampler(expected: .no) { options in
+        assertSampler(expected: .no) { options in
             options.tracesSampler = { _ in return 1.01 }
         }
     }
     
     func testStartTransaction_WhenTracesSamplersOutOfRange_TooSmall() {
-        testSampler(expected: .no) { options in
+        assertSampler(expected: .no) { options in
             options.tracesSampler = { _ in return -0.01 }
         }
         
@@ -388,50 +388,50 @@ class SentryHubTests: XCTestCase {
     }
     
     func testStartTransaction_NotSamplingProfileUsingEnableProfiling() {
-        testProfilesSampler(expected: .no) { options in
+        assertProfilesSampler(expected: .no) { options in
             options.enableProfiling_DEPRECATED_TEST_ONLY = false
         }
     }
     
     func testStartTransaction_SamplingProfileUsingEnableProfiling() {
-        testProfilesSampler(expected: .yes) { options in
+        assertProfilesSampler(expected: .yes) { options in
             options.enableProfiling_DEPRECATED_TEST_ONLY = true
         }
     }
     
     func testStartTransaction_NotSamplingProfileUsingSampleRate() {
-        testProfilesSampler(expected: .no) { options in
+        assertProfilesSampler(expected: .no) { options in
             options.profilesSampleRate = 0.49
         }
     }
     
     func testStartTransaction_SamplingProfileUsingSampleRate() {
-        testProfilesSampler(expected: .yes) { options in
+        assertProfilesSampler(expected: .yes) { options in
             options.profilesSampleRate = 0.5
         }
     }
     
     func testStartTransaction_SamplingProfileUsingProfilesSampler() {
-        testProfilesSampler(expected: .yes) { options in
+        assertProfilesSampler(expected: .yes) { options in
             options.profilesSampler = { _ in return 0.51 }
         }
     }
     
     func testStartTransaction_WhenProfilesSampleRateAndProfilesSamplerNil() {
-        testProfilesSampler(expected: .no) { options in
+        assertProfilesSampler(expected: .no) { options in
             options.profilesSampleRate = nil
             options.profilesSampler = { _ in return nil }
         }
     }
     
     func testStartTransaction_WhenProfilesSamplerOutOfRange_TooBig() {
-        testProfilesSampler(expected: .no) { options in
+        assertProfilesSampler(expected: .no) { options in
             options.profilesSampler = { _ in return 1.01 }
         }
     }
     
     func testStartTransaction_WhenProfilesSamplersOutOfRange_TooSmall() {
-        testProfilesSampler(expected: .no) { options in
+        assertProfilesSampler(expected: .no) { options in
             options.profilesSampler = { _ in return -0.01 }
         }
     }
@@ -899,7 +899,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertFalse((frames[0]["function"] as! String).isEmpty)
     }
     
-    func testSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
+    private func assertSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
         options(fixture.options)
         
         let hub = fixture.getSut()
@@ -910,7 +910,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(expected, span.context.sampled)
     }
     
-    func testProfilesSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
+    private func assertProfilesSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
         let fixtureOptions = fixture.options
         fixtureOptions.tracesSampleRate = 1.0
         options(fixtureOptions)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -899,7 +899,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertFalse((frames[0]["function"] as! String).isEmpty)
     }
     
-    private func testSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
+    func testSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
         options(fixture.options)
         
         let hub = fixture.getSut()
@@ -910,7 +910,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(expected, span.context.sampled)
     }
     
-    private func testProfilesSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
+    func testProfilesSampler(expected: SentrySampleDecision, options: (Options) -> Void) {
         let fixtureOptions = fixture.options
         fixtureOptions.tracesSampleRate = 1.0
         options(fixtureOptions)


### PR DESCRIPTION
~We had a bunch of test cases marked private, which Xcode will not run as tests.~ These weren't tests, so have been renamed instead.

We also had some tests that were purposefully skipped by malforming the name to exploit the fact that it picks up any function starting with `test`. This should instead be done by unchecking the test cases in the scheme. (See [here](https://github.com/getsentry/sentry-cocoa/issues/1415). [here](https://github.com/getsentry/sentry-cocoa/issues/2102) and [here](https://github.com/getsentry/sentry-cocoa/issues/2103).)

#skip-changelog