### PR TITLE
ref: mock clock for GPU metrics tests and fix slicing logic

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -34,5 +34,9 @@ class TestCleanup: NSObject {
         SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
 
         SentryTracer.resetAppStartMeasurementRead()
+
+#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+        SentryTracer.resetConcurrencyTracking()
+#endif
     }
 }

--- a/SentryTestUtils/TestSentryNSTimerWrapper.swift
+++ b/SentryTestUtils/TestSentryNSTimerWrapper.swift
@@ -13,7 +13,14 @@ public class TestTimer: Timer {
 public class TestSentryNSTimerWrapper: SentryNSTimerWrapper {
     public struct Overrides {
         public var timer: TestTimer!
+
         var block: ((Timer) -> Void)?
+
+        struct InvocationInfo {
+            var target: NSObject
+            var selector: Selector
+        }
+        var invocationInfo: InvocationInfo?
     }
 
     public var overrides = Overrides()
@@ -25,7 +32,19 @@ public class TestSentryNSTimerWrapper: SentryNSTimerWrapper {
         return timer
     }
 
+    public override func scheduledTimer(withTimeInterval ti: TimeInterval, target aTarget: Any, selector aSelector: Selector, userInfo: Any?, repeats yesOrNo: Bool) -> Timer {
+        let timer = TestTimer()
+        //swiftlint:disable force_cast
+        overrides.invocationInfo = Overrides.InvocationInfo(target: aTarget as! NSObject, selector: aSelector)
+        //swiftlint:enable force_cast
+        return timer
+    }
+
     public func fire() {
-        overrides.block?(overrides.timer)
+        if let block = overrides.block {
+            block(overrides.timer)
+        } else if let invocationInfo = overrides.invocationInfo {
+            try! Invocation(target: invocationInfo.target, selector: invocationInfo.selector).invoke()
+        }
     }
 }

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -160,7 +160,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     if (shouldRecordNewFrameRate) {
         SENTRY_LOG_DEBUG(@"Recording new frame rate at %llu.", self.previousFrameSystemTimestamp);
         [self.frameRateTimestamps addObject:@{
-            @"timestamp" : @(thisFrameSystemTimestamp),
+            @"timestamp" : @(self.previousFrameSystemTimestamp),
             @"frame_rate" : @(currentFrameRate),
         }];
     }

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -153,16 +153,15 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 #        endif // defined(TEST) || defined(TESTCI)
     BOOL hasNoFrameRatesYet = self.frameRateTimestamps.count == 0;
     uint64_t previousFrameRate
-        = self.frameRateTimestamps.lastObject[@"frame_rate"].unsignedLongLongValue;
+        = self.frameRateTimestamps.lastObject[@"value"].unsignedLongLongValue;
     BOOL frameRateChanged = previousFrameRate != currentFrameRate;
     BOOL shouldRecordNewFrameRate
         = shouldRecordFrameRates && (hasNoFrameRatesYet || frameRateChanged);
     if (shouldRecordNewFrameRate) {
-        SENTRY_LOG_DEBUG(@"Recording new frame rate at %llu.", self.previousFrameSystemTimestamp);
-        [self.frameRateTimestamps addObject:@{
-            @"timestamp" : @(self.previousFrameSystemTimestamp),
-            @"frame_rate" : @(currentFrameRate),
-        }];
+        SENTRY_LOG_DEBUG(@"Recording new frame rate at %llu.", thisFrameSystemTimestamp);
+        [self recordTimestamp:thisFrameSystemTimestamp
+                        value:@(currentFrameRate)
+                        array:self.frameRateTimestamps];
     }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -172,24 +171,19 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
         && frameDuration <= SentryFrozenFrameThreshold) {
         atomic_fetch_add_explicit(&_slowFrames, 1, SentryFramesMemoryOrder);
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-        SENTRY_LOG_DEBUG(@"Capturing slow frame starting at %llu and ending at %llu.",
-            self.previousFrameSystemTimestamp, thisFrameSystemTimestamp);
-        [self recordTimestampStart:@(self.previousFrameSystemTimestamp)
-                               end:@(thisFrameSystemTimestamp)
-                             array:self.slowFrameTimestamps];
+        SENTRY_LOG_DEBUG(@"Capturing slow frame starting at %llu.", thisFrameSystemTimestamp);
+        [self recordTimestamp:thisFrameSystemTimestamp
+                        value:@(thisFrameSystemTimestamp - self.previousFrameSystemTimestamp)
+                        array:self.slowFrameTimestamps];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
     } else if (frameDuration > SentryFrozenFrameThreshold) {
         atomic_fetch_add_explicit(&_frozenFrames, 1, SentryFramesMemoryOrder);
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-        SENTRY_LOG_DEBUG(@"Capturing frozen frame starting at %llu and ending at %llu.",
-            self.previousFrameSystemTimestamp, thisFrameSystemTimestamp);
-        [self recordTimestampStart:@(self.previousFrameSystemTimestamp)
-                               end:@(thisFrameSystemTimestamp)
-                             array:self.frozenFrameTimestamps];
+        SENTRY_LOG_DEBUG(@"Capturing frozen frame starting at %llu.", thisFrameSystemTimestamp);
+        [self recordTimestamp:thisFrameSystemTimestamp
+                        value:@(thisFrameSystemTimestamp - self.previousFrameSystemTimestamp)
+                        array:self.frozenFrameTimestamps];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
-    } else {
-        SENTRY_LOG_DEBUG(@"Rendered normal frame starting at %llu and ending at %llu.",
-            self.previousFrameSystemTimestamp, thisFrameSystemTimestamp);
     }
 
     atomic_fetch_add_explicit(&_totalFrames, 1, SentryFramesMemoryOrder);
@@ -211,14 +205,14 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 }
 
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-- (void)recordTimestampStart:(NSNumber *)start end:(NSNumber *)end array:(NSMutableArray *)array
+- (void)recordTimestamp:(uint64_t)timestamp value:(NSNumber *)value array:(NSMutableArray *)array
 {
     BOOL shouldRecord = [SentryProfiler isRunning];
 #        if defined(TEST) || defined(TESTCI)
     shouldRecord = YES;
 #        endif
     if (shouldRecord) {
-        [array addObject:@{ @"start_timestamp" : start, @"end_timestamp" : end }];
+        [array addObject:@{ @"timestamp" : @(timestamp), @"value" : value }];
     }
 }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/SentryMetricProfiler.mm
