### PR TITLE
fix: Crash in Tracer for idle timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - View hierarchy not sent for crashes (#2781)
+- Crash in Tracer for idle timeout (#2834)
 
 ## 8.3.2
 

--- a/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
+++ b/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
@@ -62,4 +62,13 @@ public class TestSentryDispatchQueueWrapper: SentryDispatchQueueWrapper {
     public override func dispatchOnce(_ predicate: UnsafeMutablePointer<Int>, block: @escaping () -> Void) {
         block()
     }
+    
+    public var createDispatchBlockReturnsNULL = false
+    public override func createDispatchBlock(_ block: @escaping () -> Void) -> (() -> Void)? {
+        if createDispatchBlockReturnsNULL {
+            return nil
+        }
+        return super.createDispatchBlock(block)
+    }
+    
 }

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -77,6 +77,11 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_once(predicate, block);
 }
 
+- (nullable dispatch_block_t)createDispatchBlock:(void (^)(void))block
+{
+    return dispatch_block_create(0, block);
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -227,6 +227,7 @@ static BOOL appStartMeasurementRead;
     if (_idleTimeoutBlock == NULL) {
         SENTRY_LOG_WARN(@"Couln't create idle time out block. Can't schedule idle timeout. "
                         @"Finishing transaction");
+        // If the transaction has no children, the SDK will discard it.
         [self finishInternal];
     } else {
         [self.dispatchQueueWrapper dispatchAfter:self.idleTimeout block:_idleTimeoutBlock];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -217,14 +217,20 @@ static BOOL appStartMeasurementRead;
         [self.dispatchQueueWrapper dispatchCancel:_idleTimeoutBlock];
     }
     __weak SentryTracer *weakSelf = self;
-    _idleTimeoutBlock = dispatch_block_create(0, ^{
+    _idleTimeoutBlock = [self.dispatchQueueWrapper createDispatchBlock:^{
         if (weakSelf == nil) {
             SENTRY_LOG_DEBUG(@"WeakSelf is nil. Not doing anything.");
             return;
         }
         [weakSelf finishInternal];
-    });
-    [self.dispatchQueueWrapper dispatchAfter:self.idleTimeout block:_idleTimeoutBlock];
+    }];
+    if (_idleTimeoutBlock == NULL) {
+        SENTRY_LOG_WARN(@"Couln't create idle time out block. Can't schedule idle timeout. "
+                        @"Finishing transaction");
+        [self finishInternal];
+    } else {
+        [self.dispatchQueueWrapper dispatchAfter:self.idleTimeout block:_idleTimeoutBlock];
+    }
 }
 
 - (BOOL)hasIdleTimeout

--- a/Sources/Sentry/include/SentryDispatchQueueWrapper.h
+++ b/Sources/Sentry/include/SentryDispatchQueueWrapper.h
@@ -21,6 +21,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)dispatchOnce:(dispatch_once_t *)predicate block:(void (^)(void))block;
 
+- (nullable dispatch_block_t)createDispatchBlock:(void (^)(void))block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Performance/SentryTracerTests.swift
+++ b/Tests/SentryTests/Performance/SentryTracerTests.swift
@@ -224,6 +224,26 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(status, sut.status)
     }
     
+    func testIdleTransaction_CreatingDispatchBlockFails_NoTransactionCaptured() {
+        fixture.dispatchQueue.createDispatchBlockReturnsNULL = true
+        
+        let sut = fixture.getSut(idleTimeout: fixture.idleTimeout, dispatchQueueWrapper: fixture.dispatchQueue)
+        
+        assertTransactionNotCaptured(sut)
+    }
+    
+    func testIdleTransaction_CreatingDispatchBlockFailsForFirstChild_FinishesTransaction() {
+        let sut = fixture.getSut(idleTimeout: fixture.idleTimeout, dispatchQueueWrapper: fixture.dispatchQueue)
+        
+        fixture.dispatchQueue.createDispatchBlockReturnsNULL = true
+        
+        let child = sut.startChild(operation: fixture.transactionOperation)
+        advanceTime(bySeconds: 0.1)
+        child.finish()
+        
+        assertOneTransactionCaptured(sut)
+    }
+    
     func testWaitForChildrenTransactionWithStatus_OverwriteStatusInFinish() {
         let sut = fixture.getSut()
         sut.status = .aborted


### PR DESCRIPTION


## :scroll: Description

dispatch_block_create can return NULL. If it does, we finish the transaction and don't schedule the timeout.

## :bulb: Motivation and Context

Fixes GH-2832, GH-2769

## :green_heart: How did you test it?
Unit tests, and on an iPhone to validate UI event transactions are still working properly.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
