### PR TITLE
fix: profiling transaction thread IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix issue with invalid profiles uploading (#2357)
+
 ## 7.30.0
 
 ### Features

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -651,7 +651,7 @@
 		8ECC674725C23A20000E2BF6 /* SentrySpanContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674325C23A1F000E2BF6 /* SentrySpanContext.m */; };
 		8ECC674825C23A20000E2BF6 /* SentryTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */; };
 		8ECC674925C23A20000E2BF6 /* SentrySpanId.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674525C23A20000E2BF6 /* SentrySpanId.m */; };
-		8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */; };
+		8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674625C23A20000E2BF6 /* SentryTransactionContext.mm */; };
 		8ED2D28026A6581C00CA8329 /* NSURLProtocolSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED2D27F26A6581C00CA8329 /* NSURLProtocolSwizzle.m */; };
 		8ED3D306264DFE700049393B /* SentryUIViewControllerSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED3D305264DFE700049393B /* SentryUIViewControllerSanitizerTests.swift */; };
 		8EE017A126704CD500470616 /* SentryUIViewControllerPerformanceTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA1ED0E2669152F00E62B98 /* SentryUIViewControllerPerformanceTrackerTests.swift */; };
@@ -1443,7 +1443,7 @@
 		8ECC674325C23A1F000E2BF6 /* SentrySpanContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySpanContext.m; sourceTree = "<group>"; };
 		8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryTransaction.m; sourceTree = "<group>"; };
 		8ECC674525C23A20000E2BF6 /* SentrySpanId.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySpanId.m; sourceTree = "<group>"; };
-		8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryTransactionContext.m; sourceTree = "<group>"; };
+		8ECC674625C23A20000E2BF6 /* SentryTransactionContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryTransactionContext.mm; sourceTree = "<group>"; };
 		8ED2D27E26A6581C00CA8329 /* NSURLProtocolSwizzle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLProtocolSwizzle.h; sourceTree = "<group>"; };
 		8ED2D27F26A6581C00CA8329 /* NSURLProtocolSwizzle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLProtocolSwizzle.m; sourceTree = "<group>"; };
 		8ED3D305264DFE700049393B /* SentryUIViewControllerSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUIViewControllerSanitizerTests.swift; sourceTree = "<group>"; };
@@ -2816,7 +2816,7 @@
 				8E4E7C6B25DAAAFE006AB9E2 /* SentryTransaction.h */,
 				8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */,
 				8ECC673B25C23996000E2BF6 /* SentryTransactionContext.h */,
-				8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */,
+				8ECC674625C23A20000E2BF6 /* SentryTransactionContext.mm */,
 				0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */,
 				8EC4CF4725C38CAF0093DEE9 /* SentrySpanStatus.h */,
 				8453421528BE8A9500C22EEC /* SentrySpanStatus.m */,
@@ -3328,7 +3328,7 @@
 				7B3B473825D6CC7E00D01640 /* SentryNSError.m in Sources */,
 				D8ACE3C82762187200F5A213 /* SentryNSDataTracker.m in Sources */,
 				7BE3C77D2446112C00A38442 /* SentryRateLimitParser.m in Sources */,
-				8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.m in Sources */,
+				8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.mm in Sources */,
 				03BCC38C27E1C01A003232C7 /* SentryTime.mm in Sources */,
 				A8F17B342902870300990B25 /* SentryHttpStatusCodeRange.m in Sources */,
 				03F84D3727DD4191008FE43F /* SentrySamplingProfiler.cpp in Sources */,

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -4,6 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentrySpanId;
+@class SentryThread;
 
 NS_SWIFT_NAME(TransactionContext)
 @interface SentryTransactionContext : SentrySpanContext

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -14,6 +14,7 @@ SENTRY_NO_INIT
  */
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) SentryTransactionNameSource nameSource;
+@property (nonatomic, copy, readonly) SentryThread *threadInfo;
 
 /**
  * Parent sampled

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -22,6 +22,7 @@
 #    import "SentryScreenFrames.h"
 #    import "SentrySerialization.h"
 #    import "SentrySpanId.h"
+#    import "SentryThread.h"
 #    import "SentryTime.h"
 #    import "SentryTransaction.h"
 #    import "SentryTransactionContext.h"
@@ -573,7 +574,6 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
 
     // populate info from all transactions that occurred while profiler was running
     auto transactionsInfo = [NSMutableArray array];
-    NSString *mainThreadID = [profile[@"profile"][@"samples"] firstObject][@"thread_id"];
     for (SentryTransaction *transaction in _transactions) {
         const auto relativeStart =
             [NSString stringWithFormat:@"%llu",
@@ -593,10 +593,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
             @"name" : transaction.transaction,
             @"relative_start_ns" : relativeStart,
             @"relative_end_ns" : relativeEnd,
-            @"active_thread_id" :
-                mainThreadID // TODO: we are just using the main thread ID for all transactions to
-                             // fix a backend validation error, but this needs to be gathered from
-                             // transaction starts in their contexts and carried forward to here
+            @"active_thread_id" : transaction.trace.transactionContext.threadInfo.threadId
         }];
     }
     profile[@"transactions"] = transactionsInfo;

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -1,7 +1,10 @@
 #import "SentryTransactionContext.h"
+#import "SentryThread.h"
 #include "SentryThreadHandle.hpp"
 
 NS_ASSUME_NONNULL_BEGIN
+
+static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecided;
 
 @implementation SentryTransactionContext
 
@@ -19,9 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super initWithOperation:operation]) {
         _name = [NSString stringWithString:name];
         _nameSource = source;
-        self.parentSampled = false;
-        const auto threadInfo = ThreadHandle::current()->tid();
-        NSLog(@"%@", threadInfo);
+        self.parentSampled = kSentryDefaultSamplingDecision;
+        const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
+        _threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
     }
     return self;
 }
@@ -44,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super initWithOperation:operation sampled:sampled]) {
         _name = [NSString stringWithString:name];
         _nameSource = source;
-        self.parentSampled = false;
+        self.parentSampled = kSentryDefaultSamplingDecision;
     }
     return self;
 }
@@ -77,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
                                spanId:spanId
                              parentId:parentSpanId
                             operation:operation
-                              sampled:false]) {
+                              sampled:kSentryDefaultSamplingDecision]) {
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = parentSampled;

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -1,4 +1,5 @@
 #import "SentryTransactionContext.h"
+#include "SentryThreadHandle.hpp"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = false;
+        const auto threadInfo = ThreadHandle::current()->tid();
+        NSLog(@"%@", threadInfo);
     }
     return self;
 }


### PR DESCRIPTION
required changing SentryTracer to an ObjC++ file to use our C++ interface to get thread IDs; when this happened, a latent type mismatch was uncovered, breaking the compilation. it required a bit of a nonobvious semantic change from `false` (which resolves to 0, where parentSampled used to be a boolean type property set to false, and was changed to the NSUInteger-backed enum) to `kSentrySampleDecisionUndecided` (which is the 0 value in the enum), and not kSentrySampleDecisionNo as "false" might imply