### PR TITLE
feat: Add segment property to user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- feat: Add segment property to user (#2234)
+
 ## 7.26.0
 
 ### Features

--- a/Sources/Sentry/Public/SentryUser.h
+++ b/Sources/Sentry/Public/SentryUser.h
@@ -27,6 +27,11 @@ NS_SWIFT_NAME(User)
 @property (atomic, copy) NSString *_Nullable ipAddress;
 
 /**
+ * The user segment, for apps that divide users in user segments.
+ */
+@property (atomic, copy) NSString *_Nullable segment;
+
+/**
  * Optional: Additional data
  */
 @property (atomic, strong) NSDictionary<NSString *, id> *_Nullable data;

--- a/Sources/Sentry/SentryTraceContext.m
+++ b/Sources/Sentry/SentryTraceContext.m
@@ -51,9 +51,16 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
 
     NSString *userSegment;
-    if (scope.userObject.data[@"segment"] &&
-        [scope.userObject.data[@"segment"] isKindOfClass:[NSString class]])
-        userSegment = scope.userObject.data[@"segment"];
+
+    if (scope.userObject.segment) {
+        userSegment = scope.userObject.segment;
+    } else {
+        // For backwards compatibility
+        if (scope.userObject.data[@"segment"] &&
+            [scope.userObject.data[@"segment"] isKindOfClass:[NSString class]]) {
+            userSegment = scope.userObject.data[@"segment"];
+        }
+    }
 
     NSString *sampleRate = nil;
     if ([tracer.context isKindOfClass:[SentryTransactionContext class]]) {

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
             copy.email = self.email;
             copy.username = self.username;
             copy.ipAddress = self.ipAddress;
+            copy.segment = self.segment;
             copy.data = self.data.copy;
         }
     }
@@ -45,6 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
         [serializedData setValue:self.email forKey:@"email"];
         [serializedData setValue:self.username forKey:@"username"];
         [serializedData setValue:self.ipAddress forKey:@"ip_address"];
+        [serializedData setValue:self.segment forKey:@"segment"];
         [serializedData setValue:[self.data sentry_sanitize] forKey:@"data"];
     }
 
@@ -98,6 +100,11 @@ NS_ASSUME_NONNULL_BEGIN
             return NO;
         }
 
+        NSString *otherSegment = user.segment;
+        if (self.segment != otherSegment && ![self.segment isEqualToString:otherSegment]) {
+            return NO;
+        }
+
         NSDictionary<NSString *, id> *otherUserData = user.data;
         if (self.data != otherUserData && ![self.data isEqualToDictionary:otherUserData]) {
             return NO;
@@ -116,6 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
         hash = hash * 23 + [self.email hash];
         hash = hash * 23 + [self.username hash];
         hash = hash * 23 + [self.ipAddress hash];
+        hash = hash * 23 + [self.segment hash];
         hash = hash * 23 + [self.data hash];
 
         return hash;

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -11,12 +11,14 @@ class SentryUserTests: XCTestCase {
         user.email = ""
         user.username = ""
         user.ipAddress = ""
+        user.segment = ""
         user.data?.removeAll()
         
         XCTAssertEqual(TestData.user.userId, actual["id"] as? String)
         XCTAssertEqual(TestData.user.email, actual["email"] as? String)
         XCTAssertEqual(TestData.user.username, actual["username"] as? String)
         XCTAssertEqual(TestData.user.ipAddress, actual["ip_address"] as? String)
+        XCTAssertEqual(TestData.user.segment, actual["segment"] as? String)
         XCTAssertEqual(["some": ["data": "data", "date": TestData.timestampAs8601String]], actual["data"] as? Dictionary)
     }
     
@@ -61,6 +63,7 @@ class SentryUserTests: XCTestCase {
         testIsNotEqual { user in user.email = "" }
         testIsNotEqual { user in user.username = "" }
         testIsNotEqual { user in user.ipAddress = "" }
+        testIsNotEqual { user in user.segment = "" }
         testIsNotEqual { user in user.data?.removeAll() }
     }
     
@@ -79,6 +82,7 @@ class SentryUserTests: XCTestCase {
         user.email = ""
         user.username = ""
         user.ipAddress = ""
+        user.segment = ""
         user.data = [:]
         
         XCTAssertEqual(TestData.user, copiedUser)
@@ -117,6 +121,7 @@ class SentryUserTests: XCTestCase {
                     user.email = "john@example.com"
                     user.username = "\(i)"
                     user.ipAddress = "\(i)"
+                    user.segment = "\(i)"
                     
                     user.data?["\(i)"] = "\(i)"
                     

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -59,6 +59,7 @@ class TestData {
         user.email = "user@sentry.io"
         user.username = "user123"
         user.ipAddress = "127.0.0.1"
+        user.segment = "segmentA"
         user.data = ["some": ["data": "data", "date": timestamp]]
         
         return user

--- a/Tests/SentryTests/Transaction/SentryTraceStateTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTraceStateTests.swift
@@ -29,7 +29,7 @@ class SentryTraceContextTests: XCTestCase {
             
             scope = Scope()
             scope.setUser(User(userId: userId))
-            scope.userObject?.data = ["segment": "Test Segment"]
+            scope.userObject?.segment = userSegment
             scope.span = tracer
             
             traceId = tracer.context.traceId
@@ -78,13 +78,24 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertNil(traceContext)
     }
     
-    func testUserSegment_wrongData() {
-        var traceContext = SentryTraceContext(scope: fixture.scope, options: fixture.options)
+    func testUserSegmentInData_wrongData() {
+        let scope = fixture.scope
+        scope.userObject?.segment = nil
+        scope.userObject?.data = ["segment": fixture.userSegment]
+        var traceContext = SentryTraceContext(scope: scope, options: fixture.options)
         XCTAssertNotNil(traceContext?.userSegment)
-        XCTAssertEqual(traceContext?.userSegment, "Test Segment")
-        fixture.scope.userObject?.data = ["segment": 5]
-        traceContext = SentryTraceContext(scope: fixture.scope, options: fixture.options)
+        XCTAssertEqual(traceContext?.userSegment, fixture.userSegment)
+        
+        scope.userObject?.data = ["segment": 5]
+        traceContext = SentryTraceContext(scope: scope, options: fixture.options)
         XCTAssertNil(traceContext?.userSegment)
+    }
+    
+    func testUserSegmentInDataAndUser_TakeFromUser() {
+        let scope = fixture.scope
+        scope.userObject?.data = ["segment": "Wrong segment"]
+        let traceContext = SentryTraceContext(scope: scope, options: fixture.options)
+        XCTAssertEqual(traceContext?.userSegment, fixture.userSegment)
     }
     
     func test_toBaggage() {


### PR DESCRIPTION




## :scroll: Description

Add top-level property segment to user, instead of having to set it on the data dictionary with keeping backwards compatibility.

## :bulb: Motivation and Context

Fixes GH-2149

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
