### PR TITLE
ci: Read cache for UI tests

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -30,6 +30,21 @@ jobs:
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - run: git apply ./scripts/set-device-tests-environment.patch
+      - name: Cache iOS-Swift App and dSYM build products
+        id: ios-swift-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}
+      - name: Cache iOS-Swift UI Test Runner App build product
+        id: ios-swift-benchmark-runner-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/PerformanceBenchmarks-Runner.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/PerformanceBenchmarks/**') }}
       - run: fastlane build_ios_swift_for_tests
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -37,6 +37,21 @@ jobs:
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - run: git apply ./scripts/set-device-tests-environment.patch
+      - name: Cache iOS-Swift App and dSYM build products
+        id: ios-swift-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
+            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}
+      - name: Cache iOS-Swift UI Test Runner App build product
+        id: ios-swift-uitest-runner-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-SwiftUITests/**') }}-Xcode-${{ matrix.xcode }}
       - run: fastlane build_ios_swift_for_tests
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}


### PR DESCRIPTION
Add cache for benchmarks and saucelabs UI tests again, but don't skip compiling.

Related to https://github.com/getsentry/sentry-cocoa/pull/2210.

#skip-changelog