### PR TITLE
PR template breaking changes for hybrid SDKs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,11 +13,12 @@
 
 <!--- Put an `x` in the boxes that apply -->
 
-- [ ] I reviewed the submitted code
-- [ ] I added tests to verify the changes
-- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled
-- [ ] I updated the docs if needed
-- [ ] Review from the native team if needed
-- [ ] No breaking changes
+- [ ] I reviewed the submitted code.
+- [ ] I added tests to verify the changes.
+- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
+- [ ] I updated the docs if needed.
+- [ ] Review from the native team if needed.
+- [ ] No breaking change or entry added to the changelog.
+- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
 
 ## :crystal_ball: Next steps


### PR DESCRIPTION
Add an item to remind the author of a PR to communicate breaking changes for hybrid SDKs.

Fixes https://github.com/getsentry/sentry-cocoa/issues/2672

#skip-changelog

Related to https://github.com/getsentry/sentry-java/pull/2511.