### PR TITLE
test: Improvements for TestClient

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -102,6 +102,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     SentryTransportAdapter *transportAdapter =
         [[SentryTransportAdapter alloc] initWithTransport:transport options:options];
 
+    return [self initWithOptions:options fileManager:fileManager transportAdapter:transportAdapter];
+}
+
+/** Internal constructor for testing purposes. */
+- (instancetype)initWithOptions:(SentryOptions *)options
+                    fileManager:(SentryFileManager *)fileManager
+               transportAdapter:(SentryTransportAdapter *)transportAdapter
+
+{
     SentryInAppLogic *inAppLogic =
         [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
                                           inAppExcludes:options.inAppExcludes];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -72,12 +72,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
 {
-    return [self initWithOptions:options dispatchQueue:[[SentryDispatchQueueWrapper alloc] init]];
+    return [self initWithOptions:options
+                   dispatchQueue:[[SentryDispatchQueueWrapper alloc] init]
+          deleteOldEnvelopeItems:YES];
 }
 
 /** Internal constructor for testing purposes. */
 - (nullable instancetype)initWithOptions:(SentryOptions *)options
                            dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
+                  deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
 {
     NSError *error;
     SentryFileManager *fileManager =
@@ -89,12 +92,15 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         SENTRY_LOG_ERROR(@"Cannot init filesystem.");
         return nil;
     }
-    return [self initWithOptions:options fileManager:fileManager];
+    return [self initWithOptions:options
+                     fileManager:fileManager
+          deleteOldEnvelopeItems:deleteOldEnvelopeItems];
 }
 
 /** Internal constructor for testing purposes. */
 - (instancetype)initWithOptions:(SentryOptions *)options
                     fileManager:(SentryFileManager *)fileManager
+         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
 {
     id<SentryTransport> transport = [SentryTransportFactory initTransport:options
                                                         sentryFileManager:fileManager];
@@ -102,12 +108,16 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     SentryTransportAdapter *transportAdapter =
         [[SentryTransportAdapter alloc] initWithTransport:transport options:options];
 
-    return [self initWithOptions:options fileManager:fileManager transportAdapter:transportAdapter];
+    return [self initWithOptions:options
+                     fileManager:fileManager
+          deleteOldEnvelopeItems:deleteOldEnvelopeItems
+                transportAdapter:transportAdapter];
 }
 
 /** Internal constructor for testing purposes. */
 - (instancetype)initWithOptions:(SentryOptions *)options
                     fileManager:(SentryFileManager *)fileManager
+         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
                transportAdapter:(SentryTransportAdapter *)transportAdapter
 
 {
@@ -128,6 +138,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     return [self initWithOptions:options
                 transportAdapter:transportAdapter
                      fileManager:fileManager
+          deleteOldEnvelopeItems:deleteOldEnvelopeItems
                  threadInspector:threadInspector
                           random:[SentryDependencyContainer sharedInstance].random
                     crashWrapper:[SentryCrashWrapper sharedInstance]
@@ -139,6 +150,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 - (instancetype)initWithOptions:(SentryOptions *)options
                transportAdapter:(SentryTransportAdapter *)transportAdapter
                     fileManager:(SentryFileManager *)fileManager
+         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
                 threadInspector:(SentryThreadInspector *)threadInspector
                          random:(id<SentryRandom>)random
                    crashWrapper:(SentryCrashWrapper *)crashWrapper
@@ -160,7 +172,9 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         self.attachmentProcessors = [[NSMutableArray alloc] init];
         self.deviceWrapper = deviceWrapper;
 
-        [fileManager deleteOldEnvelopeItems];
+        if (deleteOldEnvelopeItems) {
+            [fileManager deleteOldEnvelopeItems];
+        }
     }
     return self;
 }

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -21,7 +21,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
             options.dsn = SentryCrashIntegrationTests.dsnAsString
             options.releaseName = TestData.appState.releaseName
             
-            client = TestClient(options: options, fileManager: try! SentryFileManager(options: options, andCurrentDateProvider: CurrentDate.getProvider()!, dispatchQueueWrapper: dispatchQueueWrapper))
+            client = TestClient(options: options, fileManager: try! SentryFileManager(options: options, andCurrentDateProvider: CurrentDate.getProvider()!, dispatchQueueWrapper: dispatchQueueWrapper), deleteOldEnvelopeItems: false)
             hub = TestHub(client: client, andScope: nil)
         }
         

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -10,18 +10,22 @@ NS_ASSUME_NONNULL_BEGIN
 SentryClient ()
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
-                            dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue;
+                            dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
+                   deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems;
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
-                              fileManager:(SentryFileManager *)fileManager;
+                              fileManager:(SentryFileManager *)fileManager
+                   deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems;
 
 - (instancetype)initWithOptions:(SentryOptions *)options
                     fileManager:(SentryFileManager *)fileManager
+         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
                transportAdapter:(SentryTransportAdapter *)transportAdapter;
 
 - (instancetype)initWithOptions:(SentryOptions *)options
                transportAdapter:(SentryTransportAdapter *)transportAdapter
                     fileManager:(SentryFileManager *)fileManager
