### PR TITLE
fix: Add app start to first finished transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Add app start to first finished transaction (#2252)
 - Return SentryNoOpSpan when starting a child on a finished transaction (#2239)
 
 ## 7.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Add app start to first finished transaction (#2252)
+- Add app start measurement to first finished transaction (#2252)
 - Return SentryNoOpSpan when starting a child on a finished transaction (#2239)
 - Fix profiling timestamps for slow/frozen frames (#2226)
 

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -56,7 +56,13 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readPath_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readUrl()">
+               </Test>
+               <Test
+                  Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readUrl_disabled()">
                </Test>
                <Test
                   Identifier = "SentrySDKIntegrationTestsBase">

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -62,6 +62,9 @@
                   Identifier = "SentrySessionGeneratorTests/testSendSessions()">
                </Test>
                <Test
+                  Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentrySystemEventBreadcrumbsTest/testTimezoneChangeNotificationBreadcrumb_disabled()">
                </Test>
             </SkippedTests>

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -56,6 +56,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readUrl()">
+               </Test>
+               <Test
                   Identifier = "SentrySDKIntegrationTestsBase">
                </Test>
                <Test

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -191,7 +191,7 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         ?? bundle.path(forResource: "fatal-error-binary-images-message2", ofType: "json")
     }
     
-    func test_DataConsistency_readUrl() {
+    func test_DataConsistency_readUrl_disabled() {
         SentrySDK.start(options: fixture.getOptions())
         
         let randomValue = UUID().uuidString

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -432,19 +432,41 @@ class SentryTracerTests: XCTestCase {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
         SentrySDK.setAppStartMeasurement(appStartMeasurement)
         
+        advanceTime(bySeconds: -(fixture.appStartDuration + 4))
+        
         let sut = fixture.getSut()
-        sut.startTimestamp = fixture.appStartEnd.addingTimeInterval(-5)
+        advanceTime(bySeconds: 1)
         sut.finish()
         fixture.hub.group.wait()
         
         XCTAssertEqual(1, fixture.hub.capturedEventsWithScopes.count)
-        let serializedTransaction = fixture.hub.capturedEventsWithScopes.first!.event.serialize()
-        let measurements = serializedTransaction["measurements"] as? [String: [String: Int]]
         
-        XCTAssertEqual(["app_start_warm": ["value": 500]], measurements)
+        assertAppStartMeasurementOn(transaction: fixture.hub.capturedEventsWithScopes.first!.event as! Transaction, appStartMeasurement: appStartMeasurement)
+    }
+    
+    func testAddColdStartMeasurement_PutOnFirstStartedTransaction() {
+        let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
+        SentrySDK.setAppStartMeasurement(appStartMeasurement)
         
-        let transaction = fixture.hub.capturedEventsWithScopes.first!.event as! Transaction
-        assertAppStartsSpanAdded(transaction: transaction, startType: "Warm Start", operation: fixture.appStartWarmOperation, appStartMeasurement: appStartMeasurement)
+        advanceTime(bySeconds: 0.5)
+        
+        let firstTransaction = fixture.getSut()
+        advanceTime(bySeconds: 0.5)
+        
+        let secondTransaction = fixture.getSut()
+        advanceTime(bySeconds: 0.5)
+        secondTransaction.finish()
+        
+        fixture.hub.group.wait()
+        XCTAssertEqual(1, fixture.hub.capturedEventsWithScopes.count)
+        let serializedSecondTransaction = fixture.hub.capturedEventsWithScopes.first!.event.serialize()
+        XCTAssertNil(serializedSecondTransaction["measurements"])
+        
+        firstTransaction.finish()
+        fixture.hub.group.wait()
+        
+        XCTAssertEqual(2, fixture.hub.capturedEventsWithScopes.count)
+        assertAppStartMeasurementOn(transaction: fixture.hub.capturedEventsWithScopes[1].event as! Transaction, appStartMeasurement: appStartMeasurement)
     }
     
     func testAddUnknownAppStartMeasurement_NotPutOnNextTransaction() {
@@ -488,8 +510,10 @@ class SentryTracerTests: XCTestCase {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
         SentrySDK.setAppStartMeasurement(appStartMeasurement)
         
+        advanceTime(bySeconds: fixture.appStartDuration + 5.01)
+        
         let sut = fixture.getSut()
-        sut.startTimestamp = fixture.appStartEnd.addingTimeInterval(5.1)
+        advanceTime(bySeconds: 1.0)
         sut.finish()
         fixture.hub.group.wait()
         
@@ -500,8 +524,10 @@ class SentryTracerTests: XCTestCase {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
         SentrySDK.setAppStartMeasurement(appStartMeasurement)
         
+        advanceTime(bySeconds: -(fixture.appStartDuration + 4.01))
+        
         let sut = fixture.getSut()
-        sut.startTimestamp = fixture.appStartEnd.addingTimeInterval(-5.1)
+        advanceTime(bySeconds: 1.0)
         sut.finish()
         fixture.hub.group.wait()
         
@@ -819,6 +845,15 @@ class SentryTracerTests: XCTestCase {
         assertSpan("Runtime Init to Pre Main Initializers", appStartMeasurement.runtimeInitTimestamp, appStartMeasurement.moduleInitializationTimestamp)
         assertSpan("UIKit and Application Init", appStartMeasurement.moduleInitializationTimestamp, appStartMeasurement.didFinishLaunchingTimestamp)
         assertSpan("Initial Frame Render", appStartMeasurement.didFinishLaunchingTimestamp, fixture.appStartEnd)
+    }
+    
+    private func assertAppStartMeasurementOn(transaction: Transaction, appStartMeasurement: SentryAppStartMeasurement) {
+        let serializedTransaction = transaction.serialize()
+        let measurements = serializedTransaction["measurements"] as? [String: [String: Int]]
+        
+        XCTAssertEqual(["app_start_warm": ["value": 500]], measurements)
+        
+        assertAppStartsSpanAdded(transaction: transaction, startType: "Warm Start", operation: fixture.appStartWarmOperation, appStartMeasurement: appStartMeasurement)
     }
     
     private func assertAppStartMeasurementNotPutOnTransaction() {

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -67,7 +67,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
     
-    func testAsyncStacktraces() throws {
+    func testAsyncStacktraces_disabled() throws {
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
             options.stitchAsyncCode = true


### PR DESCRIPTION


## :scroll: Description

The SDK added the app start measurement and spans to the first finished auto-generated UIViewController transaction. The first finished UIViewController transaction is not necessarily the transaction of the first loaded screen. As auto-generated transactions for UIViewControllers wait for all children to finish, it may kick off, for example, a web request that lasts for a couple of seconds in the background. In the meantime, the user navigates to another screen, which finishes loading before the web request. The SDK added the app start data to the wrong transaction in such an edge case. This is fixed now by adding the app start data to the first started transaction.


## :bulb: Motivation and Context

Fixes GH-2248

## :green_heart: How did you test it?
Unit tests and on a real device with the steps described in GH-2248.

[LoremIpsumViewController without the app start data](https://sentry.io/organizations/sentry-sdks/discover/sentry-cocoa:985e6abd923549198d1bad21a7fa7bd3/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=device&field=os&id=15529&name=Cocoa+Events&project=5428557&query=&sort=-timestamp&statsPeriod=24h&topEvents=5&yAxis=count%28%29).
<img width="857" alt="Screen Shot 2022-10-04 at 15 15 05" src="https://user-images.githubusercontent.com/2443292/193828708-453575f5-3b90-4e04-9ad3-40740304dbcc.png">

[iOS_Swift.ViewController with the app start data](https://sentry.io/organizations/sentry-sdks/discover/sentry-cocoa:985e6abd923549198d1bad21a7fa7bd3/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=device&field=os&id=15529&name=Cocoa+Events&project=5428557&query=&sort=-timestamp&statsPeriod=24h&topEvents=5&yAxis=count%28%29)
<img width="866" alt="Screen Shot 2022-10-04 at 15 15 24" src="https://user-images.githubusercontent.com/2443292/193828777-73a4e690-57c6-41a2-b478-c86521deab7d.png">


## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
