### PR TITLE
ref: remove some dead code

### DIFF
--- a/Sources/SentryCrash/Installations/SentryCrashInstallation+Private.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation+Private.h
@@ -27,31 +27,6 @@
 
 #import "SentryCrashInstallation.h"
 
-/** Implement a property to be used as a "key". */
-#define IMPLEMENT_REPORT_KEY_PROPERTY(NAME, NAMEUPPER)                                             \
-    @synthesize NAME##Key = _##NAME##Key;                                                          \
-    -(void)set##NAMEUPPER##Key : (NSString *)value                                                 \
-    {                                                                                              \
-        _##NAME##Key;                                                                              \
-        _##NAME##Key = value;                                                                      \
-        [self reportFieldForProperty:@ #NAME setKey:value];                                        \
-    }
-
-/** Implement a property to be used as a "value". */
-#define IMPLEMENT_REPORT_VALUE_PROPERTY(NAME, NAMEUPPER, TYPE)                                     \
-    @synthesize NAME = _##NAME;                                                                    \
-    -(void)set##NAMEUPPER : (TYPE)value                                                            \
-    {                                                                                              \
-        _##NAME;                                                                                   \
-        _##NAME = value;                                                                           \
-        [self reportFieldForProperty:@ #NAME setValue:value];                                      \
-    }
-
-/** Implement a standard report property (with key and value properties) */
-#define IMPLEMENT_REPORT_PROPERTY(NAME, NAMEUPPER, TYPE)                                           \
-    IMPLEMENT_REPORT_VALUE_PROPERTY(NAME, NAMEUPPER, TYPE)                                         \
-    IMPLEMENT_REPORT_KEY_PROPERTY(NAME, NAMEUPPER)
-
 typedef struct {
     const char *key;
     const char *value;
@@ -71,20 +46,6 @@ SentryCrashInstallation ()
  * @param requiredProperties Properties that MUST be set when sending reports.
  */
 - (id)initWithRequiredProperties:(NSArray *)requiredProperties;
-
-/** Set the key to be used for the specified report property.
- *
- * @param propertyName The name of the property.
- * @param key The key to use.
- */
-- (void)reportFieldForProperty:(NSString *)propertyName setKey:(id)key;
-
-/** Set the value of the specified report property.
- *
- * @param propertyName The name of the property.
- * @param value The value to set.
- */
-- (void)reportFieldForProperty:(NSString *)propertyName setValue:(id)value;
 
 /** Create a new sink. Subclasses must implement this.
  */

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -194,31 +194,6 @@ SentryCrashInstallation ()
     return g_crashHandlerData;
 }
 
-- (SentryCrashInstReportField *)reportFieldForProperty:(NSString *)propertyName
-{
-    SentryCrashInstReportField *field = [self.fields objectForKey:propertyName];
-    if (field == nil) {
-        field = [SentryCrashInstReportField fieldWithIndex:self.nextFieldIndex];
-        self.nextFieldIndex++;
-        self.crashHandlerData->reportFieldsCount = self.nextFieldIndex;
-        self.crashHandlerData->reportFields[field.index] = field.field;
-        [self.fields setObject:field forKey:propertyName];
-    }
-    return field;
-}
-
-- (void)reportFieldForProperty:(NSString *)propertyName setKey:(id)key
-{
-    SentryCrashInstReportField *field = [self reportFieldForProperty:propertyName];
-    field.key = key;
-}
-
-- (void)reportFieldForProperty:(NSString *)propertyName setValue:(id)value
-{
-    SentryCrashInstReportField *field = [self reportFieldForProperty:propertyName];
-    field.value = value;
-}
-
 - (NSError *)validateProperties
 {
     NSMutableString *errors = [NSMutableString string];

--- a/Sources/SentryCrash/Reporting/Filters/Tools/SentryCrashVarArgs.h
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/SentryCrashVarArgs.h
@@ -71,26 +71,3 @@ typedef void (^SentryCrashVA_Block)(id entry);
 #define sentrycrashva_list_to_nsarray(FIRST_ARG_NAME, ARRAY_NAME)                                  \
     NSMutableArray *ARRAY_NAME = [NSMutableArray array];                                           \
     sentrycrashva_iterate_list(FIRST_ARG_NAME, ^(id entry) { [ARRAY_NAME addObject:entry]; })
-
-/**
- * Convert a variable argument list into a dictionary, interpreting the vararg
- * list as object, key, object, key, ...
- * An autoreleased NSMutableDictionary will be created in the current scope with
- * the specified name.
- *
- * @param FIRST_ARG_NAME The name of the first argument in the vararg list.
- * @param DICT_NAME The name of the dictionary to create in the current scope.
- */
-#define sentrycrashva_list_to_nsdictionary(FIRST_ARG_NAME, DICT_NAME)                              \
-    NSMutableDictionary *DICT_NAME = [NSMutableDictionary dictionary];                             \
-    {                                                                                              \
-        __block id sentrycrashva_object = nil;                                                     \
-        sentrycrashva_iterate_list(FIRST_ARG_NAME, ^(id entry) {                                   \
-            if (sentrycrashva_object == nil) {                                                     \
-                sentrycrashva_object = entry;                                                      \
-            } else {                                                                               \
-                [DICT_NAME setObject:sentrycrashva_object forKey:entry];                           \
-                sentrycrashva_object = nil;                                                        \
-            }                                                                                      \
-        });                                                                                        \
-    }


### PR DESCRIPTION
I was looking at a couple places where we use a dynamic key to insert values into dictionaries as possible candidates for an exception to be thrown, and found a couple macros that expand to such code, but don't appear to be used in the codebase.

#skip-changelog