### PR TITLE
ref: Remove not needed check for SentryTracer

### DIFF
--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -85,9 +85,7 @@ SentryPerformanceTracker () <SentryTracerDelegate>
                                                   customSamplingContext:@{}
                                                            timerWrapper:nil];
 
-            if ([newSpan isKindOfClass:[SentryTracer class]]) {
-                [(SentryTracer *)newSpan setDelegate:self];
-            }
+            [(SentryTracer *)newSpan setDelegate:self];
         }];
     }
 


### PR DESCRIPTION
Remove not needed check for isKindOfClass SentryTracer in SentryPerformanceTracker as the code calls startTransactionWithContext, which always returns a SentryTracer.

#skip-changelog