### PR TITLE
ref: Remove not existent SentryContext

### DIFF
--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -5,7 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryThread, SentryException, SentryStacktrace, SentryUser, SentryDebugMeta, SentryContext,
+@class SentryThread, SentryException, SentryStacktrace, SentryUser, SentryDebugMeta,
     SentryBreadcrumb, SentryId, SentryMessage;
 
 NS_SWIFT_NAME(Event)


### PR DESCRIPTION
The SentryEvent had a @class definition for SentryContext, which doesn't exist.

#skip-changelog