### PR TITLE
test: Use flush in TestObserver

### DIFF
--- a/Tests/SentryTests/TestUtils/SentryTestObserver.m
+++ b/Tests/SentryTests/TestUtils/SentryTestObserver.m
@@ -63,6 +63,8 @@ SentryTestObserver ()
     return self;
 }
 
+#pragma mark - XCTestObservation
+
 - (void)testCaseWillStart:(XCTestCase *)testCase
 {
     SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelDebug
@@ -71,6 +73,11 @@ SentryTestObserver ()
     // The tests might have a different time set
     [crumb setTimestamp:[NSDate new]];
     [self.scope addBreadcrumb:crumb];
+}
+
+- (void)testBundleDidFinish:(NSBundle *)testBundle
+{
+    [SentrySDK flush:5.0];
 }
 
 - (void)testCase:(XCTestCase *)testCase didRecordIssue:(XCTIssue *)issue
@@ -91,11 +98,6 @@ SentryTestObserver ()
     [hub captureException:exception withScope:hub.scope];
 
     [SentryCurrentDate setCurrentDateProvider:currentDateProvider];
-}
-
-- (void)testBundleDidFinish:(NSBundle *)testBundle
-{
-    [SentrySDK flush:5.0];
 }
 
 @end

--- a/Tests/SentryTests/TestUtils/SentryTestObserver.m
+++ b/Tests/SentryTests/TestUtils/SentryTestObserver.m
@@ -95,8 +95,7 @@ SentryTestObserver ()
 
 - (void)testBundleDidFinish:(NSBundle *)testBundle
 {
-    // Wait for events to flush out.
-    [NSThread sleepForTimeInterval:3.0];
+    [SentrySDK flush:5.0];
 }
 
 @end


### PR DESCRIPTION
We can replace thread sleep with flush to wait until the event gets sent to Sentry.

#skip-changelog