### PR TITLE
Add `sent_at` to envelope header

### DIFF
--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -10,6 +10,7 @@
 #import "SentrySdkInfo.h"
 #import "SentrySession.h"
 #import "SentryTraceContext.h"
+#import "NSDate+SentryExtras.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -67,6 +68,11 @@ NS_ASSUME_NONNULL_BEGIN
     SentryTraceContext *traceContext = envelope.header.traceContext;
     if (traceContext != nil) {
         [serializedData setValue:[traceContext serialize] forKey:@"trace"];
+    }
+    
+    NSDate *sentAt = envelope.header.sentAt;
+    if (sentAt != nil) {
+        [serializedData setValue:[sentAt sentry_toIso8601String] forKey:@"sent_at"];
     }
 
     NSData *header = [SentrySerialization dataWithJSONObject:serializedData error:error];
@@ -192,10 +198,14 @@ NS_ASSUME_NONNULL_BEGIN
                     traceContext =
                         [[SentryTraceContext alloc] initWithDict:headerDictionary[@"trace"]];
                 }
-
+                
                 envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:eventId
                                                                   sdkInfo:sdkInfo
                                                              traceContext:traceContext];
+                
+                if (nil != headerDictionary[@"sent_at"]) {
+                    envelopeHeader.sentAt = [NSDate sentry_fromIso8601String:headerDictionary[@"sent_at"]];
+                }
             }
             break;
         }

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -1,4 +1,5 @@
 #import "SentryTransportAdapter.h"
+#import "SentryCurrentDate.h"
 #import "SentryEnvelope.h"
 #import "SentryEvent.h"
 #import "SentryOptions.h"
@@ -94,6 +95,7 @@ SentryTransportAdapter ()
 
 - (void)sendEnvelope:(SentryEnvelope *)envelope
 {
+    envelope.header.sentAt = SentryCurrentDate.date;
     [self.transport sendEnvelope:envelope];
 }
 

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
@@ -63,6 +63,8 @@ SENTRY_NO_INIT
 
 @property (nullable, nonatomic, readonly, copy) SentryTraceContext *traceContext;
 
+@property (nullable, nonatomic, copy) NSDate *sentAt;
+
 @end
 
 @interface SentryEnvelopeItem : NSObject

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -33,6 +33,8 @@ class SentrySerializationTests: XCTestCase {
 
         let item = SentryEnvelopeItem(event: event)
         let envelope = SentryEnvelope(id: event.eventId, singleItem: item)
+        envelope.header.sentAt = Date(timeIntervalSince1970: 9001)
+        
         // Sanity check
         XCTAssertEqual(event.eventId, envelope.header.eventId)
         XCTAssertEqual(1, envelope.items.count)
@@ -46,6 +48,7 @@ class SentrySerializationTests: XCTestCase {
             XCTAssertEqual(envelope.items[0].header.length, deserializedEnvelope.items[0].header.length)
             XCTAssertEqual(envelope.items[0].data, deserializedEnvelope.items[0].data)
             XCTAssertNil(deserializedEnvelope.header.traceContext)
+            XCTAssertEqual(Date(timeIntervalSince1970: 9001), deserializedEnvelope.header.sentAt)
         }
     }
 

--- a/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
@@ -30,6 +30,11 @@ class SentryTransportAdapterTests: XCTestCase {
         sut = fixture.sut
     }
     
+    override func tearDown() {
+        clearTestState()
+        super.tearDown()
+    }
+    
     func testSendEventWithSession_SendsCorrectEnvelope() throws {
         let session = SentrySession(releaseName: "1.0.1")
         let event = TestData.event
@@ -40,6 +45,7 @@ class SentryTransportAdapterTests: XCTestCase {
             SentryEnvelopeItem(attachment: fixture.attachment, maxAttachmentSize: fixture.options.maxAttachmentSize)!,
             SentryEnvelopeItem(session: session)
         ])
+        expectedEnvelope.header.sentAt = CurrentDate.date()
         
         assertEnvelope(expected: expectedEnvelope)
     }
@@ -52,6 +58,7 @@ class SentryTransportAdapterTests: XCTestCase {
             SentryEnvelopeItem(event: event),
             SentryEnvelopeItem(attachment: fixture.attachment, maxAttachmentSize: fixture.options.maxAttachmentSize)!
         ])
+        expectedEnvelope.header.sentAt = CurrentDate.date()
         
         assertEnvelope(expected: expectedEnvelope)
     }
@@ -61,8 +68,18 @@ class SentryTransportAdapterTests: XCTestCase {
         sut.send(userFeedback: userFeedback)
         
         let expectedEnvelope = SentryEnvelope(userFeedback: userFeedback)
+        expectedEnvelope.header.sentAt = CurrentDate.date()
         
         assertEnvelope(expected: expectedEnvelope)
+    }
+    
+    func testSendingEnvelopeSetsSentAt() {
+        let event = Event()
+        let envelope = SentryEnvelope(event: event)
+        sut.send(envelope: envelope)
+        
+        let sent = fixture.transport.sentEnvelopes.first!
+        XCTAssertEqual(sent.header.sentAt, CurrentDate.date())
     }
     
     private func assertEnvelope(expected: SentryEnvelope) {


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

- Add `sent_at` to envelope header
- Set to current date before sending out envelope in transport adapter

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Relates to https://github.com/getsentry/sentry-dart/issues/1337
Documentation https://develop.sentry.dev/sdk/envelopes/
## :green_heart: How did you test it?

Added tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Test if this works correctly wit hybrid (dart) sdks.