### PR TITLE
disable flaky `testActOnSubclassesOfViewController`

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -89,6 +89,9 @@
                   Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces_disabled()">
                </Test>
                <Test
+                  Identifier = "SentrySubClassFinderTests/testActOnSubclassesOfViewController_disabled()">
+               </Test>
+               <Test
                   Identifier = "SentryUIApplicationTests/test_applicationWithScenes()">
                </Test>
                <Test

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -38,7 +38,7 @@ class SentrySubClassFinderTests: XCTestCase {
         fixture = Fixture()
     }
     
-    func testActOnSubclassesOfViewController() {
+    func testActOnSubclassesOfViewController_disabled() {
         assertActOnSubclassesOfViewController(expected: [FirstViewController.self, SecondViewController.self, ViewControllerNumberThree.self, VCAnyNaming.self])
     }
     


### PR DESCRIPTION
#skip-changelog

I've seen this a few times now, most recently failed [here](https://github.com/getsentry/sentry-cocoa/actions/runs/3887880161/jobs/6634638115#step:11:46) and then succeeded on retry.