### PR TITLE
fix: ARC issue for FileManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This version adds a dependency on Swift.
 - The SDK no longer reports an OOM when a crash happens after closing the SDK (#2468)
 - Don't capture zero size screenshots ([#2459](https://github.com/getsentry/sentry-cocoa/pull/2459))
 - Use the preexisting app release version format for profiles (#2470)
+- Fix ARC issue for FileManager (#2525)
 
 ### Breaking Changes
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -77,11 +77,15 @@ SentryFileManager ()
         self.currentFileCounter = 0;
         self.maxEnvelopes = options.maxCacheItems;
 
+        __weak SentryFileManager *weakSelf = self;
         [dispatchQueueWrapper
             dispatchAfter:10
                     block:^{
-                        SENTRY_LOG_DEBUG(@"Dispatched deletion of old envelopes from %@", self);
-                        [self deleteOldEnvelopesFromAllSentryPaths];
+                        if (weakSelf == nil) {
+                            return;
+                        }
+                        SENTRY_LOG_DEBUG(@"Dispatched deletion of old envelopes from %@", weakSelf);
+                        [weakSelf deleteOldEnvelopesFromAllSentryPaths];
                     }];
     }
     return self;

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -136,14 +136,7 @@ class SentryFileManagerTests: XCTestCase {
     func testDeleteOldEnvelopes() throws {
         fixture.dispatchQueueWrapper.dispatchAfterExecutesBlock = true
 
-        let envelope = TestConstants.envelope
-        let path = sut.store(envelope)
-
-        let timeIntervalSince1970 = fixture.currentDateProvider.date().timeIntervalSince1970 - (90 * 24 * 60 * 60)
-        let date = Date(timeIntervalSince1970: timeIntervalSince1970 - 1)
-        try FileManager.default.setAttributes([FileAttributeKey.creationDate: date], ofItemAtPath: path)
-
-        XCTAssertEqual(sut.getAllEnvelopes().count, 1)
+        try givenOldEnvelopes()
 
         sut = fixture.getSut()
 
@@ -179,6 +172,22 @@ class SentryFileManagerTests: XCTestCase {
 
         sut = fixture.getSut()
 
+        XCTAssertEqual(sut.getAllEnvelopes().count, 1)
+    }
+    
+    func testFileManagerDeallocated_OldEnvelopesNotDeleted() throws {
+        try givenOldEnvelopes()
+        
+        fixture.dispatchQueueWrapper.dispatchAfterExecutesBlock = false
+
+        // Initialize sut in extra function so ARC deallocates it
+        func getSut() {
+            _ = fixture.getSut()
+        }
+        getSut()
+        
+        fixture.dispatchQueueWrapper.invokeLastDispatchAfter()
+        
         XCTAssertEqual(sut.getAllEnvelopes().count, 1)
     }
 
@@ -633,6 +642,17 @@ class SentryFileManagerTests: XCTestCase {
         } catch {
             XCTFail("Failed to store garbage in Envelopes folder.")
         }
+    }
+    
+    private func givenOldEnvelopes() throws {
+        let envelope = TestConstants.envelope
+        let path = sut.store(envelope)
+
+        let timeIntervalSince1970 = fixture.currentDateProvider.date().timeIntervalSince1970 - (90 * 24 * 60 * 60)
+        let date = Date(timeIntervalSince1970: timeIntervalSince1970 - 1)
+        try FileManager.default.setAttributes([FileAttributeKey.creationDate: date], ofItemAtPath: path)
+
+        XCTAssertEqual(sut.getAllEnvelopes().count, 1)
     }
 
     private func storeEvent() {


### PR DESCRIPTION


## :scroll: Description

The SentryFileManager kept a strong reference to self for running code 10 seconds delayed. The strong reference stops ARC from deallocating the SentryFileManager. This is fixed now by using a weak reference.

## :bulb: Motivation and Context

Came across this cause tests are sometimes crashing with `malloc: double free for ptr`
The raw logs show logs from SentryFileManager
```
Test Case '-[SentryTests.SentryProfilerSwiftTests testStartTransaction_NotSamplingProfileUsingSampleRate]' started.
2022-12-13 09:52:30.402191+0000 xctest[5072:27885] [Sentry] [error] [SentryFileManager:215] Couldn't load files in folder /Users/runner/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSFilePath=/Users/runner/Library/Caches/io.sentry/envelopes/envelopes, NSUserStringVariant=(
    Folder
), NSUnderlyingError=0x7fa66ede8560 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}}
2022-12-13 09:52:30.402564+0000 xctest[5072:27885] [Sentry] [debug] [SentryFileManager:83] Dispatched deletion of old envelopes from <SentryFileManager: 0x7fa66de76c40>
2022-12-13 09:52:30.402646+0000 xctest[5072:27101] [Sentry] [debug] [SentryFileManager:643] SentryFileManager.cachePath: /Users/runner/Library/Caches
2022-12-13 09:52:30.402763+0000 xctest[5072:27101] [Sentry] [debug] [SentryFileManager:226] Deleting /Users/runner/Library/Caches/io.sentry/f7bb27206055cbb77c5019791680370519b4854a/events
2022-12-13 09:52:30.405494+0000 xctest[5072:27101] [Sentry] [debug] [SentryHttpTransport:244] sendAllCachedEnvelopes start.
2022-12-13 09:52:30.406054+0000 xctest[5072:27101] [Sentry] [debug] [SentryHttpTransport:256] No envelopes left to send.
2022-12-13 09:52:30.406261+0000 xctest[5072:27101] [Sentry] [debug] [SentryHttpTransport:323] Finished sending.
2022-12-13 09:52:30.408322+0000 xctest[5072:27101] [Sentry] [debug] [SentrySpanContext:56] Created span context with trace ID ba6bd2f9c4ae44f7953656c5e2e2d7c7; span ID e9a3e562d3a04fd2; parent span ID (null); operation Some Operation
2022-12-13 09:52:30.408475+0000 xctest[5072:27101] [Sentry] [debug] [SentryTransactionContext:140] Created transaction context with name Some Transaction
2022-12-13 09:52:30.408624+0000 xctest[5072:27101] [Sentry] [debug] [SentrySpanContext:56] Created span context with trace ID ba6bd2f9c4ae44f7953656c5e2e2d7c7; span ID e9a3e562d3a04fd2; parent span ID (null); operation Some Operation
2022-12-13 09:52:30.408689+0000 xctest[5072:27885] [Sentry] [error] [SentryFileManager:215] Couldn't load files in folder /Users/runner/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSFilePath=/Users/runner/Library/Caches/io.sentry/envelopes/envelopes, NSUserStringVariant=(
    Folder
), NSUnderlyingError=0x7fa689d7b5b0 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}}
2022-12-13 09:52:30.409531+0000 xctest[5072:27101] [Sentry] [debug] [SentryTracer:150] Starting transaction ID ba6bd2f9c4ae44f7953656c5e2e2d7c7 and name Some Transaction for span ID e9a3e562d3a04fd2 at system time 1288316001947
2022-12-13 09:52:30.409724+0000 xctest[5072:27101] [Sentry] [debug] [SentrySpan:30] Created span e9a3e562d3a04fd2 for trace ID (null)
2022-12-13 09:52:30.409814+0000 xctest[5072:27885] [Sentry] [debug] [SentryFileManager:83] Dispatched deletion of old envelopes from <SentryFileManager: 0x7fa66beb18c0>
2022-12-13 09:52:30.417099+0000 xctest[5072:27885] [Sentry] [error] [SentryFileManager:215] Couldn't load files in folder /Users/runner/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSFilePath=/Users/runner/Library/Caches/io.sentry/envelopes/envelopes, NSUserStringVariant=(
    Folder
), NSUnderlyingError=0x7fa66eb99780 {Error Domain=NSOSStatusErrorDomain Code=-43 "fnfErr: File not found"}}
2022-12-13 09:52:30.663047+0000 xctest[5072:28237] [Sentry] [debug] [SentryFileManager:83] Dispatched deletion of old envelopes from <SentryFileManager: 0x7fa66de876b0>
2022-12-13 09:52:30.663047+0000 xctest[5072:27885] [Sentry] [debug] [SentryFileManager:83] Dispatched deletion of old envelopes from <SentryFileManager: 0x7fa66bffb230>
2022-12-13 09:52:30.663047+0000 xctest[5072:27372] [Sentry] [debug] [SentryFileManager:83] Dispatched deletion of old envelopes from <SentryFileManager: 0x7fa66becb510>
xctest(5072,0x7000015f6000) malloc: double free for ptr 0x7fa67b0d9800
xctest(5072,0x7000015f6000) malloc: *** set a breakpoint in malloc_error_break to debug

Restarting after unexpected exit, crash, or test timeout in SentryProfilerSwiftTests.testStartTransaction_NotSamplingProfileUsingSampleRate(); summary will include totals from previous launches.
```

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
