### PR TITLE
ref: Remove not needed TransactionContext

### DIFF
--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -4,7 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryTracer, SentryTransactionContext;
+@class SentryTracer;
 
 NS_SWIFT_NAME(Transaction)
 @interface SentryTransaction : SentryEvent


### PR DESCRIPTION
`SentryTransactionContext` is not used in the header file `SentryTransaction.h`.

#skip-changelog