### PR TITLE
test: Skip delete old envelopes for most tests

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -148,6 +148,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         self.timezone = timezone;
         self.attachmentProcessors = [[NSMutableArray alloc] init];
         self.deviceWrapper = deviceWrapper;
+
+        [fileManager deleteOldEnvelopeItems];
     }
     return self;
 }

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -49,6 +49,8 @@ SENTRY_NO_INIT
 - (void)deleteAllEnvelopes;
 - (void)deleteAllFolders;
 
+- (void)deleteOldEnvelopeItems;
+
 /**
  * Get all envelopes sorted ascending by the timeIntervalSince1970 the envelope was stored and if
  * two envelopes are stored at the same time sorted by the order they were stored.

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -137,6 +137,7 @@ class SentryFileManagerTests: XCTestCase {
         try givenOldEnvelopes()
 
         sut = fixture.getSut()
+        sut.deleteOldEnvelopeItems()
 
         XCTAssertEqual(sut.getAllEnvelopes().count, 0)
     }
@@ -144,10 +145,11 @@ class SentryFileManagerTests: XCTestCase {
     func testDeleteOldEnvelopes_WithEmptyDSN() throws {
         fixture.options.dsn = nil
         sut = fixture.getSut()
+        sut.deleteOldEnvelopeItems()
         
         try givenOldEnvelopes()
 
-        sut = fixture.getSut()
+        sut.deleteOldEnvelopeItems()
 
         XCTAssertEqual(sut.getAllEnvelopes().count, 0)
     }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
@@ -91,7 +91,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         let appState = SentryAppState(releaseName: fixture.options.releaseName ?? "", osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: fixture.sysctl.systemBootTimestamp)
         
         XCTAssertEqual(appState, actual)
-        XCTAssertEqual(2, fixture.dispatchQueue.dispatchAsyncCalled)
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchAsyncCalled)
     }
     
     func testGoToForeground_SetsIsActive() {
@@ -106,7 +106,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         goToBackground()
         
         XCTAssertFalse(fixture.realFileManager.readAppState()?.isActive ?? true)
-        XCTAssertEqual(4, fixture.dispatchQueue.dispatchAsyncCalled)
+        XCTAssertEqual(3, fixture.dispatchQueue.dispatchAsyncCalled)
     }
     
     func testGoToForeground_WhenAppStateNil_NothingIsStored() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -138,6 +138,14 @@ class SentryClientTest: XCTestCase {
         clearTestState()
     }
     
+    func testInit_CallsDeleteOldEnvelopeItemsInvocations() throws {
+        let fileManager = try TestFileManager(options: Options())
+        
+        _ = SentryClient(options: Options(), fileManager: fileManager)
+        
+        XCTAssertEqual(1, fileManager.deleteOldEnvelopeItemsInvocations.count)
+    }
+    
     func testClientIsEnabled() {
         XCTAssertTrue(fixture.getSut().isEnabled)
     }

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -142,6 +142,11 @@ class TestFileManager: SentryFileManager {
     init(options: Options, andCurrentDateProvider currentDateProvider: CurrentDateProvider) throws {
         try super.init(options: options, andCurrentDateProvider: currentDateProvider, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
     }
+    
+    var deleteOldEnvelopeItemsInvocations = Invocations<Void>()
+    override func deleteOldEnvelopeItems() {
+        deleteOldEnvelopeItemsInvocations.record(Void())
+    }
 
     override func readTimestampLastInForeground() -> Date? {
         readTimestampLastInForegroundInvocations += 1


### PR DESCRIPTION
Deleting old envelope items in the SentryFileManager can cause side effects for tests as it could delete envelope items needed for other tests async. Now the SentryClient runs the deletion in production and we only run the deletion for selected tests.

Came up in https://github.com/getsentry/sentry-cocoa/actions/runs/4013580316

#skip-changelog