### PR TITLE
ci: Pin Fastlane to 2.210.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,11 @@ source "https://rubygems.org"
 
 gem "bundler", ">= 2"
 gem "cocoapods", ">= 1.9.1"
-gem "fastlane"
+# Pin fastlane to 2.210.1 to avoid CI failure with "Could not install WWDR certificate".
+# Although https://github.com/fastlane/fastlane/issues/20960 was fixed with 
+# https://github.com/fastlane/fastlane/releases/tag/2.212.0 we still see it happening,
+# sometimes. We keep pinning to 2.210.1.
+gem "fastlane", "= 2.210.1" 
 gem "rest-client"
 gem "xcpretty"
 gem "slather"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,13 +17,13 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.714.0)
+    aws-partitions (1.720.0)
     aws-sdk-core (3.170.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.62.0)
+    aws-sdk-kms (1.63.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.119.1)
@@ -117,7 +117,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.212.0)
+    fastlane (2.210.1)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -175,8 +175,8 @@ GEM
       webrick
     google-apis-iamcredentials_v1 (0.17.0)
       google-apis-core (>= 0.11.0, < 2.a)
-    google-apis-playcustomapp_v1 (0.12.0)
-      google-apis-core (>= 0.9.1, < 2.a)
+    google-apis-playcustomapp_v1 (0.13.0)
+      google-apis-core (>= 0.11.0, < 2.a)
     google-apis-storage_v1 (0.19.0)
       google-apis-core (>= 0.9.0, < 2.a)
     google-cloud-core (1.6.0)
@@ -184,7 +184,7 @@ GEM
       google-cloud-errors (~> 1.0)
     google-cloud-env (1.6.0)
       faraday (>= 0.17.3, < 3.0)
-    google-cloud-errors (1.3.0)
+    google-cloud-errors (1.3.1)
     google-cloud-storage (1.44.0)
       addressable (~> 2.8)
       digest-crc (~> 0.4)
@@ -230,7 +230,7 @@ GEM
       racc (~> 1.4)
     optparse (0.1.1)
     os (1.1.4)
-    plist (3.6.0)
+    plist (3.7.0)
     public_suffix (4.0.7)
     racc (1.6.2)
     rake (13.0.6)
@@ -302,7 +302,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 2)
   cocoapods (>= 1.9.1)
-  fastlane
+  fastlane (= 2.210.1)
   fastlane-plugin-sentry
   rest-client
   slather


### PR DESCRIPTION
Pin Fastlane to 2.210.1 to avoid CI failure with "Could not install WWDR certificate".
Related PRs
 * https://github.com/getsentry/sentry-cocoa/pull/2634
 * https://github.com/getsentry/sentry-cocoa/pull/2707

#skip-changelog