### PR TITLE
meta: Changelog link start-up crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Report start up crashes (#2220)
+- Report [start up crashes](https://docs.sentry.io/platforms/apple/guides/ios/) (#2220)
 - Add segment property to user (#2234)
 
 ## 7.26.0


### PR DESCRIPTION
The feature list will show start-up crashes after merging https://github.com/getsentry/sentry-docs/pull/5579.

#skip-changelog