### PR TITLE
ref: Add typealias for bytes

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */; };
 		0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */; };
 		0A9BF4EB28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */; };
+		0A9E917128DC7E7000FB4182 /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9E917028DC7E7000FB4182 /* SentryInternalDefines.h */; };
 		0AABE2ED2885924A0057ED69 /* SentryPermissionsObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */; };
 		0ACBA10128A6406400D711F7 /* UIView+Sentry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0ACBA10028A6406400D711F7 /* UIView+Sentry.m */; };
 		0ACBA10328A6407200D711F7 /* UIView+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0ACBA10228A6407200D711F7 /* UIView+Sentry.h */; };
@@ -757,6 +758,7 @@
 		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
 		0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryViewHierarchy.swift; sourceTree = "<group>"; };
 		0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyIntegrationTests.swift; sourceTree = "<group>"; };
+		0A9E917028DC7E7000FB4182 /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		0AABE2EC2885924A0057ED69 /* SentryPermissionsObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPermissionsObserver.m; sourceTree = "<group>"; };
 		0AABE2EE288592750057ED69 /* SentryPermissionsObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryPermissionsObserver.h; path = include/SentryPermissionsObserver.h; sourceTree = "<group>"; };
 		0AABE2EF2885C2120057ED69 /* TestSentryPermissionsObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryPermissionsObserver.swift; sourceTree = "<group>"; };
@@ -1808,6 +1810,7 @@
 				7B2A70DC27D6083D008B0D15 /* SentryThreadWrapper.m */,
 				7B18DE3F28D9F748004845C6 /* SentryNSNotificationCenterWrapper.h */,
 				7B18DE4128D9F794004845C6 /* SentryNSNotificationCenterWrapper.m */,
+				0A9E917028DC7E7000FB4182 /* SentryInternalDefines.h */,
 			);
 			name = Helper;
 			sourceTree = "<group>";
@@ -2957,6 +2960,7 @@
 				D8479328278873A100BE8E99 /* SentryByteCountFormatter.h in Headers */,
 				63AA76981EB9C1C200D153DE /* SentryClient.h in Headers */,
 				63AA76971EB9C1C200D153DE /* Sentry.h in Headers */,
+				0A9E917128DC7E7000FB4182 /* SentryInternalDefines.h in Headers */,
 				63FE711F20DA4C1000CDBAE8 /* SentryCrashObjC.h in Headers */,
 				7BC3936825B1AB3E004F03D3 /* SentryLevelMapper.h in Headers */,
 				8E4E7C6E25DAAAFE006AB9E2 /* SentrySpan.h in Headers */,

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -768,35 +768,35 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
 - (void)applyExtraDeviceContextToEvent:(SentryEvent *)event
 {
-    [self modifyContext:event
-                    key:@"device"
-                  block:^(NSMutableDictionary *device) {
-                      device[SentryDeviceContextFreeMemoryKey] = @(self.crashWrapper.freeMemory);
-                      device[@"free_storage"] = @(self.crashWrapper.freeStorage);
+    [self
+        modifyContext:event
+                  key:@"device"
+                block:^(NSMutableDictionary *device) {
+                    device[SentryDeviceContextFreeMemoryKey] = @(self.crashWrapper.freeMemorySize);
+                    device[@"free_storage"] = @(self.crashWrapper.freeStorageSize);
 
 #if TARGET_OS_IOS
-                      if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {
-                          device[@"orientation"]
-                              = UIDeviceOrientationIsPortrait(self.deviceWrapper.orientation)
-                              ? @"portrait"
-                              : @"landscape";
-                      }
+                    if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {
+                        device[@"orientation"]
+                            = UIDeviceOrientationIsPortrait(self.deviceWrapper.orientation)
+                            ? @"portrait"
+                            : @"landscape";
+                    }
 
-                      if (self.deviceWrapper.isBatteryMonitoringEnabled) {
-                          device[@"charging"]
-                              = self.deviceWrapper.batteryState == UIDeviceBatteryStateCharging
-                              ? @(YES)
-                              : @(NO);
-                          device[@"battery_level"] =
-                              @((int)(self.deviceWrapper.batteryLevel * 100));
-                      }
+                    if (self.deviceWrapper.isBatteryMonitoringEnabled) {
+                        device[@"charging"]
+                            = self.deviceWrapper.batteryState == UIDeviceBatteryStateCharging
+                            ? @(YES)
+                            : @(NO);
+                        device[@"battery_level"] = @((int)(self.deviceWrapper.batteryLevel * 100));
+                    }
 #endif
-                  }];
+                }];
 
     [self modifyContext:event
                     key:@"app"
                   block:^(NSMutableDictionary *app) {
-                      app[SentryDeviceContextAppMemoryKey] = @(self.crashWrapper.appMemory);
+                      app[SentryDeviceContextAppMemoryKey] = @(self.crashWrapper.appMemorySize);
                   }];
 }
 

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -249,8 +249,8 @@ SentryCrashIntegration ()
     [deviceData setValue:systemInfo[@"cpuArchitecture"] forKey:@"arch"];
     [deviceData setValue:systemInfo[@"machine"] forKey:@"model"];
     [deviceData setValue:systemInfo[@"model"] forKey:@"model_id"];
