### PR TITLE
test: Fix flaky testFaultyReportIsNotSentAndDeleted

### DIFF
--- a/Sources/Sentry/SentryCrashInstallationReporter.m
+++ b/Sources/Sentry/SentryCrashInstallationReporter.m
@@ -37,12 +37,7 @@ SentryCrashInstallationReporter ()
                                                dispatchQueue:self.dispatchQueue];
 }
 
-- (void)sendAllReports
-{
-    [self sendAllReportsWithCompletion:NULL];
-}
-
-- (void)sendAllReportsWithCompletion:(SentryCrashReportFilterCompletion)onCompletion
+- (void)sendAllReportsWithCompletion:(nullable SentryCrashReportFilterCompletion)onCompletion
 {
     [super
         sendAllReportsWithCompletion:^(NSArray *filteredReports, BOOL completed, NSError *error) {

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -151,7 +151,7 @@ SentryCrashIntegration ()
  */
 + (void)sendAllSentryCrashReports
 {
-    [installation sendAllReports];
+    [installation sendAllReportsWithCompletion:NULL];
 }
 
 - (void)uninstall

--- a/Sources/Sentry/include/SentryCrashInstallationReporter.h
+++ b/Sources/Sentry/include/SentryCrashInstallationReporter.h
@@ -14,7 +14,7 @@ SENTRY_NO_INIT
                       crashWrapper:(SentryCrashWrapper *)crashWrapper
                      dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue;
 
-- (void)sendAllReports;
+- (void)sendAllReportsWithCompletion:(nullable SentryCrashReportFilterCompletion)onCompletion;
 
 @end
 


### PR DESCRIPTION
The test validated the wrong invocation on the test client. Instead of captureEventWithScopeInvocations it should have been captureCrashEventInvocations. Anyways, we can improve the test by not validating no events being passed down to the client but instead using the completion callback of the SentryCrashInstallationReporter to get rid of the delayNonBlocking.

#skip-changelog