### PR TITLE
fix: Enable testCaptureMessage again

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -56,9 +56,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "SentryClientTest/testCaptureMessage()">
-               </Test>
-               <Test
                   Identifier = "SentrySDKIntegrationTestsBase">
                </Test>
                <Test


### PR DESCRIPTION
Locally it's 100% fine and I haven't seen this one come up in https://github.com/getsentry/sentry-cocoa/pull/2142 either. Let's see what happens and if we can re-enable it.

#skip-changelog