### PR TITLE
test: disable testStartUpCrash_CallsFlush as it flakes

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -56,6 +56,9 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "SentryCrashIntegrationTests/testStartUpCrash_CallsFlush()">
+               </Test>
+               <Test
                   Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readPath_disabled()">
                </Test>
                <Test

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -264,8 +264,9 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         
         assertLocaleOnHub(locale: Locale.autoupdatingCurrent.identifier, hub: hub)
     }
-    
-    func testStartUpCrash_CallsFlush() throws {
+
+    // !!!: Disabled until flakiness can be fixed
+    func testStartUpCrash_CallsFlush_disabled() throws {
         let (sut, hub) = givenSutWithGlobalHubAndCrashWrapper()
         sut.install(with: Options())
         


### PR DESCRIPTION
Disabling per https://github.com/getsentry/sentry-cocoa/issues/2269

#skip-changelog