### PR TITLE
fix: Crash in Client when reading integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Crash in Client when reading integrations (#2397)
+
 ## 7.31.1
 
 ### Fixes

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -641,7 +641,13 @@ NSString *const kSentryDefaultEnvironment = @"production";
     id integrations = event.extra[@"__sentry_sdk_integrations"];
     if (!integrations) {
         integrations = [NSMutableArray new];
-        for (NSString *integration in SentrySDK.currentHub.installedIntegrationNames) {
+
+        // The SDK can send an event before it installs all integrations, which add to this list. To
+        // avoid an exception while iterating over a list while items get added to it, we copy it.
+        // With that approach, we might not have the complete integration list. To fix this, the SDK
+        // would need to ask all integrations first if they should be installed before actually
+        // installing them, which would be quite a bit a of a refactoring.
+        for (NSString *integration in SentrySDK.currentHub.installedIntegrationNames.copy) {
             // Every integration starts with "Sentry" and ends with "Integration". To keep the
             // payload of the event small we remove both.
             NSString *withoutSentry = [integration stringByReplacingOccurrencesOfString:@"Sentry"


### PR DESCRIPTION




## :scroll: Description

Fix reading from the integrations list while it's being modified on another thread on the client.

## :bulb: Motivation and Context

Fixes GH-2397

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
