### PR TITLE
test: Fix dispatch failure on M1

### DIFF
--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -47,8 +47,10 @@ NS_ASSUME_NONNULL_BEGIN
     });
 }
 
-- (void)dispatchAfter:(dispatch_time_t)when block:(dispatch_block_t)block
+- (void)dispatchAfter:(NSTimeInterval)interval block:(dispatch_block_t)block
 {
+    dispatch_time_t delta = (int64_t)(interval * NSEC_PER_SEC);
+    dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delta);
     dispatch_after(when, queue, ^{
         @autoreleasepool {
             block();

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -196,16 +196,12 @@ static NSLock *profilerLock;
 
 - (void)dispatchIdleTimeout
 {
-    dispatch_time_t now = [SentryCurrentDate dispatchTimeNow];
-    dispatch_time_t delta = (int64_t)(self.idleTimeout * NSEC_PER_SEC);
-    dispatch_time_t when = dispatch_time(now, delta);
-
     if (_idleTimeoutBlock != nil) {
         [self.dispatchQueueWrapper dispatchCancel:_idleTimeoutBlock];
     }
     __block SentryTracer *_self = self;
     _idleTimeoutBlock = dispatch_block_create(0, ^{ [_self finishInternal]; });
-    [self.dispatchQueueWrapper dispatchAfter:when block:_idleTimeoutBlock];
+    [self.dispatchQueueWrapper dispatchAfter:self.idleTimeout block:_idleTimeoutBlock];
 }
 
 - (BOOL)hasIdleTimeout

--- a/Sources/Sentry/include/SentryDispatchQueueWrapper.h
+++ b/Sources/Sentry/include/SentryDispatchQueueWrapper.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)dispatchOnMainQueue:(void (^)(void))block;
 
-- (void)dispatchAfter:(dispatch_time_t)when block:(dispatch_block_t)block;
+- (void)dispatchAfter:(NSTimeInterval)interval block:(dispatch_block_t)block;
 
 - (void)dispatchCancel:(dispatch_block_t)block;
 

--- a/Tests/SentryTests/Networking/TestSentryDispatchQueueWrapper.swift
+++ b/Tests/SentryTests/Networking/TestSentryDispatchQueueWrapper.swift
@@ -19,9 +19,9 @@ class TestSentryDispatchQueueWrapper: SentryDispatchQueueWrapper {
         }
     }
     
-    var dispatchAfterInvocations = Invocations<(when: dispatch_time_t, block: () -> Void)>()
-    override func dispatch(after when: dispatch_time_t, block: @escaping () -> Void) {
-        dispatchAfterInvocations.record((when, block))
+    var dispatchAfterInvocations = Invocations<(interval: TimeInterval, block: () -> Void)>()
+    override func dispatch(after interval: TimeInterval, block: @escaping () -> Void) {
+        dispatchAfterInvocations.record((interval, block))
     }
     
     func invokeLastDispatchAfter() {

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -210,8 +210,7 @@ class SentryTracerTests: XCTestCase {
         
         fixture.dispatchQueue.invokeLastDispatchAfter()
         
-        let expectedWhen = fixture.currentDateProvider.dispatchTimeNow() + UInt64(fixture.idleTimeout) * NSEC_PER_SEC
-        XCTAssertEqual(expectedWhen, fixture.dispatchQueue.dispatchAfterInvocations.invocations.first?.when)
+        XCTAssertEqual(fixture.idleTimeout, fixture.dispatchQueue.dispatchAfterInvocations.invocations.first?.interval)
     }
     
     func testIdleTimeout_SpanAdded_IdleTimeoutCancelled() {


### PR DESCRIPTION
The testIdleTimeout_InvokesDispatchAfterWithCorrectWhen always failed on M1 Macs. This was because we used a different way of calculating the expected dispatch_time in the tests than in the ObjC code. The failing test's purpose is to validate that the proper timeout is used to schedule the cancel block. This PR restructures the code so the SentryDispatchQueueWrapper hides this complexity, and callers don't need to calculate the dispatch_time themselves. Now the test validates that the proper timeout is passed down to SentryDispatchQueueWrapper.

Fixes GH-2164

#skip-changelog.