### PR TITLE
fix: SDK reports OOM when crashing after calling close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This version adds a dependency on Swift.
 - Use the same default environment for events and sessions (#2447)
 - Increase `SentryCrashMAX_STRINGBUFFERSIZE` to reduce the instances where we're dropping a crash due to size limit (#2465)
 - `SentryAppStateManager` correctly unsubscribes from `NSNotificationCenter` when closing the SDK (#2460)
+- The SDK no longer reports an OOM when a crash happens after closing the SDK (#2468)
 
 ### Breaking Changes
 

--- a/Sources/Sentry/SentryAppState.m
+++ b/Sources/Sentry/SentryAppState.m
@@ -25,6 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
         _isActive = NO;
         _wasTerminated = NO;
         _isANROngoing = NO;
+        _isSDKRunning = YES;
     }
     return self;
 }
@@ -89,6 +90,15 @@ NS_ASSUME_NONNULL_BEGIN
         } else {
             _isANROngoing = [isANROngoing boolValue];
         }
+
+        id isSDKRunning = [jsonObject valueForKey:@"is_sdk_running"];
+        if (isSDKRunning == nil || ![isSDKRunning isKindOfClass:[NSNumber class]]) {
+            // This property was added later so instead of returning nil,
+            // we're setting it to the default value.
+            _isSDKRunning = YES;
+        } else {
+            _isSDKRunning = [isSDKRunning boolValue];
+        }
     }
     return self;
 }
@@ -106,6 +116,7 @@ NS_ASSUME_NONNULL_BEGIN
     [data setValue:@(self.isActive) forKey:@"is_active"];
     [data setValue:@(self.wasTerminated) forKey:@"was_terminated"];
     [data setValue:@(self.isANROngoing) forKey:@"is_anr_ongoing"];
