### PR TITLE
ci: Fix Slather for Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,6 +185,7 @@ jobs:
 
       # Some tests run only on iOS so we only collect code coverage there.
       - name: Install Slather
+        if: ${{ contains(matrix.platform, 'iOS') }}
         run: gem install slather
       
       - name: Running tests
@@ -193,14 +194,6 @@ jobs:
         # because GitHub Actions don't provide an easy way of
         # manipulating string in expressions.
         run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME
-
-      - name: Archiving Slather Report
-        uses: actions/upload-artifact@v3
-        if: ${{ contains(matrix.platform, 'iOS') }}
-        with:
-          name: slather-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
-          path: |
-            slather/**
 
       - name: Archiving DerivedData Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -213,6 +213,14 @@ jobs:
           gem install slather
           slather coverage -x --output-directory slather/ --scheme Sentry --workspace Sentry.xcworkspace Sentry.xcodeproj
 
+      - name: Archiving Slather Report
+        uses: actions/upload-artifact@v3
+        if: success() && ${{ contains(matrix.platform, 'iOS') }}
+        with:
+          name: slather-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          path: |
+            slather/**
+
       # We can upload all coverage reports, because codecov merges them.
       # See https://docs.codecov.io/docs/merging-reports
       # Checkout .codecov.yml to see the config of Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,13 +206,6 @@ jobs:
           path: |
             raw-test-output.log
 
-      # Some tests run only on iOS so we only collect code coverage there.
-      - name: Run Slather
-        if: ${{ contains(matrix.platform, 'iOS') }}
-        run: | 
-          gem install slather
-          slather coverage --configuration Test
-
       - name: Archiving Slather Report
         uses: actions/upload-artifact@v3
         if: ${{ contains(matrix.platform, 'iOS') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,6 @@ jobs:
 
       # Some tests run only on iOS so we only collect code coverage there.
       - name: Install Slather
-        if: ${{ contains(matrix.platform, 'iOS') }}
         run: gem install slather
       
       - name: Running tests
@@ -194,6 +193,14 @@ jobs:
         # because GitHub Actions don't provide an easy way of
         # manipulating string in expressions.
         run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME
+
+      - name: Archiving Slather Report
+        uses: actions/upload-artifact@v3
+        if: ${{ contains(matrix.platform, 'iOS') }}
+        with:
+          name: slather-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          path: |
+            slather/**
 
       - name: Archiving DerivedData Logs
         uses: actions/upload-artifact@v3
@@ -210,14 +217,6 @@ jobs:
           name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
             raw-test-output.log
-
-      - name: Archiving Slather Report
-        uses: actions/upload-artifact@v3
-        if: ${{ contains(matrix.platform, 'iOS') }}
-        with:
-          name: slather-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
-          path: |
-            slather/**
 
       # We can upload all coverage reports, because codecov merges them.
       # See https://docs.codecov.io/docs/merging-reports

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,14 +208,14 @@ jobs:
 
       # Some tests run only on iOS so we only collect code coverage there.
       - name: Run Slather
-        if: success() && ${{ contains(matrix.platform, 'iOS') }}
+        if: ${{ contains(matrix.platform, 'iOS') }}
         run: | 
           gem install slather
-          slather coverage -x --output-directory slather/ --scheme Sentry --workspace Sentry.xcworkspace Sentry.xcodeproj
+          slather coverage --configuration Test
 
       - name: Archiving Slather Report
         uses: actions/upload-artifact@v3
-        if: success() && ${{ contains(matrix.platform, 'iOS') }}
+        if: ${{ contains(matrix.platform, 'iOS') }}
         with:
           name: slather-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,6 +183,11 @@ jobs:
           sudo ln -s /Applications/Xcode_12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 14.5.simruntime
           xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-14-5"
 
+      # Some tests run only on iOS so we only collect code coverage there.
+      - name: Install Slather
+        if: ${{ contains(matrix.platform, 'iOS') }}
+        run: gem install slather
+      
       - name: Running tests
         # We call a script with the platform so the destination
         # passed to xcodebuild doesn't end up in the job name,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,9 +183,7 @@ jobs:
           sudo ln -s /Applications/Xcode_12.5.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime /Library/Developer/CoreSimulator/Profiles/Runtimes/iOS\ 14.5.simruntime
           xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-14-5"
 
-      # Some tests run only on iOS so we only collect code coverage there.
       - name: Install Slather
-        if: ${{ contains(matrix.platform, 'iOS') }}
         run: gem install slather
       
       - name: Running tests

--- a/.slather.yml
+++ b/.slather.yml
@@ -1,0 +1,8 @@
+# .slather.yml
+
+coverage_service: cobertura_xml
+xcodeproj: Sentry.xcodeproj
+workspace: Sentry.xcworkspace
+scheme: Sentry
+source_directory: 'Sources/**'
+output_directory: slather

--- a/.slather.yml
+++ b/.slather.yml
@@ -4,5 +4,5 @@ coverage_service: cobertura_xml
 xcodeproj: Sentry.xcodeproj
 workspace: Sentry.xcworkspace
 scheme: Sentry
-source_directory: 'Sources/**'
+source_directory: Sources
 output_directory: slather

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,6 @@ gem "cocoapods", ">= 1.9.1"
 gem "fastlane"
 gem "rest-client"
 gem "xcpretty"
+gem "slather"
 
 eval_gemfile("fastlane/Pluginfile")

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.4)
     claide (1.1.0)
+    clamp (1.3.2)
     cocoapods (1.11.3)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
@@ -215,6 +216,7 @@ GEM
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
     molinillo (0.8.0)
     multi_json (1.15.0)
@@ -223,10 +225,14 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    nokogiri (1.13.9)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     optparse (0.1.1)
     os (1.1.4)
     plist (3.6.0)
     public_suffix (4.0.7)
+    racc (1.6.1)
     rake (13.0.6)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -252,6 +258,12 @@ GEM
     simctl (1.6.8)
       CFPropertyList
       naturally
+    slather (2.7.3)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport
+      clamp (~> 1.3)
+      nokogiri (>= 1.13.9)
+      xcodeproj (~> 1.21)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -293,6 +305,7 @@ DEPENDENCIES
   fastlane
   fastlane-plugin-sentry
   rest-client
+  slather
   xcpretty
 
 BUNDLED WITH

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ format-swift:
 	swiftlint --fix
 
 
+## Current git reference name
 GIT-REF := $(shell git rev-parse --abbrev-ref HEAD)
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -34,9 +34,12 @@ format-clang:
 format-swift:
 	swiftlint --fix
 
+
+GIT-REF := $(shell git rev-parse --abbrev-ref HEAD)
+
 test:
 	@echo "--> Running all tests"
-	xcodebuild -workspace Sentry.xcworkspace -scheme Sentry -configuration Test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES -enableCodeCoverage YES -destination "platform=macOS" test | rbenv exec bundle exec xcpretty -t
+	./scripts/xcode-test.sh iOS latest $(GIT-REF) YES
 .PHONY: test
 
 run-test-server:

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -62,13 +62,13 @@ if [ $PLATFORM == "iOS" -a $OS == "12.4" ]; then
     # Skip some tests that fail on iOS 12.4.
     env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
         -scheme Sentry -configuration $CONFIGURATION \
-        GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES -enableCodeCoverage YES -destination "$DESTINATION" \
+        -destination "$DESTINATION" \
         -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfAddingBreadcrumbs" \
         -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfTransactions" \
         test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}
 else
     env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
         -scheme Sentry -configuration $CONFIGURATION \
-        GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES -enableCodeCoverage YES -destination "$DESTINATION" \
+        -destination "$DESTINATION" \
         test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}
 fi

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -65,10 +65,10 @@ if [ $PLATFORM == "iOS" -a $OS == "12.4" ]; then
         GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES -enableCodeCoverage YES -destination "$DESTINATION" \
         -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfAddingBreadcrumbs" \
         -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfTransactions" \
-        test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && exit ${PIPESTATUS[0]}
+        test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}
 else
     env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
         -scheme Sentry -configuration $CONFIGURATION \
         GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES -enableCodeCoverage YES -destination "$DESTINATION" \
-        test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && exit ${PIPESTATUS[0]}
+        test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}
 fi


### PR DESCRIPTION
Slather, most of the time, reported code coverage of 0%. This is fixed now by removing the extra flags when calling Xcode
`GCC_GENERATE_TEST_COVERAGE_FILES=YES GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES -enableCodeCoverage YES` as we already enable gathering code coverage in the Xcode schema.

Furthermore, `make test` calls the `xcode-test.sh` to make it easier to call unit tests the same way CI does.

#skip-changelog