### PR TITLE
ref: Remove a possible race condition related to reading previous app state

### DIFF
--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -57,6 +57,11 @@ SentryAppStateManager ()
                                    systemBootTimestamp:self.sysctl.systemBootTimestamp];
 }
 
+- (SentryAppState *)loadPreviousAppState
+{
+    return [self.fileManager readPreviousAppState];
+}
+
 - (SentryAppState *)loadCurrentAppState
 {
     return [self.fileManager readAppState];

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -72,7 +72,7 @@ SentryAppStateManager ()
     [self.fileManager storeAppState:[self buildCurrentAppState]];
 }
 
-- (void)removeCurrentAppState
+- (void)removeAppState
 {
     [self.fileManager deleteAppState];
 }

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -72,7 +72,7 @@ SentryAppStateManager ()
     [self.fileManager storeAppState:[self buildCurrentAppState]];
 }
 
-- (void)removeAppState
+- (void)deleteAppState
 {
     [self.fileManager deleteAppState];
 }

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -445,17 +445,24 @@ SentryFileManager ()
 
 - (void)deleteAppState
 {
+    @synchronized(self.appStateFilePath) {
+        [self deleteAppStateFrom:self.appStateFilePath];
+        [self deleteAppStateFrom:self.previousAppStateFilePath];
+    }
+}
+
+- (void)deleteAppStateFrom:(NSString *)path
+{
     NSError *error = nil;
     NSFileManager *fileManager = [NSFileManager defaultManager];
-    @synchronized(self.appStateFilePath) {
-        [fileManager removeItemAtPath:self.appStateFilePath error:&error];
+    [fileManager removeItemAtPath:path error:&error];
 
-        // We don't want to log an error if the file doesn't exist.
-        if (nil != error && error.code != NSFileNoSuchFileError) {
-            [SentryLog
-                logWithMessage:[NSString stringWithFormat:@"Failed to delete app state %@", error]
-                      andLevel:kSentryLevelError];
-        }
+    // We don't want to log an error if the file doesn't exist.
+    if (nil != error && error.code != NSFileNoSuchFileError) {
+        [SentryLog
+            logWithMessage:[NSString stringWithFormat:@"Failed to delete app state from %@: %@",
+                                     path, error]
+                  andLevel:kSentryLevelError];
     }
 }
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -23,6 +23,7 @@ SentryFileManager ()
 @property (nonatomic, copy) NSString *currentSessionFilePath;
 @property (nonatomic, copy) NSString *crashedSessionFilePath;
 @property (nonatomic, copy) NSString *lastInForegroundFilePath;
+@property (nonatomic, copy) NSString *previousAppStateFilePath;
 @property (nonatomic, copy) NSString *appStateFilePath;
 @property (nonatomic, copy) NSString *timezoneOffsetFilePath;
 @property (nonatomic, assign) NSUInteger currentFileCounter;
@@ -65,6 +66,8 @@ SentryFileManager ()
         self.lastInForegroundFilePath =
             [self.sentryPath stringByAppendingPathComponent:@"lastInForeground.timestamp"];
 
+        self.previousAppStateFilePath =
+            [self.sentryPath stringByAppendingPathComponent:@"previous.app.state"];
         self.appStateFilePath = [self.sentryPath stringByAppendingPathComponent:@"app.state"];
         self.timezoneOffsetFilePath =
             [self.sentryPath stringByAppendingPathComponent:@"timezone.offset"];
@@ -395,15 +398,47 @@ SentryFileManager ()
     }
 }
 
+- (void)moveAppStateToPreviousAppState
+{
+    @synchronized(self.appStateFilePath) {
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSError *error = nil;
+        [fileManager moveItemAtPath:self.appStateFilePath
+                             toPath:self.previousAppStateFilePath
+                              error:&error];
+
+        // We don't want to log an error if the file doesn't exist.
+        if (nil != error && error.code != NSFileNoSuchFileError) {
+            [SentryLog
+                logWithMessage:[NSString
+                                   stringWithFormat:
+                                       @"Failed to move app state to previous app state: %@", error]
+                      andLevel:kSentryLevelError];
+        }
+    }
+}
+
 - (SentryAppState *_Nullable)readAppState
