### PR TITLE
ref: json serialization error reporting

### DIFF
--- a/Sources/Sentry/Public/SentryError.h
+++ b/Sources/Sentry/Public/SentryError.h
@@ -15,6 +15,10 @@ typedef NS_ENUM(NSInteger, SentryError) {
 };
 
 SENTRY_EXTERN NSError *_Nullable NSErrorFromSentryError(SentryError error, NSString *description);
+SENTRY_EXTERN NSError *_Nullable NSErrorFromSentryErrorWithUnderlyingError(
+    SentryError error, NSString *description, NSError *underlyingError);
+SENTRY_EXTERN NSError *_Nullable NSErrorFromSentryErrorWithException(
+    SentryError error, NSString *description, NSException *exception);
 
 SENTRY_EXTERN NSString *const SentryErrorDomain;
 

--- a/Sources/Sentry/SentryError.m
+++ b/Sources/Sentry/SentryError.m
@@ -4,33 +4,30 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *const SentryErrorDomain = @"SentryErrorDomain";
 
+NSError *_Nullable _SentryError(SentryError error, NSDictionary *userInfo)
+{
+    return [NSError errorWithDomain:SentryErrorDomain code:error userInfo:userInfo];
+}
+
 NSError *_Nullable NSErrorFromSentryErrorWithUnderlyingError(
     SentryError error, NSString *description, NSError *underlyingError)
 {
-    return [NSError errorWithDomain:SentryErrorDomain
-                               code:error
-                           userInfo:@ {
-                               NSLocalizedDescriptionKey : description,
-                               NSUnderlyingErrorKey : underlyingError
-                           }];
+    return _SentryError(error,
+        @ { NSLocalizedDescriptionKey : description, NSUnderlyingErrorKey : underlyingError });
 }
 
 NSError *_Nullable NSErrorFromSentryErrorWithException(
     SentryError error, NSString *description, NSException *exception)
 {
-    return [NSError errorWithDomain:SentryErrorDomain
-                               code:error
-                           userInfo:@ {
-                               NSLocalizedDescriptionKey : [NSString
-                                   stringWithFormat:@"%@ (%@)", description, exception.reason],
-                           }];
+    return _SentryError(error, @ {
+        NSLocalizedDescriptionKey :
+            [NSString stringWithFormat:@"%@ (%@)", description, exception.reason],
+    });
 }
 
 NSError *_Nullable NSErrorFromSentryError(SentryError error, NSString *description)
 {
-    return [NSError errorWithDomain:SentryErrorDomain
-                               code:error
-                           userInfo:@ { NSLocalizedDescriptionKey : description }];
+    return _SentryError(error, @ { NSLocalizedDescriptionKey : description });
 }
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryError.m
+++ b/Sources/Sentry/SentryError.m
@@ -4,11 +4,33 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *const SentryErrorDomain = @"SentryErrorDomain";
 
