### PR TITLE
test: use NSMutableArray instead of Swift array for test invocations

### DIFF
--- a/Tests/SentryTests/TestUtils/Invocations.swift
+++ b/Tests/SentryTests/TestUtils/Invocations.swift
@@ -4,44 +4,42 @@ import Foundation
  * For recording invocations of methods in a list in a thread safe manner.
  */
 class Invocations<T> {
-    
     private let queue = DispatchQueue(label: "Invocations", attributes: .concurrent)
-    
-    private var _invocations: [T] = []
-    
+    private var _invocations = NSMutableArray()
+
     var invocations: [T] {
         return queue.sync {
-            return self._invocations
+            return self._invocations as! [T]
         }
     }
-    
+
     var count: Int {
         return queue.sync {
             return self._invocations.count
         }
     }
-    
+
     var first: T? {
         return queue.sync {
-            return self._invocations.first
+            return self._invocations.firstObject as? T
         }
     }
-    
+
     var last: T? {
         return queue.sync {
-            return self._invocations.last
+            return self._invocations.lastObject as? T
         }
     }
-    
+
     var isEmpty: Bool {
         return queue.sync {
-            return self._invocations.isEmpty
+            return self._invocations.count == 0
         }
     }
-    
+
     func record(_ invocation: T) {
         queue.async(flags: .barrier) {
-            self._invocations.append(invocation)
+            self._invocations.add(invocation)
         }
     }
 }


### PR DESCRIPTION
... to disallow inadvertently adding `nil`. I noticed this while working on some tests and it took me a while to figure out this was causing a problem. With `NSMutableArray`, adding `nil` throws an exception so will fail faster for people in the future.

#skip-changelog