### PR TITLE
test: generate profiles with different levels of efficiency

### DIFF
--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -55,35 +55,25 @@
         }
       },
       "swiftlint": {
-        "version": "0.47.1",
+        "version": "0.49.1",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:13b6b6d881b6cfa3f5399c14150ef6da0f1d1cec2b58fd24c6dcbc432c462106",
-              "sha256": "13b6b6d881b6cfa3f5399c14150ef6da0f1d1cec2b58fd24c6dcbc432c462106"
-            },
-            "arm64_big_sur": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:406fb7b019a5b7f0c052a7d4738f6cda5eaf15ef9c1bc1f89bdc3dc2efc719b6",
-              "sha256": "406fb7b019a5b7f0c052a7d4738f6cda5eaf15ef9c1bc1f89bdc3dc2efc719b6"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:d983879e2d9ea075bf80e223da5adb258f01d9fab4fc6f71f83c4add80490290",
+              "sha256": "d983879e2d9ea075bf80e223da5adb258f01d9fab4fc6f71f83c4add80490290"
             },
             "monterey": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:3c02d2875bef6dbd474c60a4ce42cce5f9e1da64580c00c351753adeaece5700",
-              "sha256": "3c02d2875bef6dbd474c60a4ce42cce5f9e1da64580c00c351753adeaece5700"
-            },
-            "big_sur": {
-              "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:775d4db3c21549bb18384be86ee82a43c92af12b74f9135e7b44f448cd6e0eff",
-              "sha256": "775d4db3c21549bb18384be86ee82a43c92af12b74f9135e7b44f448cd6e0eff"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:73a9664d8a62c7b5d506a70bf100e0289795df04ece6df12f0b77651e497d42b",
+              "sha256": "73a9664d8a62c7b5d506a70bf100e0289795df04ece6df12f0b77651e497d42b"
             },
             "x86_64_linux": {
               "cellar": "/home/linuxbrew/.linuxbrew/Cellar",
-              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:f00160b4eb1d370d6baf4341341f813af80ba2fcfa2e65657f96153713d1c774",
-              "sha256": "f00160b4eb1d370d6baf4341341f813af80ba2fcfa2e65657f96153713d1c774"
+              "url": "https://ghcr.io/v2/homebrew/core/swiftlint/blobs/sha256:705904346a73422be8f053d7b1c413e5d18623bd7244cb33d188d921a072e600",
+              "sha256": "705904346a73422be8f053d7b1c413e5d18623bd7244cb33d188d921a072e600"
             }
           }
         }
