### PR TITLE
meta: add log source to format; update log format

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -84,16 +84,15 @@ SentryHttpTransport ()
         [self sendAllCachedEnvelopes];
 
 #if !TARGET_OS_WATCH
-        [self.reachability
-               monitorURL:[NSURL URLWithString:@"https://sentry.io"]
-            usingCallback:^(BOOL connected, NSString *_Nonnull typeDescription) {
-                if (connected) {
-                    SENTRY_LOG_DEBUG(@"SentryHttpTransport: Internet connection is back.");
-                    [self sendAllCachedEnvelopes];
-                } else {
-                    SENTRY_LOG_DEBUG(@"SentryHttpTransport: Lost internet connection.");
-                }
-            }];
+        [self.reachability monitorURL:[NSURL URLWithString:@"https://sentry.io"]
+                        usingCallback:^(BOOL connected, NSString *_Nonnull typeDescription) {
+                            if (connected) {
+                                SENTRY_LOG_DEBUG(@"Internet connection is back.");
+                                [self sendAllCachedEnvelopes];
+                            } else {
+                                SENTRY_LOG_DEBUG(@"Lost internet connection.");
+                            }
+                        }];
 #endif
     }
     return self;
@@ -111,7 +110,7 @@ SentryHttpTransport ()
     envelope = [self.envelopeRateLimit removeRateLimitedItems:envelope];
 
     if (envelope.items.count == 0) {
-        SENTRY_LOG_DEBUG(@"SentryHttpTransport: RateLimit is active for all envelope items.");
+        SENTRY_LOG_DEBUG(@"RateLimit is active for all envelope items.");
         return;
     }
 
@@ -154,17 +153,17 @@ SentryHttpTransport ()
 {
     // Double-Checked Locking to avoid acquiring unnecessary locks.
     if (_isFlushing) {
-        SENTRY_LOG_DEBUG(@"SentryHttpTransport: Already flushing.");
+        SENTRY_LOG_DEBUG(@"Already flushing.");
         return NO;
     }
 
     @synchronized(self) {
         if (_isFlushing) {
-            SENTRY_LOG_DEBUG(@"SentryHttpTransport: Already flushing.");
+            SENTRY_LOG_DEBUG(@"Already flushing.");
             return NO;
         }
 
-        SENTRY_LOG_DEBUG(@"SentryHttpTransport: Start flushing.");
+        SENTRY_LOG_DEBUG(@"Start flushing.");
 
         _isFlushing = YES;
         dispatch_group_enter(self.dispatchGroup);
@@ -182,10 +181,10 @@ SentryHttpTransport ()
     }
 
     if (result == 0) {
-        SENTRY_LOG_DEBUG(@"SentryHttpTransport: Finished flushing.");
+        SENTRY_LOG_DEBUG(@"Finished flushing.");
         return YES;
     } else {
-        SENTRY_LOG_DEBUG(@"SentryHttpTransport: Flushing timed out.");
+        SENTRY_LOG_DEBUG(@"Flushing timed out.");
         return NO;
     }
 }
