### PR TITLE
test: allow running tests in parallel

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -46,7 +46,8 @@
       </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            parallelizable = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63AA76641EB8CB2F00D153DE"

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -95,6 +95,11 @@ class SentryTracerTests: XCTestCase {
         SentryFramesTracker.sharedInstance().stop()
 #endif
     }
+
+    /// Only added to trip the unit test CI trigger.
+    func testSuccess() {
+        XCTAssertTrue(true)
+    }
     
     func testFinish_WithChildren_WaitsForAllChildren() {
         let sut = fixture.getSut()


### PR DESCRIPTION
Let's try flipping this option in the scheme's test action and see what happens: 
<img width="231" alt="image" src="https://user-images.githubusercontent.com/3241469/190564617-310e41ce-cc99-46b1-a82d-36abfb3ecabd.png">


#skip-changelog