### PR TITLE
test: cancel the profiling thread at the end of the test

### DIFF
--- a/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
@@ -54,12 +54,17 @@ using namespace sentry::profiling;
     XCTAssertGreaterThan(std::chrono::duration_cast<std::chrono::seconds>(duration).count(), 0);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(numIdleSamples, 0);
-    pthread_cancel(idleThread);
+
+    // end the test idle thread
+    XCTAssertEqual(pthread_cancel(idleThread), 0);
+    XCTAssertEqual(pthread_join(idleThread, nullptr), 0);
 }
 
 static void *
 idleThreadEntry(__unused void *ptr)
 {
+    pthread_testcancel();
+
     // Wait on a condition variable that will never be signaled to make the thread idle.
     pthread_cond_t cv;
     pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryTests/Profiling/SentrySamplingProfilerTests.mm
@@ -54,6 +54,7 @@ using namespace sentry::profiling;
     XCTAssertGreaterThan(std::chrono::duration_cast<std::chrono::seconds>(duration).count(), 0);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(numIdleSamples, 0);
+    pthread_cancel(idleThread);
 }
 
 static void *


### PR DESCRIPTION
I noticed looking through the open threads when a [probably] unrelated crash occurred while running tests locally that there is still a thread hanging around from `-[SentrySamplingProfilerTests testProfiling]` where we never end the `idleThreadEntry` thread. This fixes that.

#skip-changelog