### PR TITLE
ci: Rotate test DSN

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -15,7 +15,7 @@ AppDelegate ()
     // Override point for customization after application launch.
 
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-        options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
+        options.dsn = @"https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557";
         options.debug = YES;
         options.sessionTrackingIntervalMillis = 5000UL;
         // Sampling 100% - In Production you probably want to adjust this

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -6,7 +6,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     var window: UIWindow?
 
-    static let defaultDSN = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+    static let defaultDSN = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         

--- a/Samples/iOS-Swift/iOS-SwiftClip/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-SwiftClip/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.beforeSend = { event in
                 return event
             }

--- a/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
@@ -4,7 +4,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    static let defaultDSN = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+    static let defaultDSN = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
                    

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct SwiftUIApp: App {
     init() {
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.sessionTrackingIntervalMillis = 5_000
             // Sampling 100% - In Production you probably want to adjust this

--- a/Samples/iOS15-SwiftUI/iOS15-SwiftUI/App.swift
+++ b/Samples/iOS15-SwiftUI/iOS15-SwiftUI/App.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct SwiftUIApp: App {
     init() {
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.sessionTrackingIntervalMillis = 5_000
             // Sampling 100% - In Production you probably want to adjust this

--- a/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
+++ b/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.sessionTrackingIntervalMillis = 5_000
             // Sampling 100% - In Production you probably want to adjust this

--- a/Samples/tvOS-Swift/tvOS-SBSwift/AppDelegate.swift
+++ b/Samples/tvOS-Swift/tvOS-SBSwift/AppDelegate.swift
@@ -7,7 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.sessionTrackingIntervalMillis = 5_000
             // Sampling 100% - In Production you probably want to adjust this

--- a/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
+++ b/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
@@ -10,7 +10,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
         SentrySDK.start { options in
-            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
             options.sessionTrackingIntervalMillis = 5_000
             // Sampling 100% - In Production you probably want to adjust this

--- a/Tests/SentryTests/TestConstants.swift
+++ b/Tests/SentryTests/TestConstants.swift
@@ -5,7 +5,7 @@ struct TestConstants {
     /**
      * Real dsn for integration tests.
      */
-    static let realDSN: String = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
+    static let realDSN: String = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
     
     static func dsnAsString(username: String) -> String {
         return "https://\(username):password@app.getsentry.com/12345"

--- a/Tests/SentryTests/TestUtils/SentryTestObserver.m
+++ b/Tests/SentryTests/TestUtils/SentryTestObserver.m
@@ -44,7 +44,7 @@ SentryTestObserver ()
 {
     if (self = [super init]) {
         SentryOptions *options = [[SentryOptions alloc] init];
-        options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
+        options.dsn = @"https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557";
         options.environment = @"unit-tests";
         options.debug = YES;
         options.enableAutoSessionTracking = NO;

--- a/scripts/add-sentry-to-alamofire.patch
+++ b/scripts/add-sentry-to-alamofire.patch
@@ -116,7 +116,7 @@ index 1eeafe7..f5f3dea 100644
 +        
 +        if (!SentryInitialized) {
 +            SentrySDK.start { options in
-+                options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
++                options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
 +                options.environment = "integration-tests"
 +                options.tracesSampleRate = 1.0
 +                options.enableFileIOTracking = true

--- a/scripts/add-sentry-to-homekit.patch
+++ b/scripts/add-sentry-to-homekit.patch
@@ -40,7 +40,7 @@ index 8e0e35f4..3d34887d 100644
          didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
      ) -> Bool {
 +        SentrySDK.start { options in
-+            options.dsn = "https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557"
++            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
 +            options.environment = "integration-tests"
 +            options.tracesSampleRate = 1.0
 +            options.enableFileIOTracking = true

--- a/scripts/add-sentry-to-vlc.patch
+++ b/scripts/add-sentry-to-vlc.patch
@@ -27,7 +27,7 @@ index 2c1fc802..21495fd7 100644
  - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
  {
 +    [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
-+        options.dsn = @"https://a92d50327ac74b8b9aa4ea80eccfb267@o447951.ingest.sentry.io/5428557";
++        options.dsn = @"https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557";
 +        options.environment = @"integration-tests";
 +        options.tracesSampleRate = @1.0;
 +        options.enableFileIOTracking = YES;


### PR DESCRIPTION
It seems like somebody is using our test DSN. Let's rotate it and
soon deprecate the old one to eliminate the noise.

#skip-changelog