### PR TITLE
fix: Errors shortly after SentrySDK.init don't affect the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This version adds a dependency on Swift.
 
 - Properly demangle Swift class name (#2162)
 
+### Fixes
+
+- Errors shortly after SentrySDK.init now affect the session (#2430)
+
 ### Breaking Changes
 
 - Remove `- [SentryOptions initWithDict:didFailWithError:]` (#2404)

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -208,7 +208,7 @@ SentryHub ()
 {
     SentrySession *sessionCopy = nil;
     @synchronized(_sessionLock) {
-        if (_session != nil) {
+        if (nil != _session) {
             [_session incrementErrors];
             [self storeCurrentSession:_session];
             sessionCopy = [_session copy];

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -1,8 +1,8 @@
-#import "SentrySession.h"
 #import "NSDate+SentryExtras.h"
 #import "SentryCurrentDate.h"
 #import "SentryInstallation.h"
 #import "SentryLog.h"
+#import "SentrySession+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,11 +21,6 @@ nameForSentrySessionStatus(SentrySessionStatus status)
         return @"abnormal";
     }
 }
-
-@interface
-SentrySession ()
-@property (nonatomic) NSUInteger errors;
-@end
 
 @implementation SentrySession
 

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -22,6 +22,11 @@ nameForSentrySessionStatus(SentrySessionStatus status)
     }
 }
 
+@interface
+SentrySession ()
+@property (nonatomic) NSUInteger errors;
+@end
+
 @implementation SentrySession
 
 @synthesize flagInit = _init;

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -8,6 +8,8 @@ NSString *nameForSentrySessionStatus(SentrySessionStatus status);
 @interface
 SentrySession (Private)
 
+@property (nonatomic) NSUInteger errors;
+
 - (void)setFlagInit;
 
 @end

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 NSString *nameForSentrySessionStatus(SentrySessionStatus status);
 
 @interface
-SentrySession (Private)
+SentrySession ()
 
 @property (nonatomic) NSUInteger errors;
 

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -394,6 +394,19 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
     }
 
+    func testCaptureErrorBeforeSession() {
+        let sut = fixture.getSut()
+        sut.capture(error: fixture.error, scope: fixture.scope).assertIsNotEmpty()
+        sut.startSession()
+
+        XCTAssertEqual(fixture.client.captureErrorWithScopeInvocations.count, 1)
+        XCTAssertEqual(fixture.client.captureSessionInvocations.count, 1)
+
+        if let session = fixture.client.captureSessionInvocations.first {
+            XCTAssertEqual(session.errors, 1)
+        }
+    }
+
     func testCaptureWithoutIncreasingErrorCount() {
         let sut = fixture.getSut()
         sut.startSession()

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -394,7 +394,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
     }
 
-    func testCaptureErrorBeforeSession() {
+    func testCaptureErrorBeforeSessionStart() {
         let sut = fixture.getSut()
         sut.capture(error: fixture.error, scope: fixture.scope).assertIsNotEmpty()
         sut.startSession()
@@ -404,6 +404,20 @@ class SentryHubTests: XCTestCase {
 
         if let session = fixture.client.captureSessionInvocations.first {
             XCTAssertEqual(session.errors, 1)
+        }
+    }
+
+    func testCaptureErrorBeforeSessionStart_DisabledAutoSessionTracking() {
+        fixture.options.enableAutoSessionTracking = false
+        let sut = fixture.getSut()
+        sut.capture(error: fixture.error, scope: fixture.scope).assertIsNotEmpty()
+        sut.startSession()
+
+        XCTAssertEqual(fixture.client.captureErrorWithScopeInvocations.count, 1)
+        XCTAssertEqual(fixture.client.captureSessionInvocations.count, 1)
+
+        if let session = fixture.client.captureSessionInvocations.first {
+            XCTAssertEqual(session.errors, 0)
         }
     }
 


### PR DESCRIPTION
## :scroll: Description

Errors shortly after SentrySDK.init now do affect the session.

## :bulb: Motivation and Context

Closes #2150

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
