### PR TITLE
fix: SentryTracer instances should be called "tracer", not "transaction"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     platforms: [.iOS(.v9), .macOS(.v10_10), .tvOS(.v9), .watchOS(.v2)],
     products: [
         .library(name: "Sentry", targets: ["Sentry"]),
-        .library(name: "Sentry-Dynamic", type: .dynamic, targets: ["Sentry"]),
+        .library(name: "Sentry-Dynamic", type: .dynamic, targets: ["Sentry"])
     ],
     targets: [
         .target(

--- a/Samples/SPM-Dynamic/Package.swift
+++ b/Samples/SPM-Dynamic/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "SPM-Dynamic",
     products: [
-        .library(name: "SPM-Dynamic", type: .dynamic, targets: ["SPM-Dynamic"]),
+        .library(name: "SPM-Dynamic", type: .dynamic, targets: ["SPM-Dynamic"])
     ],
     dependencies: [
         // branch is replaced in CI to the current sha

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -18,10 +18,10 @@ SentrySpan ()
     BOOL _isFinished;
 }
 
-- (instancetype)initWithTransaction:(SentryTracer *)transaction context:(SentrySpanContext *)context
+- (instancetype)initWithTracer:(SentryTracer *)tracer context:(SentrySpanContext *)context
 {
     if (self = [super init]) {
-        _transaction = transaction;
+        _tracer = tracer;
         _context = context;
         self.startTimestamp = [SentryCurrentDate date];
         _data = [[NSMutableDictionary alloc] init];
@@ -39,11 +39,11 @@ SentrySpan ()
 - (id<SentrySpan>)startChildWithOperation:(NSString *)operation
                               description:(nullable NSString *)description
 {
-    if (self.transaction == nil) {
+    if (self.tracer == nil) {
         return [SentryNoOpSpan shared];
     }
 
-    return [self.transaction startChildWithParentId:[self.context spanId]
+    return [self.tracer startChildWithParentId:[self.context spanId]
                                           operation:operation
                                         description:description];
 }
@@ -112,8 +112,8 @@ SentrySpan ()
     if (self.timestamp == nil) {
         self.timestamp = [SentryCurrentDate date];
     }
-    if (self.transaction != nil) {
-        [self.transaction spanFinished:self];
+    if (self.tracer != nil) {
+        [self.tracer spanFinished:self];
     }
 }
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -44,8 +44,8 @@ SentrySpan ()
     }
 
     return [self.tracer startChildWithParentId:[self.context spanId]
-                                          operation:operation
-                                        description:description];
+                                     operation:operation
+                                   description:description];
 }
 
 - (void)setDataValue:(nullable id)value forKey:(NSString *)key

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -144,7 +144,7 @@ static NSLock *profilerLock;
           dispatchQueueWrapper:(nullable SentryDispatchQueueWrapper *)dispatchQueueWrapper
 {
     if (self = [super init]) {
-        self.rootSpan = [[SentrySpan alloc] initWithTransaction:self context:transactionContext];
+        self.rootSpan = [[SentrySpan alloc] initWithTracer:self context:transactionContext];
         self.transactionContext = transactionContext;
         _children = [[NSMutableArray alloc] init];
         self.hub = hub;
@@ -268,7 +268,7 @@ static NSLock *profilerLock;
                                            sampled:_rootSpan.context.sampled];
     context.spanDescription = description;
 
-    SentrySpan *child = [[SentrySpan alloc] initWithTransaction:self context:context];
+    SentrySpan *child = [[SentrySpan alloc] initWithTracer:self context:context];
     @synchronized(_children) {
         [_children addObject:child];
     }
@@ -739,7 +739,7 @@ static NSLock *profilerLock;
                                            sampled:_rootSpan.context.sampled];
     context.spanDescription = description;
 
-    return [[SentrySpan alloc] initWithTransaction:self context:context];
+    return [[SentrySpan alloc] initWithTracer:self context:context];
 }
 
 - (NSDictionary *)serialize
@@ -791,7 +791,7 @@ static NSLock *profilerLock;
     if ([span isKindOfClass:[SentryTracer class]]) {
         return span;
     } else if ([span isKindOfClass:[SentrySpan class]]) {
-        return [(SentrySpan *)span transaction];
+        return [(SentrySpan *)span tracer];
     }
     return nil;
 }

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -43,8 +43,7 @@ SENTRY_NO_INIT
  *
  * @return SentrySpan
  */
-- (instancetype)initWithTracer:(SentryTracer *)transaction
-                            context:(SentrySpanContext *)context;
+- (instancetype)initWithTracer:(SentryTracer *)transaction context:(SentrySpanContext *)context;
 
 @end
 

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -33,17 +33,17 @@ SENTRY_NO_INIT
 /**
  * The Transaction this span is associated with.
  */
-@property (nullable, nonatomic, readonly, weak) SentryTracer *transaction;
+@property (nullable, nonatomic, readonly, weak) SentryTracer *tracer;
 
 /**
  * Init a SentrySpan with given transaction and context.
  *
- * @param transaction The Transaction this span is associated with.
+ * @param transaction The @c SentryTracer managing the transaction this span is associated with.
  * @param context This span context information.
  *
  * @return SentrySpan
  */
-- (instancetype)initWithTransaction:(SentryTracer *)transaction
+- (instancetype)initWithTracer:(SentryTracer *)transaction
                             context:(SentrySpanContext *)context;
 
 @end

--- a/Tests/SentryTests/Performance/SentryTracerObjCTests.m
+++ b/Tests/SentryTests/Performance/SentryTracerObjCTests.m
@@ -31,7 +31,7 @@
     }
 
     XCTAssertNotNil(child);
