### PR TITLE
chore: Remove private references from public headers

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -745,7 +745,7 @@
 		D885266427739D01001269FC /* SentryFileIOTrackingIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D885266327739D01001269FC /* SentryFileIOTrackingIntegrationTests.swift */; };
 		D8853C842833EABC00700D64 /* SentryANRTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BCFA71427D0BAB7008C662C /* SentryANRTracker.h */; };
 		D88817D826D7149100BF2251 /* SentryTraceContext.m in Sources */ = {isa = PBXBuildFile; fileRef = D88817D626D7149100BF2251 /* SentryTraceContext.m */; };
-		D88817DA26D72AB800BF2251 /* SentryTraceContext.h in Headers */ = {isa = PBXBuildFile; fileRef = D88817D926D72AB800BF2251 /* SentryTraceContext.h */; };
+		D88817DA26D72AB800BF2251 /* SentryTraceContext.h in Headers */ = {isa = PBXBuildFile; fileRef = D88817D926D72AB800BF2251 /* SentryTraceContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		D88817DD26D72BA500BF2251 /* SentryTraceStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88817DB26D72B7B00BF2251 /* SentryTraceStateTests.swift */; };
 		D8918B222849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8918B212849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift */; };
 		D8AB40DB2806EC1900E5E9F7 /* SentryScreenshotIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = D8AB40DA2806EC1900E5E9F7 /* SentryScreenshotIntegration.h */; };

--- a/Sources/Sentry/Public/SentryClient.h
+++ b/Sources/Sentry/Public/SentryClient.h
@@ -1,6 +1,6 @@
 #import "SentryDefines.h"
 
-@class SentryOptions, SentrySession, SentryEvent, SentryScope, SentryFileManager, SentryId,
+@class SentryOptions, SentryEvent, SentryScope, SentryFileManager, SentryId,
     SentryUserFeedback, SentryTransaction;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -107,8 +107,6 @@ SENTRY_NO_INIT
  */
 - (void)captureUserFeedback:(SentryUserFeedback *)userFeedback
     NS_SWIFT_NAME(capture(userFeedback:));
