### PR TITLE
fix: Remove Media Library Permission check from permission observer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Remove Media Library Permission check from permission observer (#2123)
+
 ## 7.24.0
 
 ### Features

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -691,9 +691,6 @@ NSString *const kSentryDefaultEnvironment = @"production";
                           @"location_access" :
                               [self stringForPermissionStatus:self.permissionsObserver
                                                                   .locationPermissionStatus],
-                          @"media_library" :
-                              [self stringForPermissionStatus:self.permissionsObserver
-                                                                  .mediaLibraryPermissionStatus],
                           @"photo_library" :
                               [self stringForPermissionStatus:self.permissionsObserver
                                                                   .photoLibraryPermissionStatus],

--- a/Sources/Sentry/SentryPermissionsObserver.m
+++ b/Sources/Sentry/SentryPermissionsObserver.m
@@ -7,10 +7,6 @@
 #    import <UIKit/UIKit.h>
 #endif
 
-#if TARGET_OS_IOS
-#    import <MediaPlayer/MediaPlayer.h>
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
@@ -55,12 +51,6 @@ SentryPermissionsObserver () <CLLocationManagerDelegate>
 
 - (void)refreshPermissions
 {
-#if TARGET_OS_IOS
-    if (@available(iOS 9.3, *)) {
-        [self setMediaLibraryPermissionFromStatus:MPMediaLibrary.authorizationStatus];
-    }
-#endif
-
 #if SENTRY_HAS_UIKIT
     if (@available(iOS 9, tvOS 10, *)) {
         [self setPhotoLibraryPermissionFromStatus:PHPhotoLibrary.authorizationStatus];
@@ -74,30 +64,6 @@ SentryPermissionsObserver () <CLLocationManagerDelegate>
     }
 #endif
 }
-
-#if TARGET_OS_IOS
-- (void)setMediaLibraryPermissionFromStatus:(MPMediaLibraryAuthorizationStatus)status
-    API_AVAILABLE(ios(9.3))
-{
-    switch (status) {
-    case MPMediaLibraryAuthorizationStatusNotDetermined:
-        self.mediaLibraryPermissionStatus = kSentryPermissionStatusUnknown;
-        break;
-
-    case MPMediaLibraryAuthorizationStatusDenied:
-        self.mediaLibraryPermissionStatus = kSentryPermissionStatusDenied;
-        break;
-
-    case MPMediaLibraryAuthorizationStatusRestricted:
-        self.mediaLibraryPermissionStatus = kSentryPermissionStatusPartial;
-        break;
-
-    case MPMediaLibraryAuthorizationStatusAuthorized:
-        self.mediaLibraryPermissionStatus = kSentryPermissionStatusGranted;
-        break;
-    }
-}
-#endif
 
 #if SENTRY_HAS_UIKIT
 - (void)setPhotoLibraryPermissionFromStatus:(PHAuthorizationStatus)status

--- a/Sources/Sentry/include/SentryPermissionsObserver.h
+++ b/Sources/Sentry/include/SentryPermissionsObserver.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
  * but we had to remove the media permission because it was preventing some developers from
  * publishing their apps. Apple was requiring developers to include NSAppleMusicUsageDescription in
  * their plist files, even when they don't use this feature. More info at
- * https://github.com/getsentry/sentry-cocoa/issues/2065#issuecomment-1237016049
+ * https://github.com//issues/2065
  */
 
 @property (nonatomic) SentryPermissionStatus pushPermissionStatus;

--- a/Sources/Sentry/include/SentryPermissionsObserver.h
+++ b/Sources/Sentry/include/SentryPermissionsObserver.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
  * but we had to remove the media permission because it was preventing some developers from
  * publishing their apps. Apple was requiring developers to include NSAppleMusicUsageDescription in
  * their plist files, even when they don't use this feature. More info at
- * https://github.com//issues/2065
+ * https://github.com/getsentry/sentry-cocoa/issues/2065
  */
 
 @property (nonatomic) SentryPermissionStatus pushPermissionStatus;

--- a/Sources/Sentry/include/SentryPermissionsObserver.h
+++ b/Sources/Sentry/include/SentryPermissionsObserver.h
@@ -7,7 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) SentryPermissionStatus pushPermissionStatus;
 @property (nonatomic) SentryPermissionStatus locationPermissionStatus;
-@property (nonatomic) SentryPermissionStatus mediaLibraryPermissionStatus;
 @property (nonatomic) SentryPermissionStatus photoLibraryPermissionStatus;
 
 - (void)startObserving;

--- a/Sources/Sentry/include/SentryPermissionsObserver.h
+++ b/Sources/Sentry/include/SentryPermissionsObserver.h
@@ -5,6 +5,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryPermissionsObserver : NSObject
 
+/*
+ * We want as many permissions as possible,
+ * but we had to remove the media permission because it was preventing some developers from
+ * publishing their apps. Apple was requiring developers to include NSAppleMusicUsageDescription in
+ * their plist files, even when they don't use this feature. More info at
+ * https://github.com/getsentry/sentry-cocoa/issues/2065#issuecomment-1237016049
+ */
+
 @property (nonatomic) SentryPermissionStatus pushPermissionStatus;
 @property (nonatomic) SentryPermissionStatus locationPermissionStatus;
 @property (nonatomic) SentryPermissionStatus photoLibraryPermissionStatus;

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -556,7 +556,6 @@ class SentryClientTest: XCTestCase {
             let permissions = actual.context?["app"]?["permissions"] as? [String: String]
             XCTAssertEqual(permissions?["push_notifications"], "granted")
             XCTAssertEqual(permissions?["location_access"], "granted")
-            XCTAssertEqual(permissions?["media_library"], "not_granted")
             XCTAssertEqual(permissions?["photo_library"], "partial")
         }
     }

--- a/Tests/SentryTests/SentryCrash/TestSentryPermissionsObserver.swift
+++ b/Tests/SentryTests/SentryCrash/TestSentryPermissionsObserver.swift
@@ -24,13 +24,6 @@ class TestSentryPermissionsObserver: SentryPermissionsObserver {
         set {}
     }
 
-    override var mediaLibraryPermissionStatus: SentryPermissionStatus {
-        get {
-            return internalMediaLibraryPermissionStatus
-        }
-        set {}
-    }
-
     override var photoLibraryPermissionStatus: SentryPermissionStatus {
         get {
             return internalPhotoLibraryPermissionStatus


### PR DESCRIPTION
## :scroll: Description

Removed media library permission check from permission observer.

## :bulb: Motivation and Context

We're getting complains that the SDK is preventing people from publishing their apps because they are missing NSAppleMusicUsageDescription information, for more information see #2065 

We intended to create an alpha release with this feature to capture more feedback, but the feature was rollout into GA. The amount of value added is minimum compared to the head ache that this could cause if we're really the problem, so we decide to remove this for now until more investigation is done.

closes #2065 

## :green_heart: How did you test it?

Updated unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
