### PR TITLE
Enable bitcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Enable bitcode
+- Enable bitcode (#2307)
 
 ## 7.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Offline caching improvements (#2263)
 - Report usage of stitchAsyncCode (#2281)
 
+### Fixes
+
+- Enable bitcode
+
 ## 7.28.0
 
 ### Features

--- a/Sources/Configuration/Sentry.xcconfig
+++ b/Sources/Configuration/Sentry.xcconfig
@@ -20,7 +20,7 @@ SDKROOT__CARTHAGE_ = iphoneos
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY = 1,2,3,4
 SKIP_INSTALL = YES
-
+ENABLE_BITCODE = YES
 DEFINES_MODULE = YES
 DYLIB_COMPATIBILITY_VERSION = 1
 DYLIB_CURRENT_VERSION = 1


### PR DESCRIPTION
## :scroll: Description

Manually enabled bitcode

## :bulb: Motivation and Context

Xcode 14 changed the default value for BitCote to 'NO', now our framework generated with Carthage don't have the bitcode information and this causes warning on customer projects that uses bitcode. 

closes #2304 

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
