### PR TITLE
feat: File I/O Tracking GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) GA (#2212)
 - Add flush (#2140)
 - Add more device context (#2190)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) GA (#2212)
+- [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) is stable (#2212)
 - Add flush (#2140)
 - Add more device context (#2190)
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -248,8 +248,6 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableNetworkTracking;
 
 /**
- * This feature is EXPERIMENTAL.
- *
  * When enabled, the SDK tracks performance for file IO reads and writes with NSData if auto
  * performance tracking and enableSwizzling are enabled. The default is <code>NO</code>.
  */


### PR DESCRIPTION
Make file IO tracking GA and keep it disabled by default.

The feature was in beta since the beginning of 2022 with https://github.com/getsentry/sentry-cocoa/pull/1557. We have 45 orgs that tried the feature in the past 90 days and didn't report any issues. Therefore it's safe to remove the experimental flag for this.

Docs PR https://github.com/getsentry/sentry-docs/pull/5548