### PR TITLE
ref: Specifically remove notification observers

### DIFF
--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -246,6 +246,26 @@ SentryAppStartTracker ()
 
 - (void)stop
 {
+    // Remove the observers with the most specific detail possible, see
+    // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
+    [NSNotificationCenter.defaultCenter removeObserver:self
+                                                  name:UIApplicationDidFinishLaunchingNotification
+                                                object:nil];
+
+    [NSNotificationCenter.defaultCenter removeObserver:self
+                                                  name:UIWindowDidBecomeVisibleNotification
+                                                object:nil];
+
+    [NSNotificationCenter.defaultCenter removeObserver:self
+                                                  name:UIApplicationDidEnterBackgroundNotification
+                                                object:nil];
+}
+
+- (void)dealloc
+{
+    [self stop];
+    // In dealloc it's safe to unsubscribe for all, see
+    // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
     [NSNotificationCenter.defaultCenter removeObserver:self];
 }
 

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -150,7 +150,9 @@ SentryCrashIntegration ()
         installationToken = 0;
     }
 
-    [NSNotificationCenter.defaultCenter removeObserver:self];
+    [NSNotificationCenter.defaultCenter removeObserver:self
+                                                  name:NSCurrentLocaleDidChangeNotification
+                                                object:nil];
 }
 
 - (void)configureScope


### PR DESCRIPTION
According to Apple docs it's better to remove NSNotification observers with the most specific detail possible. This came up when investigating flaky SentrySessionTracker tests.

#skip-changelog