### PR TITLE
fix: profiling GPU information timestamp choice

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -34,5 +34,6 @@ class TestCleanup: NSObject {
         SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
 
         SentryTracer.resetAppStartMeasurementRead()
+        SentryTracer.resetConcurrencyTracking()
     }
 }

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -34,6 +34,9 @@ class TestCleanup: NSObject {
         SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
 
         SentryTracer.resetAppStartMeasurementRead()
+
+#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
         SentryTracer.resetConcurrencyTracking()
+#endif
     }
 }

--- a/SentryTestUtils/TestSentryNSTimerWrapper.swift
+++ b/SentryTestUtils/TestSentryNSTimerWrapper.swift
@@ -34,7 +34,9 @@ public class TestSentryNSTimerWrapper: SentryNSTimerWrapper {
 
     public override func scheduledTimer(withTimeInterval ti: TimeInterval, target aTarget: Any, selector aSelector: Selector, userInfo: Any?, repeats yesOrNo: Bool) -> Timer {
         let timer = TestTimer()
+        //swiftlint:disable force_cast
         overrides.invocationInfo = Overrides.InvocationInfo(target: aTarget as! NSObject, selector: aSelector)
+        //swiftlint:enable force_cast
         return timer
     }
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -162,6 +162,8 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
         [self recordTimestamp:thisFrameSystemTimestamp
                         value:@(currentFrameRate)
                         array:self.frameRateTimestamps];
+    } else {
+        SENTRY_LOG_DEBUG(@"Won't record frame rate at %llu", thisFrameSystemTimestamp);
     }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -162,8 +162,6 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
         [self recordTimestamp:thisFrameSystemTimestamp
                         value:@(currentFrameRate)
                         array:self.frameRateTimestamps];
-    } else {
-        SENTRY_LOG_DEBUG(@"Won't record frame rate at %llu", thisFrameSystemTimestamp);
     }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -184,8 +184,6 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
                         value:@(thisFrameSystemTimestamp - self.previousFrameSystemTimestamp)
                         array:self.frozenFrameTimestamps];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
-    } else {
-        SENTRY_LOG_DEBUG(@"Rendered normal frame starting at %llu.", thisFrameSystemTimestamp);
     }
 
     atomic_fetch_add_explicit(&_totalFrames, 1, SentryFramesMemoryOrder);

--- a/Sources/Sentry/SentryNSTimerWrapper.m
+++ b/Sources/Sentry/SentryNSTimerWrapper.m
@@ -9,4 +9,17 @@
     return [NSTimer scheduledTimerWithTimeInterval:interval repeats:repeats block:block];
 }
 
+- (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)ti
+                                     target:(id)aTarget
+                                   selector:(SEL)aSelector
+                                   userInfo:(nullable id)userInfo
+                                    repeats:(BOOL)yesOrNo
+{
+    return [NSTimer scheduledTimerWithTimeInterval:ti
+                                            target:aTarget
+                                          selector:aSelector
+                                          userInfo:userInfo
+                                           repeats:yesOrNo];
+}
+
 @end

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -175,7 +175,7 @@ static BOOL appStartMeasurementRead;
     }];
 
     if (_idleTimeoutBlock == NULL) {
-        SENTRY_LOG_WARN(@"Couln't create idle time out block. Can't schedule idle timeout. "
+        SENTRY_LOG_WARN(@"Couldn't create idle time out block. Can't schedule idle timeout. "
                         @"Finishing transaction");
         // If the transaction has no children, the SDK will discard it.
         [self finishInternal];
@@ -795,6 +795,16 @@ static BOOL appStartMeasurementRead;
 {
     return _startTimeChanged ? _originalStartTimestamp : self.startTimestamp;
 }
+
+#if defined(TEST) || defined(TESTCI)
+// this just calls through to SentryTracerConcurrency.resetConcurrencyTracking(). we have to do this
+// through SentryTracer because SentryTracerConcurrency cannot be included in test targets via ObjC
+// bridging headers because it contains C++.
++ (void)resetConcurrencyTracking
+{
+    resetConcurrencyTracking();
+}
+#endif // defined(TEST) || defined(TESTCI)
 
 @end
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -796,7 +796,7 @@ static BOOL appStartMeasurementRead;
     return _startTimeChanged ? _originalStartTimestamp : self.startTimestamp;
 }
 
-#if defined(TEST) || defined(TESTCI)
+#if SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
 // this just calls through to SentryTracerConcurrency.resetConcurrencyTracking(). we have to do this
 // through SentryTracer because SentryTracerConcurrency cannot be included in test targets via ObjC
 // bridging headers because it contains C++.
@@ -804,7 +804,7 @@ static BOOL appStartMeasurementRead;
 {
     resetConcurrencyTracking();
 }
-#endif // defined(TEST) || defined(TESTCI)
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
 
 @end
 

--- a/Sources/Sentry/SentryTracerConcurrency.mm
+++ b/Sources/Sentry/SentryTracerConcurrency.mm
@@ -38,4 +38,13 @@ stopTrackingTracerWithID(SentryId *traceID, SentryConcurrentTransactionCleanupBl
     }
 }
 