@@ -239,11 +238,11 @@ SentryHttpTransport ()
 
 - (void)sendAllCachedEnvelopes
 {
-    SENTRY_LOG_DEBUG(@"SentryHttpTransport: sendAllCachedEnvelopes start.");
+    SENTRY_LOG_DEBUG(@"sendAllCachedEnvelopes start.");
 
     @synchronized(self) {
         if (self.isSending || ![self.requestManager isReady]) {
-            SENTRY_LOG_DEBUG(@"SentryHttpTransport: Already sending.");
+            SENTRY_LOG_DEBUG(@"Already sending.");
             return;
         }
         self.isSending = YES;
@@ -251,7 +250,7 @@ SentryHttpTransport ()
 
     SentryFileContents *envelopeFileContents = [self.fileManager getOldestEnvelope];
     if (nil == envelopeFileContents) {
-        SENTRY_LOG_DEBUG(@"SentryHttpTransport: No envelopes left to send.");
+        SENTRY_LOG_DEBUG(@"No envelopes left to send.");
         [self finishedSending];
         return;
     }
@@ -286,7 +285,7 @@ SentryHttpTransport ()
 
 - (void)deleteEnvelopeAndSendNext:(NSString *)envelopePath
 {
-    SENTRY_LOG_DEBUG(@"SentryHttpTransport: Deleting envelope and sending next.");
+    SENTRY_LOG_DEBUG(@"Deleting envelope and sending next.");
     [self.fileManager removeFileAtPath:envelopePath];
     self.isSending = NO;
     [self.dispatchQueue dispatchAfter:cachedEnvelopeSendDelay
@@ -310,7 +309,7 @@ SentryHttpTransport ()
                 [_self.rateLimits update:response];
                 [_self deleteEnvelopeAndSendNext:envelopePath];
             } else {
-                SENTRY_LOG_DEBUG(@"SentryHttpTransport: No internet connection.");
+                SENTRY_LOG_DEBUG(@"No internet connection.");
                 [_self finishedSending];
             }
         }];
@@ -318,11 +317,11 @@ SentryHttpTransport ()
 
 - (void)finishedSending
 {
-    SENTRY_LOG_DEBUG(@"SentryHttpTransport: Finished sending.");
+    SENTRY_LOG_DEBUG(@"Finished sending.");
     @synchronized(self) {
         self.isSending = NO;
         if (self.isFlushing) {
-            SENTRY_LOG_DEBUG(@"SentryHttpTransport: Stop flushing.");
+            SENTRY_LOG_DEBUG(@"Stop flushing.");
             self.isFlushing = NO;
             dispatch_group_leave(self.dispatchGroup);
         }

--- a/Sources/Sentry/SentryLog.m
+++ b/Sources/Sentry/SentryLog.m
@@ -26,7 +26,7 @@ static SentryLogOutput *logOutput;
     }
 
     if (isDebug && level != kSentryLevelNone && level >= diagnosticLevel) {
-        [logOutput log:[NSString stringWithFormat:@"Sentry - %@:: %@", nameForSentryLevel(level),
+        [logOutput log:[NSString stringWithFormat:@"[Sentry] [%@] %@", nameForSentryLevel(level),
                                  message]];
     }
 }

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -599,10 +599,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
     NSError *error = nil;
     const auto JSONData = [SentrySerialization dataWithJSONObject:profile error:&error];
     if (JSONData == nil) {
-        [SentryLog
-            logWithMessage:[NSString
-                               stringWithFormat:@"Failed to encode profile to JSON: %@", error]
-                  andLevel:kSentryLevelError];
+        SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON: %@", error);
         return;
     }
 

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -16,15 +16,35 @@ SENTRY_NO_INIT
 NS_ASSUME_NONNULL_END
 
 #define SENTRY_LOG_DEBUG(...)                                                                      \
-    [SentryLog logWithMessage:[NSString stringWithFormat:__VA_ARGS__] andLevel:kSentryLevelDebug]
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+                                        [[[NSString stringWithUTF8String:__FILE__]                 \
+                                            lastPathComponent] stringByDeletingPathExtension],     \
+                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                     andLevel:kSentryLevelDebug]
 #define SENTRY_LOG_INFO(...)                                                                       \
-    [SentryLog logWithMessage:[NSString stringWithFormat:__VA_ARGS__] andLevel:kSentryLevelInfo]
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+                                        [[[NSString stringWithUTF8String:__FILE__]                 \
+                                            lastPathComponent] stringByDeletingPathExtension],     \
+                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                     andLevel:kSentryLevelInfo]
 #define SENTRY_LOG_WARN(...)                                                                       \
-    [SentryLog logWithMessage:[NSString stringWithFormat:__VA_ARGS__] andLevel:kSentryLevelWarning]
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+                                        [[[NSString stringWithUTF8String:__FILE__]                 \
+                                            lastPathComponent] stringByDeletingPathExtension],     \
+                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                     andLevel:kSentryLevelWarning]
 #define SENTRY_LOG_ERROR(...)                                                                      \
-    [SentryLog logWithMessage:[NSString stringWithFormat:__VA_ARGS__] andLevel:kSentryLevelError]
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+                                        [[[NSString stringWithUTF8String:__FILE__]                 \
+                                            lastPathComponent] stringByDeletingPathExtension],     \
+                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                     andLevel:kSentryLevelError]
 #define SENTRY_LOG_CRITICAL(...)                                                                   \
