### PR TITLE
fix: InApp for MetricKit stack traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Crash in AppHangs when no threads (#2725)
 - MetricKit stack traces (#2723)
+- InApp for MetricKit stack traces (#2738)
 
 ## 8.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Crash in AppHangs when no threads (#2725)
 - MetricKit stack traces (#2723)
-- InApp for MetricKit stack traces (#2738)
+- InApp for MetricKit stack traces (#2739)
 
 ## 8.2.0
 

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -7,6 +7,7 @@
 #import <SentryException.h>
 #import <SentryFrame.h>
 #import <SentryHexAddressFormatter.h>
+#import <SentryInAppLogic.h>
 #import <SentryLog.h>
 #import <SentryMechanism.h>
 #import <SentryMetricKitIntegration.h>
@@ -46,6 +47,7 @@ SentryMetricKitIntegration ()
 
 @property (nonatomic, strong, nullable) SentryMXManager *metricKitManager;
 @property (nonatomic, strong) NSMeasurementFormatter *measurementFormatter;
+@property (nonatomic, strong) SentryInAppLogic *inAppLogic;
 
 @end
 
@@ -63,6 +65,8 @@ SentryMetricKitIntegration ()
     self.measurementFormatter = [[NSMeasurementFormatter alloc] init];
     self.measurementFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US"];
     self.measurementFormatter.unitOptions = NSMeasurementFormatterUnitOptionsProvidedUnit;
+    self.inAppLogic = [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
+                                                        inAppExcludes:options.inAppExcludes];
 
     return YES;
 }
@@ -380,6 +384,7 @@ SentryMetricKitIntegration ()
     for (SentryMXFrame *mxFrame in mxFrames) {
         SentryFrame *frame = [[SentryFrame alloc] init];
         frame.package = mxFrame.binaryName;
+        frame.inApp = @([self.inAppLogic isInApp:mxFrame.binaryName]);
         frame.instructionAddress = sentry_formatHexAddress(@(mxFrame.address));
         NSNumber *imageAddress = @(mxFrame.address - mxFrame.offsetIntoBinaryTextSegment);
         frame.imageAddress = sentry_formatHexAddress(imageAddress);


### PR DESCRIPTION




## :scroll: Description

Apply the InAppLogic for MetricKit stack traces.

## :bulb: Motivation and Context

Fixes GH-2738

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
