### PR TITLE
test: fix raw log output ids for ui tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -287,7 +287,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          name: raw-uitest-output-${{matrix.target}}
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -353,7 +353,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          name: raw-uitest-output-${{matrix.target}}-ios-12
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -375,7 +375,7 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          name: raw-uitest-output-asan
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**


### PR DESCRIPTION
This was producing raw output logs from ui test runs that overwrote each other because they collided when no differentiating pieces existed to interpolate: 
<img width="316" alt="image" src="https://user-images.githubusercontent.com/3241469/227064311-f35d359b-16d4-4517-9869-19dbc37d0a43.png">


#skip-changelog