### PR TITLE
chore: Rename master branch to main

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,5 +1,5 @@
 codecov:
-  branch: 8.0.0
+  branch: main
   require_ci_to_pass: yes
   notify:
     wait_for_ci: yes

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
 
   pull_request:
     paths:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
       - release/**
 
   pull_request:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
 
   pull_request:
     paths:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
     paths:
       - 'Sources/**'
       - 'Tests/**'

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
 
   pull_request:
     paths:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
       - release/**
 
   pull_request:

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - master
-      - 8.0.0
+      - main
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-This version adds a dependency on Swift.
+This version adds a dependency on Swift. We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers not pointing to the `master` branch.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 
 This SDK is written in Objective-C but also provides a nice Swift interface.
 
+**Where is the master branch?**
+
+We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers not pointing to the [`master` branch](https://github.com/getsentry/sentry-cocoa/tree/master).
+
 # Initialization
 
 *Remember to call this as early in your application life cycle as possible*

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -173,3 +173,10 @@ since version 0.37.0, released in January 2021. Therefore, it's acceptable to us
 Date: December 14, 2022
 
 We [removed](https://github.com/getsentry/sentry-cocoa/pull/2529) the permissions feature that we added in [7.24.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.24.0). Multiple people reported getting denied in app review because of permission access without the corresponding Info.plist entry: see [#2528](https://github.com/getsentry/sentry-cocoa/issues/2528) and [2065](https://github.com/getsentry/sentry-cocoa/issues/2065).
+
+## Rename master to main
+
+Date: January 16th, 2023
+Contributors: @kahest, @brustolin and @philipphofmann
+
+With 8.0.0, we rename the default branch from `master` to `main`. We will keep the `master` branch for backwards compatibility for package managers pointing to the `master` branch.


### PR DESCRIPTION
Rename the master branch to main with entries to changelog and decision log.

#skip-changelog.