### PR TITLE
ci: update and pin GHA to commit hash

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -8,10 +8,10 @@ on:
 
   pull_request:
     paths:
-        # test changes to Sentry SDK sources
+      # test changes to Sentry SDK sources
       - 'Sources/**'
 
-        # test changes to benchmarking implementation
+      # test changes to benchmarking implementation
       - 'Samples/iOS-Swift/iOS-Swift/**'
       - 'Samples/iOS-Swift/PerformanceBenchmarks/**'
       - '.github/workflows/benchmarking.yml'
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: ["High-end device", "Mid-range device", "Low-end device"]
+        suite: ['High-end device', 'Mid-range device', 'Low-end device']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - run: ./scripts/ci-select-xcode.sh 
+      - run: ./scripts/ci-select-xcode.sh
 
       - name: Run Fastlane
         env:
@@ -43,12 +43,12 @@ jobs:
       fail-fast: false
       matrix:
         beforeXcode: ['']
+        # other sample projects are built in ui-tests
         scheme:
           - macOS-Swift
           - iOS13-Swift
-        # other sample projects are built in ui-tests
 
-        # WatchOS needs Sentry as a XCFramework  
+        # WatchOS needs Sentry as a XCFramework
         include:
           - scheme: watchOS-Swift WatchKit App
             beforeXcode: 'make build-for-watchos'
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
       - run: ${{matrix.beforeXcode}}
-      
+
       # Disable code signing. We just want to make sure these compile.
       - run: >-
           env NSUnbufferedIO=YES
