### PR TITLE
fix: App Hang report crashes with too many threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Updating AppHang state on main thread (#2793)
+- App Hang report crashes with too many threads (#2811)
 
 ## 8.3.1
 

--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -119,14 +119,15 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
         thread_act_array_t suspendedThreads = NULL;
         mach_msg_type_number_t numSuspendedThreads = 0;
 
-        //We add a limit of 70 threads because in every test up to a 100 seems fine.
-        //We are giving it an extra safety margin.
-        sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(&suspendedThreads, &numSuspendedThreads, 70);
+        // We add a limit of 70 threads because in every test up to a 100 seems fine.
+        // We are giving it an extra safety margin.
+        sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
+            &suspendedThreads, &numSuspendedThreads, 70);
         // DANGER: Do not try to allocate memory in the heap or call Objective-C code in this
         // section Doing so when the threads are suspended may lead to deadlocks or crashes.
 
-        //If no threads was suspended we don't need to do anything.
-        //This may happen if there is more than max amount of threads (70).
+        // If no threads was suspended we don't need to do anything.
+        // This may happen if there is more than max amount of threads (70).
         if (numSuspendedThreads == 0) {
             return threads;
         }

--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -119,7 +119,8 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
         thread_act_array_t suspendedThreads = NULL;
         mach_msg_type_number_t numSuspendedThreads = 0;
 
-        // We add a limit of 70 threads because in every test up to a 100 seems fine.
+        // SentryThreadInspector is crashing when there is too many threads.
+        // We add a limit of 70 threads because in test with up to 100 threads it seems fine.
         // We are giving it an extra safety margin.
         sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
             &suspendedThreads, &numSuspendedThreads, 70);

--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -119,9 +119,15 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
         thread_act_array_t suspendedThreads = NULL;
         mach_msg_type_number_t numSuspendedThreads = 0;
 
-        sentrycrashmc_suspendEnvironment(&suspendedThreads, &numSuspendedThreads);
+        sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(&suspendedThreads, &numSuspendedThreads, 70);
         // DANGER: Do not try to allocate memory in the heap or call Objective-C code in this
         // section Doing so when the threads are suspended may lead to deadlocks or crashes.
+
+        //If no threads was suspended we don't need to do anything.
+        //This may happen if there is more than max amount of threads (70).
+        if (numSuspendedThreads == 0) {
+            return threads;
+        }
 
         SentryThreadInfo threadsInfos[numSuspendedThreads];
 

--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -119,6 +119,8 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
         thread_act_array_t suspendedThreads = NULL;
         mach_msg_type_number_t numSuspendedThreads = 0;
 
