### PR TITLE
chore: Add repo link to all KSCrash files

### DIFF
--- a/Sources/SentryCrash/Installations/SentryCrashInstallation+Private.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation+Private.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFieldProperties.h
 //

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashInstallation.h
 //

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashInstallation.m
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor.c
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitorContext.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorType.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorType.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitorType.c
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorType.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorType.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitorType.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_AppState.c
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_AppState.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_CPPException.c
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_CPPException.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_MachException.c
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_MachException.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_NSException.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_NSException.m
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_Signal.c
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_Signal.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_System.h
 //

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_System.m
 //

--- a/Sources/SentryCrash/Recording/SentryCrash.h
+++ b/Sources/SentryCrash/Recording/SentryCrash.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrash.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrash.m
 //

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashC.c
 //

--- a/Sources/SentryCrash/Recording/SentryCrashC.h
+++ b/Sources/SentryCrash/Recording/SentryCrashC.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashC.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.c
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCachedData.c
 //

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.h
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCachedData.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashDoctor.h
+++ b/Sources/SentryCrash/Recording/SentryCrashDoctor.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDoctor.h
 //  SentryCrash

--- a/Sources/SentryCrash/Recording/SentryCrashDoctor.m
+++ b/Sources/SentryCrash/Recording/SentryCrashDoctor.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDoctor.m
 //  SentryCrash

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReport.m
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReport.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReport.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportFields.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFields.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFields.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFixer.c
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportFixer.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFixer.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFixer.c
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportStore.c
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportStore.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportVersion.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportVersion.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportVersion.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashReportWriter.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportWriter.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportWriter.h
 //

--- a/Sources/SentryCrash/Recording/SentryCrashSystemCapabilities.h
+++ b/Sources/SentryCrash/Recording/SentryCrashSystemCapabilities.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSystemCapabilities.h
 //

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  NSError+SimpleConstructor.h
 //

--- a/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
+++ b/Sources/SentryCrash/Recording/Tools/NSError+SentrySimpleConstructor.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  NSError+SimpleConstructor.m
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_Apple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_Apple.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU_Apple.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU_arm.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU_arm64_Apple.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU_x86_32.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU_x86_64.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDebug.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDebug.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDynamicLinker.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDynamicLinker.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashFileUtils.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashFileUtils.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashID.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashID.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashID.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashID.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashID.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashID.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashJSONCodec.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashJSONCodec.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashJSONCodecObjC.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashJSONCodecObjC.m
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashLogger.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashLogger.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMachineContext.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMachineContext.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMachineContext_Apple.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMemory.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMemory.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashObjC.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjC.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashObjC.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSignalInfo.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSignalInfo.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor_Backtrace.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor_Backtrace.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor_MachineContext.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor_MachineContext.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor_SelfThread.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashStackCursor_SelfThread.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashString.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashString.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashString.m
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashString.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashString.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashString.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSymbolicator.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSymbolicator.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSysCtl.m
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSysCtl.h
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashThread.c
 //

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashThread.h
 //

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilter.h
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilter.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFilter.h
 //

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.h
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFilterBasic.h
 //

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFilterBasic.m
 //

--- a/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.h
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  Container+DeepSearch
 //

--- a/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.m
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/Container+SentryDeepSearch.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  Container+DeepSearch
 //

--- a/Sources/SentryCrash/Reporting/Filters/Tools/SentryCrashVarArgs.h
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/SentryCrashVarArgs.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashVarArgs.h
 //

--- a/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.h
+++ b/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCString.h
 //

--- a/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.m
+++ b/Sources/SentryCrash/Reporting/Tools/SentryCrashCString.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCString.m
 //

--- a/Tests/SentryTests/SentryCrash/Container+DeepSearch_Tests.m
+++ b/Tests/SentryTests/SentryCrash/Container+DeepSearch_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  Container+DeepSearch_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/FileBasedTestCase.h
+++ b/Tests/SentryTests/SentryCrash/FileBasedTestCase.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  FileBasedTestCase.h
 //

--- a/Tests/SentryTests/SentryCrash/FileBasedTestCase.m
+++ b/Tests/SentryTests/SentryCrash/FileBasedTestCase.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  FileBasedTestCase.m
 //

--- a/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/NSError+SimpleConstructor_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  NSError+SimpleConstructor_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/RFC3339UTFString_Tests.m
+++ b/Tests/SentryTests/SentryCrash/RFC3339UTFString_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 // RFC3339DateTool_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashCPU_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashCPU_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCPU_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashCString_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashCString_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCString_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashCachedData_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashCachedData_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashCachedData_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashDynamicLinker_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashDynamicLinker_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashDynamicLinker_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashFileUtils_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashFileUtils_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashFileUtils_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashJSONCodec_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashLogger_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashLogger_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashLogger_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashMach_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMach_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMach_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashMemory_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMemory_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  sentrycrashmemory_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_AppState_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_AppState_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_AppState_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_NSException_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_NSException_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_NSException_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_Signal_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_Signal_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_Signal_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashMonitor_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashMonitor_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashMonitor_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashObjC_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashObjC_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashObjC_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportFilter_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportFilter_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportFilter_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashReportStore_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashSignalInfo_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashSignalInfo_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSignalInfo_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashString_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashString_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashString_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/SentryCrashSysCtl_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashSysCtl_Tests.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SentryCrashSysCtl_Tests.m
 //

--- a/Tests/SentryTests/SentryCrash/TestThread.h
+++ b/Tests/SentryTests/SentryCrash/TestThread.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  TestThread.h
 //

--- a/Tests/SentryTests/SentryCrash/TestThread.m
+++ b/Tests/SentryTests/SentryCrash/TestThread.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  TestThread.m
 //

--- a/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.h
+++ b/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.h
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SenTestCase+SentryCrash.h
 //

--- a/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.m
+++ b/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.m
@@ -1,3 +1,4 @@
+// Adapted from: https://github.com/kstenerud/KSCrash
 //
 //  SenTestCase+SentryCrash.m
 //


### PR DESCRIPTION
Add repo link to all KSCrash forked files.

Part of https://github.com/getsentry/sentry-cocoa/issues/2844.