### PR TITLE
tests: Remove disabled `SentryFileIOTrackingIntegrationTests` tests

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -87,16 +87,6 @@
                </Test>
             </SkippedTests>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "7B64386726A6C544000D0F65"
-               BuildableName = "iOS-SwiftUITests.xctest"
-               BlueprintName = "iOS-SwiftUITests"
-               ReferencedContainer = "container:Samples/iOS-Swift/iOS-Swift.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -62,16 +62,13 @@
                   Identifier = "SentryCrashReportStore_Tests/testCrashReportCount1_disabled">
                </Test>
                <Test
-                  Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readPath_disabled()">
-               </Test>
-               <Test
-                  Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readUrl_disabled()">
-               </Test>
-               <Test
                   Identifier = "SentryNSErrorTests/testSerializeWithUnderlyingNSException_disabled()">
                </Test>
                <Test
                   Identifier = "SentryNetworkTrackerIntegrationTests/testGetRequest_SpanCreatedAndBaggageHeaderAdded_disabled()">
+               </Test>
+               <Test
+                  Identifier = "SentryProfilerSwiftTests/testConcurrentSpansWithTimeout_disabled()">
                </Test>
                <Test
                   Identifier = "SentryProfilerSwiftTests/testProfileTimeoutTimer_disabled()">
@@ -88,10 +85,17 @@
                <Test
                   Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces_disabled()">
                </Test>
-               <Test
-                  Identifier = "SentryProfilerSwiftTests/testConcurrentSpansWithTimeout_disabled()">
-               </Test>
             </SkippedTests>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "7B64386726A6C544000D0F65"
+               BuildableName = "iOS-SwiftUITests.xctest"
+               BlueprintName = "iOS-SwiftUITests"
+               ReferencedContainer = "container:Samples/iOS-Swift/iOS-Swift.xcodeproj">
+            </BuildableReference>
          </TestableReference>
       </Testables>
    </TestAction>

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -191,33 +191,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         ?? bundle.path(forResource: "fatal-error-binary-images-message2", ofType: "json")
     }
     
-    func test_DataConsistency_readUrl_disabled() {
-        SentrySDK.start(options: fixture.getOptions())
-        
-        let randomValue = UUID().uuidString
-        try? randomValue.data(using: .utf8)?.write(to: fixture.fileURL, options: .atomic)
-        print("\(String(describing: fixture.fileURL))")
-        guard let data = try? Data(contentsOf: fixture.fileURL, options: .uncached) else {
-            XCTFail("Could not load resource file")
-            return
-        }
-        let readValue = String(data: data, encoding: .utf8)
-        XCTAssertEqual(randomValue, readValue)
-    }
-    
-    func test_DataConsistency_readPath_disabled() {
-        SentrySDK.start(options: fixture.getOptions())
-        
-        let randomValue = UUID().uuidString
-        try? randomValue.data(using: .utf8)?.write(to: fixture.fileURL, options: .atomic)
-        guard let data = try? NSData(contentsOfFile: fixture.filePath) as Data else {
-            XCTFail("Could not load resource file")
-            return 
-        }
-        let readValue = String(data: data, encoding: .utf8)
-        XCTAssertEqual(randomValue, readValue)
-    }
-    
     private func assertWriteWithNoSpans() {
         assertSpans(0, "file.write") {
             try? fixture.data.write(to: fixture.fileURL)


### PR DESCRIPTION
## :scroll: Description

I'm not really sure what `test_DataConsistency_readUrl` even tried to test. It writes to a file and immediately reads from it, and checks if the values are equal. I don't think we need to test writing data to and reading from disk? Same with `test_DataConsistency_readPath`, it really doesn't seem to actually test any SDK logic.

So, I removed the two tests. If you disagree with this, I can just close the PR :)

#skip-changelog

## :bulb: Motivation and Context

Closes #2199