### PR TITLE
test: Remove not needed thread safe comment

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -473,8 +473,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         assertOneSpanCreated(transaction)
     }
     
-    // Although we only run this test above the below specified versions, we expect the
-    // implementation to be thread safe
     func testResumeCalledMultipleTimesConcurrent_OneSpanCreated() {
         let task = createDataTask()
         let sut = fixture.getSut()
@@ -498,8 +496,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         assertOneSpanCreated(transaction)
     }
     
-    // Although we only run this test above the below specified versions, we expect the
-    // implementation to be thread safe
     func testChangeStateMultipleTimesConcurrent_OneSpanFinished() {
         let task = createDataTask()
         let sut = fixture.getSut()

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -88,9 +88,6 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(TestData.user, copiedUser)
     }
     
-    // Although we only run this test above the below specified versions, we expect the
-    // implementation to be thread safe
-    // With this test we test if modifications from multiple threads don't lead to a crash.
     func testModifyingFromMultipleThreads() {
         let queue = DispatchQueue(label: "SentryScopeTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()


### PR DESCRIPTION
As we bumped the min supported OS versions, we could remove the available annotations for tests
using the dispatch queue. We forgot to remove the comments explaining why we used the available
annotation.

#skip-changelog