### PR TITLE
fix: use new API to fix test compilation error

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -238,7 +238,9 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
 
         let hub = TestHub(client: SentryClient(options: Options()), andScope: nil)
-        let tracer = SentryTracer(transactionContext: TransactionContext(operation: "Test Operation"), hub: hub, waitForChildren: true)
+        let tracer = SentryTracer(transactionContext: TransactionContext(operation: "Test Operation"), hub: hub, configuration: SentryTracerConfiguration(block: { config in
+            config.waitForChildren = true
+        }))
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
 
         sut.start(for: tracer)


### PR DESCRIPTION
looks like [this pr](https://github.com/getsentry/sentry-cocoa/pull/2821/files#diff-aa3354dc4f53abbd601caf720ac9b121b1aa5a6ffcd6cf345841f413c8e02c42L81-L99) inadvertently broke a test on `main`: https://github.com/getsentry/sentry-cocoa/actions/runs/4619928851

[this other pr](https://github.com/getsentry/sentry-cocoa/pull/2843/files#diff-dcef7541efabf9ddb4cef77f33a2d118975aec4f6aa9c55ab1f0120b31acec76R241) added a test using a SentryTracer init that was removed in the other one, but CI wasn't smart enough to rerun in the PR. 

This changes to the new API to use for the equivalent initialization.

#skip-changelog