+#    if defined(TEST) || defined(TESTCI)
+void
+resetConcurrencyTracking()
+{
+    std::lock_guard<std::mutex> l(_gStateLock);
+    [_gInFlightTraceIDs removeAllObjects];
+}
+#    endif // defined(TEST) || defined(TESTCI)
+
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryNSTimerWrapper.h
+++ b/Sources/Sentry/include/SentryNSTimerWrapper.h
@@ -8,6 +8,12 @@ NS_ASSUME_NONNULL_BEGIN
                                     repeats:(BOOL)repeats
                                       block:(void (^)(NSTimer *timer))block;
 
+- (NSTimer *)scheduledTimerWithTimeInterval:(NSTimeInterval)ti
+                                     target:(id)aTarget
+                                   selector:(SEL)aSelector
+                                   userInfo:(nullable id)userInfo
+                                    repeats:(BOOL)yesOrNo;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -22,7 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN const int kSentryProfilerFrequencyHz;
 SENTRY_EXTERN NSString *const kTestStringConst;
-FOUNDATION_EXPORT NSTimeInterval kSentryProfilerTimeoutInterval;
 
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;

--- a/Sources/Sentry/include/SentryTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryTracerConcurrency.h
@@ -22,6 +22,10 @@ void trackTracerWithID(SentryId *traceID);
  */
 void stopTrackingTracerWithID(SentryId *traceID, SentryConcurrentTransactionCleanupBlock cleanup);
 
+#    if defined(TEST) || defined(TESTCI)
+void resetConcurrencyTracking(void);
+#    endif // defined(TEST) || defined(TESTCI)
+
 SENTRY_EXTERN_C_END
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -215,7 +215,10 @@ class SentryProfilerSwiftTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
+
+        // If a test early exits because of a thrown error, it may not finish the spans it created. This ensures any open spans are closed before starting the next test case.
         fixture.timeoutTimerWrapper.fire()
+
         clearTestState()
     }
 

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -216,7 +216,7 @@ class SentryProfilerSwiftTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
 
-        // If a test early exits because of a thrown error, it may not finish the spans it created. This ensures any open spans are closed before starting the next test case.
+        // If a test early exits because of a thrown error, it may not finish the spans it created. This ensures the profiler stops before starting the next test case.
         fixture.timeoutTimerWrapper.fire()
 
         clearTestState()

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -626,7 +626,8 @@ private extension SentryProfilerSwiftTests {
             case .yes:
                 return NSNumber(value: 1)
             @unknown default:
-                fatalError("Unexpected value for sample decision")
+                XCTFail("Unexpected value for sample decision")
+                return NSNumber(value: 0)
             }
         }
         options(fixtureOptions)
