### PR TITLE
ci: Ping clang-format to 14.0.6

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -13,11 +13,11 @@ jobs:
   # if necessary
   format-code:
     name: Format Code
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Install Clang-Format
-        run: brew install clang-format
+      - name: Use Clang-Format 14 
+        run: $(brew --prefix llvm@14)/bin/clang
       - name: Format Code
         run: make format
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Clang-Format
-        run: brew install clang-format@14.0.6
+        run: brew install clang-format 14.0.6
       - name: Format Code
         run: make format
 

--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: Use Clang-Format 14 
-        run: $(brew --prefix llvm@14)/bin/clang
+      - name: Install Clang-Format
+        run: brew install clang-format@14.0.6
       - name: Format Code
         run: make format
 


### PR DESCRIPTION
Pin clang-format version to 14.0.6. We had issues in the past when 
clang-format was updated, it came with changes to code formatting, 
and suddenly the code was formatted differently. Instead, we want
to choose ourselves when to update the clang-format version.

#skip-changelog