### PR TITLE
chore(hybrid): Move extra context to standalone class

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -1,6 +1,7 @@
 #import "PrivateSentrySDKOnly.h"
 #import "SentryClient.h"
 #import "SentryDebugImageProvider.h"
+#import "SentryExtraContextProvider.h"
 #import "SentryHub+Private.h"
 #import "SentryInstallation.h"
 #import "SentryMeta.h"
@@ -98,6 +99,11 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 + (NSString *)getSdkVersionString
 {
     return SentryMeta.versionString;
+}
+
++ (NSDictionary *)getExtraContext
+{
+    return [[SentryExtraContextProvider sharedInstance] getExtraContext];
 }
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryExtraContextProvider.h
+++ b/Sources/Sentry/SentryExtraContextProvider.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Provider of dynamic context data that we need to read at the time of an exception.
+ */
+@interface SentryExtraContextProvider : NSObject
+
++ (instancetype)sharedInstance;
+
+- (_Nonnull instancetype)init;
+
+- (NSDictionary *)getExtraContext;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryExtraContextProvider.m
+++ b/Sources/Sentry/SentryExtraContextProvider.m
@@ -1,0 +1,75 @@
+#import "SentryExtraContextProvider.h"
+#import "SentryCrashIntegration.h"
+#import "SentryCrashWrapper.h"
+#import "SentryNSProcessInfoWrapper.h"
+#import "SentryUIDeviceWrapper.h"
+
+@interface
+SentryExtraContextProvider ()
+
+@property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
+@property (nonatomic, strong) SentryUIDeviceWrapper *deviceWrapper;
+@property (nonatomic, strong) SentryNSProcessInfoWrapper *processInfoWrapper;
+
+@end
+
+@implementation SentryExtraContextProvider
+
++ (instancetype)sharedInstance
+{
+    static SentryExtraContextProvider *instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ instance = [[self alloc] init]; });
+    return instance;
+}
+
+- (_Nonnull instancetype)init
+{
+    self.crashWrapper = [SentryCrashWrapper sharedInstance];
+    self.deviceWrapper = [[SentryUIDeviceWrapper alloc] init];
+    self.processInfoWrapper = [[SentryNSProcessInfoWrapper alloc] init];
+    return self;
+}
+
+- (NSDictionary *)getExtraContext
+{
+    NSMutableDictionary *extraContext = [[NSMutableDictionary alloc] init];
+
+    [extraContext setValue:[self getExtraDeviceContext] forKey:@"device"];
+    [extraContext setValue:[self getExtraAppContext] forKey:@"app"];
+
+    return extraContext;
+}
+
+- (NSDictionary *)getExtraDeviceContext
+{
+    NSMutableDictionary *extraDeviceContext = [[NSMutableDictionary alloc] init];
+
+    extraDeviceContext[SentryDeviceContextFreeMemoryKey] = @(self.crashWrapper.freeMemorySize);
+    extraDeviceContext[@"free_storage"] = @(self.crashWrapper.freeStorageSize);
+    extraDeviceContext[@"processor_count"] = @([self.processInfoWrapper processorCount]);
+
+#if TARGET_OS_IOS
+    if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {
+        extraDeviceContext[@"orientation"]
+            = UIDeviceOrientationIsPortrait(self.deviceWrapper.orientation) ? @"portrait"
+                                                                            : @"landscape";
+    }
+
+    if (self.deviceWrapper.isBatteryMonitoringEnabled) {
+        extraDeviceContext[@"charging"]
+            = self.deviceWrapper.batteryState == UIDeviceBatteryStateCharging ? @(YES) : @(NO);
+        extraDeviceContext[@"battery_level"] = @((int)(self.deviceWrapper.batteryLevel * 100));
+    }
+#endif
+    return extraDeviceContext;
+}
+
+- (NSDictionary *)getExtraAppContext
+{
+    NSMutableDictionary *extraAppContext = [[NSMutableDictionary alloc] init];
+    extraAppContext[SentryDeviceContextAppMemoryKey] = @(self.crashWrapper.appMemorySize);
+    return extraAppContext;
+}
+
+@end

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -63,6 +63,11 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (NSString *)getSdkVersionString;
 
+/**
+ * Retrieves extra context
+ */
++ (NSDictionary *)getExtraContext;
+
 @property (class, nullable, nonatomic, copy)
     SentryOnAppStartMeasurementAvailable onAppStartMeasurementAvailable;
 

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -377,7 +377,10 @@ getBasePath()
 // ============================================================================
 
 #define SYNTHESIZE_CRASH_STATE_PROPERTY(TYPE, NAME)                                                \
-    -(TYPE)NAME { return sentrycrashstate_currentState()->NAME; }
+    -(TYPE)NAME                                                                                    \
+    {                                                                                              \
+        return sentrycrashstate_currentState()->NAME;                                              \
+    }
 
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, activeDurationSinceLastCrash)
 SYNTHESIZE_CRASH_STATE_PROPERTY(NSTimeInterval, backgroundDurationSinceLastCrash)


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

This enables us to reuse the same extra context logic in hybrid SDKs.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- https://github.com/getsentry/sentry-react-native/issues/2884

## :green_heart: How did you test it?

cocoa sample app and rn sample app

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
#skip-changelog 