### PR TITLE
fix: Reads UI Windows in the main thread while fetching view hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Gather profiling timeseries metrics for CPU usage and memory footprint, and thermal and memory pressure events (#2493)
 
+### Fixes
+
+- Reads UI Windows in the main thread while fetching view hierarchy (#2629)
+
 ## 8.0.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Reads UI Windows in the main thread while fetching view hierarchy (#2629)
+- Always fetch view hierarchy on the main thread (#2629)
 
 ## 8.0.0
 

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -48,11 +48,11 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
 
 - (NSData *)fetchViewHierarchy
 {
-    NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
-
     __block NSMutableData *result = [[NSMutableData alloc] init];
 
     void (^save)(void) = ^{
+        NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
+
         if (![self processViewHierarchy:windows
                             addFunction:writeJSONDataToMemory
                                userData:(__bridge void *)(result)]) {

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -51,7 +51,8 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
     __block NSMutableData *result = [[NSMutableData alloc] init];
 
     void (^save)(void) = ^{
-        NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
+        NSArray<UIWindow *> *windows =
+            [SentryDependencyContainer.sharedInstance.application windows];
 
         if (![self processViewHierarchy:windows
                             addFunction:writeJSONDataToMemory

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -172,14 +172,37 @@ class SentryViewHierarchyTests: XCTestCase {
         wait(for: [ex], timeout: 1)
     }
 
+    func test_fetch_usesMainThread() {
+        let sut = TestSentryViewHierarchy()
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+        fixture.uiApplication.windows = [window]
+
+        let ex = expectation(description: "Running on background Thread")
+        let dispatch = DispatchQueue(label: "background")
+        dispatch.async {
+            let _ = sut.fetch()
+            ex.fulfill()
+        }
+
+        wait(for: [ex], timeout: 1)
+        XCTAssertTrue(fixture.uiApplication.calledOnMainThread, "fetchViewHierarchy is not using the main thread to get UI windows")
+    }
+
     class TestSentryUIApplication: SentryUIApplication {
         private var _windows: [UIWindow]?
+        private var _calledOnMainThread = true
+
+        var calledOnMainThread : Bool {
+            return _calledOnMainThread
+        }
 
         override var windows: [UIWindow]? {
             get {
+                _calledOnMainThread = Thread.isMainThread
                 return _windows
             }
             set {
+                _calledOnMainThread = Thread.isMainThread
                 _windows = newValue
             }
         }

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -192,7 +192,7 @@ class SentryViewHierarchyTests: XCTestCase {
         private var _windows: [UIWindow]?
         private var _calledOnMainThread = true
 
-        var calledOnMainThread : Bool {
+        var calledOnMainThread: Bool {
             return _calledOnMainThread
         }
 


### PR DESCRIPTION
## :scroll: Description

Reads UI Windows in the main thread while fetching view hierarchy

## :bulb: Motivation and Context

Closes #2586 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
