### PR TITLE
fix: Fixed flaky testTimezoneChangeNotificationBreadcrumb

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -82,9 +82,6 @@
                <Test
                   Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces_disabled()">
                </Test>
-               <Test
-                  Identifier = "SentrySystemEventBreadcrumbsTest/testTimezoneChangeNotificationBreadcrumb_disabled()">
-               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
@@ -16,6 +16,7 @@ SENTRY_NO_INIT
 
 #if TARGET_OS_IOS
 - (void)start:(UIDevice *)currentDevice;
+- (void)timezoneEventTriggered;
 #endif
 
 - (void)stop;

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -252,13 +252,16 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         }
     }
 
-    func testTimezoneChangeNotificationBreadcrumb_disabled() {
+    func testTimezoneChangeNotificationBreadcrumb() {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: nil)
 
         fixture.currentDateProvider.timezoneOffsetValue = 7_200
 
         NotificationCenter.default.post(Notification(name: NSNotification.Name.NSSystemTimeZoneDidChange))
+
+        Thread.sleep(forTimeInterval: 0.1)
+
         assertBreadcrumbAction(scope: scope, action: "TIMEZONE_CHANGE") { data in
             XCTAssertEqual(data["previous_seconds_from_gmt"] as? Int, 0)
             XCTAssertEqual(data["current_seconds_from_gmt"] as? Int, 7_200)

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -258,9 +258,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
 
         fixture.currentDateProvider.timezoneOffsetValue = 7_200
 
-        NotificationCenter.default.post(Notification(name: NSNotification.Name.NSSystemTimeZoneDidChange))
-
-        Thread.sleep(forTimeInterval: 0.1)
+        sut.timezoneEventTriggered()
 
         assertBreadcrumbAction(scope: scope, action: "TIMEZONE_CHANGE") { data in
             XCTAssertEqual(data["previous_seconds_from_gmt"] as? Int, 0)


### PR DESCRIPTION
Locally it never failed; I can run it 1000 times repeatedly and it will succeed just fine. Maybe adding this tiny sleep will help on CI.

Closes #2247
#skip-changelog