### PR TITLE
fix: MXFrames reversed

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		7B4E375525822C4500059C93 /* SentryAttachment.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B4E375425822C4500059C93 /* SentryAttachment.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7B4E375B2582313100059C93 /* SentryAttachmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4E375A2582313100059C93 /* SentryAttachmentTests.swift */; };
 		7B4E375F258231FC00059C93 /* SentryAttachment.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B4E375E258231FC00059C93 /* SentryAttachment.m */; };
+		7B4F22DC294089530067EA17 /* FormatHexAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4F22DB294089530067EA17 /* FormatHexAddress.swift */; };
 		7B569E002590EEF600B653FC /* SentryScope+Equality.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B569DFF2590EEF600B653FC /* SentryScope+Equality.m */; };
 		7B56D73124616CCD00B842DA /* SentryConcurrentRateLimitsDictionary.h in Headers */ = {isa = PBXBuildFile; fileRef = 7B56D73024616CCD00B842DA /* SentryConcurrentRateLimitsDictionary.h */; };
 		7B56D73324616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = 7B56D73224616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m */; };
@@ -1111,6 +1112,7 @@
 		7B4E375425822C4500059C93 /* SentryAttachment.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryAttachment.h; path = Public/SentryAttachment.h; sourceTree = "<group>"; };
 		7B4E375A2582313100059C93 /* SentryAttachmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAttachmentTests.swift; sourceTree = "<group>"; };
 		7B4E375E258231FC00059C93 /* SentryAttachment.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAttachment.m; sourceTree = "<group>"; };
+		7B4F22DB294089530067EA17 /* FormatHexAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormatHexAddress.swift; sourceTree = "<group>"; };
 		7B569DFE2590EEF600B653FC /* SentryScope+Equality.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryScope+Equality.h"; sourceTree = "<group>"; };
 		7B569DFF2590EEF600B653FC /* SentryScope+Equality.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentryScope+Equality.m"; sourceTree = "<group>"; };
 		7B569E052590F04700B653FC /* SentryScope+Properties.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryScope+Properties.h"; sourceTree = "<group>"; };
@@ -2794,6 +2796,7 @@
 				7BF1F6AD282A4FE2006BD6AB /* SentryTestObserver.m */,
 				7B72D23928D074BC0014798A /* TestExtensions.swift */,
 				7BB7E7C629267A28004BF96B /* EmptyIntegration.swift */,
+				7B4F22DB294089530067EA17 /* FormatHexAddress.swift */,
 			);
 			path = TestUtils;
 			sourceTree = "<group>";
@@ -3892,6 +3895,7 @@
 				7BAF3DD2243DD05C008A5414 /* SentryTransportInitializerTests.swift in Sources */,
 				7B68D93625FF5F1A0082D139 /* SentryAppState+Equality.m in Sources */,
 				7B5CAF7E27F5AD3500ED0DB6 /* TestNSURLRequestBuilder.m in Sources */,
+				7B4F22DC294089530067EA17 /* FormatHexAddress.swift in Sources */,
 				8EAC7FF8265C8910005B44E5 /* SentryTracerTests.swift in Sources */,
 				0A1B497328E597DD00D7BFA3 /* TestLogOutput.swift in Sources */,
 				7BA61CBD247BC6B900C130A8 /* TestSentryCrashBinaryImageProvider.swift in Sources */,

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -158,7 +158,9 @@ SentryMetricKitIntegration ()
     for (SentryMXCallStack *callStack in callStacks) {
 
         NSMutableArray<SentryFrame *> *frames = [NSMutableArray array];
-        for (SentryMXFrame *mxFrame in callStack.flattenedRootFrames) {
+
+        // The MXFrames are in reversed order compared to how we order them in Sentry.
+        for (SentryMXFrame *mxFrame in [callStack.flattenedRootFrames reverseObjectEnumerator]) {
 
             SentryFrame *frame = [[SentryFrame alloc] init];
             frame.package = mxFrame.binaryName;

--- a/Tests/SentryTests/TestUtils/FormatHexAddress.swift
+++ b/Tests/SentryTests/TestUtils/FormatHexAddress.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+func formatHexAddress(value: UInt64) -> String {
+    return String(format: "0x%016llx", value)
+}


### PR DESCRIPTION
## :scroll: Description

MXFrames are in reversed order compared to how we order them in Sentry. This is fixed now by reversing them.

#skip-changelog

## :bulb: Motivation and Context

This is one of the multiple fixes for the MetricKit integration. Instead of doing all of them in one branch, I split these up into multiple PRs targeting the `feat/metric-kit` branch so they are easier to review.

## :green_heart: How did you test it?
Unit tests and sending sample crash events see

Before: https://sentry.io/organizations/sentry-sdks/issues/3780372963/events/5c5a780f3b6c48a58c287e84f36c8255/?project=5428557

After: https://sentry.io/organizations/sentry-sdks/issues/3780372963/events/7aa6bfda7bd443daa4894f858c72c6c7/?project=5428557

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
