### PR TITLE
fix: Updating AppHang state on main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Stop using UIScreen.main (#2762)
 - Profile timestamp alignment with transactions (#2771) and app start spans (#2772)
+- Updating AppHang state on main thread (#2793)
 
 ## 8.3.0
 

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -251,18 +251,31 @@ class ViewController: UIViewController {
     @IBAction func anrFillingRunLoop(_ sender: Any) {
         let buttonTitle = self.anrFillingRunLoopButton.currentTitle
         var i = 0
+        
+        func sleep(timeout: Double) {
+            let group = DispatchGroup()
+            group.enter()
+            let queue = DispatchQueue(label: "delay", qos: .background, attributes: [])
+            
+            queue.asyncAfter(deadline: .now() + timeout) {
+                group.leave()
+            }
+            
+            group.wait()
+        }
 
         dispatchQueue.async {
-            for _ in 0...100_000 {
+            for _ in 0...30 {
                 i += Int.random(in: 0...10)
                 i -= 1
                 
                 DispatchQueue.main.async {
-                    self.anrFillingRunLoopButton.setTitle("Work in Progress \(i)", for: .normal)
+                    sleep(timeout: 0.1)
+                    self.anrFillingRunLoopButton.setTitle("Title \(i)", for: .normal)
                 }
             }
             
-            DispatchQueue.main.async {
+            DispatchQueue.main.sync {
                 self.anrFillingRunLoopButton.setTitle(buttonTitle, for: .normal)
             }
         }

--- a/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
+++ b/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
@@ -9,7 +9,7 @@ public class TestSentryDispatchQueueWrapper: SentryDispatchQueueWrapper {
     /// - SeeAlso: `delayDispatches`, which controls whether the block should execute immediately or with the requested delay.
     public var dispatchAfterExecutesBlock = false
 
-    var dispatchAsyncInvocations = Invocations<() -> Void>()
+    public var dispatchAsyncInvocations = Invocations<() -> Void>()
     public var dispatchAsyncExecutesBlock = true
     public override func dispatchAsync(_ block: @escaping () -> Void) {
         dispatchAsyncCalled += 1

--- a/Sources/Sentry/SentryANRTracker.m
+++ b/Sources/Sentry/SentryANRTracker.m
@@ -89,7 +89,13 @@ SentryANRTracker ()
 
             if (reported) {
                 SENTRY_LOG_WARN(@"ANR stopped.");
-                [self ANRStopped];
+
+                // The ANR stopped, don't block the main thread with calling ANRStopped listeners.
+                // While the ANR code reports an ANR and collects the stack trace, the ANR might
+                // stop simultaneously. In that case, the ANRs stack trace would contain the
+                // following code running on the main thread. To avoid this, we offload work to a
+                // background thread.
+                [self.dispatchQueueWrapper dispatchAsyncWithBlock:^{ [self ANRStopped]; }];
             }
 
             reported = NO;

--- a/Sources/Sentry/include/SentryANRTracker.h
+++ b/Sources/Sentry/include/SentryANRTracker.h
@@ -39,6 +39,9 @@ SENTRY_NO_INIT
 
 @end
 
+/**
+ * The ``SentryANRTracker`` calls the methods from background threads.
+ */
 @protocol SentryANRTrackerDelegate <NSObject>
 
 - (void)anrDetected;

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -90,8 +90,9 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
     
     func testMultipleANRs_MultipleReported() {
         anrDetectedExpectation.expectedFulfillmentCount = 3
+        let expectedANRStoppedInvocations = 2
         anrStoppedExpectation.isInverted = false
-        anrStoppedExpectation.expectedFulfillmentCount = 2
+        anrStoppedExpectation.expectedFulfillmentCount = expectedANRStoppedInvocations
         
         fixture.dispatchQueue.blockBeforeMainBlock = {
             self.advanceTime(bySeconds: self.fixture.timeoutInterval)
@@ -105,6 +106,7 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
         start()
         
         wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: waitTimeout)
+        XCTAssertEqual(expectedANRStoppedInvocations, fixture.dispatchQueue.dispatchAsyncInvocations.count)
     }
     
     func testAppSuspended_NoANR() {


### PR DESCRIPTION


## :scroll: Description

Move updating the app hang state to a background thread for anrStopped.

## :bulb: Motivation and Context

It came up while investigating https://github.com/getsentry/sentry-cocoa/issues/2791

## :green_heart: How did you test it?
Unit tests and on a real device.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
