### PR TITLE
test: disable flaky testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -65,6 +65,9 @@
                   Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readUrl_disabled()">
                </Test>
                <Test
+                  Identifier = "SentryHttpTransportTests/testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentryHttpTransportTests/testFlush_CalledSequentially_BlocksTwice_disabled()">
                </Test>
                <Test

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -681,7 +681,7 @@ class SentryHttpTransportTests: XCTestCase {
         assertFlushBlocksAndFinishesSuccessfully()
     }
     
-    func testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse() {
+    func testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse_disabled() {
         CurrentDate.setCurrentDateProvider(DefaultCurrentDateProvider.sharedInstance())
         
         givenCachedEvents()


### PR DESCRIPTION
#skip-changelog

failing: https://github.com/getsentry/sentry-cocoa/actions/runs/3342304891/jobs/5534412242#step:9:42
passing again: https://github.com/getsentry/sentry-cocoa/actions/runs/3342304891/jobs/5546207690