### PR TITLE
Fix changelog CPU core count wasn't in 8.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,17 @@
 
 ## Unreleased
 
-### Fixes
-
-- View hierarchy not sent for crashes (#2781)
-
-## 8.3.2
-
 ### Features
 
 - Add CPU core count in device context (#2814)
 
 ### Fixes
 
+- View hierarchy not sent for crashes (#2781)
+
+## 8.3.2
+
+### Fixes
 
 - Updating AppHang state on main thread (#2793)
 - App Hang report crashes with too many threads (#2811)


### PR DESCRIPTION
## :scroll: Description

Just a changelog fix. Noticed when updating the library in RN.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
