### PR TITLE
ci: Compile test-server once

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
+          key: test-server-${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
       - name: Build Test Server
-        # if: steps.cache_test_server.outputs.cache-hit != 'true'
+        if: steps.cache_test_server.outputs.cache-hit != 'true'
         working-directory: test-server
         run: >-
           swift build -c release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - release/**
+      - ci/build-testserver-once
 
   pull_request:
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
       - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true'
+        # if: steps.cache_test_server.outputs.cache-hit != 'true'
         working-directory: test-server
         run: >-
           swift build -c release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: test-server
+      - run: chmod +x ./test-server-exec
       - run: ./test-server-exec &
 
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,14 @@ jobs:
 
       - name: Build Test Server
         if: steps.cache_test_server.outputs.cache-hit != 'true'
+        working-directory: test-server
         run: >-
           swift build -c release
           cp $(swift build --show-bin-path -c release)/Run exec
+
+      - name: Copy exec
         working-directory: test-server
+        run: cp $(swift build --show-bin-path -c release)/Run exec
 
       - name: Archiving DerivedData
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,30 @@ on:
       - 'scripts/xcode-test.sh'
 
 jobs:
+  build-test-server:
+    name: Build test server
+    runs-on: macos-12
+    steps:
+      - uses: actions/checkout@v3
+      - name: Cache for Test Server
+        id: cache_test_server
+        uses: actions/cache@v3
+        with:
+          path: ./test-server/.build
+          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
+
+      - name: Build Test Server
+        if: steps.cache_test_server.outputs.cache-hit != 'true'
+        run: swift build
+        working-directory: test-server
+
+      - name: Archiving DerivedData
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-server
+          path: |
+            ./test-server/.build/**/release/Run
+
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
     runs-on: ${{matrix.runs-on}}
@@ -98,31 +122,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
-      # As we use swift-tools-version:5.5 the test server only compiles with Xcode 13.
-      # macos-10.15 doesn't have Xcode 13 and macos-11 doesn't have a simulator with
-      # iOS 12. Ideally, we would compile the test-server on macos-11 and use it on
-      # macos-10.15. For now, disable the tests on iOS 12 requiring the test server in
-      # xcode-test.sh
-      - name: Cache for Test Server
-        id: cache_test_server
-        if: matrix.runs-on == 'macos-11' ||  matrix.runs-on == 'macos-12'
-        uses: actions/cache@v3
+      - uses: actions/download-artifact@v3
         with:
-          path: ./test-server/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
+          name: test-server
+      - run: ./Run &
 
-      - name: Build Test Server
-        if: steps.cache_test_server.outputs.cache-hit != 'true' && ( matrix.runs-on == 'macos-11' ||  matrix.runs-on == 'macos-12' )
-        run: swift build
-        working-directory: test-server
-
-      - name: Run Test Server in Background
-        if: matrix.runs-on == 'macos-11' ||  matrix.runs-on == 'macos-12'
-        run: swift run &
-        working-directory: test-server
-
-      # Select Xcode after starting server, because the server needs Xcode 13
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
 
       # Only Xcode 10.3 has an iOS 12.4 simulator. As we have a reference to MacCatalyst in our unit tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,14 +29,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}-Xcode-${{matrix.xcode}}
+          key: ${{ runner.os }}-spm-${{ hashFiles('./test-server/Package.resolved') }}
 
       - name: Build Test Server
         if: steps.cache_test_server.outputs.cache-hit != 'true'
         working-directory: test-server
         run: >-
           swift build -c release
-          cp $(swift build --show-bin-path -c release)/Run exec
 
       - name: Copy exec
         working-directory: test-server

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,9 @@ jobs:
 
       - name: Build Test Server
         if: steps.cache_test_server.outputs.cache-hit != 'true'
-        run: swift build -c release
+        run: >-
+          swift build -c release
+          cp $(swift build --show-bin-path -c release)/Run exec
         working-directory: test-server
 
       - name: Archiving DerivedData
@@ -41,7 +43,7 @@ jobs:
         with:
           name: test-server
           path: |
-            ./test-server/.build/**/release/Run
+            ./test-server/exec
 
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
@@ -127,7 +129,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: test-server
-      - run: ./Run &
+      - run: ./test-server/exec &
 
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Build Test Server
         if: steps.cache_test_server.outputs.cache-hit != 'true'
-        run: swift build
+        run: swift build -c release
         working-directory: test-server
 
       - name: Archiving DerivedData

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,14 +39,14 @@ jobs:
 
       - name: Copy exec
         working-directory: test-server
-        run: cp $(swift build --show-bin-path -c release)/Run exec
+        run: cp $(swift build --show-bin-path -c release)/Run test-server-exec
 
       - name: Archiving DerivedData
         uses: actions/upload-artifact@v3
         with:
           name: test-server
           path: |
-            ./test-server/exec
+            ./test-server/test-server-exec
 
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: test-server
-      - run: ./test-server/exec &
+      - run: ./test-server-exec &
 
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,7 +132,8 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: test-server
-      - run: chmod +x ./test-server-exec
+      - name: Allow test-server to run
+        run: chmod +x ./test-server-exec
       - run: ./test-server-exec &
 
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - release/**
-      - ci/build-testserver-once
 
   pull_request:
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
     runs-on: ${{matrix.runs-on}}
     timeout-minutes: 20
+    needs: build-test-server
     
     strategy:      
       fail-fast: false

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -60,7 +60,6 @@ if [ $PLATFORM == "iOS" -a $OS == "12.4" ]; then
     env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
         -scheme Sentry -configuration $CONFIGURATION \
         GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES -destination "$DESTINATION" \
-        -skip-testing:"SentryTests/SentryNetworkTrackerIntegrationTests/testGetRequest_SpanCreatedAndTraceHeaderAdded" \
         -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfAddingBreadcrumbs" \
         -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfTransactions" \
         test | tee raw-test-output.log | xcpretty -t && exit ${PIPESTATUS[0]}

--- a/test-server/Package.swift
+++ b/test-server/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     ],
     dependencies: [
         // 💧 A server-side Swift web framework.
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0")
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.65.2")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Compiles the test server only once and stores it as an artifact. This allows us
to run the `SentryNetworkTrackerIntegrationTests` on iOS 12.

Fixes GH-1615

#skip-changelog