### PR TITLE
fix: SentryCrash writing nan for invalid number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Stop profiler when app moves to background (#2331)
 - Clean up old envelopes (#2322)
+- SentryCrash writing nan for invalid number (#2348)
 
 ## 7.29.0
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <inttypes.h>
+#include <math.h>
 #include <stdio.h>
 #include <string.h>
 #include <unistd.h>
@@ -311,6 +312,10 @@ int
 sentrycrashjson_addFloatingPointElement(
     SentryCrashJSONEncodeContext *const context, const char *const name, double value)
 {
+    if (isnan(value)) {
+        return sentrycrashjson_addNullElement(context, name);
+    }
+
     int result = sentrycrashjson_beginElement(context, name);
     unlikely_if(result != SentryCrashJSON_OK) { return result; }
     char buff[50];

--- a/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
@@ -25,6 +25,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import <math.h>
 
 #import "FileBasedTestCase.h"
 #import "SentryCrashJSONCodec.h"
@@ -798,6 +799,24 @@ toString(NSData *data)
         [[result objectAtIndex:0] floatValue] == [[original objectAtIndex:0] floatValue], @"");
 }
 
+- (void)testSerializeDeserializeNanFloat
+{
+    NSError *error = (NSError *)self;
+    NSString *expected = @"[null]";
+    float nanValue = nanf("");
+    id original = [NSArray arrayWithObjects:[NSNumber numberWithFloat:nanValue], nil];
+    NSString *jsonString = toString([SentryCrashJSONCodec encode:original
+                                                         options:SentryCrashJSONEncodeOptionSorted
+                                                           error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [SentryCrashJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertTrue([[result objectAtIndex:0] isKindOfClass:[NSNull class]]);
+}
+
 - (void)testSerializeDeserializeDouble
 {
     NSError *error = (NSError *)self;
@@ -814,6 +833,25 @@ toString(NSData *data)
     XCTAssertNil(error, @"");
     XCTAssertTrue(
         [[result objectAtIndex:0] floatValue] == [[original objectAtIndex:0] floatValue], @"");
+}
+
+- (void)testSerializeDeserializeNANDouble
+{
+    NSError *error = (NSError *)self;
+    NSString *expected = @"[null]";
+    double nanValue = nan("");
+    id original = [NSArray arrayWithObjects:[NSNumber numberWithDouble:nanValue], nil];
+
+    NSString *jsonString = toString([SentryCrashJSONCodec encode:original
+                                                         options:SentryCrashJSONEncodeOptionSorted
+                                                           error:&error]);
+    XCTAssertNotNil(jsonString, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertEqualObjects(jsonString, expected, @"");
+    id result = [SentryCrashJSONCodec decode:toData(jsonString) options:0 error:&error];
+    XCTAssertNotNil(result, @"");
+    XCTAssertNil(error, @"");
+    XCTAssertTrue([[result objectAtIndex:0] isKindOfClass:[NSNull class]]);
 }
 
 - (void)testSerializeDeserializeChar


### PR DESCRIPTION
## :scroll: Description

Instead of writing `nan` (which is invalid for json format) in the crash report for invalid numbers, start writing `null`.

## :bulb: Motivation and Context

closes #2327 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes
