### PR TITLE
test: Fixing 'testGetCaptureFailedRequestsEnabled'

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -246,9 +246,9 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         wait(for: [expect], timeout: 5)
         
         XCTAssertNotNil(sentryEvent)
-        XCTAssertNotNil(sentryEvent!.request)
+        XCTAssertNotNil(sentryEvent?.request)
         
-        let sentryResponse = sentryEvent!.context?["response"]
+        let sentryResponse = sentryEvent?.context?["response"]
 
         XCTAssertEqual(sentryResponse?["status_code"] as? NSNumber, 400)
     }


### PR DESCRIPTION
`testGetCaptureFailedRequestsEnabled` should fail and not crash when the test server is not running.


_#skip-changelog_ 