### PR TITLE
Fix: Saucelab iPad benchmark test

### DIFF
--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -15,7 +15,7 @@ suites:
   - name: "High-end device"
     devices:
       - name: "iPad Pro 12.9 2021"
-        platformVersion: "15.5"
+        platformVersion: "15.6.1"
   - name: "Mid-range device"
     devices:
       - name: "iPhone 8"


### PR DESCRIPTION
Saucelab updated the iPad iOS version, we need to update the yaml file.

_#skip-changelog_ 