+         deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
                 threadInspector:(SentryThreadInspector *)threadInspector
                          random:(id<SentryRandom>)random
                    crashWrapper:(SentryCrashWrapper *)crashWrapper

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -16,6 +16,10 @@ SentryClient ()
                               fileManager:(SentryFileManager *)fileManager;
 
 - (instancetype)initWithOptions:(SentryOptions *)options
+                    fileManager:(SentryFileManager *)fileManager
+               transportAdapter:(SentryTransportAdapter *)transportAdapter;
+
+- (instancetype)initWithOptions:(SentryOptions *)options
                transportAdapter:(SentryTransportAdapter *)transportAdapter
                     fileManager:(SentryFileManager *)fileManager
                 threadInspector:(SentryThreadInspector *)threadInspector

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -73,6 +73,7 @@ class SentryClientTest: XCTestCase {
                     options: options,
                     transportAdapter: transportAdapter,
                     fileManager: fileManager,
+                    deleteOldEnvelopeItems: false,
                     threadInspector: threadInspector,
                     random: random,
                     crashWrapper: crashWrapper,
@@ -141,7 +142,7 @@ class SentryClientTest: XCTestCase {
     func testInit_CallsDeleteOldEnvelopeItemsInvocations() throws {
         let fileManager = try TestFileManager(options: Options())
         
-        _ = SentryClient(options: Options(), fileManager: fileManager)
+        _ = SentryClient(options: Options(), fileManager: fileManager, deleteOldEnvelopeItems: true)
         
         XCTAssertEqual(1, fileManager.deleteOldEnvelopeItemsInvocations.count)
     }
@@ -1175,7 +1176,7 @@ class SentryClientTest: XCTestCase {
 
         let options = Options()
         options.dsn = SentryClientTest.dsn
-        let client = SentryClient(options: options, dispatchQueue: TestSentryDispatchQueueWrapper())
+        let client = SentryClient(options: options, dispatchQueue: TestSentryDispatchQueueWrapper(), deleteOldEnvelopeItems: false)
 
         XCTAssertNil(client)
 

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -2,11 +2,15 @@ import Foundation
 
 class TestClient: SentryClient {
     override init?(options: Options) {
-        super.init(options: options, fileManager: try! TestFileManager(options: options))
+        super.init(options: options, fileManager: try! TestFileManager(options: options), transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
     }
 
     override init?(options: Options, fileManager: SentryFileManager) {
-        super.init(options: options, fileManager: fileManager)
+        super.init(options: options, fileManager: fileManager, transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
+    }
+    
+    override init(options: Options, fileManager: SentryFileManager, transportAdapter: SentryTransportAdapter) {
+        super.init(options: options, fileManager: fileManager, transportAdapter: transportAdapter)
     }
     
     // Without this override we get a fatal error: use of unimplemented initializer

--- a/Tests/SentryTests/TestClient.swift
+++ b/Tests/SentryTests/TestClient.swift
@@ -2,24 +2,25 @@ import Foundation
 
 class TestClient: SentryClient {
     override init?(options: Options) {
-        super.init(options: options, fileManager: try! TestFileManager(options: options), transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
+        super.init(options: options, fileManager: try! TestFileManager(options: options), deleteOldEnvelopeItems: false, transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
     }
 
-    override init?(options: Options, fileManager: SentryFileManager) {
-        super.init(options: options, fileManager: fileManager, transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
+    override init?(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool) {
+        super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
     }
     
-    override init(options: Options, fileManager: SentryFileManager, transportAdapter: SentryTransportAdapter) {
-        super.init(options: options, fileManager: fileManager, transportAdapter: transportAdapter)
+    override init(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, transportAdapter: SentryTransportAdapter) {
+        super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: transportAdapter)
     }
     
     // Without this override we get a fatal error: use of unimplemented initializer
     // see https://stackoverflow.com/questions/28187261/ios-swift-fatal-error-use-of-unimplemented-initializer-init
-    override init(options: Options, transportAdapter: SentryTransportAdapter, fileManager: SentryFileManager, threadInspector: SentryThreadInspector, random: SentryRandomProtocol, crashWrapper: SentryCrashWrapper, deviceWrapper: SentryUIDeviceWrapper, locale: Locale, timezone: TimeZone) {
+    override init(options: Options, transportAdapter: SentryTransportAdapter, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, threadInspector: SentryThreadInspector, random: SentryRandomProtocol, crashWrapper: SentryCrashWrapper, deviceWrapper: SentryUIDeviceWrapper, locale: Locale, timezone: TimeZone) {
         super.init(
             options: options,
             transportAdapter: transportAdapter,
             fileManager: fileManager,
+            deleteOldEnvelopeItems: false,
             threadInspector: threadInspector,
             random: random,
             crashWrapper: crashWrapper,


### PR DESCRIPTION
Use the TestTransportAdapter in default init of TestClient, and only deleteOldEnvelopeItems in production.

The `SentryProfilerSwiftTests` keep failing, and the test logs show entries of calls in SentryHttpTransport and SentryFileManager.

https://github.com/getsentry/sentry-cocoa/actions/runs/4321925443/jobs/7545278715

#skip-changelog