### PR TITLE
ref: Code docs default for sessionTrackingInterval

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -146,6 +146,7 @@ NS_SWIFT_NAME(Options)
 
 /**
  * The interval to end a session if the App goes to the background.
+ * The default is 30000 millis / 30 seconds.
  */
 @property (nonatomic, assign) NSUInteger sessionTrackingIntervalMillis;
 


### PR DESCRIPTION
Add default value for SentryOptions.sessionTrackingIntervalMillis to code docs.

#skip-changelog