### PR TITLE
test: Build TestFlight with Xcode 14.2

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -16,8 +16,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      # Xcode 14.1 has a bug with fastlane see https://github.com/fastlane/fastlane/issues/20910
-      - run: ./scripts/ci-select-xcode.sh 14.0.1
+      - run: ./scripts/ci-select-xcode.sh 14.2
       - run: bundle install
 
       # We upload a new version to TestFlight on every commit on main


### PR DESCRIPTION
A bug in Fastlane required us to pin Fastlane to Xcode 14.0.1,
which is fixed: https://github.com/fastlane/fastlane/issues/20910.
Now, we can build with Xcode 14.2.

#skip-changelog

