### PR TITLE
Fix and reenable testANRDetected_UpdatesAppStateToTrue

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -74,9 +74,6 @@
                   Identifier = "SentryNetworkTrackerIntegrationTests/testGetRequest_SpanCreatedAndBaggageHeaderAdded_disabled()">
                </Test>
                <Test
-                  Identifier = "SentryWatchdogTerminationIntegrationTests/testANRDetected_UpdatesAppStateToTrue_disabled()">
-               </Test>
-               <Test
                   Identifier = "SentryProfilerSwiftTests/testProfileTimeoutTimer_disabled()">
                </Test>
                <Test

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -173,7 +173,7 @@ SentryAppStateManager ()
 {
     @synchronized(self) {
         SentryAppState *appState = [self.fileManager readAppState];
-        if (nil != appState) {
+        if (appState != nil) {
             block(appState);
             [self.fileManager storeAppState:appState];
         }

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -439,7 +439,7 @@ SentryFileManager ()
     NSError *error = nil;
     NSData *data = [SentrySerialization dataWithJSONObject:[appState serialize] error:&error];
 
-    if (nil != error) {
+    if (error != nil) {
         SENTRY_LOG_ERROR(
             @"Failed to store app state, because of an error in serialization: %@", error);
         return;

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
@@ -17,6 +17,7 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
             
             crashWrapper = TestSentryCrashWrapper.sharedInstance()
             SentryDependencyContainer.sharedInstance().crashWrapper = crashWrapper
+            SentryDependencyContainer.sharedInstance().fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDate)
 
             let hub = SentryHub(client: client, andScope: nil, andCrashWrapper: crashWrapper, andCurrentDateProvider: currentDate)
             SentrySDK.setCurrentHub(hub)

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
@@ -64,15 +64,12 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
     }
     
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-    func testANRDetected_UpdatesAppStateToTrue_disabled() {
+    func testANRDetected_UpdatesAppStateToTrue() throws {
         givenInitializedTracker()
         
         Dynamic(sut).anrDetected()
-        
-        guard let appState = fixture.fileManager.readAppState() else {
-            XCTFail("appState must not be nil")
-            return
-        }
+
+        let appState = try XCTUnwrap(fixture.fileManager.readAppState())
         
         XCTAssertTrue(appState.isANROngoing)
     }

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -163,12 +163,12 @@ class TestFileManager: SentryFileManager {
     var readAppStateInvocations = Invocations<Void>()
     override func readAppState() -> SentryAppState? {
         readAppStateInvocations.record(Void())
-        return super.readAppState()
+        return nil
     }
 
     var readPreviousAppStateInvocations = Invocations<Void>()
     override func readPreviousAppState() -> SentryAppState? {
         readPreviousAppStateInvocations.record(Void())
-        return super.readPreviousAppState()
+        return nil
     }
 }

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -163,12 +163,12 @@ class TestFileManager: SentryFileManager {
     var readAppStateInvocations = Invocations<Void>()
     override func readAppState() -> SentryAppState? {
         readAppStateInvocations.record(Void())
-        return nil
+        return super.readAppState()
     }
 
     var readPreviousAppStateInvocations = Invocations<Void>()
     override func readPreviousAppState() -> SentryAppState? {
         readPreviousAppStateInvocations.record(Void())
-        return nil
+        return super.readPreviousAppState()
     }
 }


### PR DESCRIPTION
## :scroll: Description

- The test calls `SentryWatchdogTerminationTrackingIntegration.anrDetected`.
- This calls `self.appStateManager.updateAppState`, but that used the TestFileManager under the hood!
- `updateAppState` fails because `[self.fileManager readAppState]` returns `nil`.

Using the normal file manager fixes the test. 

#skip-changelog

## :bulb: Motivation and Context

Closes #2522

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