-    [deviceData setValue:systemInfo[@"freeMemory"] forKey:SentryDeviceContextFreeMemoryKey];
-    [deviceData setValue:systemInfo[@"usableMemory"] forKey:@"usable_memory"];
+    [deviceData setValue:systemInfo[@"freeMemorySize"] forKey:SentryDeviceContextFreeMemoryKey];
+    [deviceData setValue:systemInfo[@"usableMemorySize"] forKey:@"usable_memory"];
     [deviceData setValue:systemInfo[@"memorySize"] forKey:@"memory_size"];
     [deviceData setValue:systemInfo[@"totalStorageSize"] forKey:@"storage_size"];
     [deviceData setValue:systemInfo[@"freeStorageSize"] forKey:@"free_storage"];

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -71,17 +71,17 @@ NS_ASSUME_NONNULL_BEGIN
     return sharedInfo;
 }
 
-- (bytes)freeMemory
+- (bytes)freeMemorySize
 {
-    return sentrycrashcm_system_freememory();
+    return sentrycrashcm_system_freememory_size();
 }
 
-- (bytes)freeStorage
+- (bytes)freeStorageSize
 {
-    return sentrycrashcm_system_freestorage();
+    return sentrycrashcm_system_freestorage_size();
 }
 
-- (bytes)appMemory
+- (bytes)appMemorySize
 {
     task_vm_info_data_t info;
     mach_msg_type_number_t size = TASK_VM_INFO_COUNT;

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -71,17 +71,17 @@ NS_ASSUME_NONNULL_BEGIN
     return sharedInfo;
 }
 
-- (uint64_t)freeMemory
+- (bytes)freeMemory
 {
     return sentrycrashcm_system_freememory();
 }
 
-- (uint64_t)freeStorage
+- (bytes)freeStorage
 {
     return sentrycrashcm_system_freestorage();
 }
 
