### PR TITLE
fix: Use the `component` name source for SentryPerformanceTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Use the component name source for SentryPerformanceTracke (#2168)
+
 ## 7.25.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Use the component name source for SentryPerformanceTracke (#2168)
+- Use the `component` name source for SentryPerformanceTracker (#2168)
 
 ## 7.25.1
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		0A2D8D9828997887008720F6 /* NSLocale+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */; };
 		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
 		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
+		0A4EDEA928D3461B00FA67CB /* SentryPerformanceTracker+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A4EDEA828D3461B00FA67CB /* SentryPerformanceTracker+Private.h */; };
 		0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */; };
 		0A56DA5F28ABA01B00C400D5 /* SentryTransactionContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */; };
 		0A6EEADD28A657970076B469 /* UIViewRecursiveDescriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */; };
@@ -740,6 +741,7 @@
 		0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSLocale+Sentry.h"; path = "include/NSLocale+Sentry.h"; sourceTree = "<group>"; };
 		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
 		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
+		0A4EDEA828D3461B00FA67CB /* SentryPerformanceTracker+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryPerformanceTracker+Private.h"; path = "include/SentryPerformanceTracker+Private.h"; sourceTree = "<group>"; };
 		0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
 		0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryTransactionContext+Private.h"; path = "include/SentryTransactionContext+Private.h"; sourceTree = "<group>"; };
 		0A6EEADC28A657970076B469 /* UIViewRecursiveDescriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewRecursiveDescriptionTests.swift; sourceTree = "<group>"; };
@@ -2486,6 +2488,7 @@
 				8EAE9804261E87120073B6B3 /* SentryUIViewControllerPerformanceTracker.m */,
 				8EAE9809261E9F530073B6B3 /* SentryPerformanceTracker.h */,
 				8EBF870726140D37001A6853 /* SentryPerformanceTracker.m */,
+				0A4EDEA828D3461B00FA67CB /* SentryPerformanceTracker+Private.h */,
 			);
 			name = UIViewController;
 			sourceTree = "<group>";
@@ -2907,6 +2910,7 @@
 				7BFC169B2524995700FF6266 /* SentryMessage.h in Headers */,
 				03F84D1E27DD414C008FE43F /* SentryBacktrace.hpp in Headers */,
 				63AA76991EB9C1C200D153DE /* SentryDefines.h in Headers */,
