### PR TITLE
fix: Crash in AppHangs when no threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased 
+
+### Fixes
+
+- Crash in AppHangs when no threads (#2725)
+
 ## 8.2.0
 
 ### Features

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -33,6 +33,14 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         SentrySDK.setCurrentHub(SentryHub(client: nil, andScope: nil))
     }
     
+    func assertNoEventCaptured() {
+        guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+            XCTFail("Hub Client is not a `TestClient`")
+            return
+        }
+        XCTAssertEqual(0, client.captureEventInvocations.count, "No event should be captured.")
+    }
+    
     func assertEventCaptured(_ callback: (Event?) -> Void) {
         guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")


### PR DESCRIPTION




## :scroll: Description

Fix a crash (index 0 beyond bounds for empty array) in the AppHangs logic when creating the app hang event, and the SDK can't retrieve threads by not reporting an AppHang in such a case.

## :bulb: Motivation and Context

Fixes GH-2713

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
