### PR TITLE
fix: Align core data span operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Sentry-trace header incorrectly assigned to http requests (#2167)
 - Use the `component` name source for SentryPerformanceTracker (#2168)
 - Add support for arm64 architecture to the device context (#2185)
+- Align core data span operations (#2222)
 
 ## 7.25.1
 

--- a/Sources/Sentry/include/SentryCoreDataTracker.h
+++ b/Sources/Sentry/include/SentryCoreDataTracker.h
@@ -4,9 +4,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSString *const SENTRY_COREDATA_FETCH_OPERATION = @"db.query";
-
-static NSString *const SENTRY_COREDATA_SAVE_OPERATION = @"db.transaction";
+static NSString *const SENTRY_COREDATA_FETCH_OPERATION = @"db.sql.query";
+static NSString *const SENTRY_COREDATA_SAVE_OPERATION = @"db.sql.transaction";
 
 @interface SentryCoreDataTracker : NSObject <SentryCoreDataMiddleware>
 

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -31,9 +31,8 @@ class SentryCoreDataTrackerTests: XCTestCase {
     
     func testConstants() {
         //Test constants to make sure we don't accidentally change it
-        XCTAssertEqual(SENTRY_COREDATA_FETCH_OPERATION, "db.query")
-        XCTAssertEqual(SENTRY_COREDATA_SAVE_OPERATION, "db.transaction")
-        
+        XCTAssertEqual(SENTRY_COREDATA_FETCH_OPERATION, "db.sql.query")
+        XCTAssertEqual(SENTRY_COREDATA_SAVE_OPERATION, "db.sql.transaction")
     }
     
     func testFetchRequest() {

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -78,7 +78,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         try? stack.managedObjectContext.save()
         
         XCTAssertEqual(transaction.children.count, 1)
-        XCTAssertEqual(transaction.children[0].context.operation, "db.transaction")
+        XCTAssertEqual(transaction.children[0].context.operation, "db.sql.transaction")
     }
     
     func test_Save_noChanges() {


### PR DESCRIPTION


## :scroll: Description

Rename db.query to db.sql.query and db.transaction to db.sql.transaction.

## :bulb: Motivation and Context

[Aligning span operation names](https://www.notion.so/sentry/Set-up-an-audit-for-SDK-consistency-for-span-operations-to-enable-performance-issues-addf02a8fa234dda8acf48d4ff9b8efb).

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
