### PR TITLE
chore: Remove master branch from ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This SDK is written in Objective-C but also provides a nice Swift interface.
 
 **Where is the master branch?**
 
-We renamed the default branch from `master` to `main`. We are going to keep the `master` branch for backwards compatibility for package managers pointing to the [`master` branch](https://github.com/getsentry/sentry-cocoa/tree/master).
+We renamed the default branch from `master` to `main`.
 
 # Initialization
 


### PR DESCRIPTION
We decided to remove the master branch from the GH repo, as users pointing to it won't notice that we migrated to the main branch. Pointing to the master branch is considered a bit experimental cause you always point to the latest changes without relying on official SDK releases.

#skip-changelog