### PR TITLE
ci: Print Swift Version

### DIFF
--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -10,3 +10,4 @@ set -euo pipefail
 XCODE_VERSION="${1:-13.2.1}"
 
 sudo xcode-select -s /Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer
+swiftc --version


### PR DESCRIPTION
To know which Swift version Xcode is using. Came up in https://github.com/getsentry/sentry-cocoa/pull/2060.

#skip-changelog