### PR TITLE
ci: Specify only iPhone Pro for high-end devices

### DIFF
--- a/.sauce/profile-data-generator-config.yml
+++ b/.sauce/profile-data-generator-config.yml
@@ -14,8 +14,7 @@ xcuitest:
 suites:
   - name: "High-end device"
     devices:
-      - name: "iPhone 13 Pro Max"
-        platformVersion: "15"
+      - name: "iPhone .* Pro .*"
   - name: "Mid-range device"
     devices:
       - name: "iPhone 8"


### PR DESCRIPTION
Expand to any iPhone Pro and not only iPhone Pro Max 13 to speed up CI. 
Currently, the run profile data generator for high-end devices often times out, see, for example, https://github.com/getsentry/sentry-cocoa/actions/runs/3247850509/jobs/5329186271

#skip-changelog