### PR TITLE
feat: Disable bitcode for Carthage distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Profile concurrent transactions (#2227)
+- Disable bitcode for Carthage distribution (#2341)
 
 ### Fixes
 

--- a/Sources/Configuration/Sentry.xcconfig
+++ b/Sources/Configuration/Sentry.xcconfig
@@ -20,7 +20,6 @@ SDKROOT__CARTHAGE_ = iphoneos
 SUPPORTED_PLATFORMS = macosx iphoneos iphonesimulator watchos watchsimulator appletvos appletvsimulator
 TARGETED_DEVICE_FAMILY = 1,2,3,4
 SKIP_INSTALL = YES
-ENABLE_BITCODE = YES
 DEFINES_MODULE = YES
 DYLIB_COMPATIBILITY_VERSION = 1
 DYLIB_CURRENT_VERSION = 1


### PR DESCRIPTION
## :scroll: Description

Disabled bitcode

## :bulb: Motivation and Context

We [recently](https://github.com/getsentry/sentry-cocoa/pull/2307) enabled bitcode because of some [complaints](https://github.com/getsentry/sentry-cocoa/issues/2304) (plus Unity project not compiling), this is basically a breaking change, but one enforced by Apple.
It turns out Apple will not accept new Apps with bitcode enabled, the solution for this complaints will be to tell users to also disabled it in their projects.

From [Apple's release notes](https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes) 

> Deprecations
Starting with Xcode 14, bitcode is no longer required for watchOS and tvOS applications, and the App Store no longer accepts bitcode submissions from Xcode 14.
> 
> Xcode no longer builds bitcode by default and generates a warning message if a project explicitly enables bitcode: “Building with bitcode is deprecated. Please update your project and/or target settings to disable bitcode.” The capability to build with bitcode will be removed in a future Xcode release. IPAs that contain bitcode will have the bitcode stripped before being submitted to the App Store. Debug symbols can only be downloaded from App Store Connect / TestFlight for existing bitcode submissions and are no longer available for submissions made with Xcode 14. (86118779)

Related to https://github.com/getsentry/sentry-dotnet/issues/2022
May be related to #2332 
