### PR TITLE
chore: Remove confusing transaction tag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ This version adds a dependency on Swift.
 - Rename `SentryOptions.enableOutOfMemoryTracking` to `SentryOptions.enableWatchdogTerminationTracking` (#2499)
 - Remove the automatic `viewAppearing` span for UIViewController APM (#2511)
 - Remove the permission context for events (#2529)
+- Remove confusing transaction tag (#2574)
 
 ## 8.0.0-beta.4
 

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -192,10 +192,7 @@ SentryBreadcrumbTracker ()
                 crumb.data = [SentryBreadcrumbTracker fetchInfoAboutViewController:self];
 
                 // Adding crumb via the SDK calls SentryBeforeBreadcrumbCallback
-                [SentrySDK addBreadcrumb:crumb];
-                [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull scope) {
-                    [scope setExtraValue:crumb.data[@"screen"] forKey:@"__sentry_transaction"];
-                }];
+                [SentrySDK addBreadcrumb:crumb]; 
             }
             SentrySWCallOriginal(animated);
         }),

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -135,9 +135,7 @@ SentryEvent ()
 
     if (self.transaction) {
         [serializedData setValue:self.transaction forKey:@"transaction"];
-    } else if (self.extra[@"__sentry_transaction"]) {
-        [serializedData setValue:self.extra[@"__sentry_transaction"] forKey:@"transaction"];
-    }
+    } 
 
     [serializedData setValue:self.fingerprint forKey:@"fingerprint"];
 

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -78,16 +78,6 @@ class SentryEventTests: XCTestCase {
         )
     }
     
-    func testSerializeWithExtraTransaction() {
-        let event = TestData.event
-        event.transaction = nil
-        let sentryTransaction = "trans"
-        event.extra?["__sentry_transaction"] = sentryTransaction
-        
-        let actual = event.serialize()
-        XCTAssertEqual(sentryTransaction, actual["transaction"] as? String)
-    }
-    
     func testSerializeWithoutBreadcrumbs() {
         let event = TestData.event
         event.breadcrumbs = nil

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -148,7 +148,6 @@
 
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelInfo];
     event.timestamp = date;
-    event.extra = @{ @"__sentry_transaction" : @"yoyoyo" };
     event.sdk = @{
         @"version" : @"0.15.2",
         @"name" : @"sentry-react-native",
@@ -157,8 +156,6 @@
     NSDictionary *serialized = @{
         @"event_id" : [event.eventId sentryIdString],
         @"level" : @"info",
-        @"extra" : @ {},
-        @"transaction" : @"yoyoyo",
         @"platform" : @"cocoa",
         @"sdk" : @ {
             @"name" : @"sentry-react-native",

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -94,7 +94,6 @@ class TestClient: SentryClient {
     var captureCrashEventInvocations = Invocations<(event: Event, scope: Scope)>()
     override func captureCrash(_ event: Event, with scope: Scope) -> SentryId {
         captureCrashEventInvocations.record((event, scope))
-        print("### Captured")
         return SentryId()
     }
     


### PR DESCRIPTION
Removed `__sentry_transaction`  added to the scope during `viewDidAppear`.
Now we have automatic view controller transactions and this tag is confusing hack
