### PR TITLE
test: include Sentry changes in hash keys

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -37,7 +37,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
-          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-${{ hashFiles('Sentry/Sources/**') }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-benchmark-runner-cache
         uses: actions/cache@v3

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -30,7 +30,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app
             DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app.dSYM
-          key: trendingmovies-app-cache-key-${{ hashFiles('Samples/TrendingMovies/TrendingMovies/**') }}
+          key: trendingmovies-app-cache-key-${{ hashFiles('Samples/TrendingMovies/TrendingMovies/**') }}-${{ hashFiles('Sentry/Sources/**') }}
       - name: Cache ProfileDataGenerator UI Test Runner App build product
         id: cache-profiledatagenerator-test-runner-app
         uses: actions/cache@v3

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -44,7 +44,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
-          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}-${{ hashFiles('Sentry/Sources/**') }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-uitest-runner-cache
         uses: actions/cache@v3


### PR DESCRIPTION
Previously, test apps that link in compiled Sentry sources weren't getting rebuilt even if the sentry sources changed.

#skip-changelog