### PR TITLE
test: Use flush for macOS-SPM sample

### DIFF
--- a/Samples/macOS-SPM-CommandLine/Sources/macOS-SPM-CommandLine/main.swift
+++ b/Samples/macOS-SPM-CommandLine/Sources/macOS-SPM-CommandLine/main.swift
@@ -11,17 +11,8 @@ SentrySDK.start { options in
  */
 private func captureMessage() {
     let eventId = SentrySDK.capture(message: "Yeah captured a message")
-
-    // Some Delay to wait for sending the message
-    let group = DispatchGroup()
-    group.enter()
-    let queue = DispatchQueue(label: "delay", qos: .background, attributes: [])
-    queue.asyncAfter(deadline: .now() + 2) {
-        group.leave()
-    }
-    group.wait()
-    
     print("\(String(describing: eventId))")
+    SentrySDK.flush(timeout: 5)
 }
 
 captureMessage()


### PR DESCRIPTION
Replace delay with DispatchQueue with flush.

#skip-changelog