### PR TITLE
fix: Crash with screenshot is reported twice

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.c
@@ -107,7 +107,7 @@ getReportCount()
     }
     struct dirent *ent;
     while ((ent = readdir(dir)) != NULL) {
-        if (getReportIDFromFilename(ent->d_name) > 0) {
+        if (ent->d_type != 4 && getReportIDFromFilename(ent->d_name) > 0) {
             count++;
         }
     }

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -149,6 +149,26 @@
     [self expectHasReportCount:1];
 }
 
+- (void)testCrashReportCount1_WithAttachments
+{
+    [self prepareReportStoreWithPathEnd:@"testCrashReportCount1"];
+    NSString *reportContents = @"Testing";
+
+    char crashReportPath[SentryCrashCRS_MAX_PATH_LENGTH];
+    sentrycrashcrs_getNextCrashReportPath(crashReportPath);
+    NSString *pathToCrashReport = [NSString stringWithUTF8String:crashReportPath];
+    NSError *someError;
+    [NSFileManager.defaultManager
+              createDirectoryAtPath:[pathToCrashReport stringByDeletingPathExtension]
+        withIntermediateDirectories:true
+                         attributes:nil
+                              error:&someError];
+    XCTAssertNil(someError);
+
+    [self writeCrashReportWithStringContents:reportContents];
+    [self expectHasReportCount:1];
+}
+
 - (void)testStoresLoadsOneCrashReport
 {
     [self prepareReportStoreWithPathEnd:@"testStoresLoadsOneCrashReport"];


### PR DESCRIPTION
## :scroll: Description

Fix a bug where crashes with screenshots were reported twice.

## :bulb: Motivation and Context

closes #2130 

## :green_heart: How did you test it?

Unit Test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x]  No breaking changes
