### PR TITLE
feat: Add synthetic for mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This version adds a dependency on Swift.
 
 - Properly demangle Swift class name (#2162)
 - Enable File I/O APM by default (#2497)
-- feat: Add synthetic for mechanism (#2501)
+- Add synthetic for mechanism (#2501)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This version adds a dependency on Swift.
 
 - Properly demangle Swift class name (#2162)
 - Enable File I/O APM by default (#2497)
+- feat: Add synthetic for mechanism (#2501)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryMechanism.h
+++ b/Sources/Sentry/Public/SentryMechanism.h
@@ -36,6 +36,12 @@ SENTRY_NO_INIT
 @property (nonatomic, copy) NSNumber *_Nullable handled;
 
 /**
+ * An optional flag indicating a synthetic exception. For more info visit
+ * https://develop.sentry.dev/sdk/event-payloads/exception/#exception-mechanism.
+ */
+@property (nonatomic, copy, nullable) NSNumber *synthetic;
+
+/**
  * Fully qualified URL to an online help resource, possible
  * interpolated with error parameters
  */

--- a/Sources/Sentry/SentryMechanism.m
+++ b/Sources/Sentry/SentryMechanism.m
@@ -21,6 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary *serializedData = @{ @"type" : self.type }.mutableCopy;
 
     [serializedData setValue:self.handled forKey:@"handled"];
+    [serializedData setValue:self.synthetic forKey:@"synthetic"];
     [serializedData setValue:self.desc forKey:@"description"];
     [serializedData setValue:[self.data sentry_sanitize] forKey:@"data"];
     [serializedData setValue:self.helpLink forKey:@"help_link"];

--- a/Tests/SentryTests/Protocol/SentryMechanismTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismTests.swift
@@ -15,6 +15,7 @@ class SentryMechanismTests: XCTestCase {
         XCTAssertEqual(expected.type, actual["type"] as! String)
         XCTAssertEqual(expected.desc, actual["description"] as? String)
         XCTAssertEqual(expected.handled, actual["handled"] as? NSNumber)
+        XCTAssertEqual(expected.synthetic, actual["synthetic"] as? NSNumber)
         XCTAssertEqual(expected.helpLink, actual["help_link"] as? String)
 
         guard let something = (actual["data"] as? [String: Any])?["something"] as? [String: Any] else {
@@ -27,5 +28,14 @@ class SentryMechanismTests: XCTestCase {
         XCTAssertEqual(date.sentry_toIso8601String(), something["date"] as? String)
 
         XCTAssertNotNil(actual["meta"])
+    }
+    
+    func testSerialize_OnlyType_NullablePropertiesNotAdded() {
+        let type = "type"
+        let mechanism = Mechanism(type: type)
+        
+        let actual = mechanism.serialize()
+        XCTAssertEqual(1, actual.count)
+        XCTAssertEqual(type, actual["type"] as? String)
     }
 }

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -94,6 +94,7 @@ class TestData {
         mechanism.data = ["something": ["date": currentDateProvider.date()]]
         mechanism.desc = "desc"
         mechanism.handled = true
+        mechanism.synthetic = false
         mechanism.helpLink = "https://www.sentry.io"
         mechanism.meta = mechanismMeta
         


### PR DESCRIPTION


## :scroll: Description

Add synthetic property for SentryMechanism as it's part of the protocol https://develop.sentry.dev/sdk/event-payloads/exception/#exception-mechanism

## :bulb: Motivation and Context

https://github.com/getsentry/sentry-cocoa/issues/1192

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
