### PR TITLE
fix: Serialization of nullable booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix atomic import error for profiling (#2683)
 - Don't create breadcrumb for UITextField editingChanged event (#2686)
 - Fix EXC_BAD_ACCESS in SentryTracer (#2697)
+- Serialization of nullable booleans (#2706)
 
 ### Improvements
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		15E0A8F0240F638200F044E3 /* SentrySerializationNilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 15E0A8EF240F638200F044E3 /* SentrySerializationNilTests.m */; };
 		15E0A8F22411A45A00F044E3 /* SentrySession.m in Sources */ = {isa = PBXBuildFile; fileRef = 15E0A8F12411A45A00F044E3 /* SentrySession.m */; };
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
+		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
 		630435FE1EBCA9D900C4D3FA /* SentryNSURLRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 630435FC1EBCA9D900C4D3FA /* SentryNSURLRequest.h */; };
 		630435FF1EBCA9D900C4D3FA /* SentryNSURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 630435FD1EBCA9D900C4D3FA /* SentryNSURLRequest.m */; };
 		6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */ = {isa = PBXBuildFile; fileRef = 630436081EC0595B00C4D3FA /* NSData+SentryCompression.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -880,6 +881,8 @@
 		15E0A8EF240F638200F044E3 /* SentrySerializationNilTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySerializationNilTests.m; sourceTree = "<group>"; };
 		15E0A8F12411A45A00F044E3 /* SentrySession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySession.m; sourceTree = "<group>"; };
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
+		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
+		62F226B829A37C270038080D /* SentryBooleanSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryBooleanSerialization.h; sourceTree = "<group>"; };
 		630435FC1EBCA9D900C4D3FA /* SentryNSURLRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNSURLRequest.h; path = include/SentryNSURLRequest.h; sourceTree = "<group>"; };
 		630435FD1EBCA9D900C4D3FA /* SentryNSURLRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryNSURLRequest.m; sourceTree = "<group>"; };
 		630436081EC0595B00C4D3FA /* NSData+SentryCompression.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "NSData+SentryCompression.h"; path = "include/NSData+SentryCompression.h"; sourceTree = "<group>"; };
@@ -2915,6 +2918,8 @@
 				7B72D23928D074BC0014798A /* TestExtensions.swift */,
 				7BB7E7C629267A28004BF96B /* EmptyIntegration.swift */,
 				7B4F22DB294089530067EA17 /* FormatHexAddress.swift */,
+				62F226B829A37C270038080D /* SentryBooleanSerialization.h */,
+				62F226B629A37C120038080D /* SentryBooleanSerialization.m */,
 			);
 			path = TestUtils;
 			sourceTree = "<group>";
@@ -4066,6 +4071,7 @@
 				0A94158228F6C4C2006A5DD1 /* SentryAppStateManagerTests.swift in Sources */,
 				7B6D98E924C6D336005502FA /* SentrySdkInfo+Equality.m in Sources */,
 				7BDB03BF25136A7D00BAE198 /* TestSentryDispatchQueueWrapper.swift in Sources */,
+				62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */,
 				7B6438A726A70DDB000D0F65 /* UIViewControllerSentryTests.swift in Sources */,
 				15E0A8F0240F638200F044E3 /* SentrySerializationNilTests.m in Sources */,
 				0A2D8D8728992260008720F6 /* SentryBaseIntegrationTests.swift in Sources */,

--- a/Sources/Sentry/NSMutableDictionary+Sentry.m
+++ b/Sources/Sentry/NSMutableDictionary+Sentry.m
@@ -18,4 +18,11 @@ NSMutableDictionary (Sentry)
     }];
 }
 
+- (void)setBoolValue:(nullable NSNumber *)value forKey:(NSString *)key
+{
+    if (value != nil) {
+        [self setValue:@([value boolValue]) forKey:key];
+    }
+}
+
 @end

--- a/Sources/Sentry/SentryFrame.m
+++ b/Sources/Sentry/SentryFrame.m
@@ -1,4 +1,5 @@
 #import "SentryFrame.h"
