### PR TITLE
docs: call out beta status for all public-facing profiling APIs

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -160,8 +160,8 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachStacktrace;
 
 /**
- * Attention: This is an experimental feature. Turning this feature on can have an impact on
- * the grouping of your issues.
+ * @warning This is an experimental feature and may still have bugs. Turning this feature on can
+ * have an impact on the grouping of your issues.
  *
  * When enabled, the SDK stitches stack traces of asynchronous code together.
  *
@@ -213,7 +213,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachScreenshot;
 
 /**
- * This feature is EXPERIMENTAL.
+ * @warning This is an experimental feature and may still have bugs.
  *
  * Automatically attaches a textual representation of the view hierarchy when capturing an error
  * event.
@@ -235,7 +235,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) NSTimeInterval idleTimeout;
 
 /**
- * This feature is EXPERIMENTAL.
+ * @warning This is an experimental feature and may still have bugs.
  *
  * Report pre-warmed app starts by dropping the first app start spans if pre-warming paused during
  * these steps. This approach will shorten the app start duration, but it represents the duration a
@@ -349,7 +349,8 @@ NS_SWIFT_NAME(Options)
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 /**
- * This feature is experimental. Profiling is not supported on watchOS or tvOS.
+ * @warning This is a beta feature and may still have bugs.
+ * @note Profiling is not supported on watchOS or tvOS.
  *
  * Indicates the percentage profiles being sampled out of the sampled transactions.
  *
@@ -359,42 +360,37 @@ NS_SWIFT_NAME(Options)
  * This property is dependent on `tracesSampleRate` -- if `tracesSampleRate` is 0 (default),
  * no profiles will be collected no matter what this property is set to. This property is
  * used to undersample profiles *relative to* `tracesSampleRate`.
- *
- * @Note This feature is not supported on watchOS or tvOS.
- * @warning This is a beta feature and may still have bugs.
  */
 @property (nullable, nonatomic, strong) NSNumber *profilesSampleRate;
 
 /**
- * This feature is experimental. Profiling is not supported on watchOS or tvOS.
+ * @warning This is a beta feature and may still have bugs.
+ * @note Profiling is not supported on watchOS or tvOS.
  *
  * A callback to a user defined profiles sampler function. This is similar to setting
  * `profilesSampleRate`, but instead of a static value, the callback function will be called to
  * determine the sample rate.
- *
- * @Note This feature is not supported on watchOS or tvOS.
- * @warning This is a beta feature and may still have bugs.
  */
 @property (nullable, nonatomic) SentryTracesSamplerCallback profilesSampler;
 
 /**
+ * @warning This is a beta feature and may still have bugs.
+ * @note Profiling is not supported on watchOS or tvOS.
+ *
  * If profiling should be enabled or not. Returns YES if either a profilesSampleRate > 0 and
  * <=1 or a profilesSampler is set otherwise NO.
- *
- * @Note This feature is not supported on watchOS or tvOS.
- * @warning This is a beta feature and may still have bugs.
  */
 @property (nonatomic, assign, readonly) BOOL isProfilingEnabled;
 
 /**
  * DEPRECATED: Use `profilesSampleRate` instead. Setting `enableProfiling` to YES is the equivalent
  * of setting `profilesSampleRate` to `1.0`. If `profilesSampleRate` is set, it will take precedence
+ * @warning This is a beta feature and may still have bugs.
+ * @note Profiling is not supported on watchOS or tvOS.
+ *
  * over this setting.
  *
  * Whether to enable the sampling profiler. Default is NO.
- *
- * @Note This feature is not supported on watchOS or tvOS.
- * @warning This is a beta feature and may still have bugs.
  */
 @property (nonatomic, assign) BOOL enableProfiling DEPRECATED_MSG_ATTRIBUTE(
     "Use profilesSampleRate or profilesSampler instead. This property will be removed in a future "
@@ -470,7 +466,7 @@ NS_SWIFT_NAME(Options)
 #if SENTRY_HAS_METRIC_KIT
 
 /**
- * ATTENTION: This is an experimental feature.
+ * @warning This is an experimental feature and may still have bugs.
  *
  * This feature is disabled by default. When enabled, the SDK sends
  * ``MXDiskWriteExceptionDiagnostic``, ``MXCPUExceptionDiagnostic`` and ``MXHangDiagnostic``  to

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -359,6 +359,9 @@ NS_SWIFT_NAME(Options)
  * This property is dependent on `tracesSampleRate` -- if `tracesSampleRate` is 0 (default),
  * no profiles will be collected no matter what this property is set to. This property is
  * used to undersample profiles *relative to* `tracesSampleRate`.
+ *
+ * @Note This feature is not supported on watchOS or tvOS.
+ * @warning This is a beta feature and may still have bugs.
  */
 @property (nullable, nonatomic, strong) NSNumber *profilesSampleRate;
 
@@ -368,12 +371,18 @@ NS_SWIFT_NAME(Options)
  * A callback to a user defined profiles sampler function. This is similar to setting
  * `profilesSampleRate`, but instead of a static value, the callback function will be called to
  * determine the sample rate.
+ *
+ * @Note This feature is not supported on watchOS or tvOS.
+ * @warning This is a beta feature and may still have bugs.
  */
 @property (nullable, nonatomic) SentryTracesSamplerCallback profilesSampler;
 
 /**
  * If profiling should be enabled or not. Returns YES if either a profilesSampleRate > 0 and
  * <=1 or a profilesSampler is set otherwise NO.
+ *
+ * @Note This feature is not supported on watchOS or tvOS.
+ * @warning This is a beta feature and may still have bugs.
  */
 @property (nonatomic, assign, readonly) BOOL isProfilingEnabled;
 
@@ -383,8 +392,9 @@ NS_SWIFT_NAME(Options)
  * over this setting.
  *
  * Whether to enable the sampling profiler. Default is NO.
- * @note This is a beta feature that is currently not available to all Sentry customers. This
- * feature is not supported on watchOS or tvOS.
+ *
+ * @Note This feature is not supported on watchOS or tvOS.
+ * @warning This is a beta feature and may still have bugs.
  */
 @property (nonatomic, assign) BOOL enableProfiling DEPRECATED_MSG_ATTRIBUTE(
     "Use profilesSampleRate or profilesSampler instead. This property will be removed in a future "

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -5,8 +5,7 @@ import SwiftUI
 import SentryInternal
 #endif
 
-///
-/// This feature is EXPERIMENTAL.
+/// - warning: This is an experimental feature and may still have bugs.
 ///
 /// A control to measure the performance of your views and send the result as a transaction to Sentry.io.
 ///
@@ -93,11 +92,9 @@ public struct SentryTracedView<Content: View>: View {
     }
 }
 
-///
-/// This feature is EXPERIMENTAL.
-///
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 public extension View {
+    /// - warning: This is an experimental feature and may still have bugs.
     func sentryTrace(_ viewName: String? = nil) -> some View {
         return SentryTracedView(viewName) {
             return self


### PR DESCRIPTION
Add notes and beta warnings to all public-facing APIs for profiling.

#skip-changelog