+++ b/Sources/Sentry/SentryMetricProfiler.mm
@@ -48,7 +48,7 @@ SentrySerializedMetricEntry *_Nullable serializeValuesWithNormalizedTime(
     [absoluteTimestampValues enumerateObjectsUsingBlock:^(
         SentryMetricReading *_Nonnull reading, NSUInteger idx, BOOL *_Nonnull stop) {
         // if the metric reading wasn't recorded until the transaction ended, don't include it
-        if (orderedChronologically(transaction.endSystemTime, reading.absoluteTimestamp)) {
+        if (!orderedChronologically(reading.absoluteTimestamp, transaction.endSystemTime)) {
             return;
         }
 

--- a/Sources/Sentry/SentryNSTimerWrapper.m
+++ b/Sources/Sentry/SentryNSTimerWrapper.m
@@ -9,4 +9,17 @@
     return [NSTimer scheduledTimerWithTimeInterval:interval repeats:repeats block:block];
 }
 
+- (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)ti
+                                     target:(id)aTarget
+                                   selector:(SEL)aSelector
+                                   userInfo:(nullable id)userInfo
+                                    repeats:(BOOL)yesOrNo
+{
+    return [NSTimer scheduledTimerWithTimeInterval:ti
+                                            target:aTarget
+                                          selector:aSelector
+                                          userInfo:userInfo
+                                           repeats:yesOrNo];
+}
+
 @end

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -201,11 +201,13 @@ processFrameRenders(SentryFrameInfoTimeSeries *frameInfo, SentryTransaction *tra
         const auto frameRenderStart = obj[@"start_timestamp"].unsignedLongLongValue;
 
         if (!orderedChronologically(transaction.startSystemTime, frameRenderStart)) {
-            SENTRY_LOG_DEBUG(@"GPU frame render started before profile start, will not report it.");
+            SENTRY_LOG_DEBUG(@"GPU frame render started (%llu) before transaction start (%llu), "
+                             @"will not report it.",
+                frameRenderStart, transaction.startSystemTime);
             return;
         }
         const auto frameRenderEnd = obj[@"end_timestamp"].unsignedLongLongValue;
-        if (orderedChronologically(transaction.endSystemTime, frameRenderEnd)) {
+        if (!orderedChronologically(frameRenderEnd, transaction.endSystemTime)) {
             SENTRY_LOG_DEBUG(@"Frame render finished after transaction finished, won't record.");
             return;
         }
@@ -248,7 +250,7 @@ processFrameRates(SentryFrameInfoTimeSeries *frameRates, SentryTransaction *tran
         if (!orderedChronologically(transaction.startSystemTime, timestamp)) {
             return;
         }
-        if (orderedChronologically(transaction.endSystemTime, timestamp)) {
+        if (!orderedChronologically(timestamp, transaction.endSystemTime)) {
             return;
         }
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -162,7 +162,8 @@ std::mutex _gProfilerLock;
 SentryProfiler *_Nullable _gCurrentProfiler;
 SentryNSProcessInfoWrapper *_gCurrentProcessInfoWrapper;
 SentrySystemWrapper *_gCurrentSystemWrapper;
-SentryNSTimerWrapper *_gCurrentTimerWrapper;
+SentryNSTimerWrapper *_gMetricTimerWrapper;
+SentryNSTimerWrapper *_gTimeoutTimerWrapper;
 #    if SENTRY_HAS_UIKIT
 SentryFramesTracker *_gCurrentFramesTracker;
 #    endif // SENTRY_HAS_UIKIT
@@ -193,75 +194,32 @@ serializedUnsigned64BitInteger(uint64_t value)
  * didn't occur within the profile time.
  */
 NSArray<SentrySerializedMetricReading *> *
-processFrameRenders(SentryFrameInfoTimeSeries *frameInfo, SentryTransaction *transaction)
+sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, SentryTransaction *transaction)
 {
-    auto relativeFrameInfo = [NSMutableArray<SentrySerializedMetricEntry *> array];
+    auto slicedGPUEntries = [NSMutableArray<SentrySerializedMetricEntry *> array];
     [frameInfo enumerateObjectsUsingBlock:^(
         NSDictionary<NSString *, NSNumber *> *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-        const auto frameRenderStart = obj[@"start_timestamp"].unsignedLongLongValue;
-
-        if (!orderedChronologically(transaction.startSystemTime, frameRenderStart)) {
-            SENTRY_LOG_DEBUG(@"GPU frame render started (%llu) before transaction start (%llu), "
-                             @"will not report it.",
-                frameRenderStart, transaction.startSystemTime);
-            return;
-        }
-        const auto frameRenderEnd = obj[@"end_timestamp"].unsignedLongLongValue;
-        if (!orderedChronologically(frameRenderEnd, transaction.endSystemTime)) {
-            SENTRY_LOG_DEBUG(@"Frame render finished after transaction finished, won't record.");
-            return;
-        }
-        const auto relativeFrameRenderStart
-            = getDurationNs(transaction.startSystemTime, frameRenderStart);
-        const auto relativeFrameRenderEnd
-            = getDurationNs(transaction.startSystemTime, frameRenderEnd);
-
-        // this probably won't happen, but doesn't hurt to have one last defensive check before
-        // calling getDurationNs
-        if (!orderedChronologically(relativeFrameRenderStart, relativeFrameRenderEnd)) {
-            SENTRY_LOG_WARN(
-                @"Computed relative start and end timestamps are not chronologically ordered.");
-            return;
-        }
-        const auto frameRenderDurationNs
-            = getDurationNs(relativeFrameRenderStart, relativeFrameRenderEnd);
-
-        [relativeFrameInfo addObject:@{
-            @"elapsed_since_start_ns" : serializedUnsigned64BitInteger(relativeFrameRenderStart),
-            @"value" : @(frameRenderDurationNs),
-        }];
-    }];
-    return relativeFrameInfo;
-}
-
-/**
- * Convert the data structure that records timestamps for GPU frame rate info from
- * SentryFramesTracker to the structure expected for profiling metrics.
- */
-NSArray<NSDictionary *> *
-processFrameRates(SentryFrameInfoTimeSeries *frameRates, SentryTransaction *transaction)
-{
-    auto relativeFrameRates = [NSMutableArray array];
-    [frameRates enumerateObjectsUsingBlock:^(
-        NSDictionary<NSString *, NSNumber *> *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
         const auto timestamp = obj[@"timestamp"].unsignedLongLongValue;
-        const auto refreshRate = obj[@"frame_rate"];
 
         if (!orderedChronologically(transaction.startSystemTime, timestamp)) {
-            return;
-        }
-        if (!orderedChronologically(timestamp, transaction.endSystemTime)) {
+            SENTRY_LOG_DEBUG(@"GPU info recorded (%llu) before transaction start (%llu), "
+                             @"will not report it.",
+                timestamp, transaction.startSystemTime);
             return;
         }
 
+        if (!orderedChronologically(timestamp, transaction.endSystemTime)) {
+            SENTRY_LOG_DEBUG(@"GPU info recorded after transaction finished, won't record.");
+            return;
+        }
         const auto relativeTimestamp = getDurationNs(transaction.startSystemTime, timestamp);
 
-        [relativeFrameRates addObject:@ {
+        [slicedGPUEntries addObject:@ {
             @"elapsed_since_start_ns" : serializedUnsigned64BitInteger(relativeTimestamp),
-            @"value" : refreshRate,
+            @"value" : obj[@"value"],
         }];
     }];
-    return relativeFrameRates;
+    return slicedGPUEntries;
 }
 #    endif // SENTRY_HAS_UIKIT
 
@@ -343,12 +301,15 @@ serializedSamplesWithRelativeTimestamps(
 
     [_gCurrentProfiler start];
 
+    if (_gTimeoutTimerWrapper == nil) {
+        _gTimeoutTimerWrapper = [[SentryNSTimerWrapper alloc] init];
+    }
     _gCurrentProfiler->_timeoutTimer =
-        [NSTimer scheduledTimerWithTimeInterval:kSentryProfilerTimeoutInterval
-                                         target:self
-                                       selector:@selector(timeoutAbort)
-                                       userInfo:nil
-                                        repeats:NO];
+        [_gTimeoutTimerWrapper scheduledTimerWithTimeInterval:kSentryProfilerTimeoutInterval
+                                                       target:self
+                                                     selector:@selector(timeoutAbort)
+                                                     userInfo:nil
+                                                      repeats:NO];
 #    if SENTRY_HAS_UIKIT
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(backgroundAbort)
@@ -427,21 +388,21 @@ serializedSamplesWithRelativeTimestamps(
     const auto metrics = [_gCurrentProfiler->_metricProfiler serializeForTransaction:transaction];
 
 #    if SENTRY_HAS_UIKIT
-    const auto slowFrames = processFrameRenders(
-        _gCurrentFramesTracker.currentFrames.slowFrameTimestamps, transaction);
+    const auto slowFrames
+        = sliceGPUData(_gCurrentFramesTracker.currentFrames.slowFrameTimestamps, transaction);
     if (slowFrames.count > 0) {
         metrics[@"slow_frame_renders"] = @{ @"unit" : @"nanosecond", @"values" : slowFrames };
     }
 
-    const auto frozenFrames = processFrameRenders(
-        _gCurrentFramesTracker.currentFrames.frozenFrameTimestamps, transaction);
+    const auto frozenFrames
+        = sliceGPUData(_gCurrentFramesTracker.currentFrames.frozenFrameTimestamps, transaction);
     if (frozenFrames.count > 0) {
         metrics[@"frozen_frame_renders"] = @{ @"unit" : @"nanosecond", @"values" : frozenFrames };
     }
 
     if (slowFrames.count > 0 || frozenFrames.count > 0) {
-        const auto frameRates = processFrameRates(
-            _gCurrentFramesTracker.currentFrames.frameRateTimestamps, transaction);
+        const auto frameRates
+            = sliceGPUData(_gCurrentFramesTracker.currentFrames.frameRateTimestamps, transaction);
         if (frameRates.count > 0) {
             metrics[@"screen_frame_rates"] = @{ @"unit" : @"hz", @"values" : frameRates };
         }
@@ -479,10 +440,16 @@ serializedSamplesWithRelativeTimestamps(
     _gCurrentProcessInfoWrapper = processInfoWrapper;
 }
 
-+ (void)useTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
++ (void)useMetricTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
 {
     std::lock_guard<std::mutex> l(_gProfilerLock);
-    _gCurrentTimerWrapper = timerWrapper;
+    _gMetricTimerWrapper = timerWrapper;
+}
+
++ (void)useTimeoutTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
+{
+    std::lock_guard<std::mutex> l(_gProfilerLock);
+    _gTimeoutTimerWrapper = timerWrapper;
 }
 
 #    if SENTRY_HAS_UIKIT
@@ -547,8 +514,8 @@ serializedSamplesWithRelativeTimestamps(
     if (_gCurrentProcessInfoWrapper == nil) {
         _gCurrentProcessInfoWrapper = [[SentryNSProcessInfoWrapper alloc] init];
     }
-    if (_gCurrentTimerWrapper == nil) {
-        _gCurrentTimerWrapper = [[SentryNSTimerWrapper alloc] init];
+    if (_gMetricTimerWrapper == nil) {
+        _gMetricTimerWrapper = [[SentryNSTimerWrapper alloc] init];
     }
 #    if SENTRY_HAS_UIKIT
     if (_gCurrentFramesTracker == nil) {
@@ -558,7 +525,7 @@ serializedSamplesWithRelativeTimestamps(
     _metricProfiler =
         [[SentryMetricProfiler alloc] initWithProcessInfoWrapper:_gCurrentProcessInfoWrapper
                                                    systemWrapper:_gCurrentSystemWrapper
-                                                    timerWrapper:_gCurrentTimerWrapper];
+                                                    timerWrapper:_gMetricTimerWrapper];
     [_metricProfiler start];
 }
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -175,7 +175,7 @@ static BOOL appStartMeasurementRead;
     }];
 
     if (_idleTimeoutBlock == NULL) {
-        SENTRY_LOG_WARN(@"Couln't create idle time out block. Can't schedule idle timeout. "
+        SENTRY_LOG_WARN(@"Couldn't create idle time out block. Can't schedule idle timeout. "
                         @"Finishing transaction");
         // If the transaction has no children, the SDK will discard it.
         [self finishInternal];
@@ -795,6 +795,16 @@ static BOOL appStartMeasurementRead;
 {
     return _startTimeChanged ? _originalStartTimestamp : self.startTimestamp;
 }
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
+// this just calls through to SentryTracerConcurrency.resetConcurrencyTracking(). we have to do this
+// through SentryTracer because SentryTracerConcurrency cannot be included in test targets via ObjC
+// bridging headers because it contains C++.
++ (void)resetConcurrencyTracking
+{
+    resetConcurrencyTracking();
+}
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
 
 @end
 

--- a/Sources/Sentry/SentryTracerConcurrency.mm
+++ b/Sources/Sentry/SentryTracerConcurrency.mm
@@ -38,4 +38,13 @@ stopTrackingTracerWithID(SentryId *traceID, SentryConcurrentTransactionCleanupBl
     }
 }
 
+#    if defined(TEST) || defined(TESTCI)
+void
+resetConcurrencyTracking()
+{
+    std::lock_guard<std::mutex> l(_gStateLock);
+    [_gInFlightTraceIDs removeAllObjects];
+}
+#    endif // defined(TEST) || defined(TESTCI)
+
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryNSTimerWrapper.h
+++ b/Sources/Sentry/include/SentryNSTimerWrapper.h
@@ -8,6 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
                                     repeats:(BOOL)repeats
                                       block:(void (^)(NSTimer *timer))block;
 
+- (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)ti
+                                     target:(id)aTarget
+                                   selector:(SEL)aSelector
+                                   userInfo:(nullable id)userInfo
+                                    repeats:(BOOL)yesOrNo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN const int kSentryProfilerFrequencyHz;
 SENTRY_EXTERN NSString *const kTestStringConst;
-FOUNDATION_EXPORT NSTimeInterval kSentryProfilerTimeoutInterval;
 
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;

--- a/Sources/Sentry/include/SentryTime.h
+++ b/Sources/Sentry/include/SentryTime.h
@@ -21,7 +21,8 @@ uint64_t getAbsoluteTime(void);
  * Check whether two timestamps provided as 64 bit unsigned integers are in normal
  * chronological order, as a convenience runtime check before using @c getDurationNs.
  * Equal timestamps are considered to be valid chronological order.
- * @return @c true if @c b>=a, otherwise return @c false.
+ * @return @c true if @c a<=b, otherwise return @c false.
+ * @note Negating the return value implies @c a>b .
  */
 bool orderedChronologically(uint64_t a, uint64_t b);
 

--- a/Sources/Sentry/include/SentryTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryTracerConcurrency.h
@@ -22,6 +22,10 @@ void trackTracerWithID(SentryId *traceID);
  */
 void stopTrackingTracerWithID(SentryId *traceID, SentryConcurrentTransactionCleanupBlock cleanup);
 
+#    if defined(TEST) || defined(TESTCI)
+void resetConcurrencyTracking(void);
+#    endif // defined(TEST) || defined(TESTCI)
+
 SENTRY_EXTERN_C_END
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -265,8 +265,10 @@ class SentryProfilerSwiftTests: XCTestCase {
         // do everything again to make sure that stopping and starting the profiler over again works
         spans.removeAll()
         fixture.currentDateProvider.reset()
+#if !os(macOS)
         fixture.resetGPUExpectations()
         fixture.framesTracker.resetFrames()
+#endif
         fixture.prepareMetricsMocks()
 
         for _ in 0 ..< numberOfTransactions {
@@ -275,7 +277,9 @@ class SentryProfilerSwiftTests: XCTestCase {
 
         forceProfilerSample()
 
+#if !os(macOS)
         fixture.displayLinkWrapper.call()
+#endif
         for (i, span) in spans.enumerated() {
             try fixture.gatherMockedMetrics(span: span)
             span.finish()

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -519,10 +519,10 @@ private extension SentryProfilerSwiftTests {
         }
     }
 
-    func printTimestamps(entries: [[String: Any]]) {
-        print(entries.reduce(into: [NSString](), { partialResult, entry in
+    func printTimestamps(entries: [[String: Any]]) -> [NSString] {
+        entries.reduce(into: [NSString](), { partialResult, entry in
             partialResult.append(entry["elapsed_since_start_ns"] as! NSString)
-        }))
+        })
     }
 
     func assertMetricEntries(measurements: [String: Any], key: String, expectedEntries: [[String: Any]], transaction: Transaction) throws {
@@ -536,7 +536,7 @@ private extension SentryProfilerSwiftTests {
         let sortedExpectedEntries = sortedByTimestamps(expectedEntries)
 
         let expectedAmountOfReadings = actualEntries.count == expectedEntries.count
-        XCTAssert(expectedAmountOfReadings, "Wrong number of values under \(key). expected: \(sortedExpectedEntries); actual: \(sortedActualEntries); transaction start time: \(transaction.startSystemTime)")
+        XCTAssert(expectedAmountOfReadings, "Wrong number of values under \(key). expected: \(printTimestamps(entries: sortedExpectedEntries)); actual: \(printTimestamps(entries: sortedActualEntries)); transaction start time: \(transaction.startSystemTime)")
 
         guard expectedAmountOfReadings else {
             throw TestError.unexpectedAmountOfValues

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -417,6 +417,7 @@ private extension SentryProfilerSwiftTests {
         case malformedMetricValueEntry
         case noMetricsReported
         case noMetricValuesFound
+        case unexpectedAmountOfValues
     }
 
     func getLatestProfileData() throws -> Data {
@@ -538,7 +539,7 @@ private extension SentryProfilerSwiftTests {
         XCTAssert(expectedAmountOfReadings, "Wrong number of values under \(key). expected: \(sortedExpectedEntries); actual: \(sortedActualEntries); transaction start time: \(transaction.startSystemTime)")
 
         guard expectedAmountOfReadings else {
-            return
+            throw TestError.unexpectedAmountOfValues
         }
 
         for i in 0..<actualEntries.count {

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -97,7 +97,7 @@ class SentryProfilerSwiftTests: XCTestCase {
 
     #if !os(macOS)
             var shouldRecordFrameRateExpectation = false
-            var _previousSystemTime = currentDateProvider.systemTime()
+            var previousSystemTime = currentDateProvider.systemTime()
 
             func changeFrameRate(_ new: FrameRate) {
                 displayLinkWrapper.changeFrameRate(new)
@@ -107,9 +107,9 @@ class SentryProfilerSwiftTests: XCTestCase {
             func renderGPUFrame(_ type: GPUFrame) {
                 if shouldRecordFrameRateExpectation {
                     shouldRecordFrameRateExpectation = false
-                    print("will expect frame rate \(displayLinkWrapper.currentFrameRate.rawValue) at \(_previousSystemTime)")
+                    print("will expect frame rate \(displayLinkWrapper.currentFrameRate.rawValue) at \(previousSystemTime)")
                     expectedFrameRateChanges.append([
-                        "elapsed_since_start_ns": String(_previousSystemTime),
+                        "elapsed_since_start_ns": String(previousSystemTime),
                         "value": NSNumber(value: displayLinkWrapper.currentFrameRate.rawValue)
                     ])
                 }
@@ -118,32 +118,32 @@ class SentryProfilerSwiftTests: XCTestCase {
                 case .normal:
                     currentDateProvider.advanceBy(nanoseconds: 1)
                     let currentSystemTime: UInt64 = currentDateProvider.systemTime()
-                    print("expect normal frame to start at \(_previousSystemTime) and end at \(currentSystemTime)")
-                    _previousSystemTime = currentSystemTime
+                    print("expect normal frame to start at \(previousSystemTime) and end at \(currentSystemTime)")
+                    previousSystemTime = currentSystemTime
 
                     displayLinkWrapper.normalFrame()
                 case .slow:
                     let duration: UInt64 = 3
                     currentDateProvider.advanceBy(nanoseconds: duration)
                     let currentSystemTime = currentDateProvider.systemTime()
-                    print("will expect \(String(describing: type)) frame starting at \(_previousSystemTime) and ending at \(currentSystemTime)")
+                    print("will expect \(String(describing: type)) frame starting at \(previousSystemTime) and ending at \(currentSystemTime)")
                     expectedSlowFrames.append([
-                        "elapsed_since_start_ns": String(_previousSystemTime),
+                        "elapsed_since_start_ns": String(previousSystemTime),
                         "value": duration
                     ])
-                    _previousSystemTime = currentSystemTime
+                    previousSystemTime = currentSystemTime
 
                     displayLinkWrapper.middlingSlowFrame()
                 case .frozen:
                     let duration: UInt64 = 10
                     currentDateProvider.advanceBy(nanoseconds: duration)
                     let currentSystemTime = currentDateProvider.systemTime()
-                    print("will expect \(String(describing: type)) frame starting at \(_previousSystemTime) and ending at \(currentSystemTime)")
+                    print("will expect \(String(describing: type)) frame starting at \(previousSystemTime) and ending at \(currentSystemTime)")
                     expectedFrozenFrames.append([
-                        "elapsed_since_start_ns": String(_previousSystemTime),
+                        "elapsed_since_start_ns": String(previousSystemTime),
                         "value": duration
                     ])
-                    _previousSystemTime = currentSystemTime
+                    previousSystemTime = currentSystemTime
 
                     displayLinkWrapper.fastestFrozenFrame()
                 }

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -27,18 +27,39 @@ class SentryProfilerSwiftTests: XCTestCase {
 
         lazy var systemWrapper = TestSentrySystemWrapper()
         lazy var processInfoWrapper = TestSentryNSProcessInfoWrapper()
-        lazy var timerWrapper = TestSentryNSTimerWrapper()
+        lazy var metricTimerWrapper = TestSentryNSTimerWrapper()
+        lazy var timeoutTimerWrapper = TestSentryNSTimerWrapper()
 
         let currentDateProvider = TestCurrentDateProvider()
 
 #if !os(macOS)
-        lazy var displayLinkWrapper = TestDisplayLinkWrapper()
+        lazy var displayLinkWrapper = TestDisplayLinkWrapper(dateProvider: currentDateProvider)
         lazy var framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper)
 #endif
 
+        init() {
+            CurrentDate.setCurrentDateProvider(currentDateProvider)
+            options.profilesSampleRate = 1.0
+            options.tracesSampleRate = 1.0
+
+            SentryProfiler.useSystemWrapper(systemWrapper)
+            SentryProfiler.useProcessInfoWrapper(processInfoWrapper)
+            SentryProfiler.useMetricTimerWrapper(metricTimerWrapper)
+            SentryProfiler.useTimeoutTimerWrapper(timeoutTimerWrapper)
+
+            systemWrapper.overrides.cpuUsagePerCore = mockCPUUsages.map { NSNumber(value: $0) }
+            processInfoWrapper.overrides.processorCount = UInt(mockCPUUsages.count)
+            systemWrapper.overrides.memoryFootprintBytes = mockMemoryFootprint
+
+#if !os(macOS)
+            SentryProfiler.useFramesTracker(framesTracker)
+            framesTracker.start()
+            displayLinkWrapper.call()
+#endif
+        }
+
         /// Advance the mock date provider, start a new transaction and return its handle.
         func newTransaction(testingAppLaunchSpans: Bool = false) throws -> SentryTracer {
-            currentDateProvider.advanceBy(nanoseconds: 2)
             if testingAppLaunchSpans {
                 return try XCTUnwrap(hub.startTransaction(name: transactionName, operation: SentrySpanOperationUILoad) as? SentryTracer)
             }
@@ -55,22 +76,6 @@ class SentryProfilerSwiftTests: XCTestCase {
         // SentryFramesTracker starts assuming a frame rate of 60 Hz and will only log an update if it changes, so the first value here needs to be different for it to register.
         let mockFrameRateChangesPerBatch: [FrameRate] = [.high, .low, .high, .low]
 #endif
-
-        func prepareMetricsMocks() {
-            SentryProfiler.useSystemWrapper(systemWrapper)
-            SentryProfiler.useProcessInfoWrapper(processInfoWrapper)
-            SentryProfiler.useTimerWrapper(timerWrapper)
-
-            systemWrapper.overrides.cpuUsagePerCore = mockCPUUsages.map { NSNumber(value: $0) }
-            processInfoWrapper.overrides.processorCount = UInt(mockCPUUsages.count)
-            systemWrapper.overrides.memoryFootprintBytes = mockMemoryFootprint
-
-#if !os(macOS)
-            SentryProfiler.useFramesTracker(framesTracker)
-            framesTracker.start()
-            displayLinkWrapper.call()
-#endif
-        }
 
 #if !os(macOS)
         // Absolute timestamps must be adjusted per span when asserting
@@ -92,12 +97,11 @@ class SentryProfilerSwiftTests: XCTestCase {
 
             // gather mock cpu usages and memory footprints
             for _ in 0..<mockUsageReadingsPerBatch {
-                self.timerWrapper.fire()
+                self.metricTimerWrapper.fire()
             }
 
     #if !os(macOS)
-            var shouldRecordFrameRateExpectation = false
-            var previousSystemTime = currentDateProvider.systemTime()
+            var shouldRecordFrameRateExpectation = true
 
             func changeFrameRate(_ new: FrameRate) {
                 displayLinkWrapper.changeFrameRate(new)
@@ -105,47 +109,36 @@ class SentryProfilerSwiftTests: XCTestCase {
             }
 
             func renderGPUFrame(_ type: GPUFrame) {
-                if shouldRecordFrameRateExpectation {
-                    shouldRecordFrameRateExpectation = false
-                    print("will expect frame rate \(displayLinkWrapper.currentFrameRate.rawValue) at \(previousSystemTime)")
-                    expectedFrameRateChanges.append([
-                        "elapsed_since_start_ns": String(previousSystemTime),
-                        "value": NSNumber(value: displayLinkWrapper.currentFrameRate.rawValue)
-                    ])
-                }
-
                 switch type {
                 case .normal:
-                    currentDateProvider.advanceBy(nanoseconds: 1)
                     let currentSystemTime: UInt64 = currentDateProvider.systemTime()
-                    print("expect normal frame to start at \(previousSystemTime) and end at \(currentSystemTime)")
-                    previousSystemTime = currentSystemTime
-
+                    print("expect normal frame to start at \(currentSystemTime)")
                     displayLinkWrapper.normalFrame()
                 case .slow:
-                    let duration: UInt64 = 3
-                    currentDateProvider.advanceBy(nanoseconds: duration)
+                    let duration = displayLinkWrapper.middlingSlowFrame().toNanoSeconds()
                     let currentSystemTime = currentDateProvider.systemTime()
-                    print("will expect \(String(describing: type)) frame starting at \(previousSystemTime) and ending at \(currentSystemTime)")
+                    print("will expect \(String(describing: type)) frame starting at \(currentSystemTime)")
                     expectedSlowFrames.append([
-                        "elapsed_since_start_ns": String(previousSystemTime),
+                        "elapsed_since_start_ns": String(currentSystemTime),
                         "value": duration
                     ])
-                    previousSystemTime = currentSystemTime
-
-                    displayLinkWrapper.middlingSlowFrame()
                 case .frozen:
-                    let duration: UInt64 = 10
-                    currentDateProvider.advanceBy(nanoseconds: duration)
+                    let duration = displayLinkWrapper.fastestFrozenFrame().toNanoSeconds()
                     let currentSystemTime = currentDateProvider.systemTime()
-                    print("will expect \(String(describing: type)) frame starting at \(previousSystemTime) and ending at \(currentSystemTime)")
+                    print("will expect \(String(describing: type)) frame starting at \(currentSystemTime)")
                     expectedFrozenFrames.append([
-                        "elapsed_since_start_ns": String(previousSystemTime),
+                        "elapsed_since_start_ns": String(currentSystemTime),
                         "value": duration
                     ])
-                    previousSystemTime = currentSystemTime
-
-                    displayLinkWrapper.fastestFrozenFrame()
+                }
+                if shouldRecordFrameRateExpectation {
+                    shouldRecordFrameRateExpectation = false
+                    let currentSystemTime = currentDateProvider.systemTime()
+                    print("will expect frame rate \(displayLinkWrapper.currentFrameRate.rawValue) at \(currentSystemTime)")
+                    expectedFrameRateChanges.append([
+                        "elapsed_since_start_ns": String(currentSystemTime),
+                        "value": NSNumber(value: displayLinkWrapper.currentFrameRate.rawValue)
+                    ])
                 }
             }
 
@@ -158,6 +151,7 @@ class SentryProfilerSwiftTests: XCTestCase {
              * refresh rate:  |---60hz--------------|---120hz------|---60hz--------------------------------------|
              * time:          N--S----N--F----------N-N-S--N-F-----N--N--S----N--F----------N--S----N--F----------
              */
+            changeFrameRate(.low)
             renderGPUFrame(.normal)
             renderGPUFrame(.slow)
             renderGPUFrame(.normal)
@@ -175,6 +169,8 @@ class SentryProfilerSwiftTests: XCTestCase {
             renderGPUFrame(.normal)
             renderGPUFrame(.frozen)
             renderGPUFrame(.normal)
+            changeFrameRate(.high)
+            renderGPUFrame(.normal)
             renderGPUFrame(.slow)
             renderGPUFrame(.normal)
             renderGPUFrame(.frozen)
@@ -183,7 +179,7 @@ class SentryProfilerSwiftTests: XCTestCase {
             // mock errors gathering cpu usage and memory footprint and fire a callback for them to ensure they don't add more information to the payload
             systemWrapper.overrides.cpuUsageError = NSError(domain: "test-error", code: 0)
             systemWrapper.overrides.memoryFootprintError = NSError(domain: "test-error", code: 1)
-            timerWrapper.fire()
+            metricTimerWrapper.fire()
         }
 
         // app start simulation
@@ -207,112 +203,88 @@ class SentryProfilerSwiftTests: XCTestCase {
 
     private var fixture: Fixture!
 
+    override class func setUp() {
+        super.setUp()
+        SentryLog.configure(true, diagnosticLevel: .debug)
+    }
+
     override func setUp() {
         super.setUp()
         fixture = Fixture()
-        SentryLog.configure(true, diagnosticLevel: .debug)
-        CurrentDate.setCurrentDateProvider(fixture.currentDateProvider)
-        fixture.options.profilesSampleRate = 1.0
-        fixture.options.tracesSampleRate = 1.0
-        fixture.prepareMetricsMocks()
     }
 
     override func tearDown() {
         super.tearDown()
+
+        // If a test early exits because of a thrown error, it may not finish the spans it created. This ensures the profiler stops before starting the next test case.
+        fixture.timeoutTimerWrapper.fire()
+
         clearTestState()
     }
 
     func testMetricProfiler() throws {
-        // start span
         let span = try fixture.newTransaction()
         forceProfilerSample()
-
         try fixture.gatherMockedMetrics(span: span)
-
-        // finish profile
-        let exp = expectation(description: "Receives profile payload")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            span.finish()
-            do {
-                try self.assertMetricsPayload()
-                exp.fulfill()
-            } catch {
-                XCTFail("Encountered error: \(error)")
-            }
-        }
-        waitForExpectations(timeout: 3)
+        self.fixture.currentDateProvider.advanceBy(nanoseconds: 1.toNanoSeconds())
+        span.finish()
+        try self.assertMetricsPayload()
     }
 
     func testConcurrentProfilingTransactions() throws {
         let numberOfTransactions = 10
         var spans = [Span]()
 
-        for _ in 0 ..< numberOfTransactions {
-            spans.append(try fixture.newTransaction())
+        func createConcurrentSpansWithMetrics() throws {
+            for _ in 0 ..< numberOfTransactions {
+                let span = try fixture.newTransaction()
+                spans.append(span)
+                fixture.currentDateProvider.advanceBy(nanoseconds: 100)
+            }
+
+            forceProfilerSample()
+
+            for (i, span) in spans.enumerated() {
+                try fixture.gatherMockedMetrics(span: span)
+                span.finish()
+
+                try self.assertValidProfileData()
+                try self.assertMetricsPayload(metricsBatches: i + 1)
+            }
         }
 
-        forceProfilerSample()
-
-        for (i, span) in spans.enumerated() {
-            try fixture.gatherMockedMetrics(span: span)
-            span.finish()
-
-            try self.assertValidProfileData()
-            try self.assertMetricsPayload(metricsBatches: i + 1)
-        }
+        try createConcurrentSpansWithMetrics()
 
         // do everything again to make sure that stopping and starting the profiler over again works
         spans.removeAll()
-        fixture.currentDateProvider.reset()
 #if !os(macOS)
         fixture.resetGPUExpectations()
         fixture.framesTracker.resetFrames()
-#endif
-        fixture.prepareMetricsMocks()
-
-        for _ in 0 ..< numberOfTransactions {
-            spans.append(try fixture.newTransaction())
-        }
-
-        forceProfilerSample()
-
-#if !os(macOS)
         fixture.displayLinkWrapper.call()
 #endif
-        for (i, span) in spans.enumerated() {
-            try fixture.gatherMockedMetrics(span: span)
-            span.finish()
 
-            try self.assertValidProfileData()
-            try self.assertMetricsPayload(metricsBatches: i + 1)
-        }
+        try createConcurrentSpansWithMetrics()
     }
 
     /// Test a situation where a long-running span starts the profiler, which winds up timing out, and then another span starts that begins a new profile, then finishes, and then the long-running span finishes; both profiles should be separately captured in envelopes.
     /// ```
-    ///    time                0s                         1s     2s     2.5s     3s  (these times are adjusted to the 1s profile timeout for testing only)
+    ///                        time->
     ///    transaction A       |---------------------------------------------------|
     ///    profiler A          |---------------------------x  <- timeout
     ///    transaction B                                           |-------|
     ///    profiler B                                              |-------|  <- normal finish
     ///   ```
     func testConcurrentSpansWithTimeout() throws {
-        let originalTimeoutInterval = kSentryProfilerTimeoutInterval
-        kSentryProfilerTimeoutInterval = 1
-
         let spanA = try fixture.newTransaction()
-
+        fixture.currentDateProvider.advanceBy(nanoseconds: 1.toNanoSeconds())
         forceProfilerSample()
+        fixture.currentDateProvider.advanceBy(nanoseconds: 30.toNanoSeconds())
+        fixture.timeoutTimerWrapper.fire()
 
-        // cause spanA profiler to time out
-        let exp = expectation(description: "spanA times out")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            exp.fulfill()
-        }
-        waitForExpectations(timeout: 3)
+        fixture.currentDateProvider.advanceBy(nanoseconds: 0.5.toNanoSeconds())
 
         let spanB = try fixture.newTransaction()
-
+        fixture.currentDateProvider.advanceBy(nanoseconds: 0.5.toNanoSeconds())
         forceProfilerSample()
 
         spanB.finish()
@@ -320,8 +292,6 @@ class SentryProfilerSwiftTests: XCTestCase {
 
         spanA.finish()
         try self.assertValidProfileData()
-
-        kSentryProfilerTimeoutInterval = originalTimeoutInterval
     }
 
     func testProfileTimeoutTimer() throws {
@@ -441,32 +411,16 @@ private extension SentryProfilerSwiftTests {
             SentrySDK.setAppStartMeasurement(appStartMeasurement)
         }
 
-        let originalTimeoutInterval = kSentryProfilerTimeoutInterval
-        if shouldTimeOut {
-            kSentryProfilerTimeoutInterval = 1
-        }
         let span = try fixture.newTransaction(testingAppLaunchSpans: testingAppLaunchSpans)
-
         forceProfilerSample()
-
-        let exp = expectation(description: "profiler should finish")
+        fixture.currentDateProvider.advance(by: 31)
         if shouldTimeOut {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                span.finish()
-                exp.fulfill()
-            }
-        } else {
-            span.finish()
-            exp.fulfill()
+            fixture.timeoutTimerWrapper.fire()
         }
 
-        waitForExpectations(timeout: 10)
+        span.finish()
 
         try self.assertValidProfileData(transactionEnvironment: transactionEnvironment, shouldTimeout: shouldTimeOut)
-
-        if shouldTimeOut {
-            kSentryProfilerTimeoutInterval = originalTimeoutInterval
-        }
     }
 
     func assertMetricsPayload(metricsBatches: Int = 1) throws {
@@ -672,7 +626,8 @@ private extension SentryProfilerSwiftTests {
             case .yes:
                 return NSNumber(value: 1)
             @unknown default:
-                fatalError("Unexpected value for sample decision")
+                XCTFail("Unexpected value for sample decision")
+                return NSNumber(value: 0)
             }
         }
         options(fixtureOptions)
@@ -681,36 +636,22 @@ private extension SentryProfilerSwiftTests {
         Dynamic(hub).tracesSampler.random = TestRandom(value: 1.0)
 
         let span = try fixture.newTransaction()
-        let exp = expectation(description: "Span finishes")
-        DispatchQueue.global().asyncAfter(deadline: .now() + 2.0) {
-            span.finish()
+        forceProfilerSample()
+        fixture.currentDateProvider.advance(by: 5)
+        span.finish()
 
-            guard let client = self.fixture.client else {
-                XCTFail("Expected a valid test client to exist")
-                return
-            }
+        let client = try XCTUnwrap(self.fixture.client)
 
-            switch expectedDecision {
-            case .undecided, .no:
-                guard let event = client.captureEventWithScopeInvocations.first else {
-                    XCTFail("Expected to capture at least 1 event, but without a profile")
-                    return
-                }
-                XCTAssertEqual(0, event.additionalEnvelopeItems.count)
-            case .yes:
-                guard let event = client.captureEventWithScopeInvocations.first else {
-                    XCTFail("Expected to capture at least 1 event with a profile")
-                    return
-                }
-                XCTAssertEqual(1, event.additionalEnvelopeItems.count)
-            @unknown default:
-                fatalError("Unexpected value for sample decision")
-            }
-
-            exp.fulfill()
+        switch expectedDecision {
+        case .undecided, .no:
+            let event = try XCTUnwrap(client.captureEventWithScopeInvocations.first)
+            XCTAssertEqual(0, event.additionalEnvelopeItems.count)
+        case .yes:
+            let event = try XCTUnwrap(client.captureEventWithScopeInvocations.first)
+            XCTAssertEqual(1, event.additionalEnvelopeItems.count)
+        @unknown default:
+            XCTFail("Unexpected value for sample decision")
         }
-
-        waitForExpectations(timeout: 3)
     }
 }
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/Helper/SentryProfiler+SwiftTest.h
+++ b/Tests/SentryTests/Helper/SentryProfiler+SwiftTest.h
@@ -21,7 +21,11 @@ SentryProfiler ()
 + (void)useProcessInfoWrapper:(SentryNSProcessInfoWrapper *)processInfoWrapper
     NS_SWIFT_NAME(useProcessInfoWrapper(_:));
 
-+ (void)useTimerWrapper:(SentryNSTimerWrapper *)timerWrapper NS_SWIFT_NAME(useTimerWrapper(_:));
++ (void)useMetricTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
+    NS_SWIFT_NAME(useMetricTimerWrapper(_:));
+
++ (void)useTimeoutTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
+    NS_SWIFT_NAME(useTimeoutTimerWrapper(_:));
 
 #    if SENTRY_HAS_UIKIT
 + (void)useFramesTracker:(SentryFramesTracker *)framesTracker NS_SWIFT_NAME(useFramesTracker(_:));

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -98,9 +98,6 @@ class SentryFramesTrackerTests: XCTestCase {
         
         group.wait()
         try assert(slow: frames, frozen: frames, total: 3 * frames)
-
-        // ok, set logs back to debug for other tests
-        SentryLog.configure(true, diagnosticLevel: .debug)
     }
     
     func testPerformanceOfTrackingFrames() throws {

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -77,9 +77,6 @@ class SentryFramesTrackerTests: XCTestCase {
     }
     
     func testAllFrames_ConcurrentRead() throws {
-        // this is a really long test and the logs slow it down
-        SentryLog.configure(false, diagnosticLevel: .error)
-
         let sut = fixture.sut
         sut.start()
         

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -18,11 +18,6 @@ class SentryFramesTrackerTests: XCTestCase {
     }
     
     private var fixture: Fixture!
-
-    override class func setUp() {
-        super.setUp()
-        SentryLog.configure(true, diagnosticLevel: .debug)
-    }
     
     override func setUp() {
         super.setUp()

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -18,6 +18,11 @@ class SentryFramesTrackerTests: XCTestCase {
     }
     
     private var fixture: Fixture!
+
+    override class func setUp() {
+        super.setUp()
+        SentryLog.configure(true, diagnosticLevel: .debug)
+    }
     
     override func setUp() {
         super.setUp()
@@ -46,9 +51,9 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
         
         fixture.displayLinkWrapper.call()
-        fixture.displayLinkWrapper.fastestSlowFrame()
+        _ = fixture.displayLinkWrapper.fastestSlowFrame()
         fixture.displayLinkWrapper.normalFrame()
-        fixture.displayLinkWrapper.slowestSlowFrame()
+        _ = fixture.displayLinkWrapper.slowestSlowFrame()
 
         try assert(slow: 2, frozen: 0, total: 3)
     }
@@ -58,8 +63,8 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
         
         fixture.displayLinkWrapper.call()
-        fixture.displayLinkWrapper.fastestSlowFrame()
-        fixture.displayLinkWrapper.fastestFrozenFrame()
+        _ = fixture.displayLinkWrapper.fastestSlowFrame()
+        _ = fixture.displayLinkWrapper.fastestFrozenFrame()
 
         try assert(slow: 1, frozen: 1, total: 2)
     }
@@ -69,14 +74,17 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
 
         fixture.displayLinkWrapper.call()
-        fixture.displayLinkWrapper.fastestSlowFrame()
+        _ = fixture.displayLinkWrapper.fastestSlowFrame()
         fixture.displayLinkWrapper.changeFrameRate(.high)
-        fixture.displayLinkWrapper.fastestFrozenFrame()
+        _ = fixture.displayLinkWrapper.fastestFrozenFrame()
 
         try assert(slow: 1, frozen: 1, total: 2, frameRates: 2)
     }
     
     func testAllFrames_ConcurrentRead() throws {
+        // this is a really long test and the logs slow it down
+        SentryLog.configure(false, diagnosticLevel: .error)
+
         let sut = fixture.sut
         sut.start()
         
@@ -92,12 +100,15 @@ class SentryFramesTrackerTests: XCTestCase {
         let frames: UInt = 600_000
         for _ in 0 ..< frames {
             fixture.displayLinkWrapper.normalFrame()
-            fixture.displayLinkWrapper.fastestSlowFrame()
-            fixture.displayLinkWrapper.fastestFrozenFrame()
+            _ = fixture.displayLinkWrapper.fastestSlowFrame()
+            _ = fixture.displayLinkWrapper.fastestFrozenFrame()
         }
         
         group.wait()
         try assert(slow: frames, frozen: frames, total: 3 * frames)
+
+        // ok, set logs back to debug for other tests
+        SentryLog.configure(true, diagnosticLevel: .debug)
     }
     
     func testPerformanceOfTrackingFrames() throws {
@@ -186,10 +197,9 @@ private extension SentryFramesTrackerTests {
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     func assertProfilingData(slow: UInt? = nil, frozen: UInt? = nil, frameRates: UInt? = nil) throws {
-        func assertStartAndEndOrdering(frame: [String: NSNumber]) throws {
-            let start = try XCTUnwrap(frame["start_timestamp"], "Expected a start timestamp for the frame.")
-            let end = try XCTUnwrap(frame["end_timestamp"], "Expected an end timestamp for the frame.")
-            XCTAssert(start.compare(end) != .orderedDescending)
+        func assertFrameInfo(frame: [String: NSNumber]) throws {
+            XCTAssertNotNil(frame["timestamp"], "Expected a timestamp for the frame.")
+            XCTAssertNotNil(frame["value"], "Expected a duration value for the frame.")
         }
 
         let currentFrames = fixture.sut.currentFrames
@@ -197,13 +207,13 @@ private extension SentryFramesTrackerTests {
         if let slow = slow {
             XCTAssertEqual(currentFrames.slowFrameTimestamps.count, Int(slow))
             for frame in currentFrames.slowFrameTimestamps {
-                try assertStartAndEndOrdering(frame: frame)
+                try assertFrameInfo(frame: frame)
             }
         }
         if let frozen = frozen {
             XCTAssertEqual(currentFrames.frozenFrameTimestamps.count, Int(frozen))
             for frame in currentFrames.frozenFrameTimestamps {
-                try assertStartAndEndOrdering(frame: frame)
+                try assertFrameInfo(frame: frame)
             }
         }
         if let frameRates = frameRates {

--- a/Tests/SentryTests/Transaction/SentryTracer+Test.h
+++ b/Tests/SentryTests/Transaction/SentryTracer+Test.h
@@ -1,4 +1,4 @@
-
+#import "SentryProfilingConditionals.h"
 #import "SentryTracer.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -9,6 +9,10 @@ SentryTracer (Test)
 + (void)resetAppStartMeasurementRead;
 
 - (void)updateStartTime:(NSDate *)startTime;
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
++ (void)resetConcurrencyTracking;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
 
 @end
 


### PR DESCRIPTION
#skip-changelog

I noticed recently that a frozen GPU frame reported during an ANR from iOS-Swift was not aligned to where it should be with the stack frames that likely caused it ([profile](https://sentry-sdks.sentry.io/profiling/profile/sentry-cocoa/b09733aa309b4b1f875eb987abf20363/flamechart/?colorCoding=by+system+vs+application+frame&query=&sorting=call+order&tid=12291&view=top+down)): 
![image](https://user-images.githubusercontent.com/3241469/228710876-5cfd2335-4684-4194-bf8e-b642b3f7767b.png)

This is an investigation to see if there's an SDK bug.

As part of this, I'm refactoring the profiling tests to validate the timestamp values of the reported metrics, originally mentioned [here](https://github.com/getsentry/sentry-cocoa/pull/2545#discussion_r1113599464) (and later, [here](https://github.com/getsentry/sentry-cocoa/pull/2786#issuecomment-1468537060) and [here](https://github.com/getsentry/sentry-cocoa/pull/2823#discussion_r1147962530))

The commits basically represent 3 different bodies of work:
1. https://github.com/getsentry/sentry-cocoa/commit/4618eb6d530498008403e02e699e7c4d947e05e6 .. https://github.com/getsentry/sentry-cocoa/commit/2ef0faed5579e90efe3d1c32b63d15a73639bf83 are some refactors to be able to mock everything in the profiler tests and make the test wrappers easier to work with
2. https://github.com/getsentry/sentry-cocoa/commit/0c33454ddfaddc3b58757f7b1b33601f131ac205 reworks the profiler tests to mock the date provider, set the expectations around what GPU frame info should be reported, and validate the values the profiler reports
3. everything after are fixes in the SDK to get the mocked test working again

**Updates**
- Moved refactor of other components and test helpers to https://github.com/getsentry/sentry-cocoa/pull/2849
- The bug being investigated might not be client-side. We're going to consider the investigation closed while fronted checks a few things. Updated the PR title to reflect the changes that will be merged.

**Update 2**
- We believe we found the bug in the client and fixed in #2856 