### PR TITLE
ref: Add EventOptions

### DIFF
--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -5,6 +5,7 @@
 #import "SentryClient.h"
 #import "SentryCurrentDate.h"
 #import "SentryDebugMeta.h"
+#import "SentryEvent+Private.h"
 #import "SentryException.h"
 #import "SentryId.h"
 #import "SentryLevelMapper.h"
@@ -20,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryEvent ()
 
-@property (nonatomic) BOOL isCrashEvent;
+@property (nonatomic, assign) SentryEventOptions eventOptions;
 
 // We're storing serialized breadcrumbs to disk in JSON, and when we're reading them back (in
 // the case of OOM), we end up with the serialized breadcrumbs again. Instead of turning those
@@ -47,6 +48,7 @@ SentryEvent ()
         self.level = level;
         self.platform = @"cocoa";
         self.timestamp = [SentryCurrentDate date];
+        self.eventOptions = kSentryEventOptionsNone;
     }
     return self;
 }

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -229,7 +229,8 @@ SentryHub ()
  */
 - (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope
 {
-    event.isCrashEvent = YES;
+    event.eventOptions
+        = kSentryEventOptionsAddNoScreenshots | kSentryEventOptionsAddNoViewHierarchy;
 
     SentryClient *client = _client;
     if (client == nil) {

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -49,8 +49,8 @@ saveScreenShot(const char *path)
 {
 
     // We don't take screenshots if there is no exception/error.
-    // We dont take screenshots if the event is a crash event.
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent) {
+    if ((event.exceptions == nil && event.error == nil)
+        || event.eventOptions & kSentryEventOptionsAddNoScreenshots) {
         return attachments;
     }
 

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -49,8 +49,8 @@ saveViewHierarchy(const char *path)
                                            forEvent:(nonnull SentryEvent *)event
 {
     // We don't attach the view hierarchy if there is no exception/error.
-    // We dont attach the view hierarchy if the event is a crash event.
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent) {
+    if ((event.exceptions == nil && event.error == nil)
+        || event.eventOptions & kSentryEventOptionsAddNoViewHierarchy) {
         return attachments;
     }
 

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -1,13 +1,22 @@
+#import "SentryDefines.h"
 #import "SentryEvent.h"
 #import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_OPTIONS(NSUInteger, SentryEventOptions) {
+    kSentryEventOptionsNone = 0,
+    kSentryEventOptionsAddNoScreenshots = 1 << 0,
+    kSentryEventOptionsAddNoViewHierarchy = 1 << 1,
+};
 
 @interface
 SentryEvent (Private)
 
-/**
- * This indicates whether this event is a result of a crash.
- */
-@property (nonatomic) BOOL isCrashEvent;
+@property (nonatomic) SentryEventOptions eventOptions;
+
 @property (nonatomic, strong) NSArray *serializedBreadcrumbs;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -109,7 +109,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
     func test_noScreenShot_CrashEvent() {
         let sut = fixture.getSut()
         let event = Event(error: NSError(domain: "", code: -1))
-        event.isCrashEvent = true
+        event.eventOptions = .addNoScreenshots
         
         let newAttachmentList = sut.processAttachments([], for: event)
         

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -64,7 +64,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
     func test_noViewHierarchy_CrashEvent() {
         let sut = fixture.getSut()
         let event = Event(error: NSError(domain: "", code: -1))
-        event.isCrashEvent = true
+        event.eventOptions = .addNoViewHierarchy
 
         let newAttachmentList = sut.processAttachments([], for: event)
 

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
@@ -349,7 +349,7 @@ class SentryWatchdogTerminationsTrackerTests: NotificationCenterTestCase {
         
         XCTAssertEqual(SentryLevel.fatal, crashEvent?.level)
         XCTAssertEqual(crashEvent?.breadcrumbs?.count, 0)
-        XCTAssertEqual(crashEvent?.serializedBreadcrumbs?.count, expectedBreadcrumbs)
+        XCTAssertEqual(crashEvent?.serializedBreadcrumbs.count, expectedBreadcrumbs)
         
         XCTAssertEqual(1, crashEvent?.exceptions?.count)
         

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -12,6 +12,7 @@ class SentryEventTests: XCTestCase {
         XCTAssertEqual(event.platform, "cocoa")
         XCTAssertEqual(event.level, .debug)
         XCTAssertEqual(event.timestamp, dateProvider.date())
+        XCTAssertEqual([], event.eventOptions)
     }
     
     func testSerialize() {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -847,14 +847,17 @@ class SentryHubTests: XCTestCase {
         let arguments = fixture.client.captureEventWithScopeInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
-        XCTAssertFalse(arguments.first?.event.isCrashEvent ?? true)
+        
+        XCTAssertFalse(arguments.first?.event.eventOptions.isEmpty ?? true, "EventOptions should be empty.")
     }
     
     private func assertCrashEventSent() {
         let arguments = fixture.client.captureCrashEventInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
-        XCTAssertTrue(arguments.first?.event.isCrashEvent ?? false)
+        
+        let result = arguments.first?.event.eventOptions.contains([.addNoScreenshots, .addNoViewHierarchy])
+        XCTAssertTrue(result ?? false)
     }
 
     private func assertEventSentWithSession() {


### PR DESCRIPTION


## :scroll: Description

Add an internal property called event options to the SentryEvent, so we can set option flags to treat events differently in the SDK.

#skip-changelog

## :bulb: Motivation and Context

We need to remove some extra data from the event for MetricKit events. Instead of adding an extra boolean
flag like `isCrashEvent`, we now have an options flag on the event to set things like don't add an attachment, 
view hierarchy, screenshots, remove some extra context, etc.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
