### PR TITLE
feat(hybrid-sdks): Add captureScreenshots to PrivateSDKOnly

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -8,6 +8,7 @@
 #import "SentrySerialization.h"
 #import <SentryDependencyContainer.h>
 #import <SentryFramesTracker.h>
+#import <SentryScreenshot.h>
 
 @implementation PrivateSentrySDKOnly
 
@@ -122,7 +123,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (NSArray<NSData *> *)captureScreenshots
 {
-    return [[SentryDependencyContainer sharedInstance].screenshot takeScreenshots];
+    return [SentryDependencyContainer.sharedInstance.screenshot takeScreenshots];
 }
 
 #endif

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -120,6 +120,11 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [SentryFramesTracker sharedInstance].currentFrames;
 }
 
++ (NSArray<NSData *> *)captureScreenshots
+{
+    return [[SentryDependencyContainer sharedInstance].screenshot takeScreenshots];
+}
+
 #endif
 
 @end

--- a/Sources/Sentry/include/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/PrivateSentrySDKOnly.h
@@ -95,6 +95,8 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 @property (class, nonatomic, assign, readonly) BOOL isFramesTrackingRunning;
 
 @property (class, nonatomic, assign, readonly) SentryScreenFrames *currentScreenFrames;
+
++ (NSArray<NSData *> *)captureScreenShots;
 #endif
 
 @end

--- a/Sources/Sentry/include/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/PrivateSentrySDKOnly.h
@@ -96,7 +96,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 @property (class, nonatomic, assign, readonly) SentryScreenFrames *currentScreenFrames;
 
-+ (NSArray<NSData *> *)captureScreenShots;
++ (NSArray<NSData *> *)captureScreenshots;
 #endif
 
 @end

--- a/Sources/Sentry/include/SentryScreenshot.h
+++ b/Sources/Sentry/include/SentryScreenshot.h
@@ -14,6 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSArray<NSData *> *)appScreenshots;
 
 - (void)saveScreenShots:(NSString *)path;
+
+- (NSArray<NSData *> *)takeScreenshots;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## :scroll: Description
To avoid duplication code I would like to expose the screenshot function via the PrivateSDKOnly header.

## :bulb: Motivation and Context
- https://github.com/getsentry/team-mobile/issues/11
- https://github.com/getsentry/sentry-react-native/pull/2610

## :green_heart: How did you test it?
Not yet.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [ ] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps

#skip-changelog 