### PR TITLE
ci: Use major OS versions for SauceLabs

### DIFF
--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -15,12 +15,12 @@ suites:
   - name: "High-end device"
     devices:
       - name: "iPad Pro 12.9 2021"
-        platformVersion: "15.6.1"
+        platformVersion: "15.*"
   - name: "Mid-range device"
     devices:
       - name: "iPhone 8"
-        platformVersion: "14.8"
+        platformVersion: "14.*"
   - name: "Low-end device"
     devices:
       - name: "iPhone 6S"
-        platformVersion: "15.3.1"
+        platformVersion: "15.*"

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -15,12 +15,12 @@ suites:
   - name: "High-end device"
     devices:
       - name: "iPad Pro 12.9 2021"
-        platformVersion: "15.*"
+        platformVersion: "15"
   - name: "Mid-range device"
     devices:
       - name: "iPhone 8"
-        platformVersion: "14.*"
+        platformVersion: "14"
   - name: "Low-end device"
     devices:
       - name: "iPhone 6S"
-        platformVersion: "15.*"
+        platformVersion: "15"


### PR DESCRIPTION
Don't pin specific OS versions for test suites,
as when SauceLabs updates devices, the tests
start to fail.

#skip-changelog