### PR TITLE
docs: Mention attachScreenshot works for crashes

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -200,7 +200,7 @@ NS_SWIFT_NAME(Options)
 /**
  * This feature is EXPERIMENTAL.
  *
- * Automatically attaches a screenshot when capturing an error or exception.
+ * Automatically attaches a screenshot when capturing an error, exception, or a crash.
  *
  * Default value is <code>NO</code>
  */


### PR DESCRIPTION
Was forgotten to add in GH-1920.

#skip-changelog