### PR TITLE
ci: Fix fastlane bundle version mismatch

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ci/fastlane-fixes # TODO: Remove
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'
@@ -25,10 +26,10 @@ jobs:
       - name: Bump Bundle Version
         env: 
           FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
-        run: fastlane bump_bundle_version
+        run: bundle fastlane bump_bundle_version
 
       - name: Remove preview version suffixes
-        run: fastlane remove_preview_version_suffixes
+        run: bundle fastlane remove_preview_version_suffixes
 
       - name: Run Fastlane
         env:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - ci/fastlane-fixes # TODO: Remove
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -22,11 +22,11 @@ jobs:
       - run: bundle install
 
       # We upload a new version to TestFlight on every commit on Master
-      # So we need to bump the bundle version each time
-      - name: Bump Bundle Version
+      # So we need to bump the build number each time
+      - name: Bump Build Version
         env: 
-          FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
-        run: bundle exec fastlane bump_bundle_version
+          FASTLANE_BUILD_NUMBER: ${{ github.run_number }}
+        run: bundle exec fastlane bump_build_number
 
       - name: Remove preview version suffixes
         run: bundle exec fastlane remove_preview_version_suffixes

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -26,10 +26,10 @@ jobs:
       - name: Bump Bundle Version
         env: 
           FASTLANE_BUNDLE_VERSION: ${{ github.run_number }}
-        run: bundle fastlane bump_bundle_version
+        run: bundle exec fastlane bump_bundle_version
 
       - name: Remove preview version suffixes
-        run: bundle fastlane remove_preview_version_suffixes
+        run: bundle exec fastlane remove_preview_version_suffixes
 
       - name: Run Fastlane
         env:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,8 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.625.0)
-    aws-sdk-core (3.139.0)
+    aws-partitions (1.631.0)
+    aws-sdk-core (3.148.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -116,7 +116,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.209.1)
+    fastlane (2.210.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -161,9 +161,9 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.25.0)
+    google-apis-androidpublisher_v3 (0.26.0)
       google-apis-core (>= 0.7, < 2.a)
-    google-apis-core (0.7.0)
+    google-apis-core (0.7.2)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -183,8 +183,8 @@ GEM
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.2.0)
-    google-cloud-storage (1.39.0)
+    google-cloud-errors (1.3.0)
+    google-cloud-storage (1.40.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
@@ -296,4 +296,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.3.15
+   2.3.21

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,11 +16,20 @@ platform :ios do
       value: ENV["FASTLANE_BUNDLE_VERSION"]
     )
 
+    putBundleVersions
+  end
+
+  lane :putBundleVersions do
+    swift_bundle_version = get_info_plist_value(
+      path: ios_swift_infoplist_path,
+      key: "CFBundleVersion"
+    )
+    puts("iOS-Swift CFBundleVersion: " + swift_bundle_version)
+
     swift_clip_bundle_version = get_info_plist_value(
       path: ios_swift_clip_infoplist_path,
       key: "CFBundleVersion"
     )
-
     puts("SwiftClip CFBundleVersion: " + swift_clip_bundle_version)
   end
 
@@ -55,6 +64,8 @@ platform :ios do
       key: "CFBundleVersion",
       value: version
     )
+
+    putBundleVersions
   end
 
   desc "Build iOS-Swift with Release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -4,33 +4,11 @@ platform :ios do
   ios_swift_infoplist_path = "./Samples/iOS-Swift/iOS-Swift/Info.plist"
   ios_swift_clip_infoplist_path = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
 
-  lane :bump_bundle_version do
-    set_info_plist_value(
-      path: ios_swift_infoplist_path,
-      key: "CFBundleVersion",
-      value: ENV["FASTLANE_BUNDLE_VERSION"]
+  lane :bump_build_number do
+    increment_build_number(
+      build_number: ENV["FASTLANE_BUILD_NUMBER"],
+      xcodeproj: "./Samples/iOS-Swift/iOS-Swift.xcodeproj"
     )
-    set_info_plist_value(
-      path: ios_swift_clip_infoplist_path,
-      key: "CFBundleVersion",
-      value: ENV["FASTLANE_BUNDLE_VERSION"]
-    )
-
-    putBundleVersions
-  end
-
-  lane :putBundleVersions do
-    swift_bundle_version = get_info_plist_value(
-      path: ios_swift_infoplist_path,
-      key: "CFBundleVersion"
-    )
-    puts("iOS-Swift CFBundleVersion: " + swift_bundle_version)
-
-    swift_clip_bundle_version = get_info_plist_value(
-      path: ios_swift_clip_infoplist_path,
-      key: "CFBundleVersion"
-    )
-    puts("SwiftClip CFBundleVersion: " + swift_clip_bundle_version)
   end
 
   # The version for all Info.plist must be a period-separated list of at most three non-negative integers
@@ -64,8 +42,6 @@ platform :ios do
       key: "CFBundleVersion",
       value: version
     )
-
-    putBundleVersions
   end
 
   desc "Build iOS-Swift with Release"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,13 @@ platform :ios do
       key: "CFBundleVersion",
       value: ENV["FASTLANE_BUNDLE_VERSION"]
     )
+
+    swift_clip_bundle_version = get_info_plist_value(
+      path: ios_swift_clip_infoplist_path,
+      key: "CFBundleVersion"
+    )
+
+    puts("SwiftClip CFBundleVersion: " + swift_clip_bundle_version)
   end
 
   # The version for all Info.plist must be a period-separated list of at most three non-negative integers


### PR DESCRIPTION
The upload to Testflight via Fastlane failed with
```
error: The CFBundleVersion of an App Clip ('1') must match that of its containing parent app ('817').
```
This is fixed now by using `increment_build_number` instead of using `set_info_plist_value`.

[Successful run](https://github.com/getsentry/sentry-cocoa/actions/runs/3065964712/jobs/4950617570). 

#skip-changelog