### PR TITLE
fix: Support for arm64 architecture

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -297,6 +297,9 @@ getCPUArchForCPUType(cpu_type_t cpuType, cpu_subtype_t subType)
         }
         break;
     }
+    case CPU_TYPE_ARM64: {
+        return "arm64";
+    }
     case CPU_TYPE_X86:
         return "x86";
     case CPU_TYPE_X86_64:


### PR DESCRIPTION
## :scroll: Description

Add support for the arm64 architecture by adding a missing case to the switch.

## :bulb: Motivation and Context

Closes #1226

## :green_heart: How did you test it?

Manually by running on an iPhone 12 mini

![Screen Shot 2022-09-19 at 11 37 13](https://user-images.githubusercontent.com/229384/190991003-ebf85b2e-3d54-4811-9d61-27c5296be700.png)

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
