### PR TITLE
ci: temporarily disable profile generation scheduled runs

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,16 +1,7 @@
 name: Benchmarking
 on:
-  schedule:
-    - cron: '0 0 * * *' # every night at midnight UTC
-  push:
-    branches:
-      - master
-
   pull_request:
     paths:
-        # test changes to Sentry SDK sources
-      - 'Sources/**'
-
         # test changes to benchmarking implementation
       - 'Samples/iOS-Swift/iOS-Swift/**'
       - 'Samples/iOS-Swift/PerformanceBenchmarks/**'

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -2,11 +2,6 @@
 
 name: Generate Profiling Test Data
 on:
-  schedule:
-    - cron: '0 */6 * * *' # every 6 hours = 4x/day
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - '.github/workflows/profile-data-generator.yml'


### PR DESCRIPTION
We're trying to validate where spikes are originating from for symbol uploads, this is a likely candidate.

#skip-changelog