### PR TITLE
Revert "test: shorten some tests (#2422)"

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -314,7 +314,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
             let queue = DispatchQueue(label: "SentryPerformanceTrackerTests", attributes: [.concurrent, .initiallyInactive])
             let group = DispatchGroup()
             
-            for _ in 0 ..< 50 {
+            for _ in 0 ..< 50_000 {
                 group.enter()
                 queue.async {
                     let childId = self.startSpan(tracker: sut)

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -697,14 +697,12 @@ class SentryTracerTests: XCTestCase {
         
         let queue = DispatchQueue(label: "SentryTracerTests", attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
-
-        let children = 5
-        let grandchildren = 10
-        for _ in 0 ..< children {
+        
+        for _ in 0 ..< 5_000 {
             group.enter()
             queue.async {
                 let grandChild = child.startChild(operation: self.fixture.transactionOperation)
-                for _ in 0 ..< grandchildren {
+                for _ in 0 ..< 9 {
                     let grandGrandChild = grandChild.startChild(operation: self.fixture.transactionOperation)
                     grandGrandChild.finish()
                 }
@@ -723,7 +721,7 @@ class SentryTracerTests: XCTestCase {
         assertOneTransactionCaptured(sut)
         
         let spans = getSerializedTransaction()["spans"]! as! [[String: Any]]
-        XCTAssertEqual(spans.count, children * (grandchildren + 1) + 1)
+        XCTAssertEqual(spans.count, 50_001)
     }
     
     // Although we only run this test above the below specified versions, we expect the
@@ -737,7 +735,7 @@ class SentryTracerTests: XCTestCase {
         let queue = DispatchQueue(label: "", qos: .background, attributes: [.concurrent, .initiallyInactive] )
         let group = DispatchGroup()
         
-        let transactions = 5
+        let transactions = 10_000
         for _ in 0..<transactions {
             group.enter()
             queue.async {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -331,9 +331,9 @@ class SentryScopeSwiftTests: XCTestCase {
             group.enter()
             queue.async {
                 
-                // The number is kept small for the CI to not take too long.
+                // The number is kept small for the CI to not take to long.
                 // If you really want to test this increase to 100_000 or so.
-                for _ in 0...10 {
+                for _ in 0...1_000 {
                     // Simulate some real world modifications of the user
                     self.modifyScope(scope: scope)
                 }

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -2,6 +2,7 @@ import Foundation
 
 class TestClient: Client {
     let sentryFileManager: SentryFileManager
+    let queue = DispatchQueue(label: "TestClient", attributes: .concurrent)
 
     override init?(options: Options) {
         sentryFileManager = try! SentryFileManager(options: options, andCurrentDateProvider: TestCurrentDateProvider())


### PR DESCRIPTION
This reverts commit 189472a1a0654f1c4f94941fefa46da76eb05a4a.

I should have merged this to 8.0.0.

#skip-changelog