### PR TITLE
feat: add profiling context info to transactions

### DIFF
--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -1,8 +1,10 @@
+#import "SentryProfilingConditionals.h"
 #import "SentrySampleDecision.h"
 #import "SentrySpanContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SentryId;
 @class SentrySpanId;
 @class SentryThread;
 
@@ -25,6 +27,15 @@ SENTRY_NO_INIT
  * Sample rate used for this transaction
  */
 @property (nonatomic, strong, nullable) NSNumber *sampleRate;
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+/**
+ * The profile associated with the transaction.
+ * @note Only one profile may be associated with a transaction, but many transactions may be
+ * associated with the same profile.
+ */
+@property (nonatomic, strong, nullable) SentryId *profileID;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 /**
  * Init a SentryTransactionContext with given name and set other fields by default

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -327,6 +327,7 @@ processFrameRates(SentryFrameInfoTimeSeries *frameRates, uint64_t start)
 }
 
 + (SentryEnvelopeItem *)createProfilingEnvelopeItemForTransaction:(SentryTransaction *)transaction
+                                                        profileID:(SentryId *)profileID
 {
     std::lock_guard<std::mutex> l(_gProfilerLock);
 
@@ -420,7 +421,6 @@ processFrameRates(SentryFrameInfoTimeSeries *frameRates, uint64_t start)
     }
 
     // add the remaining basic metadata for the profile
-    const auto profileID = [[SentryId alloc] init];
     [self serializeBasicProfileInfo:payload
                     profileDuration:profileDuration
                           profileID:profileID

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -537,12 +537,15 @@ static NSMutableArray<SentrySpanId *> *_gInFlightSpanIDs;
         return;
     }
 
+    SentryId *profileID = [[SentryId alloc] init];
     SentryEnvelopeItem *profileEnvelopeItem =
-        [SentryProfiler createProfilingEnvelopeItemForTransaction:transaction];
+        [SentryProfiler createProfilingEnvelopeItemForTransaction:transaction profileID:profileID];
     if (!profileEnvelopeItem) {
         [_hub captureTransaction:transaction withScope:_hub.scope];
         return;
     }
+
+    _transactionContext.profileID = profileID;
 
     SENTRY_LOG_DEBUG(@"Capturing transaction with profiling data attached.");
     [_hub captureTransaction:transaction

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -1,7 +1,9 @@
 #import "SentryTransaction.h"
 #import "NSDictionary+SentrySanitize.h"
 #import "SentryEnvelopeItemType.h"
+#import "SentryId.h"
 #import "SentryMeasurementValue.h"
+#import "SentryProfilingConditionals.h"
 #import "SentryTransactionContext.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -86,9 +88,15 @@ SentryTransaction ()
 
     if (self.trace) {
         [serializedData setValue:self.trace.transactionContext.name forKey:@"transaction"];
-
         serializedData[@"transaction_info"] =
             @{ @"source" : [self stringForNameSource:self.trace.transactionContext.nameSource] };
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+        if (self.trace.transactionContext.profileID) {
+            serializedData[@"contexts"][@"profile"] = @{
+                @"profile_id" : self.trace.transactionContext.profileID.sentryIdString,
+            };
+        }
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
 
     return serializedData;

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -63,7 +63,8 @@ SENTRY_EXTERN_C_END
 /** Given a transaction, return an envelope item containing any corresponding profile data to be
  * attached to the transaction envelope. */
 + (nullable SentryEnvelopeItem *)createProfilingEnvelopeItemForTransaction:
-    (SentryTransaction *)transaction;
+                                     (SentryTransaction *)transaction
+                                                                 profileID:(SentryId *)profileID;
 
 @end
 

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 class TestClient: SentryClient {
+    typealias CapturedEvent = (event: Event, scope: Scope, additionalEnvelopeItems: [SentryEnvelopeItem])
+
     override init?(options: Options) {
         super.init(options: options, fileManager: try! TestFileManager(options: options))
     }
@@ -36,7 +38,7 @@ class TestClient: SentryClient {
         return event.eventId
     }
     
-    var captureEventWithScopeInvocations = Invocations<(event: Event, scope: Scope, additionalEnvelopeItems: [SentryEnvelopeItem])>()
+    var captureEventWithScopeInvocations = Invocations<CapturedEvent>()
     override func capture(event: Event, scope: Scope, additionalEnvelopeItems: [SentryEnvelopeItem]) -> SentryId {
         captureEventWithScopeInvocations.record((event, scope, additionalEnvelopeItems))
         return event.eventId


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

Add a new subdictionary to transaction event envelopes under `contexts` named `profile` that contains the associated profile ID, if there was a profile running during the transaction. For https://github.com/getsentry/team-profiling/issues/165.

## :bulb: Motivation and Context

See https://github.com/getsentry/rfcs/blob/main/text/0047-introduce-profile-context.md.

## :green_heart: How did you test it?

Added a test point to `testStartTransaction_ProfilingDataIsValid` to ensure the profile ID is located in the proper place in the data structure of the serialized transaction.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
~- [ ] I updated the docs if needed.~
~- [ ] Review from the native team if needed.~
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
