### PR TITLE
fix: Strong reference cycle for HttpTransport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This version adds a dependency on Swift.
 - Don't add out of date context for crashes (#2523)
 - Fix ARC issue for FileManager (#2525)
 - Remove delay for deleting old envelopes (#2541)
+- Fix strong reference cycle for HttpTransport (#2552)
 
 ### Breaking Changes
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -88,6 +88,7 @@ SentryHttpTransport ()
         [self.reachability monitorURL:[NSURL URLWithString:@"https://sentry.io"]
                         usingCallback:^(BOOL connected, NSString *_Nonnull typeDescription) {
                             if (weakSelf == nil) {
+                                SENTRY_LOG_DEBUG(@"WeakSelf is nil. Not doing anything.");
                                 return;
                             }
 
@@ -317,6 +318,7 @@ SentryHttpTransport ()
                addRequest:request
         completionHandler:^(NSHTTPURLResponse *_Nullable response, NSError *_Nullable error) {
             if (weakSelf == nil) {
+                SENTRY_LOG_DEBUG(@"WeakSelf is nil. Not doing anything.");
                 return;
             }
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -581,7 +581,8 @@ class SentryHttpTransportTests: XCTestCase {
             dispatchAfterBlock.block()
         }
         
-        assertEnvelopesStored(envelopeCount: 10)
+        // The amount of sent envelopes is non deterministic as it depends on how fast ARC deallocates the sut above. We only want to ensure that not all envelopes are sent, so 7 should be fine.
+        XCTAssertLessThan(7, fixture.fileManager.getAllEnvelopes().count)
     }
     
     func testBuildingRequestFailsAndRateLimitActive_RecordsLostEvents() {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -137,7 +137,8 @@ class SentryHttpTransportTests: XCTestCase {
 
         waitForAllRequests()
         givenOkResponse()
-        _ = fixture.sut
+        let sut = fixture.sut
+        XCTAssertNotNil(sut)
         waitForAllRequests()
 
         assertEnvelopesStored(envelopeCount: 0)
@@ -561,6 +562,28 @@ class SentryHttpTransportTests: XCTestCase {
         assertRequestsSent(requestCount: 1)
     }
     
+    func testDeallocated_CachedEnvelopesNotAllSent() throws {
+        givenNoInternetConnection()
+        givenCachedEvents(amount: 10)
+    
+        givenOkResponse()
+        fixture.dispatchQueueWrapper.dispatchAfterExecutesBlock = false
+        
+        // Interact with sut in extra function so ARC deallocates it
+        func getSut() {
+            let sut = fixture.sut
+            sut.send(envelope: fixture.eventEnvelope)
+            waitForAllRequests()
+        }
+        getSut()
+        
+        for dispatchAfterBlock in fixture.dispatchQueueWrapper.dispatchAfterInvocations.invocations {
+            dispatchAfterBlock.block()
+        }
+        
+        assertEnvelopesStored(envelopeCount: 10)
+    }
+    
     func testBuildingRequestFailsAndRateLimitActive_RecordsLostEvents() {
         givenRateLimitResponse(forCategory: "error")
         sendEvent()
@@ -759,6 +782,18 @@ class SentryHttpTransportTests: XCTestCase {
         fixture.reachability.triggerNetworkReachable()
 
         XCTAssertEqual(2, fixture.requestManager.requests.count)
+    }
+    
+    func testDealloc_StopsReachabilityMonitoring() {
+        _ = fixture.sut
+
+        XCTAssertEqual(1, fixture.reachability.stopMonitoringInvocations.count)
+    }
+    
+    func testDealloc_TriggerNetworkReachable_NoCrash() {
+        _ = fixture.sut
+        
+        fixture.reachability.triggerNetworkReachable()
     }
 
     private func givenRetryAfterResponse() -> HTTPURLResponse {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -581,7 +581,8 @@ class SentryHttpTransportTests: XCTestCase {
             dispatchAfterBlock.block()
         }
         
-        // The amount of sent envelopes is non deterministic as it depends on how fast ARC deallocates the sut above. We only want to ensure that not all envelopes are sent, so 7 should be fine.
+        // The amount of sent envelopes is non deterministic as it depends on how fast ARC deallocates the sut above.
+        // We only want to ensure that not all envelopes are sent, so 7 should be fine.
         XCTAssertLessThan(7, fixture.fileManager.getAllEnvelopes().count)
     }
     

--- a/Tests/SentryTests/Networking/TestSentryReachability.swift
+++ b/Tests/SentryTests/Networking/TestSentryReachability.swift
@@ -8,4 +8,9 @@ class TestSentryReachability: SentryReachability {
     func triggerNetworkReachable() {
         block?(true, "wifi")
     }
+    
+    var stopMonitoringInvocations = Invocations<Void>()
+    override func stopMonitoring() {
+        stopMonitoringInvocations.record(Void())
+    }
 }


### PR DESCRIPTION


## :scroll: Description

Dealloc for the SentryHttpTransport was never called. This is fixed now by using weak references to break the strong reference cycle.

## :bulb: Motivation and Context

Came across this while investigating test crashes due to `malloc: double free for ptr`.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
