### PR TITLE
meta: add macros for easier logging

### DIFF
--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -15,3 +15,9 @@ SENTRY_NO_INIT
 @end
 
 NS_ASSUME_NONNULL_END
+
+#define SENTRY_LOG_DEBUG(...) [SentryLog logWithMessage:[NSString stringWithFormat: __VA_ARGS__] andLevel:kSentryLevelDebug]
+#define SENTRY_LOG_INFO(...) [SentryLog logWithMessage:[NSString stringWithFormat: __VA_ARGS__] andLevel:kSentryLevelInfo]
+#define SENTRY_LOG_WARN(...) [SentryLog logWithMessage:[NSString stringWithFormat: __VA_ARGS__] andLevel:kSentryLevelWarning]
+#define SENTRY_LOG_ERROR(...) [SentryLog logWithMessage:[NSString stringWithFormat: __VA_ARGS__] andLevel:kSentryLevelError]
+#define SENTRY_LOG_CRITICAL(...) [SentryLog logWithMessage:[NSString stringWithFormat: __VA_ARGS__] andLevel:kSentryLevelCritical]


### PR DESCRIPTION
Using macros for this is fairly industry-standard, and IMO makes reading code easier as macros are usually syntax-colored differently (along with the scream-case convention for macros 😄) which allows for easier visual scanning/filtering, and are more concise than the ObjC methods we currently use to log messages.

I don't think we ever use debug logs from production deployments, so we could even consider defining everything ≥ warn level to an empty value for Release config, which would avoid a whole bunch of dispatched messages for logs that aren't going to be used. We could always revisit this later, just an idea.

#skip-changelog