### PR TITLE
meta: User interaction tracing enabled per default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ This version adds a dependency on Swift.
 - Properly demangle Swift class name (#2162)
 - Enable [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) by default (#2497)
 - [User Interaction Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing) is stable and enabled by default(#2503)
-- Enable File I/O APM by default (#2497)
 - Add synthetic for mechanism (#2501)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This version adds a dependency on Swift.
 
 - Properly demangle Swift class name (#2162)
 - Enable [File I/O Tracking](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#file-io-tracking) by default (#2497)
-- [User Interaction Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing) is stable (#2503)
+- [User Interaction Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing) is stable and enabled by default(#2503)
 - Enable File I/O APM by default (#2497)
 - Add synthetic for mechanism (#2501)
 


### PR DESCRIPTION
See https://github.com/getsentry/sentry-cocoa/blob/bd284cf0e4c0c759aebc240e29d1569b44a3d5ea/Sources/Sentry/SentryOptions.m#L81

#skip-changelog