### PR TITLE
test: run tests on scheme changes

### DIFF
--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -18,6 +18,10 @@ on:
       - 'scripts/set-device-tests-environment.patch'
       - 'scripts/ci-select-xcode.sh'
 
+      # run the workflow any time an Xcode scheme changes for one of the sample apps with a UI test suite we run in saucelabs
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUITests.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme'
+
 jobs:
   build-ui-tests:
     name: Build UITests with Xcode ${{matrix.xcode}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ on:
       - 'scripts/tests-with-thread-sanitizer.sh'
       - 'scripts/ci-select-xcode.sh'
       - 'scripts/xcode-test.sh'
+
+      # run the workflow any time an Xcode scheme changes for any tested target
       - 'Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme'
       - 'Samples/tvOS-Swift/tvOS-Swift.xcodeproj/xcshareddata/xcschemes/tvOS-Swift.xcscheme'
       - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS13-Swift.xcscheme'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,13 @@ on:
       - 'scripts/tests-with-thread-sanitizer.sh'
       - 'scripts/ci-select-xcode.sh'
       - 'scripts/xcode-test.sh'
+      - 'Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme'
+      - 'Samples/tvOS-Swift/tvOS-Swift.xcodeproj/xcshareddata/xcschemes/tvOS-Swift.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS13-Swift.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUITests.xcscheme'
+      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme'
+      - 'Samples/macOS-Swift/macOS-Swift.xcodeproj/xcshareddata/xcschemes/macOS-Swift.xcscheme'
+      - 'Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/xcshareddata/xcschemes/iOS-ObjectiveC.xcscheme'
 
 jobs:
   build-test-server:


### PR DESCRIPTION
I noticed in https://github.com/getsentry/sentry-cocoa/pull/2761 that changes to scheme options weren't running the tests associated with the scheme.

#skip-changelog