### PR TITLE
test: prevent crashing on nil or index out of bounds

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -410,7 +410,11 @@ class SentryHttpTransportTests: XCTestCase {
         let sessionData = try! SentrySerialization.data(with: sessionEnvelope)
         let sessionRequest = try! SentryNSURLRequest(envelopeRequestWith: SentryHttpTransportTests.dsn, andData: sessionData)
 
-        XCTAssertEqual(sessionRequest.httpBody, fixture.requestManager.requests.invocations[3].httpBody, "Envelope with only session item should be sent.")
+        if fixture.requestManager.requests.invocations.count > 3 {
+            XCTAssertEqual(sessionRequest.httpBody, fixture.requestManager.requests.invocations[3].httpBody, "Envelope with only session item should be sent.")
+        } else {
+            XCTFail("Expected a fourth invocation")
+        }
     }
 
     func testAllCachedEnvelopesCantDeserializeEnvelope() throws {
@@ -435,7 +439,11 @@ class SentryHttpTransportTests: XCTestCase {
         XCTAssertEqual(3, fixture.requestManager.requests.count)
         XCTAssertEqual(fixture.eventWithAttachmentRequest.httpBody, fixture.requestManager.requests.invocations[1].httpBody, "Cached envelope was not sent first.")
 
-        XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests.invocations[2].httpBody, "Cached envelope was not sent first.")
+        if fixture.requestManager.requests.invocations.count > 2 {
+            XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests.invocations[2].httpBody, "Cached envelope was not sent first.")
+        } else {
+            XCTFail("Expected a third invocation")
+        }
     }
     
     func testRecordLostEvent_SendingEvent_AttachesClientReport() {

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -398,7 +398,10 @@ class SentrySDKTests: XCTestCase {
         
         XCTAssertEqual(2, fixture.client.captureSessionInvocations.count)
         
-        let actual = fixture.client.captureSessionInvocations.invocations[1]
+        guard let actual = fixture.client.captureSessionInvocations.invocations.last else {
+            XCTFail("Expected a captured session")
+            return
+        }
         
         XCTAssertNil(actual.flagInit)
         XCTAssertEqual(0, actual.errors)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -389,7 +389,7 @@ class SentrySDKTests: XCTestCase {
         XCTAssertNil(actual?.duration)
     }
     
-    func testEndSession() {
+    func testEndSession() throws {
         givenSdkWithHub()
         
         SentrySDK.startSession()
@@ -398,10 +398,7 @@ class SentrySDKTests: XCTestCase {
         
         XCTAssertEqual(2, fixture.client.captureSessionInvocations.count)
         
-        guard let actual = fixture.client.captureSessionInvocations.invocations.last else {
-            XCTFail("Expected a captured session")
-            return
-        }
+        let actual = try XCTUnwrap(fixture.client.captureSessionInvocations.invocations.last)
         
         XCTAssertNil(actual.flagInit)
         XCTAssertEqual(0, actual.errors)


### PR DESCRIPTION
While testing after making changes for #2228, the test suite would crash in various places due to changes in behavior changing e.g. the amount of things in an array. Change such logic to allow graceful degradation into simply failing the test case instead of crashing the test run.

#skip-changelog