### PR TITLE
Revert "feat: Track usage of the enableCaptureFailedRequests option"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Features
-
-- Report usage of enableCaptureFailedRequests (#2368)
-
 ### Fixes
 
 - Fix issue with invalid profiles uploading (#2358 and #2359)

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -416,7 +416,7 @@ NS_SWIFT_NAME(Options)
 
 /**
  * When enabled, the SDK captures HTTP Client errors. Default value is NO.
- * This feature requires enableSwizzling enabled as well, default value is YES.
+ * This feature requires enableSwizzling enabled as well, Default value is YES.
  */
 @property (nonatomic, assign) BOOL enableCaptureFailedRequests;
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -654,10 +654,6 @@ NSString *const kSentryDefaultEnvironment = @"production";
         if (self.options.stitchAsyncCode) {
             [integrations addObject:@"StitchAsyncCode"];
         }
-
-        if (self.options.enableCaptureFailedRequests) {
-            [integrations addObject:@"CaptureFailedRequests"];
-        }
     }
 
     event.sdk = @{

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1047,22 +1047,6 @@ class SentryClientTest: XCTestCase {
             )
         }
     }
-
-    func testTrackEnableCaptureFailedRequests() {
-        SentrySDK.start(options: Options())
-
-        let eventId = fixture.getSut(configureOptions: { options in
-            options.enableCaptureFailedRequests = true
-        }).capture(message: fixture.messageAsString)
-
-        eventId.assertIsNotEmpty()
-        assertLastSentEvent { actual in
-            assertArrayEquals(
-                expected: ["AutoBreadcrumbTracking", "AutoSessionTracking", "Crash", "NetworkTracking", "CaptureFailedRequests"],
-                actual: actual.sdk?["integrations"] as? [String]
-            )
-        }
-    }
     
     func testSetSDKIntegrations_NoIntegrations() {
         let expected: [String] = []


### PR DESCRIPTION
Reverts getsentry/sentry-cocoa#2368

We can already track this in Looker with the mechanism type
https://github.com/getsentry/sentry-cocoa/blob/59afa00cc8164effb2b774ed683685eda7ae017c/Sources/Sentry/SentryNetworkTracker.m#L339

Sorry about that, @kevinrenskers. We can undo this PR. No need to send the data twice.

#skip-changelog