### PR TITLE
fix: Disable crashes for MetricKit

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -536,6 +536,7 @@
 		7BDB03B7251364F800BAE198 /* SentryDispatchQueueWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BDB03B6251364F800BAE198 /* SentryDispatchQueueWrapper.h */; };
 		7BDB03BB2513652900BAE198 /* SentryDispatchQueueWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BDB03BA2513652900BAE198 /* SentryDispatchQueueWrapper.m */; };
 		7BDB03BF25136A7D00BAE198 /* TestSentryDispatchQueueWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDB03BE25136A7D00BAE198 /* TestSentryDispatchQueueWrapper.swift */; };
+		7BDDE3CC2966BD4700EB9177 /* SentryMXManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDDE3CB2966BD4700EB9177 /* SentryMXManagerTests.swift */; };
 		7BDEAA022632A4580001EA25 /* SentryOptions+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BDEAA002632A4580001EA25 /* SentryOptions+Private.h */; };
 		7BE0DC29272A9E1C004FA8B7 /* SentryBreadcrumbTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE0DC28272A9E1C004FA8B7 /* SentryBreadcrumbTrackerTests.swift */; };
 		7BE0DC2F272ABAF6004FA8B7 /* SentryAutoBreadcrumbTrackingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BE0DC2E272ABAF6004FA8B7 /* SentryAutoBreadcrumbTrackingIntegrationTests.swift */; };
@@ -1337,6 +1338,7 @@
 		7BDB03B6251364F800BAE198 /* SentryDispatchQueueWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDispatchQueueWrapper.h; path = include/SentryDispatchQueueWrapper.h; sourceTree = "<group>"; };
 		7BDB03BA2513652900BAE198 /* SentryDispatchQueueWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDispatchQueueWrapper.m; sourceTree = "<group>"; };
 		7BDB03BE25136A7D00BAE198 /* TestSentryDispatchQueueWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryDispatchQueueWrapper.swift; sourceTree = "<group>"; };
+		7BDDE3CB2966BD4700EB9177 /* SentryMXManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMXManagerTests.swift; sourceTree = "<group>"; };
 		7BDEAA002632A4580001EA25 /* SentryOptions+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryOptions+Private.h"; path = "include/SentryOptions+Private.h"; sourceTree = "<group>"; };
 		7BE0DC28272A9E1C004FA8B7 /* SentryBreadcrumbTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTrackerTests.swift; sourceTree = "<group>"; };
 		7BE0DC2E272ABAF6004FA8B7 /* SentryAutoBreadcrumbTrackingIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAutoBreadcrumbTrackingIntegrationTests.swift; sourceTree = "<group>"; };
@@ -2852,6 +2854,7 @@
 			children = (
 				7BF6505E292B77EC00BBA5A8 /* SentryMetricKitIntegrationTests.swift */,
 				7BF65063292B905A00BBA5A8 /* SentryMXCallStackTreeTests.swift */,
+				7BDDE3CB2966BD4700EB9177 /* SentryMXManagerTests.swift */,
 				7B87C915295ECFD700510C52 /* SentryMetricKitEventTests.swift */,
 			);
 			path = MetricKit;
@@ -3992,6 +3995,7 @@
 				0AE455AD28F584D2006680E5 /* SentryReachabilityTests.m in Sources */,
 				63FE720420DA66EC00CDBAE8 /* SentryCrashString_Tests.m in Sources */,
 				7B944FB22469C01E00A10721 /* TestClient.swift in Sources */,
+				7BDDE3CC2966BD4700EB9177 /* SentryMXManagerTests.swift in Sources */,
 				7BC6EC0C255C3DF80059822A /* SentryThreadTests.swift in Sources */,
 				D884A20527C80F6300074664 /* SentryCoreDataTrackerTest.swift in Sources */,
 				8E70B10125CB8695002B3155 /* SentrySpanIdTests.swift in Sources */,

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -219,7 +219,10 @@ static NSObject *sentryDependencyContainerLock;
     if (_metricKitManager == nil) {
         @synchronized(sentryDependencyContainerLock) {
             if (_metricKitManager == nil) {
-                _metricKitManager = [[SentryMXManager alloc] init];
+                // Disable crash diagnostics as we only use it for validation of the symbolication
+                // of stacktraces, because crashes are easy to trigger for MetricKit. We don't want
+                // crash reports of MetricKit in production as we have SentryCrash.
+                _metricKitManager = [[SentryMXManager alloc] initWithDisableCrashDiagnostics:YES];
             }
         }
     }

