### PR TITLE
feat: Bump MetricKit to iOS 15 and macOS 12

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -19,7 +19,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 return event
             }
             options.debug = true
-            if #available(iOS 14.0, *) {
+            if #available(iOS 15.0, *) {
                 options.enableMetricKit = true
             }
             // Sampling 100% - In Production you probably want to adjust this
@@ -53,7 +53,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         AppDelegate.startSentry()
         
-        if #available(iOS 14.0, *) {
+        if #available(iOS 15.0, *) {
             metricKit.receiveReports()
         }
         
@@ -61,14 +61,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func applicationWillTerminate(_ application: UIApplication) {
-        if #available(iOS 14.0, *) {
+        if #available(iOS 15.0, *) {
             metricKit.pauseReports()
         }
     }
     
     // Workaround for 'Stored properties cannot be marked potentially unavailable with '@available''
     private var _metricKit: Any?
-    @available(iOS 14.0, *)
+    @available(iOS 15.0, *)
     fileprivate var metricKit: MetricKitManager {
         if _metricKit == nil {
             _metricKit = MetricKitManager()

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -450,10 +450,12 @@ NS_SWIFT_NAME(Options)
  * ATTENTION: This is an experimental feature.
  *
  * This feature is disabled by default. When enabled, the SDK sends ``MXDiagnosticPayload`` data to
- * Sentry.
+ * Sentry. The SDK supports this feature from iOS 15 and later and macOS 12 and later because, on
+ * these versions, MetricKit delivers diagnostic reports immediately, which allows the Sentry SDK to
+ * apply the current data from the scope.
  */
-@property (nonatomic, assign) BOOL enableMetricKit API_AVAILABLE(
-    ios(14.0), macos(12.0), macCatalyst(14.0)) API_UNAVAILABLE(tvos, watchos);
+@property (nonatomic, assign) BOOL enableMetricKit API_AVAILABLE(ios(15.0), macos(12.0))
+    API_UNAVAILABLE(tvos, watchos, macCatalyst);
 
 #endif
 

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -147,7 +147,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
 #if SENTRY_HAS_METRIC_KIT
-    if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
+    if (@available(iOS 15.0, macOS 12.0, *)) {
         if ((integrationOptions & kIntegrationOptionEnableMetricKit) && !options.enableMetricKit) {
             [self logWithOptionName:@"enableMetricKit"];
             return NO;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -44,7 +44,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         ]
             .mutableCopy;
 
-    if (@available(iOS 14.0, macCatalyst 14.0, macOS 12.0, *)) {
+    if (@available(iOS 15.0, macOS 12.0, *)) {
         [defaultIntegrations addObject:@"SentryMetricKitIntegration"];
     }
 
@@ -147,7 +147,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.failedRequestStatusCodes = @[ defaultHttpStatusCodeRange ];
 
 #if SENTRY_HAS_METRIC_KIT
-        if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
+        if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {
             self.enableMetricKit = NO;
         }
 #endif

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -43,7 +43,7 @@ SENTRY_NO_INIT
 
 #if SENTRY_HAS_METRIC_KIT
 @property (nonatomic, strong) SentryMXManager *metricKitManager API_AVAILABLE(
-    ios(14.0), macos(12.0)) API_UNAVAILABLE(tvos, watchos);
+    ios(15.0), macos(12.0)) API_UNAVAILABLE(tvos, watchos, macCatalyst);
 #endif
 
 @end

--- a/Sources/Sentry/include/SentryMetricKitIntegration.h
+++ b/Sources/Sentry/include/SentryMetricKitIntegration.h
@@ -14,8 +14,8 @@ static NSString *const SentryMetricKitCpuExceptionMechanism = @"mx_cpu_exception
 
 #if SENTRY_HAS_METRIC_KIT
 
-API_AVAILABLE(ios(14.0), macos(12.0))
-API_UNAVAILABLE(tvos, watchos)
+API_AVAILABLE(ios(15.0), macos(12.0))
+API_UNAVAILABLE(tvos, watchos, macCatalyst)
 @interface SentryMetricKitIntegration
     : SentryBaseIntegration <SentryIntegrationProtocol, SentryMXManagerDelegate>
 

--- a/Sources/Swift/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/MetricKit/SentryMXManager.swift
@@ -9,9 +9,10 @@ import Foundation
 import MetricKit
 #endif
 
-@available(iOS 14.0, macOS 12.0, *)
+@available(iOS 15.0, macOS 12.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@available(macCatalyst, unavailable)
 @objc public protocol SentryMXManagerDelegate {
     
     func didReceiveCrashDiagnostic(_ diagnostic: MXCrashDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)
@@ -21,7 +22,7 @@ import MetricKit
     func didReceiveCpuExceptionDiagnostic(_ diagnostic: MXCPUExceptionDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)
 }
 
-@available(iOS 14.0, macOS 12.0, *)
+@available(iOS 15.0, macOS 12.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @objcMembers public class SentryMXManager: NSObject, MXMetricManagerSubscriber {

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -34,7 +34,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
 
     func testOptionEnabled_MetricKitManagerInitialized() {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             let sut = SentryMetricKitIntegration()
             
             givenInstalledWithEnabled(sut)
@@ -44,7 +44,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     func testOptionDisabled_MetricKitManagerNotInitialized() {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             let sut = SentryMetricKitIntegration()
             
             sut.install(with: Options())
@@ -54,7 +54,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     func testUninstall_MetricKitManagerSetToNil() {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             let sut = SentryMetricKitIntegration()
             
             let options = Options()
@@ -67,7 +67,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     func testMXCrashPayloadReceived() throws {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             givenSDKWithHubWithScope()
             
             let sut = SentryMetricKitIntegration()
@@ -81,7 +81,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     func testCPUExceptionDiagnostic_PerThread() throws {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             givenSDKWithHubWithScope()
             
             let sut = SentryMetricKitIntegration()
@@ -95,7 +95,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     func testCPUExceptionDiagnostic_NotPerThread() throws {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             givenSDKWithHubWithScope()
             
             let sut = SentryMetricKitIntegration()
@@ -109,7 +109,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     func testDiskWriteExceptionDiagnostic() throws {
-        if #available(iOS 14, macOS 12, macCatalyst 14, *) {
+        if #available(iOS 15, macOS 12, *) {
             givenSDKWithHubWithScope()
             
             let sut = SentryMetricKitIntegration()
@@ -122,7 +122,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         }
     }
     
-    @available(iOS 14, macOS 12, macCatalyst 14, *)
+    @available(iOS 15, macOS 12, *)
     private func givenInstalledWithEnabled(_ integration: SentryMetricKitIntegration) {
         let options = Options()
         options.enableMetricKit = true
@@ -230,9 +230,10 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
   
 }
 
-@available(iOS 14, macOS 12, macCatalyst 14, *)
+@available(iOS 15, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@available(macCatalyst, unavailable)
 class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
     
     override var totalCPUTime: Measurement<UnitDuration> {
@@ -244,9 +245,10 @@ class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
     }
 }
 
-@available(iOS 14, macOS 12, macCatalyst 14, *)
+@available(iOS 15, macOS 12, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+@available(macCatalyst, unavailable)
 class TestMXDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
     override var totalWritesCaused: Measurement<UnitInformationStorage> {
         return Measurement(value: 5.5, unit: .mebibits)

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -121,7 +121,7 @@
     XCTAssertEqual(YES, options.enableAutoBreadcrumbTracking);
 
 #if SENTRY_HAS_METRIC_KIT
-    if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
+    if (@available(iOS 15.0, macOS 12.0, *)) {
         XCTAssertEqual(NO, options.enableMetricKit);
     }
 #endif


### PR DESCRIPTION
Bump MetricKit to iOS 15 and macOS 12 cause on these versions, MetricKit delivers MXDiagnosticPayload data immediately.

