### PR TITLE
added 'strong' attribute

### DIFF
--- a/Sources/Sentry/include/SentryTraceContext.h
+++ b/Sources/Sentry/include/SentryTraceContext.h
@@ -50,7 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Sample rate used for this trace.
  */
-@property (nullable, nonatomic) NSString *sampleRate;
+@property (nullable, nonatomic, strong) NSString *sampleRate;
 
 /**
  * Initializes a SentryTraceContext with given properties.


### PR DESCRIPTION
## :scroll: Description

From what I can tell: The prebuilt engine seems to be very specific and treats some warnings as errors.
Basically the same issue we were running into with: https://github.com/getsentry/sentry-cocoa/pull/2698

## :bulb: Motivation and Context

```
/sentry-unreal/sample/Plugins/sentry/Source/ThirdParty/Mac/include/Headers/SentryTraceContext.h:53:1: Error  : no 'assign', 'retain', or 'copy' attribute is specified - 'assign' is assumed [-Werror,-Wobjc-property-no-attribute]
```

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
