### PR TITLE
chore: Fix wording for master branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.0.0
 
-This version adds a dependency on Swift. We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers not pointing to the `master` branch.
+This version adds a dependency on Swift. We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers pointing to the `master` branch.
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This SDK is written in Objective-C but also provides a nice Swift interface.
 
 **Where is the master branch?**
 
-We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers not pointing to the [`master` branch](https://github.com/getsentry/sentry-cocoa/tree/master).
+We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers pointing to the [`master` branch](https://github.com/getsentry/sentry-cocoa/tree/master).
 
 # Initialization
 


### PR DESCRIPTION
It should be for package managers pointing to the master branch, and not package managers not pointing to the master branch.

#skip-changelog