+				0A4EDEA928D3461B00FA67CB /* SentryPerformanceTracker+Private.h in Headers */,
 				0A8F0A392886CC70000B15F6 /* SentryPermissionsObserver.h in Headers */,
 				63FE70CF20DA4C1000CDBAE8 /* SentryCrashMonitor_User.h in Headers */,
 				7B2A70DB27D607CF008B0D15 /* SentryThreadWrapper.h in Headers */,

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -41,6 +41,15 @@ SentryPerformanceTracker () <SentryTracerDelegate>
 
 - (SentrySpanId *)startSpanWithName:(NSString *)name operation:(NSString *)operation
 {
+    return [self startSpanWithName:name
+                        nameSource:kSentryTransactionNameSourceCustom
+                         operation:operation];
+}
+
+- (SentrySpanId *)startSpanWithName:(NSString *)name
+                         nameSource:(SentryTransactionNameSource)source
+                          operation:(NSString *)operation
+{
     id<SentrySpan> activeSpan;
     @synchronized(self.activeSpanStack) {
         activeSpan = [self.activeSpanStack lastObject];
@@ -52,7 +61,7 @@ SentryPerformanceTracker () <SentryTracerDelegate>
     } else {
         SentryTransactionContext *context =
             [[SentryTransactionContext alloc] initWithName:name
-                                                nameSource:kSentryTransactionNameSourceComponent
+                                                nameSource:source
                                                  operation:operation];
 
         [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> span) {
@@ -95,6 +104,17 @@ SentryPerformanceTracker () <SentryTracerDelegate>
                          operation:(NSString *)operation
                            inBlock:(void (^)(void))block
 {
+    [self measureSpanWithDescription:description
+                          nameSource:kSentryTransactionNameSourceCustom
+                           operation:operation
+                             inBlock:block];
+}
+
+- (void)measureSpanWithDescription:(NSString *)description
+                        nameSource:(SentryTransactionNameSource)source
+                         operation:(NSString *)operation
+                           inBlock:(void (^)(void))block
+{
     SentrySpanId *spanId = [self startSpanWithName:description operation:operation];
     [self pushActiveSpan:spanId];
     block();
@@ -103,6 +123,19 @@ SentryPerformanceTracker () <SentryTracerDelegate>
 }
 
 - (void)measureSpanWithDescription:(NSString *)description
+                         operation:(NSString *)operation
+                      parentSpanId:(SentrySpanId *)parentSpanId
+                           inBlock:(void (^)(void))block
+{
+    [self measureSpanWithDescription:description
+                          nameSource:kSentryTransactionNameSourceCustom
+                           operation:operation
+                        parentSpanId:parentSpanId
+                             inBlock:block];
+}
+
+- (void)measureSpanWithDescription:(NSString *)description
+                        nameSource:(SentryTransactionNameSource)source
                          operation:(NSString *)operation
                       parentSpanId:(SentrySpanId *)parentSpanId
                            inBlock:(void (^)(void))block

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -51,7 +51,9 @@ SentryPerformanceTracker () <SentryTracerDelegate>
         newSpan = [activeSpan startChildWithOperation:operation description:name];
     } else {
         SentryTransactionContext *context =
-            [[SentryTransactionContext alloc] initWithName:name operation:operation];
+            [[SentryTransactionContext alloc] initWithName:name
+                                                nameSource:kSentryTransactionNameSourceComponent
+                                                 operation:operation];
 
         [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> span) {
             BOOL bindToScope = true;

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -115,7 +115,9 @@ SentryPerformanceTracker () <SentryTracerDelegate>
                          operation:(NSString *)operation
                            inBlock:(void (^)(void))block
 {
-    SentrySpanId *spanId = [self startSpanWithName:description operation:operation];
+    SentrySpanId *spanId = [self startSpanWithName:description
+                                        nameSource:source
+                                         operation:operation];
     [self pushActiveSpan:spanId];
     block();
     [self popActiveSpan];
@@ -142,7 +144,10 @@ SentryPerformanceTracker () <SentryTracerDelegate>
 {
     [self activateSpan:parentSpanId
            duringBlock:^{
-               [self measureSpanWithDescription:description operation:operation inBlock:block];
+               [self measureSpanWithDescription:description
+                                     nameSource:source
+                                      operation:operation
+                                        inBlock:block];
            }];
 }
 

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -1,6 +1,7 @@
 #import "SentryUIViewControllerPerformanceTracker.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
+#import "SentryPerformanceTracker+Private.h"
 #import "SentryPerformanceTracker.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope.h"
@@ -89,7 +90,9 @@ SentryUIViewControllerPerformanceTracker ()
     // and override the previous id stored.
     if (spanId == nil) {
         NSString *name = [SentryUIViewControllerSanitizer sanitizeViewControllerName:controller];
-        spanId = [self.tracker startSpanWithName:name operation:SentrySpanOperationUILoad];
+        spanId = [self.tracker startSpanWithName:name
+                                      nameSource:kSentryTransactionNameSourceComponent
+                                       operation:SentrySpanOperationUILoad];
 
         // Use the target itself to store the spanId to avoid using a global mapper.
         objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID, spanId,
@@ -113,11 +116,13 @@ SentryUIViewControllerPerformanceTracker ()
 
         void (^duringBlock)(void) = ^{
             [self.tracker measureSpanWithDescription:@"viewWillAppear"
+                                          nameSource:kSentryTransactionNameSourceComponent
                                            operation:SentrySpanOperationUILoad
                                              inBlock:callbackToOrigin];
 
             SentrySpanId *viewAppearingId =
                 [self.tracker startSpanWithName:@"viewAppearing"
+                                     nameSource:kSentryTransactionNameSourceComponent
                                       operation:SentrySpanOperationUILoad];
 
             objc_setAssociatedObject(controller,
@@ -190,6 +195,7 @@ SentryUIViewControllerPerformanceTracker ()
             }
 
             [self.tracker measureSpanWithDescription:lifecycleMethod
+                                          nameSource:kSentryTransactionNameSourceComponent
                                            operation:SentrySpanOperationUILoad
                                              inBlock:callbackToOrigin];
         };
@@ -224,11 +230,13 @@ SentryUIViewControllerPerformanceTracker ()
 
         void (^duringBlock)(void) = ^{
             [self.tracker measureSpanWithDescription:@"viewWillLayoutSubviews"
+                                          nameSource:kSentryTransactionNameSourceComponent
                                            operation:SentrySpanOperationUILoad
                                              inBlock:callbackToOrigin];
 
             SentrySpanId *layoutSubViewId =
                 [self.tracker startSpanWithName:@"layoutSubViews"
+                                     nameSource:kSentryTransactionNameSourceComponent
                                       operation:SentrySpanOperationUILoad];
 
             objc_setAssociatedObject(controller,
@@ -267,6 +275,7 @@ SentryUIViewControllerPerformanceTracker ()
             }
 
             [self.tracker measureSpanWithDescription:@"viewDidLayoutSubviews"
+                                          nameSource:kSentryTransactionNameSourceComponent
                                            operation:SentrySpanOperationUILoad
                                              inBlock:callbackToOrigin];
 
@@ -327,6 +336,7 @@ SentryUIViewControllerPerformanceTracker ()
         callbackToOrigin();
     } else {
         [self.tracker measureSpanWithDescription:description
+                                      nameSource:kSentryTransactionNameSourceComponent
                                        operation:SentrySpanOperationUILoad
                                     parentSpanId:spanId
                                          inBlock:callbackToOrigin];

--- a/Sources/Sentry/include/SentryPerformanceTracker+Private.h
+++ b/Sources/Sentry/include/SentryPerformanceTracker+Private.h
@@ -1,0 +1,21 @@
+#import "SentryPerformanceTracker.h"
+
+@interface
+SentryPerformanceTracker (Private)
+
+- (SentrySpanId *)startSpanWithName:(NSString *)name
+                         nameSource:(SentryTransactionNameSource)source
+                          operation:(NSString *)operation;
+
+- (void)measureSpanWithDescription:(NSString *)description
+                        nameSource:(SentryTransactionNameSource)source
+                         operation:(NSString *)operation
+                           inBlock:(void (^)(void))block;
+
+- (void)measureSpanWithDescription:(NSString *)description
+                        nameSource:(SentryTransactionNameSource)source
+                         operation:(NSString *)operation
+                      parentSpanId:(SentrySpanId *)parentSpanId
+                           inBlock:(void (^)(void))block;
+
+@end

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -113,7 +113,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             callbackExpectation.fulfill()
         }
         XCTAssertEqual((transactionSpan as! SentryTracer?)!.transactionContext.name, fixture.viewControllerName)
-        XCTAssertEqual((transactionSpan as! SentryTracer?)!.transactionContext.nameSource, .custom)
+        XCTAssertEqual((transactionSpan as! SentryTracer?)!.transactionContext.nameSource, .component)
         XCTAssertFalse(transactionSpan.isFinished)
 
         sut.viewControllerViewDidLoad(viewController) {


### PR DESCRIPTION
## :scroll: Description

I don't think this needs a changelog entry, what do you guys think?
#skip-changelog

## :bulb: Motivation and Context

Closes #2125

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
