### PR TITLE
fix: Correctly attribute enterprise builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Correctly attribute enterprise builds (#2235)
+
 ## 7.26.0
 
 ### Features

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -368,26 +368,15 @@ sentrycrash_isSimulatorBuild(void)
 
 /** The file path for the bundle’s App Store receipt.
  *
- * @return App Store receipt for iOS 7+, nil otherwise.
+ * @return App Store receipt for iOS, nil otherwise.
  */
 static NSString *
 getReceiptUrlPath()
 {
-    NSString *path = nil;
 #if SentryCrashCRASH_HOST_IOS
-    // For iOS 6 compatibility
-#    ifdef __IPHONE_11_0
-    if (@available(iOS 7, *)) {
-#    else
-    if ([[UIDevice currentDevice].systemVersion compare:@"7" options:NSNumericSearch]
-        != NSOrderedAscending) {
-#    endif
+    return [NSBundle mainBundle].appStoreReceiptURL.path;
 #endif
-        path = [NSBundle mainBundle].appStoreReceiptURL.path;
-#if SentryCrashCRASH_HOST_IOS
-    }
-#endif
-    return path;
+    return nil;
 }
 
 /** Generate a 20 byte SHA1 hash that remains unique across a single device and
@@ -468,6 +457,15 @@ hasAppStoreReceipt()
     return isAppStoreReceipt && receiptExists;
 }
 
+/**
+ * Check if the app has an embdded.mobileprovision file in the bundle.
+ */
+static bool
+hasEmbeddedMobileProvision()
+{
+    return [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"] != nil;
+}
+
 static const char *
 getBuildType()
 {
@@ -476,6 +474,9 @@ getBuildType()
     }
     if (isDebugBuild()) {
         return "debug";
+    }
+    if (hasEmbeddedMobileProvision()) {
+        return "enterprise";
     }
     if (isTestBuild()) {
         return "test";


### PR DESCRIPTION
## :scroll: Description

This uses the check as suggested in the ticket, and I've found similar suggestions in StackOverflow and in HockeySDK-iOS (the old HockeyApp SDK). But I have no way of verifying this, and it feels a bit scary. I am also not sure how well this will age, maybe this will change with future iOS versions?

If users already have a way of overriding the build type, I am not 100% convinced we should add this to the SDK.

## :bulb: Motivation and Context

Closes #778

## :green_heart: How did you test it?

Impossible :/

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
