### PR TITLE
chore: Improve documentation on how to setup certificate and provisioning profiles

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ You can run samples in a real device without changing certificates and provision
 * You will need `Cocoa codesigning match encryption password` from your Sentry 1Password account.
 * run `fastlane match_local`
 
-This will setup certificates and provisioning profiles into your machine, but in order to be able to run a sample in a real device you need to register that device with Sentry AppConnect account, add the device to the provisioning profile you want to use, download the profile again and open it with xCode.
+This will setup certificates and provisioning profiles into your machine, but in order to be able to run a sample in a real device you need to register that device with Sentry AppConnect account, add the device to the provisioning profile you want to use, download the profile again and open it with Xcode.
 
 ## Final Notes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,16 @@ To make a header public follow these steps:
 * Add it to the Umbrella Header [Sentry.h](/Sources/Sentry/Public/Sentry.h).
 * Set the target membership to public.
 
+## Configuring certificates and provisioning profiles locally
+
+You can run samples in a real device without changing certificates and provisioning profiles if you are a Sentry employee with access to Sentry profiles repository and 1Password account.
+
+* Configure your environment to use SSH to access GitHub. Follow [this instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+* You will need `Cocoa codesigning match encryption password` from your Sentry 1Password account.
+* run `fastlane match_local`
+
+This will setup certificates and provisioning profiles into your machine, but in order to be able to run a sample in a real device you need to register that device with Sentry AppConnect account, add the device to the provisioning profile you want to use, download the profile again and open it with xCode.
+
 ## Final Notes
 
 When contributing to the codebase, please make note of the following:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -57,7 +57,8 @@ platform :ios do
          "io.sentry.cocoa.perf-test-app-plain",
          "io.sentry.*",
          "io.sentry.iOS-Benchmarking.xctrunner",
-         "io.sentry.cocoa.perf-test-app-sentry"]
+         "io.sentry.cocoa.perf-test-app-sentry"],
+        readonly: true
      )
      match(
        type: "appstore",
@@ -69,7 +70,8 @@ platform :ios do
          "io.sentry.cocoa.perf-test-app-plain",
          "io.sentry.*",
          "io.sentry.iOS-Benchmarking.xctrunner",
-         "io.sentry.cocoa.perf-test-app-sentry"]
+         "io.sentry.cocoa.perf-test-app-sentry"],
+        readonly: true
      )
   end
 


### PR DESCRIPTION
Added instructions into `CONTRIBUTING` file on how to setup certificate and provisioning profiles in order to run samples on a real device.

_#skip-changelog_