### PR TITLE
fix: typos

### DIFF
--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -254,7 +254,7 @@ class SentrySessionTrackerTests: XCTestCase {
         assertEndSessionSent(started: sessionStarted, duration: 1)
     }
     
-    func testAppRunning_LaunchBackgroundTaskImmidiately_UserResumesApp() {
+    func testAppRunning_LaunchBackgroundTaskImmediately_UserResumesApp() {
         let sessionStarted = fixture.currentDateProvider.date()
         sut.start()
         goToForeground()

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -191,7 +191,7 @@ class SentryUIEventTrackerTests: XCTestCase {
         assertFinishesTransaction(firstTransaction, operationClick)
     }
     
-    func testFinishedTransaction_DoesntFinishImmidiately_KeepsTransactionInMemory() {
+    func testFinishedTransaction_DoesntFinishImmediately_KeepsTransactionInMemory() {
         
         // We want firstTransaction to be deallocated by ARC
         func startChild() -> Span {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -672,7 +672,7 @@ class SentryHttpTransportTests: XCTestCase {
         assertFlushBlocksAndFinishesSuccessfully()
     }
     
-    func testFlush_CalledMultipleTimes_ImmidiatelyReturnsFalse() {
+    func testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse() {
         CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider.sharedInstance())
         
         givenCachedEvents()


### PR DESCRIPTION
We should all enable spellchecker in Xcode to help catch these kinds of things: 
<img width="899" alt="image" src="https://user-images.githubusercontent.com/3241469/195910486-8a666b83-728f-4994-a7c8-41f5e4c7071f.png">


#skip-changelog