### PR TITLE
fix: Add missing atomic import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Cleanup AppHangTracking properly when closing SDK (#2671)
 - Add EXC_BAD_ACCESS subtypes to events (#2667)
-- Fix atomic import error for profiling (#2682)
+- Fix atomic import error for profiling (#2683)
 
 ## 8.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Cleanup AppHangTracking properly when closing SDK (#2671)
 - Add EXC_BAD_ACCESS subtypes to events (#2667)
+- Fix atomic import error for profiling (#2682)
 
 ## 8.1.0
 

--- a/Sources/Sentry/include/SentrySamplingProfiler.hpp
+++ b/Sources/Sentry/include/SentrySamplingProfiler.hpp
@@ -4,6 +4,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
+#    include <atomic>
 #    include <cstdint>
 #    include <functional>
 #    include <mach/mach.h>


### PR DESCRIPTION




## :scroll: Description

Add missing atomic import for SentryProfilingConditionals as for some nightly Swift versions the project didn't compile.

## :bulb: Motivation and Context

Fixes GH-2678

## :green_heart: How did you test it?

I didn't. Testing this with a nightly swift version is not worth the effort. We only added one import.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
