### PR TITLE
perf: Remove not needed locks in SentryUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Updating AppHang state on main thread (#2793)
 
+### Improvements
+
+- Remove not needed locks in SentryUser (#2809)
+
 ## 8.3.1
 
 ### Fixes 

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -23,15 +23,13 @@ NS_ASSUME_NONNULL_BEGIN
 {
     SentryUser *copy = [[SentryUser allocWithZone:zone] init];
 
-    @synchronized(self) {
-        if (copy != nil) {
-            copy.userId = self.userId;
-            copy.email = self.email;
-            copy.username = self.username;
-            copy.ipAddress = self.ipAddress;
-            copy.segment = self.segment;
-            copy.data = self.data.copy;
-        }
+    if (copy != nil) {
+        copy.userId = self.userId;
+        copy.email = self.email;
+        copy.username = self.username;
+        copy.ipAddress = self.ipAddress;
+        copy.segment = self.segment;
+        copy.data = self.data.copy;
     }
 
     return copy;
@@ -41,93 +39,83 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSMutableDictionary *serializedData = [[NSMutableDictionary alloc] init];
 
-    @synchronized(self) {
-        [serializedData setValue:self.userId forKey:@"id"];
-        [serializedData setValue:self.email forKey:@"email"];
-        [serializedData setValue:self.username forKey:@"username"];
-        [serializedData setValue:self.ipAddress forKey:@"ip_address"];
-        [serializedData setValue:self.segment forKey:@"segment"];
-        [serializedData setValue:[self.data sentry_sanitize] forKey:@"data"];
-    }
+    [serializedData setValue:self.userId forKey:@"id"];
+    [serializedData setValue:self.email forKey:@"email"];
+    [serializedData setValue:self.username forKey:@"username"];
+    [serializedData setValue:self.ipAddress forKey:@"ip_address"];
+    [serializedData setValue:self.segment forKey:@"segment"];
+    [serializedData setValue:[self.data sentry_sanitize] forKey:@"data"];
 
     return serializedData;
 }
 
 - (BOOL)isEqual:(id _Nullable)other
 {
-    @synchronized(self) {
-        if (other == self) {
-            return YES;
-        }
-        if (!other || ![[other class] isEqual:[self class]]) {
-            return NO;
-        }
 
-        return [self isEqualToUser:other];
+    if (other == self) {
+        return YES;
     }
+    if (!other || ![[other class] isEqual:[self class]]) {
+        return NO;
+    }
+
+    return [self isEqualToUser:other];
 }
 
 - (BOOL)isEqualToUser:(SentryUser *)user
 {
-    @synchronized(self) {
-        // We need to get some local copies of the properties, because they could be modified during
-        // the if statements
-
-        if (self == user) {
-            return YES;
-        }
-        if (user == nil) {
-            return NO;
-        }
-
-        NSString *otherUserId = user.userId;
-        if (self.userId != otherUserId && ![self.userId isEqualToString:otherUserId]) {
-            return NO;
-        }
-
-        NSString *otherEmail = user.email;
-        if (self.email != otherEmail && ![self.email isEqualToString:otherEmail]) {
-            return NO;
-        }
-
-        NSString *otherUsername = user.username;
-        if (self.username != otherUsername && ![self.username isEqualToString:otherUsername]) {
-            return NO;
-        }
-
-        NSString *otherIpAdress = user.ipAddress;
-        if (self.ipAddress != otherIpAdress && ![self.ipAddress isEqualToString:otherIpAdress]) {
-            return NO;
-        }
-
-        NSString *otherSegment = user.segment;
-        if (self.segment != otherSegment && ![self.segment isEqualToString:otherSegment]) {
-            return NO;
-        }
-
-        NSDictionary<NSString *, id> *otherUserData = user.data;
-        if (self.data != otherUserData && ![self.data isEqualToDictionary:otherUserData]) {
-            return NO;
-        }
-
+    if (self == user) {
         return YES;
     }
+    if (user == nil) {
+        return NO;
+    }
+
+    NSString *otherUserId = user.userId;
+    if (self.userId != otherUserId && ![self.userId isEqualToString:otherUserId]) {
+        return NO;
+    }
+
+    NSString *otherEmail = user.email;
+    if (self.email != otherEmail && ![self.email isEqualToString:otherEmail]) {
+        return NO;
+    }
+
+    NSString *otherUsername = user.username;
+    if (self.username != otherUsername && ![self.username isEqualToString:otherUsername]) {
+        return NO;
+    }
+
+    NSString *otherIpAdress = user.ipAddress;
+    if (self.ipAddress != otherIpAdress && ![self.ipAddress isEqualToString:otherIpAdress]) {
+        return NO;
+    }
+
+    NSString *otherSegment = user.segment;
+    if (self.segment != otherSegment && ![self.segment isEqualToString:otherSegment]) {
+        return NO;
+    }
+
+    NSDictionary<NSString *, id> *otherUserData = user.data;
+    if (self.data != otherUserData && ![self.data isEqualToDictionary:otherUserData]) {
+        return NO;
+    }
+
+    return YES;
 }
 
 - (NSUInteger)hash
 {
-    @synchronized(self) {
-        NSUInteger hash = 17;
+    NSUInteger hash = 17;
 
-        hash = hash * 23 + [self.userId hash];
-        hash = hash * 23 + [self.email hash];
-        hash = hash * 23 + [self.username hash];
-        hash = hash * 23 + [self.ipAddress hash];
-        hash = hash * 23 + [self.segment hash];
-        hash = hash * 23 + [self.data hash];
+    hash = hash * 23 + [self.userId hash];
+    hash = hash * 23 + [self.email hash];
+    hash = hash * 23 + [self.username hash];
+    hash = hash * 23 + [self.ipAddress hash];
+    hash = hash * 23 + [self.segment hash];
+    hash = hash * 23 + [self.data hash];
 
-        return hash;
-    }
+    return hash;
 }
 
 @end

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -92,7 +92,7 @@ class SentryUserTests: XCTestCase {
     // implementation to be thread safe
     // With this test we test if modifications from multiple threads don't lead to a crash.
     func testModifyingFromMultipleThreads() {
-        let queue = DispatchQueue(label: "SentryScopeTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+        let queue = DispatchQueue(label: "SentryUserTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
         
         let user = TestData.user.copy() as! User


### PR DESCRIPTION


## :scroll: Description

Remove added not needed locks with https://github.com/getsentry/sentry-cocoa/pull/888 in SentryUser. The copy, isEqual, serialize, and hash methods don't need to be thread safe. When modifying the user from multiple threads and calling any of these methods, the callee should use locks.

## :bulb: Motivation and Context

Came up in https://github.com/getsentry/sentry-cocoa/pull/2710#discussion_r1139953738

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
