### PR TITLE
chore: PR template check all checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@
 
 ## :pencil: Checklist
 
-<!--- Put an `x` in the boxes that apply -->
+You have to check all boxes before merging:
 
 - [ ] I reviewed the submitted code.
 - [ ] I added tests to verify the changes.


### PR DESCRIPTION
Make it clearer to check all checkboxes of the checklist before merging a PR.

#skip-changelog

