### PR TITLE
ci: Fix Validate podspec

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
+      - run: ./scripts/ci-select-xcode.sh
       - name: Validate Podspec
         run: pod lib lint --verbose
         shell: sh


### PR DESCRIPTION
Since October 3rd, the default Xcode version is 14.0.1 on [GH actions macos-12](https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md), which breaks pod lib lint. Ideally, we fix the underlying issue but for now, let's keep using Xcode 13.4.1 for pod lib lint.

Issue for making it work for Xcode 14.0.1 https://github.com/getsentry/sentry-cocoa/issues/2254

#skip-changelog