### PR TITLE
chore: Upload iOS-Swift dSYMs patch script

### DIFF
--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -51,6 +51,15 @@ Once daily and for every PR via [Github action](../.github/workflows/benchmarkin
     - Sauce Labs allows relaxing the timeout for a suite of tests and for a `XCTestCase` subclass' collection of test case methods, but each test case in the suite must run in less than 15 minutes. 20 trials takes too long, so we split it up into multiple test cases, each running a subset of the trials. 
     - This is done by dynamically generating test case methods in `SentrySDKPerformanceBenchmarkTests`, which is necessarily written in Objective-C since this is not possible to do in Swift tests. By doing this dynamically, we can easily fine tune how we split up the work to account for changes in the test duration or in constraints on how things run in Sauce Labs etc.
 
+## Upload iOS-Swift's dSYMs with Xcode Run Script
+
+The following script applies a patch so Xcode uploads the iOS-Swift's dSYMs to Sentry during Xcode's build phase.
+Ensure to not commit the patch file after running this script, which then contains your auth token.
+
+```sh
+./scripts/upload-dsyms-with-xcode-build-phase.sh YOUR_AUTH_TOKEN
+```
+
 ## Auto UI Performance Class Overview
 
 ![Auto UI Performance Class Overview](./auto-ui-performance-tracking.svg)

--- a/scripts/upload-dsyms-with-xcode-build-phase.patch
+++ b/scripts/upload-dsyms-with-xcode-build-phase.patch
@@ -1,0 +1,40 @@
+diff --git a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+index 9adac264..8ef3a3bb 100644
+--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
++++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+@@ -561,6 +561,7 @@
+ 				637AFDA4243B02760034958B /* Resources */,
+ 				630853552440C60F00DDE4CE /* Embed Frameworks */,
+ 				D840D535273A07F600CDF142 /* Embed App Clips */,
++				62F226AA29A35FAE0038080D /* ShellScript */,
+ 			);
+ 			buildRules = (
+ 			);
+@@ -821,6 +822,27 @@
+ 		};
+ /* End PBXResourcesBuildPhase section */
+ 
++/* Begin PBXShellScriptBuildPhase section */
++		62F226AA29A35FAE0038080D /* ShellScript */ = {
++			isa = PBXShellScriptBuildPhase;
++			buildActionMask = 2147483647;
++			files = (
++			);
++			inputFileListPaths = (
++			);
++			inputPaths = (
++				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
++			);
++			outputFileListPaths = (
++			);
++			outputPaths = (
++			);
++			runOnlyForDeploymentPostprocessing = 0;
++			shellPath = /bin/sh;
++			shellScript = "if which sentry-cli >/dev/null; then\nexport SENTRY_ORG=sentry-sdks\nexport SENTRY_PROJECT=sentry-cocoa\nexport SENTRY_AUTH_TOKEN=YOUR_AUTH_TOKEN\nERROR=$(sentry-cli upload-dif \"$DWARF_DSYM_FOLDER_PATH\" 2>&1 >/dev/null)\nif [ ! $? -eq 0 ]; then\necho \"warning: sentry-cli - $ERROR\"\nfi\nelse\necho \"warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases\"\nfi\n";
++		};
++/* End PBXShellScriptBuildPhase section */
++
+ /* Begin PBXSourcesBuildPhase section */
+ 		637AFDA2243B02760034958B /* Sources */ = {
+ 			isa = PBXSourcesBuildPhase;

--- a/scripts/upload-dsyms-with-xcode-build-phase.sh
+++ b/scripts/upload-dsyms-with-xcode-build-phase.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -uox pipefail
+
+# Use this script to apply a patch so Xcode uploads the iOS-Swift's dSYMs to
+# Sentry during Xcode's build phase.
+# Ensure to not commit the patch file after running this script, which then contains
+# your auth token.
+
+SENTRY_AUTH_TOKEN="${1}"
+
+# Replace revision with SHA
+REPLACE="s/YOUR_AUTH_TOKEN/${SENTRY_AUTH_TOKEN}/g"
+sed -i '' $REPLACE ./scripts/upload-dsyms-with-xcode-build-phase.patch
+
+git apply ./scripts/upload-dsyms-with-xcode-build-phase.patch


### PR DESCRIPTION
Add a script that applies a patch, so Xcode uploads iOS-Swift's dSyms to Sentry when building.

#skip-changelog