### PR TITLE
test: shorten profile generation jobs

### DIFF
--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -70,6 +70,7 @@ jobs:
             **/Debug-iphoneos/ProfileDataGeneratorUITest-Runner.app
 
   run-profile-data-generator:
+    timeout-minutes: 10
     name: Run profile generation on Sauce Labs
     runs-on: ubuntu-latest
     needs: build-profile-data-generator-targets
@@ -87,4 +88,5 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: saucectl run --select-suite "${{ matrix.suite }}" --config .sauce/profile-data-generator-config.yml --retries 5
+        run: |
+          saucectl run --select-suite "${{ matrix.suite }}" --config .sauce/profile-data-generator-config.yml ||:


### PR DESCRIPTION
A couple PRs were submitted to try to shorten how long profile generation runs (https://github.com/getsentry/sentry-cocoa/pull/2291 and https://github.com/getsentry/sentry-cocoa/pull/2292). Overall, the job could still run up to an hour (the default GitHub Action timeout) in certain cases.

This sets a timeout on the GitHub action job that runs the saucelabs job, and ignores if that fails (like if it times out on their end). We can see from the dashboard if this job is really failing and can fix it in that case, but this particular workflow should never cause a CI failure since it's not really testing anything, just providing us with test data.

#skip-changelog