@@ -86,7 +86,7 @@ jobs:
           path: |
             ${{ github.workspace }}/*.zip
 
-  # The framework requires Xcode 12          
+  # The framework requires Xcode 12
   build-framework:
     name: Build & Validate Framework
     runs-on: macos-11
@@ -105,10 +105,10 @@ jobs:
           if-no-files-found: error
           path: |
             ${{ github.workspace }}/*.zip
- 
-# Use github.event.pull_request.head.sha instead of github.sha when available as 
-# the github.sha is be the pre merge commit id for PRs.
-# See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
+
+  # Use github.event.pull_request.head.sha instead of github.sha when available as
+  # the github.sha is be the pre merge commit id for PRs.
+  # See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
   validate-spm:
     name: Validate Swift Package Manager
     runs-on: macos-12
@@ -120,7 +120,7 @@ jobs:
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/macOS-SPM-CommandLine/Package.swift
-          fi  
+          fi
         shell: bash
       - run: swift build
         working-directory: Samples/macOS-SPM-CommandLine
@@ -137,7 +137,7 @@ jobs:
             sed -i '' 's/.branch("master")/.revision("${{ github.event.pull_request.head.sha }}")/g' Samples/SPM-Dynamic/Package.swift
           else
             sed -i '' 's/.branch("master")/.revision("${{ github.sha }}")/g' Samples/SPM-Dynamic/Package.swift
-          fi  
+          fi
         shell: bash
       - run: swift build
         working-directory: Samples/SPM-Dynamic

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,8 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
   schedule:
     - cron: '40 4 * * 6'
@@ -15,24 +15,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'cpp' ]
+        language: ['cpp']
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: ${{ matrix.language }}
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2
+        with:
+          languages: ${{ matrix.language }}
 
-    - run: >-
-        env NSUnbufferedIO=YES
-        xcodebuild 
-        -workspace Sentry.xcworkspace 
-        -scheme Sentry 
-        -configuration Release 
-        -destination platform="iOS Simulator,OS=latest,name=iPhone 11 Pro"
+      - run: >-
+          env NSUnbufferedIO=YES
+          xcodebuild
+          -workspace Sentry.xcworkspace
+          -scheme Sentry
+          -configuration Release
+          -destination platform="iOS Simulator,OS=latest,name=iPhone 11 Pro"
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # pin@v2

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -9,10 +9,8 @@ on:
       - '.github/workflows/format-code.yml'
 
 jobs:
-
-# Formats Swift, Objective-C, C++, and C code and commits the formatted code
-# if necessary
-
+  # Formats Swift, Objective-C, C++, and C code and commits the formatted code
+  # if necessary
   format-code:
     name: Format Code
     runs-on: macos-11
@@ -22,7 +20,7 @@ jobs:
         run: brew install clang-format
       - name: Format Code
         run: make format
-      
+
       # actions/checkout fetches only a single commit in a detached HEAD state. Therefore
       # we need to pass the current branch, otherwise we can't commit the changes.
       # GITHUB_HEAD_REF is the name of the head branch. GitHub Actions only sets this for PRs.

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-  
+
   pull_request:
     paths:
       - 'Sources/**'
@@ -13,11 +13,10 @@ on:
       - 'fastlane/**'
 
 jobs:
-
   # Ensure the swizzling of network classes doesn't break the normal functionality of web requests.
   # We borrow the tests of Alamofire under the MIT license: https://github.com/Alamofire/Alamofire.
   # The following steps checkout Alamofire and apply a github patch to the project. The patch adds
-  # Sentry to the tests with auto performance monitoring enabled. While the tests are running a 
+  # Sentry to the tests with auto performance monitoring enabled. While the tests are running a
   # transaction is bound to the scope, so the Sentry SDK adds spans to the transaction. This doesn't
   # validate if the Sentry SDK adds proper spans. It only validates that the swizzling logic
   # doesn't break web requests.
@@ -30,8 +29,8 @@ jobs:
         with:
           repository: 'Alamofire/Alamofire'
           ref: 'f82c23a8a7ef8dc1a49a8bfc6a96883e79121864'
-     
-      # Use github.event.pull_request.head.sha instead of github.sha when available as 
+
+      # Use github.event.pull_request.head.sha instead of github.sha when available as
       # the github.sha is the pre merge commit id for PRs.
       # See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
       - name: Download Apply Patch Script
@@ -41,7 +40,7 @@ jobs:
           else
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.sha }}/scripts/apply-patch.sh --output apply-patch.sh
           fi
-          
+
           chmod +x apply-patch.sh
         shell: bash
 
@@ -53,7 +52,7 @@ jobs:
 
       - name: Start Firewalk
         run: firewalk &
- 
+
       - name: Validate Firewalk is running
         run: curl http://localhost:8080/
 
@@ -83,8 +82,8 @@ jobs:
         with:
           repository: 'home-assistant/iOS'
           ref: '6d6606aed63a778c5a2bd64f8981823433a7f2fa'
-      
-      # Use github.event.pull_request.head.sha instead of github.sha when available as 
+
+      # Use github.event.pull_request.head.sha instead of github.sha when available as
       # the github.sha is the pre merge commit id for PRs.
       # See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
       - name: Download Apply Patch Script
@@ -102,14 +101,14 @@ jobs:
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-homekit
 
       - uses: actions/cache@v3
-        name: "Cache: Gems"
+        name: 'Cache: Gems'
         id: cache_gems
         with:
           path: vendor/bundle
           key: home-assistant-integration-gems-${{ runner.os }}-${{ env.ImageVersion }}-${{ env.DEVELOPER_DIR }}-${{ hashFiles('**/Gemfile.lock') }}
 
       - uses: actions/cache@v3
-        name: "Cache: Pods"
+        name: 'Cache: Pods'
         id: cache_pods
         if: steps.cache_gems.outputs.cache-hit == 'true'
         with:
@@ -133,7 +132,7 @@ jobs:
           bundle exec pod install --repo-update
 
       - name: Run tests
-      # Run the tests twice in case they are flaky.
+        # Run the tests twice in case they are flaky.
         run: |
           bundle config set --local path 'vendor/bundle'
           for i in {1..2}; do bundle exec fastlane test && break ; done
@@ -150,7 +149,7 @@ jobs:
           repository: 'videolan/vlc-ios'
           ref: '5d2b5505edc3387cad43deca14c0bd0b19e3f133'
 
-      # Use github.event.pull_request.head.sha instead of github.sha when available as 
+      # Use github.event.pull_request.head.sha instead of github.sha when available as
       # the github.sha is the pre merge commit id for PRs.
       # See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
       - name: Download Apply Patch Script
@@ -168,7 +167,7 @@ jobs:
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-vlc
 
       - uses: actions/cache@v3
-        name: "Cache: Pods"
+        name: 'Cache: Pods'
         id: cache-pods
         with:
           path: Pods
@@ -180,5 +179,5 @@ jobs:
         run: pod install
 
       - name: Run UI Tests
