### PR TITLE
fix: CoreData tracking entity name retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Enable bitcode (#2307)
 - Fix moving app state to previous app state (#2321)
+- Use CoreData entity names instead of "NSManagedObject" (#2329)
 
 ## 7.28.0
 

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -108,11 +108,11 @@
     __block NSMutableArray *resultParts = [NSMutableArray new];
 
     void (^operationInfo)(NSUInteger, NSString *) = ^void(NSUInteger total, NSString *op) {
-        NSDictionary *itens = operations[op];
-        if (itens && itens.count > 0) {
-            if (itens.count == 1) {
+        NSDictionary *items = operations[op];
+        if (items && items.count > 0) {
+            if (items.count == 1) {
                 [resultParts addObject:[NSString stringWithFormat:@"%@ %@ '%@'", op,
-                                                 itens.allValues[0], itens.allKeys[0]]];
+                                                 items.allValues[0], items.allKeys[0]]];
             } else {
                 [resultParts addObject:[NSString stringWithFormat:@"%@ %lu items", op,
                                                  (unsigned long)total]];
@@ -147,8 +147,8 @@
 {
     NSMutableDictionary<NSString *, NSNumber *> *result = [NSMutableDictionary new];
 
-    for (id item in entities) {
-        NSString *cl = NSStringFromClass([item class]);
+    for (NSManagedObject *item in entities) {
+        NSString *cl = item.entity.name;
         NSNumber *count = result[cl];
         result[cl] = [NSNumber numberWithInt:count.intValue + 1];
     }

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -9,11 +9,17 @@ class SentryCoreDataTrackerTests: XCTestCase {
         func getSut() -> SentryCoreDataTracker {
             return SentryCoreDataTracker()
         }
-        
+
         func testEntity() -> TestEntity {
             let entityDescription = NSEntityDescription()
             entityDescription.name = "TestEntity"
             return TestEntity(entity: entityDescription, insertInto: context)
+        }
+
+        func secondTestEntity() -> SecondTestEntity {
+            let entityDescription = NSEntityDescription()
+            entityDescription.name = "SecondTestEntity"
+            return SecondTestEntity(entity: entityDescription, insertInto: context)
         }
     }
     
@@ -72,68 +78,68 @@ class SentryCoreDataTrackerTests: XCTestCase {
     }
     
     func test_Save_1Insert_1Entity() {
-        fixture.context.inserted = [TestEntity()]
+        fixture.context.inserted = [fixture.testEntity()]
         assertSave("INSERTED 1 'TestEntity'")
     }
     
     func test_Save_2Insert_1Entity() {
-        fixture.context.inserted = [TestEntity(), TestEntity()]
+        fixture.context.inserted = [fixture.testEntity(), fixture.testEntity()]
         assertSave("INSERTED 2 'TestEntity'")
     }
     
     func test_Save_2Insert_2Entity() {
-        fixture.context.inserted = [TestEntity(), SecondTestEntity()]
+        fixture.context.inserted = [fixture.testEntity(), fixture.secondTestEntity()]
         assertSave("INSERTED 2 items")
     }
     
     func test_Save_1Update_1Entity() {
-        fixture.context.updated = [TestEntity()]
+        fixture.context.updated = [fixture.testEntity()]
         assertSave("UPDATED 1 'TestEntity'")
     }
     
     func test_Save_2Update_1Entity() {
-        fixture.context.updated = [TestEntity(), TestEntity()]
+        fixture.context.updated = [fixture.testEntity(), fixture.testEntity()]
         assertSave("UPDATED 2 'TestEntity'")
     }
     
     func test_Save_2Update_2Entity() {
-        fixture.context.updated = [TestEntity(), SecondTestEntity()]
+        fixture.context.updated = [fixture.testEntity(), fixture.secondTestEntity()]
         assertSave("UPDATED 2 items")
     }
     
     func test_Save_1Delete_1Entity() {
-        fixture.context.deleted = [TestEntity()]
+        fixture.context.deleted = [fixture.testEntity()]
         assertSave("DELETED 1 'TestEntity'")
     }
     
     func test_Save_2Delete_1Entity() {
-        fixture.context.deleted = [TestEntity(), TestEntity()]
+        fixture.context.deleted = [fixture.testEntity(), fixture.testEntity()]
         assertSave("DELETED 2 'TestEntity'")
     }
     
     func test_Save_2Delete_2Entity() {
-        fixture.context.deleted = [TestEntity(), SecondTestEntity()]
+        fixture.context.deleted = [fixture.testEntity(), fixture.secondTestEntity()]
         assertSave("DELETED 2 items")
     }
     
     func test_Save_Insert_Update_Delete_1Entity() {
-        fixture.context.inserted = [TestEntity()]
-        fixture.context.updated = [TestEntity()]
-        fixture.context.deleted = [TestEntity()]
+        fixture.context.inserted = [fixture.testEntity()]
+        fixture.context.updated = [fixture.testEntity()]
+        fixture.context.deleted = [fixture.testEntity()]
         assertSave("INSERTED 1 'TestEntity', UPDATED 1 'TestEntity', DELETED 1 'TestEntity'")
     }
     
     func test_Save_Insert_Update_Delete_2Entity() {
-        fixture.context.inserted = [TestEntity(), SecondTestEntity()]
-        fixture.context.updated = [TestEntity(), SecondTestEntity()]
-        fixture.context.deleted = [TestEntity(), SecondTestEntity()]
+        fixture.context.inserted = [fixture.testEntity(), fixture.secondTestEntity()]
+        fixture.context.updated = [fixture.testEntity(), fixture.secondTestEntity()]
+        fixture.context.deleted = [fixture.testEntity(), fixture.secondTestEntity()]
         assertSave("INSERTED 2 items, UPDATED 2 items, DELETED 2 items")
     }
     
     func test_Operation_InData() {
-        fixture.context.inserted = [TestEntity(), TestEntity(), SecondTestEntity()]
-        fixture.context.updated = [TestEntity(), SecondTestEntity(), SecondTestEntity()]
-        fixture.context.deleted = [TestEntity(), TestEntity(), SecondTestEntity(), SecondTestEntity(), SecondTestEntity()]
+        fixture.context.inserted = [fixture.testEntity(), fixture.testEntity(), fixture.secondTestEntity()]
+        fixture.context.updated = [fixture.testEntity(), fixture.secondTestEntity(), fixture.secondTestEntity()]
+        fixture.context.deleted = [fixture.testEntity(), fixture.testEntity(), fixture.secondTestEntity(), fixture.secondTestEntity(), fixture.secondTestEntity()]
         
         let sut = fixture.getSut()
         

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -17,12 +17,6 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         func getSut() -> SentryCoreDataTrackingIntegration {
             return SentryCoreDataTrackingIntegration()
         }
-        
-        func testEntity() -> TestEntity {
-            let entityDescription = NSEntityDescription()
-            entityDescription.name = "TestEntity"
-            return TestEntity(entity: entityDescription, insertInto: nil)
-        }
     }
     
     private var fixture: Fixture!

--- a/Tests/SentryTests/Integrations/Performance/CoreData/TestCoreDataStack.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/TestCoreDataStack.swift
@@ -5,12 +5,20 @@ import Foundation
 public class TestEntity: NSManagedObject {
     var field1: String?
     var field2: Int?
+
+    public override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
 }
 
 @objc(SecondTestEntity)
 public class SecondTestEntity: NSManagedObject {
     var field1: String?
     var field2: Int?
+
+    public override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
+        super.init(entity: entity, insertInto: context)
+    }
 }
 
 class TestCoreDataStack {


### PR DESCRIPTION
Fixes #2328 and possible bug in CoreData tracker.

I originally noticed a system error logged for us using a non-designated initializer for an NSManagedObject subclass. Fixing that led to some test failures: 

![image](https://user-images.githubusercontent.com/3241469/197859316-d48e9aef-799b-4709-ae24-f8d8f61160f0.png)


which led to me discovering that we might have only ever tracked CoreData entity transactions using "NSManagedObject" in the span descriptions instead of the actual entity names being used by developers.