### PR TITLE
ci: Generate profile data only on schedule

### DIFF
--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -4,16 +4,6 @@ name: Generate Profiling Test Data
 on:
   schedule:
     - cron: '0 */6 * * *' # every 6 hours = 4x/day
-  push:
-    branches:
-      - master
-  pull_request:
-    paths:
-      - '.github/workflows/profile-data-generator.yml'
-      - 'fastlane/**'
-      - 'Samples/TrendingMovies/**'
-      - '.sauce/profile-data-generator-config.yml'
-      - 'scripts/ci-select-xcode.sh'
 
 jobs:
   build-profile-data-generator-targets:


### PR DESCRIPTION
Only run the profile data generator workflow on schedule.

@armcknight, any reason we should also run them on master and every PR? As they generate data, I think a scheduled run should be sufficient. These runs eat up quite some CI time, and I don't think we need to run them for every PR.

#skip-changelog