### PR TITLE
meta: accept swiftformat changes

### DIFF
--- a/Samples/TrendingMovies/TrendingMovies/ImageProcessing/ColorArt.swift
+++ b/Samples/TrendingMovies/TrendingMovies/ImageProcessing/ColorArt.swift
@@ -319,7 +319,7 @@ private struct RGBADecimalComponents: Hashable {
 
     // Relative luminance formula: https://en.wikipedia.org/wiki/Relative_luminance
     var luminance: CGFloat {
-        0.212_6 * r + 0.715_2 * g + 0.072_2 * b
+        0.2126 * r + 0.7152 * g + 0.0722 * b
     }
 
     var isDarkColor: Bool {

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/PerformanceViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/PerformanceViewController.swift
@@ -37,7 +37,7 @@ class PerformanceViewController: UIViewController {
     // refresh rate of 60 hz is 0.0167
     // 120 hz is 0.0083
     // 240 hz is 0.004167
-    private let interval = 0.000_000_05
+    private let interval = 0.00000005
 
     private var timer: Timer?
     private let iterations = 5_000_000

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -397,7 +397,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
         
         let expectedAppStartDuration = expectedDuration ?? fixture.appStartDuration
         let actualAppStartDuration = appStartMeasurement.duration
-        XCTAssertEqual(expectedAppStartDuration, actualAppStartDuration, accuracy: 0.000_1)
+        XCTAssertEqual(expectedAppStartDuration, actualAppStartDuration, accuracy: 0.0001)
         
         if preWarmed {
             XCTAssertEqual(fixture.moduleInitializationTimestamp, appStartMeasurement.appStartTimestamp)
@@ -420,7 +420,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
         XCTAssertEqual(type.rawValue, appStartMeasurement.type.rawValue)
         
         let actualAppStartDuration = appStartMeasurement.duration
-        XCTAssertEqual(0.0, actualAppStartDuration, accuracy: 0.000_1)
+        XCTAssertEqual(0.0, actualAppStartDuration, accuracy: 0.0001)
         
         XCTAssertEqual(fixture.sysctl.processStartTimestamp, appStartMeasurement.appStartTimestamp)
         XCTAssertEqual(fixture.runtimeInitTimestamp, appStartMeasurement.runtimeInitTimestamp)

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashScopeObserverTests.swift
@@ -297,7 +297,7 @@ class SentryCrashScopeObserverTests: XCTestCase {
         return jsonPointer!.pointee
     }
     
-    private func getScopeJson(getField: (SentryCrashScope)-> UnsafeMutablePointer<CChar>?) -> String? {
+    private func getScopeJson(getField: (SentryCrashScope) -> UnsafeMutablePointer<CChar>?) -> String? {
         guard let scopePointer = sentrycrash_scopesync_getScope() else {
             return nil
         }

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -528,7 +528,7 @@ class SentryHttpTransportTests: XCTestCase {
 
     func testSendEnvelopesConcurrent() {
         self.measure {
-            fixture.requestManager.responseDelay = 0.000_1
+            fixture.requestManager.responseDelay = 0.0001
 
             let queue = fixture.queue
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
@@ -89,7 +89,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
     }
     
     func testAppStartCrash_DurationTooBig_DoesNotCallFlush() {
-        fixture.crashWrapper.internalDurationFromCrashStateInitToLastCrash = 2.000_01
+        fixture.crashWrapper.internalDurationFromCrashStateInitToLastCrash = 2.00001
         
         filterReportWithAttachment()
         

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -221,7 +221,7 @@ class SentryScopeSwiftTests: XCTestCase {
     
     func testUseSpanForClear() {
         fixture.scope.span = fixture.transaction
-        fixture.scope.useSpan { (span) in
+        fixture.scope.useSpan { (_) in
             self.fixture.scope.span = nil
         }
         XCTAssertNil(fixture.scope.span)


### PR DESCRIPTION
A bunch of unrelated swift files were modified by swiftformat as part of the pre-commit hook when working on my branch, so I figure we can commit these separately so they don't bother other folks later.

#skip-changelog