@@ -172,40 +162,40 @@
         }
       },
       "pre-commit": {
-        "version": "2.19.0",
+        "version": "2.20.0",
         "bottle": {
-          "rebuild": 0,
+          "rebuild": 1,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_monterey": {
-              "cellar": ":any",
-              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:35830ae8dc83700b547c078a43e0cae5b99c69d820e6a70b7dd43872105cc075",
-              "sha256": "35830ae8dc83700b547c078a43e0cae5b99c69d820e6a70b7dd43872105cc075"
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:4a480973522d0180cfd1414ec3d31f8aa284f26243a89036098dd3343ace6a96",
+              "sha256": "4a480973522d0180cfd1414ec3d31f8aa284f26243a89036098dd3343ace6a96"
             },
             "arm64_big_sur": {
-              "cellar": ":any",
-              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:ae925eb818c247559e36558216c63a5298653d65ecd528383340a0ee8b92c07e",
-              "sha256": "ae925eb818c247559e36558216c63a5298653d65ecd528383340a0ee8b92c07e"
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:cb061bc7f86b3149975d8bee8a209410c786d11ffa4091ad7769d6810a37ef5a",
+              "sha256": "cb061bc7f86b3149975d8bee8a209410c786d11ffa4091ad7769d6810a37ef5a"
             },
             "monterey": {
-              "cellar": ":any",
-              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:fa8795f2fc5231708ac69b3447732d3342ac77084c75d4cd92636e4cb3306918",
-              "sha256": "fa8795f2fc5231708ac69b3447732d3342ac77084c75d4cd92636e4cb3306918"
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:b822f396ca2e6523195d6c17ac8bf41eb6aee2e7ceac2ac0c18fbfd708c6a3ab",
+              "sha256": "b822f396ca2e6523195d6c17ac8bf41eb6aee2e7ceac2ac0c18fbfd708c6a3ab"
             },
             "big_sur": {
-              "cellar": ":any",
-              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:1eb31671ec49ce4703bdf821c46238a541ef5972f462174f4765dac8a2cf72c3",
-              "sha256": "1eb31671ec49ce4703bdf821c46238a541ef5972f462174f4765dac8a2cf72c3"
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:40508e1e583f42c3581c2488d8fcb4b88e4138bfb775e88041166ae8385f25a3",
+              "sha256": "40508e1e583f42c3581c2488d8fcb4b88e4138bfb775e88041166ae8385f25a3"
             },
             "catalina": {
-              "cellar": ":any",
-              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:4852270ec8f9249be28101899cfc2f5718b8b5ac79432089484af3e754a075cf",
-              "sha256": "4852270ec8f9249be28101899cfc2f5718b8b5ac79432089484af3e754a075cf"
+              "cellar": ":any_skip_relocation",
+              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:4bd415259c3ca8fe8255c8116865d88e5841cd618d9e75ddfdf04ce79c19e53d",
+              "sha256": "4bd415259c3ca8fe8255c8116865d88e5841cd618d9e75ddfdf04ce79c19e53d"
             },
             "x86_64_linux": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:6376d63fa6a158bd89dcf23bf75c6b684c542ca933c4c47e434287f92649cd17",
-              "sha256": "6376d63fa6a158bd89dcf23bf75c6b684c542ca933c4c47e434287f92649cd17"
+              "url": "https://ghcr.io/v2/homebrew/core/pre-commit/blobs/sha256:95bb496c02885d65a8db70ad434fda479a99a146e0244308c9be91322b0a2dd3",
+              "sha256": "95bb496c02885d65a8db70ad434fda479a99a146e0244308c9be91322b0a2dd3"
             }
           }
         }
@@ -215,12 +205,12 @@
   "system": {
     "macos": {
       "monterey": {
-        "HOMEBREW_VERSION": "3.5.4",
-        "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "5d8199d4653c34f7d06d716c762e23b19c27ffe3",
-        "CLT": "13.0.0.0.1.1627064638",
-        "Xcode": "13.4.1",
-        "macOS": "12.4"
+        "HOMEBREW_VERSION": "3.6.5",
+        "HOMEBREW_PREFIX": "/opt/homebrew",
+        "Homebrew/homebrew-core": "8953dee9c8266b88d45b1697cc931bdf0112342d",
+        "CLT": "14.0.0.0.1.1661618636",
+        "Xcode": "14.0",
+        "macOS": "12.6"
       }
     }
   }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.5)
       rexml
-    activesupport (6.1.6.1)
+    activesupport (6.1.7)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,8 +17,8 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.636.0)
-    aws-sdk-core (3.154.0)
+    aws-partitions (1.644.0)
+    aws-sdk-core (3.159.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
       aws-sigv4 (~> 1.1)
@@ -30,7 +30,7 @@ GEM
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
-    aws-sigv4 (1.5.1)
+    aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.1.0)
@@ -86,7 +86,7 @@ GEM
     escape (0.0.4)
     ethon (0.15.0)
       ffi (>= 1.15.0)
-    excon (0.92.5)
+    excon (0.93.0)
     faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -155,13 +155,13 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-sentry (1.13.0)
+    fastlane-plugin-sentry (1.14.0)
       os (~> 1.1, >= 1.1.4)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.28.0)