-      # Run the tests twice in case they are flaky.
+        # Run the tests twice in case they are flaky.
         run: for i in {1..2} ; do set -o pipefail && env NSUnbufferedIO=YES xcodebuild -workspace "VLC.xcworkspace" -scheme "VLC-iOS-UITests" -destination "OS=15.5,name=iPhone 13 Pro" test | xcpretty && break ; done

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: ["High-end device", "Mid-range device"]
+        suite: ['High-end device', 'Mid-range device']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -22,14 +22,14 @@ jobs:
   build-ui-tests:
     name: Build UITests with Xcode ${{matrix.xcode}}
     runs-on: ${{matrix.runs-on}}
-    strategy:      
+    strategy:
       matrix:
         include:
           - runs-on: macos-11
-            xcode: "12.5.1"
+            xcode: '12.5.1'
 
           - runs-on: macos-12
-            xcode: "13.4.1"
+            xcode: '13.4.1'
 
     steps:
       - uses: actions/checkout@v3
@@ -81,33 +81,31 @@ jobs:
             **/Debug-iphoneos/iOS-Swift.app
             **/Debug-iphoneos/iOS-SwiftUITests-Runner.app
 
-
   run-ui-tests-with-sauce:
     name: Run UI Tests for iOS ${{ matrix.suite }} on Sauce Labs
     runs-on: ubuntu-latest
     needs: build-ui-tests
-    strategy:      
+    strategy:
       fail-fast: false
       matrix:
         include:
-          - xcode: "13.4.1"
-            suite: "iOS-15"
+          - xcode: '13.4.1'
+            suite: 'iOS-15'
 
           # We want to test the frame tracker at 120 fps
-          - xcode: "13.4.1"
-            suite: "iPhone-Pro"
+          - xcode: '13.4.1'
+            suite: 'iPhone-Pro'
 
-          - xcode: "13.4.1"
-            suite: "iOS-14"
+          - xcode: '13.4.1'
+            suite: 'iOS-14'
 
-          - xcode: "13.4.1"
-            suite: "iOS-13"
+          - xcode: '13.4.1'
+            suite: 'iOS-13'
 
           # iOS 12 has a failing test that we need to fix https://github.com/getsentry/sentry-cocoa/issues/1566
           # iOS 11 keeps timing out and we don't know how to fix it.
-
-          - xcode: "12.5.1"
-            suite: "iOS-10"
+          - xcode: '12.5.1'
+            suite: 'iOS-10'
 
     steps:
       - uses: actions/checkout@v3
@@ -123,4 +121,4 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: for i in {1..5}; do saucectl run --select-suite ${{ matrix.suite }} && break ; done     
+        run: for i in {1..5}; do saucectl run --select-suite ${{ matrix.suite }} && break ; done

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,14 +12,14 @@ jobs:
           repo-token: ${{ github.token }}
           days-before-stale: 21
           days-before-close: 7
-          only-labels: ""
+          only-labels: ''
           operations-per-run: 100
           remove-stale-when-updated: true
           debug-only: false
           ascending: false
 
-          exempt-issue-labels: "Status: Backlog,Status: In Progress"
-          stale-issue-label: "Status: Stale"
+          exempt-issue-labels: 'Status: Backlog,Status: In Progress'
+          stale-issue-label: 'Status: Stale'
           stale-issue-message: |-
             This issue has gone three weeks without activity. In another week, I will close it.
 
@@ -29,11 +29,11 @@ jobs:
 
             "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
           skip-stale-issue-message: false
-          close-issue-label: ""
-          close-issue-message: ""
+          close-issue-label: ''
+          close-issue-message: ''
 
-          exempt-pr-labels: "Status: Backlog,Status: In Progress"
-          stale-pr-label: "Status: Stale"
+          exempt-pr-labels: 'Status: Backlog,Status: In Progress'
+          stale-pr-label: 'Status: Stale'
           stale-pr-message: |-
             This pull request has gone three weeks without activity. In another week, I will close it.
 
@@ -44,4 +44,4 @@ jobs:
             "A weed is but an unloved flower." ― _Ella Wheeler Wilcox_ 🥀
           skip-stale-pr-message: false
           close-pr-label:
-          close-pr-message: ""
+          close-pr-message: ''

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,79 +55,78 @@ jobs:
     runs-on: ${{matrix.runs-on}}
     timeout-minutes: 20
     needs: build-test-server
