### PR TITLE
chore: Add missing changelog for 2535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ We renamed the default branch from `master` to `main`. We are going to keep the 
   - [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic) 
   - [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic)
   - [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic)
+- Add a timeout for auto-generated transactions (#2535)
 
 ### Fixes
 


### PR DESCRIPTION
We missed adding https://github.com/getsentry/sentry-cocoa/pull/2535 to the Changelog of 8.0.0.

#skip-changelog