### PR TITLE
CI: UITest for crash recoverability 

### DIFF
--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -20,7 +20,7 @@ class LaunchUITests: XCTestCase {
         super.tearDown()
     }
 
-    func testCrashRecovery(){
+    func testCrashRecovery() {
         app.buttons["crash"].tap()
         if app.buttons["crash"].exists {
             XCTFail("App did not crashed")

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -20,6 +20,15 @@ class LaunchUITests: XCTestCase {
         super.tearDown()
     }
 
+    func testCrashRecovery(){
+        app.buttons["crash"].tap()
+        if app.buttons["crash"].exists {
+            XCTFail("App did not crashed")
+        }
+        app.launch()
+        waitForExistenseOfMainScreen()
+    }
+
     func testBreadcrumbData() {
         let breadcrumbLabel = app.staticTexts["breadcrumbLabel"]
         breadcrumbLabel.waitForExistence("Breadcrumb label not found.")


### PR DESCRIPTION
Created a ui test for iOS-Swift sample that press the crash button and try to open the app again.
If we introduce any error in the crash report process this test may identify it.

To avoid issues like https://github.com/getsentry/sentry-cocoa/pull/2664.

_#skip-changelog_