### PR TITLE
fix: Prewarmed app start detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Fixes
+
+- Prewarmed app start detection (#2151)
+
 ## 7.25.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## Unreleased
+
 ### Fixes
 
 - Prewarmed app start detection (#2151)

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -47,7 +47,8 @@ SentryAppStartTracker ()
     // The OS sets this environment variable if the app start is pre warmed. There are no official
     // docs for this. Found at https://eisel.me/startup. Investigations show that this variable is
     // deleted after UIApplicationDidFinishLaunchingNotification, so we have to check it here.
-    isActivePrewarm = [[NSProcessInfo processInfo].environment[@"ActivePrewarm"] isEqual:@"1"];
+    isActivePrewarm =
+        [[NSProcessInfo processInfo].environment[@"ActivePrewarm"] isEqualToString:@"1"];
 }
 
 - (instancetype)initWithCurrentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider


### PR DESCRIPTION

## :scroll: Description

Use isEqualToString instead of isEqual. This could potentially lead to wrong prewarmed app start detection.

## :bulb: Motivation and Context

It seems like the logic is not working properly. Still saw a few pre-warmed app starts in customer data. Maybe this is the root cause.

## :green_heart: How did you test it?

Unit tests use the same string constant so it won't fail.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
