### PR TITLE
ci: Run pod lib lint in parallel

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,11 +43,15 @@ jobs:
   validate-podspec:
     name: Validate Podspec
     runs-on: macos-12
+    strategy:
+      matrix:
+        platform: ['iOS', 'macOS', 'tvOS', 'watchOS']
+
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
       - name: Validate Podspec
-        run: pod lib lint --verbose
+        run: pod lib lint --verbose --platforms=${{ matrix.platform }}
         shell: sh
 
   validate-high-risk-files:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: macos-12
     strategy:
       matrix:
-        platform: ['iOS', 'macOS', 'tvOS', 'watchOS']
+        platform: ['ios', 'macos', 'tvos', 'watchos']
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Pod lib lint runs validations for all platforms sequentially. We can speed up CI by using a matrix for each platform, so they run in parallel.

#skip-changelog

