### PR TITLE
ci: Specify Codecov token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,6 +220,9 @@ jobs:
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         if: ${{ contains(matrix.platform, 'iOS') }}
         with:
+          # Although public repos should have to specify a token there seems to be a bug with the Codecov GH action, which can
+          # be solved by specifying the token, see https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -220,7 +220,7 @@ jobs:
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # pin@v3.1.1
         if: ${{ contains(matrix.platform, 'iOS') }}
         with:
-          # Although public repos should have to specify a token there seems to be a bug with the Codecov GH action, which can
+          # Although public repos should not have to specify a token there seems to be a bug with the Codecov GH action, which can
           # be solved by specifying the token, see https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Codecov uploads sometimes fail. There is a workaround for this as described in https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469

#skip-changelog