### PR TITLE
fix: profiling transaction timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix issue with invalid profiles uploading (#2358)
+- Fix issue with invalid profiles uploading (#2357 and #2358)
 
 ## 7.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix issue with invalid profiles uploading (#2358)
 - Fix issue with invalid profiles uploading (#2357 and #2358)
+- Fix issue with invalid profiles uploading (#2358 and #2359)
 
 ## 7.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 ### Fixes
 
-- Fix issue with invalid profiles uploading (#2358)
-- Fix issue with invalid profiles uploading (#2357 and #2358)
 - Fix issue with invalid profiles uploading (#2358 and #2359)
 
 ## 7.30.0

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -581,6 +581,8 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
                           ? 0
                           : (unsigned long long)(
                               [transaction.startTimestamp timeIntervalSinceDate:_startDate] * 1e9)];
+        SENTRY_LOG_DEBUG(@"Transaction %@ end timestamp: %@", transaction.trace.context.traceId,
+            transaction.timestamp);
         const auto relativeEnd =
             [NSString stringWithFormat:@"%llu",
                       [transaction.timestamp compare:_endDate] == NSOrderedDescending

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -128,7 +128,8 @@ SentrySpan ()
     _isFinished = YES;
     if (self.timestamp == nil) {
         self.timestamp = [SentryCurrentDate date];
-        SENTRY_LOG_DEBUG(@"Setting span timestamp: %@", self.timestamp);
+        SENTRY_LOG_DEBUG(@"Setting span timestamp: %@ at system time %llu", self.timestamp,
+            (unsigned long long)getAbsoluteTime());
     }
     if (self.tracer != nil) {
         [self.tracer spanFinished:self];

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -25,8 +25,8 @@ SentrySpan ()
 - (instancetype)initWithTracer:(SentryTracer *)tracer context:(SentrySpanContext *)context
 {
     if (self = [super init]) {
-        SENTRY_LOG_DEBUG(
-            @"Starting span %@ with tracer %@", context.spanId.sentrySpanIdString, tracer);
+        SENTRY_LOG_DEBUG(@"Created span %@ for trace ID %@", context.spanId.sentrySpanIdString,
+            tracer.context.traceId);
         _tracer = tracer;
         _context = context;
         self.startTimestamp = [SentryCurrentDate date];
@@ -128,6 +128,7 @@ SentrySpan ()
     _isFinished = YES;
     if (self.timestamp == nil) {
         self.timestamp = [SentryCurrentDate date];
+        SENTRY_LOG_DEBUG(@"Setting span timestamp: %@", self.timestamp);
     }
     if (self.tracer != nil) {
         [self.tracer spanFinished:self];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -143,6 +143,8 @@ static BOOL appStartMeasurementRead;
           dispatchQueueWrapper:(nullable SentryDispatchQueueWrapper *)dispatchQueueWrapper
 {
     if (self = [super init]) {
+        SENTRY_LOG_DEBUG(
+            @"Starting transaction at system time %llu", (unsigned long long)getAbsoluteTime());
         self.rootSpan = [[SentrySpan alloc] initWithTracer:self context:transactionContext];
         self.transactionContext = transactionContext;
         _children = [[NSMutableArray alloc] init];
@@ -399,6 +401,8 @@ static BOOL appStartMeasurementRead;
 
 - (void)finish
 {
+    SENTRY_LOG_DEBUG(
+        @"-[SentryTracer finish] for trace ID %@", _traceContext.traceId.sentryIdString);
     [self finishWithStatus:kSentrySpanStatusOk];
 }
 

--- a/Tests/SentryTests/Profiling/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryTests/Profiling/SentryProfilerSwiftTests.swift
@@ -327,7 +327,7 @@ private extension SentryProfilerSwiftTests {
             }
             XCTAssertNotNil(transaction["trace_id"])
             XCTAssertNotNil(transaction["relative_start_ns"])
-            XCTAssertNotNil(transaction["relative_end_ns"])
+            XCTAssertFalse((transaction["relative_end_ns"] as! NSString).isEqual(to: "0"))
             XCTAssertNotNil(transaction["active_thread_id"])
         }
 


### PR DESCRIPTION
follows on with #2358 to fix some backend validation issues with how we're building profiles in the client. fixes #2352 

The quick fix here is to simply discard transactions that end before the profiler started, and discard profiles that have no transactions associated after removing such. This will probably always be a good check to make, but we will want to try to minimize the time between transaction start and profiler start, so we can still gather shorter and shorter transactions instead of throwing them out.

- [x] merge #2358 before this one