### PR TITLE
fix: profile payload issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix issue with invalid profiles uploading (#2358 and #2359)
 - Call UIDevice methods on the main thread (#2369)
+- Avoid sending profiles with 0 samples or incorrectly deduplicated backtrace elements (#2375)
 
 ## 7.30.0
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -443,6 +443,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
                     [stacks addObject:stack];
                 }
 
+                SENTRY_LOG_DEBUG(@"Adding sample.");
                 [samples addObject:sample];
             },
             kSentryProfilerFrequencyHz);
@@ -621,6 +622,11 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
         return;
     }
     profile[@"transactions"] = transactionsInfo;
+
+    if ([((NSArray *)profile[@"profile"][@"samples"]) count] == 0) {
+        SENTRY_LOG_DEBUG(@"No samples located in profile");
+        return;
+    }
 
     NSError *error = nil;
     const auto JSONData = [SentrySerialization dataWithJSONObject:profile error:&error];

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -72,7 +72,7 @@ processBacktrace(const Backtrace &backtrace,
     NSMutableArray<NSMutableArray<NSNumber *> *> *stacks,
     NSMutableArray<NSDictionary<NSString *, id> *> *frames,
     NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup, uint64_t startTimestamp,
-    NSMutableDictionary<NSArray<NSNumber *> *, NSNumber *> *stackIndexLookup)
+    NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup)
 {
     const auto threadID = [@(backtrace.threadMetadata.threadID) stringValue];
     NSString *queueAddress = nil;
@@ -130,13 +130,14 @@ processBacktrace(const Backtrace &backtrace,
         sample[@"queue_address"] = queueAddress;
     }
 
-    const auto stackIndex = stackIndexLookup[stack];
+    const auto stackKey = [stack componentsJoinedByString:@"|"];
+    const auto stackIndex = stackIndexLookup[stackKey];
     if (stackIndex) {
         sample[@"stack_id"] = stackIndex;
     } else {
         const auto nextStackIndex = @(stacks.count);
         sample[@"stack_id"] = nextStackIndex;
-        stackIndexLookup[stack] = nextStackIndex;
+        stackIndexLookup[stackKey] = nextStackIndex;
         [stacks addObject:stack];
     }
 
@@ -430,8 +431,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
         const auto stacks = [NSMutableArray<NSMutableArray<NSNumber *> *> array];
         const auto frames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
         const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-        const auto stackIndexLookup =
-            [NSMutableDictionary<NSArray<NSNumber *> *, NSNumber *> dictionary];
+        const auto stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
         sampledProfile[@"samples"] = samples;
         sampledProfile[@"stacks"] = stacks;
         sampledProfile[@"frames"] = frames;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -129,23 +129,24 @@ processBacktrace(const Backtrace &backtrace,
         sample[@"queue_address"] = queueAddress;
     }
 
-    const auto stackIndex = NSNotFound;
+    auto stackIndex = NSNotFound;
     if (stack.count > 0) {
-        [stacks indexOfObjectPassingTest:^BOOL(NSMutableArray<NSNumber *> *_Nonnull nextStack,
-            NSUInteger nextStackIdx, BOOL *_Nonnull stopStackEnumeration) {
-            __block BOOL found = YES;
-            [nextStack enumerateObjectsUsingBlock:^(NSNumber *_Nonnull nextStackFrame,
-                NSUInteger nextStackFrameIdx, BOOL *_Nonnull stopFrameEnumeration) {
-                if (![nextStackFrame isEqualToNumber:stack[nextStackFrameIdx]]) {
-                    *stopFrameEnumeration = YES;
-                    found = NO;
+        stackIndex =
+            [stacks indexOfObjectPassingTest:^BOOL(NSMutableArray<NSNumber *> *_Nonnull nextStack,
+                NSUInteger nextStackIdx, BOOL *_Nonnull stopStackEnumeration) {
+                __block BOOL found = YES;
+                [nextStack enumerateObjectsUsingBlock:^(NSNumber *_Nonnull nextStackFrame,
+                    NSUInteger nextStackFrameIdx, BOOL *_Nonnull stopFrameEnumeration) {
+                    if (![nextStackFrame isEqualToNumber:stack[nextStackFrameIdx]]) {
+                        *stopFrameEnumeration = YES;
+                        found = NO;
+                    }
+                }];
+                if (found) {
+                    *stopStackEnumeration = YES;
                 }
+                return found;
             }];
-            if (found) {
-                *stopStackEnumeration = YES;
-            }
-            return found;
-        }];
     }
     if (stackIndex != NSNotFound) {
         sample[@"stack_id"] = @(stackIndex);

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -514,6 +514,12 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
     @synchronized(self) {
         profile = [_profile mutableCopy];
     }
+
+    if ([((NSArray *)profile[@"profile"][@"samples"]) count] == 0) {
+        SENTRY_LOG_DEBUG(@"No samples located in profile");
+        return;
+    }
+
     profile[@"version"] = @"1";
     const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
     const auto debugMeta = [_debugImageProvider getDebugImages];
@@ -649,11 +655,6 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
         return;
     }
     profile[@"transactions"] = transactionsInfo;
-
-    if ([((NSArray *)profile[@"profile"][@"samples"]) count] == 0) {
-        SENTRY_LOG_DEBUG(@"No samples located in profile");
-        return;
-    }
 
     NSError *error = nil;
     const auto JSONData = [SentrySerialization dataWithJSONObject:profile error:&error];

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -515,7 +515,7 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
         profile = [_profile mutableCopy];
     }
 
-    if ([((NSArray *)profile[@"profile"][@"samples"]) count] == 0) {
+    if ([((NSArray *)profile[@"profile"][@"samples"]) count] < 2) {
         SENTRY_LOG_DEBUG(@"No samples located in profile");
         return;
     }

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -116,10 +116,7 @@ processBacktrace(const Backtrace &backtrace,
             [stack addObject:@(frames.count)];
             frameIndexLookup[instructionAddress] = @(frames.count);
             [frames addObject:frame];
-            SENTRY_LOG_DEBUG(@"No tracked frame for %@; storing in frame index at location %@",
-                instructionAddress, frameIndexLookup[instructionAddress]);
         } else {
-            SENTRY_LOG_DEBUG(@"Found index %@ for frame %@", frameIndex, instructionAddress);
             [stack addObject:frameIndex];
         }
     }
@@ -132,7 +129,8 @@ processBacktrace(const Backtrace &backtrace,
         sample[@"queue_address"] = queueAddress;
     }
 
-    const auto stackIndex =
+    const auto stackIndex = NSNotFound;
+    if (stack.count > 0) {
         [stacks indexOfObjectPassingTest:^BOOL(NSMutableArray<NSNumber *> *_Nonnull nextStack,
             NSUInteger nextStackIdx, BOOL *_Nonnull stopStackEnumeration) {
             __block BOOL found = YES;
@@ -148,17 +146,14 @@ processBacktrace(const Backtrace &backtrace,
             }
             return found;
         }];
+    }
     if (stackIndex != NSNotFound) {
         sample[@"stack_id"] = @(stackIndex);
-        SENTRY_LOG_DEBUG(@"Found previous copy of stack at index %lu", stackIndex);
     } else {
         sample[@"stack_id"] = @(stacks.count);
         [stacks addObject:stack];
-        SENTRY_LOG_DEBUG(
-            @"No previous copy of stack %@, storing at index %@", stack, sample[@"stack_id"]);
     }
 
-    SENTRY_LOG_DEBUG(@"Adding sample.");
     [samples addObject:sample];
 }
 

--- a/Sources/Sentry/include/SentryProfiler+Test.h
+++ b/Sources/Sentry/include/SentryProfiler+Test.h
@@ -2,6 +2,7 @@
 #import "SentryProfiler.h"
 #import "SentryProfilingConditionals.h"
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
 void processBacktrace(const sentry::profiling::Backtrace &backtrace,
     NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata,
     NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata,
@@ -10,3 +11,4 @@ void processBacktrace(const sentry::profiling::Backtrace &backtrace,
     NSMutableArray<NSDictionary<NSString *, id> *> *frames,
     NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup, uint64_t startTimestamp,
     NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup);
+#endif

--- a/Sources/Sentry/include/SentryProfiler+Test.h
+++ b/Sources/Sentry/include/SentryProfiler+Test.h
@@ -8,4 +8,5 @@ void processBacktrace(const sentry::profiling::Backtrace &backtrace,
     NSMutableArray<NSDictionary<NSString *, id> *> *samples,
     NSMutableArray<NSMutableArray<NSNumber *> *> *stacks,
     NSMutableArray<NSDictionary<NSString *, id> *> *frames,
-    NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup, uint64_t startTimestamp);
+    NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup, uint64_t startTimestamp,
+    NSMutableDictionary<NSArray<NSNumber *> *, NSNumber *> *stackIndexLookup);

--- a/Sources/Sentry/include/SentryProfiler+Test.h
+++ b/Sources/Sentry/include/SentryProfiler+Test.h
@@ -9,4 +9,4 @@ void processBacktrace(const sentry::profiling::Backtrace &backtrace,
     NSMutableArray<NSMutableArray<NSNumber *> *> *stacks,
     NSMutableArray<NSDictionary<NSString *, id> *> *frames,
     NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup, uint64_t startTimestamp,
-    NSMutableDictionary<NSArray<NSNumber *> *, NSNumber *> *stackIndexLookup);
+    NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup);

--- a/Sources/Sentry/include/SentryProfiler+Test.h
+++ b/Sources/Sentry/include/SentryProfiler+Test.h
@@ -1,11 +1,11 @@
+#include "SentryBacktrace.hpp"
 #import "SentryProfiler.h"
 #import "SentryProfilingConditionals.h"
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-@interface
-SentryProfiler (SentryTest)
-
-+ (void)timeoutAbort;
-
-@end
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+void processBacktrace(const sentry::profiling::Backtrace &backtrace,
+    NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata,
+    NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata,
+    NSMutableArray<NSDictionary<NSString *, id> *> *samples,
+    NSMutableArray<NSMutableArray<NSNumber *> *> *stacks,
+    NSMutableArray<NSDictionary<NSString *, id> *> *frames,
+    NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup, uint64_t startTimestamp);

--- a/Tests/SentryTests/Profiling/SentryProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentryProfilerTests.mm
@@ -1,9 +1,9 @@
 #import "SentryProfiler+Test.h"
 #import "SentryProfilingConditionals.h"
 
-using namespace sentry::profiling;
-
 #if SENTRY_TARGET_PROFILING_SUPPORTED
+
+using namespace sentry::profiling;
 
 #    import "SentryProfiler.h"
 #    import <XCTest/XCTest.h>

--- a/Tests/SentryTests/Profiling/SentryProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentryProfilerTests.mm
@@ -61,6 +61,8 @@ using namespace sentry::profiling;
     const auto resolvedSamples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
     const auto resolvedFrames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
     const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
+    const auto stackIndexLookup =
+        [NSMutableDictionary<NSArray<NSNumber *> *, NSNumber *> dictionary];
     const auto profileStartTimestamp = 0;
 
     // record an initial backtrace
@@ -83,7 +85,7 @@ using namespace sentry::profiling;
     backtrace1.addresses = addresses1;
 
     processBacktrace(backtrace1, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp);
+        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp, stackIndexLookup);
 
     // record a second backtrace with some common addresses to test frame deduplication
 
