### PR TITLE
fix: Don't create breadcrumb for UITextField editingChanged event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Cleanup AppHangTracking properly when closing SDK (#2671)
 - Add EXC_BAD_ACCESS subtypes to events (#2667)
 - Fix atomic import error for profiling (#2683)
+- Don't create breadcrumb for UITextField editingChanged event (#2686)
 
 ## 8.1.0
 

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -50,8 +50,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = ""
-      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -149,7 +149,8 @@ SentryBreadcrumbTracker ()
         // Textfield may invoke many types of event, in order to check if is a
         // `UIControlEventEditingChanged` we need to compare the current action to all events
         // attached to the control. This may cause a false negative if the developer is using the
-        // same action for different events.
+        // same action for different events, but this trade off is acceptable because using the same
+        // action for `.editingChanged` and another event is not supposed to happen.
         UITextField *textField = sender;
         NSArray<NSString *> *actions = [textField actionsForTarget:target
                                                    forControlEvent:UIControlEventEditingChanged];

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -141,31 +141,46 @@ SentryBreadcrumbTracker ()
     [SentrySDK addBreadcrumb:crumb];
 }
 
++ (BOOL)avoidSender:(id)sender forTarget:(id)target action:(NSString *)action {
+#if SENTRY_HAS_UIKIT
+    if ([sender isKindOfClass:UITextField.self]) {
+        //This is required to avoid creating breadcrumbs for every key pressed in a text field.
+        //Textfield may invoke many types of event, in order to check if is a `UIControlEventEditingChanged`
+        //we need to compare the current action to all events attached to the control.
+        //This may cause a false negative if the developer is using the same action for different events.
+        UITextField* textField = sender;
+        NSArray<NSString *> * actions = [textField actionsForTarget:target forControlEvent:UIControlEventEditingChanged];
+        return [actions containsObject:action];
+    }
+#endif
+
+    return false;
+}
+
 - (void)swizzleSendAction
 {
 #if SENTRY_HAS_UIKIT
-
     [self.swizzleWrapper
-        swizzleSendAction:^(NSString *action, id target, id sender, UIEvent *event) {
-            if ([SentrySDK.currentHub getClient] == nil) {
-                return;
-            }
-
-            NSDictionary *data = nil;
-            for (UITouch *touch in event.allTouches) {
-                if (touch.phase == UITouchPhaseCancelled || touch.phase == UITouchPhaseEnded) {
-                    data = [SentryBreadcrumbTracker extractDataFromView:touch.view];
-                }
-            }
-
-            SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo
-                                                                     category:@"touch"];
-            crumb.type = @"user";
-            crumb.message = action;
-            crumb.data = data;
-            [SentrySDK addBreadcrumb:crumb];
+     swizzleSendAction:^(NSString *action, id target, id sender, UIEvent *event) {
+        if ([SentrySDK.currentHub getClient] == nil || [SentryBreadcrumbTracker avoidSender:sender forTarget:target action:action]) {
+            return;
         }
-                   forKey:SentryBreadcrumbTrackerSwizzleSendAction];
+
+        NSDictionary *data = nil;
+        for (UITouch *touch in event.allTouches) {
+            if (touch.phase == UITouchPhaseCancelled || touch.phase == UITouchPhaseEnded) {
+                data = [SentryBreadcrumbTracker extractDataFromView:touch.view];
+            }
+        }
+
+        SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo
+                                                                 category:@"touch"];
+        crumb.type = @"user";
+        crumb.message = action;
+        crumb.data = data;
+        [SentrySDK addBreadcrumb:crumb];
+    }
+     forKey:SentryBreadcrumbTrackerSwizzleSendAction];
 
 #else
     SENTRY_LOG_DEBUG(@"NO UIKit -> [SentryBreadcrumbTracker swizzleSendAction] does nothing.");

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -141,9 +141,9 @@ SentryBreadcrumbTracker ()
     [SentrySDK addBreadcrumb:crumb];
 }
 
+#if SENTRY_HAS_UIKIT
 + (BOOL)avoidSender:(id)sender forTarget:(id)target action:(NSString *)action
 {
-#if SENTRY_HAS_UIKIT
     if ([sender isKindOfClass:UITextField.self]) {
         // This is required to avoid creating breadcrumbs for every key pressed in a text field.
         // Textfield may invoke many types of event, in order to check if is a
@@ -155,10 +155,9 @@ SentryBreadcrumbTracker ()
                                                    forControlEvent:UIControlEventEditingChanged];
         return [actions containsObject:action];
     }
-#endif
-
     return false;
 }
+#endif
 
 - (void)swizzleSendAction
 {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -120,11 +120,11 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
     }
 
     func test_dont_avoidSender_not_UITextField() {
-        let uiSwitch = UISwitch()
+        let button = UIButton()
         let viewController = ViewControllerForBreadcrumbTest()
-        uiSwitch.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .editingChanged)
+        button.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .touchUpInside)
 
-        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(uiSwitch, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) ).asBool ?? false
+        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(button, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) ).asBool ?? false
 
         XCTAssertFalse(result)
     }

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -97,6 +97,54 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         XCTAssertEqual(result?["view"] as? String, String(describing: view))
         XCTAssertNil(result?["title"] as Any?)
     }
+
+    func test_avoidSender() {
+        let textField = UITextField()
+        let viewController = ViewControllerForBreadcrumbTest()
+        textField.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .editingChanged)
+
+        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(textField, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldTextChanged(_:))) ).asBool ?? false
+
+        XCTAssertTrue(result)
+    }
+
+    func test_dont_avoidSender() {
+        let textField = UITextField()
+        let viewController = ViewControllerForBreadcrumbTest()
+        textField.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .editingChanged)
+        textField.addTarget(viewController, action: #selector(viewController.textFieldEndChange(_:)), for: .editingDidEnd)
+
+        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(textField, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) ).asBool ?? false
+
+        XCTAssertFalse(result)
+    }
+
+    func test_dont_avoidSender_not_UITextField() {
+        let uiSwitch = UISwitch()
+        let viewController = ViewControllerForBreadcrumbTest()
+        uiSwitch.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .editingChanged)
+
+        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(uiSwitch, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) ).asBool ?? false
+
+        XCTAssertFalse(result)
+    }
+
 #endif
     
 }
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+private class ViewControllerForBreadcrumbTest : UIViewController {
+
+    @objc
+    func textFieldTextChanged(_ sender : Any) {
+    }
+
+    @objc
+    func textFieldEndChange(_ sender : Any) {
+    }
+
+}
+
+#endif


### PR DESCRIPTION
## :scroll: Description

Created a filter to avoid creating breadcrumbs for every key pressed in a UITextField control

## :bulb: Motivation and Context

close #2682 

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
