### PR TITLE
Fix issue reference in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -563,7 +563,7 @@ For a detailed explanation  how to upgrade please checkout the [migration guide]
 - ref: SentryEvent.timestamp changed to nullable.
 - ref: Add read-only scope property to Hub (#975)
 - ref: Remove SentryException.userReported (#974)
-- ref: Replace SentryLogLevel with SentryLevel (#978)
+- ref: Replace SentryLogLevel with SentryLevel (#979)
 - fix: Mark frames as inApp (#956)
 
 ### Features


### PR DESCRIPTION
## :scroll: Description

While looking at the `CHANGELOG.md` for 7.x to check what could be breaking when we bumped to the next major version, I wanted to get more details about this breaking change about `SentryLogLevel`, but when following the reference to get more details, it led me to the wrong PR. After searching PRs in GitHub, I found out the correct PR # was supposed to be #979 instead of 978

## :bulb: Motivation and Context

The PR reference # in the CHANGELOG for this entry is incorrect.

## :green_heart: How did you test it?

N/A, this is just a typo fix.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps

N/A