### PR TITLE
meta: allow enabling profiling in more sample apps

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -24,6 +24,9 @@ AppDelegate ()
         options.attachScreenshot = YES;
         options.attachViewHierarchy = YES;
         options.enableUserInteractionTracing = YES;
+        if ([NSProcessInfo.processInfo.arguments containsObject:@"--io.sentry.profiling.enable"]) {
+            options.profilesSampleRate = @1;
+        }
     }];
 
     return YES;

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS13-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS13-Swift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1400"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,10 +14,10 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "637AFDC5243B036B0034958B"
-               BuildableName = "iOS-ObjectiveC.app"
-               BlueprintName = "iOS-ObjectiveC"
-               ReferencedContainer = "container:iOS-ObjectiveC.xcodeproj">
+               BlueprintIdentifier = "D8269A38274C095E00BD5BD5"
+               BuildableName = "iOS13-Swift.app"
+               BlueprintName = "iOS13-Swift"
+               ReferencedContainer = "container:iOS-Swift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
@@ -32,10 +32,10 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7B64387626A6C69F000D0F65"
-               BuildableName = "iOS-ObjectiveCUITests.xctest"
-               BlueprintName = "iOS-ObjectiveCUITests"
-               ReferencedContainer = "container:iOS-ObjectiveC.xcodeproj">
+               BlueprintIdentifier = "D85DAA48274C244F004DF43C"
+               BuildableName = "iOS13-SwiftTests.xctest"
+               BlueprintName = "iOS13-SwiftTests"
+               ReferencedContainer = "container:iOS-Swift.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>
@@ -54,10 +54,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "637AFDC5243B036B0034958B"
-            BuildableName = "iOS-ObjectiveC.app"
-            BlueprintName = "iOS-ObjectiveC"
-            ReferencedContainer = "container:iOS-ObjectiveC.xcodeproj">
+            BlueprintIdentifier = "D8269A38274C095E00BD5BD5"
+            BuildableName = "iOS13-Swift.app"
+            BlueprintName = "iOS13-Swift"
+            ReferencedContainer = "container:iOS-Swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
       <CommandLineArguments>
@@ -77,10 +77,10 @@
          runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "637AFDC5243B036B0034958B"
-            BuildableName = "iOS-ObjectiveC.app"
-            BlueprintName = "iOS-ObjectiveC"
-            ReferencedContainer = "container:iOS-ObjectiveC.xcodeproj">
+            BlueprintIdentifier = "D8269A38274C095E00BD5BD5"
+            BuildableName = "iOS13-Swift.app"
+            BlueprintName = "iOS13-Swift"
+            ReferencedContainer = "container:iOS-Swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
    </ProfileAction>

--- a/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
@@ -21,6 +21,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 // Sampling 100% - In Production you probably want to adjust this
                 options.tracesSampleRate = 1.0
                 options.sessionTrackingIntervalMillis = 5_000
+                if ProcessInfo.processInfo.arguments.contains("--io.sentry.profiling.enable") {
+                    options.profilesSampleRate = 1
+                }
             }
         
         return true

--- a/Samples/macOS-Swift/macOS-Swift.xcodeproj/xcshareddata/xcschemes/macOS-Swift.xcscheme
+++ b/Samples/macOS-Swift/macOS-Swift.xcodeproj/xcshareddata/xcschemes/macOS-Swift.xcscheme
@@ -32,8 +32,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:macOS-Swift.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--io.sentry.profiling.enable"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
+++ b/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
@@ -13,6 +13,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
             options.enableFileIOTracking = true
+            if ProcessInfo.processInfo.arguments.contains("--io.sentry.profiling.enable") {
+                options.profilesSampleRate = 1
+            }
         }
         
         SentrySDK.configureScope { scope in


### PR DESCRIPTION
I've needed to test profiling in a few other apps that didn't have it yet. Instead of just adding it to always run, I gated it behind a launch argument.

Also turned debugging back on for macOS-Swift runs.

#skip-changelog