### PR TITLE
fix: Don't add out of date context for crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This version adds a dependency on Swift.
 - The SDK no longer reports an OOM when a crash happens after closing the SDK (#2468)
 - Don't capture zero size screenshots ([#2459](https://github.com/getsentry/sentry-cocoa/pull/2459))
 - Use the preexisting app release version format for profiles (#2470)
-- Don't add out of date context for crashes (#2522)
+- Don't add out of date context for crashes (#2523)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This version adds a dependency on Swift.
 - The SDK no longer reports an OOM when a crash happens after closing the SDK (#2468)
 - Don't capture zero size screenshots ([#2459](https://github.com/getsentry/sentry-cocoa/pull/2459))
 - Use the preexisting app release version format for profiles (#2470)
+- Don't attach current context to crashes (#2522)
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This version adds a dependency on Swift.
 - The SDK no longer reports an OOM when a crash happens after closing the SDK (#2468)
 - Don't capture zero size screenshots ([#2459](https://github.com/getsentry/sentry-cocoa/pull/2459))
 - Use the preexisting app release version format for profiles (#2470)
-- Don't attach current context to crashes (#2522)
+- Don't add out of date context for crashes (#2522)
 
 ### Breaking Changes
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -578,14 +578,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         // Remove some mutable properties from the device/app contexts which are no longer
         // applicable
         [self removeExtraDeviceContextFromEvent:event];
-    } else {
+    } else if (!isCrashEvent) {
         // Store the current free memory, free storage, battery level and more mutable properties,
-        // at the time of this event
+        // at the time of this event, but not for crashes as the current data isn't guaranteed to be
+        // the same as when the app crashed.
         [self applyExtraDeviceContextToEvent:event];
+        [self applyPermissionsToEvent:event];
+        [self applyCultureContextToEvent:event];
     }
-
-    [self applyPermissionsToEvent:event];
-    [self applyCultureContextToEvent:event];
 
     // With scope applied, before running callbacks run:
     if (event.environment == nil) {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -56,6 +56,10 @@ class SentryClientTest: XCTestCase {
             
             transport = TestTransport()
             transportAdapter = TestTransportAdapter(transport: transport, options: options)
+            
+            crashWrapper.internalFreeMemorySize = 123_456
+            crashWrapper.internalAppMemorySize = 234_567
+            crashWrapper.internalFreeStorageSize = 345_678
         }
 
         func getSut(configureOptions: (Options) -> Void = { _ in }) -> SentryClient {
@@ -576,19 +580,29 @@ class SentryClientTest: XCTestCase {
             XCTAssertNil(actual.debugMeta)
         }
     }
-
-    func testCaptureCrash_CrashWrapper_MemoryAndStorage() {
+    
+    func testCaptureCrash_NoExtraContext() {
         let event = TestData.event
-        event.threads = nil
-        event.debugMeta = nil
 
-        fixture.crashWrapper.internalFreeMemorySize = 123_456
-        fixture.crashWrapper.internalAppMemorySize = 234_567
-        fixture.crashWrapper.internalFreeStorageSize = 345_678
         fixture.getSut().captureCrash(event, with: fixture.scope)
 
         assertLastSentEventWithAttachment { actual in
-            let eventFreeMemory = actual.context?["device"]?["free_memory"] as? Int
+            XCTAssertEqual(1, actual.context?["device"]?.count, "The device context should only contain free_memory")
+            
+            let eventFreeMemory = actual.context?["device"]?[SentryDeviceContextFreeMemoryKey] as? Int
+            XCTAssertEqual(eventFreeMemory, 2_000)
+            
+            XCTAssertNil(actual.context?["app"], "The app context should be nil")
+            XCTAssertNil(actual.context?["culture"], "The culture context should be nil")
+        }
+    }
+
+    func testCaptureEvent_AddCurrentMemoryAndStorage() {
+
+        fixture.getSut().capture(event: TestData.event)
+
+        assertLastSentEvent { actual in
+            let eventFreeMemory = actual.context?["device"]?[SentryDeviceContextFreeMemoryKey] as? Int
             XCTAssertEqual(eventFreeMemory, 123_456)
 
             let eventAppMemory = actual.context?["app"]?["app_memory"] as? Int
@@ -598,16 +612,12 @@ class SentryClientTest: XCTestCase {
             XCTAssertEqual(eventFreeStorage, 345_678)
         }
     }
-
-    func testCaptureCrash_DeviceProperties() {
+    
+    func testCaptureEvent_DeviceProperties() {
 #if os(iOS)
-        let event = TestData.event
-        event.threads = nil
-        event.debugMeta = nil
+        fixture.getSut().capture(event: TestData.event)
 
-        fixture.getSut().captureCrash(event, with: fixture.scope)
-
-        assertLastSentEventWithAttachment { actual in
+        assertLastSentEvent { actual in
             let orientation = actual.context?["device"]?["orientation"] as? String
             XCTAssertEqual(orientation, "portrait")
 
@@ -620,18 +630,14 @@ class SentryClientTest: XCTestCase {
 #endif
     }
 
-    func testCaptureCrash_DeviceProperties_OtherValues() {
+    func testCaptureEvent_DeviceProperties_OtherValues() {
 #if os(iOS)
-        let event = TestData.event
-        event.threads = nil
-        event.debugMeta = nil
-
         fixture.deviceWrapper.internalOrientation = .landscapeLeft
         fixture.deviceWrapper.interalBatteryState = .full
 
-        fixture.getSut().captureCrash(event, with: fixture.scope)
+        fixture.getSut().capture(event: TestData.event)
 
-        assertLastSentEventWithAttachment { actual in
+        assertLastSentEvent { actual in
             let orientation = actual.context?["device"]?["orientation"] as? String
             XCTAssertEqual(orientation, "landscape")
 
@@ -641,19 +647,15 @@ class SentryClientTest: XCTestCase {
 #endif
     }
 
-    func testCaptureCrash_Permissions() {
+    func testCaptureEvent_AddCurrentPermissions() {
         fixture.permissionsObserver.internalLocationPermissionStatus = SentryPermissionStatus.granted
         fixture.permissionsObserver.internalPushPermissionStatus = SentryPermissionStatus.granted
         fixture.permissionsObserver.internalMediaLibraryPermissionStatus = SentryPermissionStatus.denied
         fixture.permissionsObserver.internalPhotoLibraryPermissionStatus = SentryPermissionStatus.partial
 
-        let event = TestData.event
-        event.threads = nil
-        event.debugMeta = nil
+        fixture.getSut().capture(event: TestData.event)
 
-        fixture.getSut().captureCrash(event, with: fixture.scope)
-
-        assertLastSentEventWithAttachment { actual in
+        assertLastSentEvent { actual in
             let permissions = actual.context?["app"]?["permissions"] as? [String: String]
             XCTAssertEqual(permissions?["push_notifications"], "granted")
             XCTAssertEqual(permissions?["location_access"], "granted")
@@ -661,14 +663,10 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    func testCaptureCrash_Culture() {
-        let event = TestData.event
-        event.threads = nil
-        event.debugMeta = nil
+    func testCaptureEvent_AddCurrentCulture() {
+        fixture.getSut().capture(event: TestData.event)
 
-        fixture.getSut().captureCrash(event, with: fixture.scope)
-
-        assertLastSentEventWithAttachment { actual in
+        assertLastSentEvent { actual in
             let culture = actual.context?["culture"]
             XCTAssertEqual(culture?["calendar"] as? String, "Gregorian Calendar")
             XCTAssertEqual(culture?["display_name"] as? String, "English (United States)")


### PR DESCRIPTION

## :scroll: Description

The client attached the current app, permission, and culture context to crashes. We can't guarantee that this data matches the data of a previous run when the app crashed. As this data could be misleading, we remove it from crashes.

## :bulb: Motivation and Context

I came across this while removing context data for MetricKit events.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps

Make the removed context data available for crashes with https://github.com/getsentry/sentry-cocoa/issues/2524.
