### PR TITLE
fix: EXC_BAD_ACCESS in SentryTracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Keep status of auto transactions when finishing (#2684)
 - Fix atomic import error for profiling (#2683)
 - Don't create breadcrumb for UITextField editingChanged event (#2686)
+- Fix EXC_BAD_ACCESS in SentryTracer (#2697)
 
 ## 8.1.0
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -212,8 +212,14 @@ static BOOL appStartMeasurementRead;
     if (_idleTimeoutBlock != nil) {
         [self.dispatchQueueWrapper dispatchCancel:_idleTimeoutBlock];
     }
-    __block SentryTracer *_self = self;
-    _idleTimeoutBlock = dispatch_block_create(0, ^{ [_self finishInternal]; });
+    __weak SentryTracer *weakSelf = self;
+    _idleTimeoutBlock = dispatch_block_create(0, ^{
+        if (weakSelf == nil) {
+            SENTRY_LOG_DEBUG(@"WeakSelf is nil. Not doing anything.");
+            return;
+        }
+        [weakSelf finishInternal];
+    });
     [self.dispatchQueueWrapper dispatchAfter:self.idleTimeout block:_idleTimeoutBlock];
 }
 

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -431,6 +431,23 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(expectedEndTimestamp, sut.timestamp)
     }
     
+    func testIdleTimeout_TracerDeallocated() {
+        // Interact with sut in extra function so ARC deallocates it
+        func getSut() {
+            let sut = fixture.getSut(idleTimeout: fixture.idleTimeout, dispatchQueueWrapper: fixture.dispatchQueue)
+            
+            _ = sut.startChild(operation: fixture.transactionOperation)
+        }
+        
+        getSut()
+            
+        for dispatchAfterBlock in fixture.dispatchQueue.dispatchAfterInvocations.invocations {
+            dispatchAfterBlock.block()
+        }
+        
+        XCTAssertEqual(0, fixture.hub.capturedEventsWithScopes.count)
+    }
+    
     func testNonIdleTransaction_CallFinish_DoesNotTrimEndTimestamp() {
         let sut = fixture.getSut()
         


### PR DESCRIPTION




## :scroll: Description

Fix EXC_BAD_ACCESS in SentryTracer by using a weak reference when dispatching the idle timeout to avoid accessing a garbage pointer.

## :bulb: Motivation and Context

Fixes GH-2696

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
