### PR TITLE
chore: Remove args for no-commit-to-branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
       - id: detect-private-key
       - id: end-of-file-fixer
       - id: no-commit-to-branch
-        args: ["-b main"]
 
   - repo: local
     hooks:


### PR DESCRIPTION
main and master are default for no-commit-to-branch; see https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch.

#skip-changelog