### PR TITLE
ci: Reduce saucelabs profile data timeout to 10m

### DIFF
--- a/.sauce/profile-data-generator-config.yml
+++ b/.sauce/profile-data-generator-config.yml
@@ -5,7 +5,7 @@ sauce:
   concurrency: 2
 
 defaults:
-  timeout: 20m
+  timeout: 10m
 
 xcuitest:
   app: ./DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app


### PR DESCRIPTION
The high end tests quite often time out in Saucelabs. The tests usually pass in 10m or less. Reduce the timeout to speed up retry.

#skip-changelog