@@ -105,12 +107,12 @@ using namespace sentry::profiling;
     backtrace2.addresses = addresses2;
 
     processBacktrace(backtrace2, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp);
+        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp, stackIndexLookup);
 
     // record a third backtrace that's identical to the second to test stack deduplication
 
     processBacktrace(backtrace2, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp);
+        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp, stackIndexLookup);
 
     XCTAssertEqual(resolvedFrames.count, 5UL);
     XCTAssertEqual(resolvedStacks.count, 2UL);

--- a/Tests/SentryTests/Profiling/SentryProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentryProfilerTests.mm
@@ -1,4 +1,7 @@
+#import "SentryProfiler+Test.h"
 #import "SentryProfilingConditionals.h"
+
+using namespace sentry::profiling;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -47,6 +50,71 @@
     });
     [self waitForExpectationsWithTimeout:1.0
                                  handler:^(NSError *_Nullable error) { NSLog(@"%@", error); }];
+}
+
+- (void)testProfilerPayload
+{
+    const auto resolvedThreadMetadata =
+        [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
+    const auto resolvedQueueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
+    const auto resolvedStacks = [NSMutableArray<NSMutableArray<NSNumber *> *> array];
+    const auto resolvedSamples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
+    const auto resolvedFrames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
+    const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
+    const auto profileStartTimestamp = 0;
+
+    // record an initial backtrace
+
+    ThreadMetadata threadMetadata1;
+    threadMetadata1.name = "testThread";
+    threadMetadata1.threadID = 12345568910;
+    threadMetadata1.priority = 666;
+
+    QueueMetadata queueMetadata1;
+    queueMetadata1.address = 9876543210;
+    queueMetadata1.label = std::make_shared<std::string>("testQueue");
+
+    const auto addresses1 = std::vector<std::uintptr_t>({ 123, 456, 789 });
+
+    Backtrace backtrace1;
+    backtrace1.threadMetadata = threadMetadata1;
+    backtrace1.queueMetadata = queueMetadata1;
+    backtrace1.absoluteTimestamp = 5;
+    backtrace1.addresses = addresses1;
+
+    processBacktrace(backtrace1, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
+        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp);
+
+    // record a second backtrace with some common addresses to test frame deduplication
+
+    ThreadMetadata threadMetadata2;
+    threadMetadata2.name = "testThread";
+    threadMetadata2.threadID = 12345568910;
+    threadMetadata2.priority = 666;
+
+    QueueMetadata queueMetadata2;
+    queueMetadata2.address = 9876543210;
+    queueMetadata2.label = std::make_shared<std::string>("testQueue");
+
+    const auto addresses2 = std::vector<std::uintptr_t>({ 777, 888, 789 });
+
+    Backtrace backtrace2;
+    backtrace2.threadMetadata = threadMetadata2;
+    backtrace2.queueMetadata = queueMetadata2;
+    backtrace2.absoluteTimestamp = 5;
+    backtrace2.addresses = addresses2;
+
+    processBacktrace(backtrace2, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
+        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp);
+
+    // record a third backtrace that's identical to the second to test stack deduplication
+
+    processBacktrace(backtrace2, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
+        resolvedStacks, resolvedFrames, frameIndexLookup, profileStartTimestamp);
+
+    XCTAssertEqual(resolvedFrames.count, 5UL);
+    XCTAssertEqual(resolvedStacks.count, 2UL);
+    XCTAssertEqual(resolvedSamples.count, 3UL);
 }
 
 @end

--- a/Tests/SentryTests/Profiling/SentryProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentryProfilerTests.mm
@@ -61,8 +61,7 @@ using namespace sentry::profiling;
     const auto resolvedSamples = [NSMutableArray<NSDictionary<NSString *, id> *> array];
     const auto resolvedFrames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
     const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-    const auto stackIndexLookup =
-        [NSMutableDictionary<NSArray<NSNumber *> *, NSNumber *> dictionary];
+    const auto stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
     const auto profileStartTimestamp = 0;
 
     // record an initial backtrace

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -116,7 +116,7 @@
 #import "SentryPerformanceTracker.h"
 #import "SentryPerformanceTrackingIntegration.h"
 #import "SentryPredicateDescriptor.h"
-#import "SentryProfiler+Test.h"
+#import "SentryProfiler.h"
 #import "SentryQueueableRequestManager.h"
 #import "SentryRandom.h"
 #import "SentryRateLimitParser.h"


### PR DESCRIPTION
There were a couple remaining issues with profile payloads:
- sometimes we still try to send an envelope with 0 samples, presumably for very fast start/stop of profiler. we simply discard these and log for now
- we weren't deduplicating frames across an entire profile, only per sample
- we weren't performing a correct deep equality check between stacks