### PR TITLE
ci: Enable source context for TestFlight

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - master
       - 8.0.0
-      - ci/include-sources
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
       - 8.0.0
+      - ci/include-sources
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -214,7 +214,8 @@ platform :ios do
     sentry_upload_dif(
       auth_token: ENV["SENTRY_AUTH_TOKEN"],
       org_slug: 'sentry-sdks',
-      project_slug: 'sentry-cocoa'
+      project_slug: 'sentry-cocoa',
+      include_sources: true
     )
   end
 


### PR DESCRIPTION
Enable source context for TestFlight builds by adding the include_sources
for Fastlane.

Successful ci run: https://github.com/getsentry/sentry-cocoa/actions/runs/3827637963/jobs/6512391581.
[Event with source context](https://sentry.io/organizations/sentry-sdks/issues/2862440026/events/33fc8f10333840eeaf96d4970d86fee0/?project=5428557)

<img width="1273" alt="Screenshot 2023-01-03 at 08 48 50" src="https://user-images.githubusercontent.com/2443292/210317291-da1bc154-c888-4f3e-bfad-cfcc1b358fe0.png">

Related to https://github.com/getsentry/team-mobile/issues/42

#skip-changelog