### PR TITLE
Make all Sentry products dynamic frameworks.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,9 +5,8 @@ let package = Package(
     name: "Sentry",
     platforms: [.iOS(.v11), .macOS(.v10_13), .tvOS(.v11), .watchOS(.v4)],
     products: [
-        .library(name: "Sentry", targets: ["Sentry"]),
-        .library(name: "Sentry-Dynamic", type: .dynamic, targets: ["Sentry"]),
-        .library(name: "SentrySwiftUI", targets: ["SentrySwiftUI"])
+        .library(name: "SentryOnly", type: .dynamic, targets: ["Sentry"]),
+        .library(name: "SentryWithSwiftUI", type: .dynamic, targets: ["SentrySwiftUI"])
     ],
     targets: [
         .target(


### PR DESCRIPTION
## :scroll: Description

This allows use of Sentry from both internal (dynamic) frameworks as well as the main product without statically linking Sentry into both binaries.

The SentrySwiftUI target also needs Sentry. It links Sentry statically, so the consumer should EITHER link SentryOnly OR SentryWithSwiftUI, not both.

Unfortunately this also means that frameworks which use Sentry but not its SwiftUI extensions will now need to link SentryWithSwiftUI. The reason is because their Sentry dependency needs to be embedded by the application target. If they use SentryOnly and the application target uses SentryWithSwiftUI, then only the latter is embedded and the framework's SentryOnly will not be included.

## :bulb: Motivation and Context

Currently it is impossible to use Sentry from a framework.

Two options exist: link Sentry statically or link it dynamically.

### Static linking

Firstly, this is currently impossible since SPM resolves the Sentry product as a dynamic type when linked from a dynamic framework.

Secondly, if both the application target and a framework were to link Sentry statically, then Sentry would end up in multiple binaries, leading to excessively sized binaries and possible duplication of runtime symbols.

    One of the two will be used. Which one is undefined.

### Dynamic linking

This is currently also impossible since SPM resolves the Sentry product as a static type when linked with an application target.

### Dynamically linking for frameworks and statically linking for applications

This is possible currently, but it leads to runtime problems. When a framework links Sentry dynamically, it will need to embed the dynamic framework into the application bundle. But since the application target links Sentry statically, it will not include a dynamic library into its Embed Frameworks step. The result is an application bundle which does not include the dynamic Sentry framework at the application bundle level / `@rpath`.

Curiously, the application will run fine when attached to Xcode but will fail when opened directly from the device/simulator.

## :green_heart: How did you test it?

1. Make a new SwiftUI iOS application in Xcode
2. Add a framework which imports Sentry
3. Add `SentryWithSwiftUI` to both the application target and the framework.

You can optionally delete the `Embed Frameworks` step added to the framework target, it is not used.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [ ] I updated the docs if needed
- [ ] Review from the native team if needed
- [ ] No breaking changes

## :crystal_ball: Next steps

This will need special consideration. I've had to rename the product name `Sentry` since it duplicates against the target name `Sentry`, which confuses SPM when trying to resolve the `Sentry` dependency of `SentrySwiftUI`. It may be better to rename the internal target names rather than the product names to minimize breaking changes for consumers.

For instance, Firebase uses "Target" suffixes to differentiate their target names from their product names: https://github.com/firebase/firebase-ios-sdk/blob/master/Package.swift