### PR TITLE
test: shorten some tests

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -314,7 +314,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
             let queue = DispatchQueue(label: "SentryPerformanceTrackerTests", attributes: [.concurrent, .initiallyInactive])
             let group = DispatchGroup()
             
-            for _ in 0 ..< 50_000 {
+            for _ in 0 ..< 50 {
                 group.enter()
                 queue.async {
                     let childId = self.startSpan(tracker: sut)

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -697,12 +697,14 @@ class SentryTracerTests: XCTestCase {
         
         let queue = DispatchQueue(label: "SentryTracerTests", attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
-        
-        for _ in 0 ..< 5_000 {
+
+        let children = 5
+        let grandchildren = 10
+        for _ in 0 ..< children {
             group.enter()
             queue.async {
                 let grandChild = child.startChild(operation: self.fixture.transactionOperation)
-                for _ in 0 ..< 9 {
+                for _ in 0 ..< grandchildren {
                     let grandGrandChild = grandChild.startChild(operation: self.fixture.transactionOperation)
                     grandGrandChild.finish()
                 }
@@ -721,7 +723,7 @@ class SentryTracerTests: XCTestCase {
         assertOneTransactionCaptured(sut)
         
         let spans = getSerializedTransaction()["spans"]! as! [[String: Any]]
-        XCTAssertEqual(spans.count, 50_001)
+        XCTAssertEqual(spans.count, children * (grandchildren + 1) + 1)
     }
     
     // Although we only run this test above the below specified versions, we expect the
@@ -735,7 +737,7 @@ class SentryTracerTests: XCTestCase {
         let queue = DispatchQueue(label: "", qos: .background, attributes: [.concurrent, .initiallyInactive] )
         let group = DispatchGroup()
         
-        let transactions = 10_000
+        let transactions = 5
         for _ in 0..<transactions {
             group.enter()
             queue.async {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -331,9 +331,9 @@ class SentryScopeSwiftTests: XCTestCase {
             group.enter()
             queue.async {
                 
-                // The number is kept small for the CI to not take to long.
+                // The number is kept small for the CI to not take too long.
                 // If you really want to test this increase to 100_000 or so.
-                for _ in 0...1_000 {
+                for _ in 0...10 {
                     // Simulate some real world modifications of the user
                     self.modifyScope(scope: scope)
                 }

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -2,7 +2,6 @@ import Foundation
 
 class TestClient: Client {
     let sentryFileManager: SentryFileManager
-    let queue = DispatchQueue(label: "TestClient", attributes: .concurrent)
 
     override init?(options: Options) {
         sentryFileManager = try! SentryFileManager(options: options, andCurrentDateProvider: TestCurrentDateProvider())


### PR DESCRIPTION
While making various refactorings (for https://github.com/getsentry/sentry-cocoa/pull/2228) and running tests locally, there were a few that ran really slowly.

How do we feel about shortening these loops, and then if we want something like a stress test suite that runs nightly or post-merge, do it separately there?

#skip-changelog