### PR TITLE
feat: Track usage of the enableCaptureFailedRequests option

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -416,7 +416,7 @@ NS_SWIFT_NAME(Options)
 
 /**
  * When enabled, the SDK captures HTTP Client errors. Default value is NO.
- * This feature requires enableSwizzling enabled as well, Default value is YES.
+ * This feature requires enableSwizzling enabled as well, default value is YES.
  */
 @property (nonatomic, assign) BOOL enableCaptureFailedRequests;
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -654,6 +654,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
         if (self.options.stitchAsyncCode) {
             [integrations addObject:@"StitchAsyncCode"];
         }
+
+        if (self.options.enableCaptureFailedRequests) {
+            [integrations addObject:@"HTTPClientErrors"];
+        }
     }
 
     event.sdk = @{

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1047,6 +1047,22 @@ class SentryClientTest: XCTestCase {
             )
         }
     }
+
+    func testTrackEnableCaptureFailedRequests() {
+        SentrySDK.start(options: Options())
+
+        let eventId = fixture.getSut(configureOptions: { options in
+            options.enableCaptureFailedRequests = true
+        }).capture(message: fixture.messageAsString)
+
+        eventId.assertIsNotEmpty()
+        assertLastSentEvent { actual in
+            assertArrayEquals(
+                expected: ["AutoBreadcrumbTracking", "AutoSessionTracking", "Crash", "NetworkTracking", "HTTPClientErrors"],
+                actual: actual.sdk?["integrations"] as? [String]
+            )
+        }
+    }
     
     func testSetSDKIntegrations_NoIntegrations() {
         let expected: [String] = []


### PR DESCRIPTION
## :scroll: Description

We can now report usage of the enableCaptureFailedRequests option, as an integration.

(Very similar to https://github.com/getsentry/sentry-cocoa/pull/2281.)

## :bulb: Motivation and Context

Closes #2354

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps
