### PR TITLE
test: Collect MetricKit payloads

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		637AFDB6243B02770034958B /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB4243B02770034958B /* LaunchScreen.storyboard */; };
 		7B3427F825876A5200056519 /* Tongariro.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7B3427F725876A5200056519 /* Tongariro.jpg */; };
 		7B64386B26A6C544000D0F65 /* LaunchUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B64386A26A6C544000D0F65 /* LaunchUITests.swift */; };
+		7B79000429028C7300A7F467 /* MetricKitManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B79000329028C7300A7F467 /* MetricKitManager.swift */; };
 		7BFC8B0626D4D24B000D3504 /* LoremIpsum.txt in Resources */ = {isa = PBXBuildFile; fileRef = 7BFC8B0526D4D24B000D3504 /* LoremIpsum.txt */; };
 		844DA821282584C300E6B62E /* CoreDataViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F57BC427BBD787000D09D4 /* CoreDataViewController.swift */; };
 		844DA822282584F700E6B62E /* SentryData.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = D845F35927BAD4CC00A4D7A2 /* SentryData.xcdatamodeld */; };
@@ -240,6 +241,7 @@
 		7B64386826A6C544000D0F65 /* iOS-SwiftUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS-SwiftUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B64386A26A6C544000D0F65 /* LaunchUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchUITests.swift; sourceTree = "<group>"; };
 		7B64386C26A6C544000D0F65 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7B79000329028C7300A7F467 /* MetricKitManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricKitManager.swift; sourceTree = "<group>"; };
 		7BFC8B0526D4D24B000D3504 /* LoremIpsum.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LoremIpsum.txt; sourceTree = "<group>"; };
 		848A2573286E3351008A8858 /* PerformanceBenchmarks.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PerformanceBenchmarks.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		848A2578286E3490008A8858 /* PerformanceBenchmarks-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PerformanceBenchmarks-Info.plist"; sourceTree = "<group>"; };
@@ -493,6 +495,7 @@
 		D8DBDA74274D4E1600007380 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				7B79000329028C7300A7F467 /* MetricKitManager.swift */,
 				84FB8125284001B800F3A94A /* SentryBenchmarking.h */,
 				84FB8129284001B800F3A94A /* SentryBenchmarking.mm */,
 				D8F3D04F274E572F00B56F8C /* DSNStorage.swift */,
@@ -802,6 +805,7 @@
 				D8F3D052274E572F00B56F8C /* DSNStorage.swift in Sources */,
 				D8F3D054274E572F00B56F8C /* RandomErrors.swift in Sources */,
 				D8D7BB4C2750095800044146 /* UIViewExtension.swift in Sources */,
+				7B79000429028C7300A7F467 /* MetricKitManager.swift in Sources */,
 				D8D7BB4A2750067900044146 /* UIAssert.swift in Sources */,
 				D8F3D057274E574200B56F8C /* LoremIpsumViewController.swift in Sources */,
 				D8DBDA78274D5FC400007380 /* SplitViewController.swift in Sources */,

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -42,6 +42,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.appHangTimeoutInterval = 2
         }
         
+        if #available(iOS 14.0, *) {
+            metricKit.receiveReports()
+        }
+        
         return true
+    }
+    
+    func applicationWillTerminate(_ application: UIApplication) {
+        if #available(iOS 14.0, *) {
+            metricKit.pauseReports()
+        }
+    }
+    
+    // Workaround for 'Stored properties cannot be marked potentially unavailable with '@available''
+    private var _metricKit: Any?
+    @available(iOS 14.0, *)
+    fileprivate var metricKit: MetricKitManager {
+        if _metricKit == nil {
+            _metricKit = MetricKitManager()
+        }
+        return _metricKit as! MetricKitManager
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -62,6 +62,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if _metricKit == nil {
             _metricKit = MetricKitManager()
         }
+        
+        // We know the type so it's fine to force cast.
+        // swiftlint:disable force_cast
         return _metricKit as! MetricKitManager
+        // swiftlint:enable force_cast
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/Tools/MetricKitManager.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/MetricKitManager.swift
@@ -1,0 +1,40 @@
+import Foundation
+import MetricKit
+import Sentry
+
+@available(iOS 14.0, *)
+class MetricKitManager: NSObject, MXMetricManagerSubscriber {
+    func receiveReports() {
+        let shared = MXMetricManager.shared
+        shared.add(self)
+    }
+    
+    func pauseReports() {
+        let shared = MXMetricManager.shared
+        shared.remove(self)
+    }
+    
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        var attachments: [Attachment] = []
+        for payload in payloads {
+            let attachment = Attachment(data: payload.jsonRepresentation(), filename: "MXDiagnosticPayload.json")
+            attachments.append(attachment)
+        }
+        
+        SentrySDK.capture(message: "MetricKit received MXMetricPayload.") { scope in
+            attachments.forEach { scope.add($0) }
+        }
+    }
+    
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        var attachments: [Attachment] = []
+        for payload in payloads {
+            let attachment = Attachment(data: payload.jsonRepresentation(), filename: "MXDiagnosticPayload.json")
+            attachments.append(attachment)
+        }
+        
+        SentrySDK.capture(message: "MetricKit received MXDiagnosticPayload.") { scope in
+            attachments.forEach { scope.add($0) }
+        }
+    }
+}


### PR DESCRIPTION
Add code to the iOS-Swift sample app to collect MetricKit payloads by sending them to Sentry as receiving an MXDiagnosticPayload via Xcode debug Simulate MeticKit Payload doesn't work.

Related to https://github.com/getsentry/sentry-cocoa/issues/1661

#skip-changelog