### PR TITLE
feat: Add CPU Core count in device context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add CPU core count in device context (#2814)
+
 ### Fixes
 
 - Updating AppHang state on main thread (#2793)

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -31,6 +31,7 @@
 #import "SentryMessage.h"
 #import "SentryMeta.h"
 #import "SentryNSError.h"
+#import "SentryNSProcessInfoWrapper.h"
 #import "SentryOptions+Private.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"
@@ -46,7 +47,6 @@
 #import "SentryUser.h"
 #import "SentryUserFeedback.h"
 #import "SentryWatchdogTerminationTracker.h"
-#import "SentryNSProcessInfoWrapper.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -64,7 +64,7 @@ SentryClient ()
 @property (nonatomic, strong) SentryUIDeviceWrapper *deviceWrapper;
 @property (nonatomic, strong) NSLocale *locale;
 @property (nonatomic, strong) NSTimeZone *timezone;
-@property (nonatomic, strong) SentryNSProcessInfoWrapper * processInfoWrapper;
+@property (nonatomic, strong) SentryNSProcessInfoWrapper *processInfoWrapper;
 
 @end
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -794,6 +794,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                 block:^(NSMutableDictionary *device) {
                     device[SentryDeviceContextFreeMemoryKey] = @(self.crashWrapper.freeMemorySize);
                     device[@"free_storage"] = @(self.crashWrapper.freeStorageSize);
+                    device[@"processor_count"] = @(NSProcessInfo.processInfo.processorCount);
 
 #if TARGET_OS_IOS
                     if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -46,6 +46,7 @@
 #import "SentryUser.h"
 #import "SentryUserFeedback.h"
 #import "SentryWatchdogTerminationTracker.h"
+#import "SentryNSProcessInfoWrapper.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -63,6 +64,7 @@ SentryClient ()
 @property (nonatomic, strong) SentryUIDeviceWrapper *deviceWrapper;
 @property (nonatomic, strong) NSLocale *locale;
 @property (nonatomic, strong) NSTimeZone *timezone;
+@property (nonatomic, strong) SentryNSProcessInfoWrapper * processInfoWrapper;
 
 @end
 
@@ -171,6 +173,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         self.timezone = timezone;
         self.attachmentProcessors = [[NSMutableArray alloc] init];
         self.deviceWrapper = deviceWrapper;
+        self.processInfoWrapper = [[SentryNSProcessInfoWrapper alloc] init];
 
         if (deleteOldEnvelopeItems) {
             [fileManager deleteOldEnvelopeItems];
@@ -794,7 +797,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                 block:^(NSMutableDictionary *device) {
                     device[SentryDeviceContextFreeMemoryKey] = @(self.crashWrapper.freeMemorySize);
                     device[@"free_storage"] = @(self.crashWrapper.freeStorageSize);
-                    device[@"processor_count"] = @(NSProcessInfo.processInfo.processorCount);
+                    device[@"processor_count"] = @([self.processInfoWrapper processorCount]);
 
 #if TARGET_OS_IOS
                     if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -609,7 +609,12 @@ class SentryClientTest: XCTestCase {
 
     func testCaptureEvent_AddCurrentMemoryStorageAndCPUCoreCount() {
 
-        fixture.getSut().capture(event: TestData.event)
+        let sut = fixture.getSut()
+        let testProcessWrapper = TestSentryNSProcessInfoWrapper()
+        testProcessWrapper.overrides.processorCount = 12
+        Dynamic(sut).processInfoWrapper = testProcessWrapper
+
+        sut.capture(event: TestData.event)
 
         assertLastSentEvent { actual in
             let eventFreeMemory = actual.context?["device"]?[SentryDeviceContextFreeMemoryKey] as? Int
@@ -621,8 +626,8 @@ class SentryClientTest: XCTestCase {
             let eventFreeStorage = actual.context?["device"]?["free_storage"] as? Int
             XCTAssertEqual(eventFreeStorage, 345_678)
 
-            let cpuCoreCount = actual.context?["device"]?["processor_count"]
-            XCTAssertNotNil(cpuCoreCount)
+            let cpuCoreCount = actual.context?["device"]?["processor_count"] as? UInt
+            XCTAssertEqual(testProcessWrapper.processorCount, cpuCoreCount)
         }
     }
     

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -607,7 +607,7 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    func testCaptureEvent_AddCurrentMemoryAndStorage() {
+    func testCaptureEvent_AddCurrentMemoryStorageAndCPUCoreCount() {
 
         fixture.getSut().capture(event: TestData.event)
 
@@ -620,6 +620,9 @@ class SentryClientTest: XCTestCase {
 
             let eventFreeStorage = actual.context?["device"]?["free_storage"] as? Int
             XCTAssertEqual(eventFreeStorage, 345_678)
+
+            let cpuCoreCount = actual.context?["device"]?["processor_count"]
+            XCTAssertNotNil(cpuCoreCount)
         }
     }
     


### PR DESCRIPTION
## :scroll: Description

Added the amount of CPU cores in the device context.

## :bulb: Motivation and Context

closes #2740 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
