### PR TITLE
fix: Deleting old envelopes for empty DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This version adds a dependency on Swift.
 - Fix ARC issue for FileManager (#2525)
 - Remove delay for deleting old envelopes (#2541)
 - Fix strong reference cycle for HttpTransport (#2552)
+- Deleting old envelopes for empty DSN (#2562)
 
 ### Breaking Changes
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -16,6 +16,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+NSString *const EnvelopesPathComponent = @"envelopes";
+
 @interface
 SentryFileManager ()
 
@@ -173,8 +175,17 @@ SentryFileManager ()
             continue;
         }
 
+        // If the options don't have a DSN the sentry path doesn't contain a hash and the envelopes
+        // folder is stored in the base path.
+        NSString *envelopesPath;
+        if ([fullPath hasSuffix:EnvelopesPathComponent]) {
+            envelopesPath = fullPath;
+        } else {
+            envelopesPath = [fullPath stringByAppendingPathComponent:EnvelopesPathComponent];
+        }
+
         // Then we will remove all old items from the envelopes subdirectory
-        [self deleteOldEnvelopesFromPath:[fullPath stringByAppendingPathComponent:@"envelopes"]];
+        [self deleteOldEnvelopesFromPath:envelopesPath];
     }
 }
 
@@ -472,7 +483,7 @@ SentryFileManager ()
 
 - (void)moveState:(NSString *)stateFilePath toPreviousState:(NSString *)previousStateFilePath
 {
-    SENTRY_LOG_DEBUG(@"Moving current app state to previous app state.");
+    SENTRY_LOG_DEBUG(@"Moving state %@ to previous %@.", stateFilePath, previousStateFilePath);
     NSFileManager *fileManager = [NSFileManager defaultManager];
 
     // We first need to remove the old previous state file,
@@ -664,7 +675,7 @@ SentryFileManager ()
         [self.sentryPath stringByAppendingPathComponent:@"breadcrumbs.2.state"];
     self.timezoneOffsetFilePath =
         [self.sentryPath stringByAppendingPathComponent:@"timezone.offset"];
-    self.envelopesPath = [self.sentryPath stringByAppendingPathComponent:@"envelopes"];
+    self.envelopesPath = [self.sentryPath stringByAppendingPathComponent:EnvelopesPathComponent];
 }
 
 - (BOOL)createDirectoryIfNotExists:(NSString *)path error:(NSError **)error

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -134,7 +134,17 @@ class SentryFileManagerTests: XCTestCase {
     }
 
     func testDeleteOldEnvelopes() throws {
+        try givenOldEnvelopes()
 
+        sut = fixture.getSut()
+
+        XCTAssertEqual(sut.getAllEnvelopes().count, 0)
+    }
+    
+    func testDeleteOldEnvelopes_WithEmptyDSN() throws {
+        fixture.options.dsn = nil
+        sut = fixture.getSut()
+        
         try givenOldEnvelopes()
 
         sut = fixture.getSut()


### PR DESCRIPTION

## :scroll: Description

The SentryFileManager doesn't append the DSN hash to the basePath if the DSN is nil. We didn't handle this edge case when deleting old envelopes. This is fixed now.

## :bulb: Motivation and Context

Came up while investigating flaky tests, such as https://github.com/getsentry/sentry-cocoa/actions/runs/3792592319.

```
Test Case '-[SentryTests.SentrySystemEventBreadcrumbsTest testBatteryChargingStateBreadcrumb]' started.
2022-12-28 08:11:48.336935+0000 xctest[7787:30340] [Sentry] [debug] [SentryFileManager:644] SentryFileManager.cachePath: /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches
2022-12-28 08:11:48.337176+0000 xctest[7787:30340] [Sentry] [debug] [SentryFileManager:227] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/5f62ec4a55360b39302e7fc4c45703c42e9b08ae/events
2022-12-28 08:11:48.337847+0000 xctest[7787:44511] [Sentry] [debug] [SentryFileManager:84] Dispatched deletion of old envelopes from <SentryFileManager: 0x600000ab5a40>
2022-12-28 08:11:48.337938+0000 xctest[7787:30340] [Sentry] [debug] [SentryHttpTransport:251] sendAllCachedEnvelopes start.
2022-12-28 08:11:48.338870+0000 xctest[7787:30340] [Sentry] [debug] [SentryHttpTransport:263] No envelopes left to send.
2022-12-28 08:11:48.339303+0000 xctest[7787:30340] [Sentry] [debug] [SentryHttpTransport:342] Finished sending.
2022-12-28 08:11:48.340592+0000 xctest[7787:30340] [Sentry] [debug] [SentryFileManager:590] Reading timezone offset
2022-12-28 08:11:48.340891+0000 xctest[7787:44511] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600007558570 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:11:48.341192+0000 xctest[7787:30340] [Sentry] [debug] [SentryFileManager:597] No timezone offset found.
2022-12-28 08:12:02.962875+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003474360 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.965979+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035be130 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.968790+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035be820 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.971517+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035dd5c0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.974453+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035bef10 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.977313+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003475680 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.980107+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003475d70 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.982909+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003476430 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.985640+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035ddcb0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.988434+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003476b20 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.991166+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035de3a0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.994023+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035bf600 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.996786+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x6000035dea90 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:02.999644+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003477210 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
2022-12-28 08:12:03.002419+0000 xctest[14859:46529] [Sentry] [error] [SentryFileManager:216] Couldn't load files in folder /Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes: Error Domain=NSCocoaErrorDomain Code=260 "The folder “envelopes” doesn’t exist." UserInfo={NSUserStringVariant=(
    Folder
), NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/DB259A71-C861-4F5F-8C86-76C405AD45E4/data/Library/Caches/io.sentry/envelopes/envelopes, NSUnderlyingError=0x600003477900 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}

Restarting after unexpected exit, crash, or test timeout in SentrySystemEventBreadcrumbsTest.testBatteryChargingStateBreadcrumb(); summary will include totals from previous launches.

```

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
