### PR TITLE
fix: avoid screenshots with either dimension of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Crash when serializing invalid objects (#2858)
+- Don't send screenshots with either width or height of 0 (#2876))
 
 ## 8.4.0
 

--- a/Sources/Sentry/SentryScreenshot.m
+++ b/Sources/Sentry/SentryScreenshot.m
@@ -56,8 +56,7 @@
         if ([window drawViewHierarchyInRect:window.bounds afterScreenUpdates:false]) {
             UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
             // this shouldn't happen now that we discard windows with either 0 height or 0 width,
-            // but still, we shouldn't send any images with either one. previously we'd allow a 0
-            // dimension. change the || to &&
+            // but still, we shouldn't send any images with either one.
             if (LIKELY(img.size.width > 0 && img.size.height > 0)) {
                 NSData *bytes = UIImagePNGRepresentation(img);
                 if (bytes && bytes.length > 0) {

--- a/Sources/Sentry/SentryScreenshot.m
+++ b/Sources/Sentry/SentryScreenshot.m
@@ -1,4 +1,5 @@
 #import "SentryScreenshot.h"
+#import "SentryCompiler.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryUIApplication.h"
@@ -43,11 +44,21 @@
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:windows.count];
 
     for (UIWindow *window in windows) {
-        UIGraphicsBeginImageContext(window.frame.size);
+        CGSize size = window.frame.size;
+        if (size.width == 0 || size.height == 0) {
+            // avoid API errors reported as e.g.:
+            // [Graphics] Invalid size provided to UIGraphicsBeginImageContext(): size={0, 0},
+            // scale=1.000000
+            continue;
+        }
+        UIGraphicsBeginImageContext(size);
 
         if ([window drawViewHierarchyInRect:window.bounds afterScreenUpdates:false]) {
             UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
-            if (img.size.width > 0 || img.size.height > 0) {
+            // this shouldn't happen now that we discard windows with either 0 height or 0 width,
+            // but still, we shouldn't send any images with either one. previously we'd allow a 0
+            // dimension. change the || to &&
+            if (LIKELY(img.size.width > 0 && img.size.height > 0)) {
                 NSData *bytes = UIImagePNGRepresentation(img);
                 if (bytes && bytes.length > 0) {
                     [result addObject:bytes];

--- a/Tests/SentryTests/SentryScreenShotTests.swift
+++ b/Tests/SentryTests/SentryScreenShotTests.swift
@@ -82,17 +82,41 @@ class SentryScreenShotTests: XCTestCase {
         XCTAssertEqual(image?.size.width, 10)
         XCTAssertEqual(image?.size.height, 10)
     }
-    
+
     func test_ZeroSizeScreenShot_GetsDiscarded() {
         let testWindow = TestWindow(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         fixture.uiApplication.windows = [testWindow]
-        
+
         guard let data = self.fixture.sut.appScreenshots() else {
             XCTFail("Could not make window screenshot")
             return
         }
-        
+
         XCTAssertEqual(0, data.count, "No screenshot should be taken, cause the image has zero size.")
+    }
+
+    func test_ZeroWidthScreenShot_GetsDiscarded() {
+        let testWindow = TestWindow(frame: CGRect(x: 0, y: 0, width: 0, height: 1_000))
+        fixture.uiApplication.windows = [testWindow]
+
+        guard let data = self.fixture.sut.appScreenshots() else {
+            XCTFail("Could not make window screenshot")
+            return
+        }
+
+        XCTAssertEqual(0, data.count, "No screenshot should be taken, cause the image has zero width.")
+    }
+
+    func test_ZeroHeightScreenShot_GetsDiscarded() {
+        let testWindow = TestWindow(frame: CGRect(x: 0, y: 0, width: 1_000, height: 0))
+        fixture.uiApplication.windows = [testWindow]
+
+        guard let data = self.fixture.sut.appScreenshots() else {
+            XCTFail("Could not make window screenshot")
+            return
+        }
+
+        XCTAssertEqual(0, data.count, "No screenshot should be taken, cause the image has zero height.")
     }
     
     class TestSentryUIApplication: SentryUIApplication {


### PR DESCRIPTION
## :scroll: Description

I noticed a test error on a Runtime Issue breakpoint for the test case that tries to take a screenshot of a 0 width window, when setting up the graphics context. We should never even let it get that far. 

I'll still leave the check for the image size, just in case somehow a nonzero width/height window still produces an image like that. But I changed the `||` to a `&&` in the comparison to make sure that _both_ dimensions must be greater than zero; otherwise, there's not much customers could do with something like that.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Added new unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
