### PR TITLE
chore: Add missing Changelog entry for PR 2489

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ We renamed the default branch from `master` to `main`. We are going to keep the 
 - Remove delay for deleting old envelopes (#2541)
 - Fix strong reference cycle for HttpTransport (#2552)
 - Deleting old envelopes for empty DSN (#2562)
+- Remove `SentrySystemEventBreadcrumbs` observers with the most specific detail possible (#2489)
 
 ### Breaking Changes
 


### PR DESCRIPTION
Missing entry for https://github.com/getsentry/sentry-cocoa/pull/2489.

#skip-changelog