### PR TITLE
test: Fix SystemEventBreadcrumbTests

### DIFF
--- a/Tests/SentryTests/Helper/TestNSNotificationCenterWrapper.swift
+++ b/Tests/SentryTests/Helper/TestNSNotificationCenterWrapper.swift
@@ -8,7 +8,6 @@ import Foundation
 
     public override func addObserver(_ observer: Any, selector aSelector: Selector, name aName: NSNotification.Name) {
         addObserverInvocations.record((observer, aSelector, aName))
-        NotificationCenter.default.addObserver(observer, selector: aSelector, name: aName, object: nil)
     }
 
     var removeObserverWithNameInvocations = Invocations<(observer: Any, name: NSNotification.Name)>()
@@ -17,7 +16,6 @@ import Foundation
     }
     public override func removeObserver(_ observer: Any, name aName: NSNotification.Name) {
         removeObserverWithNameInvocations.record((observer, aName))
-        NotificationCenter.default.removeObserver(observer, name: aName, object: nil)
     }
 
     var removeObserverInvocations = Invocations<Any>()
@@ -26,6 +24,5 @@ import Foundation
     }
     public override func removeObserver(_ observer: Any) {
         removeObserverInvocations.record(observer)
-        NotificationCenter.default.removeObserver(observer)
     }
 }

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -75,7 +75,9 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
         
-        NotificationCenter.default.post(Notification(name: UIDevice.batteryLevelDidChangeNotification, object: currentDevice))
+        _ = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        
+        postBatteryLevelNotification(uiDevice: currentDevice)
         
         assertBatteryBreadcrumb(scope: scope, charging: true, level: 56)
     }
@@ -86,7 +88,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
         
-        NotificationCenter.default.post(Notification(name: UIDevice.batteryLevelDidChangeNotification, object: currentDevice))
+        postBatteryLevelNotification(uiDevice: currentDevice)
         
         assertBatteryBreadcrumb(scope: scope, charging: false, level: -1)
     }
@@ -97,7 +99,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
         
-        NotificationCenter.default.post(Notification(name: UIDevice.batteryLevelDidChangeNotification, object: currentDevice))
+        postBatteryLevelNotification(uiDevice: currentDevice)
         
         assertBatteryBreadcrumb(scope: scope, charging: true, level: -1)
     }
@@ -108,7 +110,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
         
-        NotificationCenter.default.post(Notification(name: UIDevice.batteryStateDidChangeNotification, object: currentDevice))
+        postBatteryLevelNotification(uiDevice: currentDevice)
         
         assertBatteryBreadcrumb(scope: scope, charging: true, level: 100)
     }
@@ -216,6 +218,9 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         sut = fixture.getSut(scope: scope, currentDevice: nil)
         
         NotificationCenter.default.post(Notification(name: UIWindow.keyboardDidShowNotification))
+        
+        Dynamic(sut).systemEventTriggered(Notification(name: UIWindow.keyboardDidShowNotification))
+        
         assertBreadcrumbAction(scope: scope, action: "UIKeyboardDidShowNotification")
     }
     
@@ -223,7 +228,8 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: nil)
         
-        NotificationCenter.default.post(Notification(name: UIWindow.keyboardDidHideNotification))
+        Dynamic(sut).systemEventTriggered(Notification(name: UIWindow.keyboardDidHideNotification))
+        
         assertBreadcrumbAction(scope: scope, action: "UIKeyboardDidHideNotification")
     }
     
@@ -231,7 +237,8 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         let scope = Scope()
         sut = fixture.getSut(scope: scope, currentDevice: nil)
         
-        NotificationCenter.default.post(Notification(name: UIApplication.userDidTakeScreenshotNotification))
+        Dynamic(sut).systemEventTriggered(Notification(name: UIApplication.userDidTakeScreenshotNotification))
+        
         assertBreadcrumbAction(scope: scope, action: "UIApplicationUserDidTakeScreenshotNotification")
     }
 
@@ -276,6 +283,10 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         sut = fixture.getSut(scope: scope, currentDevice: nil)
         sut.stop()
         XCTAssertEqual(fixture.notificationCenterWrapper.removeObserverWithNameInvocations.count, 7)
+    }
+    
+    private func postBatteryLevelNotification(uiDevice: UIDevice) {
+        Dynamic(sut).batteryStateChanged(Notification(name: UIDevice.batteryLevelDidChangeNotification, object: uiDevice))
     }
 
     private func assertBreadcrumbAction(scope: Scope, action: String, checks: (([String: Any]) -> Void)? = nil) {


### PR DESCRIPTION
The SystemEventBreadcrumbTests are failing in CI. We had a similar problem in the past that we fixed by using the TestNSNotificationCenterWrapper.

#skip-changelog