### PR TITLE
meta: Fix Changelog concurrent transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 - [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) is stable (#2212)
 - Add flush (#2140)
 - Add more device context (#2190)
-- Profile concurrent transactions (#2105)
 
 ### Fixes
 


### PR DESCRIPTION
The PR was reverted with https://github.com/getsentry/sentry-cocoa/pull/2225.

#skip-changelog