### PR TITLE
test: Add Error Description in iOS-Swift sample

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Tools/RandomErrors.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/RandomErrors.swift
@@ -6,6 +6,23 @@ enum SampleError: Error {
     case awesomeCentaur
 }
 
+extension SampleError: CustomNSError {
+    var errorUserInfo: [String: Any] {
+        func getDebugDescription() -> String {
+            switch self {
+            case SampleError.bestDeveloper:
+                return  "bestDeveloper"
+            case .happyCustomer:
+                return  "happyCustomer"
+            case .awesomeCentaur:
+                return "awesomeCentaur"
+            }
+        }
+        
+        return [NSDebugDescriptionErrorKey: getDebugDescription()]
+    }
+}
+
 class RandomErrorGenerator {
     
     static func generate() throws {


### PR DESCRIPTION
Add custom error description when capturing swift errors.

This came up while investigating https://github.com/getsentry/sentry-cocoa/issues/2760.

#skip-changelog