-    XCTAssertNil(child.transaction);
+    XCTAssertNil(child.tracer);
     [child finish];
 }
 

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -87,7 +87,7 @@ class SentrySpanTests: XCTestCase {
     }
 
     func testFinishSpanWithDefaultTimestamp() {
-        let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
+        let span = SentrySpan(tracer: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
         span.finish()
 
         XCTAssertEqual(span.startTimestamp, TestData.timestamp)
@@ -97,7 +97,7 @@ class SentrySpanTests: XCTestCase {
     }
 
     func testFinishSpanWithCustomTimestamp() {
-        let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
+        let span = SentrySpan(tracer: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
         span.timestamp = Date(timeIntervalSince1970: 123)
         span.finish()
 
@@ -211,7 +211,7 @@ class SentrySpanTests: XCTestCase {
     }
 
     func testSanitizeDataSpan() {
-        let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
+        let span = SentrySpan(tracer: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
 
         span.setExtra(value: Date(timeIntervalSince1970: 10), key: "date")
         span.finish()
@@ -231,7 +231,7 @@ class SentrySpanTests: XCTestCase {
     func testMergeTagsInSerialization() {
         let context = SpanContext(operation: fixture.someOperation)
         context.setTag(value: fixture.someTransaction, key: fixture.extraKey)
-        let span = SentrySpan(transaction: fixture.tracer, context: context)
+        let span = SentrySpan(tracer: fixture.tracer, context: context)
         
         let originalSerialization = span.serialize()
         XCTAssertEqual((originalSerialization["tags"] as! Dictionary)[fixture.extraKey], fixture.someTransaction)
@@ -265,7 +265,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testTraceHeaderUndecided() {
-        let span = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
+        let span = SentrySpan(tracer: fixture.tracer, context: SpanContext(operation: fixture.someOperation, sampled: .undecided))
         let header = span.toTraceHeader()
         
         XCTAssertEqual(header.traceId, span.context.traceId)
@@ -275,7 +275,7 @@ class SentrySpanTests: XCTestCase {
     }
     
     func testSetExtra_ForwardsToSetData() {
-        let sut = SentrySpan(transaction: fixture.tracer, context: SpanContext(operation: "test"))
+        let sut = SentrySpan(tracer: fixture.tracer, context: SpanContext(operation: "test"))
         sut.setExtra(value: 0, key: "key")
         
         XCTAssertEqual(["key": 0], sut.data as! [String: Int])
@@ -286,7 +286,7 @@ class SentrySpanTests: XCTestCase {
         // to the tracer ARC will deallocate the tracer.
         let sutGenerator : () -> Span = {
             let tracer = SentryTracer()
-            return SentrySpan(transaction: tracer, context: SpanContext(operation: ""))
+            return SentrySpan(tracer: tracer, context: SpanContext(operation: ""))
         }
         
         let sut = sutGenerator()


### PR DESCRIPTION
Looks like this might've been a casualty of a faulty search/replace in https://github.com/getsentry/sentry-cocoa/pull/1400. It's tripped me up a couple times so I think should be changed.

#skip-changelog