+    [data setValue:@(self.isSDKRunning) forKey:@"is_sdk_running"];
 
     return data;
 }

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -101,6 +101,9 @@ SentryAppStateManager ()
     }
 
     if (self.startCount == 0) {
+        [self
+            updateAppStateInBackground:^(SentryAppState *appState) { appState.isSDKRunning = NO; }];
+
         // Remove the observers with the most specific detail possible, see
         // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
         [self.notificationCenterWrapper

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -88,6 +88,7 @@ SentryAppStateManager ()
     [self stopWithForce:NO];
 }
 
+// forceStop is YES when the SDK gets closed
 - (void)stopWithForce:(BOOL)forceStop
 {
     if (self.startCount <= 0) {
@@ -95,15 +96,15 @@ SentryAppStateManager ()
     }
 
     if (forceStop) {
+        [self
+            updateAppStateInBackground:^(SentryAppState *appState) { appState.isSDKRunning = NO; }];
+
         self.startCount = 0;
     } else {
         self.startCount -= 1;
     }
 
     if (self.startCount == 0) {
-        [self
-            updateAppStateInBackground:^(SentryAppState *appState) { appState.isSDKRunning = NO; }];
-
         // Remove the observers with the most specific detail possible, see
         // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
         [self.notificationCenterWrapper

--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -85,7 +85,7 @@ SentryOutOfMemoryLogic ()
     }
 
     // The SDK wasn't running, so *any* crash after the SDK got closed would be seen as OOM.
-    if (previousAppState.isSDKRunning) {
+    if (!previousAppState.isSDKRunning) {
         return NO;
     }
 

--- a/Sources/Sentry/SentryOutOfMemoryLogic.m
+++ b/Sources/Sentry/SentryOutOfMemoryLogic.m
@@ -44,7 +44,7 @@ SentryOutOfMemoryLogic ()
     SentryAppState *currentAppState = [self.appStateManager buildCurrentAppState];
 
     // If there is no previous app state, we can't do anything.
-    if (nil == previousAppState) {
+    if (previousAppState == nil) {
         return NO;
     }
 
@@ -81,6 +81,11 @@ SentryOutOfMemoryLogic ()
 
     // The app crashed on the previous run. No OOM.
     if (self.crashAdapter.crashedLastLaunch) {
+        return NO;
+    }
+
+    // The SDK wasn't running, so *any* crash after the SDK got closed would be seen as OOM.
+    if (previousAppState.isSDKRunning) {
         return NO;
     }
 

--- a/Sources/Sentry/include/SentryAppState.h
+++ b/Sources/Sentry/include/SentryAppState.h
@@ -42,6 +42,8 @@ SENTRY_NO_INIT
 
 @property (nonatomic, assign) BOOL isANROngoing;
 
+@property (nonatomic, assign) BOOL isSDKRunning;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
@@ -78,6 +78,18 @@ class SentryAppStateManagerTests: XCTestCase {
         XCTAssertNotNil(fixture.fileManager.readAppState())
     }
 
+    func testStopUpdatesAppState() {
+        sut.start()
+
+        let stateBeforeStop = fixture.fileManager.readAppState()
+        XCTAssertTrue(stateBeforeStop!.isSDKRunning)
+
+        sut.stop(withForce: true)
+
+        let stateAfterStop = fixture.fileManager.readAppState()
+        XCTAssertFalse(stateAfterStop!.isSDKRunning)
+    }
+
     func testForcedStop() {
         XCTAssertNil(fixture.fileManager.readAppState())
 

--- a/Tests/SentryTests/Helper/SentryAppStateTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateTests.swift
@@ -14,6 +14,7 @@ class SentryAppStateTests: XCTestCase {
         XCTAssertEqual(appState.isActive, actual["is_active"] as? Bool)
         XCTAssertEqual(appState.wasTerminated, actual["was_terminated"] as? Bool)
         XCTAssertEqual(appState.isANROngoing, actual["is_anr_ongoing"] as? Bool)
+        XCTAssertEqual(appState.isSDKRunning, actual["is_sdk_running"] as? Bool)
     }
     
     func testInitWithJSON_AllFields() {
@@ -26,7 +27,8 @@ class SentryAppStateTests: XCTestCase {
             "system_boot_timestamp": (appState.systemBootTimestamp as NSDate).sentry_toIso8601String(),
             "is_active": appState.isActive,
             "was_terminated": appState.wasTerminated,
-            "is_anr_ongoing": appState.isANROngoing
+            "is_anr_ongoing": appState.isANROngoing,
+            "is_sdk_running": appState.isSDKRunning
         ] as [String: Any]
         
         let actual = SentryAppState(jsonObject: dict)

--- a/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/OutOfMemory/SentryOutOfMemoryTrackerTests.swift
@@ -187,7 +187,16 @@ class SentryOutOfMemoryTrackerTests: NotificationCenterTestCase {
         
         assertNoOOMSent()
     }
-    
+
+    func testSDKWasClosed_NoOOM() {
+        let appState = SentryAppState(releaseName: TestData.appState.releaseName, osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: fixture.currentDate.date())
+        appState.isSDKRunning = false
+
+        givenPreviousAppState(appState: appState)
+        sut.start()
+        assertNoOOMSent()
+    }
+
     func testAppWasInBackground_NoOOM() {
         sut.start()
         goToForeground()

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -513,6 +513,9 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.close()
 
         XCTAssertEqual(appStateManager.startCount, 0)
+
+        let stateAfterStop = fixture.fileManager.readAppState()
+        XCTAssertFalse(stateAfterStop!.isSDKRunning)
     }
 #endif
     


### PR DESCRIPTION
## :scroll: Description

The app state has a new property `isSDKRunning` which gets set to `false` when the SDK closes. This property is then used in the OOM logic, returning `false` when `isSDKRunning` is `false`.

## :bulb: Motivation and Context

Closes #2457

## :green_heart: How did you test it?

Unit tests, and steps as described in #2457.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