+        //We add a limit of 70 threads because in every test up to a 100 seems fine.
+        //We are giving it an extra safety margin.
         sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(&suspendedThreads, &numSuspendedThreads, 70);
         // DANGER: Do not try to allocate memory in the heap or call Objective-C code in this
         // section Doing so when the threads are suspended may lead to deadlocks or crashes.

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -385,10 +385,7 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME                                                                                    \
-    {                                                                                              \
-        return sentrycrashstate_currentState()->NAME;                                              \
-    }
+    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -148,7 +148,7 @@ sentrycrashmc_suspendEnvironment(
     thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads)
 {
     sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
-        suspendedThreads, numSuspendedThreads, 1000);
+        suspendedThreads, numSuspendedThreads, UINT32_MAX);
 }
 
 void

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -147,6 +147,12 @@ void
 sentrycrashmc_suspendEnvironment(
     thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads)
 {
+    sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(suspendedThreads, numSuspendedThreads, 1000);
+}
+
+void sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
+        thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads, mach_msg_type_number_t maxSupportedThreads )
+    {
 #if SentryCrashCRASH_HAS_THREADS_API
     SentryCrashLOG_DEBUG("Suspending environment.");
     kern_return_t kr;
@@ -155,6 +161,12 @@ sentrycrashmc_suspendEnvironment(
 
     if ((kr = task_threads(thisTask, suspendedThreads, numSuspendedThreads)) != KERN_SUCCESS) {
         SentryCrashLOG_ERROR("task_threads: %s", mach_error_string(kr));
+        return;
+    }
+
+    if (*numSuspendedThreads > maxSupportedThreads) {
+        *numSuspendedThreads = 0;
+        SentryCrashLOG_DEBUG("Too many threads to suspend. Aborting operation.");
         return;
     }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -147,12 +147,14 @@ void
 sentrycrashmc_suspendEnvironment(
     thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads)
 {
-    sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(suspendedThreads, numSuspendedThreads, 1000);
+    sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
+        suspendedThreads, numSuspendedThreads, 1000);
 }
 
-void sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
-        thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads, mach_msg_type_number_t maxSupportedThreads )
-    {
+void
+sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(thread_act_array_t *suspendedThreads,
+    mach_msg_type_number_t *numSuspendedThreads, mach_msg_type_number_t maxSupportedThreads)
+{
 #if SentryCrashCRASH_HAS_THREADS_API
     SentryCrashLOG_DEBUG("Suspending environment.");
     kern_return_t kr;

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -40,6 +40,13 @@ extern "C" {
 void sentrycrashmc_suspendEnvironment(
     thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads);
 
+
+/**
+ Suspend the runtime environment only if the amount of threads is not higher than maxSupportedThreads.
+ */
+void sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
+    thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads, mach_msg_type_number_t maxSupportedThreads );
+
 /** Resume the runtime environment.
  */
 void sentrycrashmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_number_t numThreads);

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -40,12 +40,12 @@ extern "C" {
 void sentrycrashmc_suspendEnvironment(
     thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads);
 
-
 /**
- Suspend the runtime environment only if the amount of threads is not higher than maxSupportedThreads.
+ Suspend the runtime environment only if the amount of threads is not higher than
+ maxSupportedThreads.
  */
-void sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(
-    thread_act_array_t *suspendedThreads, mach_msg_type_number_t *numSuspendedThreads, mach_msg_type_number_t maxSupportedThreads );
+void sentrycrashmc_suspendEnvironment_upToMaxSupportedThreads(thread_act_array_t *suspendedThreads,
+    mach_msg_type_number_t *numSuspendedThreads, mach_msg_type_number_t maxSupportedThreads);
 
 /** Resume the runtime environment.
  */

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 
-
 class SentryThreadInspectorTests: XCTestCase {
     
     private class Fixture {
@@ -91,7 +90,7 @@ class SentryThreadInspectorTests: XCTestCase {
         for _ in 0..<expect.expectedFulfillmentCount {
             Thread.detachNewThread {
                 expect.fulfill()
-                while (self.fixture.keepThreadAlive) {
+                while self.fixture.keepThreadAlive {
                     Thread.sleep(forTimeInterval: 0.001)
                 }
             }
@@ -99,7 +98,7 @@ class SentryThreadInspectorTests: XCTestCase {
 
         wait(for: [expect], timeout: 1)
         let suspendedThreads = sut.getCurrentThreadsWithStackTrace()
-        fixture.keepThreadAlive = false;
+        fixture.keepThreadAlive = false
         XCTAssertEqual(suspendedThreads.count, 0)
     }
 

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -1,10 +1,12 @@
 import XCTest
 
+
 class SentryThreadInspectorTests: XCTestCase {
     
     private class Fixture {
         var testMachineContextWrapper = TestMachineContextWrapper()
         var stacktraceBuilder = TestSentryStacktraceBuilder(crashStackEntryMapper: SentryCrashStackEntryMapper(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])))
+        var keepThreadAlive = true
         
         func getSut(testWithRealMachineContextWrapper: Bool = false) -> SentryThreadInspector {
             
@@ -78,6 +80,27 @@ class SentryThreadInspectorTests: XCTestCase {
         
         queue.activate()
         wait(for: [expect], timeout: 10)
+    }
+
+    func testGetCurrentThreadWithStackTrack_TooManyThreads() {
+        let expect = expectation(description: "Wait all Threads")
+        expect.expectedFulfillmentCount = 70
+
+        let sut = self.fixture.getSut(testWithRealMachineContextWrapper: true)
+
+        for _ in 0..<expect.expectedFulfillmentCount {
+            Thread.detachNewThread {
+                expect.fulfill()
+                while (self.fixture.keepThreadAlive) {
+                    Thread.sleep(forTimeInterval: 0.001)
+                }
+            }
+        }
+
+        wait(for: [expect], timeout: 1)
+        let suspendedThreads = sut.getCurrentThreadsWithStackTrace()
+        fixture.keepThreadAlive = false;
+        XCTAssertEqual(suspendedThreads.count, 0)
     }
 
     func testStackTrackForCurrentThreadAsyncUnsafe() {

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -96,7 +96,7 @@ class SentryThreadInspectorTests: XCTestCase {
             }
         }
 
-        wait(for: [expect], timeout: 1)
+        wait(for: [expect], timeout: 5)
         let suspendedThreads = sut.getCurrentThreadsWithStackTrace()
         fixture.keepThreadAlive = false
         XCTAssertEqual(suspendedThreads.count, 0)


### PR DESCRIPTION
## :scroll: Description

Add a limit of 70 threads to report App hang. 
More than 100 is causing the SDK to crash, we add an extra safety margin.

## :bulb: Motivation and Context

closes #2794 

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
