### PR TITLE
ref: Clean up unused imports

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -6,7 +6,6 @@
 #import "SentryMeta.h"
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
-#import <Foundation/Foundation.h>
 #import <SentryDependencyContainer.h>
 #import <SentryFramesTracker.h>
 

--- a/Sources/Sentry/Public/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/Public/PrivateSentrySDKOnly.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryDefines.h"
 
 @class SentryEnvelope, SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames,

--- a/Sources/Sentry/Public/SentryClient.h
+++ b/Sources/Sentry/Public/SentryClient.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryDefines.h"
 
 @class SentryOptions, SentrySession, SentryEvent, SentryEnvelope, SentryScope, SentryFileManager,

--- a/Sources/Sentry/Public/SentryError.h
+++ b/Sources/Sentry/Public/SentryError.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryDefines.h"
 
 @protocol SentrySpan;

--- a/Sources/Sentry/Public/SentryTraceHeader.h
+++ b/Sources/Sentry/Public/SentryTraceHeader.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentrySampleDecision.h"
-#import <Foundation/Foundation.h>
 
 @class SentryId, SentrySpanId;
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -16,7 +16,6 @@
 #import "SentryThreadWrapper.h"
 #import <Foundation/Foundation.h>
 #import <SentryAppState.h>
-#import <SentryAppStateManager.h>
 #import <SentryDependencyContainer.h>
 #import <SentryOptions+Private.h>
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -8,14 +8,11 @@
 #import "SentryEvent.h"
 #import "SentryException.h"
 #import "SentryHub+Private.h"
-#import "SentryLog.h"
 #import "SentryMechanism.h"
 #import "SentrySDK+Private.h"
 #import "SentryThread.h"
 #import "SentryThreadInspector.h"
 #import "SentryThreadWrapper.h"
-#import <Foundation/Foundation.h>
-#import <SentryAppState.h>
 #import <SentryDependencyContainer.h>
 #import <SentryOptions+Private.h>
 

--- a/Sources/Sentry/SentryAppState.m
+++ b/Sources/Sentry/SentryAppState.m
@@ -1,4 +1,3 @@
-#import <Foundation/Foundation.h>
 #import <NSDate+SentryExtras.h>
 #import <SentryAppState.h>
 

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -2,7 +2,6 @@
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryUIApplication.h"
-#import <Foundation/Foundation.h>
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
 #import <SentryCrashWrapper.h>

--- a/Sources/Sentry/SentryFileContents.m
+++ b/Sources/Sentry/SentryFileContents.m
@@ -1,5 +1,4 @@
 #import "SentryFileContents.h"
-#import <Foundation/Foundation.h>
 
 @interface
 SentryFileContents ()

--- a/Sources/Sentry/SentryMigrateSessionInit.m
+++ b/Sources/Sentry/SentryMigrateSessionInit.m
@@ -4,7 +4,6 @@
 #import "SentryLog.h"
 #import "SentrySerialization.h"
 #import "SentrySession+Private.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
+++ b/Sources/Sentry/SentryOutOfMemoryTrackingIntegration.m
@@ -1,14 +1,11 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 #import <SentryAppState.h>
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
 #import <SentryCrashWrapper.h>
-#import <SentryDefaultCurrentDateProvider.h>
 #import <SentryDependencyContainer.h>
 #import <SentryDispatchQueueWrapper.h>
 #import <SentryHub.h>
-#import <SentryLog.h>
 #import <SentryOptions+Private.h>
 #import <SentryOutOfMemoryLogic.h>
 #import <SentryOutOfMemoryTracker.h>

--- a/Sources/Sentry/SentrySwizzleWrapper.m
+++ b/Sources/Sentry/SentrySwizzleWrapper.m
@@ -1,6 +1,5 @@
 #import "SentrySwizzleWrapper.h"
 #import "SentrySwizzle.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentrySystemEventBreadcrumbs.m
+++ b/Sources/Sentry/SentrySystemEventBreadcrumbs.m
@@ -1,6 +1,4 @@
 #import "SentrySystemEventBreadcrumbs.h"
