### PR TITLE
perf: Use double-checked lock for flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - [Custom measurements API](https://docs.sentry.io/platforms/apple/performance/instrumentation/custom-instrumentation/) (#2268)
 
+
+### Performance Improvements
+
+- Use double-checked lock for flush (#2290)
+
 ## 7.27.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - [Custom measurements API](https://docs.sentry.io/platforms/apple/performance/instrumentation/custom-instrumentation/) (#2268)
 
+### Fixes
+
+- Device info details for profiling (#2205)
 
 ### Performance Improvements
 
 - Use double-checked lock for flush (#2290)
-### Fixes
-
-- Device info details for profiling (#2205)
 
 ## 7.27.1
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -126,6 +126,12 @@ SentryHttpTransport ()
 
 - (BOOL)flush:(NSTimeInterval)timeout
 {
+    // Double-Checked Locking to avoid acquiring unnecessary locks.
+    if (_isFlushing) {
+        SENTRY_LOG_DEBUG(@"SentryHttpTransport: Already flushing.");
+        return NO;
+    }
+
     @synchronized(self) {
         if (_isFlushing) {
             SENTRY_LOG_DEBUG(@"SentryHttpTransport: Already flushing.");

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -38,7 +38,7 @@ class SentryHttpTransportTests: XCTestCase {
         let clientReportEnvelope: SentryEnvelope
         let clientReportRequest: SentryNSURLRequest
         
-        let queue = DispatchQueue(label: "SentryHttpTransportTests", qos: .utility, attributes: [.concurrent, .initiallyInactive])
+        let queue = DispatchQueue(label: "SentryHttpTransportTests", qos: .userInitiated, attributes: [.concurrent, .initiallyInactive])
 
         init() {
             currentDateProvider = TestCurrentDateProvider()
@@ -676,35 +676,56 @@ class SentryHttpTransportTests: XCTestCase {
         CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider.sharedInstance())
         
         givenCachedEvents()
-        fixture.requestManager.responseDelay = fixture.flushTimeout + 0.1
+        fixture.requestManager.responseDelay = fixture.flushTimeout * 2
         
-        var blockingDurations: [TimeInterval] = []
-        var flushResults: [Bool] = []
+        let allFlushCallsGroup = DispatchGroup()
+        let ensureFlushingGroup = DispatchGroup()
+        let ensureFlushingQueue = DispatchQueue(label: "First flushing")
         
-        let queue = fixture.queue
-        let group = DispatchGroup()
-        let count = 1_000
+        allFlushCallsGroup.enter()
+        ensureFlushingGroup.enter()
+        ensureFlushingQueue.async {
+            ensureFlushingGroup.leave()
+            let beforeFlush = getAbsoluteTime()
+            let result = self.sut.flush(self.fixture.flushTimeout)
+            let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
+            
+            XCTAssertFalse(result)
+            XCTAssertLessThan(self.fixture.flushTimeout, blockingDuration)
+            
+            allFlushCallsGroup.leave()
+        }
+        
+        // Ensure transport is flushing.
+        ensureFlushingGroup.waitWithTimeout()
+        
+        // Even when the dispatch group above waited successfully, there is not guarantee
+        // that the transport is already flushing. The queue above could stop it's execution,
+        // and the main thread could continue here. With the blocking call we give the
+        // queue some time to call the blocking flushing method.
+        delayNonBlocking(timeout: 0.1)
+        
+        // Now the transport should also have left the synchronized block, and the
+        // double-checked lock, should return immediately.
+        
+        let initiallyInactiveQueue = fixture.queue
+        let count = 100
         for _ in 0..<count {
-            group.enter()
-            queue.async {
+            allFlushCallsGroup.enter()
+            initiallyInactiveQueue.async {
                 let beforeFlush = getAbsoluteTime()
                 let result = self.sut.flush(self.fixture.flushTimeout)
                 let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
                 
-                queue.async(flags: .barrier) {
-                    blockingDurations.append(blockingDuration)
-                    flushResults.append(result)
-                    group.leave()
-                }
+                XCTAssertGreaterThan(0.1, blockingDuration, "The flush call should have returned immediately.")
+                XCTAssertFalse(result)
+
+                allFlushCallsGroup.leave()
             }
         }
 
-        queue.activate()
-        group.waitWithTimeout()
-        
-        // Only one call should block. The others should return immidiately
-        XCTAssertEqual(count - 1, blockingDurations.filter { $0 < 0.01 }.count)
-        XCTAssertEqual(count, flushResults.filter { $0 == false }.count, "All flush results should be false.")
+        initiallyInactiveQueue.activate()
+        allFlushCallsGroup.waitWithTimeout()
     }
 
     private func givenRetryAfterResponse() -> HTTPURLResponse {


### PR DESCRIPTION




## :scroll: Description

Use a double-checked lock to avoid unnecessary locks when calling flush. Also fix the flaky test testFlush_CalledMultipleTimes_ImmidiatelyReturnsFalse.

If this doesn't fix the flaky test, we could consider removing it or making it less strict. Calling flush on multiple threads in a tight loop is definitely an edge case.

## :bulb: Motivation and Context

I identified that we could use a double-checked lock while investigating the flaky test
`testFlush_CalledMultipleTimes_ImmidiatelyReturnsFalse` GH-2267

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
