### PR TITLE
test: try letting the tests that keep timing out run 5 more minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,7 @@ jobs:
             platform: 'iOS'
             xcode: '13.2.1'
             test-destination-os: '14.5'
-            timeout-minutes: 15
+            timeout-minutes: 20
 
           # iOS 15
           - runs-on: macos-12


### PR DESCRIPTION
This test job keeps timing out, I just want to see if letting it go longer lets it finish. The test logs don't seem to have any failures/crashes.

#skip-changelog