-
-- (void)captureSession:(SentrySession *)session NS_SWIFT_NAME(capture(session:));
 
 /**
  * Waits synchronously for the SDK to flush out all queued and cached items for up to the specified

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -2,7 +2,7 @@
 #import "SentryIntegrationProtocol.h"
 #import "SentrySpanProtocol.h"
 
-@class SentryEvent, SentryClient, SentryScope, SentrySession, SentryUser, SentryBreadcrumb,
+@class SentryEvent, SentryClient, SentryScope, SentryUser, SentryBreadcrumb,
     SentryId, SentryUserFeedback, SentryTransactionContext;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -11,11 +11,6 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithClient:(SentryClient *_Nullable)client
                       andScope:(SentryScope *_Nullable)scope;
-
-/**
- * Since there's no scope stack, single hub instance,  we keep the session here.
- */
-@property (nonatomic, readonly, strong) SentrySession *_Nullable session;
 
 /**
  * Starts a new SentrySession. If there's a running SentrySession, it ends it before starting the

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -28,6 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 SentryHub ()
 
 @property (nullable, nonatomic, strong) SentryClient *client;
+@property (nullable, nonatomic, strong) SentrySession *session;
 @property (nullable, nonatomic, strong) SentryScope *scope;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryTracesSampler *tracesSampler;

--- a/Sources/Sentry/SentryTraceContext.m
+++ b/Sources/Sentry/SentryTraceContext.m
@@ -8,6 +8,7 @@
 #import "SentryTracer.h"
 #import "SentryTransactionContext.h"
 #import "SentryUser.h"
+#import "SentryId.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -2,8 +2,9 @@
 #import "SentryAppStartMeasurement.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryScreenFrames.h"
+#import "SentryEnvelope.h"
 
-@class SentryEnvelope, SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames,
+@class SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames,
     SentryOptions;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -1,8 +1,14 @@
 #import "PrivatesHeader.h"
 #import "SentryAppStartMeasurement.h"
-#import "SentryEnvelope.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryScreenFrames.h"
+
+#if COCOAPODS
+@class SentryEnvelope;
+#else
+#import "SentryEnvelope.h"
+#endif
+
 
 @class SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames, SentryOptions;
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -2,12 +2,7 @@
 #import "SentryAppStartMeasurement.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryScreenFrames.h"
-
-#if COCOAPODS
-@class SentryEnvelope;
-#else
-#    import "SentryEnvelope.h"
-#endif
+#import "SentryEnvelope.h"
 
 @class SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames, SentryOptions;
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -6,9 +6,8 @@
 #if COCOAPODS
 @class SentryEnvelope;
 #else
-#import "SentryEnvelope.h"
+#    import "SentryEnvelope.h"
 #endif
-
 
 @class SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames, SentryOptions;
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -1,8 +1,8 @@
 #import "PrivatesHeader.h"
 #import "SentryAppStartMeasurement.h"
+#import "SentryEnvelope.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryScreenFrames.h"
-#import "SentryEnvelope.h"
 
 @class SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames, SentryOptions;
 

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
@@ -8,8 +8,8 @@
 #if COCOAPODS
 @class SentrySdkInfo, SentryTraceContext;
 #else
-#import "SentrySdkInfo.h"
-#import "SentryTraceContext.h"
+#    import "SentrySdkInfo.h"
+#    import "SentryTraceContext.h"
 
 #endif
 

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
@@ -4,8 +4,14 @@
 #else
 #    import "SentryEnvelopeItemHeader.h"
 #endif
+
+#if COCOAPODS
+@class SentrySdkInfo, SentryTraceContext;
+#else
 #import "SentrySdkInfo.h"
 #import "SentryTraceContext.h"
+
+#endif
 
 @class SentryEvent, SentrySession, SentryId, SentryUserFeedback, SentryAttachment,
     SentryTransaction, SentryClientReport, SentryEnvelopeItemHeader;

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
@@ -1,8 +1,14 @@
 #import "PrivatesHeader.h"
+#if __has_include(<Sentry/SentryEnvelopeItemHeader.h>)
+#import <Sentry/SentryEnvelopeItemHeader.h>
+#else
 #import "SentryEnvelopeItemHeader.h"
+#endif
+#import "SentrySdkInfo.h"
+#import "SentryTraceContext.h"
 
-@class SentryEvent, SentrySession, SentrySdkInfo, SentryId, SentryUserFeedback, SentryAttachment,
-    SentryTransaction, SentryTraceContext, SentryClientReport, SentryEnvelopeItemHeader;
+@class SentryEvent, SentrySession, SentryId, SentryUserFeedback, SentryAttachment,
+    SentryTransaction, SentryClientReport, SentryEnvelopeItemHeader;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -2,7 +2,7 @@
 #import "SentryDataCategory.h"
 #import "SentryDiscardReason.h"
 
-@class SentryEnvelopeItem, SentryId, SentryAttachment, SentryThreadInspector, SentryEnvelope;
+@class SentrySession, SentryEnvelopeItem, SentryId, SentryAttachment, SentryThreadInspector, SentryEnvelope;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -40,6 +40,8 @@ SentryClient ()
                   withScope:(SentryScope *)scope
     additionalEnvelopeItems:(NSArray<SentryEnvelopeItem *> *)additionalEnvelopeItems
     NS_SWIFT_NAME(capture(event:scope:additionalEnvelopeItems:));
+
+- (void)captureSession:(SentrySession *)session NS_SWIFT_NAME(capture(session:));
 
 /**
  * Needed by hybrid SDKs as react-native to synchronously store an envelope to disk.

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -1,5 +1,10 @@
-#import "SentrySerializable.h"
 #import <Foundation/Foundation.h>
+
+#if __has_include(<Sentry/SentrySerializable.h>)
+#import <Sentry/SentrySerializable.h>
+#else
+#import "SentrySerializable.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryTraceContext.h
+++ b/Sources/Sentry/include/SentryTraceContext.h
@@ -12,7 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryScope, SentryId, SentryOptions, SentryTracer, SentryUser, SentryBaggage;
+@class SentryScope, SentryOptions, SentryTracer, SentryUser, SentryBaggage;
 
 @interface SentryTraceContext : NSObject <SentrySerializable>
 

--- a/Sources/Sentry/include/SentryTraceContext.h
+++ b/Sources/Sentry/include/SentryTraceContext.h
@@ -1,9 +1,18 @@
-#import "SentryId.h"
+#if __has_include(<Sentry/SentrySerializable.h>)
+#import <Sentry/SentrySerializable.h>
+#else
 #import "SentrySerializable.h"
+#endif
+
+#if __has_include(<Sentry/SentryId.h>)
+#import <Sentry/SentryId.h>
+#else
+#import "SentryId.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryScope, SentryOptions, SentryTracer, SentryUser, SentryBaggage;
+@class SentryScope, SentryId, SentryOptions, SentryTracer, SentryUser, SentryBaggage;
 
 @interface SentryTraceContext : NSObject <SentrySerializable>
 

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -196,3 +196,7 @@ Date: January 18th, 2023
 Contributors: @brustolin and @philipphofmann
 
 We release experimental SentrySwiftUI cocoa package with the version 8.0.0 because all podspecs file in a repo need to have the same version. 
+
+## Usage of `__has_include`
+
+Some private headers add a dependency of a public header, when those private headers are used in a sample project, or referenced from a hybrid SDK, it is treated as part of the project using it, therefore, if it points to a header that is not part of said project, a compilation error will occur. To solve this we make use of `__has_include` to try to point to the SDK version of the header, or to fallback to the direct reference when compiling the SDK.


### PR DESCRIPTION
## :scroll: Description

We made SentrySession private but we did not remove references from public headers.

Also changing a few forward declarations to #import to help with .NET hybrid SDK.

**This may be considered a "breaking change" since we're removing property from a public header, but is a property that was not meant to be used.**

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog. 
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

_#skip-changelog_

