### PR TITLE
fix: dont require profiler to start on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Stop profiler when app moves to background (#2331)
 - Clean up old envelopes (#2322)
+- Crash when starting a profile from a non-main thread (#2345)
 
 ## 7.29.0
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -108,11 +108,6 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
 - (instancetype)init
 {
-    if (![NSThread isMainThread]) {
-        SENTRY_LOG_ERROR(@"SentryProfiler must be initialized on the main thread");
-        return nil;
-    }
-
     if (!(self = [super init])) {
         return nil;
     }
@@ -148,6 +143,10 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
 
     if (_gCurrentProfiler == nil) {
         _gCurrentProfiler = [[SentryProfiler alloc] init];
+        if (_gCurrentProfiler == nil) {
+            SENTRY_LOG_WARN(@"Profiler was not initialized, will not proceed.");
+            return;
+        }
 #        if SENTRY_HAS_UIKIT
         [SentryFramesTracker.sharedInstance resetProfilingTimestamps];
 #        endif // SENTRY_HAS_UIKIT

--- a/Tests/SentryTests/Profiling/SentryProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentryProfilerTests.mm
@@ -38,11 +38,11 @@
     XCTAssertNotNil([[SentryProfiler alloc] init]);
 }
 
-- (void)testProfilerCannotBeInitializedOffMainThread
+- (void)testProfilerCanBeInitializedOffMainThread
 {
     const auto expectation = [self expectationWithDescription:@"background initializing profiler"];
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul), ^{
-        XCTAssertNil([[SentryProfiler alloc] init]);
+        XCTAssertNotNil([[SentryProfiler alloc] init]);
         [expectation fulfill];
     });
     [self waitForExpectationsWithTimeout:1.0


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cocoa/issues/2342