+{
+    @synchronized(self.appStateFilePath) {
+        return [self readAppStateFrom:self.appStateFilePath];
+    }
+}
+
+- (SentryAppState *_Nullable)readPreviousAppState
+{
+    @synchronized(self.previousAppStateFilePath) {
+        return [self readAppStateFrom:self.previousAppStateFilePath];
+    }
+}
+
+- (SentryAppState *_Nullable)readAppStateFrom:(NSString *)path
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSData *currentData = nil;
-    @synchronized(self.appStateFilePath) {
-        currentData = [fileManager contentsAtPath:self.appStateFilePath];
-        if (nil == currentData) {
-            return nil;
-        }
+    currentData = [fileManager contentsAtPath:path];
+    if (nil == currentData) {
+        return nil;
     }
     return [SentrySerialization appStateWithData:currentData];
 }

--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -40,7 +40,7 @@ SentryOutOfMemoryLogic ()
     }
 
 #if SENTRY_HAS_UIKIT
-    SentryAppState *previousAppState = [self.appStateManager loadCurrentAppState];
+    SentryAppState *previousAppState = [self.appStateManager loadPreviousAppState];
     SentryAppState *currentAppState = [self.appStateManager buildCurrentAppState];
 
     // If there is no previous app state, we can't do anything.

--- a/Sources/Sentry/SentryOutOfMemoryTracker.m
+++ b/Sources/Sentry/SentryOutOfMemoryTracker.m
@@ -129,7 +129,7 @@ SentryOutOfMemoryTracker ()
         removeObserver:self
                   name:SentryNSNotificationCenterWrapper.willTerminateNotificationName
                 object:nil];
-    [self.appStateManager removeCurrentAppState];
+    [self.appStateManager removeAppState];
 #endif
 }
 

--- a/Sources/Sentry/SentryOutOfMemoryTracker.m
+++ b/Sources/Sentry/SentryOutOfMemoryTracker.m
@@ -129,7 +129,7 @@ SentryOutOfMemoryTracker ()
         removeObserver:self
                   name:SentryNSNotificationCenterWrapper.willTerminateNotificationName
                 object:nil];
-    [self.appStateManager removeAppState];
+    [self.appStateManager deleteAppState];
 #endif
 }
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -146,7 +146,10 @@ static NSUInteger startInvocations;
     startInvocations++;
 
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
+
     SentryClient *newClient = [[SentryClient alloc] initWithOptions:options];
+    [newClient.fileManager moveAppStateToPreviousAppState];
+
     // The Hub needs to be initialized with a client so that closing a session
     // can happen.
     [SentrySDK setCurrentHub:[[SentryHub alloc] initWithClient:newClient andScope:nil]];

--- a/Sources/Sentry/include/SentryAppStateManager.h
+++ b/Sources/Sentry/include/SentryAppStateManager.h
@@ -32,7 +32,7 @@ SENTRY_NO_INIT
 
 - (void)storeCurrentAppState;
 
-- (void)removeAppState;
+- (void)deleteAppState;
 
 - (void)updateAppState:(void (^)(SentryAppState *))block;
 

--- a/Sources/Sentry/include/SentryAppStateManager.h
+++ b/Sources/Sentry/include/SentryAppStateManager.h
@@ -32,7 +32,7 @@ SENTRY_NO_INIT
 
 - (void)storeCurrentAppState;
 
-- (void)removeCurrentAppState;
+- (void)removeAppState;
 
 - (void)updateAppState:(void (^)(SentryAppState *))block;
 

--- a/Sources/Sentry/include/SentryAppStateManager.h
+++ b/Sources/Sentry/include/SentryAppStateManager.h
@@ -26,6 +26,8 @@ SENTRY_NO_INIT
  */
 - (SentryAppState *)buildCurrentAppState;
 
+- (SentryAppState *)loadPreviousAppState;
+
 - (SentryAppState *)loadCurrentAppState;
 
 - (void)storeCurrentAppState;

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -60,7 +60,9 @@ SENTRY_NO_INIT
 - (NSString *)storeDictionary:(NSDictionary *)dictionary toPath:(NSString *)path;
 
 - (void)storeAppState:(SentryAppState *)appState;
+- (void)moveAppStateToPreviousAppState;
 - (SentryAppState *_Nullable)readAppState;
+- (SentryAppState *_Nullable)readPreviousAppState;
 - (void)deleteAppState;
 
 - (NSNumber *_Nullable)readTimezoneOffset;

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -471,6 +471,14 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertNotNil(sut.readAppState())
     }
 
