### PR TITLE
fix: Cleanup AppHangTracking properly when closing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Cleanup AppHangTracking properly when closing SDK (#2671)
+
 ## 8.1.0
 
 ### Features

--- a/Sources/Sentry/SentryANRTracker.m
+++ b/Sources/Sentry/SentryANRTracker.m
@@ -6,6 +6,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
+    kSentryANRTrackerNotRunning = 1,
+    kSentryANRTrackerRunning,
+    kSentryANRTrackerStarting,
+    kSentryANRTrackerStopping
+};
+
 @interface
 SentryANRTracker ()
 
@@ -16,13 +23,11 @@ SentryANRTracker ()
 @property (nonatomic, strong) NSMutableSet<id<SentryANRTrackerDelegate>> *listeners;
 @property (nonatomic, assign) NSTimeInterval timeoutInterval;
 
-@property (weak, nonatomic) NSThread *thread;
-
 @end
 
 @implementation SentryANRTracker {
     NSObject *threadLock;
-    BOOL running;
+    SentryANRTrackerState state;
 }
 
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
@@ -37,17 +42,28 @@ SentryANRTracker ()
         self.crashWrapper = crashWrapper;
         self.dispatchQueueWrapper = dispatchQueueWrapper;
         self.threadWrapper = threadWrapper;
-        self.listeners = [NSMutableSet new];
+        self.listeners = [NSMutableSet set];
         threadLock = [[NSObject alloc] init];
-        running = NO;
+        state = kSentryANRTrackerNotRunning;
     }
     return self;
 }
 
 - (void)detectANRs
 {
-    NSThread.currentThread.name = @"io.sentry.app-hang-tracker";
-    self.thread = NSThread.currentThread;
+    NSUUID *threadID = [NSUUID UUID];
+
+    @synchronized(threadLock) {
+        [self.threadWrapper threadStarted:threadID];
+
+        if (state != kSentryANRTrackerStarting) {
+            [self.threadWrapper threadFinished:threadID];
+            return;
+        }
+
+        NSThread.currentThread.name = @"io.sentry.app-hang-tracker";
+        state = kSentryANRTrackerRunning;
+    }
 
     __block NSInteger ticksSinceUiUpdate = 0;
     __block BOOL reported = NO;
@@ -55,7 +71,14 @@ SentryANRTracker ()
     NSInteger reportThreshold = 5;
     NSTimeInterval sleepInterval = self.timeoutInterval / reportThreshold;
 
-    while (![self.thread isCancelled]) {
+    // Canceling the thread can take up to sleepInterval.
+    while (true) {
+        @synchronized(threadLock) {
+            if (state != kSentryANRTrackerRunning) {
+                break;
+            }
+        }
+
         NSDate *blockDeadline =
             [[self.currentDate date] dateByAddingTimeInterval:self.timeoutInterval];
 
@@ -98,6 +121,11 @@ SentryANRTracker ()
             [self ANRDetected];
         }
     }
+
+    @synchronized(threadLock) {
+        state = kSentryANRTrackerNotRunning;
+        [self.threadWrapper threadFinished:threadID];
+    }
 }
 
 - (void)ANRDetected
@@ -129,10 +157,13 @@ SentryANRTracker ()
     @synchronized(self.listeners) {
         [self.listeners addObject:listener];
 
-        if (self.listeners.count > 0 && !running) {
+        if (self.listeners.count > 0 && state == kSentryANRTrackerNotRunning) {
             @synchronized(threadLock) {
-                if (!running) {
-                    [self start];
+                if (state == kSentryANRTrackerNotRunning) {
+                    state = kSentryANRTrackerStarting;
+                    [NSThread detachNewThreadSelector:@selector(detectANRs)
+                                             toTarget:self
+                                           withObject:nil];
                 }
             }
         }
@@ -158,20 +189,11 @@ SentryANRTracker ()
     }
 }
 
-- (void)start
-{
-    @synchronized(threadLock) {
-        [NSThread detachNewThreadSelector:@selector(detectANRs) toTarget:self withObject:nil];
-        running = YES;
-    }
-}
-
 - (void)stop
 {
     @synchronized(threadLock) {
         SENTRY_LOG_INFO(@"Stopping ANR detection");
-        [self.thread cancel];
-        running = NO;
+        state = kSentryANRTrackerStopping;
     }
 }
 

--- a/Sources/Sentry/SentryThreadWrapper.m
+++ b/Sources/Sentry/SentryThreadWrapper.m
@@ -9,6 +9,16 @@ NS_ASSUME_NONNULL_BEGIN
     [NSThread sleepForTimeInterval:timeInterval];
 }
 
