### PR TITLE
chore: Update description for Event.transaction

### DIFF
--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -76,7 +76,7 @@ NS_SWIFT_NAME(Event)
 @property (nonatomic, copy) NSString *_Nullable environment;
 
 /**
- * The current transaction (state) on the crash
+ * The name of the transaction which caused this event.
  */
 @property (nonatomic, copy) NSString *_Nullable transaction;
 


### PR DESCRIPTION
Updated the description of `transaction` property in  `SentryEvent` to copy develop docs description.

This is the last think to close #1437 

_#skip-changelog_