### PR TITLE
randomize test execution order with scheme option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,13 @@ on:
       - 'scripts/tests-with-thread-sanitizer.sh'
       - 'scripts/ci-select-xcode.sh'
       - 'scripts/xcode-test.sh'
+      - 'Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme'
+      - 'Samples/tvOS-Swift/tvOS-Swift.xcodeproj/xcshareddata/xcschemes/tvOS-Swift.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS13-Swift.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUITests.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme'
+      - 'Samples/macOS-Swift/macOS-Swift.xcodeproj/xcshareddata/xcschemes/macOS-Swift.xcscheme'
+      - 'Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/xcshareddata/xcschemes/iOS-ObjectiveC.xcscheme'
 
 jobs:
   build-test-server:

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -46,7 +46,8 @@
       </EnvironmentVariables>
       <Testables>
          <TestableReference
-            skipped = "NO">
+            skipped = "NO"
+            testExecutionOrdering = "random">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "63AA76641EB8CB2F00D153DE"


### PR DESCRIPTION
We shouldn't merge this, I just want to see the behavior of our tests if the order is randomized using the Xcode scheme option:
<img width="1120" alt="Screenshot 2023-03-06 at 9 27 38 AM" src="https://user-images.githubusercontent.com/3241469/223198750-5194c196-8e76-4891-b037-38ae85b7e0c1.png">

Needed to adjust the test triggers in test.yml to run the workflow whenever a scheme file changes, which we should definitely merge in a separate PR!

#skip-changelog