### PR TITLE
ref: Use dispatch queue in dependency container

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -8,7 +8,6 @@
 #import <SentryDebugImageProvider.h>
 #import <SentryDefaultCurrentDateProvider.h>
 #import <SentryDependencyContainer.h>
-#import <SentryDispatchQueueWrapper.h>
 #import <SentryHub.h>
 #import <SentryNSNotificationCenterWrapper.h>
 #import <SentrySDK+Private.h>
@@ -204,7 +203,7 @@ static NSObject *sentryDependencyContainerLock;
                     initWithTimeoutInterval:timeout
                         currentDateProvider:[SentryDefaultCurrentDateProvider sharedInstance]
                                crashWrapper:self.crashWrapper
-                       dispatchQueueWrapper:[[SentryDispatchQueueWrapper alloc] init]
+                       dispatchQueueWrapper:self.dispatchQueueWrapper
                               threadWrapper:self.threadWrapper];
             }
         }


### PR DESCRIPTION
Avoid allocating one extra dispatch queue in the dependency container.

#skip-changelog