### PR TITLE
ref: Add delegate for SystemEventCrumbs

### DIFF
--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -5,6 +5,7 @@
 #import "SentryFileManager.h"
 #import "SentryLog.h"
 #import "SentryOptions.h"
+#import "SentrySDK.h"
 #import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,7 +20,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 @implementation SentryAutoBreadcrumbTrackingIntegration
 
-- (BOOL)installWithOptions:(nonnull SentryOptions *)options
+- (BOOL)installWithOptions:(SentryOptions *)options
 {
     if (![super installWithOptions:options]) {
         return NO;
@@ -59,7 +60,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
     }
 
     self.systemEventBreadcrumbs = systemEventBreadcrumbs;
-    [self.systemEventBreadcrumbs start];
+    [self.systemEventBreadcrumbs startWithDelegate:self];
 }
 
 - (void)uninstall
@@ -70,6 +71,11 @@ SentryAutoBreadcrumbTrackingIntegration ()
     if (nil != self.systemEventBreadcrumbs) {
         [self.systemEventBreadcrumbs stop];
     }
+}
+
+- (void)addBreadcrumb:(SentryBreadcrumb *)crumb
+{
+    [SentrySDK addBreadcrumb:crumb];
 }
 
 @end

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,5 +1,6 @@
 #import "SentryBaseIntegration.h"
 #import "SentryIntegrationProtocol.h"
+#import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -7,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This automatically adds breadcrumbs for different user actions.
  */
 @interface SentryAutoBreadcrumbTrackingIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol>
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentrySystemEventBreadcrumbsDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
@@ -6,7 +6,11 @@
 #    import <UIKit/UIKit.h>
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class SentryNSNotificationCenterWrapper;
+
+@protocol SentrySystemEventBreadcrumbsDelegate;
 
 @interface SentrySystemEventBreadcrumbs : NSObject
 SENTRY_NO_INIT
@@ -15,13 +19,22 @@ SENTRY_NO_INIT
              andCurrentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider
        andNotificationCenterWrapper:(SentryNSNotificationCenterWrapper *)notificationCenterWrapper;
 
-- (void)start;
+- (void)startWithDelegate:(id<SentrySystemEventBreadcrumbsDelegate>)delegate;
 
 #if TARGET_OS_IOS
-- (void)start:(UIDevice *)currentDevice;
+- (void)startWithDelegate:(id<SentrySystemEventBreadcrumbsDelegate>)delegate
+            currentDevice:(nullable UIDevice *)currentDevice;
 - (void)timezoneEventTriggered;
 #endif
 
 - (void)stop;
 
 @end
+
+@protocol SentrySystemEventBreadcrumbsDelegate <NSObject>
+
+- (void)addBreadcrumb:(SentryBreadcrumb *)crumb;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -6,6 +6,8 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
     private class Fixture {
         let tracker = SentryTestBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper.sharedInstance)
         
+        var systemEventBreadcrumbs: SentryTestSystemEventBreadcrumbs?
+        
         var sut: SentryAutoBreadcrumbTrackingIntegration {
             return SentryAutoBreadcrumbTrackingIntegration()
         }
@@ -23,21 +25,22 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
         clearTestState()
     }
 