-- (uint64_t)appMemory
+- (bytes)appMemory
 {
     task_vm_info_data_t info;
     mach_msg_type_number_t size = TASK_VM_INFO_COUNT;

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -4,8 +4,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef uint64_t bytes;
-
 /** A wrapper around SentryCrash for testability.
  */
 @interface SentryCrashWrapper : NSObject

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentryInternalDefines.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -3,6 +3,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef uint64_t bytes;
+
 /** A wrapper around SentryCrash for testability.
  */
 @interface SentryCrashWrapper : NSObject
@@ -30,11 +32,11 @@ SENTRY_NO_INIT
 
 - (NSDictionary *)systemInfo;
 
-- (uint64_t)freeMemory;
+- (bytes)freeMemory;
 
-- (uint64_t)appMemory;
+- (bytes)appMemory;
 
-- (uint64_t)freeStorage;
+- (bytes)freeStorage;
 
 @end
 

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -33,11 +33,11 @@ SENTRY_NO_INIT
 
 - (NSDictionary *)systemInfo;
 
-- (bytes)freeMemory;
+- (bytes)freeMemorySize;
 
-- (bytes)appMemory;
+- (bytes)appMemorySize;
 
-- (bytes)freeStorage;
+- (bytes)freeStorageSize;
 
 @end
 

--- a/Sources/Sentry/include/SentryInternalDefines.h
+++ b/Sources/Sentry/include/SentryInternalDefines.h
@@ -1,0 +1,1 @@
+typedef unsigned long long bytes;

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
@@ -204,8 +204,8 @@ typedef struct SentryCrash_MonitorContext {
         uint64_t totalStorageSize;
         uint64_t freeStorageSize;
         uint64_t memorySize;
-        uint64_t freeMemory;
-        uint64_t usableMemory;
+        uint64_t freeMemorySize;
+        uint64_t usableMemorySize;
     } System;
 
     struct {

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
@@ -40,8 +40,8 @@ SentryCrashMonitorAPI *sentrycrashcm_system_getAPI(void);
 
 bool sentrycrash_isSimulatorBuild(void);
 
-bytes sentrycrashcm_system_freememory(void);
-bytes sentrycrashcm_system_freestorage(void);
+bytes sentrycrashcm_system_freememory_size(void);
+bytes sentrycrashcm_system_freestorage_size(void);
 
 #ifdef __cplusplus
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
@@ -32,8 +32,7 @@ extern "C" {
 #endif
 
 #include "SentryCrashMonitor.h"
-
-typedef uint64_t bytes;
+#import "SentryInternalDefines.h"
 
 /** Access the Monitor API.
  */

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
@@ -33,14 +33,16 @@ extern "C" {
 
 #include "SentryCrashMonitor.h"
 
+typedef uint64_t bytes;
+
 /** Access the Monitor API.
  */
 SentryCrashMonitorAPI *sentrycrashcm_system_getAPI(void);
 
 bool sentrycrash_isSimulatorBuild(void);
 
-uint64_t sentrycrashcm_system_freememory(void);
-uint64_t sentrycrashcm_system_freestorage(void);
+bytes sentrycrashcm_system_freememory(void);
+bytes sentrycrashcm_system_freestorage(void);
 
 #ifdef __cplusplus
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -71,9 +71,9 @@ typedef struct {
     int parentProcessID;
     const char *deviceAppHash;
     const char *buildType;
-    uint64_t totalStorageSize;
-    uint64_t freeStorageSize;
-    uint64_t memorySize;
+    bytes totalStorageSize;
+    bytes freeStorageSize;
+    bytes memorySize;
 } SystemData;
 
 static SystemData g_systemData;
@@ -189,29 +189,29 @@ VMStats(vm_statistics_data_t *const vmStats, vm_size_t *const pageSize)
 }
 
 static bytes
-freeMemory(void)
+freeMemorySize(void)
 {
     vm_statistics_data_t vmStats;
     vm_size_t pageSize;
     if (VMStats(&vmStats, &pageSize)) {
-        return ((uint64_t)pageSize) * vmStats.free_count;
+        return ((bytes)pageSize) * vmStats.free_count;
     }
     return 0;
 }
 
 bytes
-sentrycrashcm_system_freememory(void)
+sentrycrashcm_system_freememory_size(void)
 {
-    return freeMemory();
+    return freeMemorySize();
 }
 
 static bytes
-usableMemory(void)
+usableMemorySize(void)
 {
     vm_statistics_data_t vmStats;
     vm_size_t pageSize;
     if (VMStats(&vmStats, &pageSize)) {
-        return ((uint64_t)pageSize)
+        return ((bytes)pageSize)
             * (vmStats.active_count + vmStats.inactive_count + vmStats.wire_count
                 + vmStats.free_count);
     }
@@ -504,8 +504,8 @@ getFreeStorageSize()
     return storageSize.unsignedLongLongValue;
 }
 
-uint64_t
-sentrycrashcm_system_freestorage(void)
+bytes
+sentrycrashcm_system_freestorage_size(void)
 {
     return getFreeStorageSize();
 }
@@ -642,8 +642,8 @@ addContextualInfoToEvent(SentryCrash_MonitorContext *eventContext)
         COPY_REFERENCE(totalStorageSize);
         COPY_REFERENCE(freeStorageSize);
         COPY_REFERENCE(memorySize);
-        eventContext->System.freeMemory = freeMemory();
-        eventContext->System.usableMemory = usableMemory();
+        eventContext->System.freeMemorySize = freeMemorySize();
+        eventContext->System.usableMemorySize = usableMemorySize();
     }
 }
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -188,7 +188,7 @@ VMStats(vm_statistics_data_t *const vmStats, vm_size_t *const pageSize)
     return true;
 }
 
-static uint64_t
+static bytes
 freeMemory(void)
 {
     vm_statistics_data_t vmStats;
@@ -199,13 +199,13 @@ freeMemory(void)
     return 0;
 }
 
