### PR TITLE
ref: Clarify waitForChildren in SentryTracer

### DIFF
--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -413,13 +413,13 @@ static NSLock *profilerLock;
     if (self.rootSpan.isFinished)
         return;
 
-    BOOL hasChildSpansToWaitFor = [self hasUnfinishedChildSpansToWaitFor];
+    BOOL hasUnfinishedChildSpansToWaitFor = [self hasUnfinishedChildSpansToWaitFor];
     if (!self.wasFinishCalled && !hasChildSpansToWaitFor && [self hasIdleTimeout]) {
         [self dispatchIdleTimeout];
         return;
     }
 
-    if (!self.wasFinishCalled || hasChildSpansToWaitFor)
+    if (!self.wasFinishCalled || hasUnfinishedChildSpansToWaitFor)
         return;
 
     [self finishInternal];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -413,7 +413,7 @@ static NSLock *profilerLock;
     if (self.rootSpan.isFinished)
         return;
 
-    BOOL hasChildSpansToWaitFor = [self hasUnfinishedChildSpansAndNeedToWaitUntilTheyAreFinished];
+    BOOL hasChildSpansToWaitFor = [self hasUnfinishedChildSpansToWaitFor];
     if (!self.wasFinishCalled && !hasChildSpansToWaitFor && [self hasIdleTimeout]) {
         [self dispatchIdleTimeout];
         return;
@@ -425,7 +425,7 @@ static NSLock *profilerLock;
     [self finishInternal];
 }
 
-- (BOOL)hasUnfinishedChildSpansAndNeedToWaitUntilTheyAreFinished
+- (BOOL)hasUnfinishedChildSpansToWaitFor
 {
     if (!_waitForChildren) {
         return NO;

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -414,7 +414,7 @@ static NSLock *profilerLock;
         return;
 
     BOOL hasUnfinishedChildSpansToWaitFor = [self hasUnfinishedChildSpansToWaitFor];
-    if (!self.wasFinishCalled && !hasChildSpansToWaitFor && [self hasIdleTimeout]) {
+    if (!self.wasFinishCalled && !hasUnfinishedChildSpansToWaitFor && [self hasIdleTimeout]) {
         [self dispatchIdleTimeout];
         return;
     }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -414,7 +414,7 @@ static NSLock *profilerLock;
         return;
 
     BOOL hasChildSpansToWaitFor = [self hasUnfinishedChildSpansAndNeedToWaitUntilTheyAreFinished];
-    if (self.wasFinishCalled == NO && !hasChildSpansToWaitFor && [self hasIdleTimeout]) {
+    if (!self.wasFinishCalled && !hasChildSpansToWaitFor && [self hasIdleTimeout]) {
         [self dispatchIdleTimeout];
         return;
     }


### PR DESCRIPTION
Clarify the concept of waitForChildren with renamings and adding some comments.

It was a bit confusing for @armcknight.

#skip-changelog