### PR TITLE
fix: web integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,11 +48,14 @@ jobs:
       - name: Download and Apply Patch
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire
 
-      - name: Install Firewalk
-        run: brew install alamofire/alamofire/firewalk
+      - name: Download Firewalk
+        run: curl "https://github.com/Alamofire/Firewalk/releases/download/0.8.1/firewalk.zip" --output firewalk.zip -L
+
+      - name: Unzip Firewalk
+        run: Unzip "firewalk.zip"
 
       - name: Start Firewalk
-        run: firewalk &
+        run: ./firewalk &
 
       - name: Validate Firewalk is running
         run: curl http://localhost:8080/


### PR DESCRIPTION
Fixing the web integration test by pinning `firewalk` to a specific version.


_#skip-changelog_ 