### PR TITLE
chore: Remove SwiftUI from craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -9,9 +9,6 @@ targets:
   - name: cocoapods
     id: sentry-cocoapod
     specPath: Sentry.podspec
-  - name: cocoapods
-    id: sentry-swift-ui-cocoapod
-    specPath: SentrySwiftUI.podspec
   - name: registry
     sdks:
       cocoapods:sentry-cocoa:


### PR DESCRIPTION
Remove until we fix the podspec (https://github.com/getsentry/sentry-cocoa/issues/2581) so we can release successfully.

#skip-changelog