+- (void)threadStarted:(NSUUID *)threadID;
+{
+    // No op. Only needed for testing.
+}
+
+- (void)threadFinished:(NSUUID *)threadID
+{
+    // No op. Only needed for testing.
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryThreadWrapper.h
+++ b/Sources/Sentry/include/SentryThreadWrapper.h
@@ -9,6 +9,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sleepForTimeInterval:(NSTimeInterval)timeInterval;
 
+- (void)threadStarted:(NSUUID *)threadID;
+
+- (void)threadFinished:(NSUUID *)threadID;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Helper/SentryTestThreadWrapper.swift
+++ b/Tests/SentryTests/Helper/SentryTestThreadWrapper.swift
@@ -1,9 +1,26 @@
 import Foundation
+import XCTest
 
 class SentryTestThreadWrapper: SentryThreadWrapper {
     
+    var threadFinishedExpectation = XCTestExpectation(description: "Thread Finished Expectation")
+    var threads: Set<UUID> = Set()
+    var threadStartedInvocations = Invocations<UUID>()
+    var threadFinishedInvocations = Invocations<UUID>()
+    
     override func sleep(forTimeInterval timeInterval: TimeInterval) {
         // Don't sleep. Do nothing.
+    }
+
+    override func threadStarted(_ threadID: UUID) {
+        threadStartedInvocations.record(threadID)
+        threads.insert(threadID)
+    }
+    
+    override func threadFinished(_ threadID: UUID) {
+        threadFinishedInvocations.record(threadID)
+        threads.remove(threadID)
+        threadFinishedExpectation.fulfill()
     }
 
 }


### PR DESCRIPTION
## :scroll: Description

When closing the SDK directly after starting it, it could happen that the ANRTracker didn't start its watchdog thread yet. Canceling the ANRTrackers thread required the instance of the watchdog thread and didn't work correctly. This is fixed now by using simple state management in the ANRTracker. While this is an edge case, it can help with flaky tests, as the test logs showed signs of the ANRTracker running in the background.

## :bulb: Motivation and Context

This came up while checking the raw test logs of failing tests on the main branch, see https://github.com/getsentry/sentry-cocoa/actions/runs/4045915250/jobs/6958149321. The logs contain several statements, although the ANRTracker shouldn't be running.
```
Test Case '-[SentryTests.SentryLogTests testLevelNone_PrintsEverythingExceptNone]' started.
2023-01-30 16:35:42.447867+0000 xctest[10355:27467] [Sentry] [fatal] 0
2023-01-30 16:35:42.448038+0000 xctes2023-01-30 16:35:42.457839+0000 xctest[10355:29827] [Sentry] [warning] [SentryANRTracker:97] ANR detected.
t[10355:27467] [Sentry] [error] 1
2023-01-30 16:35:42.462238+0000 xctest[10355:27467] [Sentry] [warning] 2
2023-01-30 16:35:42.462394+0000 xctest[10355:27467] [Sentry] [info] 3
2023-01-30 16:35:42.462848+0000 xctest[10355:27467] [Sentry] [debug] 4
2023-01-30 16:35:42.467022+0000 xctest[10355:27467] [Sentry] [debug] [SentryFileManager:659] SentryFileManager.cachePath: /Users/runner/Library/Developer/CoreSimulator/Devices/76C9311A-80D8-48DB-8FD8-A408B736C8F1/data/Library/Caches
2023-01-30 16:35:42.467370+0000 xctest[10355:27467] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/76C9311A-80D8-48DB-8FD8-A408B736C8F1/data/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/events
2023-01-30 16:35:42.468337+0000 xctest[10355:27467] [Sentry] [debug] [SentryHttpTransport:251] sendAllCachedEnvelopes start.
2023-01-30 16:35:42.468602+0000 xctest[10355:27467] [Sentry] [debug] [SentryHttpTransport:263] No envelopes left to send.
2023-01-30 16:35:42.469163+0000 xctest[10355:27467] [Sentry] [debug] [SentryHttpTransport:342] Finished sending.
2023-01-30 16:35:42.471268+0000 xctest[10355:32063] [Sentry] [debug] [SentryFileManager:97] Dispatched deletion of old envelopes from <SentryFileManager: 0x6000006b7980>
2023-01-30 16:35:42.502122+0000 xctest[10355:32063] [Sentry] [debug] [SentryFileManager:423] Writing to file: /Users/runner/Library/Developer/CoreSimulator/Devices/76C9311A-80D8-48DB-8FD8-A408B736C8F1/data/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/envelopes/1675096542.502065-00000-2F1BFA76-6E3E-4E8B-9F4C-3E9D860217DA.json
/Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/Helper/SentryLogTests.swift:65: error: -[SentryTests.SentryLogTests testLevelNone_PrintsEverythingExceptNone] : XCTAssertEqual failed: ("["[Sentry] [fatal] 0", "[Sentry] [error] 1", "[Sentry] [warning] 2", "[Sentry] [info] 3", "[Sentry] [debug] 4"]") is not equal to ("["[Sentry] [fatal] 0", "[Sentry] [warning] [SentryANRTracker:97] ANR detected.", "[Sentry] [error] 1", "[Sentry] [warning] 2", "[Sentry] [info] 3", "[Sentry] [debug] 4"]")
Test Case '-[SentryTests.SentryLogTests testLevelNone_PrintsEverythingExceptNone]' failed (0.059 seconds).
```

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code
- [x] I added tests to verify the changes
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
- [x] I updated the docs if needed
- [x] Review from the native team if needed
- [x] No breaking changes

## :crystal_ball: Next steps
