### PR TITLE
build: Update fastlane from 2.210.1 to 2.212.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,7 @@ source "https://rubygems.org"
 
 gem "bundler", ">= 2"
 gem "cocoapods", ">= 1.9.1"
-# Pin fastlane to 2.210.1 to avoid CI failure with "Could not install WWDR certificate" until
-# https://github.com/fastlane/fastlane/issues/20960 is resolved.
-gem "fastlane", "= 2.210.1" 
+gem "fastlane"
 gem "rest-client"
 gem "xcpretty"
 gem "slather"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.5)
+    CFPropertyList (3.0.6)
       rexml
-    activesupport (6.1.7.1)
+    activesupport (6.1.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -17,8 +17,8 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.695.0)
-    aws-sdk-core (3.169.0)
+    aws-partitions (1.714.0)
+    aws-sdk-core (3.170.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
@@ -26,7 +26,7 @@ GEM
     aws-sdk-kms (1.62.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.118.0)
+    aws-sdk-s3 (1.119.1)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
@@ -76,7 +76,7 @@ GEM
     colored2 (3.1.2)
     commander (4.6.0)
       highline (~> 2.0.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.0)
     declarative (0.0.20)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
@@ -87,7 +87,7 @@ GEM
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    excon (0.97.1)
+    excon (0.99.0)
     faraday (1.10.3)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -117,7 +117,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.210.1)
+    fastlane (2.212.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -156,15 +156,15 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
-    fastlane-plugin-sentry (1.14.0)
+    fastlane-plugin-sentry (1.15.0)
       os (~> 1.1, >= 1.1.4)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.32.0)
+    google-apis-androidpublisher_v3 (0.34.0)
       google-apis-core (>= 0.9.1, < 2.a)
-    google-apis-core (0.9.5)
+    google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
       googleauth (>= 0.16.2, < 2.a)
       httpclient (>= 2.8.1, < 3.a)
@@ -173,8 +173,8 @@ GEM
       retriable (>= 2.0, < 4.a)
       rexml
       webrick
-    google-apis-iamcredentials_v1 (0.16.0)
-      google-apis-core (>= 0.9.1, < 2.a)
+    google-apis-iamcredentials_v1 (0.17.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-playcustomapp_v1 (0.12.0)
       google-apis-core (>= 0.9.1, < 2.a)
     google-apis-storage_v1 (0.19.0)
@@ -208,12 +208,12 @@ GEM
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jmespath (1.6.2)
-    json (2.6.2)
-    jwt (2.6.0)
+    json (2.6.3)
+    jwt (2.7.0)
     memoist (0.16.2)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2022.0105)
+    mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.1)
@@ -225,7 +225,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.14.0)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     optparse (0.1.1)
@@ -255,7 +255,7 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    simctl (1.6.8)
+    simctl (1.6.10)
       CFPropertyList
       naturally
     slather (2.7.4)
@@ -274,14 +274,14 @@ GEM
       tty-cursor (~> 0.7)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (2.0.5)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     uber (0.1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
-    webrick (1.7.0)
+    webrick (1.8.1)
     word_wrap (1.0.0)
     xcodeproj (1.22.0)
       CFPropertyList (>= 2.3.3, < 4.0)
@@ -294,7 +294,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby
@@ -302,11 +302,11 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 2)
   cocoapods (>= 1.9.1)
-  fastlane (= 2.210.1)
+  fastlane
   fastlane-plugin-sentry
   rest-client
   slather
   xcpretty
 
 BUNDLED WITH
-   2.3.21
+   2.4.7


### PR DESCRIPTION
https://github.com/fastlane/fastlane/issues/20960 is now fixed so we can update to the latest version.

#skip-changelog