### PR TITLE
fix: MetricKit remove view hierarchy and screenshots

### DIFF
--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -4,6 +4,7 @@
 #import "SentryDependencyContainer.h"
 #import "SentryEvent+Private.h"
 #import "SentryHub+Private.h"
+#import "SentryMetricKitIntegration.h"
 #import "SentrySDK+Private.h"
 
 #if SENTRY_HAS_UIKIT
@@ -50,7 +51,8 @@ saveScreenShot(const char *path)
 
     // We don't take screenshots if there is no exception/error.
     // We dont take screenshots if the event is a crash event.
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent) {
+    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent
+        || event.isMetricKitEvent) {
         return attachments;
     }
 

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -4,6 +4,7 @@
 #import "SentryDependencyContainer.h"
 #import "SentryEvent+Private.h"
 #import "SentryHub+Private.h"
+#import "SentryMetricKitIntegration.h"
 #import "SentrySDK+Private.h"
 #import "SentryViewHierarchy.h"
 
@@ -49,8 +50,9 @@ saveViewHierarchy(const char *path)
                                            forEvent:(nonnull SentryEvent *)event
 {
     // We don't attach the view hierarchy if there is no exception/error.
-    // We dont attach the view hierarchy if the event is a crash event.
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent) {
+    // We don't attach the view hierarchy if the event is a crash event.
+    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent
+        || event.isMetricKitEvent) {
         return attachments;
     }
 

--- a/Sources/Sentry/include/SentryMetricKitIntegration.h
+++ b/Sources/Sentry/include/SentryMetricKitIntegration.h
@@ -1,4 +1,5 @@
 #import "SentryBaseIntegration.h"
+#import "SentryEvent.h"
 #import "SentryIntegrationProtocol.h"
 #import "SentrySwift.h"
 #import <Foundation/Foundation.h>
@@ -7,10 +8,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+static NSString *const SentryMetricKitDiskWriteExceptionType = @"MXDiskWriteException";
+static NSString *const SentryMetricKitDiskWriteExceptionMechanism = @"mx_disk_write_exception";
+
+static NSString *const SentryMetricKitCpuExceptionType = @"MXCPUException";
+static NSString *const SentryMetricKitCpuExceptionMechanism = @"mx_cpu_exception";
+
 API_AVAILABLE(ios(14.0), macos(12.0))
 API_UNAVAILABLE(tvos, watchos)
 @interface SentryMetricKitIntegration
     : SentryBaseIntegration <SentryIntegrationProtocol, SentryMXManagerDelegate>
+
+@end
+
+@interface
+SentryEvent (MetricKit)
+
+@property (nonatomic, readonly) BOOL isMetricKitEvent;
 
 @end
 

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -116,6 +116,14 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         XCTAssertEqual(newAttachmentList?.count, 0)
     }
     
+    func test_noScreenShot_MetricKitEvent() {
+        let sut = fixture.getSut()
+        
+        let newAttachmentList = sut.processAttachments([], for: TestData.metricKitEvent)
+        
+        XCTAssertEqual(newAttachmentList?.count, 0)
+    }
+    
     func test_noScreenshot_keepAttachment() {
         let sut = fixture.getSut()
         let event = Event()

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -81,6 +81,14 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         XCTAssertEqual(newAttachmentList?.count, 0)
     }
+    
+    func test_noViewHierarchy_MetricKitEvent() {
+        let sut = fixture.getSut()
+        
+        let newAttachmentList = sut.processAttachments([], for: TestData.metricKitEvent)
+
+        XCTAssertEqual(newAttachmentList?.count, 0)
+    }
 
     func test_noViewHierarchy_keepAttachment() {
         let sut = fixture.getSut()

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -183,6 +183,14 @@ class TestData {
         return event
     }
     
+    static var metricKitEvent: Event {
+        let event = Event(level: .warning)
+        let exception = Exception(value: "MXCPUException totalCPUTime:90.009 sec totalSampledTime:91.952 sec", type: SentryMetricKitCpuExceptionType)
+        exception.mechanism = Mechanism(type: SentryMetricKitCpuExceptionMechanism)
+        event.exceptions = [exception]
+        return event
+    }
+    
     static func scopeWith(observer: SentryScopeObserver) -> Scope {
         let scope = Scope()
         scope.add(observer)

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -22,9 +22,9 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         clearTestState()
     }
     
-    func givenSdkWithHub(_ options: Options? = nil) {
+    func givenSdkWithHub(_ options: Options? = nil, scope: Scope = Scope()) {
         let client = TestClient(options: options ?? self.options)
-        let hub = SentryHub(client: client, andScope: Scope(), andCrashWrapper: TestSentryCrashWrapper.sharedInstance(), andCurrentDateProvider: currentDate)
+        let hub = SentryHub(client: client, andScope: scope, andCrashWrapper: TestSentryCrashWrapper.sharedInstance(), andCurrentDateProvider: currentDate)
         
         SentrySDK.setCurrentHub(hub)
     }


### PR DESCRIPTION
Remove screenshots and view hierarchy from MetricKit events.

#skip-changelog