-uint64_t
+bytes
 sentrycrashcm_system_freememory(void)
 {
     return freeMemory();
 }
 
-static uint64_t
+static bytes
 usableMemory(void)
 {
     vm_statistics_data_t vmStats;
@@ -486,7 +486,7 @@ getBuildType()
     return "unknown";
 }
 
-static uint64_t
+static bytes
 getTotalStorageSize()
 {
     NSNumber *storageSize = [[[NSFileManager defaultManager]
@@ -495,7 +495,7 @@ getTotalStorageSize()
     return storageSize.unsignedLongLongValue;
 }
 
-static uint64_t
+static bytes
 getFreeStorageSize()
 {
     NSNumber *storageSize = [[[NSFileManager defaultManager]

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -261,8 +261,8 @@ getBasePath()
     COPY_PRIMITIVE(totalStorageSize);
     COPY_PRIMITIVE(freeStorageSize);
     COPY_PRIMITIVE(memorySize);
-    COPY_PRIMITIVE(freeMemory);
-    COPY_PRIMITIVE(usableMemory);
+    COPY_PRIMITIVE(freeMemorySize);
+    COPY_PRIMITIVE(usableMemorySize);
 
     return dict;
 }

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1252,9 +1252,9 @@ writeMemoryInfo(const SentryCrashReportWriter *const writer, const char *const k
         writer->addUIntegerElement(
             writer, SentryCrashField_Size, monitorContext->System.memorySize);
         writer->addUIntegerElement(
-            writer, SentryCrashField_Usable, monitorContext->System.usableMemory);
+            writer, SentryCrashField_Usable, monitorContext->System.usableMemorySize);
         writer->addUIntegerElement(
-            writer, SentryCrashField_Free, monitorContext->System.freeMemory);
+            writer, SentryCrashField_Free, monitorContext->System.freeMemorySize);
     }
     writer->endContainer(writer);
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -561,9 +561,9 @@ class SentryClientTest: XCTestCase {
         event.threads = nil
         event.debugMeta = nil
 
-        fixture.crashWrapper.internalFreeMemory = 123_456
-        fixture.crashWrapper.internalAppMemory = 234_567
-        fixture.crashWrapper.internalFreeStorage = 345_678
+        fixture.crashWrapper.internalFreeMemorySize = 123_456
+        fixture.crashWrapper.internalAppMemorySize = 234_567
+        fixture.crashWrapper.internalFreeStorageSize = 345_678
         fixture.getSut().captureCrash(event, with: fixture.scope)
 
         assertLastSentEventWithAttachment { actual in

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
@@ -25,11 +25,11 @@ SENTRY_NO_INIT
 
 @property (nonatomic, assign) BOOL closeCalled;
 
-@property (nonatomic, assign) uint64_t internalFreeMemory;
+@property (nonatomic, assign) uint64_t internalFreeMemorySize;
 
-@property (nonatomic, assign) uint64_t internalAppMemory;
+@property (nonatomic, assign) uint64_t internalAppMemorySize;
 
-@property (nonatomic, assign) uint64_t internalFreeStorage;
+@property (nonatomic, assign) uint64_t internalFreeStorageSize;
 
 @end
 

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
@@ -14,9 +14,9 @@
     instance.internalIsApplicationInForeground = YES;
     instance.installAsyncHooksCalled = NO;
     instance.closeCalled = NO;
-    instance.internalFreeMemory = 0;
-    instance.internalAppMemory = 0;
-    instance.internalFreeStorage = 0;
+    instance.internalFreeMemorySize = 0;
+    instance.internalAppMemorySize = 0;
+    instance.internalFreeStorageSize = 0;
     return instance;
 }
 
@@ -60,19 +60,19 @@
     return @{};
 }
 
-- (uint64_t)freeMemory
+- (bytes)freeMemorySize
 {
-    return self.internalFreeMemory;
+    return self.internalFreeMemorySize;
 }
 
-- (uint64_t)appMemory
+- (bytes)appMemorySize
 {
-    return self.internalAppMemory;
+    return self.internalAppMemorySize;
 }
 
-- (uint64_t)freeStorage
+- (bytes)freeStorageSize
 {
-    return self.internalFreeStorage;
+    return self.internalFreeStorageSize;
 }
 
 @end


### PR DESCRIPTION
This should make it clear what kind of size these variables are. Are they KB, MB, GB? Nope, they are all bytes.

#skip-changelog