### PR TITLE
test: Use Invocation in TestHub

### DIFF
--- a/SentryTestUtils/TestSentryNSTimerWrapper.swift
+++ b/SentryTestUtils/TestSentryNSTimerWrapper.swift
@@ -16,7 +16,7 @@ public class TestSentryNSTimerWrapper: SentryNSTimerWrapper {
         var block: ((Timer) -> Void)?
     }
 
-    public lazy var overrides = Overrides()
+    public var overrides = Overrides()
 
     public override func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Void) -> Timer {
         let timer = TestTimer()

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -625,8 +625,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         
         sut.urlSessionTask(task, setState: .completed)
         
-        fixture.hub.group.wait()
-        
         guard let envelope = self.fixture.hub.capturedEventsWithScopes.first else {
             XCTFail("Expected to capture 1 event")
             return
@@ -656,8 +654,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         
         sut.urlSessionTask(task, setState: .completed)
         
-        fixture.hub.group.wait()
-        
         guard let envelope = self.fixture.hub.capturedEventsWithScopes.first else {
             XCTFail("Expected to capture 1 event")
             return
@@ -676,8 +672,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         task.setResponse(createResponse(code: 500))
         
         sut.urlSessionTask(task, setState: .completed)
-        
-        fixture.hub.group.wait()
         
         guard let envelope = self.fixture.hub.capturedEventsWithScopes.first else {
             XCTFail("Expected to capture 1 event")


### PR DESCRIPTION
Use thread-safe Invocation in TestHub, as running the tests locally sometimes lead to crashes in capturedTransactionsWithScope. Furthermore, remove DispatchGroup so we can remove plenty of calls to fixture.hub.group.wait().

#skip-changelog