### PR TITLE
ref: Use weak references for ANRTracker listeners

### DIFF
--- a/Sources/Sentry/SentryANRTracker.m
+++ b/Sources/Sentry/SentryANRTracker.m
@@ -20,7 +20,7 @@ SentryANRTracker ()
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 @property (nonatomic, strong) SentryThreadWrapper *threadWrapper;
-@property (nonatomic, strong) NSMutableSet<id<SentryANRTrackerDelegate>> *listeners;
+@property (nonatomic, strong) NSHashTable<id<SentryANRTrackerDelegate>> *listeners;
 @property (nonatomic, assign) NSTimeInterval timeoutInterval;
 
 @end
@@ -42,7 +42,7 @@ SentryANRTracker ()
         self.crashWrapper = crashWrapper;
         self.dispatchQueueWrapper = dispatchQueueWrapper;
         self.threadWrapper = threadWrapper;
-        self.listeners = [NSMutableSet set];
+        self.listeners = [NSHashTable weakObjectsHashTable];
         threadLock = [[NSObject alloc] init];
         state = kSentryANRTrackerNotRunning;
     }

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -55,6 +55,11 @@ SentryANRTrackingIntegration ()
     [self.tracker removeListener:self];
 }
 
+- (void)dealloc
+{
+    [self uninstall];
+}
+
 - (void)anrDetected
 {
     SentryThreadInspector *threadInspector = SentrySDK.currentHub.getClient.threadInspector;

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -156,6 +156,26 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
 
     }
     
+    func testNotRemovingDeallocatedListener_DoesNotRetainListener_AndStopsTracking() {
+        anrDetectedExpectation.isInverted = true
+        anrStoppedExpectation.isInverted = true
+        
+        // So ARC deallocates SentryANRTrackerTestDelegate
+        func addSecondListener() {
+            self.sut.addListener(SentryANRTrackerTestDelegate())
+        }
+        addSecondListener()
+        
+        sut.addListener(self)
+        sut.removeListener(self)
+        
+        let listeners = Dynamic(sut).listeners.asObject as? NSHashTable<NSObject>
+        
+        XCTAssertEqual(0, listeners?.count)
+        
+        wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: 0.0)
+    }
+    
     func testClearDirectlyAfterStart() {
         anrDetectedExpectation.isInverted = true
         

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -161,17 +161,20 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
         anrStoppedExpectation.isInverted = true
         
         // So ARC deallocates SentryANRTrackerTestDelegate
-        func addSecondListener() {
-            self.sut.addListener(SentryANRTrackerTestDelegate())
+        let addListenersCount = 10
+        func addListeners() {
+            for _ in 0..<addListenersCount {
+                self.sut.addListener(SentryANRTrackerTestDelegate())
+            }
         }
-        addSecondListener()
+        addListeners()
         
         sut.addListener(self)
         sut.removeListener(self)
         
         let listeners = Dynamic(sut).listeners.asObject as? NSHashTable<NSObject>
         
-        XCTAssertEqual(0, listeners?.count)
+        XCTAssertGreaterThan(addListenersCount, listeners?.count ?? addListenersCount)
         
         wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: 0.0)
     }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -107,6 +107,25 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         
         assertNoEventCaptured()
     }
+    
+    func testDealloc_CallsUninstall() {
+        givenInitializedTracker()
+        
+        // // So ARC deallocates the SentryANRTrackingIntegration
+        func initIntegration() {
+            self.crashWrapper.internalIsBeingTraced = false
+            let sut = SentryANRTrackingIntegration()
+            sut.install(with: self.options)
+        }
+        
+        initIntegration()
+        
+        let tracker = SentryDependencyContainer.sharedInstance().getANRTracker(self.options.appHangTimeoutInterval)
+        
+        let listeners = Dynamic(tracker).listeners.asObject as? NSHashTable<NSObject>
+        
+        XCTAssertEqual(1, listeners?.count ?? 2)
+    }
 
     private func givenInitializedTracker(isBeingTraced: Bool = false) {
         givenSdkWithHub()


### PR DESCRIPTION

## :scroll: Description

Replace NSMutableSet with NSHashTable and use weakObjectsHashTable to avoid retaining strong references to ANR tracker listeners.

#skip-changelog

## :bulb: Motivation and Context

A failing flaky test contained a message of the ANRTrackingIntegration, although the `ANRTrackingIntegration` should not be running.

```
SentryTests.SentryLogTests
ertEqual failed: ("["[Sentry] [fatal] 0", "[Sentry] [error] 1", "[Sentry] [warning] 2", "[Sentry] [info] 3", "[Sentry] [debug] 4"]") is not equal to ("["[Sentry] [fatal] 0", "[Sentry] [warning] [SentryANRTracker:120] ANR detected.", "[Sentry] [warning] [SentryANRTrackingIntegration:66] Getting current thread returned an empty list. Can\'t create AppHang event without a stacktrace.", "[Sentry] [error] 1", "[Sentry] [warning] 2", "[Sentry] [info] 3", "[Sentry] [debug] 4"]")
  /Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/Helper/SentryLogTests.swift:65
```
https://github.com/getsentry/sentry-cocoa/actions/runs/4304750086/jobs/7506245458

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
