### PR TITLE
test: FileManager remove perf test

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -375,21 +375,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(0, fixture.delegate.envelopeItemsDeleted.count)
     }
 
-    /**
-     * We need to deserialize every envelope and check if it contains a session.
-     */
-    func testMigrateSessionInit_WorstCasePerformance() {
-        sut.store(fixture.sessionEnvelope)
-        sut.store(fixture.sessionUpdateEnvelope)
-        for _ in 0...(fixture.maxCacheItems - 3) {
-            sut.store(TestConstants.envelope)
-        }
-
-        measure {
-            sut.store(TestConstants.envelope)
-        }
-    }
-
     func testGetAllEnvelopesAreSortedByDateAscending() {
         givenMaximumEnvelopes()
 


### PR DESCRIPTION
CI can't compare the performance test with `measure` against anything, as Xcode needs baseline files for the same computer. In CI, the computer specifications might change frequently, so it's a lot of effort to create those baseline files. This test only slows down CI, and therefore, we can remove it. For more context see https://github.com/getsentry/sentry-cocoa/issues/1482.

#skip-changelog