### PR TITLE
feat: Allow Private SDK to change only SDK name

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -84,6 +84,21 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     SentryMeta.versionString = versionString;
 }
 
++ (void)setSdkName:(NSString *)sdkName
+{
+    SentryMeta.sdkName = sdkName;
+}
+
++ (NSString *)getSdkName
+{
+    return SentryMeta.sdkName;
+}
+
++ (NSString *)getSdkVersionString
+{
+    return SentryMeta.versionString;
+}
+
 #if SENTRY_HAS_UIKIT
 
 + (BOOL)framesTrackingMeasurementHybridSDKMode

--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -47,6 +47,21 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (void)setSdkName:(NSString *)sdkName andVersionString:(NSString *)versionString;
 
+/**
+ * Override SDK information.
+ */
++ (void)setSdkName:(NSString *)sdkName;
+
+/**
+ * Retrieves the SDK name
+ */
++ (NSString *)getSdkName;
+
+/**
+ * Retrieves the SDK version string
+ */
++ (NSString *)getSdkVersionString;
+
 @property (class, nullable, nonatomic, copy)
     SentryOnAppStartMeasurementAvailable onAppStartMeasurementAvailable;
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -226,7 +226,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
     // If the error has a debug description, use that.
     NSString *customExceptionValue = [[error userInfo] valueForKey:NSDebugDescriptionErrorKey];
     if (customExceptionValue != nil) {
-        exceptionValue = [NSString stringWithFormat:@"%@ (Code: %ld)", customExceptionValue, (long)error.code];
+        exceptionValue =
+            [NSString stringWithFormat:@"%@ (Code: %ld)", customExceptionValue, (long)error.code];
     } else {
         exceptionValue = [NSString stringWithFormat:@"Code: %ld", (long)error.code];
     }

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -4,6 +4,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
+        PrivateSentrySDKOnly.setSdkName(name, andVersionString: version)
         clearTestState()
     }
 
@@ -30,20 +31,34 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     }
 
     func testSetSdkName() {
+        let originalName = PrivateSentrySDKOnly.getSdkName()
         let name = "Some SDK name"
         PrivateSentrySDKOnly.setSdkName(name)
         XCTAssertEqual(SentryMeta.sdkName, name)
         XCTAssertEqual(PrivateSentrySDKOnly.getSdkName(), name)
+        PrivateSentrySDKOnly.setSdkName(originalName)
+        XCTAssertEqual(SentryMeta.sdkName, originalName)
+        XCTAssertEqual(PrivateSentrySDKOnly.getSdkName(), originalName)
     }
     
     func testSetSdkNameAndVersion() {
+        let originalName = PrivateSentrySDKOnly.getSdkName()
+        let originalVersion = PrivateSentrySDKOnly.getSdkVersionString()
         let name = "Some SDK name"
         let version = "1.2.3.4"
+
         PrivateSentrySDKOnly.setSdkName(name, andVersionString: version)
         XCTAssertEqual(SentryMeta.sdkName, name)
         XCTAssertEqual(SentryMeta.versionString, version)
         XCTAssertEqual(PrivateSentrySDKOnly.getSdkName(), name)
         XCTAssertEqual(PrivateSentrySDKOnly.getSdkVersionString(), version)
+        
+        PrivateSentrySDKOnly.setSdkName(originalName, andVersionString: originalVersion)
+        XCTAssertEqual(SentryMeta.sdkName, originalName)
+        XCTAssertEqual(SentryMeta.versionString, originalVersion)
+        XCTAssertEqual(PrivateSentrySDKOnly.getSdkName(), originalName)
+        XCTAssertEqual(PrivateSentrySDKOnly.getSdkVersionString(), originalVersion)
+        
     }
     
     func testEnvelopeWithData() throws {

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -4,7 +4,6 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     
     override func tearDown() {
         super.tearDown()
-        PrivateSentrySDKOnly.setSdkName(name, andVersionString: version)
         clearTestState()
     }
 

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -29,6 +29,23 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(envelope, client?.captureEnvelopeInvocations.first)
     }
 
+    func testSetSdkName() {
+        let name = "Some SDK name"
+        PrivateSentrySDKOnly.setSdkName(name)
+        XCTAssertEqual(SentryMeta.sdkName, name)
+        XCTAssertEqual(PrivateSentrySDKOnly.getSdkName(), name)
+    }
+    
+    func testSetSdkNameAndVersion() {
+        let name = "Some SDK name"
+        let version = "1.2.3.4"
+        PrivateSentrySDKOnly.setSdkName(name, andVersionString: version)
+        XCTAssertEqual(SentryMeta.sdkName, name)
+        XCTAssertEqual(SentryMeta.versionString, version)
+        XCTAssertEqual(PrivateSentrySDKOnly.getSdkName(), name)
+        XCTAssertEqual(PrivateSentrySDKOnly.getSdkVersionString(), version)
+    }
+    
     func testEnvelopeWithData() throws {
         let itemData = "{}\n{\"length\":0,\"type\":\"attachment\"}\n".data(using: .utf8)!
         XCTAssertNotNil(PrivateSentrySDKOnly.envelope(with: itemData))


### PR DESCRIPTION
Added a function to private SDKs change only the SDK name value.

Added functions to retrieve SDK name and version.


Related to #2010

_#skip-changelog_