### PR TITLE
Disable testProfilingDataContainsEnvironmentSetFromConfigureScope

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -68,6 +68,9 @@
                   Identifier = "SentryHttpTransportTests/testFlush_CalledSequentially_BlocksTwice_disabled()">
                </Test>
                <Test
+                  Identifier = "SentryHubTests/testProfilingDataContainsEnvironmentSetFromConfigureScope_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentryHubTests/testStartTransaction_ProfilingDataIsValid_disabled()">
                </Test>
                <Test

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -881,7 +881,7 @@ extension SentryHubTests {
         }
     }
 
-    func testProfilingDataContainsEnvironmentSetFromConfigureScope() {
+    func testProfilingDataContainsEnvironmentSetFromConfigureScope_disabled() {
         let options = fixture.options
         options.profilesSampleRate = 1.0
         options.tracesSampler = {(_: SamplingContext) -> NSNumber in


### PR DESCRIPTION
#skip-changelog

Issue to fix it https://github.com/getsentry/sentry-cocoa/issues/2314