### PR TITLE
fix: Added 'strong' attribute to `SentrySpanProtocol` properties

### DIFF
--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -12,17 +12,17 @@ NS_SWIFT_NAME(Span)
 /**
  * Determines which trace the Span belongs to.
  */
-@property (nonatomic) SentryId *traceId;
+@property (nonatomic, strong) SentryId *traceId;
 
 /**
  * Span id.
  */
-@property (nonatomic) SentrySpanId *spanId;
+@property (nonatomic, strong) SentrySpanId *spanId;
 
 /**
  * The id of the parent span.
  */
-@property (nullable, nonatomic) SentrySpanId *parentSpanId;
+@property (nullable, nonatomic, strong) SentrySpanId *parentSpanId;
 
 /**
  * The sampling decision of the trace.


### PR DESCRIPTION
## :scroll: Description

Adding the `strong` attribute to `SentrySpanProtocol` where applicable.

## :bulb: Motivation and Context

I consume the Cocoa SDK `8.1.0` as part of the Unreal SDK in this form:
```
Mac/
├─ bin/
│  ├─ sentry.dylib
├─ include/
│  ├─ Headers/
│  ├─ PrivateHeaders/
```

When trying to build the compilation fails with
```
error - no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed [-Werror,-Wobjc-property-no-attribute]
error - default property attribute 'assign' not appropriate for object [-Werror,-Wobjc-property-no-attribute]
```

After going over it with @brustolin it looks like `assign` is indeed the [wrong attribute](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjectiveC/Chapters/ocProperties.html#:~:text=%C2%A0%20protocol.-,assign,this%20attribute%20for%20scalar%20types%20such%20as%20NSInteger%20and%20CGRect.,-retain) and instead it should be `strong`.

## :green_heart: How did you test it?

## :pencil: Checklist

<!--- Put an `x` in the boxes that apply -->

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

_#skip-changelog_