+    google-apis-androidpublisher_v3 (0.29.0)
       google-apis-core (>= 0.9.0, < 2.a)
     google-apis-core (0.9.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -176,19 +176,19 @@ GEM
       google-apis-core (>= 0.9.0, < 2.a)
     google-apis-playcustomapp_v1 (0.11.0)
       google-apis-core (>= 0.9.0, < 2.a)
-    google-apis-storage_v1 (0.17.0)
-      google-apis-core (>= 0.7, < 2.a)
+    google-apis-storage_v1 (0.19.0)
+      google-apis-core (>= 0.9.0, < 2.a)
     google-cloud-core (1.6.0)
       google-cloud-env (~> 1.0)
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
     google-cloud-errors (1.3.0)
-    google-cloud-storage (1.42.0)
+    google-cloud-storage (1.43.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
       google-apis-iamcredentials_v1 (~> 0.1)
-      google-apis-storage_v1 (~> 0.17.0)
+      google-apis-storage_v1 (~> 0.19.0)
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
@@ -282,7 +282,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby
@@ -296,4 +296,4 @@ DEPENDENCIES
   xcpretty
 
 BUNDLED WITH
-   2.3.21
+   2.3.23

--- a/Samples/TrendingMovies/ProfileDataGeneratorUITest/ProfileDataGeneratorUITest.m
+++ b/Samples/TrendingMovies/ProfileDataGeneratorUITest/ProfileDataGeneratorUITest.m
@@ -53,7 +53,7 @@ generateProfileData(NSUInteger nCellsPerTab, BOOL clearState, BOOL efficiently)
     }
     if (efficiently) {
         [launchArguments
-            addObject:@"--io.sentry.sample.trending-movies.launch-arg.blur-images-on-main-thread"];
+            addObject:@"--io.sentry.sample.trending-movies.launch-arg.blur-images-on-bg-thread"];
     }
     app.launchArguments = launchArguments;
     [app launch];

