### PR TITLE
ref: Remove useDlAddr from struct

### DIFF
--- a/Sources/Sentry/SentryStacktraceBuilder.m
+++ b/Sources/Sentry/SentryStacktraceBuilder.m
@@ -3,6 +3,7 @@
 #import "SentryCrashStackCursor_MachineContext.h"
 #import "SentryCrashStackCursor_SelfThread.h"
 #import "SentryCrashStackEntryMapper.h"
+#import "SentryCrashSymbolicator.h"
 #import "SentryFrame.h"
 #import "SentryFrameRemover.h"
 #import "SentryStacktrace.h"
@@ -106,7 +107,7 @@ SentryStacktraceBuilder ()
 {
     SentryCrashStackCursor stackCursor;
     sentrycrashsc_initSelfThread(&stackCursor, 0);
-    stackCursor.useDlAddr = true;
+    stackCursor.symbolicate = sentrycrashsymbolicator_symbolicate_async_unsafe;
     return [self retrieveStacktraceFromCursor:stackCursor];
 }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
@@ -50,7 +50,6 @@ sentrycrashsc_resetCursor(SentryCrashStackCursor *cursor)
     cursor->stackEntry.imageName = NULL;
     cursor->stackEntry.symbolAddress = 0;
     cursor->stackEntry.symbolName = NULL;
-    cursor->useDlAddr = false;
 }
 
 void

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.h
@@ -92,8 +92,6 @@ typedef struct SentryCrashStackCursor {
 
     /** Internal context-specific information. */
     void *context[SentryCrashSC_CONTEXT_SIZE];
-
-    bool useDlAddr;
 } SentryCrashStackCursor;
 
 /** Common initialization routine for a stack cursor.

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.c
@@ -49,8 +49,8 @@
  */
 #define CALL_INSTRUCTION_FROM_RETURN_ADDRESS(A) (DETAG_INSTRUCTION_ADDRESS((A)) - 1)
 
-bool
-sentrycrashsymbolicator_symbolicate(SentryCrashStackCursor *cursor)
+static bool
+symbolicate_internal(SentryCrashStackCursor *cursor, bool asyncUnsafe)
 {
     if (cursor->stackEntry.address == SentryCrashSC_ASYNC_MARKER) {
         cursor->stackEntry.imageAddress = 0;
@@ -64,7 +64,7 @@ sentrycrashsymbolicator_symbolicate(SentryCrashStackCursor *cursor)
 
     bool symbols_succeed = false;
 
-    if (cursor->useDlAddr) {
+    if (asyncUnsafe) {
         symbols_succeed = dladdr((void *)cursor->stackEntry.address, &symbolsBuffer) != 0;
     } else {
         symbols_succeed = sentrycrashdl_dladdr(
@@ -84,4 +84,16 @@ sentrycrashsymbolicator_symbolicate(SentryCrashStackCursor *cursor)
     cursor->stackEntry.symbolAddress = 0;
     cursor->stackEntry.symbolName = 0;
     return false;
+}
+
+bool
+sentrycrashsymbolicator_symbolicate(SentryCrashStackCursor *cursor)
+{
+    return symbolicate_internal(cursor, false);
+}
+
+bool
+sentrycrashsymbolicator_symbolicate_async_unsafe(SentryCrashStackCursor *cursor)
+{
+    return symbolicate_internal(cursor, true);
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.h
@@ -40,6 +40,10 @@ extern "C" {
  */
 bool sentrycrashsymbolicator_symbolicate(SentryCrashStackCursor *cursor);
 
+/** Same as ``sentrycrashsymbolicator_symbolicate`` but faster and async unsafe.
+ */
+bool sentrycrashsymbolicator_symbolicate_async_unsafe(SentryCrashStackCursor *cursor);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Instead of adding an extra field to the struct we change the symbolication function in StacktraceBuilder.

#skip-changelog