### PR TITLE
Update SentryOptionsTest.m

### DIFF
--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -467,7 +467,6 @@
         @"inAppIncludes" : [NSNull null],
         @"inAppExcludes" : [NSNull null],
         @"urlSessionDelegate" : [NSNull null],
-        @"experimentalEnableTraceSampling" : [NSNull null],
         @"enableSwizzling" : [NSNull null],
         @"enableIOTracking" : [NSNull null],
         @"sdk" : [NSNull null]


### PR DESCRIPTION
Removed a flag from option dictionary test that is not being used anymore.

_#skip-changelog_ 