### PR TITLE
feat: support SENTRY_DSN environment var on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This version adds a dependency on Swift.
 - [User Interaction Tracing](https://docs.sentry.io/platforms/apple/performance/instrumentation/automatic-instrumentation/#user-interaction-tracing) is stable and enabled by default(#2503)
 - Add synthetic for mechanism (#2501)
 - Enable CaptureFailedRequests by default (#2507)
+- Support the [`SENTRY_DSN` environment variable](https://docs.sentry.io/platforms/apple/guides/macos/configuration/options/#dsn) on macOS (#2534)
 
 ### Fixes
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -99,6 +99,13 @@ NSString *const kSentryDefaultEnvironment = @"production";
         _enableSwizzling = YES;
         self.sendClientReports = YES;
 
+#if TARGET_OS_OSX
+        NSString *dsn = [[[NSProcessInfo processInfo] environment] objectForKey:@"SENTRY_DSN"];
+        if (dsn.length > 0) {
+            self.dsn = dsn;
+        }
+#endif
+
         // Use the name of the bundle’s executable file as inAppInclude, so SentryInAppLogic
         // marks frames coming from there as inApp. With this approach, the SDK marks public
         // frameworks such as UIKitCore, CoreFoundation, GraphicsServices, and so forth, as not
@@ -112,7 +119,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         // them as inApp. To fix this, the user can use stack trace rules on Sentry.
         NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
         NSString *bundleExecutable = infoDict[@"CFBundleExecutable"];
-        if (nil == bundleExecutable) {
+        if (bundleExecutable == nil) {
             _inAppIncludes = [NSArray new];
         } else {
             _inAppIncludes = @[ bundleExecutable ];
@@ -121,7 +128,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         _inAppExcludes = [NSArray new];
 
         // Set default release name
-        if (nil != infoDict) {
+        if (infoDict != nil) {
             self.releaseName =
                 [NSString stringWithFormat:@"%@@%@+%@", infoDict[@"CFBundleIdentifier"],
                           infoDict[@"CFBundleShortVersionString"], infoDict[@"CFBundleVersion"]];
@@ -201,7 +208,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
     NSError *error = nil;
     self.parsedDsn = [[SentryDsn alloc] initWithString:dsn didFailWithError:&error];
 
-    if (nil == error) {
+    if (error == nil) {
         _dsn = dsn;
     } else {
         SENTRY_LOG_ERROR(@"Could not parse the DSN: %@.", error);

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -190,6 +190,15 @@
     XCTAssertEqualObjects(options.dsn, @"https://username:password@sentry.io/1");
     XCTAssertNotNil(options.parsedDsn);
 }
+
+- (void)testInvalidDsnViaEnvironment
+{
+    setenv("SENTRY_DSN", "foo_bar", 1);
+    SentryOptions *options = [[SentryOptions alloc] init];
+    XCTAssertNil(options.dsn);
+    XCTAssertNil(options.parsedDsn);
+    XCTAssertEqual(options.enabled, YES);
+}
 #endif
 
 - (void)testTracesSampleRate_SetToNil

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -182,6 +182,16 @@
     XCTAssertEqual(YES, options.enabled);
 }
 
+#if TARGET_OS_OSX
+- (void)testDsnViaEnvironment
+{
+    setenv("SENTRY_DSN", "https://username:password@sentry.io/1", 1);
+    SentryOptions *options = [[SentryOptions alloc] init];
+    XCTAssertEqualObjects(options.dsn, @"https://username:password@sentry.io/1");
+    XCTAssertNotNil(options.parsedDsn);
+}
+#endif
+
 - (void)testTracesSampleRate_SetToNil
 {
     SentryOptions *options = [[SentryOptions alloc] init];

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -189,6 +189,7 @@
     SentryOptions *options = [[SentryOptions alloc] init];
     XCTAssertEqualObjects(options.dsn, @"https://username:password@sentry.io/1");
     XCTAssertNotNil(options.parsedDsn);
+    setenv("SENTRY_DSN", "", 1);
 }
 
 - (void)testInvalidDsnViaEnvironment
@@ -198,6 +199,7 @@
     XCTAssertNil(options.dsn);
     XCTAssertNil(options.parsedDsn);
     XCTAssertEqual(options.enabled, YES);
+    setenv("SENTRY_DSN", "", 1);
 }
 #endif
 


### PR DESCRIPTION
## :scroll: Description

We now read the `SENTRY_DSN` environment variable, on macOS only.

## :bulb: Motivation and Context

Closes #2515 

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
