### PR TITLE
feat: Core Data Tracking is stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- [Core Data Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#core-data-tracking) GA (#2213)
+- [Core Data Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#core-data-tracking) is stable (#2213)
 - [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) is stable (#2212)
 - Add flush (#2140)
 - Add more device context (#2190)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- [Core Data Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#core-data-tracking) GA (#2213)
 - Add flush (#2140)
 - Add more device context (#2190)
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -321,8 +321,6 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableSwizzling;
 
 /**
- * This feature is experimental.
- *
  * When enabled, the SDK tracks the performance of Core Data operations. It requires enabling
  * performance monitoring. The default is <code>NO</code>.
  * @see <https://docs.sentry.io/platforms/apple/performance/>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -73,17 +73,12 @@ platform :ios do
       force: true
     )
 
-    sync_code_signing(
-      type: "development",
-      readonly: true,
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"]
-    )
-
     build_app(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
       derived_data_path: "DerivedData",
-      skip_archive: true
+      skip_archive: true,
+      skip_codesigning: true
     )
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci


### PR DESCRIPTION
Make core data IO tracking GA and keep it disabled by default.

The feature has been in beta since around March 2022 with https://github.com/getsentry/sentry-cocoa/pull/1682. We have 45 orgs that tried the feature in the past 90 days and didn't report any issues. Therefore it's safe to remove the experimental flag for this.

Docs PR https://github.com/getsentry/sentry-docs/pull/5548
