### PR TITLE
chore: Rename SentryTraceView to SentryTracedView

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
@@ -93,7 +93,7 @@ struct ContentView: View {
     }
     
     var body: some View {
-        SentryTraceView("Content View Body") {
+        SentryTracedView("Content View Body") {
             NavigationView {
                 VStack(alignment: HorizontalAlignment.center, spacing: 16) {
                     Text(getCurrentTracer()?.transactionContext.name ?? "NO SPAN")
@@ -101,7 +101,7 @@ struct ContentView: View {
                     Text(getCurrentTracer()?.transactionContext.spanId.sentrySpanIdString ?? "NO ID")
                         .accessibilityIdentifier("TRANSACTION_ID")
                     
-                    SentryTraceView("Child Span") {
+                    SentryTracedView("Child Span") {
                         VStack {
                             Text(getCurrentSpan()?.spanDescription ?? "NO SPAN")
                                 .accessibilityIdentifier("CHILD_NAME")

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/LoremIpsumView.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/LoremIpsumView.swift
@@ -7,7 +7,7 @@ struct LoremIpsumView: View {
     @StateObject var viewModel = LoremIpsumViewModel()
     
     var body: some View {
-        SentryTraceView("Lorem Ipsum") {
+        SentryTracedView("Lorem Ipsum") {
             Text(viewModel.text)
                 .padding(16)
         }

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -687,7 +687,7 @@
 		D8199DBE29376EDE0074249E /* SentryInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = D8199DB829376ECC0074249E /* SentryInternal.h */; };
 		D8199DBF29376EE20074249E /* SentryInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = D8199DB929376ECC0074249E /* SentryInternal.m */; };
 		D8199DC029376EE80074249E /* SentrySwiftUI.h in Headers */ = {isa = PBXBuildFile; fileRef = D8199DB529376ECC0074249E /* SentrySwiftUI.h */; };
-		D8199DC129376EEC0074249E /* SentryTraceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8199DB629376ECC0074249E /* SentryTraceView.swift */; };
+		D8199DC129376EEC0074249E /* SentryTracedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8199DB629376ECC0074249E /* SentryTracedView.swift */; };
 		D8199DC229376FC10074249E /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63AA759B1EB8AEF500D153DE /* Sentry.framework */; };
 		D81A346C291AECC7005A27A9 /* PrivateSentrySDKOnly.h in Headers */ = {isa = PBXBuildFile; fileRef = D81A346B291AECC7005A27A9 /* PrivateSentrySDKOnly.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D81A3491291D0AC8005A27A9 /* SwiftDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D800942628F82F3A005D3943 /* SwiftDescriptor.swift */; };
@@ -1529,7 +1529,7 @@
 		D8137D53272B53070082656C /* TestSentrySpan.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = TestSentrySpan.m; sourceTree = "<group>"; };
 		D8199DAA29376E9B0074249E /* SentrySwiftUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SentrySwiftUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D8199DB529376ECC0074249E /* SentrySwiftUI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentrySwiftUI.h; sourceTree = "<group>"; };
-		D8199DB629376ECC0074249E /* SentryTraceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryTraceView.swift; sourceTree = "<group>"; };
+		D8199DB629376ECC0074249E /* SentryTracedView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryTracedView.swift; sourceTree = "<group>"; };
 		D8199DB829376ECC0074249E /* SentryInternal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryInternal.h; sourceTree = "<group>"; };
 		D8199DB929376ECC0074249E /* SentryInternal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryInternal.m; sourceTree = "<group>"; };
 		D8199DCF29376FF40074249E /* SentrySwiftUI.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SentrySwiftUI.xcconfig; sourceTree = "<group>"; };
@@ -1586,13 +1586,13 @@
 		D8BD2E67293619F600D96C6A /* PrivatesHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = PrivatesHeader.h; path = include/HybridPublic/PrivatesHeader.h; sourceTree = "<group>"; };
 		D8C67E9928000E23007E326E /* SentryUIApplication.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryUIApplication.h; path = include/SentryUIApplication.h; sourceTree = "<group>"; };
 		D8C67E9A28000E23007E326E /* SentryScreenshot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryScreenshot.h; path = include/SentryScreenshot.h; sourceTree = "<group>"; };
-		D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUIApplicationTests.swift; sourceTree = "<group>"; };
-		D8CB742C294B294B00A5F964 /* MockUIScene.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockUIScene.h; sourceTree = "<group>"; };
-		D8CB742D294B294B00A5F964 /* MockUIScene.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockUIScene.m; sourceTree = "<group>"; };
 		D8CB74142947246600A5F964 /* SentryEnvelopeAttachmentHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeAttachmentHeader.h; path = include/SentryEnvelopeAttachmentHeader.h; sourceTree = "<group>"; };
 		D8CB7416294724CC00A5F964 /* SentryEnvelopeAttachmentHeader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeAttachmentHeader.m; sourceTree = "<group>"; };
 		D8CB74182947285A00A5F964 /* SentryEnvelopeItemHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeItemHeader.h; path = Public/SentryEnvelopeItemHeader.h; sourceTree = "<group>"; };
 		D8CB741A2947286500A5F964 /* SentryEnvelopeItemHeader.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEnvelopeItemHeader.m; sourceTree = "<group>"; };
+		D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUIApplicationTests.swift; sourceTree = "<group>"; };
+		D8CB742C294B294B00A5F964 /* MockUIScene.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockUIScene.h; sourceTree = "<group>"; };
+		D8CB742D294B294B00A5F964 /* MockUIScene.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockUIScene.m; sourceTree = "<group>"; };
 		D8CE69BB277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryFileIOTrackingIntegrationObjCTests.m; sourceTree = "<group>"; };
 		D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPredicateDescriptor.m; sourceTree = "<group>"; };
 		D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryPredicateDescriptor.h; path = include/SentryPredicateDescriptor.h; sourceTree = "<group>"; };
@@ -3014,7 +3014,7 @@
 			children = (
 				D8199DB429376ECC0074249E /* SentryInternal */,
 				D8199DB529376ECC0074249E /* SentrySwiftUI.h */,
-				D8199DB629376ECC0074249E /* SentryTraceView.swift */,
+				D8199DB629376ECC0074249E /* SentryTracedView.swift */,
 			);
 			path = SentrySwiftUI;
 			sourceTree = "<group>";
@@ -4044,7 +4044,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D8199DC129376EEC0074249E /* SentryTraceView.swift in Sources */,
+				D8199DC129376EEC0074249E /* SentryTracedView.swift in Sources */,
 				D8199DBF29376EE20074249E /* SentryInternal.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -8,7 +8,7 @@ import SentryInternal
 /// A control to measure the performance of your views and send the result as a transaction to Sentry.io.
 ///
 /// You create a transaction by wrapping your views with this.
-/// Nested `SentryTraceView` will create child spans in the transaction.
+/// Nested `SentryTracedView` will create child spans in the transaction.
 ///
 ///     SentryTracedView {
 ///         VStack {

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -10,7 +10,7 @@ import SentryInternal
 /// You create a transaction by wrapping your views with this.
 /// Nested `SentryTraceView` will create child spans in the transaction.
 ///
-///     SentryTraceView {
+///     SentryTracedView {
 ///         VStack {
 ///             // The part of your content you want to measure
 ///         }
@@ -19,7 +19,7 @@ import SentryInternal
 /// By default, the transaction name will be the first root view, in the case above `VStack`.
 /// You can give your transaction a custom name by providing the name parameter.
 ///
-///     SentryTraceView("My Awesome Screen") {
+///     SentryTracedView("My Awesome Screen") {
 ///         VStack {
 ///             // The part of your content you want to measure
 ///         }
@@ -33,7 +33,7 @@ import SentryInternal
 ///
 ///
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
-public struct SentryTraceView<Content: View>: View {
+public struct SentryTracedView<Content: View>: View {
     
     let content: () -> Content
     let name: String
@@ -41,7 +41,7 @@ public struct SentryTraceView<Content: View>: View {
     
     public init(_ transactionName: String? = nil, content: @escaping () -> Content) {
         self.content = content
-        self.name = transactionName ?? SentryTraceView.extractName(content: Content.self)
+        self.name = transactionName ?? SentryTracedView.extractName(content: Content.self)
         id = SentryPerformanceTracker.shared.startSpan(withName: self.name,
                                                        nameSource: transactionName == nil ? .component : .custom,
                                                        operation: "ui.load")
@@ -72,7 +72,7 @@ public struct SentryTraceView<Content: View>: View {
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 public extension View {
     func sentryTrace(_ transactionName: String? = nil) -> some View {
-        return SentryTraceView(transactionName) {
+        return SentryTracedView(transactionName) {
             return self
         }
     }


### PR DESCRIPTION
As pointed out by @armcknight, `TraceView` may be mistaken as a view that shows Trace, as "TracedView" shows an action being taken.

close #2550 

_#skip-changelog_