### PR TITLE
ci: Reduce unit test timeout to 15 min

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}}
     runs-on: ${{matrix.runs-on}}
-    timeout-minutes: 20
+    timeout-minutes: 15
     needs: build-test-server
 
     strategy:


### PR DESCRIPTION
As we don't have any retry mechanisms, the tests sometimes time out, and the tests usually succeed in around seven minutes or less, we can reduce the timeout to 15 min.

#skip-changelog