### PR TITLE
test: Fix asserts for SentryCrashTestInstallation

### DIFF
--- a/Tests/SentryTests/Helper/TestNSNotificationCenterWrapper.swift
+++ b/Tests/SentryTests/Helper/TestNSNotificationCenterWrapper.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-@objc public class TestNSNotificationCenterWrapper: SentryNSNotificationCenterWrapper {
+@objcMembers public class TestNSNotificationCenterWrapper: SentryNSNotificationCenterWrapper {
     var addObserverInvocations = Invocations<(observer: Any, selector: Selector, name: NSNotification.Name)>()
-    @objc public var addObserverInvocationsCount: Int {
+    public var addObserverInvocationsCount: Int {
         return addObserverInvocations.count
     }
 
@@ -12,12 +12,18 @@ import Foundation
     }
 
     var removeObserverWithNameInvocations = Invocations<(observer: Any, name: NSNotification.Name)>()
+    public var removeObserverWithNameInvocationsCount: Int {
+        return removeObserverWithNameInvocations.count
+    }
     public override func removeObserver(_ observer: Any, name aName: NSNotification.Name) {
         removeObserverWithNameInvocations.record((observer, aName))
         NotificationCenter.default.removeObserver(observer, name: aName, object: nil)
     }
 
     var removeObserverInvocations = Invocations<Any>()
+    public var removeObserverInvocationsCount: Int {
+        return removeObserverInvocations.count
+    }
     public override func removeObserver(_ observer: Any) {
         removeObserverInvocations.record(observer)
         NotificationCenter.default.removeObserver(observer)

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationTests.m
@@ -4,6 +4,7 @@
 #import "SentryCrashInstallation.h"
 #import "SentryCrashMonitor.h"
 #import "SentryCrashMonitor_MachException.h"
+#import "SentryCrashSystemCapabilities.h"
 #import "SentryNSNotificationCenterWrapper.h"
 #import "SentryTests-Swift.h"
 #import <XCTest/XCTest.h>
@@ -62,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
     [installation uninstall];
 
 #if SentryCrashCRASH_HAS_UIAPPLICATION
-    XCTAssertEqual(5, self.notificationCenter.removeObserverWithNameInvocations.count);
+    XCTAssertEqual(5, self.notificationCenter.removeObserverWithNameInvocationsCount);
 #endif
 }
 
@@ -95,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
         crashHandlerDataAfterInstall:crashHandlerDataAfterInstall];
 
 #if SentryCrashCRASH_HAS_UIAPPLICATION
-    XCTAssertEqual(55, self.notificationCenter.removeObserverWithNameInvocations.count);
+    XCTAssertEqual(55, self.notificationCenter.removeObserverWithNameInvocationsCount);
 #endif
 }
 


### PR DESCRIPTION
Two asserts wrapped with SentryCrashCRASH_HAS_UIAPPLICATION were not executed. This is fixed now.

Came up in https://github.com/getsentry/sentry-cocoa/pull/2440#discussion_r1035083448

#skip-changelog