### PR TITLE
fix: missing GPU frame info in profiler

### DIFF
--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -46,15 +46,15 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
-            DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
+            DerivedData/Build/Products/Test-iphoneos/iOS-Swift.app.dSYM
+            DerivedData/Build/Products/Test-iphoneos/iOS-Swift.app
           key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-Swift/**') }}-Xcode-${{ matrix.xcode }}-${{ hashFiles('Sources/Sentry/**') }}
       - name: Cache iOS-Swift UI Test Runner App build product
         id: ios-swift-uitest-runner-cache
         uses: actions/cache@v3
         with:
           path: |
-            DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
+            DerivedData/Build/Products/Test-iphoneos/iOS-SwiftUITests-Runner.app
           key: ios-swift-for-ui-testing-cache-key-${{ hashFiles('Samples/iOS-Swift/iOS-SwiftUITests/**') }}-Xcode-${{ matrix.xcode }}
       - run: fastlane build_ios_swift_for_tests
         env:
@@ -76,14 +76,14 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Upload dSYMs
         run: |
-          sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project sentry-cocoa DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app.dSYM
+          sentry-cli --auth-token ${{ secrets.SENTRY_AUTH_TOKEN }} upload-dif --org sentry-sdks --project sentry-cocoa DerivedData/Build/Products/Test-iphoneos/iOS-Swift.app.dSYM
       - name: Archiving DerivedData
         uses: actions/upload-artifact@v3
         with:
           name: DerivedData-Xcode-${{matrix.xcode}}
           path: |
-            **/Debug-iphoneos/iOS-Swift.app
-            **/Debug-iphoneos/iOS-SwiftUITests-Runner.app
+            **/Test-iphoneos/iOS-Swift.app
+            **/Test-iphoneos/iOS-SwiftUITests-Runner.app
 
   run-ui-tests-with-sauce:
     name: Run UI Tests for iOS ${{ matrix.suite }} on Sauce Labs

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -8,8 +8,8 @@ defaults:
   timeout: 20m
 
 xcuitest:
