### PR TITLE
ci: Fix broken Benchmark test

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,18 +73,17 @@ platform :ios do
       force: true
     )
 
-    sync_code_signing(
-      type: "development",
-      readonly: true,
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"]
-    )
+    #sync_code_signing(
+    #  type: "development",
+    #  readonly: true,
+    #  app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"]
+    #)
 
     build_app(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
       derived_data_path: "DerivedData",
-      skip_archive: true,
-      xcargs: "-allowProvisioningUpdates",
+      skip_archive: true
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,7 +83,8 @@ platform :ios do
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
       derived_data_path: "DerivedData",
-      skip_archive: true
+      skip_archive: true,
+      skip_codesigning: true
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,12 +73,6 @@ platform :ios do
       force: true
     )
 
-    #sync_code_signing(
-    #  type: "development",
-    #  readonly: true,
-    #  app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"]
-    #)
-
     build_app(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,7 +83,8 @@ platform :ios do
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
       derived_data_path: "DerivedData",
-      skip_archive: true
+      skip_archive: true,
+      xcargs: "-allowProvisioningUpdates",
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci


### PR DESCRIPTION
The re-enabled Benchmark test doesn't work with automatic code signing which we enabled a little while ago.

Closes #2207

#skip-changelog