-    [SentryLog logWithMessage:[NSString stringWithFormat:__VA_ARGS__] andLevel:kSentryLevelCritical]
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+                                        [[[NSString stringWithUTF8String:__FILE__]                 \
+                                            lastPathComponent] stringByDeletingPathExtension],     \
+                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                     andLevel:kSentryLevelCritical]
 
 /**
  * If `errno` is set to a non-zero value after `statement` finishes executing,

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -16,34 +16,34 @@ SENTRY_NO_INIT
 NS_ASSUME_NONNULL_END
 
 #define SENTRY_LOG_DEBUG(...)                                                                      \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
                                         [[[NSString stringWithUTF8String:__FILE__]                 \
                                             lastPathComponent] stringByDeletingPathExtension],     \
-                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
                      andLevel:kSentryLevelDebug]
 #define SENTRY_LOG_INFO(...)                                                                       \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
                                         [[[NSString stringWithUTF8String:__FILE__]                 \
                                             lastPathComponent] stringByDeletingPathExtension],     \
-                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
                      andLevel:kSentryLevelInfo]
 #define SENTRY_LOG_WARN(...)                                                                       \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
                                         [[[NSString stringWithUTF8String:__FILE__]                 \
                                             lastPathComponent] stringByDeletingPathExtension],     \
-                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
                      andLevel:kSentryLevelWarning]
 #define SENTRY_LOG_ERROR(...)                                                                      \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
                                         [[[NSString stringWithUTF8String:__FILE__]                 \
                                             lastPathComponent] stringByDeletingPathExtension],     \
-                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
                      andLevel:kSentryLevelError]
 #define SENTRY_LOG_CRITICAL(...)                                                                   \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@] %@",                               \
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
                                         [[[NSString stringWithUTF8String:__FILE__]                 \
                                             lastPathComponent] stringByDeletingPathExtension],     \
-                                        [NSString stringWithFormat:__VA_ARGS__]]                   \
+                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
                      andLevel:kSentryLevelCritical]
 
 /**

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -14,37 +14,17 @@ SENTRY_NO_INIT
 @end
 
 NS_ASSUME_NONNULL_END
-
-#define SENTRY_LOG_DEBUG(...)                                                                      \
+#define SENTRY_LOG(_SENTRY_LOG_LEVEL, ...)                                                         \
     [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
                                         [[[NSString stringWithUTF8String:__FILE__]                 \
                                             lastPathComponent] stringByDeletingPathExtension],     \
                                         __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
-                     andLevel:kSentryLevelDebug]
-#define SENTRY_LOG_INFO(...)                                                                       \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
-                                        [[[NSString stringWithUTF8String:__FILE__]                 \
-                                            lastPathComponent] stringByDeletingPathExtension],     \
-                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
-                     andLevel:kSentryLevelInfo]
-#define SENTRY_LOG_WARN(...)                                                                       \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
-                                        [[[NSString stringWithUTF8String:__FILE__]                 \
-                                            lastPathComponent] stringByDeletingPathExtension],     \
-                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
-                     andLevel:kSentryLevelWarning]
-#define SENTRY_LOG_ERROR(...)                                                                      \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
-                                        [[[NSString stringWithUTF8String:__FILE__]                 \
-                                            lastPathComponent] stringByDeletingPathExtension],     \
-                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
-                     andLevel:kSentryLevelError]
-#define SENTRY_LOG_CRITICAL(...)                                                                   \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
-                                        [[[NSString stringWithUTF8String:__FILE__]                 \
-                                            lastPathComponent] stringByDeletingPathExtension],     \
-                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
-                     andLevel:kSentryLevelCritical]
+                     andLevel:_SENTRY_LOG_LEVEL]
+#define SENTRY_LOG_DEBUG(...) SENTRY_LOG(kSentryLevelDebug, __VA_ARGS__)
+#define SENTRY_LOG_INFO(...) SENTRY_LOG(kSentryLevelInfo, __VA_ARGS__)
+#define SENTRY_LOG_WARN(...) SENTRY_LOG(kSentryLevelWarning, __VA_ARGS__)
+#define SENTRY_LOG_ERROR(...) SENTRY_LOG(kSentryLevelError, __VA_ARGS__)
+#define SENTRY_LOG_FATAL(...) SENTRY_LOG(kSentryLevelFatal, __VA_ARGS__)
 
 /**
  * If `errno` is set to a non-zero value after `statement` finishes executing,

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -28,7 +28,7 @@ class SentryLogTests: XCTestCase {
         SentryLog.log(withMessage: "2", andLevel: SentryLevel.warning)
         SentryLog.log(withMessage: "3", andLevel: SentryLevel.none)
         
-        XCTAssertEqual(["Sentry - fatal:: 0", "Sentry - error:: 1"], logOutput.loggedMessages)
+        XCTAssertEqual(["[Sentry] [fatal] 0", "[Sentry] [error] 1"], logOutput.loggedMessages)
     }
     
     func testDefaultInitOfLogoutPut() {
@@ -62,10 +62,10 @@ class SentryLogTests: XCTestCase {
         SentryLog.log(withMessage: "4", andLevel: SentryLevel.debug)
         SentryLog.log(withMessage: "5", andLevel: SentryLevel.none)
         
-        XCTAssertEqual(["Sentry - fatal:: 0",
-                        "Sentry - error:: 1",
-                        "Sentry - warning:: 2",
-                        "Sentry - info:: 3",
-                        "Sentry - debug:: 4"], logOutput.loggedMessages)
+        XCTAssertEqual(["[Sentry] [fatal] 0",
+                        "[Sentry] [error] 1",
+                        "[Sentry] [warning] 2",
+                        "[Sentry] [info] 3",
+                        "[Sentry] [debug] 4"], logOutput.loggedMessages)
     }
 }

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -46,6 +46,6 @@ class SentryBaseIntegrationTests: XCTestCase {
         options.enableAutoSessionTracking = false
         let result = sut.install(with: options)
         XCTAssertFalse(result)
-        XCTAssertEqual(["[Sentry] [debug] [SentryBaseIntegration] Not going to enable SentryTests.MyTestIntegration because enableAutoSessionTracking is disabled."], logOutput.loggedMessages)
+        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains("Not going to enable SentryTests.MyTestIntegration because enableAutoSessionTracking is disabled.") }).isEmpty)
     }
 }

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -46,6 +46,6 @@ class SentryBaseIntegrationTests: XCTestCase {
         options.enableAutoSessionTracking = false
         let result = sut.install(with: options)
         XCTAssertFalse(result)
-        XCTAssertEqual(["Sentry - debug:: Not going to enable SentryTests.MyTestIntegration because enableAutoSessionTracking is disabled."], logOutput.loggedMessages)
+        XCTAssertEqual(["[Sentry] [debug] [SentryBaseIntegration] Not going to enable SentryTests.MyTestIntegration because enableAutoSessionTracking is disabled."], logOutput.loggedMessages)
     }
 }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -169,7 +169,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(childSpan.context.parentSpanId)
         XCTAssertEqual(childSpan.context.operation, "")
         XCTAssertNil(childSpan.context.spanDescription)
-        XCTAssertTrue(logOutput.loggedMessages.contains("Sentry - warning:: Starting a child on a finished span is not supported; it won\'t be sent to Sentry."))
+        XCTAssertTrue(logOutput.loggedMessages.contains("[Sentry] [warning] [SentryTracer] Starting a child on a finished span is not supported; it won\'t be sent to Sentry."))
     }
 
     func testStartGrandChildOnFinishedSpan() {
@@ -182,7 +182,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(grandChild.context.parentSpanId)
         XCTAssertEqual(grandChild.context.operation, "")
         XCTAssertNil(grandChild.context.spanDescription)
-        XCTAssertTrue(logOutput.loggedMessages.contains("Sentry - warning:: Starting a child on a finished span is not supported; it won\'t be sent to Sentry."))
+        XCTAssertTrue(logOutput.loggedMessages.contains("[Sentry] [warning] [SentryTracer] Starting a child on a finished span is not supported; it won\'t be sent to Sentry."))
     }
     
     func testAddAndRemoveExtras() {

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -169,7 +169,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(childSpan.context.parentSpanId)
         XCTAssertEqual(childSpan.context.operation, "")
         XCTAssertNil(childSpan.context.spanDescription)
-        XCTAssertTrue(logOutput.loggedMessages.contains("[Sentry] [warning] [SentryTracer] Starting a child on a finished span is not supported; it won\'t be sent to Sentry."))
+        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(" Starting a child on a finished span is not supported; it won\'t be sent to Sentry.") }).isEmpty)
     }
 
     func testStartGrandChildOnFinishedSpan() {
@@ -182,7 +182,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(grandChild.context.parentSpanId)
         XCTAssertEqual(grandChild.context.operation, "")
         XCTAssertNil(grandChild.context.spanDescription)
-        XCTAssertTrue(logOutput.loggedMessages.contains("[Sentry] [warning] [SentryTracer] Starting a child on a finished span is not supported; it won\'t be sent to Sentry."))
+        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(" Starting a child on a finished span is not supported; it won\'t be sent to Sentry.") }).isEmpty)
     }
     
     func testAddAndRemoveExtras() {


### PR DESCRIPTION
As I've been adding more logging, it's getting harder to keep track of things. This PR adds a new part to the format denoting which class/file the log originated from (and the line number). I also standardized how the different tokens are formatted in the log statement, like our SDK name, log level, and the newly added log source.

Before:

```
Sentry - debug:: SentryFileManager.cachePath: /Users/andrewmcknight/Library/Developer/CoreSimulator/Devices/9DA57C91-8188-405D-87DD-4CCFFD376F99/data/Containers/Data/Application/0D15944C-6F34-4C95-BE40-3E9B5CF41ED9/Library/Caches
Sentry - debug:: SentryHttpTransport: sendAllCachedEnvelopes start.
Sentry - debug:: SentryHttpTransport: No envelopes left to send.
Sentry - debug:: SentryHttpTransport: Finished sending.
Sentry - debug:: SDK initialized! Version: 7.29.0
Sentry - debug:: Sent 0 crash report(s)
Sentry - debug:: Integration installed: SentryCrashIntegration
Sentry - debug:: Not going to enable SentryANRTrackingIntegration because the debugger is attached.
Sentry - debug:: Integration installed: SentryScreenshotIntegration
Sentry - debug:: Integration installed: SentryUIEventTrackingIntegration
Sentry - debug:: Integration installed: SentryViewHierarchyIntegration
Sentry - debug:: Integration installed: SentryFramesTrackingIntegration
Sentry - debug:: Add breadcrumb: <SentryBreadcrumb: 0x600001861900, {
```

after

```
[Sentry] [debug] [SentryFileManager:50] SentryFileManager.cachePath: /Users/andrewmcknight/Library/Developer/CoreSimulator/Devices/9DA57C91-8188-405D-87DD-4CCFFD376F99/data/Containers/Data/Application/36CE0EA5-5C63-407B-96CC-743F0F81DCEC/Library/Caches
[Sentry] [debug] [SentryHttpTransport:241] sendAllCachedEnvelopes start.
[Sentry] [debug] [SentryHttpTransport:253] No envelopes left to send.
[Sentry] [debug] [SentryHttpTransport:320] Finished sending.
[Sentry] [debug] [SentrySDK:156] SDK initialized! Version: 7.29.0
[Sentry] [debug] [SentryCrashInstallationReporter:52] Sent 0 crash report(s)
[Sentry] [debug] [SentrySDK:390] Integration installed: SentryCrashIntegration
[Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryANRTrackingIntegration because the debugger is attached.
[Sentry] [debug] [SentrySDK:390] Integration installed: SentryScreenshotIntegration
[Sentry] [debug] [SentrySDK:390] Integration installed: SentryUIEventTrackingIntegration
[Sentry] [debug] [SentrySDK:390] Integration installed: SentryViewHierarchyIntegration
[Sentry] [debug] [SentrySDK:390] Integration installed: SentryFramesTrackingIntegration
[Sentry] [debug] [SentryScope:128] Add breadcrumb: <SentryBreadcrumb: 0x60000279a1c0, {```

Someone had actually started doing this from `SentryHttpTransport`, which I removed from the actual log strings to deduplicate as this solves the same problem from the logging macros themselves so that anywhere they're used, this appears in the logs. It must be done in the macros, since it uses the `__FILE__` builtin; if that were used in SentryLogOutput.m, then all the log statements would contain `[SentryLogOutput]`.

#skip-changelog