-    
-    strategy:      
+
+    strategy:
       fail-fast: false
       matrix:
-        # Can't run tests on watchOS because XCTest is not available  
+        # Can't run tests on watchOS because XCTest is not available
         # We can't use Xcode 10.3 because our tests contain a reference to MacCatalyst,
         # which is only available since iOS 13 / Xcode 11.
         # We can't use Xcode 11.7 as we use XCTestObservation. When building with Xcode 11.7
         # we get the error 'XCTest/XCTest.h' not found. Setting ENABLE_TESTING_SEARCH_PATH=YES
-        # doesn't work. 
-        
+        # doesn't work.
         include:
           # Test on iOS 12.4
           - runs-on: macos-10.15
-            platform: "iOS"
-            xcode: "12.4"
-            test-destination-os: "12.4"
+            platform: 'iOS'
+            xcode: '12.4'
+            test-destination-os: '12.4'
 
-         # Test on iOS 13.7
-          - runs-on:  macos-11
-            platform: "iOS"
-            xcode: "13.2.1"
-            test-destination-os: "13.7"
+          # Test on iOS 13.7
+          - runs-on: macos-11
+            platform: 'iOS'
+            xcode: '13.2.1'
+            test-destination-os: '13.7'
 
           # iOS 14
           - runs-on: macos-11
-            platform: "iOS"
-            xcode: "12.5.1"
-            test-destination-os: "latest"
+            platform: 'iOS'
+            xcode: '12.5.1'
+            test-destination-os: 'latest'
 
           # iOS 15
           - runs-on: macos-12
-            platform: "iOS"
-            xcode: "13.4.1"
-            test-destination-os: "latest"
+            platform: 'iOS'
+            xcode: '13.4.1'
+            test-destination-os: 'latest'
 
           # iOS 16
           - runs-on: macos-12
-            platform: "iOS"
-            xcode: "14.0"
-            test-destination-os: "latest"
+            platform: 'iOS'
+            xcode: '14.0'
+            test-destination-os: 'latest'
 
           # macOS 11
           - runs-on: macos-11
-            platform: "macOS"
-            xcode: "12.5.1"
-            test-destination-os: "latest"
+            platform: 'macOS'
+            xcode: '12.5.1'
+            test-destination-os: 'latest'
 
           # macOS 12
           - runs-on: macos-12
-            platform: "macOS"
-            xcode: "13.4.1"
-            test-destination-os: "latest"
+            platform: 'macOS'
+            xcode: '13.4.1'
+            test-destination-os: 'latest'
 
           # Catalyst. We only test the latest version, as
           # the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
           - runs-on: macos-12
-            platform: "Catalyst"
-            xcode: "13.4.1"
-            test-destination-os: "latest"
+            platform: 'Catalyst'
+            xcode: '13.4.1'
+            test-destination-os: 'latest'
 
           # tvOS 4
           - runs-on: macos-11
-            platform: "tvOS"
-            xcode: "12.5.1"
-            test-destination-os: "latest"
+            platform: 'tvOS'
+            xcode: '12.5.1'
+            test-destination-os: 'latest'
 
           # tvOS 15
           - runs-on: macos-12
-            platform: "tvOS"
-            xcode: "13.4.1"
-            test-destination-os: "latest"
+            platform: 'tvOS'
+            xcode: '13.4.1'
+            test-destination-os: 'latest'
 
     steps:
       - uses: actions/checkout@v3
@@ -144,24 +143,24 @@ jobs:
       # we can't run the tests with Xcode 10.3. Therefore we use a workaround with a symlink pointed out in:
       # https://github.com/actions/virtual-environments/issues/551#issuecomment-637344435
       - name: Prepare iOS 12.4 simulator
-        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '12.4'}}  
+        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '12.4'}}
         run: |
           sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
           sudo ln -s /Applications/Xcode_10.3.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/Library/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 12.4.simruntime
           xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-12-4"
 
       - name: Prepare iOS 13.7 simulator
-        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '13.7'}}  
+        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '13.7'}}
         run: |
           sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
           sudo ln -s /Applications/Xcode_11.7.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 13.7.simruntime
-          xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-13-7"   
+          xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-13-7"
 
       - name: Running tests
         # We call a script with the platform so the destination
