### PR TITLE
fix: SentryOption.h reference from SentryOption+HybridSDK.h

### DIFF
--- a/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
+++ b/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
@@ -1,7 +1,7 @@
 #if __has_include(<Sentry/SentryOptions.h>)
-#import <Sentry/SentryOptions.h>
+#    import <Sentry/SentryOptions.h>
 #else
-#import "SentryOptions.h"
+#    import "SentryOptions.h"
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
+++ b/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
@@ -1,4 +1,8 @@
+#if __has_include(<Sentry/SentryOptions.h>)
+#import <Sentry/SentryOptions.h>
+#else
 #import "SentryOptions.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Fix error if a Hybrid SDKs imports `SentryOptions+HybridSDK.h` while using Carthage to add Sentry framework.

_#skip-changelog_