+#import "NSMutableDictionary+Sentry.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -27,8 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.imageAddress forKey:@"image_addr"];
     [serializedData setValue:self.instructionAddress forKey:@"instruction_addr"];
     [serializedData setValue:self.platform forKey:@"platform"];
-    [serializedData setValue:self.inApp forKey:@"in_app"];
-    [serializedData setValue:self.stackStart forKey:@"stack_start"];
+    [serializedData setBoolValue:self.inApp forKey:@"in_app"];
+    [serializedData setBoolValue:self.stackStart forKey:@"stack_start"];
 
     return serializedData;
 }

--- a/Sources/Sentry/SentryMechanism.m
+++ b/Sources/Sentry/SentryMechanism.m
@@ -1,5 +1,6 @@
 #import "SentryMechanism.h"
 #import "NSDictionary+SentrySanitize.h"
+#import "NSMutableDictionary+Sentry.h"
 #import "SentryMechanismMeta.h"
 #import "SentryNSError.h"
 
@@ -20,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSMutableDictionary *serializedData = @{ @"type" : self.type }.mutableCopy;
 
-    [serializedData setValue:self.handled forKey:@"handled"];
+    [serializedData setBoolValue:self.handled forKey:@"handled"];
     [serializedData setValue:self.synthetic forKey:@"synthetic"];
     [serializedData setValue:self.desc forKey:@"description"];
     [serializedData setValue:[self.data sentry_sanitize] forKey:@"data"];

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -1,4 +1,5 @@
 #import "NSDate+SentryExtras.h"
+#import "NSMutableDictionary+Sentry.h"
 #import "SentryCurrentDate.h"
 #import "SentryInstallation.h"
 #import "SentryLog.h"
@@ -201,9 +202,7 @@ nameForSentrySessionStatus(SentrySessionStatus status)
         }
                                                   .mutableCopy;
 
-        if (_init != nil) {
-            [serializedData setValue:_init forKey:@"init"];
-        }
+        [serializedData setBoolValue:_init forKey:@"init"];
 
         NSString *statusString = nameForSentrySessionStatus(_status);
 

--- a/Sources/Sentry/SentryStacktrace.m
+++ b/Sources/Sentry/SentryStacktrace.m
@@ -1,4 +1,5 @@
 #import "SentryStacktrace.h"
+#import "NSMutableDictionary+Sentry.h"
 #import "SentryFrame.h"
 #import "SentryLog.h"
 
@@ -55,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.registers.count > 0) {
         [serializedData setValue:self.registers forKey:@"registers"];
     }
-    [serializedData setValue:self.snapshot forKey:@"snapshot"];
+    [serializedData setBoolValue:self.snapshot forKey:@"snapshot"];
 
     return serializedData;
 }

--- a/Sources/Sentry/SentryThread.m
+++ b/Sources/Sentry/SentryThread.m
@@ -1,4 +1,5 @@
 #import "SentryThread.h"
+#import "NSMutableDictionary+Sentry.h"
 #import "SentryStacktrace.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,11 +20,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary *serializedData =
         @{ @"id" : self.threadId ? self.threadId : @(99) }.mutableCopy;
 
-    [serializedData setValue:self.crashed forKey:@"crashed"];
-    [serializedData setValue:self.current forKey:@"current"];
+    [serializedData setBoolValue:self.crashed forKey:@"crashed"];
+    [serializedData setBoolValue:self.current forKey:@"current"];
     [serializedData setValue:self.name forKey:@"name"];
     [serializedData setValue:[self.stacktrace serialize] forKey:@"stacktrace"];
-    [serializedData setValue:self.isMain forKey:@"main"];
+    [serializedData setBoolValue:self.isMain forKey:@"main"];
 
     return serializedData;
 }

--- a/Sources/Sentry/include/NSMutableDictionary+Sentry.h
+++ b/Sources/Sentry/include/NSMutableDictionary+Sentry.h
@@ -12,6 +12,8 @@ NSMutableDictionary (Sentry)
  */
 - (void)mergeEntriesFromDictionary:(NSDictionary *)otherDictionary;
 
