### PR TITLE
ref: Make SentryTime available everywhere

### DIFF
--- a/Sources/Sentry/SentryMachLogging.cpp
+++ b/Sources/Sentry/SentryMachLogging.cpp
@@ -1,7 +1,5 @@
 #include "SentryMachLogging.hpp"
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-
 namespace sentry {
 namespace profiling {
 
@@ -212,5 +210,3 @@ namespace profiling {
 
 } // namespace profiling
 } // namespace sentry
-
-#endif

--- a/Sources/Sentry/SentryTime.mm
+++ b/Sources/Sentry/SentryTime.mm
@@ -1,12 +1,10 @@
 #import "SentryTime.h"
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#import <Foundation/Foundation.h>
+#import <ctime>
+#import <mach/mach_time.h>
 
-#    import <Foundation/Foundation.h>
-#    import <ctime>
-#    import <mach/mach_time.h>
-
-#    import "SentryMachLogging.hpp"
+#import "SentryMachLogging.hpp"
 
 uint64_t
 getAbsoluteTime(void)
@@ -33,5 +31,3 @@ getDurationNs(uint64_t startTimestamp, uint64_t endTimestamp)
     duration /= info.denom;
     return duration;
 }
-
-#endif

--- a/Sources/Sentry/include/SentryMachLogging.hpp
+++ b/Sources/Sentry/include/SentryMachLogging.hpp
@@ -1,13 +1,9 @@
 #pragma once
 
 #include "SentryProfilingConditionals.h"
-
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-
-#    include "SentryProfilingLogging.hpp"
-
-#    include <mach/kern_return.h>
-#    include <mach/message.h>
+#include "SentryProfilingLogging.hpp"
+#include <mach/kern_return.h>
+#include <mach/message.h>
 
 namespace sentry {
 namespace profiling {
@@ -33,26 +29,23 @@ namespace profiling {
 } // namespace profiling
 } // namespace sentry
 
-#    define SENTRY_PROF_LOG_KERN_RETURN(statement)                                                 \
-        ({                                                                                         \
-            const kern_return_t __log_kr = statement;                                              \
-            if (__log_kr != KERN_SUCCESS) {                                                        \
-                SENTRY_PROF_LOG_ERROR("%s failed with kern return code: %d, description: %s",      \
-                    #statement, __log_kr,                                                          \
-                    sentry::profiling::kernelReturnCodeDescription(__log_kr));                     \
-            }                                                                                      \
-            __log_kr;                                                                              \
-        })
+#define SENTRY_PROF_LOG_KERN_RETURN(statement)                                                     \
+    ({                                                                                             \
+        const kern_return_t __log_kr = statement;                                                  \
+        if (__log_kr != KERN_SUCCESS) {                                                            \
+            SENTRY_PROF_LOG_ERROR("%s failed with kern return code: %d, description: %s",          \
+                #statement, __log_kr, sentry::profiling::kernelReturnCodeDescription(__log_kr));   \
+        }                                                                                          \
+        __log_kr;                                                                                  \
+    })
 
-#    define SENTRY_PROF_LOG_MACH_MSG_RETURN(statement)                                             \
-        ({                                                                                         \
-            const mach_msg_return_t __log_mr = statement;                                          \
-            if (__log_mr != MACH_MSG_SUCCESS) {                                                    \
-                SENTRY_PROF_LOG_ERROR("%s failed with mach_msg return code: %d, description: %s",  \
-                    #statement, __log_mr,                                                          \
-                    sentry::profiling::machMessageReturnCodeDescription(__log_mr));                \
-            }                                                                                      \
-            __log_mr;                                                                              \
-        })
-
-#endif
+#define SENTRY_PROF_LOG_MACH_MSG_RETURN(statement)                                                 \
+    ({                                                                                             \
+        const mach_msg_return_t __log_mr = statement;                                              \
+        if (__log_mr != MACH_MSG_SUCCESS) {                                                        \
+            SENTRY_PROF_LOG_ERROR("%s failed with mach_msg return code: %d, description: %s",      \
+                #statement, __log_mr,                                                              \
+                sentry::profiling::machMessageReturnCodeDescription(__log_mr));                    \
+        }                                                                                          \
+        __log_mr;                                                                                  \
+    })

--- a/Sources/Sentry/include/SentryTime.h
+++ b/Sources/Sentry/include/SentryTime.h
@@ -1,9 +1,6 @@
+#import "SentryCompiler.h"
 #import "SentryProfilingConditionals.h"
-
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-
-#    import "SentryCompiler.h"
-#    import <stdint.h>
+#import <stdint.h>
 
 SENTRY_EXTERN_C_BEGIN
 
@@ -19,5 +16,3 @@ uint64_t getAbsoluteTime(void);
 uint64_t getDurationNs(uint64_t startTimestamp, uint64_t endTimestamp);
 
 SENTRY_EXTERN_C_END
-
-#endif


### PR DESCRIPTION
We need SentryTime also on tvOS so we can make it
available everywhere.

Needed for tests in https://github.com/getsentry/sentry-cocoa/pull/2140.

#skip-changelog