### PR TITLE
test: generate graphs for benchmarks

### DIFF
--- a/scripts/process-benchmark-raw-results.py
+++ b/scripts/process-benchmark-raw-results.py
@@ -3,6 +3,7 @@
 import argparse
 import functools
 import math
+import matplotlib.pyplot as plt
 import sys
 
 """A script to parse an XCUITest console log, extract raw benchmark values, and statistically analyze the SDK profiler's CPU overhead."""
@@ -31,8 +32,22 @@ def main():
 
     mean = functools.reduce(lambda res, next: res + float(next), percentages, 0) / len(percentages)
 
+    p0 = percentages[0]
+
     p90_index = math.ceil(len(percentages) * 0.9)
     p90 = percentages[p90_index - 1]
+
+    p99_index = math.ceil(len(percentages) * 0.99)
+    p99 = percentages[p99_index - 1]
+
+    p99_9_index = math.ceil(len(percentages) * 0.999)
+    p99_9 = percentages[p99_9_index - 1]
+
+    p99_999_index = math.ceil(len(percentages) * 0.99999)
+    p99_999 = percentages[p99_999_index - 1]
+
+    p99_99999_index = math.ceil(len(percentages) * 0.9999999)
+    p99_99999 = percentages[p99_99999_index - 1]
 
     print(f'''Benchmark report
 ----------------
@@ -41,9 +56,22 @@ All observations (overhead, %):
 
 Median: {median:.3f}
 Mean: {mean:.3f}
+P0: {p0}
 P90: {p90}
+P99: {p99}
+P99.9: {p99_9}
+P99.999: {p99_999}
+P99.99999: {p99_99999}
     ''')
 
+percentiles = [p0, p90, p99, p99_9, p99_999, p99_99999]
+plt.title("Cpu time increase percentage for " + devClass + " devices")
+plt.plot(percentiles)
+plt.ylabel("Cpu time increase %")
+plt.xlabel("Percentile")
+plt.xticks(ticks=[0, 1, 2, 3, 4, 5], labels=["0%", "90%", "99%", "99.9%", "99.999%", "99.99999%"])
+plt.grid(True)
+plt.show()
 
 if __name__ == '__main__':
     main()

--- a/scripts/process-benchmark-raw-results.py
+++ b/scripts/process-benchmark-raw-results.py
@@ -67,7 +67,7 @@ P99.99999: {p99_99999}
 
     percentiles = [p0, p90, p99, p99_9, p99_999, p99_99999]
     plt.title("Cpu time increase percentage for " + args.device_class + " devices")
-    plt.plot(percentiles)
+    plt.plot(percentiles, marker='o')
     plt.ylabel("Cpu time increase %")
     plt.xlabel("Percentile")
     plt.xticks(ticks=[0, 1, 2, 3, 4, 5], labels=["0%", "90%", "99%", "99.9%", "99.999%", "99.99999%"])

--- a/scripts/process-benchmark-raw-results.py
+++ b/scripts/process-benchmark-raw-results.py
@@ -12,6 +12,7 @@ def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('log_file_path', help='Path to the log file to parse.')
     parser.add_argument('device_class', help='The class of device the benchmarks were run on.')
+    parser.add_argument('device_name', help='The name of the actual device the benchmarks were run on.')
     args = parser.parse_args()
 
     def extract_values(line):
