### PR TITLE
fix: trending movies build

### DIFF
--- a/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
+++ b/Samples/TrendingMovies/TrendingMovies/Utilities/Tracer.swift
@@ -75,12 +75,12 @@ extension Tracer {
         var span: Span
 
         func annotate(key: String, value: String) {
-            print("[TrendingMovies] annotating span \(span.context.spanId.sentrySpanIdString), key \(key) and value \(value)")
-            span.context.setTag(value: value, key: key)
+            print("[TrendingMovies] annotating span \(span.spanId.sentrySpanIdString), key \(key) and value \(value)")
+            span.setTag(value: value, key: key)
         }
 
         func end() {
-            print("[TrendingMovies] ending span \(span.context.spanId.sentrySpanIdString)")
+            print("[TrendingMovies] ending span \(span.spanId.sentrySpanIdString)")
             span.finish()
         }
     }


### PR DESCRIPTION
https://github.com/getsentry/sentry-cocoa/pull/2408 changed API that broke TrendingMovies but was not caught in CI due to invalid caching strategy (fixed in #2479 )

#skip-changelog