### PR TITLE
ref: update profile payload schema

### DIFF
--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -281,8 +281,7 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         @"is_emulator" : @(isEmulated),
         @"locale" : NSLocale.currentLocale.localeIdentifier,
         @"manufacturer" : @"Apple",
-        @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel(),
-        @"physical_memory_bytes" : [@(NSProcessInfo.processInfo.physicalMemory) stringValue]
+        @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel()
     };
 
     profile[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment ?: kSentryDefaultEnvironment;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -29,8 +29,6 @@
 #    endif
 
 #    import <cstdint>
-#    import <mach-o/arch.h>
-#    include <mach/machine.h>
 #    import <memory>
 
 #    if TARGET_OS_IOS

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -275,10 +275,9 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         @"locale" : NSLocale.currentLocale.localeIdentifier,
         @"manufacturer" : @"Apple",
         @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel(),
-		@"os_name" : sentry_getOSName()
+		@"os_name" : sentry_getOSName(),
+        @"physical_memory_bytes" : [@(NSProcessInfo.processInfo.physicalMemory) stringValue]
     };
-    profile[@"device_physical_memory_bytes"] =
-        [@(NSProcessInfo.processInfo.physicalMemory) stringValue];
 
     profile[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment ?: kSentryDefaultEnvironment;
     profile[@"platform"] = transaction.platform;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -101,15 +101,45 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         }
         _profile = [NSMutableDictionary<NSString *, id> dictionary];
         const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
+
+        /*
+         * Maintain an index of unique frames to avoid duplicating large amounts of data. Every unique frame is stored in an array, and every time a stack trace is captured for a sample, the stack is stored as an array of integers indexing into the array of frames. Stacks are thusly also stored as unique elements in their own index, an array of arrays of frame indices, and each sample references a stack by index, to deduplicate common stacks between samples, such as when the same deep function call runs across multiple samples.
+         *
+         * E.g. if we have the following samples in the following function call stacks:
+         *
+         *              v sample1    v sample2               v sample3    v sample4
+         * |-foo--------|------------|-----|    |-abc--------|------------|-----|
+         *    |-bar-----|------------|--|          |-def-----|------------|--|
+         *      |-baz---|------------|-|             |-ghi---|------------|-|
+         *
+         * Then we'd wind up with the following structures:
+         *
+         * frames: [
+         *   { function: foo, instruction_addr: ... },
+         *   { function: bar, instruction_addr: ... },
+         *   { function: baz, instruction_addr: ... },
+         *   { function: abc, instruction_addr: ... },
+         *   { function: def, instruction_addr: ... },
+         *   { function: ghi, instruction_addr: ... }
+         * ]
+         * stacks: [ [0, 1, 2], [3, 4, 5] ]
+         * samples: [
+         *   { stack_id: 0, ... },
+         *   { stack_id: 0, ... },
+         *   { stack_id: 1, ... },
+         *   { stack_id: 1, ... }
+         * ]
+         */
         const auto samples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-        const auto threadMetadata =