+- (void)setBoolValue:(nullable NSNumber *)value forKey:(NSString *)key;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Categories/NSMutableDictionarySentryTests.swift
+++ b/Tests/SentryTests/Categories/NSMutableDictionarySentryTests.swift
@@ -51,4 +51,42 @@ class NSMutableDictionarySentryTests: XCTestCase {
         
         XCTAssertEqual([0: 1], dict as? [Int: Int])
     }
+    
+    func testSetBool_Nil_DoesNotSetValue() {
+        let dict = NSMutableDictionary()
+        
+        dict.setBoolValue(nil, forKey: "key")
+        
+        XCTAssertEqual(0, dict.count)
+    }
+    
+    func testSetBool_True_SetsTrue() {
+        let dict = NSMutableDictionary()
+        
+        dict.setBoolValue(true, forKey: "key")
+        
+        XCTAssertTrue(dict["key"] as? Bool ?? false)
+    }
+    
+    func testSetBool_False_SetsFalse() {
+        let dict = NSMutableDictionary()
+        
+        dict.setBoolValue(false, forKey: "key")
+        
+        XCTAssertFalse(dict["key"] as? Bool ?? true)
+        XCTAssertEqual(0, dict["key"] as? NSNumber)
+    }
+    
+    func testSetBool_NonZero_SetsTrue() {
+        let dict = NSMutableDictionary()
+        
+        dict.setBoolValue(1, forKey: "key1")
+        dict.setBoolValue(-1, forKey: "key-1")
+        
+        XCTAssertTrue(dict["key1"] as? Bool ?? false)
+        XCTAssertEqual(1, dict["key1"] as? NSNumber)
+        
+        XCTAssertTrue(dict["key-1"] as? Bool ?? false)
+        XCTAssertEqual(1, dict["key-1"] as? NSNumber)
+    }
 }

--- a/Tests/SentryTests/Protocol/SentryFrameTests.swift
+++ b/Tests/SentryTests/Protocol/SentryFrameTests.swift
@@ -20,4 +20,9 @@ class SentryFrameTests: XCTestCase {
         XCTAssertEqual(frame.inApp, actual["in_app"] as? NSNumber)
         XCTAssertEqual(frame.stackStart, actual["stack_start"] as? NSNumber)
     }
+    
+    func testSerialize_Bools() {
+        SentryBooleanSerialization.test(Frame(), property: "inApp", serializedProperty: "in_app")
+        SentryBooleanSerialization.test(Frame(), property: "stackStart", serializedProperty: "stack_start")
+    }
 }

--- a/Tests/SentryTests/Protocol/SentryMechanismTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismTests.swift
@@ -38,4 +38,8 @@ class SentryMechanismTests: XCTestCase {
         XCTAssertEqual(1, actual.count)
         XCTAssertEqual(type, actual["type"] as? String)
     }
+    
+    func testSerialize_Bools() {
+        SentryBooleanSerialization.test(Mechanism(type: ""), property: "handled")
+    }
 }

--- a/Tests/SentryTests/Protocol/SentryStacktraceTests.swift
+++ b/Tests/SentryTests/Protocol/SentryStacktraceTests.swift
@@ -32,4 +32,8 @@ class SentryStacktraceTests: XCTestCase {
         
         XCTAssertNil(actual["frames"] as? [Any])
     }
+    
+    func testSerialize_Bools() {
+        SentryBooleanSerialization.test(SentryStacktrace(frames: [], registers: [:]), property: "snapshot")
+    }
 }

--- a/Tests/SentryTests/Protocol/SentryThreadTests.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadTests.swift
@@ -17,4 +17,12 @@ class SentryThreadTests: XCTestCase {
         XCTAssertNotNil(actual["stacktrace"])
         XCTAssertTrue(actual["main"] as! Bool)
     }