-#import "SentryAppState.h"
-#import "SentryAppStateManager.h"
 #import "SentryBreadcrumb.h"
 #import "SentryCurrentDateProvider.h"
 #import "SentryDependencyContainer.h"

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -1,7 +1,6 @@
 #import "SentryClient.h"
 #import "SentryDataCategory.h"
 #import "SentryDiscardReason.h"
-#import <Foundation/Foundation.h>
 
 @class SentryEnvelopeItem, SentryId, SentryAttachment, SentryThreadInspector;
 

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -1,7 +1,6 @@
 #import "SentryDefines.h"
 #import "SentryFileManager.h"
 #import "SentryRandom.h"
-#import <Foundation/Foundation.h>
 
 @class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper,
     SentryDispatchQueueWrapper, SentryDebugImageProvider, SentryANRTracker,

--- a/Sources/Sentry/include/SentryDiscardedEvent.h
+++ b/Sources/Sentry/include/SentryDiscardedEvent.h
@@ -1,7 +1,6 @@
 #import "SentryDataCategory.h"
 #import "SentryDiscardReason.h"
 #import "SentrySerializable.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryCurrentDateProvider.h"
 #import "SentryDataCategory.h"
 #import "SentryDefines.h"

--- a/Sources/Sentry/include/SentryLevelMapper.h
+++ b/Sources/Sentry/include/SentryLevelMapper.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryLogOutput;
 

--- a/Sources/Sentry/include/SentryMigrateSessionInit.h
+++ b/Sources/Sentry/include/SentryMigrateSessionInit.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryEnvelope;
 

--- a/Sources/Sentry/include/SentryScreenshot.h
+++ b/Sources/Sentry/include/SentryScreenshot.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 #if SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryDefines.h"
 
 @class SentrySession, SentryEnvelope, SentryAppState;

--- a/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
@@ -1,5 +1,5 @@
-#import "SentryAppStateManager.h"
 #import "SentryCurrentDateProvider.h"
+#import "SentryFileManager.h"
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_IOS

--- a/Sources/Sentry/include/SentryTraceContext.h
+++ b/Sources/Sentry/include/SentryTraceContext.h
@@ -1,6 +1,5 @@
 #import "SentryId.h"
 #import "SentrySerializable.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryTracesSampler.h
+++ b/Sources/Sentry/include/SentryTracesSampler.h
@@ -1,6 +1,5 @@
 #import "SentryRandom.h"
 #import "SentrySampleDecision.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryUIApplication.h
+++ b/Sources/Sentry/include/SentryUIApplication.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>

--- a/Sources/Sentry/include/SentryViewHierarchy.h
+++ b/Sources/Sentry/include/SentryViewHierarchy.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 #if SENTRY_HAS_UIKIT
 

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.h
@@ -26,7 +26,6 @@
 
 #import "SentryCrashReportFilter.h"
 #import "SentryCrashReportWriter.h"
-#import <Foundation/Foundation.h>
 
 /**
  * Crash system installation which handles backend-specific details.

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -30,7 +30,6 @@
 #include "SentryCrashMonitorContext.h"
 #import "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashThread.h"
-#import <Foundation/Foundation.h>
 
 //#define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -37,7 +37,6 @@
 #import "SentryCrashLogger.h"
 
 #import <CommonCrypto/CommonDigest.h>
-#import <Foundation/Foundation.h>
 #if SentryCrashCRASH_HAS_UIKIT
 #    import <UIKit/UIKit.h>
 #endif

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -37,6 +37,7 @@
 #import "SentryCrashLogger.h"
 
 #import <CommonCrypto/CommonDigest.h>
+#import <Foundation/Foundation.h>
 #if SentryCrashCRASH_HAS_UIKIT
 #    import <UIKit/UIKit.h>
 #endif

--- a/Sources/SentryCrash/Recording/SentryCrash.h
+++ b/Sources/SentryCrash/Recording/SentryCrash.h
@@ -24,8 +24,6 @@
 // THE SOFTWARE.
 //
 
-#import <Foundation/Foundation.h>
-
 #import "SentryCrashMonitorType.h"
 #import "SentryCrashReportFilter.h"
 #import "SentryCrashReportWriter.h"


### PR DESCRIPTION
While looking into the OOM implementation I noticed these unused imports. 

#skip-changelog