### PR TITLE
fix: Use uint64 instead of double in crash report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Support uint64 in crash reports (#2631)
+- Support uint64 in crash reports (#2631, #2642)
 - Always fetch view hierarchy on the main thread (#2629)
 - Carthage Xcode 14 compatibility issue (#2636)
 - Crash in CppException Monitor (#2639)

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -134,7 +134,7 @@ static void
 addUIntegerElement(
     const SentryCrashReportWriter *const writer, const char *const key, const uint64_t value)
 {
-    sentrycrashjson_addIntegerElement(getJsonContext(writer), key, (int64_t)value);
+    sentrycrashjson_addUIntegerElement(getJsonContext(writer), key, value);
 }
 
 static void

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
@@ -161,6 +161,19 @@ int sentrycrashjson_addBooleanElement(
 int sentrycrashjson_addIntegerElement(
     SentryCrashJSONEncodeContext *context, const char *name, int64_t value);
 
+/** Add an unsigned integer element.
+ *
+ * @param context The encoding context.
+ *
+ * @param name The element's name.
+ *
+ * @param value The element's value.
+ *
+ * @return SentryCrashJSON_OK if the process was successful.
+ */
+int sentrycrashjson_addUIntegerElement(
+    SentryCrashJSONEncodeContext *context, const char *name, uint64_t value);
+
 /** Add a floating point element.
  *
  * @param context The encoding context.
@@ -415,6 +428,19 @@ typedef struct SentryCrashJSONDecodeCallbacks {
      * @return SentryCrashJSON_OK if decoding should continue.
      */
     int (*onIntegerElement)(const char *name, int64_t value, void *userData);
+
+    /** Called when an unsigned integer element is decoded.
+     *
+     * @param name The element's name.
+     *
+     * @param value The element's value.
+     *
+     * @param userData Data that was specified when calling
+     * sentrycrashjson_decode().
+     *
+     * @return SentryCrashJSON_OK if decoding should continue.
+     */
+    int (*onUIntegerElement)(const char *name, uint64_t value, void *userData);
 
     /** Called when a null element is decoded.
      *

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -138,6 +138,7 @@ SentryCrashJSONCodec ()
         self.callbacks->onEndData = onEndData;
         self.callbacks->onFloatingPointElement = onFloatingPointElement;
         self.callbacks->onIntegerElement = onIntegerElement;
+        self.callbacks->onUIntegerElement = onUIntegerElement;
         self.callbacks->onNullElement = onNullElement;
         self.callbacks->onStringElement = onStringElement;
 
@@ -227,6 +228,15 @@ onIntegerElement(const char *const cName, const int64_t value, void *const userD
 {
     NSString *name = stringFromCString(cName);
     id element = [NSNumber numberWithLongLong:value];
+    SentryCrashJSONCodec *codec = (__bridge SentryCrashJSONCodec *)userData;
+    return onElement(codec, name, element);
+}
+
+static int
+onUIntegerElement(const char *const cName, const uint64_t value, void *const userData)
+{
+    NSString *name = stringFromCString(cName);
+    id element = [NSNumber numberWithUnsignedLongLong:value];
     SentryCrashJSONCodec *codec = (__bridge SentryCrashJSONCodec *)userData;
     return onElement(codec, name, element);
 }

--- a/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
@@ -1296,15 +1296,24 @@ toString(NSData *data)
     XCTAssertEqual([result[0] longLongValue], value);
 }
 
-- (void)testDeserializeArrayUIntMax_UsesDouble
+- (void)testDeserializeArrayIntMaxPlusOne_UsesUInt
+{
+    uint64_t value = (uint64_t)LLONG_MAX + 1;
+    NSString *jsonString = [NSString stringWithFormat:@"[%llu]", value];
+
+    NSArray<NSNumber *> *result = [self decode:jsonString];
+
+    XCTAssertEqual([result[0] unsignedLongLongValue], value);
+}
+
+- (void)testDeserializeArrayUIntMax_UsesUInt
 {
     uint64_t value = ULLONG_MAX;
     NSString *jsonString = [NSString stringWithFormat:@"[%llu]", value];
 
     NSArray<NSNumber *> *result = [self decode:jsonString];
 
-    XCTAssertNotEqual([result[0] unsignedLongLongValue], value);
-    XCTAssertEqual([result[0] doubleValue], [@(value) doubleValue]);
+    XCTAssertEqual([result[0] unsignedLongLongValue], value);
 }
 
 - (void)testDeserializeArray_NegativeLLONG_MIN_plusOne_UsesDouble
@@ -1566,7 +1575,7 @@ addJSONData(const char *data, int length, void *userData)
 {
     NSString *savedFilename = [self.tempPath stringByAppendingPathComponent:@"big.json"];
     id savedObject = @{
-        @"an_array" : @[ @1, @2, @3, @4 ],
+        @"an_array" : @[ @1, @2, @3, @4, @1.3, @(YES), @(LLONG_MIN), @(ULLONG_MAX) ],
         @"lines" : @[
             @"I cannot describe to you my sensations on the near prospect of my undertaking.",
             @"It is impossible to communicate to you a conception of the trembling sensation, half pleasurable and half fearful, with which I am preparing to depart.",


### PR DESCRIPTION

## :scroll: Description

Follow up on #2631 to use uint64 instead of double for encoding and decoding crash reports.

## :bulb: Motivation and Context

Came up while investigating https://github.com/getsentry/sentry-cocoa/issues/1589. KSCrash has some fixes in https://github.com/kstenerud/KSCrash/commits/master/Source/KSCrash/Recording/Monitors/KSCrashMonitor_MachException.c that we can apply to our fork. https://github.com/kstenerud/KSCrash/pull/350 is a first step and adding support for uint64 is one change we can apply.

Thanks again @GLinnik21, for the initial work on KSCrash.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