+    
+    func testSerialize_Bools() {
+        let thread = SentryThread(threadId: 0)
+        
+        SentryBooleanSerialization.test(thread, property: "crashed")
+        SentryBooleanSerialization.test(thread, property: "current")
+        SentryBooleanSerialization.test(thread, property: "isMain", serializedProperty: "main")
+    }
 }

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -97,6 +97,21 @@ class SentrySessionTestsSwift: XCTestCase {
         setValue(&serialized)
         XCTAssertNil(SentrySession(jsonObject: serialized))
     }
+    
+    func testSerialize_Bools() {
+        let session = SentrySession(releaseName: "")
+
+        var json = session.serialize()
+        json["init"] = 2
+        
+        let session2 = SentrySession(jsonObject: json)
+        
+        let result = session2!.serialize() 
+        
+        XCTAssertTrue(result["init"] as? Bool ?? false)
+        XCTAssertNotEqual(2, result["init"] as? NSNumber ?? 2)
+        
+    }
 }
 
 extension SentrySessionStatus {

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -21,6 +21,7 @@
 #import "SentryAutoBreadcrumbTrackingIntegration.h"
 #import "SentryAutoSessionTrackingIntegration.h"
 #import "SentryBaggage.h"
+#import "SentryBooleanSerialization.h"
 #import "SentryBreadcrumbTracker.h"
 #import "SentryByteCountFormatter.h"
 #import "SentryClassRegistrator.h"

--- a/Tests/SentryTests/TestUtils/SentryBooleanSerialization.h
+++ b/Tests/SentryTests/TestUtils/SentryBooleanSerialization.h
@@ -1,0 +1,17 @@
+#import "SentrySerializable.h"
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryBooleanSerialization : NSObject
+
++ (void)testBooleanSerialization:(id<SentrySerializable>)serializable property:(NSString *)property;
+
++ (void)testBooleanSerialization:(id<SentrySerializable>)serializable
+                        property:(NSString *)property
+              serializedProperty:(NSString *)serializedProperty;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/TestUtils/SentryBooleanSerialization.m
+++ b/Tests/SentryTests/TestUtils/SentryBooleanSerialization.m
@@ -1,0 +1,43 @@
+#import "SentryBooleanSerialization.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@implementation SentryBooleanSerialization
+
++ (void)testBooleanSerialization:(id<SentrySerializable>)serializable property:(NSString *)property
+{
+    [SentryBooleanSerialization testBooleanSerialization:serializable
+                                                property:property
+                                      serializedProperty:property];
+}
+
++ (void)testBooleanSerialization:(id<SentrySerializable>)serializable
+                        property:(NSString *)property
+              serializedProperty:(NSString *)serializedProperty
+{
+    NSString *selectorString =
+        [NSString stringWithFormat:@"set%@%@:", [[property substringToIndex:1] uppercaseString],
+                  [property substringFromIndex:1]];
+    SEL selector = NSSelectorFromString(selectorString);
+    NSAssert([serializable respondsToSelector:selector], @"Object doesn't have a property '%@'",
+        property);
+
+    NSInvocation *invocation = [NSInvocation
+        invocationWithMethodSignature:[[serializable class]
+                                          instanceMethodSignatureForSelector:selector]];
+    [invocation setSelector:selector];
+    [invocation setTarget:serializable];
+    NSNumber *param1 = @2;
+    [invocation setArgument:&param1 atIndex:2];
+    [invocation invoke];
+
+    NSDictionary *result = [serializable serialize];
+
+    XCTAssertTrue(result[serializedProperty]);
+    XCTAssertNotEqual(param1, result[serializedProperty]);
+}
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION


## :scroll: Description

The protocol contains a couple of nullable BOOLs that are of type NSNumber. Setting these properties to something different than 0 or 1 leads to a serialized NSNumber, which violates the protocol. With this refactoring 0 value always means false, and any nonzero value is interpreted as true when serializing such nullable BOOLs.

## :bulb: Motivation and Context

Came up while investigating issues for MetricKit, as the server complained for invalid boolean values.
<img width="450" alt="Screenshot 2023-02-20 at 11 50 49" src="https://user-images.githubusercontent.com/2443292/220084869-fce8179f-1e77-4bbe-83a0-01d6c189ea9d.png">


## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
