### PR TITLE
build: Split Swift and Clang format for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,14 @@ repos:
   - repo: local
     hooks:
       - id: format-clang
-        name: Clang Format
+        name: Format ObjC, C, and C++
         entry: make
         language: system
         types_or: ["objective-c", "objective-c++", "c", "c++"]
         args:
           - "format-clang"
       - id: format-swift
-        name: Clang Format
+        name: Format Swift
         entry: make
         language: system
         types_or: ["swift" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         types_or: ["objective-c", "objective-c++", "c", "c++"]
         args:
           - "format-clang"
+          
       - id: format-swift
         name: Format Swift
         entry: make

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
   - repo: local
     hooks:
       - id: format-clang
-        name: Format ObjC, C, and C++
+        name: Format ObjC, ObjC++, C, and C++
         entry: make
         language: system
         types_or: ["objective-c", "objective-c++", "c", "c++"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,10 +16,17 @@ repos:
 
   - repo: local
     hooks:
-      - id: clang-format
+      - id: format-clang
         name: Clang Format
         entry: make
         language: system
-        types_or: ["objective-c", "objective-c++", "c", "c++", "swift" ]
+        types_or: ["objective-c", "objective-c++", "c", "c++"]
         args:
-          - "format"
+          - "format-clang"
+      - id: format-swift
+        name: Clang Format
+        entry: make
+        language: system
+        types_or: ["swift" ]
+        args:
+          - "format-swift"

--- a/Makefile
+++ b/Makefile
@@ -22,14 +22,17 @@ lint:
 	swiftlint
 .PHONY: lint
 
-# Format all h,c,cpp and m files
-format:
+format: format-clang format-swift
+
+# Format all h, c, cpp, mm, and m files
+format-clang:
 	@find . -type f \( -name "*.h" -or -name "*.hpp" -or -name "*.c" -or -name "*.cpp" -or -name "*.m" -or -name "*.mm" \) -and \
 		! \( -path "**.build/*" -or -path "**Build/*" -or -path "**/Carthage/Checkouts/*"  -or -path "**/libs/**" \) \
 		| xargs clang-format -i -style=file
 
+# Format all h, c, cpp, mm, and m files
+format-swift:
 	swiftlint --fix
-.PHONY: format
 
 test:
 	@echo "--> Running all tests"

--- a/Makefile
+++ b/Makefile
@@ -24,13 +24,13 @@ lint:
 
 format: format-clang format-swift
 
-# Format all h, c, cpp, mm, and m files
+# Format ObjC, ObjC++, C, and C++
 format-clang:
 	@find . -type f \( -name "*.h" -or -name "*.hpp" -or -name "*.c" -or -name "*.cpp" -or -name "*.m" -or -name "*.mm" \) -and \
 		! \( -path "**.build/*" -or -path "**Build/*" -or -path "**/Carthage/Checkouts/*"  -or -path "**/libs/**" \) \
 		| xargs clang-format -i -style=file
 
-# Format all h, c, cpp, mm, and m files
+# Format Swift
 format-swift:
 	swiftlint --fix
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -44,7 +44,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.enableCaptureFailedRequests = true
             let httpStatusCodeRange = HttpStatusCodeRange(min: 400, max: 599)
             options.failedRequestStatusCodes = [ httpStatusCodeRange ]
-            
         }
         
         if #available(iOS 14.0, *) {

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -44,6 +44,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.enableCaptureFailedRequests = true
             let httpStatusCodeRange = HttpStatusCodeRange(min: 400, max: 599)
             options.failedRequestStatusCodes = [ httpStatusCodeRange ]
+            
         }
         
         if #available(iOS 14.0, *) {


### PR DESCRIPTION
Split Swift and Clang format for pre-commit, so it runs faster. 
Now, if you only edit Swift files, clang-format doesn't run. 

##skip-changelog