### PR TITLE
chore: Fix SentrySwiftUI pod publish

### DIFF
--- a/SentrySwiftUI.podspec
+++ b/SentrySwiftUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SentrySwiftUI"
-  s.version      = "0.1.0"
+  s.version      = "8.0.0"
   s.summary      = "Sentry client for SwiftUI"
   s.homepage     = "https://github.com/getsentry/sentry-cocoa"
   s.license      = "mit"
@@ -15,15 +15,9 @@ Pod::Spec.new do |s|
   s.module_name  = "SentrySwiftUI"
   s.requires_arc = true
   s.frameworks = 'Foundation', 'SwiftUI'
-  s.swift_versions = "5.0"
-  s.watchos.pod_target_xcconfig = {
-      'OTHER_LDFLAGS' => '$(inherited) -framework WatchKit'
-  }
+  s.swift_versions = "5.5"
+  s.watchos.framework = 'WatchKit'
 
-  s.default_subspecs = ['Core']
-  
-  s.subspec 'Core' do |sp|
-      sp.source_files = "Sources/SentrySwiftUI/**/*.{swift,h,m}"
-      sp.dependency 'Sentry', "8.0.0"
-  end
+  s.source_files = "Sources/SentrySwiftUI/**/*.{swift,h,m}"
+  s.dependency 'Sentry', "8.0.0"
 end

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -5,6 +5,9 @@ import SwiftUI
 import SentryInternal
 #endif
 
+///
+/// This feature is EXPERIMENTAL.
+///
 /// A control to measure the performance of your views and send the result as a transaction to Sentry.io.
 ///
 /// You create a transaction by wrapping your views with this.
@@ -69,6 +72,9 @@ public struct SentryTracedView<Content: View>: View {
     }
 }
 
+///
+/// This feature is EXPERIMENTAL.
+///
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 public extension View {
     func sentryTrace(_ transactionName: String? = nil) -> some View {

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -180,3 +180,10 @@ Date: January 16th, 2023
 Contributors: @kahest, @brustolin and @philipphofmann
 
 With 8.0.0, we rename the default branch from `master` to `main`. We will keep the `master` branch for backwards compatibility for package managers pointing to the `master` branch.
+
+## SentrySwiftUI version
+
+Date: January 18th, 2023
+Contributors: @brustolin and @philipphofmann
+
+We release experimental SentrySwiftUI cocoa package with the version 8.0.0 because all podspecs file in a repo need to have the same version. 


### PR DESCRIPTION
I couldn't find out whether this is a feature or a bug, but in order to be able to publish SentrySwiftUI it need to have the same version of the other podspecs in the repo.

We can go forward with this approach (fine by me), or we can open a cocoapod github issue to find out if this is a bug or intended behaviour.

_#skip-changelog_