--- a/Samples/TrendingMovies/ProfileDataGeneratorUITest/ProfileDataGeneratorUITest.m
+++ b/Samples/TrendingMovies/ProfileDataGeneratorUITest/ProfileDataGeneratorUITest.m
@@ -20,12 +20,14 @@ static NSTimeInterval const kWaitForElementTimeout = 5.0;
 {
     CFTimeInterval const startTime = CACurrentMediaTime();
     CFTimeInterval const runDuration_seconds = 3.0 * 60.0;
-    generateProfileData(5 /* nCellsPerTab */, YES /* clearState */);
+    BOOL efficiently = NO;
+    generateProfileData(5 /* nCellsPerTab */, YES /* clearState */, efficiently);
     while (true) {
         if ((CACurrentMediaTime() - startTime) >= runDuration_seconds) {
             break;
         }
-        if (!generateProfileData(5 /* nCellsPerTab */, NO /* clearState */)) {
+        efficiently = !efficiently;
+        if (!generateProfileData(5 /* nCellsPerTab */, NO /* clearState */, efficiently)) {
             break;
         }
     }
@@ -36,15 +38,24 @@ static NSTimeInterval const kWaitForElementTimeout = 5.0;
  * Sentry transaction with profiling enabled.
  * @param nCellsPerTab The number of cells to tap on, per tab.
  * @param clearState Whether to clear filesystem state when the app starts.
+ * @param efficiently Whether to perform certain operations in TrendingMovies using an efficient
+ * method or not, to help us demonstrate how to identify such issues in the profiling areas of the
+ * Sentry dashboard.
  * @return Whether the operation was successful or not.
  */
 BOOL
-generateProfileData(NSUInteger nCellsPerTab, BOOL clearState)
+generateProfileData(NSUInteger nCellsPerTab, BOOL clearState, BOOL efficiently)
 {
     XCUIApplication *app = [[XCUIApplication alloc] init];
+    NSMutableArray *launchArguments = app.launchArguments.mutableCopy;
     if (clearState) {
-        app.launchArguments = @[ @"--clear" ];
+        [launchArguments addObject:@"--clear"];
     }
+    if (efficiently) {
+        [launchArguments
+            addObject:@"--io.sentry.sample.trending-movies.launch-arg.blur-images-on-main-thread"];
+    }
+    app.launchArguments = launchArguments;
     [app launch];
     if (![app waitForState:XCUIApplicationStateRunningForeground timeout:kWaitForAppStateTimeout]) {
         XCTFail("App failed to transition to Foreground state");

--- a/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/TrendingMovies.xcscheme
+++ b/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/TrendingMovies.xcscheme
@@ -60,6 +60,12 @@
             ReferencedContainer = "container:TrendingMovies.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--io.sentry.sample.trending-movies.blur-images-on-main-thread"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/TrendingMovies.xcscheme
+++ b/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/TrendingMovies.xcscheme
@@ -62,7 +62,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--io.sentry.sample.trending-movies.blur-images-on-main-thread"
+            argument = "--io.sentry.sample.trending-movies.blur-images-on-bg-thread"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Samples/TrendingMovies/TrendingMovies/Movies/MovieCollectionViewCell.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Movies/MovieCollectionViewCell.swift
@@ -151,7 +151,7 @@ class MovieCollectionViewCell: UICollectionViewCell {
 }
 
 private func blurPosterImage(_ image: UIImage, completion: @escaping (UIImage?) -> Void) {
-    let efficiently = ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-main-thread")
+    let efficiently = ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-bg-thread")
     func performBlur() {
         let blurredImage = ImageEffects.createBlurredBackdrop(image: image, downsamplingFactor: 1.0, blurRadius: 20.0, tintColor: nil, saturationDeltaFactor: 2.0)
         if efficiently {

--- a/Samples/TrendingMovies/TrendingMovies/Movies/MovieCollectionViewCell.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Movies/MovieCollectionViewCell.swift
@@ -4,6 +4,7 @@ import UIKit
 class MovieCollectionViewCell: UICollectionViewCell {
     static let reuseIdentifier = "MovieCollectionViewCell"
     static let placeholderImageName = "MoviePosterPlaceholder"
+    static let blurWorkQueue = DispatchQueue(label: "io.sentry.sample.trending-movies.queue.blur", qos: .utility, attributes: [.concurrent])
 
     private struct Layout {
         static let imageWidth: CGFloat = 170
@@ -150,6 +151,22 @@ class MovieCollectionViewCell: UICollectionViewCell {
 }
 
 private func blurPosterImage(_ image: UIImage, completion: @escaping (UIImage?) -> Void) {
-    let blurredImage = ImageEffects.createBlurredBackdrop(image: image, downsamplingFactor: 1.0, blurRadius: 20.0, tintColor: nil, saturationDeltaFactor: 2.0)
-    completion(blurredImage)
+    let efficiently = ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-main-thread")
+    func performBlur() {
+        let blurredImage = ImageEffects.createBlurredBackdrop(image: image, downsamplingFactor: 1.0, blurRadius: 20.0, tintColor: nil, saturationDeltaFactor: 2.0)
+        if efficiently {
+            DispatchQueue.main.async {
+                completion(blurredImage)
+            }
+        } else {
+            completion(blurredImage)
+        }
+    }
+    if efficiently {
+        MovieCollectionViewCell.blurWorkQueue.async {
+            performBlur()
+        }
+    } else {
+        performBlur()
+    }
 }

--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -43,6 +43,7 @@ extension Tracer {
 
         SentrySDK.configureScope { scope in
             scope.setTag(value: setUpInDidFinishLaunching ? "didFinishLaunching" : "willFinishLaunching", key: "launch-method")
+            scope.setTag(value: "\(ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-main-thread"))", key: "efficient-implementation")
         }
     }
 }

--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -43,7 +43,7 @@ extension Tracer {
 
         SentrySDK.configureScope { scope in
             scope.setTag(value: setUpInDidFinishLaunching ? "didFinishLaunching" : "willFinishLaunching", key: "launch-method")
-            scope.setTag(value: "\(ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-main-thread"))", key: "efficient-implementation")
+            scope.setTag(value: "\(ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-bg-thread"))", key: "efficient-implementation")
         }
     }
 }


### PR DESCRIPTION
To help with demos, this generates profiles with either an efficient implementation of blurring a background image on a utility queue, vs on the main queue for an inefficient implementation. Each CI run generates multiple sessions; each session flips between using either efficient or inefficient methods. A tag is set on the scope to help find the different profiles.

#skip-changelog