### PR TITLE
test: Session status description for failing tests

### DIFF
--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -6,6 +6,22 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString *
+nameForSentrySessionStatus(SentrySessionStatus status)
+{
+    switch (status) {
+    case kSentrySessionStatusOk:
+        return @"ok";
+    case kSentrySessionStatusExited:
+        return @"exited";
+    case kSentrySessionStatusCrashed:
+        return @"crashed";
+        break;
+    case kSentrySessionStatusAbnormal:
+        return @"abnormal";
+    }
+}
+
 @implementation SentrySession
 
 @synthesize flagInit = _init;
@@ -189,26 +205,7 @@ NS_ASSUME_NONNULL_BEGIN
             [serializedData setValue:_init forKey:@"init"];
         }
 
-        NSString *statusString = nil;
-        switch (_status) {
-        case kSentrySessionStatusOk:
-            statusString = @"ok";
-            break;
-        case kSentrySessionStatusExited:
-            statusString = @"exited";
-            break;
-        case kSentrySessionStatusCrashed:
-            statusString = @"crashed";
-            break;
-        case kSentrySessionStatusAbnormal:
-            statusString = @"abnormal";
-            break;
-        default:
-            [SentryLog
-                logWithMessage:@"Missing string for SessionStatus when serializing SentrySession."
-                      andLevel:kSentryLevelWarning];
-            break;
-        }
+        NSString *statusString = nameForSentrySessionStatus(_status);
 
         if (nil != statusString) {
             [serializedData setValue:statusString forKey:@"status"];

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -3,6 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString *nameForSentrySessionStatus(SentrySessionStatus status);
+
 @interface
 SentrySession (Private)
 

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -424,7 +424,7 @@ class SentrySessionTrackerTests: XCTestCase {
             let session = fixture.client.captureSessionInvocations.invocations[endSessionIndex]
             XCTAssertFalse(session.flagInit?.boolValue ?? false)
             XCTAssertEqual(started, session.started)
-            XCTAssertEqual(SentrySessionStatus.exited, session.status, "Expected session status of \(SentrySessionStatus.exited.rawValue) but got \(session.status.rawValue)")
+            XCTAssertEqual(SentrySessionStatus.exited.description, session.status.description)
             XCTAssertEqual(errors, session.errors)
             XCTAssertEqual(started.addingTimeInterval(TimeInterval(truncating: duration)), session.timestamp)
             XCTAssertEqual(duration, session.duration)
@@ -449,7 +449,7 @@ class SentrySessionTrackerTests: XCTestCase {
     private func assertSession(session: SentrySession, started: Date, status: SentrySessionStatus, duration: NSNumber) {
         XCTAssertFalse(session.flagInit?.boolValue ?? false)
         XCTAssertEqual(started, session.started)
-        XCTAssertEqual(status, session.status, "Expected session status of \(status.rawValue) but got \(session.status.rawValue)")
+        XCTAssertEqual(status.description, session.status.description)
         XCTAssertEqual(0, session.errors)
         XCTAssertEqual(started.addingTimeInterval(TimeInterval(truncating: duration)), session.timestamp)
         XCTAssertEqual(duration, session.duration)
@@ -464,7 +464,7 @@ class SentrySessionTrackerTests: XCTestCase {
         if let session = fixture.client.captureSessionInvocations.last {
             XCTAssertTrue(session.flagInit?.boolValue ?? false)
             XCTAssertEqual(sessionStarted, session.started)
-            XCTAssertEqual(SentrySessionStatus.ok, session.status, "Expected session status of \(SentrySessionStatus.ok.rawValue) but got \(session.status.rawValue)")
+            XCTAssertEqual(SentrySessionStatus.ok.description, session.status.description)
             XCTAssertEqual(0, session.errors)
             XCTAssertNil(session.timestamp)
             XCTAssertNil(session.duration)

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -98,3 +98,9 @@ class SentrySessionTestsSwift: XCTestCase {
         XCTAssertNil(SentrySession(jsonObject: serialized))
     }
 }
+
+extension SentrySessionStatus {
+    var description: String {
+        return nameForSentrySessionStatus(self)
+    }
+}


### PR DESCRIPTION
Previously, the assert message displayed the raw value of the SessionStatus. Now it shows the string description.

#skip-changelog