--- a/Sources/Swift/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/MetricKit/SentryMXManager.swift
@@ -27,6 +27,12 @@ import MetricKit
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 @objcMembers public class SentryMXManager: NSObject, MXMetricManagerSubscriber {
+    
+    let disableCrashDiagnostics: Bool
+    
+    public init(disableCrashDiagnostics: Bool = true) {
+        self.disableCrashDiagnostics = disableCrashDiagnostics
+    }
 
     public weak var delegate: SentryMXManagerDelegate?
     
@@ -51,6 +57,9 @@ import MetricKit
         
         payloads.forEach { payload in
             payload.crashDiagnostics?.forEach { diagnostic in
+                if disableCrashDiagnostics {
+                    return
+                }
                 actOn(callStackTree: diagnostic.callStackTree) { callStackTree in
                     delegate?.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTree, timeStampBegin: payload.timeStampBegin, timeStampEnd: payload.timeStampEnd)
                 }

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
@@ -1,0 +1,172 @@
+import MetricKit
+import XCTest
+
+final class SentryMXManagerTests: XCTestCase {
+
+    func testReceiveNoPayloads() {
+        if #available(iOS 15, macOS 12, macCatalyst 15, *) {
+            let (sut, delegate) = givenSut()
+            
+            sut.didReceive([])
+            
+            XCTAssertEqual(0, delegate.crashInvocations.count)
+            XCTAssertEqual(0, delegate.diskWriteExceptionInvocations.count)
+            XCTAssertEqual(0, delegate.cpuExceptionInvocations.count)
+            XCTAssertEqual(0, delegate.hangDiagnosticInvocations.count)
+        }
+    }
+    
+    func testReceiveCrashPayload_DoesNothing() throws {
+        if #available(iOS 15, macOS 12, macCatalyst 15, *) {
+            let (sut, delegate) = givenSut()
+            
+            let payload = try givenPayloads()
+            
+            sut.didReceive([payload])
+            
+            XCTAssertEqual(0, delegate.crashInvocations.count)
+            XCTAssertEqual(1, delegate.diskWriteExceptionInvocations.count)
+            XCTAssertEqual(1, delegate.cpuExceptionInvocations.count)
+            XCTAssertEqual(1, delegate.hangDiagnosticInvocations.count)
+        }
+    }
+    
+    func testReceivePayloadsWithFaultyJSON_DoesNothing() throws {
+        if #available(iOS 15, macOS 12, macCatalyst 15, *) {
+            let (sut, delegate) = givenSut(disableCrashDiagnostics: false)
+            
+            let payload = try givenPayloads(withCallStackJSON: false)
+            
+            sut.didReceive([payload])
+            
+            XCTAssertEqual(0, delegate.crashInvocations.count)
+            XCTAssertEqual(0, delegate.diskWriteExceptionInvocations.count)
+            XCTAssertEqual(0, delegate.cpuExceptionInvocations.count)
+            XCTAssertEqual(0, delegate.hangDiagnosticInvocations.count)
+        }
+    }
+    
+    func testReceiveCrashPayloadEnabled_ForwardPayload() throws {
+        if #available(iOS 15, macOS 12, macCatalyst 15, *) {
+            let (sut, delegate) = givenSut(disableCrashDiagnostics: false)
+            
+            let payload = try givenPayloads()
+            
+            sut.didReceive([payload])
+            
+            XCTAssertEqual(1, delegate.crashInvocations.count)
+            XCTAssertEqual(1, delegate.diskWriteExceptionInvocations.count)
+            XCTAssertEqual(1, delegate.cpuExceptionInvocations.count)
+            XCTAssertEqual(1, delegate.hangDiagnosticInvocations.count)
+        }
+    }
+    
+    @available(iOS 15, macOS 12, macCatalyst 15, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    private func givenSut(disableCrashDiagnostics: Bool = true) -> (SentryMXManager, SentryMXManagerTestDelegate) {
+        let sut = SentryMXManager(disableCrashDiagnostics: disableCrashDiagnostics)
+        let delegate = SentryMXManagerTestDelegate()
+        sut.delegate = delegate
+        
+        return (sut, delegate)
+    }
+    
+    @available(iOS 15, macOS 12, macCatalyst 15, *)
+    @available(tvOS, unavailable)
+    @available(watchOS, unavailable)
+    private func givenPayloads(withCallStackJSON: Bool = true) throws -> TestMXDiagnosticPayload {
+        let payload = TestMXDiagnosticPayload()
+        
+        let callStackTree = TestMXCallStackTree()
+        if withCallStackJSON {
+            callStackTree.overrides.jsonRepresentation = try contentsOfResource("metric-kit-callstack-per-thread")
+        }
+        
+        let crashDiagnostic = TestMXCrashDiagnostic()
+        crashDiagnostic.overrides.callStackTree = callStackTree
+        
+        let cpuDiagnostic = TestMXCPUExceptionDiagnostic()
+        cpuDiagnostic.overrides.callStackTree = callStackTree
+        
+        let diskWriteDiagnostic = TestMXDiskWriteExceptionDiagnostic()
+        diskWriteDiagnostic.overrides.callStackTree = callStackTree
+        
+        let hangDiagnostic = TestMXHangDiagnostic()
+        hangDiagnostic.overrides.callStackTree = callStackTree
+        
+        payload.overrides.crashDiagnostics = [crashDiagnostic]
+        payload.overrides.cpuDiagnostic = [cpuDiagnostic]
+        payload.overrides.diskWriteDiagnostic = [diskWriteDiagnostic]
+        payload.overrides.hangDiagnostic = [hangDiagnostic]
+        
+        return payload
+    }
+}
+
+@available(iOS 15, macOS 12, macCatalyst 15, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+class TestMXDiagnosticPayload: MXDiagnosticPayload {
+    struct Override {
+        var crashDiagnostics: [MXCrashDiagnostic]?
+        var cpuDiagnostic: [MXCPUExceptionDiagnostic]?
+        var diskWriteDiagnostic: [MXDiskWriteExceptionDiagnostic]?
+        var hangDiagnostic: [MXHangDiagnostic]?
+        
+        var timeStampBegin = CurrentDate.date()
+        var timeStampEnd = CurrentDate.date()
+    }
+    
+    var overrides = Override()
+    
+    override var crashDiagnostics: [MXCrashDiagnostic]? {
+        return overrides.crashDiagnostics
+    }
+    
+    override var cpuExceptionDiagnostics: [MXCPUExceptionDiagnostic]? {
+        return overrides.cpuDiagnostic
+    }
+    
+    override var diskWriteExceptionDiagnostics: [MXDiskWriteExceptionDiagnostic]? {
+        return overrides.diskWriteDiagnostic
+    }
+    
+    override var hangDiagnostics: [MXHangDiagnostic]? {
+        return overrides.hangDiagnostic
+    }
+    
+    override var timeStampBegin: Date {
+        return overrides.timeStampBegin
+    }
+    
+    override var timeStampEnd: Date {
+        return overrides.timeStampEnd
+    }
+}
+
+@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+class SentryMXManagerTestDelegate: SentryMXManagerDelegate {
+
+    var crashInvocations = Invocations<(diagnostic: MXCrashDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)>()
+    func didReceiveCrashDiagnostic(_ diagnostic: MXCrashDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date) {
+        crashInvocations.record((diagnostic, callStackTree, timeStampBegin, timeStampEnd))
+    }
+    
+    var diskWriteExceptionInvocations = Invocations<(diagnostic: MXDiskWriteExceptionDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)>()
+    func didReceiveDiskWriteExceptionDiagnostic(_ diagnostic: MXDiskWriteExceptionDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date) {
+        diskWriteExceptionInvocations.record((diagnostic, callStackTree, timeStampBegin, timeStampEnd))
+    }
+    
+    var cpuExceptionInvocations = Invocations<(diagnostic: MXCPUExceptionDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)>()
+    func didReceiveCpuExceptionDiagnostic(_ diagnostic: MXCPUExceptionDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date) {
+        cpuExceptionInvocations.record((diagnostic, callStackTree, timeStampBegin, timeStampEnd))
+    }
+    
+    var hangDiagnosticInvocations = Invocations<(diagnostic: MXHangDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)>()
+    func didReceiveHangDiagnostic(_ diagnostic: MXHangDiagnostic, callStackTree: SentryPrivate.SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date) {
+        hangDiagnosticInvocations.record((diagnostic, callStackTree, timeStampBegin, timeStampEnd))
+    }
+}

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXManagerTests.swift
@@ -1,6 +1,15 @@
 import MetricKit
 import XCTest
 
+#if os(iOS) || os(macOS)
+
+/**
+ * We need to check if MetricKit is available for compatibility on iOS 12 and below. As there are no compiler directives for iOS versions we use canImport.
+ */
+#if canImport(MetricKit)
+import MetricKit
+#endif
+
 final class SentryMXManagerTests: XCTestCase {
 
     func testReceiveNoPayloads() {
@@ -170,3 +179,5 @@ class SentryMXManagerTestDelegate: SentryMXManagerDelegate {
         hangDiagnosticInvocations.record((diagnostic, callStackTree, timeStampBegin, timeStampEnd))
     }
 }
+
+#endif

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -247,7 +247,46 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
 @available(iOS 15, macOS 12, macCatalyst 15, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
+class TestMXCallStackTree: MXCallStackTree {
+    struct Override {
+        var jsonRepresentation = Data()
+    }
+    
+    public var overrides = Override()
+    
+    override func jsonRepresentation() -> Data {
+        return overrides.jsonRepresentation
+    }
+}
+
+@available(iOS 15, macOS 12, macCatalyst 15, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
+class TestMXCrashDiagnostic: MXCrashDiagnostic {
+    struct Override {
+        var callStackTree = TestMXCallStackTree()
+    }
+    
+    public var overrides = Override()
+    
+    override var callStackTree: MXCallStackTree {
+        return overrides.callStackTree
+    }
+}
+
+@available(iOS 15, macOS 12, macCatalyst 15, *)
+@available(tvOS, unavailable)
+@available(watchOS, unavailable)
 class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
+    struct Override {
+        var callStackTree = TestMXCallStackTree()
+    }
+    
+    public var overrides = Override()
+    
+    override var callStackTree: MXCallStackTree {
+        return overrides.callStackTree
+    }
     
     override var totalCPUTime: Measurement<UnitDuration> {
         return Measurement(value: 2.2, unit: .milliseconds)
@@ -262,6 +301,16 @@ class TestMXCPUExceptionDiagnostic: MXCPUExceptionDiagnostic {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 class TestMXDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
+    struct Override {
+        var callStackTree = TestMXCallStackTree()
+    }
+    
+    public var overrides = Override()
+    
+    override var callStackTree: MXCallStackTree {
+        return overrides.callStackTree
+    }
+    
     override var totalWritesCaused: Measurement<UnitInformationStorage> {
         return Measurement(value: 5.5, unit: .mebibits)
     }
@@ -271,6 +320,16 @@ class TestMXDiskWriteExceptionDiagnostic: MXDiskWriteExceptionDiagnostic {
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
 class TestMXHangDiagnostic: MXHangDiagnostic {
+    struct Override {
+        var callStackTree = TestMXCallStackTree()
+    }
+    
+    public var overrides = Override()
+    
+    override var callStackTree: MXCallStackTree {
+        return overrides.callStackTree
+    }
+    
     override var hangDuration: Measurement<UnitDuration> {
         return Measurement(value: 6.6, unit: .seconds)
     }


### PR DESCRIPTION
Disable crash diagnostics as we only use it for validation of the symbolication of stacktraces, because crashes are easy to trigger for MetricKit. We don't want crash reports of MetricKit in production as we have SentryCrash.

#skip-changelog