### PR TITLE
fix: profiling transaction thread IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix issue with invalid profiles uploading (#2357)
+- Fix issue with invalid profiles uploading (#2358)
 
 ## 7.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix issue with invalid profiles uploading (#2357)
+
 ## 7.30.0
 
 ### Features

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -651,7 +651,7 @@
 		8ECC674725C23A20000E2BF6 /* SentrySpanContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674325C23A1F000E2BF6 /* SentrySpanContext.m */; };
 		8ECC674825C23A20000E2BF6 /* SentryTransaction.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */; };
 		8ECC674925C23A20000E2BF6 /* SentrySpanId.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674525C23A20000E2BF6 /* SentrySpanId.m */; };
-		8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */; };
+		8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8ECC674625C23A20000E2BF6 /* SentryTransactionContext.mm */; };
 		8ED2D28026A6581C00CA8329 /* NSURLProtocolSwizzle.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ED2D27F26A6581C00CA8329 /* NSURLProtocolSwizzle.m */; };
 		8ED3D306264DFE700049393B /* SentryUIViewControllerSanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED3D305264DFE700049393B /* SentryUIViewControllerSanitizerTests.swift */; };
 		8EE017A126704CD500470616 /* SentryUIViewControllerPerformanceTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA1ED0E2669152F00E62B98 /* SentryUIViewControllerPerformanceTrackerTests.swift */; };
@@ -1443,7 +1443,7 @@
 		8ECC674325C23A1F000E2BF6 /* SentrySpanContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySpanContext.m; sourceTree = "<group>"; };
 		8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryTransaction.m; sourceTree = "<group>"; };
 		8ECC674525C23A20000E2BF6 /* SentrySpanId.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySpanId.m; sourceTree = "<group>"; };
-		8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryTransactionContext.m; sourceTree = "<group>"; };
+		8ECC674625C23A20000E2BF6 /* SentryTransactionContext.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryTransactionContext.mm; sourceTree = "<group>"; };
 		8ED2D27E26A6581C00CA8329 /* NSURLProtocolSwizzle.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSURLProtocolSwizzle.h; sourceTree = "<group>"; };
 		8ED2D27F26A6581C00CA8329 /* NSURLProtocolSwizzle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLProtocolSwizzle.m; sourceTree = "<group>"; };
 		8ED3D305264DFE700049393B /* SentryUIViewControllerSanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUIViewControllerSanitizerTests.swift; sourceTree = "<group>"; };
@@ -2816,7 +2816,7 @@
 				8E4E7C6B25DAAAFE006AB9E2 /* SentryTransaction.h */,
 				8ECC674425C23A1F000E2BF6 /* SentryTransaction.m */,
 				8ECC673B25C23996000E2BF6 /* SentryTransactionContext.h */,
-				8ECC674625C23A20000E2BF6 /* SentryTransactionContext.m */,
+				8ECC674625C23A20000E2BF6 /* SentryTransactionContext.mm */,
 				0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */,
 				8EC4CF4725C38CAF0093DEE9 /* SentrySpanStatus.h */,
 				8453421528BE8A9500C22EEC /* SentrySpanStatus.m */,
@@ -3328,7 +3328,7 @@
 				7B3B473825D6CC7E00D01640 /* SentryNSError.m in Sources */,
 				D8ACE3C82762187200F5A213 /* SentryNSDataTracker.m in Sources */,
 				7BE3C77D2446112C00A38442 /* SentryRateLimitParser.m in Sources */,
-				8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.m in Sources */,
+				8ECC674A25C23A20000E2BF6 /* SentryTransactionContext.mm in Sources */,
 				03BCC38C27E1C01A003232C7 /* SentryTime.mm in Sources */,
 				A8F17B342902870300990B25 /* SentryHttpStatusCodeRange.m in Sources */,
 				03F84D3727DD4191008FE43F /* SentrySamplingProfiler.cpp in Sources */,

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -4,6 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentrySpanId;
+@class SentryThread;
 
 NS_SWIFT_NAME(TransactionContext)
 @interface SentryTransactionContext : SentrySpanContext

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -14,6 +14,7 @@ SENTRY_NO_INIT
  */
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) SentryTransactionNameSource nameSource;
+@property (nonatomic, copy, readonly) SentryThread *threadInfo;
 
 /**
  * Parent sampled

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -15,7 +15,6 @@ SENTRY_NO_INIT
  */
 @property (nonatomic, readonly) NSString *name;
 @property (nonatomic, readonly) SentryTransactionNameSource nameSource;
