### PR TITLE
ref: Remove unused start transaction methods in hub

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -310,16 +310,6 @@ SentryHub ()
 }
 
 - (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation
-{
-    return [self
-        startTransactionWithContext:[[SentryTransactionContext alloc] initWithName:name
-                                                                        nameSource:source
-                                                                         operation:operation]];
-}
-
-- (id<SentrySpan>)startTransactionWithName:(NSString *)name
                                  operation:(NSString *)operation
                                bindToScope:(BOOL)bindToScope
 {
@@ -328,18 +318,6 @@ SentryHub ()
                                                    nameSource:kSentryTransactionNameSourceCustom
                                                     operation:operation]
                                  bindToScope:bindToScope];
-}
-
-- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation
-                               bindToScope:(BOOL)bindToScope
-{
-    return
-        [self startTransactionWithContext:[[SentryTransactionContext alloc] initWithName:name
-                                                                              nameSource:source
-                                                                               operation:operation]
-                              bindToScope:bindToScope];
 }
 
 - (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -182,9 +182,7 @@ static NSUInteger startInvocations;
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name operation:(NSString *)operation
 {
-    return [SentrySDK.currentHub startTransactionWithName:name
-                                               nameSource:kSentryTransactionNameSourceCustom
-                                                operation:operation];
+    return [SentrySDK.currentHub startTransactionWithName:name operation:operation];
 }
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name
@@ -192,7 +190,6 @@ static NSUInteger startInvocations;
                                bindToScope:(BOOL)bindToScope
 {
     return [SentrySDK.currentHub startTransactionWithName:name
-                                               nameSource:kSentryTransactionNameSourceCustom
                                                 operation:operation
                                               bindToScope:bindToScope];
 }

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -25,15 +25,6 @@ SentryHub (Private)
 
 - (void)closeCachedSessionWithTimestamp:(NSDate *_Nullable)timestamp;
 
-- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation;
-
-- (id<SentrySpan>)startTransactionWithName:(NSString *)name
-                                nameSource:(SentryTransactionNameSource)source
-                                 operation:(NSString *)operation
-                               bindToScope:(BOOL)bindToScope;
-
 - (SentryTracer *)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
                         customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -31,6 +31,8 @@ class SentrySDKTests: XCTestCase {
         }
         
         let message = "message"
+        let operation = "ui.load"
+        let transactionName = "Load Main Screen"
         
         init() {
             CurrentDate.setCurrentDateProvider(currentDate)
@@ -344,24 +346,23 @@ class SentrySDKTests: XCTestCase {
     func testStartTransaction() {
         givenSdkWithHub()
         
-        let operation = "ui.load"
-        let name = "Load Main Screen"
-        let transaction = SentrySDK.startTransaction(name: name, operation: operation)
+        let transaction = SentrySDK.startTransaction(name: fixture.transactionName, operation: fixture.operation)
         
-        XCTAssertEqual(operation, transaction.operation)
-        let tracer = transaction as! SentryTracer
-        XCTAssertEqual(name, tracer.traceContext.transaction)
-        
+        assertTransaction(transaction: transaction)
+            
         XCTAssertNil(SentrySDK.span)
     }
     
     func testStartTransaction_WithBindToScope() {
         givenSdkWithHub()
         
-        let span = SentrySDK.startTransaction(name: "Some Transaction", operation: "Operations", bindToScope: true)
+        let transaction = SentrySDK.startTransaction(name: fixture.transactionName, operation: fixture.operation, bindToScope: true)
+        
+        assertTransaction(transaction: transaction)
+        
         let newSpan = SentrySDK.span
         
-        XCTAssert(span === newSpan)
+        XCTAssert(transaction === newSpan)
     }
     
     func testInstallIntegrations() {
@@ -707,6 +708,13 @@ class SentrySDKTests: XCTestCase {
     private func assertHubScopeNotChanged() {
         let hubScope = SentrySDK.currentHub().scope
         XCTAssertEqual(fixture.scope, hubScope)
+    }
+    
+    private func assertTransaction(transaction: Span) {
+        XCTAssertEqual(fixture.operation, transaction.operation)
+        let tracer = transaction as! SentryTracer
+        XCTAssertEqual(fixture.transactionName, tracer.traceContext.transaction)
+        XCTAssertEqual(.custom, tracer.transactionContext.nameSource)
     }
     
     private func advanceTime(bySeconds: TimeInterval) {


### PR DESCRIPTION
Remove not required unused start transaction methods in the SentryHub.

Related to https://github.com/getsentry/sentry-cocoa/pull/2886.

Preparation for https://github.com/getsentry/sentry-cocoa/issues/2537

#skip-changelog