+    func testMoveAppStateAndReadPreviousAppState() {
+        sut.store(TestData.appState)
+        sut.moveAppStateToPreviousAppState()
+
+        let actual = sut.readPreviousAppState()
+        XCTAssertEqual(TestData.appState, actual)
+    }
+
     func testStoreAndReadTimezoneOffset() {
         sut.storeTimezoneOffset(7_200)
         XCTAssertEqual(sut.readTimezoneOffset(), 7_200)
@@ -600,7 +608,6 @@ class SentryFileManagerTests: XCTestCase {
     private func assertValidAppStateStored() {
         let actual = sut.readAppState()
         XCTAssertEqual(TestData.appState, actual)
-        
     }
 
     private func advanceTime(bySeconds: TimeInterval) {

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -439,6 +439,15 @@ class SentryFileManagerTests: XCTestCase {
         sut.deleteAppState()
         XCTAssertNil(sut.readAppState())
     }
+
+    func testDeletePreviousAppState() {
+        sut.store(TestData.appState)
+        sut.moveAppStateToPreviousAppState()
+        sut.deleteAppState()
+
+        XCTAssertNil(sut.readAppState())
+        XCTAssertNil(sut.readPreviousAppState())
+    }
     
     func testStore_WhenFileImmutable_AppStateIsNotOverwritten() {
         sut.store(TestData.appState)

--- a/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
@@ -189,6 +189,7 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
         sut.start()
         goToForeground()
 
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
@@ -208,7 +209,8 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
     func testAppOOM_WithOnlyHybridSdkDidBecomeActive() {
         sut.start()
         hybridSdkDidBecomeActive()
-        
+
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
@@ -217,7 +219,8 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
         sut.start()
         goToForeground()
         hybridSdkDidBecomeActive()
-        
+
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
@@ -226,7 +229,8 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
         sut.start()
         hybridSdkDidBecomeActive()
         goToForeground()
-        
+
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
@@ -253,7 +257,7 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
     func testStop_StopsObserving_NoMoreFileManagerInvocations() throws {
         let fileManager = try TestFileManager(options: Options(), andCurrentDateProvider: TestCurrentDateProvider())
         sut = fixture.getSut(fileManager: fileManager)
-        
+
         sut.start()
         sut.stop()
         
@@ -261,7 +265,7 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
         goToForeground()
         terminateApp()
         
-        XCTAssertEqual(1, fileManager.readAppStateInvocations.count)
+        XCTAssertEqual(1, fileManager.readPreviousAppStateInvocations.count)
     }
     
     private func givenPreviousAppState(appState: SentryAppState) {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -319,6 +319,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         let appState = SentryAppState(releaseName: TestData.appState.releaseName, osVersion: UIDevice.current.systemVersion, vendorId: UIDevice.current.identifierForVendor?.uuidString ?? "", isDebugging: false, systemBootTimestamp: fixture.currentDateProvider.date())
         appState.isActive = true
         fixture.fileManager.store(appState)
+        fixture.fileManager.moveAppStateToPreviousAppState()
     }
     #endif
     

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -161,4 +161,10 @@ class TestFileManager: SentryFileManager {
         readAppStateInvocations.record(Void())
         return nil
     }
+
+    var readPreviousAppStateInvocations = Invocations<Void>()
+    override func readPreviousAppState() -> SentryAppState? {
+        readPreviousAppStateInvocations.record(Void())
+        return nil
+    }
 }


### PR DESCRIPTION
From my chat with Philipp:

> The thing that worries me the most with the OOM implementation is `SentryAppState *previousAppState = [self.appStateManager loadCurrentAppState]` inside of `SentryOutOfMemoryLogic`. That seems so vulnerable to a race condition, as `SentryOutOfMemoryTracker.start` actually writes a brand new app state to disk. 
> 
> I know that it executes `[self.outOfMemoryLogic isOOM]` before `[self.appStateManager storeCurrentAppState]`, but still.. seems a bit fragile.
> 
> Same with `SentrySessionCrashedHandler.endCurrentSessionAsCrashedWhenCrashOrOOM`: it also calls `SentryOutOfMemoryLogic.isOOM`. And it relies on the order of the integrations basically to make sure that this is done before starting the OOM integration.

We can fix this possible race condition in two ways:

1. Move the previous app state to a new file (simply rename the file, basically)
2. Read the previous app state right on SDK start and pass it into `isOOM`

Option 2 proved difficult:

> Ah passing it into the `isOOM` function does mean that `SentryOutOfMemoryTrackingIntegration` ends up needing access to the previous app state, and since I can't change the `init` or `installWithOptions` methods of the integration, that's not going to work. We could store the previous app state on `SentryOptions` but that is just a nasty hack and will keep this around in memory for too long, unless we then manually clean out that property from the options, etc. Quickly becoming a worse and worse fix.

So option 1 it is. It's a tiny tiny IO operation (just rename a file), but worth it to make sure that we don't rely on integration order to make sure the previous app state isn't actually already overwritten with a new version.

#skip-changelog