@@ -639,26 +640,17 @@ private extension SentryProfilerSwiftTests {
         fixture.currentDateProvider.advance(by: 5)
         span.finish()
 
-        guard let client = self.fixture.client else {
-            XCTFail("Expected a valid test client to exist")
-            return
-        }
+        let client = try XCTUnwrap(self.fixture.client)
 
         switch expectedDecision {
         case .undecided, .no:
-            guard let event = client.captureEventWithScopeInvocations.first else {
-                XCTFail("Expected to capture at least 1 event, but without a profile")
-                return
-            }
+            let event = try XCTUnwrap(client.captureEventWithScopeInvocations.first)
             XCTAssertEqual(0, event.additionalEnvelopeItems.count)
         case .yes:
-            guard let event = client.captureEventWithScopeInvocations.first else {
-                XCTFail("Expected to capture at least 1 event with a profile")
-                return
-            }
+            let event = try XCTUnwrap(client.captureEventWithScopeInvocations.first)
             XCTAssertEqual(1, event.additionalEnvelopeItems.count)
         @unknown default:
-            fatalError("Unexpected value for sample decision")
+            XCTFail("Unexpected value for sample decision")
         }
     }
 }

--- a/Tests/SentryTests/Helper/SentryProfiler+SwiftTest.h
+++ b/Tests/SentryTests/Helper/SentryProfiler+SwiftTest.h
@@ -21,7 +21,11 @@ SentryProfiler ()
 + (void)useProcessInfoWrapper:(SentryNSProcessInfoWrapper *)processInfoWrapper
     NS_SWIFT_NAME(useProcessInfoWrapper(_:));
 
-+ (void)useTimerWrapper:(SentryNSTimerWrapper *)timerWrapper NS_SWIFT_NAME(useTimerWrapper(_:));
++ (void)useMetricTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
+    NS_SWIFT_NAME(useMetricTimerWrapper(_:));
+
++ (void)useTimeoutTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
+    NS_SWIFT_NAME(useTimeoutTimerWrapper(_:));
 
 #    if SENTRY_HAS_UIKIT
 + (void)useFramesTracker:(SentryFramesTracker *)framesTracker NS_SWIFT_NAME(useFramesTracker(_:));

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -51,9 +51,9 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
         
         fixture.displayLinkWrapper.call()
-        fixture.displayLinkWrapper.fastestSlowFrame()
+        _ = fixture.displayLinkWrapper.fastestSlowFrame()
         fixture.displayLinkWrapper.normalFrame()
-        fixture.displayLinkWrapper.slowestSlowFrame()
+        _ = fixture.displayLinkWrapper.slowestSlowFrame()
 
         try assert(slow: 2, frozen: 0, total: 3)
     }
@@ -63,8 +63,8 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
         
         fixture.displayLinkWrapper.call()
-        fixture.displayLinkWrapper.fastestSlowFrame()
-        fixture.displayLinkWrapper.fastestFrozenFrame()
+        _ = fixture.displayLinkWrapper.fastestSlowFrame()
+        _ = fixture.displayLinkWrapper.fastestFrozenFrame()
 
         try assert(slow: 1, frozen: 1, total: 2)
     }
@@ -74,9 +74,9 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
 
         fixture.displayLinkWrapper.call()
-        fixture.displayLinkWrapper.fastestSlowFrame()
+        _ = fixture.displayLinkWrapper.fastestSlowFrame()
         fixture.displayLinkWrapper.changeFrameRate(.high)
-        fixture.displayLinkWrapper.fastestFrozenFrame()
+        _ = fixture.displayLinkWrapper.fastestFrozenFrame()
 
         try assert(slow: 1, frozen: 1, total: 2, frameRates: 2)
     }