-        # passed to xcodebuild doesn't end up in the job name, 
-        # because GitHub Actions don't provide an easy way of 
-        # manipulating string in expressions.  
+        # passed to xcodebuild doesn't end up in the job name,
+        # because GitHub Actions don't provide an easy way of
+        # manipulating string in expressions.
         run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} ${{matrix.xcode}} $GITHUB_REF_NAME
 
       - name: Archiving DerivedData Logs
@@ -179,23 +178,22 @@ jobs:
           name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
             raw-test-output.log
-      
 
       # We can upload all coverage reports, because codecov merges them.
       # See https://docs.codecov.io/docs/merging-reports
       # Checkout .codecov.yml to see the config of Codecov
       - name: Push code coverage to codecov
-        uses: codecov/codecov-action@v3
-        
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3
+
         # SentrySystemEventsBreadcrumbsTest only run on Catalyst and iOS
         # so the coverage report shows a reduced coverage.
-        if: ${{ contains(matrix.platform, 'Mac Catalyst') || contains(matrix.platform, 'iOS') }}  
+        if: ${{ contains(matrix.platform, 'Mac Catalyst') || contains(matrix.platform, 'iOS') }}
 
   # We don't run all unit tests with Thread Sanitizer enabled because
   # that adds a significant overhead.
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
-    runs-on: macos-12 
+    runs-on: macos-12
     # When there are threading issues the tests sometimes keep hanging
     timeout-minutes: 20
 
@@ -221,23 +219,22 @@ jobs:
 
       - name: Running tests with ThreadSanitizer
         run: ./scripts/tests-with-thread-sanitizer.sh
-      
+
       - name: Archiving Test Logs
         uses: actions/upload-artifact@v3
         with:
           path: thread-sanitizer.log
-
 
   ui-tests:
     name: UI Tests for ${{matrix.target}} on Simulators
     runs-on: macos-12
     strategy:
       matrix:
-        target: ["ios_swift", "ios_objc", "tvos_swift" ]
+        target: ['ios_swift', 'ios_objc', 'tvos_swift']
 
     steps:
       - uses: actions/checkout@v3
-      - run: ./scripts/ci-select-xcode.sh 
+      - run: ./scripts/ci-select-xcode.sh
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
@@ -250,16 +247,16 @@ jobs:
     runs-on: ${{matrix.runs-on}}
     strategy:
       fail-fast: false
-      matrix:  
+      matrix:
         include:
           - runs-on: macos-12
-            xcode: "13.4.1"
-            device: "iPhone 8 (15.2)"
+            xcode: '13.4.1'
+            device: 'iPhone 8 (15.2)'
 
           - runs-on: macos-11
-            xcode: "12.5.1"
-            device: "iPhone 8 (14.5)"
-            
+            xcode: '12.5.1'
+            device: 'iPhone 8 (14.5)'
+
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
@@ -275,7 +272,7 @@ jobs:
     runs-on: macos-10.15
     strategy:
       matrix:
-        target: ["ios_swift", "ios_objc", "tvos_swift" ]
+        target: ['ios_swift', 'ios_objc', 'tvos_swift']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -11,7 +11,6 @@ on:
       - 'scripts/ci-select-xcode.sh'
 
 jobs:
-
   upload_to_testflight:
     name: Build and Upload iOS-Swift to Testflight
     runs-on: macos-12
@@ -23,7 +22,7 @@ jobs:
       # We upload a new version to TestFlight on every commit on Master
       # So we need to bump the build number each time
       - name: Bump Build Version
-        env: 
+        env:
           FASTLANE_BUILD_NUMBER: ${{ github.run_number }}
         run: bundle exec fastlane bump_build_number
 
@@ -48,7 +47,7 @@ jobs:
       - name: Archiving
         uses: actions/upload-artifact@v3
         with:
-          name: dSYMs 
+          name: dSYMs
           path: |
             ${{ github.workspace }}/iOS-Swift.*
             ${{ github.workspace }}/*.dSYM.zip


### PR DESCRIPTION
Used `Get-ChildItem . -Filter *.yml | Foreach-Object { pin-github-action --allow 'actions/*,getsentry/*' $_.FullName }` and manually reverted the most disturbing formatting changes it's making (line breaks on long lines)...

There should be no need to do this again + new PRs will automatically get a failure through Danger.

#skip-changelog