### PR TITLE
test: end spans at end of test case

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -19,7 +19,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         }
         
         func getSut() -> SentryPerformanceTracker {
-            return  SentryPerformanceTracker()
+            return SentryPerformanceTracker()
         }
     }
     
@@ -280,7 +280,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
             
             let queue = DispatchQueue(label: "SentryPerformanceTrackerTests", attributes: [.concurrent, .initiallyInactive])
             let group = DispatchGroup()
-            
+
             for _ in 0 ..< 5_000 {
                 group.enter()
                 queue.async {
@@ -294,6 +294,9 @@ class SentryPerformanceTrackerTests: XCTestCase {
         }
         let spans = getSpans(tracker: sut)
         XCTAssertEqual(spans.count, 5_001)
+        for span in spans {
+            sut.finishSpan(span.key)
+        }
     }
     
     func testStackAsync() {


### PR DESCRIPTION
We have some intermittent test failures that result in a large run of around 5K contiguous logs in unexpected test cases, all mentioning finishing spans. Testing locally, I noticed that they originate from the timeout timer in SentryTracer. I found this loop in a test case that generates 5K spans but never ends them, I think that's a likely culprit.

#skip-changelog