### PR TITLE
ci: Fix TestFlight upload with workaround

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-      - ci/fix-fastlane
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - ci/fix-fastlane
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,6 +181,11 @@ platform :ios do
       key_content: ENV["APP_STORE_CONNECT_KEY"]
     )
 
+    # Workaround for https://github.com/fastlane/fastlane/issues/20741
+    environment_variable(set: {
+      'ITMSTRANSPORTER_FORCE_ITMS_PACKAGE_UPLOAD' => 'true'
+    })
+
     testflight
 
     download_dsyms(


### PR DESCRIPTION
Use a workaround pointed out in https://github.com/fastlane/fastlane/issues/20741. 

Fixes https://github.com/getsentry/sentry-cocoa/issues/2309

Workaround works see https://github.com/getsentry/sentry-cocoa/actions/runs/3295118090/jobs/5433332076

#skip-changelog