### PR TITLE
Fix: Set the correct OOM event timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Set the correct OOM event timestamp (#2394)
+
 ## 7.31.0
 
 ### Features

--- a/Sources/Sentry/SentryOutOfMemoryTracker.m
+++ b/Sources/Sentry/SentryOutOfMemoryTracker.m
@@ -1,3 +1,4 @@
+#import "NSDate+SentryExtras.h"
 #import "SentryEvent+Private.h"
 #import "SentryFileManager.h"
 #import <Foundation/Foundation.h>
@@ -66,6 +67,12 @@ SentryOutOfMemoryTracker ()
                     subarrayWithRange:NSMakeRange(event.serializedBreadcrumbs.count
                                               - self.options.maxBreadcrumbs,
                                           self.options.maxBreadcrumbs)];
+            }
+
+            NSDictionary *lastBreadcrumb = event.serializedBreadcrumbs.lastObject;
+            if (lastBreadcrumb && [lastBreadcrumb objectForKey:@"timestamp"]) {
+                NSString *timestampIso8601String = [lastBreadcrumb objectForKey:@"timestamp"];
+                event.timestamp = [NSDate sentry_fromIso8601String:timestampIso8601String];
             }
 
             SentryException *exception =

--- a/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
@@ -225,6 +225,9 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
         fixture.fileManager.moveBreadcrumbsToPreviousBreadcrumbs()
         sut.start()
         assertOOMEventSent(expectedBreadcrumbs: 2)
+
+        let crashEvent = fixture.client.captureCrashEventInvocations.first?.event
+        XCTAssertEqual(crashEvent?.timestamp, breadcrumb.timestamp)
     }
 
     func testAppOOM_WithOnlyHybridSdkDidBecomeActive() {


### PR DESCRIPTION
## :scroll: Description

Use the last breadcrumb's timestamp as the OOM event timestamp

## :bulb: Motivation and Context

Fixes #2383

## :green_heart: How did you test it?

Unit tests, and ran the sample app, creating an OOM and waiting a few minutes before starting the app again. The OOM event has the correct timestamp: https://sentry.io/organizations/sentry-sdks/issues/2291658301/?project=5428557&query=is%3Aunresolved&referrer=issue-stream.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
