### PR TITLE
fix: Mutating while enumerating crash in Tracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Crash in AppHangs when no threads (#2725)
 - MetricKit stack traces (#2723)
 - InApp for MetricKit stack traces (#2739)
+- Mutating while enumerating crash in Tracer (#2744)
 
 ## 8.2.0
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -572,17 +572,18 @@ static BOOL appStartMeasurementRead;
 {
     NSArray<id<SentrySpan>> *appStartSpans = [self buildAppStartSpans];
 
-    NSArray<id<SentrySpan>> *spans;
+    NSArray<id<SentrySpan>> *childrenCopy;
     @synchronized(_children) {
         [_children addObjectsFromArray:appStartSpans];
-        spans = [_children copy];
+        childrenCopy = [_children copy];
     }
 
     if (appStartMeasurement != nil) {
         [self setStartTimestamp:appStartMeasurement.appStartTimestamp];
     }
 
-    SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
+    SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self
+                                                                     children:childrenCopy];
     transaction.transaction = self.transactionContext.name;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     transaction.startSystemTime = self.startSystemTime;
@@ -594,7 +595,7 @@ static BOOL appStartMeasurementRead;
         [framesOfAllSpans addObjectsFromArray:[(SentrySpan *)self frames]];
     }
 
-    for (SentrySpan *span in _children) {
+    for (SentrySpan *span in childrenCopy) {
         if (span.frames) {
             [framesOfAllSpans addObjectsFromArray:span.frames];
         }

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -816,8 +816,6 @@ class SentryTracerTests: XCTestCase {
         XCTAssertTrue(sutOnScope === fixture.hub.scope.span)
     }
     
-    // Although we only run this test above the below specified versions, we expect the
-    // implementation to be thread safe
     func testFinishAsync() {
         let sut = fixture.getSut()
         let child = sut.startChild(operation: fixture.transactionOperation)
@@ -854,8 +852,6 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(spans.count, children * (grandchildren + 1) + 1)
     }
     
-    // Although we only run this test above the below specified versions, we expect the
-    // implementation to be thread safe
     func testConcurrentTransactions_OnlyOneGetsMeasurement() {
         SentrySDK.setAppStartMeasurement(fixture.getAppStartMeasurement(type: .warm))
         
@@ -885,6 +881,47 @@ class SentryTracerTests: XCTestCase {
         }
         
         XCTAssertEqual(1, transactionsWithAppStartMeasurement.count)
+    }
+    
+    func testAddingSpansOnDifferentThread_WhileFinishing_DoesNotCrash() {
+        let sut = fixture.getSut(waitForChildren: false)
+        
+        let children = 1_000
+        for _ in 0..<children {
+            let child = sut.startChild(operation: self.fixture.transactionOperation)
+            child.finish()
+        }
+        
+        let queue = DispatchQueue(label: "SentryTracerTests", attributes: [.concurrent, .initiallyInactive])
+        let group = DispatchGroup()
+        
+        func addChildrenAsync() {
+            for _ in 0 ..< 100 {
+                group.enter()
+                queue.async {
+                    let child = sut.startChild(operation: self.fixture.transactionOperation)
+                    Dynamic(child).frames = []
+                    child.finish()
+                    group.leave()
+                }
+            }
+        }
+
+       addChildrenAsync()
+        
+        group.enter()
+        queue.async {
+            sut.finish()
+            group.leave()
+        }
+        
+        addChildrenAsync()
+        
+        queue.activate()
+        group.wait()
+        
+        let spans = getSerializedTransaction()["spans"]! as! [[String: Any]]
+        XCTAssertGreaterThanOrEqual(spans.count, children)
     }
     
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)


### PR DESCRIPTION


## :scroll: Description

Use copy of children span array to avoid Collection was mutated while being enumerated exception.

## :bulb: Motivation and Context

A customer reported this crash.

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