-@property (nonatomic, copy, readonly) SentryThread *threadInfo;
 
 /**
  * Parent sampled

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -593,7 +593,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
             @"name" : transaction.transaction,
             @"relative_start_ns" : relativeStart,
             @"relative_end_ns" : relativeEnd,
-            @"active_thread_id" : transaction.trace.transactionContext.threadInfo.threadId
+            @"active_thread_id" : [transaction.trace.transactionContext sentry_threadInfo].threadId
         }];
     }
     profile[@"transactions"] = transactionsInfo;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -22,6 +22,7 @@
 #    import "SentryScreenFrames.h"
 #    import "SentrySerialization.h"
 #    import "SentrySpanId.h"
+#    import "SentryThread.h"
 #    import "SentryTime.h"
 #    import "SentryTransaction.h"
 #    import "SentryTransactionContext.h"
@@ -573,7 +574,6 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
 
     // populate info from all transactions that occurred while profiler was running
     auto transactionsInfo = [NSMutableArray array];
-    NSString *mainThreadID = [profile[@"profile"][@"samples"] firstObject][@"thread_id"];
     for (SentryTransaction *transaction in _transactions) {
         const auto relativeStart =
             [NSString stringWithFormat:@"%llu",
@@ -593,10 +593,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
             @"name" : transaction.transaction,
             @"relative_start_ns" : relativeStart,
             @"relative_end_ns" : relativeEnd,
-            @"active_thread_id" :
-                mainThreadID // TODO: we are just using the main thread ID for all transactions to
-                             // fix a backend validation error, but this needs to be gathered from
-                             // transaction starts in their contexts and carried forward to here
+            @"active_thread_id" : transaction.trace.transactionContext.threadInfo.threadId
         }];
     }
     profile[@"transactions"] = transactionsInfo;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -25,7 +25,7 @@
 #    import "SentryThread.h"
 #    import "SentryTime.h"
 #    import "SentryTransaction.h"
-#    import "SentryTransactionContext.h"
+#    import "SentryTransactionContext+Private.h"
 
 #    if defined(DEBUG)
 #        include <execinfo.h>

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -8,6 +8,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecided;
 
+@interface
+SentryTransactionContext ()
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+@property (nonatomic, strong) SentryThread *threadInfo;
+#endif
+
+@end
+
 @implementation SentryTransactionContext
 
 - (instancetype)initWithName:(NSString *)name operation:(NSString *)operation
@@ -25,7 +34,7 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = kSentryDefaultSamplingDecision;
-        [self addThreadInfo];
+        [self getThreadInfo];
     }
     return self;
 }
@@ -49,7 +58,7 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = kSentryDefaultSamplingDecision;
-        [self addThreadInfo];
+        [self getThreadInfo];
     }
     return self;
 }
@@ -86,18 +95,25 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = parentSampled;
-        [self addThreadInfo];
+        [self getThreadInfo];
     }
     return self;
 }
 
-- (void)addThreadInfo
+- (void)getThreadInfo
 {
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
     self.threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
 #endif
 }
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+- (SentryThread *)sentry_threadInfo
+{
+    return self.threadInfo;
+}
+#endif
 
 @end
 

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -1,4 +1,5 @@
 #import "SentryTransactionContext.h"
+#include "SentryProfilingConditionals.h"
 #import "SentryThread.h"
 #include "SentryThreadHandle.hpp"
 

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -23,8 +23,7 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = kSentryDefaultSamplingDecision;
-        const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
-        _threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
+        [self addThreadInfo];
     }
     return self;
 }
@@ -48,6 +47,7 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = kSentryDefaultSamplingDecision;
+        [self addThreadInfo];
     }
     return self;
 }
@@ -84,8 +84,17 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = parentSampled;
+        [self addThreadInfo];
     }
     return self;
+}
+
+- (void)addThreadInfo
+{
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+    const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
+    _threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
+#endif
 }
 
 @end

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -1,7 +1,10 @@
 #import "SentryTransactionContext.h"
+#import "SentryThread.h"
 #include "SentryThreadHandle.hpp"
 
 NS_ASSUME_NONNULL_BEGIN
+
+static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecided;
 
 @implementation SentryTransactionContext
 
@@ -19,9 +22,9 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super initWithOperation:operation]) {
         _name = [NSString stringWithString:name];
         _nameSource = source;
-        self.parentSampled = false;
-        const auto threadInfo = ThreadHandle::current()->tid();
-        NSLog(@"%@", threadInfo);
+        self.parentSampled = kSentryDefaultSamplingDecision;
+        const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
+        _threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
     }
     return self;
 }
@@ -44,7 +47,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super initWithOperation:operation sampled:sampled]) {
         _name = [NSString stringWithString:name];
         _nameSource = source;
-        self.parentSampled = false;
+        self.parentSampled = kSentryDefaultSamplingDecision;
     }
     return self;
 }
@@ -77,7 +80,7 @@ NS_ASSUME_NONNULL_BEGIN
                                spanId:spanId
                              parentId:parentSpanId
                             operation:operation
-                              sampled:false]) {
+                              sampled:kSentryDefaultSamplingDecision]) {
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = parentSampled;

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -2,6 +2,7 @@
 #include "SentryProfilingConditionals.h"
 #import "SentryThread.h"
 #include "SentryThreadHandle.hpp"
+#import "SentryTransactionContext+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -94,7 +95,7 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
 {
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
-    _threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
+    self.threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
 #endif
 }
 

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -1,4 +1,5 @@
 #import "SentryTransactionContext.h"
+#include "SentryThreadHandle.hpp"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,6 +20,8 @@ NS_ASSUME_NONNULL_BEGIN
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = false;
+        const auto threadInfo = ThreadHandle::current()->tid();
+        NSLog(@"%@", threadInfo);
     }
     return self;
 }

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -6,10 +6,6 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryTransactionContext (Private)
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-@property (nonatomic, strong) SentryThread *threadInfo;
-#endif
-
 - (instancetype)initWithName:(NSString *)name
                   nameSource:(SentryTransactionNameSource)source
                    operation:(NSString *)operation;
@@ -26,6 +22,10 @@ SentryTransactionContext (Private)
                       spanId:(SentrySpanId *)spanId
                 parentSpanId:(nullable SentrySpanId *)parentSpanId
                parentSampled:(SentrySampleDecision)parentSampled;
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+- (SentryThread *)sentry_threadInfo;
+#endif
 
 @end
 

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 SentryTransactionContext (Private)
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-@property (nonatomic, copy, readonly) SentryThread *threadInfo;
+@property (nonatomic, strong) SentryThread *threadInfo;
 #endif
 
 - (instancetype)initWithName:(NSString *)name

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -1,9 +1,14 @@
+#include "SentryProfilingConditionals.h"
 #import "SentryTransactionContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
 SentryTransactionContext (Private)
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+@property (nonatomic, copy, readonly) SentryThread *threadInfo;
+#endif
 
 - (instancetype)initWithName:(NSString *)name
                   nameSource:(SentryTransactionNameSource)source

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
@@ -42,7 +42,7 @@
 
 #include <memory.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
@@ -30,7 +30,7 @@
 #include "SentryCrashJSONCodec.h"
 #include "SentryCrashMonitorContext.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -29,7 +29,7 @@
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <cxxabi.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -32,7 +32,7 @@
 #include "SentryCrashSystemCapabilities.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #if SentryCrashCRASH_HAS_MACH

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -31,7 +31,7 @@
 #import "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -32,7 +32,7 @@
 #include "SentryCrashStackCursor_MachineContext.h"
 #include "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #if SentryCrashCRASH_HAS_SIGNAL

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -33,7 +33,7 @@
 #import "SentryCrashSysCtl.h"
 #import "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 #import <CommonCrypto/CommonDigest.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
@@ -28,7 +28,7 @@
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashThread.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <memory.h>

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -38,7 +38,7 @@
 #import "SentryCrashSystemCapabilities.h"
 #import <NSData+Sentry.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 #include <inttypes.h>
@@ -355,7 +355,10 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
+    -(TYPE)NAME                                                                                    \
+    {                                                                                              \
+        return sentrycrashstate_currentState()->NAME;                                              \
+    }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -355,10 +355,7 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME                                                                                    \
-    {                                                                                              \
-        return sentrycrashstate_currentState()->NAME;                                              \
-    }
+    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -40,7 +40,7 @@
 #include "SentryCrashString.h"
 #include "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <inttypes.h>

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.c
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.c
@@ -24,7 +24,7 @@
 
 #include "SentryCrashCachedData.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -47,7 +47,7 @@
 #include "SentryCrashUUIDConversion.h"
 #include "SentryScopeSyncC.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
@@ -31,7 +31,7 @@
 #include <mach-o/arch.h>
 #include <mach/mach.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 const char *

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
@@ -32,7 +32,7 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = { "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9",

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
@@ -32,7 +32,7 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 #    define KSPACStrippingMask_ARM64e 0x0000000fffffffff

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
@@ -32,7 +32,7 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
@@ -33,7 +33,7 @@
 
 #    include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = { "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp",

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashDebug.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashFileUtils.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <dirent.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -33,7 +33,7 @@
 
 #include <mach/mach.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #ifdef __arm64__

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashMemory.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <_types/_uint8_t.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -86,7 +86,7 @@ extern "C" {
 // SentryCrash: The original values wouldn't have worked. The slot shift and
 // mask were incorrect.
 #    define TAG_COUNT 8
-//#define TAG_SLOT_MASK 0xf
+// #define TAG_SLOT_MASK 0xf
 #    define TAG_SLOT_MASK 0x07
 
 #    if SUPPORT_MSB_TAGGED_POINTERS
@@ -96,7 +96,7 @@ extern "C" {
 #        define TAG_PAYLOAD_RSHIFT 4
 #    else
 #        define TAG_MASK 1
-//#   define TAG_SLOT_SHIFT 0
+// #   define TAG_SLOT_SHIFT 0
 #        define TAG_SLOT_SHIFT 1
 #        define TAG_PAYLOAD_LSHIFT 0
 #        define TAG_PAYLOAD_RSHIFT 4

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
@@ -27,7 +27,7 @@
 #include "SentryCrashSymbolicator.h"
 #include <stdlib.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 static bool

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
@@ -25,7 +25,7 @@
 #include "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashCPU.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 static bool

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.c
@@ -26,7 +26,7 @@
 #include "SentryCrashStackCursor_Backtrace.h"
 #include <execinfo.h>
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #define MAX_BACKTRACE_LENGTH                                                                       \

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
@@ -26,7 +26,7 @@
 
 #include "SentryCrashSysCtl.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
@@ -29,7 +29,7 @@
 #include "SentryCrashMemory.h"
 #include "SentryCrashSystemCapabilities.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <dispatch/dispatch.h>

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -29,7 +29,7 @@
 #import "NSError+SentrySimpleConstructor.h"
 #import "SentryCrashVarArgs.h"
 
-//#define SentryCrashLogger_LocalLevel TRACE
+// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 @implementation SentryCrashReportFilterPassthrough

--- a/Tests/SentryTests/Profiling/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryTests/Profiling/SentryProfilerSwiftTests.swift
@@ -313,17 +313,17 @@ private extension SentryProfilerSwiftTests {
         }
         XCTAssert(foundAtLeastOneNonEmptySample)
 
-        let transactions = profile["transactions"] as? [[String: String]]
+        let transactions = profile["transactions"] as? [[String: Any]]
         XCTAssertEqual(transactions!.count, numberOfTransactions)
         for transaction in transactions! {
-            XCTAssertEqual(fixture.transactionName, transaction["name"])
+            XCTAssertEqual(fixture.transactionName, transaction["name"] as! String)
             XCTAssertNotNil(transaction["id"])
             if let idString = transaction["id"] {
-                XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: idString))
+                XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: idString as! String))
             }
             XCTAssertNotNil(transaction["trace_id"])
             if let traceIDString = transaction["trace_id"] {
-                XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: traceIDString))
+                XCTAssertNotEqual(SentryId.empty, SentryId(uuidString: traceIDString as! String))
             }
             XCTAssertNotNil(transaction["trace_id"])
             XCTAssertNotNil(transaction["relative_start_ns"])


### PR DESCRIPTION
required changing SentryTracer to an ObjC++ file to use our C++ interface to get thread IDs; when this happened, a latent type mismatch was uncovered, breaking the compilation. it required a bit of a nonobvious semantic change from false (which resolves to 0, where parentSampled used to be a boolean type property set to false, and was changed to the NSUInteger-backed enum) to kSentrySampleDecisionUndecided (which is the 0 value in the enum), and not kSentrySampleDecisionNo as "false" might imply

fixes #2356 