### PR TITLE
fix: MachException Improvements

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1278,7 +1278,7 @@ writeError(const SentryCrashReportWriter *const writer, const char *const key,
             const char *machExceptionName = sentrycrashmach_exceptionName(crash->mach.type);
             const char *machCodeName = crash->mach.code == 0
                 ? NULL
-                : sentrycrashmach_kernelReturnCodeName(crash->mach.code);
+                : sentrycrashmach_kernelReturnCodeName(crash->mach.type, crash->mach.code);
             writer->addUIntegerElement(
                 writer, SentryCrashField_Exception, (unsigned)crash->mach.type);
             if (machExceptionName != NULL) {
@@ -1289,7 +1289,7 @@ writeError(const SentryCrashReportWriter *const writer, const char *const key,
                 writer->addStringElement(writer, SentryCrashField_CodeName, machCodeName);
             }
             writer->addUIntegerElement(
-                writer, SentryCrashField_Subcode, (unsigned)crash->mach.subcode);
+                writer, SentryCrashField_Subcode, (size_t)crash->mach.subcode);
         }
         writer->endContainer(writer);
 #endif

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMach.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMach.c
@@ -27,6 +27,10 @@
 #include <mach/mach.h>
 #include <stdlib.h>
 
+#if defined(__arm__) || defined(__arm64__)
+#    include <mach/arm/exception.h>
+#endif /* defined (__arm__) || defined (__arm64__) */
+
 #define RETURN_NAME_FOR_ENUM(A)                                                                    \
     case A:                                                                                        \
         return #A
@@ -50,7 +54,7 @@ sentrycrashmach_exceptionName(const int64_t exceptionType)
 }
 
 const char *
-sentrycrashmach_kernelReturnCodeName(const int64_t returnCode)
+sentrycrashmach_kernelReturnCodeName(const int64_t exceptionType, const int64_t returnCode)
 {
     switch (returnCode) {
         RETURN_NAME_FOR_ENUM(KERN_SUCCESS);
@@ -104,6 +108,25 @@ sentrycrashmach_kernelReturnCodeName(const int64_t returnCode)
         RETURN_NAME_FOR_ENUM(KERN_NOT_WAITING);
         RETURN_NAME_FOR_ENUM(KERN_OPERATION_TIMED_OUT);
         RETURN_NAME_FOR_ENUM(KERN_CODESIGN_ERROR);
+        RETURN_NAME_FOR_ENUM(KERN_POLICY_STATIC);
+        RETURN_NAME_FOR_ENUM(KERN_INSUFFICIENT_BUFFER_SIZE);
+        RETURN_NAME_FOR_ENUM(KERN_DENIED);
+        RETURN_NAME_FOR_ENUM(KERN_MISSING_KC);
+        RETURN_NAME_FOR_ENUM(KERN_INVALID_KC);
+        RETURN_NAME_FOR_ENUM(KERN_NOT_FOUND);
+
+#if defined(__arm__) || defined(__arm64__)
+        /*
+         * Located at mach/arm/exception.h
+         * For EXC_BAD_ACCESS
+         * Note: do not conflict with kern_return_t values returned by vm_fault
+         */
+        RETURN_NAME_FOR_ENUM(EXC_ARM_DA_ALIGN);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_DA_DEBUG);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_SP_ALIGN);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_SWP);
+        RETURN_NAME_FOR_ENUM(EXC_ARM_PAC_FAIL);
+#endif /* defined (__arm__) || defined (__arm64__) */
     }
     return NULL;
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMach.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMach.h
@@ -45,7 +45,7 @@ const char *sentrycrashmach_exceptionName(int64_t exceptionType);
  *
  * @return The code's name or NULL if not found.
  */
-const char *sentrycrashmach_kernelReturnCodeName(int64_t returnCode);
+const char *sentrycrashmach_kernelReturnCodeName(int64_t exceptionType, int64_t returnCode);
 
 /** Get the signal equivalent of a mach exception.
  *


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-cocoa/pull/2642. Fixes applied from KSCrash:
* kstenerud/KSCrash#349
* kstenerud/KSCrash#350

Add exception codes for ARM from mach/arm/exception.h. Add missing kernel return codes from kern_return.h

## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

Could fix GH-1589.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [ ] I added tests to verify the changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed
- [ ] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
