### PR TITLE
tests: Reenable testAddAndRemoveData

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -74,6 +74,9 @@
                   Identifier = "SentryNetworkTrackerIntegrationTests/testGetRequest_SpanCreatedAndBaggageHeaderAdded_disabled()">
                </Test>
                <Test
+                  Identifier = "SentryProfilerSwiftTests/testConcurrentSpansWithTimeout_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentryProfilerSwiftTests/testProfileTimeoutTimer_disabled()">
                </Test>
                <Test
@@ -83,13 +86,7 @@
                   Identifier = "SentrySessionGeneratorTests/testSendSessions_disabled()">
                </Test>
                <Test
-                  Identifier = "SentrySpanTests/testAddAndRemoveData_disabled()">
-               </Test>
-               <Test
                   Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces_disabled()">
-               </Test>
-               <Test
-                  Identifier = "SentryProfilerSwiftTests/testConcurrentSpansWithTimeout_disabled()">
                </Test>
             </SkippedTests>
          </TestableReference>

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -185,7 +185,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(" Starting a child on a finished span is not supported; it won\'t be sent to Sentry.") }).isEmpty)
     }
     
-    func testAddAndRemoveData_disabled() {
+    func testAddAndRemoveData() {
         let span = fixture.getSut()
 
         span.setData(value: fixture.extraValue, key: fixture.extraKey)


### PR DESCRIPTION
I initially thought the test had failed twice, but it was actually only once. And the test failure wasn't a real test failure I think:

```
Failing tests:
	SentryTests:
		SentrySpanTests.testAddAndRemoveData()
```

But absolutely nowhere is there any information on which assert failed, and how. But since the test only uses `XCTAssertEqual` and `XCTAssertNil`, we should get proper failure messages. 

So I don't know why the test failed in https://github.com/getsentry/sentry-cocoa/actions/runs/3530734813/jobs/5923080490, but I don't think it's because the actual test function is flaky.

#skip-changelog