### PR TITLE
ci: fix caching in some CI jobs

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -38,7 +38,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
-          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-${{ hashFiles('Sentry/Sources/**') }}
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-${{ hashFiles('Sources/Sentry/**') }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-benchmark-runner-cache
         uses: actions/cache@v3

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Install Carthage deps
         if: steps.trendingmovies-carthage-cache.outputs.cache-hit != 'true'
         run: cd Samples/TrendingMovies && carthage update --use-xcframeworks
+      - name: Cache TrendingMovies App and dSYM build products
+        id: cache-trending-movies-app
+        uses: actions/cache@v3
+        with:
+          path: |
+            DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app
+            DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app.dSYM
+          key: trendingmovies-app-cache-key-${{ hashFiles('Samples/TrendingMovies/TrendingMovies/**') }}-${{ hashFiles('Sources/Sentry/**') }}
       - name: Cache ProfileDataGenerator UI Test Runner App build product
         id: cache-profiledatagenerator-test-runner-app
         uses: actions/cache@v3
@@ -35,6 +43,7 @@ jobs:
             DerivedData/Build/Products/Debug-iphoneos/ProfileDataGeneratorUITest-Runner.app
           key: profiledatagenerator-test-runner-app-cache-key-${{ hashFiles('Samples/TrendingMovies/ProfileDataGeneratorUITest/**') }}
       - run: fastlane build_trending_movies
+        if: steps.cache-trending-movies-app.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -4,6 +4,10 @@ name: Generate Profiling Test Data
 on:
   schedule:
     - cron: '0 */6 * * *' # every 6 hours = 4x/day
+  pull_request:
+    paths:
+      - 'Sources/Sentry/Public/**'
+      - 'Samples/TrendingMovies/**'
 
 jobs:
   build-profile-data-generator-targets:

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -23,14 +23,6 @@ jobs:
       - name: Install Carthage deps
         if: steps.trendingmovies-carthage-cache.outputs.cache-hit != 'true'
         run: cd Samples/TrendingMovies && carthage update --use-xcframeworks
-      - name: Cache TrendingMovies App and dSYM build products
-        id: cache-trending-movies-app
-        uses: actions/cache@v3
-        with:
-          path: |
-            DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app
-            DerivedData/Build/Products/Debug-iphoneos/TrendingMovies.app.dSYM
-          key: trendingmovies-app-cache-key-${{ hashFiles('Samples/TrendingMovies/TrendingMovies/**') }}-${{ hashFiles('Sentry/Sources/**') }}
       - name: Cache ProfileDataGenerator UI Test Runner App build product
         id: cache-profiledatagenerator-test-runner-app
         uses: actions/cache@v3
@@ -39,7 +31,6 @@ jobs:
             DerivedData/Build/Products/Debug-iphoneos/ProfileDataGeneratorUITest-Runner.app
           key: profiledatagenerator-test-runner-app-cache-key-${{ hashFiles('Samples/TrendingMovies/ProfileDataGeneratorUITest/**') }}
       - run: fastlane build_trending_movies
-        if: steps.cache-trending-movies-app.outputs.cache-hit != 'true'
         env:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -45,7 +45,7 @@ jobs:
           path: |
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
             DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
-          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}-${{ hashFiles('Sentry/Sources/**') }}
+          key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}-${{ hashFiles('Sources/Sentry/**') }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-uitest-runner-cache
         uses: actions/cache@v3


### PR DESCRIPTION
We were trying to compute a cache key on an invalid path, which did not invalidate the cached app builds when they should have been to test changes to the SDK.

I actually also found a build error on the default branch in trending movies indicating that it hasn't been built since the change that made that code invalid: https://github.com/getsentry/sentry-cocoa/pull/2480

#skip-changelog