### PR TITLE
test: Disable NSDataTracker in clearTestState

### DIFF
--- a/Tests/SentryTests/ClearTestState.swift
+++ b/Tests/SentryTests/ClearTestState.swift
@@ -25,4 +25,6 @@ func clearTestState() {
     SentryDependencyContainer.reset()
     Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()
     SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
+    
+    SentryNSDataTracker.sharedInstance.disable()
 }


### PR DESCRIPTION
To avoid unnecessary extra work.

#skip-changelog