### PR TITLE
disable flaky testStartWithConfigureOptions

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -74,6 +74,9 @@
                   Identifier = "SentrySDKIntegrationTestsBase">
                </Test>
                <Test
+                  Identifier = "SentrySDKTests/testStartWithConfigureOptions()">
+               </Test>
+               <Test
                   Identifier = "SentrySessionGeneratorTests/testSendSessions()">
                </Test>
                <Test


### PR DESCRIPTION
Failed in https://github.com/getsentry/sentry-cocoa/actions/runs/4440291597/jobs/7793934097#step:11:30

Passed in the second attempt. No changes to source in that [PR](https://github.com/getsentry/sentry-cocoa/pull/2804).

I've seen it a few times now so I opened this PR and related flaky test issue.

#skip-changelog