### PR TITLE
feat: Enable CaptureFailedRequests by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This version adds a dependency on Swift.
 - [User Interaction Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing) is stable (#2503)
 - Enable File I/O APM by default (#2497)
 - Add synthetic for mechanism (#2501)
+- Enable CaptureFailedRequests by default (#2507)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -420,7 +420,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, retain) NSArray *tracePropagationTargets;
 
 /**
- * When enabled, the SDK captures HTTP Client errors. Default value is NO.
+ * When enabled, the SDK captures HTTP Client errors.
  * This feature requires enableSwizzling enabled as well, Default value is YES.
  */
 @property (nonatomic, assign) BOOL enableCaptureFailedRequests;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -72,7 +72,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.maxAttachmentSize = 20 * 1024 * 1024;
         self.sendDefaultPii = NO;
         self.enableAutoPerformanceTracing = YES;
-        self.enableCaptureFailedRequests = NO;
+        self.enableCaptureFailedRequests = YES;
         self.environment = kSentryDefaultEnvironment;
 #if SENTRY_HAS_UIKIT
         self.enableUIViewControllerTracing = YES;

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -132,7 +132,7 @@
     NSRegularExpression *regexRequests = options.failedRequestTargets[0];
     XCTAssertTrue([regexRequests.pattern isEqualToString:@".*"]);
 
-    XCTAssertEqual(NO, options.enableCaptureFailedRequests);
+    XCTAssertEqual(YES, options.enableCaptureFailedRequests);
 
     SentryHttpStatusCodeRange *range = options.failedRequestStatusCodes[0];
     XCTAssertEqual(500, range.min);


### PR DESCRIPTION
## :scroll: Description

Enable CaptureFailedRequests by default.

## :bulb: Motivation and Context

Feature is GA and creates value for customers. They can easily disable this if they don't want it.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
