### PR TITLE
ci: Timeout for VLC tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -143,6 +143,7 @@ jobs:
   # adding our SDK doesn't cause any major issues.
   vlc-tests:
     runs-on: macos-12
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Add a timeout for the VLC integration tests so they don't keep hanging forever when something goes wrong.

#skip-changelog