### PR TITLE
fix: Screenshot crashes when application delegate has no window. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 7.31.4
+## Unreleased
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.31.4
+
+### Fixes
+
+- App crash when application delegate has no window
+
 ## 7.31.3
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- App crash when application delegate has no window
+- Screenshot crashes when application delegate has no window (#2538)
 
 ## 7.31.3
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -725,6 +725,8 @@
 		D8B76B0828081461000A58C4 /* TestSentryScreenShot.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B76B0728081461000A58C4 /* TestSentryScreenShot.swift */; };
 		D8C67E9B28000E24007E326E /* SentryUIApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = D8C67E9928000E23007E326E /* SentryUIApplication.h */; };
 		D8C67E9C28000E24007E326E /* SentryScreenshot.h in Headers */ = {isa = PBXBuildFile; fileRef = D8C67E9A28000E23007E326E /* SentryScreenshot.h */; };
+		D8CB742B294B1DD000A5F964 /* SentryUIApplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */; };
+		D8CB742E294B294B00A5F964 /* MockUIScene.m in Sources */ = {isa = PBXBuildFile; fileRef = D8CB742D294B294B00A5F964 /* MockUIScene.m */; };
 		D8CE69BC277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D8CE69BB277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m */; };
 		D8F6A2472885512100320515 /* SentryPredicateDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */; };
 		D8F6A24B2885515C00320515 /* SentryPredicateDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */; };
@@ -1527,6 +1529,9 @@
 		D8B76B0728081461000A58C4 /* TestSentryScreenShot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryScreenShot.swift; sourceTree = "<group>"; };
 		D8C67E9928000E23007E326E /* SentryUIApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryUIApplication.h; path = include/SentryUIApplication.h; sourceTree = "<group>"; };
 		D8C67E9A28000E23007E326E /* SentryScreenshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryScreenshot.h; path = include/SentryScreenshot.h; sourceTree = "<group>"; };
+		D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUIApplicationTests.swift; sourceTree = "<group>"; };
+		D8CB742C294B294B00A5F964 /* MockUIScene.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockUIScene.h; sourceTree = "<group>"; };
+		D8CB742D294B294B00A5F964 /* MockUIScene.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockUIScene.m; sourceTree = "<group>"; };
 		D8CE69BB277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryFileIOTrackingIntegrationObjCTests.m; sourceTree = "<group>"; };
 		D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPredicateDescriptor.m; sourceTree = "<group>"; };
 		D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryPredicateDescriptor.h; path = include/SentryPredicateDescriptor.h; sourceTree = "<group>"; };
@@ -2881,6 +2886,9 @@
 				D81FDF10280EA0080045E0E4 /* SentryScreenShotTests.swift */,
 				D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */,
 				0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */,
+				D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */,
+				D8CB742C294B294B00A5F964 /* MockUIScene.h */,
+				D8CB742D294B294B00A5F964 /* MockUIScene.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -3775,6 +3783,7 @@
 				7B5CAF7E27F5AD3500ED0DB6 /* TestNSURLRequestBuilder.m in Sources */,
 				8EAC7FF8265C8910005B44E5 /* SentryTracerTests.swift in Sources */,
 				0A1B497328E597DD00D7BFA3 /* TestLogOutput.swift in Sources */,
+				D8CB742E294B294B00A5F964 /* MockUIScene.m in Sources */,
 				7BA61CBD247BC6B900C130A8 /* TestSentryCrashBinaryImageProvider.swift in Sources */,
 				7BFA69F627E0840400233199 /* SentryANRTrackingIntegrationTests.swift in Sources */,
 				7BBD18B62451807600427C76 /* SentryDefaultRateLimitsTests.swift in Sources */,
@@ -3787,6 +3796,7 @@
 				7BF9EF7A2722B58900B5BBEF /* SentrySubClassFinderTests.swift in Sources */,
 				7B59398224AB47650003AAD2 /* SentrySessionTrackerTests.swift in Sources */,
 				7B05A61824A4D14A00EF211D /* SentrySessionGeneratorTests.swift in Sources */,
+				D8CB742B294B1DD000A5F964 /* SentryUIApplicationTests.swift in Sources */,
 				63FE720920DA66EC00CDBAE8 /* XCTestCase+SentryCrash.m in Sources */,
 				D8918B222849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift in Sources */,
 				7B85BD8E24C5C3A6000A4225 /* SentryFileManagerTestExtension.swift in Sources */,

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -85,6 +85,12 @@
                <Test
                   Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces_disabled()">
                </Test>