-            [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
-        const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
         const auto stacks = [NSMutableArray<NSMutableArray<NSNumber *> *> array];
         const auto frames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
         sampledProfile[@"samples"] = samples;
         sampledProfile[@"stacks"] = stacks;
         sampledProfile[@"frames"] = frames;
+
+        const auto threadMetadata =
+            [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
+        const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
         sampledProfile[@"thread_metadata"] = threadMetadata;
         sampledProfile[@"queue_metadata"] = queueMetadata;
         _profile[@"sampled_profile"] = sampledProfile;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -103,7 +103,13 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
 
         /*
-         * Maintain an index of unique frames to avoid duplicating large amounts of data. Every unique frame is stored in an array, and every time a stack trace is captured for a sample, the stack is stored as an array of integers indexing into the array of frames. Stacks are thusly also stored as unique elements in their own index, an array of arrays of frame indices, and each sample references a stack by index, to deduplicate common stacks between samples, such as when the same deep function call runs across multiple samples.
+         * Maintain an index of unique frames to avoid duplicating large amounts of data. Every
+         * unique frame is stored in an array, and every time a stack trace is captured for a
+         * sample, the stack is stored as an array of integers indexing into the array of frames.
+         * Stacks are thusly also stored as unique elements in their own index, an array of arrays
+         * of frame indices, and each sample references a stack by index, to deduplicate common
+         * stacks between samples, such as when the same deep function call runs across multiple
+         * samples.
          *
          * E.g. if we have the following samples in the following function call stacks:
          *
@@ -147,8 +153,8 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
 
         __weak const auto weakSelf = self;
         _profiler = std::make_shared<SamplingProfiler>(
-                                                       [weakSelf, threadMetadata, queueMetadata, samples, mainThreadID = _mainThreadID, frames, stacks](
-                auto &backtrace) {
+            [weakSelf, threadMetadata, queueMetadata, samples, mainThreadID = _mainThreadID, frames,
+                stacks](auto &backtrace) {
                 const auto strongSelf = weakSelf;
                 if (strongSelf == nil) {
                     return;
@@ -188,16 +194,19 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
 
                 const auto stack = [NSMutableArray<NSNumber *> array];
                 for (std::vector<uintptr_t>::size_type i = 0; i < backtrace.addresses.size(); i++) {
-                    const auto instructionAddress = sentry_formatHexAddress(@(backtrace.addresses[i]));
-                    const auto frameIndex = [frames indexOfObjectPassingTest:^BOOL(NSDictionary<NSString *,id> * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-                        return [obj[@"instruction_addr"] isEqualToString:instructionAddress];
-                    }];
+                    const auto instructionAddress
+                        = sentry_formatHexAddress(@(backtrace.addresses[i]));
+                    const auto frameIndex = [frames
+                        indexOfObjectPassingTest:^BOOL(NSDictionary<NSString *, id> *_Nonnull obj,
+                            NSUInteger idx, BOOL *_Nonnull stop) {
+                            return [obj[@"instruction_addr"] isEqualToString:instructionAddress];
+                        }];
                     if (frameIndex == NSNotFound) {
                         const auto frame = [NSMutableDictionary<NSString *, id> dictionary];
                         frame[@"instruction_addr"] = instructionAddress;
-    #    if defined(DEBUG)
+#    if defined(DEBUG)
                         frame[@"function"] = parseBacktraceSymbolsFunctionName(symbols[i]);
-    #    endif
+#    endif
                         [stack addObject:@(frames.count)];
                         [frames addObject:frame];
                     } else {
@@ -263,9 +272,9 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
     }
 
     profile[@"os"] = @{
-        @"name" : getOSName(),
-        @"version" : getOSVersion(),
-        @"build_number" : getOSBuildNumber()
+        @"name" : sentry_getOSName(),
+        @"version" : sentry_getOSVersion(),
+        @"build_number" : sentry_getOSBuildNumber()
     };
 
     const auto isEmulated = sentry_isSimulatorBuild();
@@ -275,7 +284,6 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         @"locale" : NSLocale.currentLocale.localeIdentifier,
         @"manufacturer" : @"Apple",
         @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel(),
-		@"os_name" : sentry_getOSName(),
         @"physical_memory_bytes" : [@(NSProcessInfo.processInfo.physicalMemory) stringValue]
     };
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -29,9 +29,8 @@
 #    endif
 
 #    import <cstdint>
-#import <mach-o/arch.h>
-#include <sys/types.h>
-#include <mach/machine.h>
+#    import <mach-o/arch.h>
+#    include <mach/machine.h>
 #    import <memory>
 
 #    if TARGET_OS_IOS
@@ -212,19 +211,19 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
     }
 
     profile[@"os"] = @{
-        @"name": getOSName(),
-        @"version": getOSVersion(),
-        @"build_number": getOSBuildNumber()
+        @"name" : getOSName(),
+        @"version" : getOSVersion(),
+        @"build_number" : getOSBuildNumber()
     };
 
     const auto isEmulated = sentry_isSimulatorBuild();
     profile[@"device"] = @{
-        @"architecture": sentry_getCPUArchitecture(),
-        @"is_emulator": @(isEmulated),
-        @"locale": NSLocale.currentLocale.localeIdentifier,
-        @"manufacturer": @"Apple",
-    profile[@"device_os_name"] = sentry_getOSName();
-        @"model": isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel()
+        @"architecture" : sentry_getCPUArchitecture(),
+        @"is_emulator" : @(isEmulated),
+        @"locale" : NSLocale.currentLocale.localeIdentifier,
+        @"manufacturer" : @"Apple",
+        @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel(),
+		@"os_name" : sentry_getOSName()
     };
     profile[@"device_physical_memory_bytes"] =
         [@(NSProcessInfo.processInfo.physicalMemory) stringValue];
@@ -238,7 +237,10 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
     profile[@"duration_ns"] = [@(getDurationNs(_startTimestamp, getAbsoluteTime())) stringValue];
 
     const auto bundle = NSBundle.mainBundle;
-    profile[@"release"] = [NSString stringWithFormat:@"%@ (%@)", [bundle objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey], [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"]];
+    profile[@"release"] =
+        [NSString stringWithFormat:@"%@ (%@)",
+                  [bundle objectForInfoDictionaryKey:(NSString *)kCFBundleVersionKey],
+                  [bundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"]];
 
 #    if SENTRY_HAS_UIKIT
     auto relativeFrameTimestampsNs = [NSMutableArray array];

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -981,7 +981,7 @@ extension SentryHubTests {
         let device = profile["device"] as? [String: Any?]
         XCTAssertNotNil(device)
         XCTAssertEqual("Apple", device!["manufacturer"] as! String)
-        XCTAssertFalse((device!["locale"] as! String).isEmpty)
+        XCTAssertEqual(device!["locale"] as! String, (NSLocale.current as NSLocale).localeIdentifier)
         XCTAssertFalse((device!["model"] as! String).isEmpty)
 #if targetEnvironment(simulator)
         XCTAssertTrue(device!["is_emulator"] as! Bool)
@@ -997,7 +997,11 @@ extension SentryHubTests {
 
         XCTAssertEqual("cocoa", profile["platform"] as! String)
         XCTAssertEqual(fixture.transactionName, profile["transaction_name"] as! String)
-        XCTAssertFalse((profile["release"] as! String).isEmpty)
+
+        let version = Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String)!
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString")!
+        let releaseString = "\(version) (\(build))"
+        XCTAssertEqual(profile["release"] as! String, releaseString)
 
         XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: profile["transaction_id"] as! String))
         XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: profile["profile_id"] as! String))

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1039,12 +1039,12 @@ extension SentryHubTests {
         XCTAssertFalse(stacks.isEmpty)
         for stack in stacks {
             guard !stack.isEmpty else { continue }
-            foundAtLeastOneNonemptySample = true
+            foundAtLeastOneNonEmptySample = true
             for frameIdx in stack {
                 XCTAssertNotNil(frames[frameIdx])
             }
         }
-        XCTAssert(foundAtLeastOneNonemptySample)
+        XCTAssert(foundAtLeastOneNonEmptySample)
 
         for sample in samples {
             XCTAssertNotNil(stacks[sample["stack_id"] as! Int])

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -992,11 +992,7 @@ extension SentryHubTests {
 
         let os = profile["os"] as? [String: Any?]
         XCTAssertNotNil(os)
-#if os(iOS) && !targetEnvironment(macCatalyst)
-        XCTAssertEqual("iOS", os!["name"] as! String)
-#else
-        XCTAssertEqual("macOS", os!["name"] as! String)
-#endif
+        XCTAssertNotNil(os?["name"] as? String)
         XCTAssertFalse((os!["version"] as! String).isEmpty)
         XCTAssertFalse((os!["build_number"] as! String).isEmpty)
 

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -983,6 +983,7 @@ extension SentryHubTests {
         XCTAssertEqual("Apple", device!["manufacturer"] as! String)
         XCTAssertFalse((device!["locale"] as! String).isEmpty)
         XCTAssertFalse((device!["model"] as! String).isEmpty)
+        XCTAssertFalse((device!["physical_memory_bytes"] as! String).isEmpty)
 #if targetEnvironment(simulator)
         XCTAssertTrue(device!["is_emulator"] as! Bool)
 #else
@@ -1001,7 +1002,6 @@ extension SentryHubTests {
 
         XCTAssertEqual("cocoa", profile["platform"] as! String)
         XCTAssertEqual(fixture.transactionName, profile["transaction_name"] as! String)
-        XCTAssertFalse((profile["device_physical_memory_bytes"] as! String).isEmpty)
         XCTAssertFalse((profile["release"] as! String).isEmpty)
 
         XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: profile["transaction_id"] as! String))

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1031,7 +1031,7 @@ extension SentryHubTests {
         XCTAssertFalse((frames[0]["function"] as! String).isEmpty)
 
         let stacks = sampledProfile["stacks"] as! [[Int]]
-        var foundAtLeastOneNonemptySample = false
+        var foundAtLeastOneNonEmptySample = false
         XCTAssertFalse(stacks.isEmpty)
         for stack in stacks {
             guard !stack.isEmpty else { continue }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -983,7 +983,6 @@ extension SentryHubTests {
         XCTAssertEqual("Apple", device!["manufacturer"] as! String)
         XCTAssertFalse((device!["locale"] as! String).isEmpty)
         XCTAssertFalse((device!["model"] as! String).isEmpty)
-        XCTAssertFalse((device!["physical_memory_bytes"] as! String).isEmpty)
 #if targetEnvironment(simulator)
         XCTAssertTrue(device!["is_emulator"] as! Bool)
 #else


### PR DESCRIPTION
To conform to the changes in https://github.com/getsentry/relay/pull/1462

- [x] merge #2205 (note that we won't report the model name of the machine running a simulator, we'll just directly report the simulator model and leave host machine identification until someone actually wants it; it's also already possible by combining `is_emulated` and the looking at the CPU architecture to at least distinguish between Intel-/M1-based macs; see https://github.com/getsentry/sentry-cocoa/pull/2205#discussion_r979503301)

#skip-changelog