### PR TITLE
ref: Remove unused start transaction methods

### DIFF
--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -182,17 +182,8 @@ static NSUInteger startInvocations;
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name operation:(NSString *)operation
 {
-    return [self startTransactionWithName:name
-                               nameSource:kSentryTransactionNameSourceCustom
-                                operation:operation];
-}
-
-+ (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation
-{
     return [SentrySDK.currentHub startTransactionWithName:name
-                                               nameSource:source
+                                               nameSource:kSentryTransactionNameSourceCustom
                                                 operation:operation];
 }
 
@@ -200,19 +191,8 @@ static NSUInteger startInvocations;
                                  operation:(NSString *)operation
                                bindToScope:(BOOL)bindToScope
 {
-    return [self startTransactionWithName:name
-                               nameSource:kSentryTransactionNameSourceCustom
-                                operation:operation
-                              bindToScope:bindToScope];
-}
-
-+ (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation
-                               bindToScope:(BOOL)bindToScope
-{
     return [SentrySDK.currentHub startTransactionWithName:name
-                                               nameSource:source
+                                               nameSource:kSentryTransactionNameSourceCustom
                                                 operation:operation
                                               bindToScope:bindToScope];
 }

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -36,18 +36,6 @@ SentrySDK (Private)
  */
 + (void)captureEnvelope:(SentryEnvelope *)envelope;
 
-/**
- * Start a transaction with a name and a name source.
- */
-+ (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation;
-
-+ (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation
-                               bindToScope:(BOOL)bindToScope;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -344,6 +344,20 @@ class SentrySDKTests: XCTestCase {
     func testStartTransaction() {
         givenSdkWithHub()
         
+        let operation = "ui.load"
+        let name = "Load Main Screen"
+        let transaction = SentrySDK.startTransaction(name: name, operation: operation)
+        
+        XCTAssertEqual(operation, transaction.operation)
+        let tracer = transaction as! SentryTracer
+        XCTAssertEqual(name, tracer.traceContext.transaction)
+        
+        XCTAssertNil(SentrySDK.span)
+    }
+    
+    func testStartTransaction_WithBindToScope() {
+        givenSdkWithHub()
+        
         let span = SentrySDK.startTransaction(name: "Some Transaction", operation: "Operations", bindToScope: true)
         let newSpan = SentrySDK.span
         


### PR DESCRIPTION
Remove two nonpublic start transaction methods not used [anywhere](https://github.com/search?q=org%3Agetsentry%20startTransactionWithName&type=code) in the SDK or by HybridSDKs.

#skip-changelog