@@ -100,8 +100,8 @@ class SentryFramesTrackerTests: XCTestCase {
         let frames: UInt = 600_000
         for _ in 0 ..< frames {
             fixture.displayLinkWrapper.normalFrame()
-            fixture.displayLinkWrapper.fastestSlowFrame()
-            fixture.displayLinkWrapper.fastestFrozenFrame()
+            _ = fixture.displayLinkWrapper.fastestSlowFrame()
+            _ = fixture.displayLinkWrapper.fastestFrozenFrame()
         }
         
         group.wait()

--- a/Tests/SentryTests/Transaction/SentryTracer+Test.h
+++ b/Tests/SentryTests/Transaction/SentryTracer+Test.h
@@ -10,9 +10,9 @@ SentryTracer (Test)
 
 - (void)updateStartTime:(NSDate *)startTime;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
 + (void)resetConcurrencyTracking;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
 
 @end
 

--- a/Tests/SentryTests/Transaction/SentryTracer+Test.h
+++ b/Tests/SentryTests/Transaction/SentryTracer+Test.h
@@ -1,4 +1,4 @@
-
+#import "SentryProfilingConditionals.h"
 #import "SentryTracer.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -10,7 +10,9 @@ SentryTracer (Test)
 
 - (void)updateStartTime:(NSDate *)startTime;
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
 + (void)resetConcurrencyTracking;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @end
 

--- a/Tests/SentryTests/Transaction/SentryTracer+Test.h
+++ b/Tests/SentryTests/Transaction/SentryTracer+Test.h
@@ -10,6 +10,8 @@ SentryTracer (Test)
 
 - (void)updateStartTime:(NSDate *)startTime;
 
++ (void)resetConcurrencyTracking;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
We realized that we were working under an incorrect assumption when recording GPU frame timestamps. This PR changes the timestamp that we use when we record that a slow or frozen timestamp has been encountered.

It also contains some refactoring of the associated logic in SentryProfiler and SentryFramesTracker and refactors and fixes for the profiler tests. This also includes: 
- converting the remainder of the profiling tests to use the mock date provider instead of delayed dispatches to achieve timeouts... this solves a long-standing request to speed up the profiling tests @philipphofmann!
    - this let us remove _most_ of the delayed dispatches; the remainder were exercising the profiler's timeout logic; to complete this, also used the SentryNSTimerWrapper for the NSTimer the profiler uses to abort due to an elapsed timeout period so it can be manually triggered in the tests
- using the TestCurrentDateProvider in the TestDisplayLinkWrapper instead of having that component maintain its own internal time

Here's a before and after of what reported slow/frozen frames looks like, you can see how they seem to line up better with the tested ANR event after making the fix:

[Before](https://sentry-sdks.sentry.io/profiling/profile/sentry-cocoa/b09733aa309b4b1f875eb987abf20363/flamechart/?colorCoding=by+system+vs+application+frame&query=&sorting=call+order&tid=12291&view=top+down):

![](https://user-images.githubusercontent.com/3241469/228710876-5cfd2335-4684-4194-bf8e-b642b3f7767b.png)


[After](https://sentry-sdks.sentry.io/profiling/profile/sentry-cocoa/479e2400b3084f1e8e7072717b4ec644/flamechart/?colorCoding=by+application+frame&fov=0%2C0%2C9130846208%2C23&query=&sorting=call+order&tid=8451&view=top+down):


<img width="1180" alt="Screenshot 2023-04-04 at 10 05 34 AM" src="https://user-images.githubusercontent.com/3241469/229880528-362d865e-7d97-4871-a9fa-3353634b817a.png">
<img width="1199" alt="Screenshot 2023-04-04 at 10 05 45 AM" src="https://user-images.githubusercontent.com/3241469/229880540-f52f12e8-2e42-487e-898d-e0f76e065519.png">
<img width="1135" alt="Screenshot 2023-04-04 at 10 06 05 AM" src="https://user-images.githubusercontent.com/3241469/229880548-8c1c2b9c-590c-4884-8449-03ec26b7f397.png">

#skip-changelog