-  app: ./DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app
-  testApp: ./DerivedData/Build/Products/Debug-iphoneos/iOS-SwiftUITests-Runner.app
+  app: ./DerivedData/Build/Products/Test-iphoneos/iOS-Swift.app
+  testApp: ./DerivedData/Build/Products/Test-iphoneos/iOS-SwiftUITests-Runner.app
 
 suites:
    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - View hierarchy not sent for crashes (#2781)
 - Crash in Tracer for idle timeout (#2834)
+- Correctly track and send GPU frame render data in profiles (#2823)
 
 ## 8.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+ 
+- Correctly track and send GPU frame render data in profiles (#2823)
+
 ## 8.3.3
 
 ### Fixes
 
 - View hierarchy not sent for crashes (#2781)
 - Crash in Tracer for idle timeout (#2834)
-- Correctly track and send GPU frame render data in profiles (#2823)
 
 ## 8.3.2
 

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		848A256B286E3351008A8858 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 630853322440C44F00DDE4CE /* Sentry.framework */; };
 		848A256D286E3351008A8858 /* fatal-error-binary-images-message2.json in Resources */ = {isa = PBXBuildFile; fileRef = D83A30DF279F1F5C00372D0A /* fatal-error-binary-images-message2.json */; };
 		848A256F286E3351008A8858 /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 630853322440C44F00DDE4CE /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		84A5D72629D2705000388BFA /* ProfilingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D72529D2705000388BFA /* ProfilingUITests.swift */; };
+		84A5D72D29D2708D00388BFA /* UITestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D72C29D2708D00388BFA /* UITestHelpers.swift */; };
 		84B527B928DD24BA00475E8D /* SentryDeviceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84B527B728DD24BA00475E8D /* SentryDeviceTests.mm */; };
 		84B527BD28DD25E400475E8D /* SentryDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84B527BC28DD25E400475E8D /* SentryDevice.mm */; };
 		84BE546F287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE546E287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m */; };
@@ -278,6 +280,8 @@
 		7BFC8B0526D4D24B000D3504 /* LoremIpsum.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = LoremIpsum.txt; sourceTree = "<group>"; };
 		848A2573286E3351008A8858 /* PerformanceBenchmarks.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PerformanceBenchmarks.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		848A2578286E3490008A8858 /* PerformanceBenchmarks-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PerformanceBenchmarks-Info.plist"; sourceTree = "<group>"; };
+		84A5D72529D2705000388BFA /* ProfilingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfilingUITests.swift; sourceTree = "<group>"; };
+		84A5D72C29D2708D00388BFA /* UITestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestHelpers.swift; sourceTree = "<group>"; };
 		84B527B728DD24BA00475E8D /* SentryDeviceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryDeviceTests.mm; path = ../../../Tests/SentryTests/Helper/SentryDeviceTests.mm; sourceTree = "<group>"; };
 		84B527BB28DD25E400475E8D /* SentryDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryDevice.h; path = ../../../Sources/Sentry/include/SentryDevice.h; sourceTree = "<group>"; };
 		84B527BC28DD25E400475E8D /* SentryDevice.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryDevice.mm; path = ../../../Sources/Sentry/SentryDevice.mm; sourceTree = "<group>"; };
@@ -454,6 +458,8 @@
 			children = (
 				D83A30DF279F1F5C00372D0A /* fatal-error-binary-images-message2.json */,
 				7B64386A26A6C544000D0F65 /* LaunchUITests.swift */,
+				84A5D72C29D2708D00388BFA /* UITestHelpers.swift */,
+				84A5D72529D2705000388BFA /* ProfilingUITests.swift */,
 				84B527B728DD24BA00475E8D /* SentryDeviceTests.mm */,
 				84B527BB28DD25E400475E8D /* SentryDevice.h */,
 				84B527BC28DD25E400475E8D /* SentryDevice.mm */,
@@ -882,6 +888,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84A5D72629D2705000388BFA /* ProfilingUITests.swift in Sources */,
+				84A5D72D29D2708D00388BFA /* UITestHelpers.swift in Sources */,
 				84B527B928DD24BA00475E8D /* SentryDeviceTests.mm in Sources */,
 				7B64386B26A6C544000D0F65 /* LaunchUITests.swift in Sources */,
 				84B527BD28DD25E400475E8D /* SentryDevice.mm in Sources */,

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -1364,8 +1364,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "iOS-Swift/iOS-Swift.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
@@ -1378,7 +1378,7 @@
 				MARKETING_VERSION = 7.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.sample.iOS-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.sample.iOS-Swift";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.sample.iOS-Swift";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "iOS-Swift/Tools/iOS-Swift-Bridging-Header.h";
@@ -1390,7 +1390,7 @@
 		84D4FE8228ECD1EA00EDAAFE /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 97JCY7859U;
@@ -1403,7 +1403,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.iOS-SwiftUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.iOS-SwiftUITests.xctrunner";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-SwiftUITests.xctrunner";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1441,7 +1441,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iOS-SwiftClip/iOS_SwiftClip.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
@@ -1463,7 +1463,7 @@
 				MARKETING_VERSION = 7.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.sample.iOS-Swift.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.sample.iOS-Swift.Clip";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.sample.iOS-Swift.Clip";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1587,8 +1587,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "iOS-Swift/iOS-Swift.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
@@ -1601,7 +1601,7 @@
 				MARKETING_VERSION = 7.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.sample.iOS-Swift";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.sample.iOS-Swift";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.sample.iOS-Swift";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SUPPORTS_MACCATALYST = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "iOS-Swift/Tools/iOS-Swift-Bridging-Header.h";
@@ -1613,7 +1613,7 @@
 		84D4FE8A28ECD1ED00EDAAFE /* TestCI */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = 97JCY7859U;
@@ -1626,7 +1626,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.iOS-SwiftUITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.iOS-SwiftUITests.xctrunner";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-SwiftUITests.xctrunner";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -1664,7 +1664,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "iOS-SwiftClip/iOS_SwiftClip.entitlements";
-				CODE_SIGN_IDENTITY = "iPhone Distribution";
+				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
@@ -1686,7 +1686,7 @@
 				MARKETING_VERSION = 7.27.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.sample.iOS-Swift.Clip";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.sample.iOS-Swift.Clip";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.sample.iOS-Swift.Clip";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -295,16 +295,22 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="UrL-kT-AJU">
-                                        <rect key="frame" x="0.0" y="314" width="304" height="210"/>
+                                        <rect key="frame" x="0.0" y="230" width="304" height="294"/>
                                         <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9aH-uZ-TAM">
+                                                <rect key="frame" x="8" y="32" width="288" height="42.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DSN  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="m3h-wb-Xfa">
-                                                <rect key="frame" x="8" y="32" width="288" height="34"/>
+                                                <rect key="frame" x="8" y="74.5" width="288" height="42"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="L2a-LY-eQ7">
-                                                <rect key="frame" x="8" y="66" width="288" height="34"/>
+                                                <rect key="frame" x="8" y="116.5" width="288" height="42.5"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                                 <connections>
@@ -312,21 +318,21 @@
                                                 </connections>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="piA-94-ut3">
-                                                <rect key="frame" x="8" y="100" width="288" height="34"/>
+                                                <rect key="frame" x="8" y="159" width="288" height="42.5"/>
                                                 <state key="normal" title="Reset DSN"/>
                                                 <connections>
                                                     <action selector="resetDSN:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Mc6-d3-jaa"/>
                                                 </connections>
                                             </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Frames" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lcm-n2-ys4" userLabel="frames">
-                                                <rect key="frame" x="8" y="134" width="288" height="34"/>
+                                                <rect key="frame" x="8" y="201.5" width="288" height="42"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="framesStatsLabel"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last breadcrumb" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ccs-Ny-MiI" userLabel="breadcrumb">
-                                                <rect key="frame" x="8" y="168" width="288" height="34"/>
+                                                <rect key="frame" x="8" y="243.5" width="288" height="42.5"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="breadcrumbLabel"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
@@ -354,6 +360,7 @@
                         <outlet property="breadcrumbLabel" destination="Ccs-Ny-MiI" id="WqJ-PA-KfJ"/>
                         <outlet property="dsnTextField" destination="L2a-LY-eQ7" id="TWn-0u-2v7"/>
                         <outlet property="framesLabel" destination="Lcm-n2-ys4" id="7mO-bc-HWw"/>
+                        <outlet property="uiTestNameLabel" destination="9aH-uZ-TAM" id="3xT-J1-h36"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -484,14 +491,14 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1SX-yg-zgj">
-                                <rect key="frame" x="-1" y="0.0" width="318" height="44"/>
+                                <rect key="frame" x="-3" y="0.0" width="318" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem title="Hello" id="7le-ZX-hzV"/>
                                 </items>
                             </navigationBar>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" delaysContentTouches="NO" editable="NO" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sla-j3-cfX">
-                                <rect key="frame" x="17" y="69" width="281" height="495"/>
+                                <rect key="frame" x="16" y="67" width="280" height="496"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
@@ -516,7 +523,7 @@
             <objects>
                 <navigationController id="5CD-RQ-aBU" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="SjT-Zj-cMF">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="50"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -8,7 +8,8 @@ class ViewController: UIViewController {
     @IBOutlet weak var anrFillingRunLoopButton: UIButton!
     @IBOutlet weak var framesLabel: UILabel!
     @IBOutlet weak var breadcrumbLabel: UILabel!
-    
+    @IBOutlet weak var uiTestNameLabel: UILabel!
+
     private let dispatchQueue = DispatchQueue(label: "ViewController", attributes: .concurrent)
     private let diskWriteException = DiskWriteException()
 
@@ -45,6 +46,10 @@ class ViewController: UIViewController {
                 self.dsnTextField.text = dsn
                 self.dsnTextField.backgroundColor = UIColor.systemGreen
             }
+        }
+
+        if let uiTestName = ProcessInfo.processInfo.environment["io.sentry.ui-test.test-name"] {
+            uiTestNameLabel.text = uiTestName
         }
     }
     

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -70,21 +70,24 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func addBreadcrumb(_ sender: Any) {
+    @IBAction func addBreadcrumb(_ sender: UIButton) {
+        highlightButton(sender)
         let crumb = Breadcrumb(level: SentryLevel.info, category: "Debug")
         crumb.message = "tapped addBreadcrumb"
         crumb.type = "user"
         SentrySDK.addBreadcrumb(crumb)
     }
     
-    @IBAction func captureMessage(_ sender: Any) {
+    @IBAction func captureMessage(_ sender: UIButton) {
+        highlightButton(sender)
         let eventId = SentrySDK.capture(message: "Yeah captured a message")
         // Returns eventId in case of successfull processed event
         // otherwise nil
         print("\(String(describing: eventId))")
     }
     
-    @IBAction func uiClickTransaction(_ sender: Any) {
+    @IBAction func uiClickTransaction(_ sender: UIButton) {
+        highlightButton(sender)
         dispatchQueue.async {
             if let path = Bundle.main.path(forResource: "LoremIpsum", ofType: "txt") {
                 _ = FileManager.default.contents(atPath: path)
@@ -99,7 +102,8 @@ class ViewController: UIViewController {
         dataTask.resume()
     }
     
-    @IBAction func captureUserFeedback(_ sender: Any) {
+    @IBAction func captureUserFeedback(_ sender: UIButton) {
+        highlightButton(sender)
         let error = NSError(domain: "UserFeedbackErrorDomain", code: 0, userInfo: [NSLocalizedDescriptionKey: "This never happens."])
 
         let eventId = SentrySDK.capture(error: error) { scope in
@@ -113,7 +117,8 @@ class ViewController: UIViewController {
         SentrySDK.capture(userFeedback: userFeedback)
     }
     
-    @IBAction func captureError(_ sender: Any) {
+    @IBAction func captureError(_ sender: UIButton) {
+        highlightButton(sender)
         do {
             try RandomErrorGenerator.generate()
         } catch {
@@ -126,7 +131,8 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func captureNSException(_ sender: Any) {
+    @IBAction func captureNSException(_ sender: UIButton) {
+        highlightButton(sender)
         let exception = NSException(name: NSExceptionName("My Custom exeption"), reason: "User clicked the button", userInfo: nil)
         let scope = Scope()
         scope.setLevel(.fatal)
@@ -134,14 +140,16 @@ class ViewController: UIViewController {
         SentrySDK.capture(exception: exception, scope: scope)
     }
     
-    @IBAction func captureFatalError(_ sender: Any) {
+    @IBAction func captureFatalError(_ sender: UIButton) {
+        highlightButton(sender)
         fatalError("This is a fatal error. Oh no 😬.")
     }
 
     var span: Span?
     let profilerNotification = NSNotification.Name("SentryProfileCompleteNotification")
     
-    @IBAction func startTransaction(_ sender: Any) {
+    @IBAction func startTransaction(_ sender: UIButton) {
+        highlightButton(sender)
         guard span == nil else { return }
         span = SentrySDK.startTransaction(name: "Manual Transaction", operation: "Manual Operation")
 
@@ -160,14 +168,16 @@ class ViewController: UIViewController {
         }
     }
 
-    @IBAction func stopTransaction(_ sender: Any) {
+    @IBAction func stopTransaction(_ sender: UIButton) {
+        highlightButton(sender)
         span?.finish()
         span = nil
 
         NotificationCenter.default.removeObserver(self, name: profilerNotification, object: nil)
     }
 
-    @IBAction func captureTransaction(_ sender: Any) {
+    @IBAction func captureTransaction(_ sender: UIButton) {
+        highlightButton(sender)
         let transaction = SentrySDK.startTransaction(name: "Some Transaction", operation: "Some Operation")
         
         transaction.setMeasurement(name: "duration", value: 44, unit: MeasurementUnitDuration.nanosecond)
@@ -185,19 +195,21 @@ class ViewController: UIViewController {
         })
     }
    
-    @IBAction func crash(_ sender: Any) {
+    @IBAction func crash(_ sender: UIButton) {
         SentrySDK.crash()
     }
 
     // swiftlint:disable force_unwrapping
-    @IBAction func unwrapCrash(_ sender: Any) {
+    @IBAction func unwrapCrash(_ sender: UIButton) {
+        highlightButton(sender)
         let a: String! = nil
         let b: String = a!
         print(b)
     }
     // swiftlint:enable force_unwrapping
 
-    @IBAction func asyncCrash(_ sender: Any) {
+    @IBAction func asyncCrash(_ sender: UIButton) {
+        highlightButton(sender)
         DispatchQueue.main.async {
             self.asyncCrash1()
         }
@@ -215,7 +227,8 @@ class ViewController: UIViewController {
         }
     }
 
-    @IBAction func oomCrash(_ sender: Any) {
+    @IBAction func oomCrash(_ sender: UIButton) {
+        highlightButton(sender)
         DispatchQueue.main.async {
             let megaByte = 1_024 * 1_024
             let memoryPageSize = NSPageSize()
@@ -231,14 +244,16 @@ class ViewController: UIViewController {
         }
     }
     
-    @IBAction func diskWriteException(_ sender: Any) {
+    @IBAction func diskWriteException(_ sender: UIButton) {
+        highlightButton(sender)
         diskWriteException.continuouslyWriteToDisk()
         
         // As we are writing to disk continuously we would keep adding spans to this UIEventTransaction.
         SentrySDK.span?.finish()
     }
     
-    @IBAction func highCPULoad(_ sender: Any) {
+    @IBAction func highCPULoad(_ sender: UIButton) {
+        highlightButton(sender)
         dispatchQueue.async {
             while true {
                 _ = self.calcPi()
@@ -246,7 +261,8 @@ class ViewController: UIViewController {
         }
     }
 
-    @IBAction func start100Threads(_ sender: Any) {
+    @IBAction func start100Threads(_ sender: UIButton) {
+        highlightButton(sender)
         for _ in 0..<100 {
             Thread.detachNewThread {
                 Thread.sleep(forTimeInterval: 10)
@@ -271,7 +287,8 @@ class ViewController: UIViewController {
         return pi
     }
 
-    @IBAction func anrFullyBlocking(_ sender: Any) {
+    @IBAction func anrFullyBlocking(_ sender: UIButton) {
+        highlightButton(sender)
         let buttonTitle = self.anrFullyBlockingButton.currentTitle
         var i = 0
         
@@ -285,7 +302,8 @@ class ViewController: UIViewController {
         self.anrFullyBlockingButton.setTitle(buttonTitle, for: .normal)
     }
     
-    @IBAction func anrFillingRunLoop(_ sender: Any) {
+    @IBAction func anrFillingRunLoop(_ sender: UIButton) {
+        highlightButton(sender)
         let buttonTitle = self.anrFillingRunLoopButton.currentTitle
         var i = 0
         
@@ -321,70 +339,91 @@ class ViewController: UIViewController {
     @IBAction func dsnChanged(_ sender: UITextField) {
         let options = Options()
         options.dsn = sender.text
-        
+
         if let dsn = options.dsn {
             sender.backgroundColor = UIColor.systemGreen
-            
+
             dispatchQueue.async {
                 DSNStorage.shared.saveDSN(dsn: dsn)
             }
         } else {
             sender.backgroundColor = UIColor.systemRed
-            
+
             dispatchQueue.async {
                 DSNStorage.shared.deleteDSN()
             }
         }
     }
     
-    @IBAction func resetDSN(_ sender: Any) {
+    @IBAction func resetDSN(_ sender: UIButton) {
+        highlightButton(sender)
         self.dsnTextField.text = AppDelegate.defaultDSN
         self.dsnTextField.backgroundColor = UIColor.systemGreen
-        
+
         dispatchQueue.async {
             DSNStorage.shared.saveDSN(dsn: AppDelegate.defaultDSN)
         }
     }
     
-    @IBAction func showNibController(_ sender: Any) {
+    @IBAction func showNibController(_ sender: UIButton) {
+        highlightButton(sender)
         let nib = NibViewController()
         nib.title = "Nib View Controller"
         navigationController?.pushViewController(nib, animated: false)
     }
     
-    @IBAction func showTableViewController(_ sender: Any) {
+    @IBAction func showTableViewController(_ sender: UIButton) {
+        highlightButton(sender)
         let controller = TableViewController(style: .plain)
         controller.title = "Table View Controller"
         navigationController?.pushViewController(controller, animated: false)
     }
     
-    @IBAction func useCoreData(_ sender: Any) {
+    @IBAction func useCoreData(_ sender: UIButton) {
+        highlightButton(sender)
         let controller = CoreDataViewController()
         controller.title = "CoreData"
         navigationController?.pushViewController(controller, animated: false)
     }
 
-    @IBAction func performanceScenarios(_ sender: Any) {
+    @IBAction func performanceScenarios(_ sender: UIButton) {
+        highlightButton(sender)
         let controller = PerformanceViewController()
         controller.title = "Performance Scenarios"
         navigationController?.pushViewController(controller, animated: false)
     }
 
-    @IBAction func permissions(_ sender: Any) {
+    @IBAction func permissions(_ sender: UIButton) {
+        highlightButton(sender)
         let controller = PermissionsViewController()
         controller.title = "Permissions"
         navigationController?.pushViewController(controller, animated: true)
     }
     
-    @IBAction func flush(_ sender: Any) {
+    @IBAction func flush(_ sender: UIButton) {
+        highlightButton(sender)
         SentrySDK.flush(timeout: 5)
     }
     
-    @IBAction func close(_ sender: Any) {
+    @IBAction func close(_ sender: UIButton) {
+        highlightButton(sender)
         SentrySDK.close()
     }
-    
-    @IBAction func startSDK(_ sender: Any) {
+
+    @IBAction func startSDK(_ sender: UIButton) {
+        highlightButton(sender)
         AppDelegate.startSentry()
+    }
+
+    func highlightButton(_ sender: UIButton) {
+        let originalLayerColor = sender.layer.backgroundColor
+        let originalTitleColor = sender.titleColor(for: .normal)
+        sender.layer.backgroundColor = UIColor.blue.cgColor
+        sender.setTitleColor(.white, for: .normal)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            sender.layer.backgroundColor = originalLayerColor
+            sender.setTitleColor(originalTitleColor, for: .normal)
+            sender.titleLabel?.textColor = originalTitleColor
+        }
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -149,7 +149,9 @@ class ViewController: UIViewController {
             DispatchQueue.main.async {
                 let alert = UIAlertController(title: "Profile completed", message: nil, preferredStyle: .alert)
                 alert.addTextField {
+                    //swiftlint:disable force_unwrapping
                     $0.text = try! JSONSerialization.data(withJSONObject: note.userInfo!).base64EncodedString()
+                    //swiftlint:enable force_unwrapping
                     $0.accessibilityLabel = "io.sentry.ui-tests.profile-marshaling-text-field"
                 }
                 alert.addAction(UIAlertAction(title: "OK", style: .default))

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -8,6 +8,7 @@ class LaunchUITests: XCTestCase {
         
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
+        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
         app.launch()
         
         waitForExistenceOfMainScreen()

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -90,7 +90,12 @@ class LaunchUITests: XCTestCase {
     /**
      * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
      */
-    @available(iOS 13.0, *) func testProfilingGPUInfo() throws {
+    func testProfilingGPUInfo() throws {
+        // Marking the function as @available doesn't work to skip the test on earlier OS versions. We have to manually skip it here. It seems to only fail consistently on iOS 12; I think due to the ANR causing the app to crash. We don't need to test this on multiple OSes right now, so 13+ is still more than enough coverage.
+        guard #available(iOS 13.0, *) else {
+           throw XCTSkip("Only run on iOS 13 and above.")
+        }
+
         app.buttons["Start transaction"].afterWaitingForExistence("Couldn't find button to start transaction").tap()
         app.buttons["ANR filling run loop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
         app.buttons["Stop transaction"].afterWaitingForExistence("Couldn't find button to end transaction").tap()

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -110,7 +110,7 @@ class LaunchUITests: XCTestCase {
         XCTAssertFalse(slowFrameValues.isEmpty && frozenFrameValues.isEmpty)
 
         let frameRates = try XCTUnwrap(metrics["screen_frame_rates"] as? [String: Any])
-        let frameRateValues = try XCTUnwrap(frozenFrames["values"] as? [[String: Any]])
+        let frameRateValues = try XCTUnwrap(frameRates["values"] as? [[String: Any]])
         XCTAssertFalse(frameRateValues.isEmpty)
     }
 }

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -5,7 +5,6 @@ class LaunchUITests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
         app.launchEnvironment["io.sentry.ui-test.test-name"] = name
@@ -87,38 +86,6 @@ class LaunchUITests: XCTestCase {
             assertApp()
         }
     }
-
-    /**
-     * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
-     */
-    func testProfilingGPUInfo() throws {
-        // Marking the function as @available doesn't work to skip the test on earlier OS versions. We have to manually skip it here. It seems to only fail consistently on iOS 12; I think due to the ANR causing the app to crash. We don't need to test this on multiple OSes right now, so 13+ is still more than enough coverage.
-        guard #available(iOS 13.0, *) else {
-           throw XCTSkip("Only run on iOS 13 and above.")
-        }
-
-        app.buttons["Start transaction"].afterWaitingForExistence("Couldn't find button to start transaction").tap()
-        app.buttons["ANR filling run loop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
-        app.buttons["Stop transaction"].afterWaitingForExistence("Couldn't find button to end transaction").tap()
-
-        let textField = app.textFields["io.sentry.ui-tests.profile-marshaling-text-field"]
-        textField.waitForExistence("Couldn't find profile marshaling text field.")
-
-        let profileBase64DataString = try XCTUnwrap(textField.value as? NSString)
-        let profileData = try XCTUnwrap(Data(base64Encoded: profileBase64DataString as String))
-        let profileDict = try XCTUnwrap(try JSONSerialization.jsonObject(with: profileData) as? [String: Any])
-
-        let metrics = try XCTUnwrap(profileDict["measurements"] as? [String: Any])
-        let slowFrames = try XCTUnwrap(metrics["slow_frame_renders"] as? [String: Any])
-        let slowFrameValues = try XCTUnwrap(slowFrames["values"] as? [[String: Any]])
-        let frozenFrames = try XCTUnwrap(metrics["frozen_frame_renders"] as? [String: Any])
-        let frozenFrameValues = try XCTUnwrap(frozenFrames["values"] as? [[String: Any]])
-        XCTAssertFalse(slowFrameValues.isEmpty && frozenFrameValues.isEmpty)
-
-        let frameRates = try XCTUnwrap(metrics["screen_frame_rates"] as? [String: Any])
-        let frameRateValues = try XCTUnwrap(frameRates["values"] as? [[String: Any]])
-        XCTAssertFalse(frameRateValues.isEmpty)
-    }
 }
 
 private extension LaunchUITests {
@@ -151,16 +118,5 @@ private extension LaunchUITests {
         confirmation.waitForExistence("Assertion Message Not Found")
         
         XCTAssertTrue(confirmation.label == "ASSERT: SUCCESS", errorMessage.label)
-    }
-}
-
-extension XCUIElement {
-    func waitForExistence(_ message: String) {
-        XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
-    }
-
-    func afterWaitingForExistence(_ failureMessage: String) -> XCUIElement {
-        waitForExistence(failureMessage)
-        return self
     }
 }

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -104,7 +104,7 @@ class LaunchUITests: XCTestCase {
         let slowFrameValues = try XCTUnwrap(slowFrames["values"] as? [[String: Any]])
         let frozenFrames = try XCTUnwrap(metrics["frozen_frame_renders"] as? [String: Any])
         let frozenFrameValues = try XCTUnwrap(frozenFrames["values"] as? [[String: Any]])
-        XCTAssert(slowFrameValues.count > 0 || frozenFrameValues.count > 0)
+        XCTAssertFalse(slowFrameValues.isEmpty && frozenFrameValues.isEmpty)
     }
 }
 

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -90,7 +90,7 @@ class LaunchUITests: XCTestCase {
     /**
      * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
      */
-    func testProfilingGPUInfo() throws {
+    @available(iOS 13.0, *) func testProfilingGPUInfo() throws {
         app.buttons["Start transaction"].afterWaitingForExistence("Couldn't find button to start transaction").tap()
         app.buttons["ANR filling run loop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
         app.buttons["Stop transaction"].afterWaitingForExistence("Couldn't find button to end transaction").tap()

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -88,7 +88,7 @@ class LaunchUITests: XCTestCase {
     }
 
     /**
-     * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
+     * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
      */
     func testProfilingGPUInfo() throws {
         app.buttons["Start transaction"].tap()

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -15,9 +15,9 @@ final class ProfilingUITests: XCTestCase {
      * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
      */
     func testProfilingGPUInfo() throws {
-        // Marking the function as @available doesn't work to skip the test on earlier OS versions. We have to manually skip it here. It seems to only fail consistently on iOS 12; I think due to the ANR causing the app to crash. We don't need to test this on multiple OSes right now, so 13+ is still more than enough coverage.
-        guard #available(iOS 13.0, *) else {
-           throw XCTSkip("Only run on iOS 13 and above.")
+        // We don't need to test this on multiple OSes right now, and older versions seem to have issues; older devices or VM images running simulators might just be slower. Latest OS is enough coverage for our needs for now.
+        guard #available(iOS 15.0, *) else {
+           throw XCTSkip("Only run on iOS 15 and above.")
         }
 
         app.buttons["Start transaction"].afterWaitingForExistence("Couldn't find button to start transaction").tap()

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -4,6 +4,7 @@ final class ProfilingUITests: XCTestCase {
     private let app: XCUIApplication = XCUIApplication()
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
         app.launchEnvironment["io.sentry.ui-test.test-name"] = name

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+final class ProfilingUITests: XCTestCase {
+    private let app: XCUIApplication = XCUIApplication()
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
+        app.launch()
+    }
+
+    /**
+     * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
+     */
+    func testProfilingGPUInfo() throws {
+        // Marking the function as @available doesn't work to skip the test on earlier OS versions. We have to manually skip it here. It seems to only fail consistently on iOS 12; I think due to the ANR causing the app to crash. We don't need to test this on multiple OSes right now, so 13+ is still more than enough coverage.
+        guard #available(iOS 13.0, *) else {
+           throw XCTSkip("Only run on iOS 13 and above.")
+        }
+
+        app.buttons["Start transaction"].afterWaitingForExistence("Couldn't find button to start transaction").tap()
+        app.buttons["ANR filling run loop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
+        app.buttons["Stop transaction"].afterWaitingForExistence("Couldn't find button to end transaction").tap()
+
+        let textField = app.textFields["io.sentry.ui-tests.profile-marshaling-text-field"]
+        textField.waitForExistence("Couldn't find profile marshaling text field.")
+
+        let profileBase64DataString = try XCTUnwrap(textField.value as? NSString)
+        let profileData = try XCTUnwrap(Data(base64Encoded: profileBase64DataString as String))
+        let profileDict = try XCTUnwrap(try JSONSerialization.jsonObject(with: profileData) as? [String: Any])
+
+        let metrics = try XCTUnwrap(profileDict["measurements"] as? [String: Any])
+        let slowFrames = try XCTUnwrap(metrics["slow_frame_renders"] as? [String: Any])
+        let slowFrameValues = try XCTUnwrap(slowFrames["values"] as? [[String: Any]])
+        let frozenFrames = try XCTUnwrap(metrics["frozen_frame_renders"] as? [String: Any])
+        let frozenFrameValues = try XCTUnwrap(frozenFrames["values"] as? [[String: Any]])
+        XCTAssertFalse(slowFrameValues.isEmpty && frozenFrameValues.isEmpty)
+
+        let frameRates = try XCTUnwrap(metrics["screen_frame_rates"] as? [String: Any])
+        let frameRateValues = try XCTUnwrap(frameRates["values"] as? [[String: Any]])
+        XCTAssertFalse(frameRateValues.isEmpty)
+    }
+}

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UITestHelpers.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UITestHelpers.swift
@@ -1,0 +1,12 @@
+import XCTest
+
+extension XCUIElement {
+    func waitForExistence(_ message: String) {
+        XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
+    }
+
+    func afterWaitingForExistence(_ failureMessage: String) -> XCUIElement {
+        waitForExistence(failureMessage)
+        return self
+    }
+}

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -548,9 +548,11 @@ serializedSamplesWithRelativeTimestamps(
     if (_gCurrentTimerWrapper == nil) {
         _gCurrentTimerWrapper = [[SentryNSTimerWrapper alloc] init];
     }
+#    if SENTRY_HAS_UIKIT
     if (_gCurrentFramesTracker == nil) {
         _gCurrentFramesTracker = SentryFramesTracker.sharedInstance;
     }
+#    endif // SENTRY_HAS_UIKIT
     _metricProfiler =
         [[SentryMetricProfiler alloc] initWithProcessInfoWrapper:_gCurrentProcessInfoWrapper
                                                    systemWrapper:_gCurrentSystemWrapper

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -450,6 +450,12 @@ serializedSamplesWithRelativeTimestamps(
         payload[@"measurements"] = metrics;
     }
 
+    // #if defined(TEST) || defined(TESTCI)
+    [NSNotificationCenter.defaultCenter postNotificationName:@"SentryProfileCompleteNotification"
+                                                      object:nil
+                                                    userInfo:payload];
+    // #endif // defined(TEST) || defined(TESTCI)
+
     // add the remaining basic metadata for the profile
     const auto profileID = [[SentryId alloc] init];
     [self serializeBasicProfileInfo:payload profileID:profileID transaction:transaction];

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -450,11 +450,11 @@ serializedSamplesWithRelativeTimestamps(
         payload[@"measurements"] = metrics;
     }
 
-    // #if defined(TEST) || defined(TESTCI)
+#    if defined(TEST) || defined(TESTCI)
     [NSNotificationCenter.defaultCenter postNotificationName:@"SentryProfileCompleteNotification"
                                                       object:nil
                                                     userInfo:payload];
-    // #endif // defined(TEST) || defined(TESTCI)
+#    endif // defined(TEST) || defined(TESTCI)
 
     // add the remaining basic metadata for the profile
     const auto profileID = [[SentryId alloc] init];

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -437,10 +437,12 @@ serializedSamplesWithRelativeTimestamps(
         metrics[@"frozen_frame_renders"] = @{ @"unit" : @"nanosecond", @"values" : frozenFrames };
     }
 
-    const auto frameRates
-        = processFrameRates(_gCurrentFramesTracker.currentFrames.frameRateTimestamps, transaction);
-    if (frameRates.count > 0) {
-        metrics[@"screen_frame_rates"] = @{ @"unit" : @"hz", @"values" : frameRates };
+    if (slowFrames.count > 0 || frozenFrames.count > 0) {
+        const auto frameRates = processFrameRates(
+            _gCurrentFramesTracker.currentFrames.frameRateTimestamps, transaction);
+        if (frameRates.count > 0) {
+            metrics[@"screen_frame_rates"] = @{ @"unit" : @"hz", @"values" : frameRates };
+        }
     }
 #    endif // SENTRY_HAS_UIKIT
 
@@ -539,6 +541,9 @@ serializedSamplesWithRelativeTimestamps(
     }
     if (_gCurrentTimerWrapper == nil) {
         _gCurrentTimerWrapper = [[SentryNSTimerWrapper alloc] init];
+    }
+    if (_gCurrentFramesTracker == nil) {
+        _gCurrentFramesTracker = SentryFramesTracker.sharedInstance;
     }
     _metricProfiler =
         [[SentryMetricProfiler alloc] initWithProcessInfoWrapper:_gCurrentProcessInfoWrapper

--- a/Sources/Sentry/include/SentryMetricProfiler.h
+++ b/Sources/Sentry/include/SentryMetricProfiler.h
@@ -55,8 +55,11 @@ typedef NSDictionary<NSString *, id /* <NSString, NSArray<SentrySerializedMetric
  * @"<metric-name>": @{
  *      @"unit": @"<unit-name>",
  *      @"values": @[
- *          @"elapsed_since_start_ns": @"<64-bit-unsigned-timestamp>",
- *          @"value": @"<numeric-value>"
+ *          @{
+ *              @"elapsed_since_start_ns": @"<64-bit-unsigned-timestamp>",
+ *              @"value": @"<numeric-value>"
+ *          },
+ *          // ... more dictionaries like that ...
  *      ]
  * }
  * @endcode

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -377,7 +377,10 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
+    -(TYPE)NAME                                                                                    \
+    {                                                                                              \
+        return sentrycrashstate_currentState()->NAME;                                              \
+    }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -377,10 +377,7 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME                                                                                    \
-    {                                                                                              \
-        return sentrycrashstate_currentState()->NAME;                                              \
-    }
+    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -133,7 +133,7 @@ platform :ios do
     )
 
     # don't use gym here because it always appends a "build" command which fails, since this is a test target not configured for running
-    sh "set -o pipefail && xcodebuild -workspace ../Sentry.xcworkspace -scheme iOS-SwiftUITests -derivedDataPath ../DerivedData -destination 'generic/platform=iOS' build-for-testing | xcpretty"
+    sh "set -o pipefail && xcodebuild -workspace ../Sentry.xcworkspace -scheme iOS-SwiftUITests -derivedDataPath ../DerivedData -destination 'generic/platform=iOS' -configuration Test build-for-testing | xcpretty"
 
     delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end


### PR DESCRIPTION
## :scroll: Description

We never installed a default frames tracker for the profiler, so it wasn't getting GPU frame render information. 

Also, only process frame rate info if there are slow/frozen frames to report. Otherwise it's uneeded.

## :bulb: Motivation and Context

## :green_heart: How did you test it?

Added a UI test that triggers an ANR inside of a profiled transaction to force slow and frozen frames. Then it inspects the profile payload, via a new way to get the payload data out of the profiler: a notification is posted when testing, which is observed in iOS-Swift.ViewController, which serializes the dictionary to JSON data, base64 encodes that into a string and presents that string in an alert text field, which the UI test can extract to perform assertions.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
