### PR TITLE
test: Disable flaky testSerializeWithUnderlyingNSException

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -65,6 +65,9 @@
                   Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readUrl_disabled()">
                </Test>
                <Test
+                  Identifier = "SentryNSErrorTests/testSerializeWithUnderlyingNSException_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentryNetworkTrackerIntegrationTests/testGetRequest_SpanCreatedAndBaggageHeaderAdded_disabled()">
                </Test>
                <Test

--- a/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
+++ b/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
@@ -27,7 +27,7 @@ class SentryNSErrorTests: XCTestCase {
         XCTAssertEqual(actualUnderlyingError.domain, inputUnderlyingError.domain)
     }
 
-    func testSerializeWithUnderlyingNSException() {
+    func testSerializeWithUnderlyingNSException_disabled() {
         let inputExceptionName = NSExceptionName.decimalNumberDivideByZeroException
         let inputExceptionReason = "test exception reason"
         let inputUnderlyingException = NSException(name: inputExceptionName, reason: inputExceptionReason, userInfo: ["some userinfo key": "some userinfo value"])


### PR DESCRIPTION
Flaky run https://github.com/getsentry/sentry-cocoa/actions/runs/3465967126/jobs/5789326262.

PR to fix https://github.com/getsentry/sentry-cocoa/issues/2388.

#skip-changelog