### PR TITLE
output xcodebuild logs from carthage build and archive if failed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,6 +104,14 @@ jobs:
           path: |
             ${{ github.workspace }}/*.zip
 
+      - name: Archive build log if failed
+        uses: actions/upload-artifact@v3
+        if: ${{  failure() || cancelled() }}
+        with:
+          name: raw-build-output-build-xcframework
+          path: |
+            build-xcframework.log
+
   validate-xcframework:
     name: Validate XCFramework Xcode ${{ matrix.xcode }}
     runs-on: macos-12

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ analyze:
 # For more info check out: https://github.com/Carthage/Carthage/releases/tag/0.38.0
 build-xcframework:
 	@echo "--> Carthage: creating Sentry xcframework"
-	carthage build --use-xcframeworks --no-skip-current
+	carthage build --use-xcframeworks --no-skip-current --verbose > build-xcframework.log
 # use ditto here to avoid clobbering symlinks which exist in macOS frameworks
 	ditto -c -k -X --rsrc --keepParent Carthage Sentry.xcframework.zip
 


### PR DESCRIPTION
I had the [xcframework validation build fail](https://github.com/getsentry/sentry-cocoa/actions/runs/4418446156/jobs/7745583784#step:4:13) but with no clues as to why. This tries to capture the build output.

#skip-changelog