+NSError *_Nullable NSErrorFromSentryErrorWithUnderlyingError(
+    SentryError error, NSString *description, NSError *underlyingError)
+{
+    return [NSError errorWithDomain:SentryErrorDomain
+                               code:error
+                           userInfo:@ {
+                               NSLocalizedDescriptionKey : description,
+                               NSUnderlyingErrorKey : underlyingError
+                           }];
+}
+
+NSError *_Nullable NSErrorFromSentryErrorWithException(
+    SentryError error, NSString *description, NSException *exception)
+{
+    return [NSError errorWithDomain:SentryErrorDomain
+                               code:error
+                           userInfo:@ {
+                               NSLocalizedDescriptionKey : [NSString
+                                   stringWithFormat:@"%@ (%@)", description, exception.reason],
+                           }];
+}
+
 NSError *_Nullable NSErrorFromSentryError(SentryError error, NSString *description)
 {
-    NSMutableDictionary *userInfo = [NSMutableDictionary new];
-    [userInfo setValue:description forKey:NSLocalizedDescriptionKey];
-    return [NSError errorWithDomain:SentryErrorDomain code:error userInfo:userInfo];
+    return [NSError errorWithDomain:SentryErrorDomain
+                               code:error
+                           userInfo:@ { NSLocalizedDescriptionKey : description }];
 }
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -33,8 +33,10 @@ NS_ASSUME_NONNULL_BEGIN
         data = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:error];
 #if defined(DEBUG) || defined(TEST) || defined(TESTCI)
     } @catch (NSException *exception) {
-        SENTRY_HANDLE_ERROR(NSErrorFromSentryErrorWithException(
-            kSentryErrorJsonConversionError, @"Event cannot be converted to JSON", exception));
+        if (error) {
+            SENTRY_HANDLE_ERROR(NSErrorFromSentryErrorWithException(
+                kSentryErrorJsonConversionError, @"Event cannot be converted to JSON", exception));
+        }
     }
 #else
     } else if (error) {

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -17,16 +17,31 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSData *_Nullable)dataWithJSONObject:(NSDictionary *)dictionary
                                   error:(NSError *_Nullable *_Nullable)error
 {
+// We'll do this whether we're handling an exception or library error
+#define SENTRY_HANDLE_ERROR(__sentry_error)                                                        \
+    SENTRY_LOG_ERROR(@"Invalid JSON: %@", __sentry_error);                                         \
+    *error = __sentry_error;                                                                       \
+    return nil;
+
     NSData *data = nil;
-    if ([NSJSONSerialization isValidJSONObject:dictionary] != NO) {
+
+#if defined(DEBUG) || defined(TEST) || defined(TESTCI)
+    @try {
+#else
+    if ([NSJSONSerialization isValidJSONObject:dictionary]) {
+#endif
         data = [NSJSONSerialization dataWithJSONObject:dictionary options:0 error:error];
-    } else {
-        SENTRY_LOG_ERROR(@"Invalid JSON.");
-        if (error) {
-            *error = NSErrorFromSentryError(
-                kSentryErrorJsonConversionError, @"Event cannot be converted to JSON");
-        }
+#if defined(DEBUG) || defined(TEST) || defined(TESTCI)
+    } @catch (NSException *exception) {
+        SENTRY_HANDLE_ERROR(NSErrorFromSentryErrorWithException(
+            kSentryErrorJsonConversionError, @"Event cannot be converted to JSON", exception));
     }
+#else
+    } else if (error) {
+        SENTRY_HANDLE_ERROR(NSErrorFromSentryErrorWithUnderlyingError(
+            kSentryErrorJsonConversionError, @"Event cannot be converted to JSON", *error));
+    }
+#endif
 
     return data;
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
@@ -42,7 +42,7 @@
 
 #include <memory.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
@@ -30,7 +30,7 @@
 #include "SentryCrashJSONCodec.h"
 #include "SentryCrashMonitorContext.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -29,7 +29,7 @@
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <cxxabi.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -32,7 +32,7 @@
 #include "SentryCrashSystemCapabilities.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #if SentryCrashCRASH_HAS_MACH

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -31,7 +31,7 @@
 #import "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -32,7 +32,7 @@
 #include "SentryCrashStackCursor_MachineContext.h"
 #include "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #if SentryCrashCRASH_HAS_SIGNAL

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -33,7 +33,7 @@
 #import "SentryCrashSysCtl.h"
 #import "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 #import <CommonCrypto/CommonDigest.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
@@ -28,7 +28,7 @@
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <memory.h>

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -38,7 +38,7 @@
 #import "SentryCrashSystemCapabilities.h"
 #import <NSData+Sentry.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 #include <inttypes.h>
@@ -355,7 +355,10 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
+    -(TYPE)NAME                                                                                    \
+    {                                                                                              \
+        return sentrycrashstate_currentState()->NAME;                                              \
+    }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -40,7 +40,7 @@
 #include "SentryCrashString.h"
 #include "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <inttypes.h>

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.c
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.c
@@ -24,7 +24,7 @@
 
 #include "SentryCrashCachedData.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -47,7 +47,7 @@
 #include "SentryCrashUUIDConversion.h"
 #include "SentryScopeSyncC.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
@@ -31,7 +31,7 @@
 #include <mach-o/arch.h>
 #include <mach/mach.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 const char *

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
@@ -32,7 +32,7 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = { "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9",

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
@@ -32,7 +32,7 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 #    define KSPACStrippingMask_ARM64e 0x0000000fffffffff

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
@@ -32,7 +32,7 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
@@ -33,7 +33,7 @@
 
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = { "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp",

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashDebug.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashFileUtils.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <dirent.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -33,7 +33,7 @@
 
 #include <mach/mach.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #ifdef __arm64__

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashMemory.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <_types/_uint8_t.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -86,7 +86,7 @@ extern "C" {
 // SentryCrash: The original values wouldn't have worked. The slot shift and
 // mask were incorrect.
 #    define TAG_COUNT 8
-//#define TAG_SLOT_MASK 0xf
+// #define TAG_SLOT_MASK 0xf
 #    define TAG_SLOT_MASK 0x07
 
 #    if SUPPORT_MSB_TAGGED_POINTERS
@@ -96,7 +96,7 @@ extern "C" {
 #        define TAG_PAYLOAD_RSHIFT 4
 #    else
 #        define TAG_MASK 1
-//#   define TAG_SLOT_SHIFT 0
+// #   define TAG_SLOT_SHIFT 0
 #        define TAG_SLOT_SHIFT 1
 #        define TAG_PAYLOAD_LSHIFT 0
 #        define TAG_PAYLOAD_RSHIFT 4

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
@@ -27,7 +27,7 @@
 #include "SentryCrashSymbolicator.h"
 #include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 static bool

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
@@ -25,7 +25,7 @@
 #include "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashCPU.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 static bool

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.c
@@ -26,7 +26,7 @@
 #include "SentryCrashStackCursor_Backtrace.h"
 #include <execinfo.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #define MAX_BACKTRACE_LENGTH                                                                       \

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashSysCtl.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
@@ -29,7 +29,7 @@
 #include "SentryCrashMemory.h"
 #include "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <dispatch/dispatch.h>

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -29,7 +29,7 @@
 #import "NSError+SentrySimpleConstructor.h"
 #import "SentryCrashVarArgs.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 @implementation SentryCrashReportFilterPassthrough

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -7,6 +7,24 @@ class SentrySerializationTests: XCTestCase {
         static var traceContext = SentryTraceContext(trace: SentryId(), publicKey: "PUBLIC_KEY", releaseName: "RELEASE_NAME", environment: "TEST", transaction: "transaction", userSegment: "some segment", sampleRate: "0.25")
     }
 
+    func testSerializationFailsWithInvalidJSONObject() {
+        let json: [String: Any] = [
+            "valid object": "hi, i'm a valid object",
+            "invalid object": NSDate()
+        ]
+
+        var data: Data?
+        let exp = expectation(description: "Should throw error")
+        do {
+            data = try SentrySerialization.data(withJSONObject: json)
+        } catch {
+            exp.fulfill()
+            XCTAssertEqual(error.localizedDescription, "Event cannot be converted to JSON (Invalid type in JSON write (__NSTaggedDate))")
+        }
+        waitForExpectations(timeout: 1)
+        XCTAssertNil(data)
+    }
+
     func testSentryEnvelopeSerializer_WithSingleEvent() {
         // Arrange
         let event = Event()

--- a/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
+++ b/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
@@ -18,7 +18,8 @@ class SentryNSErrorTests: XCTestCase {
         let actualError = NSErrorFromSentryErrorWithUnderlyingError(SentryError.unknownError, inputDescription, inputUnderlyingError)
 
         XCTAssertEqual(actualError?.localizedDescription, inputDescription)
-        guard let actualUnderlyingError = (actualError as? NSError)?.userInfo[NSUnderlyingErrorKey] as? NSError else {
+        
+        guard let error = actualError, let actualUnderlyingError = (error as NSError).userInfo[NSUnderlyingErrorKey] as? NSError else {
             XCTFail("Expected an underlying error in the returned error's info dict")
             return
         }

--- a/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
+++ b/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
@@ -4,11 +4,41 @@ class SentryNSErrorTests: XCTestCase {
 
     func testSerialize() {
         let error = SentryNSError(domain: "domain", code: 10)
-    
+
         let actual = error.serialize()
         
         XCTAssertEqual(error.domain, actual["domain"] as? String)
         XCTAssertEqual(error.code, actual["code"] as? Int)
+    }
+
+    func testSerializeWithUnderlyingNSError() {
+        let inputUnderlyingErrorCode = 5_123
+        let inputUnderlyingError = NSError(domain: "test-error-domain", code: inputUnderlyingErrorCode)
+        let inputDescription = "some test error"
+        let actualError = NSErrorFromSentryErrorWithUnderlyingError(SentryError.unknownError, inputDescription, inputUnderlyingError)
+
+        XCTAssertEqual(actualError?.localizedDescription, inputDescription)
+        guard let actualUnderlyingError = (actualError as? NSError)?.userInfo[NSUnderlyingErrorKey] as? NSError else {
+            XCTFail("Expected an underlying error in the returned error's info dict")
+            return
+        }
+        XCTAssertEqual(actualUnderlyingError.code, inputUnderlyingErrorCode)
+        XCTAssertEqual(actualUnderlyingError.domain, inputUnderlyingError.domain)
+    }
+
+    func testSerializeWithUnderlyingNSException() {
+        let inputExceptionName = NSExceptionName.decimalNumberDivideByZeroException
+        let inputExceptionReason = "test exception reason"
+        let inputUnderlyingException = NSException(name: inputExceptionName, reason: inputExceptionReason, userInfo: ["some userinfo key": "some userinfo value"])
+        let inputDescription = "some test exception"
+
+        let actualError = NSErrorFromSentryErrorWithException(SentryError.unknownError, inputDescription, inputUnderlyingException)
+
+        guard let actualDescription = actualError?.localizedDescription else {
+            XCTFail("Expected a localizedDescription in the resulting error")
+            return
+        }
+        XCTAssertEqual(actualDescription, "\(inputDescription) (\(inputExceptionReason))")
     }
 
 }


### PR DESCRIPTION
I had a JSON validation error, but couldn't tell what it was since we simply check for the boolean from `isValidJSON`. I had to implement just attempting the serialization and inspecting the inout error it gives, and learned that at least in my case, serialization also throws exceptions in certain cases, but the exception told me exactly what the problem was. I figured it would be helpful to keep around, but also that we may not want the exception handler in production, so I used some conditional compilation to keep it behaving as it was in release configs, but in all other configs, to get the info from the exception/error.

To that end, added some new functions to construct NSErrors that can include an underlying NSError we may get from a Cocoa library method, or an NSException, with some light refactoring of the implementations in SentryError.

#skip-changelog

Just copying here some details from one of my commits for visibility:

```
before:
    - test if input is valid JSON with `-[NSJSONSerialization
    isValidJSON]` and if not, build our own error.
    - problem: no hints as to why the JSON is invalid

after:
    - attempt direct serialization with `-[NSJSONSerialization
    dataWithJSONObject:options:error:]` and use the library error
    - this can throw an exception in certain failure modes: surround
    the call with try/catch
    - use new functions in SentryError to create an NSError from
    either an NSException or the inout NSError
    - only compile like this for nonrelease builds so we don't incur
    the performance hit of throwing an exception (see apple's docs:
    "For best performance in 64-bit, you should throw exceptions only
    when absolutely necessary.")
```