### PR TITLE
test: Include symbols for TestFlight upload

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,7 +90,7 @@ platform :ios do
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift",
       include_bitcode: false,
-      include_symbols: false,
+      include_symbols: true,
       export_method: "app-store",
       archive_path: "iOS-Swift"
     )


### PR DESCRIPTION
Include symbols for iOS-Swift TestFlight upload, to get meaningful stack traces for energy reports in the Xcode Organizer, which helps to decipher MetricKit stack traces.

#skip-changelog