### PR TITLE
fix: Fix moving app state to previous app state

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -402,6 +402,11 @@ SentryFileManager ()
 {
     @synchronized(self.appStateFilePath) {
         NSFileManager *fileManager = [NSFileManager defaultManager];
+
+        // We first need to remove the old previous app state file,
+        // or we can't move the current app state file to it.
+        [self removeFileAtPath:self.previousAppStateFilePath];
+
         NSError *error = nil;
         [fileManager moveItemAtPath:self.appStateFilePath
                              toPath:self.previousAppStateFilePath

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -488,6 +488,18 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(TestData.appState, actual)
     }
 
+    func testMoveAppStateWhenPreviousAppStateAlreadyExists() {
+        sut.store(TestData.appState)
+        sut.moveAppStateToPreviousAppState()
+
+        let newAppState = SentryAppState(releaseName: "2.0.0", osVersion: "14.4.1", vendorId: "12345678-1234-1234-1234-12344567890AB", isDebugging: false, systemBootTimestamp: Date(timeIntervalSince1970: 10))
+        sut.store(newAppState)
+        sut.moveAppStateToPreviousAppState()
+
+        let actual = sut.readPreviousAppState()
+        XCTAssertEqual(newAppState, actual)
+    }
+
     func testStoreAndReadTimezoneOffset() {
         sut.storeTimezoneOffset(7_200)
         XCTAssertEqual(sut.readTimezoneOffset(), 7_200)


### PR DESCRIPTION
This is a very high priority fix for an issue introduced in #2250

```
2022-10-24 14:37:46.961457+0200 iOS-Swift[719:27083] Sentry - error:: Failed to move app state to previous app state: Error Domain=NSCocoaErrorDomain Code=516 "“app.state” couldn’t be moved to “b810aaca937def33af3796f237e6793ec907f1e4” because an item with the same name already exists." UserInfo={NSSourceFilePathErrorKey=/var/mobile/Containers/Data/Application/C3AC2606-338F-40F4-A24C-FEA67EC08FF4/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/app.state, NSUserStringVariant=(
    Move
), NSDestinationFilePath=/var/mobile/Containers/Data/Application/C3AC2606-338F-40F4-A24C-FEA67EC08FF4/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/previous.app.state, NSFilePath=/var/mobile/Containers/Data/Application/C3AC2606-338F-40F4-A24C-FEA67EC08FF4/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/app.state, NSUnderlyingError=0x280e646f0 {Error Domain=NSPOSIXErrorDomain Code=17 "File exists"}}
```

Added a unit test to make sure this doesn't happen again.