### PR TITLE
fix: set the profile payload "timestamp" field to the transaction's start

### DIFF
--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -543,7 +543,7 @@ private extension SentryProfilerSwiftTests {
         let linkedTransactionInfo = try XCTUnwrap(profile["transaction"] as? [String: Any])
 
         let linkedTransactionTimestampString = try XCTUnwrap(profile["timestamp"] as? String)
-        let latestTransactionTimestampString = try XCTUnwrap((latestTransaction.startTimestamp as NSDate?)?.sentry_toIso8601String() as? String)
+        let latestTransactionTimestampString = (latestTransaction.startTimestamp as NSDate?)?.sentry_toIso8601String()
         XCTAssertEqual(linkedTransactionTimestampString, latestTransactionTimestampString)
 
         XCTAssertEqual(fixture.transactionName, latestTransaction.transaction)

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -469,11 +469,6 @@ private extension SentryProfilerSwiftTests {
         let profile = try XCTUnwrap(try JSONSerialization.jsonObject(with: data) as? [String: Any])
 
         XCTAssertNotNil(profile["version"])
-        if let timestampString = profile["timestamp"] as? String {
-            XCTAssertNotNil(NSDate.sentry_from(iso8601String: timestampString))
-        } else {
-            XCTFail("Expected a top-level timestamp")
-        }
 
         let device = try XCTUnwrap(profile["device"] as? [String: Any?])
         XCTAssertNotNil(device)
@@ -546,6 +541,10 @@ private extension SentryProfilerSwiftTests {
 
         let latestTransaction = try getLatestTransaction()
         let linkedTransactionInfo = try XCTUnwrap(profile["transaction"] as? [String: Any])
+
+        let linkedTransactionTimestampString = try XCTUnwrap(profile["timestamp"] as? String)
+        let latestTransactionTimestampString = try XCTUnwrap((latestTransaction.startTimestamp as NSDate?)?.sentry_toIso8601String() as? String)
+        XCTAssertEqual(linkedTransactionTimestampString, latestTransactionTimestampString)
 
         XCTAssertEqual(fixture.transactionName, latestTransaction.transaction)
         XCTAssertEqual(fixture.transactionName, try XCTUnwrap(linkedTransactionInfo["name"] as? String))


### PR DESCRIPTION
if there is one, or fall back to previous behavior

for https://github.com/getsentry/team-profiling/issues/191

#skip-changelog