-    func testInstallWithSwizzleEnabled_StartSwizzleCalled() {
+    func testInstallWithSwizzleEnabled_StartSwizzleCalled() throws {
         let sut = fixture.sut
         
-        sut.install(with: Options(), breadcrumbTracker: fixture.tracker, systemEventBreadcrumbs: SentrySystemEventBreadcrumbs(fileManager: SentryDependencyContainer.sharedInstance().fileManager, andCurrentDateProvider: DefaultCurrentDateProvider.sharedInstance(), andNotificationCenterWrapper: SentryNSNotificationCenterWrapper()))
+        try self.install(sut: sut)
         
         XCTAssertEqual(1, fixture.tracker.startInvocations.count)
         XCTAssertEqual(1, fixture.tracker.startSwizzleInvocations.count)
     }
     
-    func testInstallWithSwizzleDisabled_StartSwizzleNotCalled() {
+    func testInstallWithSwizzleDisabled_StartSwizzleNotCalled() throws {
         let sut = fixture.sut
         
         let options = Options()
         options.enableSwizzling = false
-        sut.install(with: options, breadcrumbTracker: fixture.tracker, systemEventBreadcrumbs: SentrySystemEventBreadcrumbs(fileManager: SentryDependencyContainer.sharedInstance().fileManager, andCurrentDateProvider: DefaultCurrentDateProvider.sharedInstance(), andNotificationCenterWrapper: SentryNSNotificationCenterWrapper()))
+        
+        try self.install(sut: sut, options: options)
         
         XCTAssertEqual(1, fixture.tracker.startInvocations.count)
         XCTAssertEqual(0, fixture.tracker.startSwizzleInvocations.count)
@@ -52,6 +55,39 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
 
         XCTAssertFalse(result)
     }
+    
+    func testInstall() throws {
+        let options = Options()
+        
+        let sut = SentryAutoBreadcrumbTrackingIntegration()
+        try self.install(sut: sut, options: options)
+        
+        let scope = Scope()
+        let hub = SentryHub(client: TestClient(options: Options()), andScope: scope)
+        SentrySDK.setCurrentHub(hub)
+        
+        let crumb = TestData.crumb
+        fixture.systemEventBreadcrumbs?.startWithdelegateInvocations.first?.add(crumb)
+        
+        let serializedScope = scope.serialize()
+                
+        XCTAssertNotNil(serializedScope["breadcrumbs"] as? [[String: Any]], "no scope.breadcrumbs")
+        
+        if let breadcrumbs = serializedScope["breadcrumbs"] as? [[String: Any]] {
+            XCTAssertNotNil(breadcrumbs.first, "scope.breadcrumbs is empty")
+            if let actualCrumb = breadcrumbs.first {
+                XCTAssertEqual(crumb.category, actualCrumb["category"] as? String)
+                XCTAssertEqual(crumb.type, actualCrumb["type"] as? String)
+            }
+        }
+    }
+    
+    private func install(sut: SentryAutoBreadcrumbTrackingIntegration, options: Options = Options()) throws {
+        
+        fixture.systemEventBreadcrumbs = SentryTestSystemEventBreadcrumbs(fileManager: try TestFileManager(options: options), andCurrentDateProvider: TestCurrentDateProvider(), andNotificationCenterWrapper: TestNSNotificationCenterWrapper())
+        
+        sut.install(with: options, breadcrumbTracker: fixture.tracker, systemEventBreadcrumbs: fixture.systemEventBreadcrumbs!)
+    }
 }
 
 private class SentryTestBreadcrumbTracker: SentryBreadcrumbTracker {
@@ -65,5 +101,13 @@ private class SentryTestBreadcrumbTracker: SentryBreadcrumbTracker {
     override func startSwizzle() {
         startSwizzleInvocations.record(Void())
     }
+
+}
+
+private class SentryTestSystemEventBreadcrumbs: SentrySystemEventBreadcrumbs {
     
+    let startWithdelegateInvocations = Invocations<SentrySystemEventBreadcrumbsDelegate>()
+    override func start(with delegate: SentrySystemEventBreadcrumbsDelegate) {
+        startWithdelegateInvocations.record(delegate)
+    }
 }

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -8,6 +8,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
     
     private class Fixture {
         let options: Options
+        let delegate = SentrySystemEventBreadcrumbTestDelegate()
         let fileManager: TestFileManager
         var currentDateProvider = TestCurrentDateProvider()
         let notificationCenterWrapper = TestNSNotificationCenterWrapper()
@@ -22,17 +23,14 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
             fileManager = try! TestFileManager(options: options, andCurrentDateProvider: currentDateProvider)
         }
 
-        func getSut(scope: Scope, currentDevice: UIDevice? = UIDevice.current) -> SentrySystemEventBreadcrumbs {
-            let client = SentryClient(options: self.options)
-            let hub = SentryHub(client: client, andScope: scope)
-            SentrySDK.setCurrentHub(hub)
-
+        func getSut(currentDevice: UIDevice? = UIDevice.current) -> SentrySystemEventBreadcrumbs {
             let systemEvents = SentrySystemEventBreadcrumbs(
                 fileManager: fileManager,
                 andCurrentDateProvider: currentDateProvider,
                 andNotificationCenterWrapper: notificationCenterWrapper
-            )!
-            systemEvents.start(currentDevice)
+            )
+            systemEvents.start(with: self.delegate, currentDevice: currentDevice)
+            
             return systemEvents
         }
     }
@@ -72,87 +70,76 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
     func testBatteryLevelBreadcrumb() {
         let currentDevice = MyUIDevice(batteryLevel: 0.56, batteryState: UIDevice.BatteryState.full)
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
-        _ = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        _ = fixture.getSut(currentDevice: currentDevice)
         
         postBatteryLevelNotification(uiDevice: currentDevice)
         
-        assertBatteryBreadcrumb(scope: scope, charging: true, level: 56)
+        assertBatteryBreadcrumb( charging: true, level: 56)
     }
     
     func testBatteryUnknownLevelBreadcrumb() {
         let currentDevice = MyUIDevice(batteryLevel: -1, batteryState: UIDevice.BatteryState.unknown)
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         postBatteryLevelNotification(uiDevice: currentDevice)
         
-        assertBatteryBreadcrumb(scope: scope, charging: false, level: -1)
+        assertBatteryBreadcrumb(charging: false, level: -1)
     }
     
     func testBatteryNotUnknownButNoLevelBreadcrumb() {
         let currentDevice = MyUIDevice(batteryLevel: -1, batteryState: UIDevice.BatteryState.full)
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         postBatteryLevelNotification(uiDevice: currentDevice)
         
-        assertBatteryBreadcrumb(scope: scope, charging: true, level: -1)
+        assertBatteryBreadcrumb(charging: true, level: -1)
     }
     
     func testBatteryChargingStateBreadcrumb() {
         let currentDevice = MyUIDevice()
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         postBatteryLevelNotification(uiDevice: currentDevice)
         
-        assertBatteryBreadcrumb(scope: scope, charging: true, level: 100)
+        assertBatteryBreadcrumb(charging: true, level: 100)
     }
     
     func testBatteryNotChargingStateBreadcrumb() {
         let currentDevice = MyUIDevice(batteryState: UIDevice.BatteryState.unplugged)
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         NotificationCenter.default.post(Notification(name: UIDevice.batteryStateDidChangeNotification, object: currentDevice))
         
-        assertBatteryBreadcrumb(scope: scope, charging: false, level: 100)
+        assertBatteryBreadcrumb(charging: false, level: 100)
     }
     
-    private func assertBatteryBreadcrumb(scope: Scope, charging: Bool, level: Float) {
-        let ser = scope.serialize()
+    private func assertBatteryBreadcrumb(charging: Bool, level: Float) {
         
-        XCTAssertNotNil(ser["breadcrumbs"] as? [[String: Any]], "no scope.breadcrumbs")
-        
-        if let breadcrumbs = ser["breadcrumbs"] as? [[String: Any]] {
+        XCTAssertEqual(1, fixture.delegate.addCrumbInvocations.count)
             
-            XCTAssertNotNil(breadcrumbs.first, "scope.breadcrumbs is empty")
+        if let crumb = fixture.delegate.addCrumbInvocations.first {
             
-            if let crumb = breadcrumbs.first {
+            XCTAssertEqual("device.event", crumb.category)
+            XCTAssertEqual("system", crumb.type)
+            XCTAssertEqual(.info, crumb.level)
+            
+            XCTAssertNotNil(crumb.data, "no breadcrumb.data")
+            
+            if let data = crumb.data {
                 
-                XCTAssertEqual("device.event", crumb["category"] as? String)
-                XCTAssertEqual("system", crumb["type"] as? String)
-                XCTAssertEqual("info", crumb["level"] as? String)
-                
-                XCTAssertNotNil(crumb["data"] as? [String: Any], "no breadcrumb.data")
-                
-                if let data = crumb["data"] as? [String: Any] {
-                    
-                    XCTAssertEqual("BATTERY_STATE_CHANGE", data["action"] as? String)
-                    XCTAssertEqual(charging, data["plugged"] as? Bool)
-                    // -1 = unknown
-                    if level == -1 {
-                        XCTAssertNil(data["level"])
-                    } else {
-                        XCTAssertEqual(level, data["level"] as? Float)
-                    }
+                XCTAssertEqual("BATTERY_STATE_CHANGE", data["action"] as? String)
+                XCTAssertEqual(charging, data["plugged"] as? Bool)
+                // -1 = unknown
+                if level == -1 {
+                    XCTAssertNil(data["level"])
+                } else {
+                    XCTAssertEqual(level, data["level"] as? Float)
                 }
             }
         }
@@ -161,126 +148,111 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
     func testPortraitOrientationBreadcrumb() {
         let currentDevice = MyUIDevice()
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         NotificationCenter.default.post(Notification(name: UIDevice.orientationDidChangeNotification, object: currentDevice))
-        assertPositionOrientationBreadcrumb(position: "portrait", scope: scope)
+        assertPositionOrientationBreadcrumb(position: "portrait")
     }
     
     func testLandscapeOrientationBreadcrumb() {
         let currentDevice = MyUIDevice(orientation: UIDeviceOrientation.landscapeLeft)
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         NotificationCenter.default.post(Notification(name: UIDevice.orientationDidChangeNotification, object: currentDevice))
-        assertPositionOrientationBreadcrumb(position: "landscape", scope: scope)
+        assertPositionOrientationBreadcrumb(position: "landscape")
     }
     
     func testUnknownOrientationBreadcrumb() {
         let currentDevice = MyUIDevice(orientation: UIDeviceOrientation.unknown)
         
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: currentDevice)
+        sut = fixture.getSut(currentDevice: currentDevice)
         
         NotificationCenter.default.post(Notification(name: UIDevice.orientationDidChangeNotification, object: currentDevice))
-        let ser = scope.serialize()
         
-        XCTAssertNil(ser["breadcrumbs"], "there are breadcrumbs")
+        XCTAssertEqual(0, fixture.delegate.addCrumbInvocations.count, "there are breadcrumbs")
     }
     
-    private func assertPositionOrientationBreadcrumb(position: String, scope: Scope) {
-        let ser = scope.serialize()
+    private func assertPositionOrientationBreadcrumb(position: String) {
         
-        XCTAssertNotNil(ser["breadcrumbs"] as? [[String: Any]], "no scope.breadcrumbs")
+        XCTAssertEqual(1, fixture.delegate.addCrumbInvocations.count)
         
-        if let breadcrumbs = ser["breadcrumbs"] as? [[String: Any]] {
+        if let crumb = fixture.delegate.addCrumbInvocations.first {
             
-            XCTAssertNotNil(breadcrumbs.first, "scope.breadcrumbs is empty")
+            XCTAssertEqual("device.orientation", crumb.category)
+            XCTAssertEqual("navigation", crumb.type)
+            XCTAssertEqual(.info, crumb.level)
             
-            if let crumb = breadcrumbs.first {
-                XCTAssertEqual("device.orientation", crumb["category"] as? String)
-                XCTAssertEqual("navigation", crumb["type"] as? String)
-                XCTAssertEqual("info", crumb["level"] as? String)
-                
-                XCTAssertNotNil(crumb["data"] as? [String: Any], "no breadcrumb.data")
-                
-                if let data = crumb["data"] as? [String: Any] {
-                    XCTAssertEqual(position, data["position"] as? String)
-                }
+            XCTAssertNotNil(crumb.data, "no breadcrumb.data")
+            
+            if let data = crumb.data {
+                XCTAssertEqual(position, data["position"] as? String)
             }
         }
+        
     }
     
     func testShownKeyboardBreadcrumb() {
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
         
         NotificationCenter.default.post(Notification(name: UIWindow.keyboardDidShowNotification))
         
         Dynamic(sut).systemEventTriggered(Notification(name: UIWindow.keyboardDidShowNotification))
         
-        assertBreadcrumbAction(scope: scope, action: "UIKeyboardDidShowNotification")
+        assertBreadcrumbAction( action: "UIKeyboardDidShowNotification")
     }
     
     func testHiddenKeyboardBreadcrumb() {
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
         
         Dynamic(sut).systemEventTriggered(Notification(name: UIWindow.keyboardDidHideNotification))
         
-        assertBreadcrumbAction(scope: scope, action: "UIKeyboardDidHideNotification")
+        assertBreadcrumbAction(action: "UIKeyboardDidHideNotification")
     }
     
     func testScreenshotBreadcrumb() {
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
         
         Dynamic(sut).systemEventTriggered(Notification(name: UIApplication.userDidTakeScreenshotNotification))
         
-        assertBreadcrumbAction(scope: scope, action: "UIApplicationUserDidTakeScreenshotNotification")
+        assertBreadcrumbAction(action: "UIApplicationUserDidTakeScreenshotNotification")
     }
 
     func testTimezoneFirstTimeNilNoBreadcrumb() {
         fixture.currentDateProvider.timezoneOffsetValue = 7_200
 
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
 
-        assertNoBreadcrumbAction(scope: scope, action: "TIMEZONE_CHANGE")
+        XCTAssertEqual(0, fixture.delegate.addCrumbInvocations.count)
     }
 
     func testTimezoneChangeInitialBreadcrumb() {
         fixture.fileManager.storeTimezoneOffset(0)
         fixture.currentDateProvider.timezoneOffsetValue = 7_200
 
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
 
-        assertBreadcrumbAction(scope: scope, action: "TIMEZONE_CHANGE") { data in
+        assertBreadcrumbAction(action: "TIMEZONE_CHANGE") { data in
             XCTAssertEqual(data["previous_seconds_from_gmt"] as? Int, 0)
             XCTAssertEqual(data["current_seconds_from_gmt"] as? Int, 7_200)
         }
     }
 
     func testTimezoneChangeNotificationBreadcrumb() {
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
 
         fixture.currentDateProvider.timezoneOffsetValue = 7_200
 
         sut.timezoneEventTriggered()
 
-        assertBreadcrumbAction(scope: scope, action: "TIMEZONE_CHANGE") { data in
+        assertBreadcrumbAction(action: "TIMEZONE_CHANGE") { data in
             XCTAssertEqual(data["previous_seconds_from_gmt"] as? Int, 0)
             XCTAssertEqual(data["current_seconds_from_gmt"] as? Int, 7_200)
         }
     }
 
     func testStopCallsSpecificRemoveObserverMethods() {
-        let scope = Scope()
-        sut = fixture.getSut(scope: scope, currentDevice: nil)
+        sut = fixture.getSut(currentDevice: nil)
         sut.stop()
         XCTAssertEqual(fixture.notificationCenterWrapper.removeObserverWithNameInvocations.count, 7)
     }
@@ -289,36 +261,31 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         Dynamic(sut).batteryStateChanged(Notification(name: UIDevice.batteryLevelDidChangeNotification, object: uiDevice))
     }
 
-    private func assertBreadcrumbAction(scope: Scope, action: String, checks: (([String: Any]) -> Void)? = nil) {
-        let ser = scope.serialize()
-        if let breadcrumbs = ser["breadcrumbs"] as? [[String: Any]] {
-            if let crumb = breadcrumbs.first {
-                XCTAssertEqual("device.event", crumb["category"] as? String)
-                XCTAssertEqual("system", crumb["type"] as? String)
-                XCTAssertEqual("info", crumb["level"] as? String)
-                
-                if let data = crumb["data"] as? [String: Any] {
-                    XCTAssertEqual(action, data["action"] as? String)
-                    checks?(data)
-                } else {
-                    XCTFail("no breadcrumb.data")
-                }
+    private func assertBreadcrumbAction(action: String, checks: (([String: Any]) -> Void)? = nil) {
+        XCTAssertEqual(1, fixture.delegate.addCrumbInvocations.count)
+        
+        if let crumb = fixture.delegate.addCrumbInvocations.first {
+       
+            XCTAssertEqual("device.event", crumb.category)
+            XCTAssertEqual("system", crumb.type)
+            XCTAssertEqual(.info, crumb.level)
+            
+            if let data = crumb.data {
+                XCTAssertEqual(action, data["action"] as? String)
+                checks?(data)
             } else {
-                XCTFail("scope.breadcrumbs is empty")
-            }
-        } else {
-            XCTFail("no scope.breadcrumbs")
-        }
-    }
-
-    private func assertNoBreadcrumbAction(scope: Scope, action: String) {
-        let ser = scope.serialize()
-        if let breadcrumbs = ser["breadcrumbs"] as? [[String: Any]] {
-            if let crumb = breadcrumbs.first, let data = crumb["data"] as? [String: Any], data["action"] as? String == action {
-                XCTFail("unwanted breadcrumb found")
+                XCTFail("no breadcrumb.data")
             }
         }
     }
     
     #endif
+}
+
+class SentrySystemEventBreadcrumbTestDelegate: NSObject, SentrySystemEventBreadcrumbsDelegate {
+    
+    var addCrumbInvocations = Invocations<Breadcrumb>()
+    func add(_ crumb: Breadcrumb) {
+        addCrumbInvocations.record(crumb)
+    }
 }


### PR DESCRIPTION

## :scroll: Description

Add a delegate for SentrySystemEventBreadcrumbs to be independent of SentrySDK to make validating crumbs easier in SentrySystemEventBreadcrumbsTests, and only one test in SentryAutoBreadcrumbTrackingIntegrationTests has to use the global state of the SentrySDK for testing to reduce flakiness. Furthermore, use test classes in SentryAutoBreadcrumbTrackingIntegrationTests when calling install to reduce side effects when testing.

#skip-changelog

## :bulb: Motivation and Context

`testBatteryLevelBreadcrumb` were failing here https://github.com/getsentry/sentry-cocoa/actions/runs/4225003147/jobs/7336716875.

The raw logs display logs of `SentryFileManager` and `SentryHttpTransport` which aren't required for running `testBatteryLevelBreadcrumb`.

```
Test Case '-[SentryTests.SentrySystemEventBreadcrumbsTest testBatteryLevelBreadcrumb]' started.
2023-02-20 15:51:47.733517+0000 xctest[6219:20119] [Sentry] [debug] [SentryScope:134] Add breadcrumb: <SentryBreadcrumb: 0x60002fcd0400, {
    category = "test.started";
    level = debug;
    message = "-[SentrySystemEventBreadcrumbsTest testBatteryLevelBreadcrumb]";
    timestamp = "2023-02-20T15:51:47.733Z";
}>
2023-02-20 15:51:47.741937+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:659] SentryFileManager.cachePath: /Users/runner/Library/Developer/CoreSimulator/Devices/F680170B-30F5-49B8-9BB5-5800AFD4DB5E/data/Library/Caches
2023-02-20 15:51:47.742186+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/F680170B-30F5-49B8-9BB5-5800AFD4DB5E/data/Library/Caches/io.sentry/5f62ec4a55360b39302e7fc4c45703c42e9b08ae/events
2023-02-20 15:51:47.742695+0000 xctest[6219:20119] [Sentry] [debug] [SentryHttpTransport:251] sendAllCachedEnvelopes start.
2023-02-20 15:51:47.743004+0000 xctest[6219:20119] [Sentry] [debug] [SentryHttpTransport:263] No envelopes left to send.
2023-02-20 15:51:47.743204+0000 xctest[6219:20119] [Sentry] [debug] [SentryHttpTransport:342] Finished sending.
2023-02-20 15:51:47.743852+0000 xctest[6219:22979] [Sentry] [debug] [SentryFileManager:97] Dispatched deletion of old envelopes from <SentryFileManager: 0x6000017378e0>
2023-02-20 15:51:47.744153+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:605] Reading timezone offset
2023-02-20 15:51:47.748785+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:612] No timezone offset found.
2023-02-20 15:51:47.749233+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:627] Persisting timezone offset: 0
2023-02-20 15:51:47.750415+0000 xctest[6219:22979] [Sentry] [warning] [SentryFileManager:178] Could not get NSFileTypeDirectory from /Users/runner/Library/Developer/CoreSimulator/Devices/F680170B-30F5-49B8-9BB5-5800AFD4DB5E/data/Library/Caches/io.sentry/timezone.offset
2023-02-20 15:51:47.751955+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:659] SentryFileManager.cachePath: /Users/runner/Library/Developer/CoreSimulator/Devices/F680170B-30F5-49B8-9BB5-5800AFD4DB5E/data/Library/Caches
2023-02-20 15:51:47.752177+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/F680170B-30F5-49B8-9BB5-5800AFD4DB5E/data/Library/Caches/io.sentry/5f62ec4a55360b39302e7fc4c45703c42e9b08ae/events
2023-02-20 15:51:47.752590+0000 xctest[6219:20119] [Sentry] [debug] [SentryHttpTransport:251] sendAllCachedEnvelopes start.
2023-02-20 15:51:47.752837+0000 xctest[6219:20119] [Sentry] [debug] [SentryHttpTransport:263] No envelopes left to send.
2023-02-20 15:51:47.753007+0000 xctest[6219:20119] [Sentry] [debug] [SentryHttpTransport:342] Finished sending.
2023-02-20 15:51:47.753650+0000 xctest[6219:22046] [Sentry] [debug] [SentryFileManager:97] Dispatched deletion of old envelopes from <SentryFileManager: 0x600001727020>
2023-02-20 15:51:47.754482+0000 xctest[6219:20119] [Sentry] [debug] [SentryFileManager:605] Reading timezone offset
xctest(6219,0x111302600) malloc: double free for ptr 0x7fe52a249000
xctest(6219,0x111302600) malloc: *** set a breakpoint in malloc_error_break to debug
``` 

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
