### PR TITLE
fix: Fix test hangs when accessing UIScreen.mainScreen

### DIFF
--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -271,7 +271,8 @@ SentryCrashIntegration ()
     [deviceData setValue:locale forKey:LOCALE_KEY];
 
 #if SENTRY_HAS_UIDEVICE && !defined(TESTCI)
-    // Acessessing UIScreen.mainScreen fails when using SentryTestObserver
+    // Acessessing UIScreen.mainScreen fails when using SentryTestObserver.
+    // It's a bug with the iOS 15 and 16 simulator, it runs fine with iOS 14.
     [deviceData setValue:@(UIScreen.mainScreen.bounds.size.height) forKey:@"screen_height_pixels"];
     [deviceData setValue:@(UIScreen.mainScreen.bounds.size.width) forKey:@"screen_width_pixels"];
 #endif

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -270,7 +270,8 @@ SentryCrashIntegration ()
     NSString *locale = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleIdentifier];
     [deviceData setValue:locale forKey:LOCALE_KEY];
 
-#if SENTRY_HAS_UIDEVICE
+#if SENTRY_HAS_UIDEVICE && !defined(TESTCI)
+    // Acessessing UIScreen.mainScreen fails when using SentryTestObserver
     [deviceData setValue:@(UIScreen.mainScreen.bounds.size.height) forKey:@"screen_height_pixels"];
     [deviceData setValue:@(UIScreen.mainScreen.bounds.size.width) forKey:@"screen_width_pixels"];
 #endif

--- a/Tests/SentryTests/TestUtils/SentryTestObserver.m
+++ b/Tests/SentryTests/TestUtils/SentryTestObserver.m
@@ -52,16 +52,11 @@ SentryTestObserver ()
 
         // The SentryCrashIntegration enriches the scope. We need to install the integration
         // once to get the scope data.
+        [SentrySDK startWithOptionsObject:options];
 
-        // When running the SentryTestObserver the code gets stuck when accessing the
-        // UIScreen.mainScreen in SentryCrashIntegration. We disable adding extra context for now.
-        // Ideally we somehow check here if we can access UIScreen.mainScreen, see
-        // https://github.com/getsentry/sentry-cocoa/issues/2284
-        //        [SentrySDK startWithOptionsObject:options];
-        //
-        //        self.scope = [[SentryScope alloc] init];
-        //        [SentryCrashIntegration enrichScope:self.scope
-        //                               crashWrapper:[SentryCrashWrapper sharedInstance]];
+        self.scope = [[SentryScope alloc] init];
+        [SentryCrashIntegration enrichScope:self.scope
+                               crashWrapper:[SentryCrashWrapper sharedInstance]];
 
         self.options = options;
     }


### PR DESCRIPTION
What I found via Google is that it's a bug with the iOS 15 and 16 simulator. And yup, it does run fine with iOS 14.

I don't think there is a "proper" fix for this, and just skipping these 2 lines seems to make a lot more sense than skipping the entire SentrySDK initialization.

Closes #2284
#skip-changelog