@@ -66,7 +67,7 @@ P99.99999: {p99_99999}
     ''')
 
     percentiles = [p0, p90, p99, p99_9, p99_999, p99_99999]
-    plt.title("Cpu time increase percentage for " + args.device_class + " devices")
+    plt.title(f"Cpu time increase percentage for {args.device_class} devices (run on {args.device_name})")
     plt.plot(percentiles, marker='o')
     plt.ylabel("Cpu time increase %")
     plt.xlabel("Percentile")

--- a/scripts/process-benchmark-raw-results.py
+++ b/scripts/process-benchmark-raw-results.py
@@ -4,6 +4,7 @@ import argparse
 import functools
 import math
 import matplotlib.pyplot as plt
+import subprocess
 import sys
 
 """A script to parse an XCUITest console log, extract raw benchmark values, and statistically analyze the SDK profiler's CPU overhead."""
@@ -27,6 +28,7 @@ def main():
         return 100.0 * (int(readings[0]) + int(readings[1])) / (int(readings[2]) + int(readings[3]))
 
     percentages = [f'{y:.3f}' for y in sorted([overhead(x) for x in results])]
+    percentage_values = [y for y in sorted([overhead(x) for x in results])]
     count = len(percentages)
 
     middle_index = int(math.floor(count / 2))
@@ -35,21 +37,27 @@ def main():
     mean = functools.reduce(lambda res, next: res + float(next), percentages, 0) / len(percentages)
 
     p0 = percentages[0]
+    p0_value = percentage_values[0]
 
     p90_index = math.ceil(len(percentages) * 0.9)
     p90 = percentages[p90_index - 1]
+    p90_value = percentage_values[p90_index - 1]
 
     p99_index = math.ceil(len(percentages) * 0.99)
     p99 = percentages[p99_index - 1]
+    p99_value = percentage_values[p99_index - 1]
 
     p99_9_index = math.ceil(len(percentages) * 0.999)
     p99_9 = percentages[p99_9_index - 1]
+    p99_9_value = percentage_values[p99_9_index - 1]
 
     p99_999_index = math.ceil(len(percentages) * 0.99999)
     p99_999 = percentages[p99_999_index - 1]
+    p99_999_value = percentage_values[p99_999_index - 1]
 
     p99_99999_index = math.ceil(len(percentages) * 0.9999999)
     p99_99999 = percentages[p99_99999_index - 1]
+    p99_99999_value = percentage_values[p99_99999_index - 1]
 
     print(f'''Benchmark report
 ----------------
@@ -66,14 +74,17 @@ P99.999: {p99_999}
 P99.99999: {p99_99999}
     ''')
 
-    percentiles = [p0, p90, p99, p99_9, p99_999, p99_99999]
-    plt.title(f"Cpu time increase percentage for {args.device_class} devices (run on {args.device_name})")
+    percentiles = [p0_value, p90_value, p99_value, p99_9_value, p99_999_value, p99_99999_value]
+    print(f"{percentiles=}")
+    plt.title(f'Cpu time increase percentage for {args.device_class} devices (run on {args.device_name})')
     plt.plot(percentiles, marker='o')
-    plt.ylabel("Cpu time increase %")
-    plt.xlabel("Percentile")
-    plt.xticks(ticks=[0, 1, 2, 3, 4, 5], labels=["0%", "90%", "99%", "99.9%", "99.999%", "99.99999%"])
+    plt.ylabel('Cpu time increase %')
+    plt.xlabel('Percentile')
+    plt.xticks(ticks=[0, 1, 2, 3, 4, 5], labels=['0%', '90%', '99%', '99.9%', '99.999%', '99.99999%'])
     plt.grid(True)
-    plt.show()
+    filename = f'ios_benchmarks_{args.device_class}_{args.device_name}.png'
+    plt.savefig(filename)
+    subprocess.check_call(['open', filename])
 
 if __name__ == '__main__':
     main()

--- a/scripts/process-benchmark-raw-results.py
+++ b/scripts/process-benchmark-raw-results.py
@@ -11,6 +11,7 @@ import sys
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('log_file_path', help='Path to the log file to parse.')
+    parser.add_argument('device_class', help='The class of device the benchmarks were run on.')
     args = parser.parse_args()
 
     def extract_values(line):
@@ -64,14 +65,14 @@ P99.999: {p99_999}
 P99.99999: {p99_99999}
     ''')
 
-percentiles = [p0, p90, p99, p99_9, p99_999, p99_99999]
-plt.title("Cpu time increase percentage for " + devClass + " devices")
-plt.plot(percentiles)
-plt.ylabel("Cpu time increase %")
-plt.xlabel("Percentile")
-plt.xticks(ticks=[0, 1, 2, 3, 4, 5], labels=["0%", "90%", "99%", "99.9%", "99.999%", "99.99999%"])
-plt.grid(True)
-plt.show()
+    percentiles = [p0, p90, p99, p99_9, p99_999, p99_99999]
+    plt.title("Cpu time increase percentage for " + args.device_class + " devices")
+    plt.plot(percentiles)
+    plt.ylabel("Cpu time increase %")
+    plt.xlabel("Percentile")
+    plt.xticks(ticks=[0, 1, 2, 3, 4, 5], labels=["0%", "90%", "99%", "99.9%", "99.999%", "99.99999%"])
+    plt.grid(True)
+    plt.show()
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
The script that processes benchmark results now generates a graph like the following:

![ios_benchmarks_High-end_iPhone 13 mini](https://user-images.githubusercontent.com/3241469/190127440-afb2b56b-3e13-49a3-b71c-855ca6dd31ce.png)


#skip-changelog