### PR TITLE
test: use a longer span to compare efficient implementations

### DIFF
--- a/Samples/TrendingMovies/ProfileDataGeneratorUITest/ProfileDataGeneratorUITest.m
+++ b/Samples/TrendingMovies/ProfileDataGeneratorUITest/ProfileDataGeneratorUITest.m
@@ -53,7 +53,7 @@ generateProfileData(NSUInteger nCellsPerTab, BOOL clearState, BOOL efficiently)
     }
     if (efficiently) {
         [launchArguments
-            addObject:@"--io.sentry.sample.trending-movies.launch-arg.blur-images-on-bg-thread"];
+            addObject:@"--io.sentry.sample.trending-movies.launch-arg.efficient-implementation"];
     }
     app.launchArguments = launchArguments;
     [app launch];

--- a/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/TrendingMovies.xcscheme
+++ b/Samples/TrendingMovies/TrendingMovies.xcodeproj/xcshareddata/xcschemes/TrendingMovies.xcscheme
@@ -42,8 +42,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -62,7 +62,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--io.sentry.sample.trending-movies.blur-images-on-bg-thread"
+            argument = "--io.sentry.sample.trending-movies.efficient-implementation"
             isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Samples/TrendingMovies/TrendingMovies/Movies/MovieCollectionViewCell.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Movies/MovieCollectionViewCell.swift
@@ -51,6 +51,8 @@ class MovieCollectionViewCell: UICollectionViewCell {
     }
 
     var downloadTask: DownloadTask?
+    var uncachedDownloadTask: URLSessionDownloadTask?
+    let uncachedURLSession = URLSession(configuration: .ephemeral)
 
     private let posterImageView: UIImageView = {
         let imageView = UIImageView()
@@ -151,7 +153,7 @@ class MovieCollectionViewCell: UICollectionViewCell {
 }
 
 private func blurPosterImage(_ image: UIImage, completion: @escaping (UIImage?) -> Void) {
-    let efficiently = ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-bg-thread")
+    let efficiently = ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.efficient-implementation")
     func performBlur() {
         let blurredImage = ImageEffects.createBlurredBackdrop(image: image, downsamplingFactor: 1.0, blurRadius: 20.0, tintColor: nil, saturationDeltaFactor: 2.0)
         if efficiently {

--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -43,7 +43,7 @@ extension Tracer {
 
         SentrySDK.configureScope { scope in
             scope.setTag(value: setUpInDidFinishLaunching ? "didFinishLaunching" : "willFinishLaunching", key: "launch-method")
-            scope.setTag(value: "\(ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.blur-images-on-bg-thread"))", key: "efficient-implementation")
+            scope.setTag(value: "\(ProcessInfo.processInfo.arguments.contains("--io.sentry.sample.trending-movies.launch-arg.efficient-implementation"))", key: "efficient-implementation")
         }
     }
 }


### PR DESCRIPTION
A previous PR introduced some inefficient implementations to the profile test data generator, so we can compare profiles for demo purposes (#2274). However, the spans it works with are too short. This introduces a span that runs the duration of a scroll operation in TrendingMovies' collection view, providing ample time to collect more information and hopefully produce profiles we can better use for demo purposes.

#skip-changelog