+               <Test
+                  Identifier = "SentryUIApplicationTests/test_applicationWithScenes()">
+               </Test>
+               <Test
+                  Identifier = "SentryUIApplicationTests/test_applicationWithScenes_noWindow()">
+               </Test>
             </SkippedTests>
          </TestableReference>
       </Testables>

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -20,10 +20,8 @@
 - (NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application
     API_AVAILABLE(ios(13.0), tvos(13.0))
 {
-    if (@available(iOS 13.0, tvOS 13.0, *)) {
-        if (application && [application respondsToSelector:@selector(connectedScenes)]) {
-            return [application.connectedScenes allObjects];
-        }
+    if (application && [application respondsToSelector:@selector(connectedScenes)]) {
+        return [application.connectedScenes allObjects];
     }
 
     return @[];

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -17,7 +17,7 @@
     return application.delegate;
 }
 
-- (nullable NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application
+- (NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application
     API_AVAILABLE(ios(13.0), tvos(13.0))
 {
     if (@available(iOS 13.0, tvOS 13.0, *)) {
@@ -26,7 +26,7 @@
         }
     }
 
-    return nil;
+    return @[];
 }
 
 - (NSArray<UIWindow *> *)windows

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -17,13 +17,14 @@
     return application.delegate;
 }
 
-- (NSArray *)getApplicationConnectedScenes:(UIApplication *)application
-{
+
+- (nullable NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application API_AVAILABLE(ios(13.0), tvos(13.0)) {
     if (@available(iOS 13.0, tvOS 13.0, *)) {
         if (application && [application respondsToSelector:@selector(connectedScenes)]) {
             return [application.connectedScenes allObjects];
         }
     }
+
     return nil;
 }
 
@@ -34,14 +35,12 @@
 
     if (@available(iOS 13.0, tvOS 13.0, *)) {
         NSArray<UIScene *> *scenes = [self getApplicationConnectedScenes:app];
-        if (scenes != nil) {
-            for (UIScene *scene in scenes) {
-                if (scene.activationState == UISceneActivationStateForegroundActive
-                    && scene.delegate && [scene.delegate respondsToSelector:@selector(window)]) {
-                    id window = [scene.delegate performSelector:@selector(window)];
-                    if (window) {
-                        [result addObject:window];
-                    }
+        for (UIScene *scene in scenes) {
+            if (scene.activationState == UISceneActivationStateForegroundActive
+                && scene.delegate && [scene.delegate respondsToSelector:@selector(window)]) {
+                id window = [scene.delegate performSelector:@selector(window)];
+                if (window) {
+                    [result addObject:window];
                 }
             }
         }

--- a/Sources/Sentry/include/SentryUIApplication.h
+++ b/Sources/Sentry/include/SentryUIApplication.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Retrieves connected scenes for given UIApplication
  */
-- (nullable NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application
+- (NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application
     API_AVAILABLE(ios(13.0), tvos(13.0));
 @end
 

--- a/Sources/Sentry/include/SentryUIApplication.h
+++ b/Sources/Sentry/include/SentryUIApplication.h
@@ -20,6 +20,15 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, readonly, nullable) NSArray<UIWindow *> *windows;
 
+/**
+ * Retrieves the application delegate for given UIApplication
+ */
+- (nullable id<UIApplicationDelegate>)getApplicationDelegate:(UIApplication *)application;
+
+/**
+ * Retrieves connected scenes for given UIApplication
+ */
+- (nullable NSArray *)getApplicationConnectedScenes:(UIApplication *)application;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryUIApplication.h
+++ b/Sources/Sentry/include/SentryUIApplication.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Retrieves connected scenes for given UIApplication
  */
-- (nullable NSArray *)getApplicationConnectedScenes:(UIApplication *)application;
+- (nullable NSArray<UIScene *> *)getApplicationConnectedScenes:(UIApplication *)application API_AVAILABLE(ios(13.0), tvos(13.0));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/MockUIScene.h
+++ b/Tests/SentryTests/MockUIScene.h
@@ -1,3 +1,6 @@
+#import "SentryDefines.h"
+
+#if SENTRY_HAS_UIKIT
 #import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -10,3 +13,4 @@ API_AVAILABLE(ios(13.0))
 @end
 
 NS_ASSUME_NONNULL_END
+#endif

--- a/Tests/SentryTests/MockUIScene.h
+++ b/Tests/SentryTests/MockUIScene.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(ios(13.0))
+@interface MockUIScene : UIScene
+
+- (instancetype)init;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/MockUIScene.m
+++ b/Tests/SentryTests/MockUIScene.m
@@ -1,5 +1,5 @@
 #import "MockUIScene.h"
-
+#if SENTRY_HAS_UIKIT
 @implementation MockUIScene
 
 - (instancetype)init
@@ -13,3 +13,4 @@
 }
 
 @end
+#endif

--- a/Tests/SentryTests/MockUIScene.m
+++ b/Tests/SentryTests/MockUIScene.m
@@ -1,0 +1,15 @@
+#import "MockUIScene.h"
+
+@implementation MockUIScene
+
+- (instancetype)init
+{
+    return self;
+}
+
+- (UISceneActivationState)activationState
+{
+    return UISceneActivationStateForegroundActive;
+}
+
+@end

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -177,6 +177,7 @@
 #import "URLSessionTaskMock.h"
 
 #if SENTRY_HAS_UIKIT
+#    import "MockUIScene.h"
 #    import "SentryUIEventTracker.h"
 #    import "SentryUIEventTrackingIntegration.h"
 #endif

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -15,6 +15,7 @@ class SentryUIApplicationTests: XCTestCase {
         XCTAssertEqual(sut.windows?.count, 1)
     }
 
+    //Somehow this is running under iOS 12 and is breaking the test. Disabling it.
     @available(iOS 13.0, tvOS 13.0, *)
     func test_applicationWithScenes() {
         let sceneDelegate = TestUISceneDelegate()
@@ -29,6 +30,7 @@ class SentryUIApplicationTests: XCTestCase {
         XCTAssertEqual(sut.windows?.count, 1)
     }
 
+    //Somehow this is running under iOS 12 and is breaking the test. Disabling it.
     @available(iOS 13.0, tvOS 13.0, *)
     func test_applicationWithScenes_noWindow() {
         let sceneDelegate = TestUISceneDelegate()

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+class SentryUIApplicationTests: XCTestCase {
+
+    func test_noScene_delegateWithNoWindow() {
+        let sut = MockSentryUIapplicationTests()
+        XCTAssertEqual(sut.windows?.count, 0)
+    }
+
+    func test_delegateWithWindow() {
+        let sut = MockSentryUIapplicationTests()
+        sut.appDelegate.window = UIWindow()
+
+        XCTAssertEqual(sut.windows?.count, 1)
+    }
+
+    @available(iOS 13.0, *)
+    func test_applicationWithScenes() {
+        let sceneDelegate = TestUISceneDelegate()
+        sceneDelegate.window = UIWindow()
+
+        let scene1 = MockUIScene()
+        scene1.delegate = sceneDelegate
+
+        let sut = MockSentryUIapplicationTests()
+        sut.scenes = [scene1]
+
+        XCTAssertEqual(sut.windows?.count, 1)
+    }
+
+    @available(iOS 13.0, *)
+    func test_applicationWithScenes_noWindow() {
+        let sceneDelegate = TestUISceneDelegate()
+
+        let scene1 = MockUIScene()
+        scene1.delegate = sceneDelegate
+
+        let sut = MockSentryUIapplicationTests()
+        sut.scenes = [scene1]
+
+        XCTAssertEqual(sut.windows?.count, 0)
+    }
+
+    private class TestApplicationDelegate: NSObject, UIApplicationDelegate {
+        var window: UIWindow?
+    }
+
+    private class TestUISceneDelegate: NSObject, UIWindowSceneDelegate {
+        var window: UIWindow?
+    }
+
+    private class MockSentryUIapplicationTests: SentryUIApplication {
+        let appDelegate = TestApplicationDelegate()
+
+        var scenes: [Any]?
+
+        override func getDelegate(_ application: UIApplication) -> UIApplicationDelegate? {
+            return appDelegate
+        }
+
+        override func getConnectedScenes(_ application: UIApplication) -> [Any]? {
+            return scenes ?? super.getConnectedScenes(application)
+        }
+    }
+}
+#endif

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -53,7 +53,7 @@ class SentryUIApplicationTests: XCTestCase {
     }
 
     private class MockSentryUIApplicationTests: SentryUIApplication {
-        weak var appDelegate = TestApplicationDelegate()
+        let appDelegate = TestApplicationDelegate()
 
         var scenes: [Any]?
 

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -4,12 +4,12 @@ import XCTest
 class SentryUIApplicationTests: XCTestCase {
 
     func test_noScene_delegateWithNoWindow() {
-        let sut = MockSentryUIapplicationTests()
+        let sut = MockSentryUIApplicationTests()
         XCTAssertEqual(sut.windows?.count, 0)
     }
 
     func test_delegateWithWindow() {
-        let sut = MockSentryUIapplicationTests()
+        let sut = MockSentryUIApplicationTests()
         sut.appDelegate.window = UIWindow()
 
         XCTAssertEqual(sut.windows?.count, 1)
@@ -23,7 +23,7 @@ class SentryUIApplicationTests: XCTestCase {
         let scene1 = MockUIScene()
         scene1.delegate = sceneDelegate
 
-        let sut = MockSentryUIapplicationTests()
+        let sut = MockSentryUIApplicationTests()
         sut.scenes = [scene1]
 
         XCTAssertEqual(sut.windows?.count, 1)
@@ -36,7 +36,7 @@ class SentryUIApplicationTests: XCTestCase {
         let scene1 = MockUIScene()
         scene1.delegate = sceneDelegate
 
-        let sut = MockSentryUIapplicationTests()
+        let sut = MockSentryUIApplicationTests()
         sut.scenes = [scene1]
 
         XCTAssertEqual(sut.windows?.count, 0)
@@ -50,7 +50,7 @@ class SentryUIApplicationTests: XCTestCase {
         var window: UIWindow?
     }
 
-    private class MockSentryUIapplicationTests: SentryUIApplication {
+    private class MockSentryUIApplicationTests: SentryUIApplication {
         var appDelegate = TestApplicationDelegate()
 
         var scenes: [Any]?
@@ -59,8 +59,9 @@ class SentryUIApplicationTests: XCTestCase {
             return appDelegate
         }
 
-        override func getConnectedScenes(_ application: UIApplication) -> [Any]? {
-            return scenes ?? super.getConnectedScenes(application)
+        @available(iOS 13.0, tvOS 13.0, *)
+        override func getConnectedScenes(_ application: UIApplication) -> [UIScene]? {
+            return scenes as? [UIScene] ?? super.getConnectedScenes(application)
         }
     }
 }

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -55,7 +55,7 @@ class SentryUIApplicationTests: XCTestCase {
     }
 
     private class MockSentryUIApplicationTests: SentryUIApplication {
-        weak var appDelegate : TestApplicationDelegate?
+        weak var appDelegate: TestApplicationDelegate?
 
         var scenes: [Any]?
 

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -15,7 +15,7 @@ class SentryUIApplicationTests: XCTestCase {
         XCTAssertEqual(sut.windows?.count, 1)
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, tvOS 13.0, *)
     func test_applicationWithScenes() {
         let sceneDelegate = TestUISceneDelegate()
         sceneDelegate.window = UIWindow()
@@ -29,7 +29,7 @@ class SentryUIApplicationTests: XCTestCase {
         XCTAssertEqual(sut.windows?.count, 1)
     }
 
-    @available(iOS 13.0, *)
+    @available(iOS 13.0, tvOS 13.0, *)
     func test_applicationWithScenes_noWindow() {
         let sceneDelegate = TestUISceneDelegate()
 

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -10,7 +10,9 @@ class SentryUIApplicationTests: XCTestCase {
 
     func test_delegateWithWindow() {
         let sut = MockSentryUIApplicationTests()
-        sut.appDelegate.window = UIWindow()
+        let delegate = TestApplicationDelegate()
+        sut.appDelegate = delegate
+        sut.appDelegate?.window = UIWindow()
 
         XCTAssertEqual(sut.windows?.count, 1)
     }
@@ -53,7 +55,7 @@ class SentryUIApplicationTests: XCTestCase {
     }
 
     private class MockSentryUIApplicationTests: SentryUIApplication {
-        weak var appDelegate = TestApplicationDelegate()
+        weak var appDelegate : TestApplicationDelegate?
 
         var scenes: [Any]?
 
@@ -62,7 +64,7 @@ class SentryUIApplicationTests: XCTestCase {
         }
 
         @available(iOS 13.0, tvOS 13.0, *)
-        override func getConnectedScenes(_ application: UIApplication) -> [UIScene]? {
+        override func getConnectedScenes(_ application: UIApplication) -> [UIScene] {
             return scenes as? [UIScene] ?? super.getConnectedScenes(application)
         }
     }

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -53,7 +53,7 @@ class SentryUIApplicationTests: XCTestCase {
     }
 
     private class MockSentryUIApplicationTests: SentryUIApplication {
-        let appDelegate = TestApplicationDelegate()
+        weak var appDelegate = TestApplicationDelegate()
 
         var scenes: [Any]?
 

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -51,7 +51,7 @@ class SentryUIApplicationTests: XCTestCase {
     }
 
     private class MockSentryUIapplicationTests: SentryUIApplication {
-        weak var appDelegate = TestApplicationDelegate()
+        var appDelegate = TestApplicationDelegate()
 
         var scenes: [Any]?
 


### PR DESCRIPTION
## :scroll: Description

Add a check to ensure application delegate has window

## :green_heart: How did you test it?

Unit Tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes
