### PR TITLE
Chore : Fixing CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -326,31 +326,6 @@ jobs:
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
 
-  # macos-11 doesn't have a simulator for iOS 12
-  ui-tests-swift-ios-12:
-    name: UI Tests on iOS 12 Simulator
-    runs-on: macos-11
-    strategy:
-      matrix:
-        target: ['tvos_swift']
-
-    steps:
-      - uses: actions/checkout@v3
-
-      # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
-      - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_${{matrix.target}} device:"iPhone 8 (12.4)" address_sanitizer:false && break ; done
-        shell: sh
-
-      - name: Archiving Raw Test Logs
-        uses: actions/upload-artifact@v3
-        if: ${{  failure() || cancelled() }}
-        with:
-          name: raw-uitest-output-${{matrix.target}}-ios-12
-          path: |
-            ~/Library/Logs/scan/*.log
-            ./fastlane/test_output/**
-
   ui-tests-address-sanitizer:
     name: UI Tests with Address Sanitizer
     runs-on: macos-12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -337,13 +337,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # GH action images don't have an iOS 12.4 simulator. Therefore we have to download and install the simulator manually.
-      - name: Install iOS 12.4 simulator
-        run: |
-          gem install xcode-install
-          xcversion simulators --install='iOS 12.4'
-          xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-12-4"
-
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
         run: for i in {1..2}; do fastlane ui_tests_${{matrix.target}} device:"iPhone 8 (12.4)" address_sanitizer:false && break ; done

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -332,7 +332,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        target: ['ios_swift', 'ios_objc', 'tvos_swift']
+        target: ['tvos_swift']
 
     steps:
       - uses: actions/checkout@v3

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -88,9 +88,6 @@
                <Test
                   Identifier = "SentryUIApplicationTests/test_applicationWithScenes_noWindow()">
                </Test>
-               <Test
-                  Identifier = "SentryViewHierarchyTests">
-               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -88,6 +88,9 @@
                <Test
                   Identifier = "SentryUIApplicationTests/test_applicationWithScenes_noWindow()">
                </Test>
+               <Test
+                  Identifier = "SentryViewHierarchyTests">
+               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -35,7 +35,9 @@ SentryAppStartTracker ()
 @property (nonatomic, assign) BOOL wasInBackground;
 @property (nonatomic, strong) NSDate *didFinishLaunchingTimestamp;
 @property (nonatomic, assign) BOOL enablePreWarmedAppStartTracing;
-
+#    if TEST
+@property (nonatomic) BOOL isRunning;
+#    endif
 @end
 
 @implementation SentryAppStartTracker
@@ -67,6 +69,9 @@ SentryAppStartTracker ()
         self.wasInBackground = NO;
         self.didFinishLaunchingTimestamp = [currentDateProvider date];
         self.enablePreWarmedAppStartTracing = enablePreWarmedAppStartTracing;
+#    if TEST
+        self.isRunning = NO;
+#    endif
     }
     return self;
 }
@@ -115,6 +120,10 @@ SentryAppStartTracker ()
 
 #    if SENTRY_HAS_UIKIT
     [self.appStateManager start];
+#    endif
+
+#    if TEST
+    self.isRunning = YES;
 #    endif
 }
 
@@ -208,8 +217,8 @@ SentryAppStartTracker ()
         SentrySDK.appStartMeasurement = appStartMeasurement;
     };
 
-    // With only running this once we know that the process is a new one when the following
-    // code is executed.
+// With only running this once we know that the process is a new one when the following
+// code is executed.
 // We need to make sure the block runs on each test instead of only once
 #    if TEST
     block();
@@ -285,6 +294,10 @@ SentryAppStartTracker ()
     [NSNotificationCenter.defaultCenter removeObserver:self
                                                   name:UIApplicationDidEnterBackgroundNotification
                                                 object:nil];
+
+#    if TEST
+    self.isRunning = NO;
+#    endif
 }
 
 - (void)dealloc

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -35,9 +35,7 @@ SentryAppStartTracker ()
 @property (nonatomic, assign) BOOL wasInBackground;
 @property (nonatomic, strong) NSDate *didFinishLaunchingTimestamp;
 @property (nonatomic, assign) BOOL enablePreWarmedAppStartTracing;
-#    if TEST
-@property (nonatomic) BOOL isRunning;
-#    endif
+
 @end
 
 @implementation SentryAppStartTracker
@@ -69,9 +67,7 @@ SentryAppStartTracker ()
         self.wasInBackground = NO;
         self.didFinishLaunchingTimestamp = [currentDateProvider date];
         self.enablePreWarmedAppStartTracing = enablePreWarmedAppStartTracing;
-#    if TEST
         self.isRunning = NO;
-#    endif
     }
     return self;
 }
@@ -122,9 +118,7 @@ SentryAppStartTracker ()
     [self.appStateManager start];
 #    endif
 
-#    if TEST
     self.isRunning = YES;
-#    endif
 }
 
 - (void)buildAppStartMeasurement

--- a/Sources/Sentry/include/SentryAppStartTracker.h
+++ b/Sources/Sentry/include/SentryAppStartTracker.h
@@ -16,6 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryAppStartTracker : NSObject
 SENTRY_NO_INIT
 
+@property (nonatomic) BOOL isRunning;
+
 - (instancetype)initWithCurrentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider
                        dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                             appStateManager:(SentryAppStateManager *)appStateManager

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -40,26 +40,35 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
         sut.stop()
     }
     
-    func testAppStartMeasuringEnabledAndSampleRate_DoesUpdatesAppState() {
+    func testAppStartMeasuringEnabledAndSampleRate_properlySetupTracker() throws {
         sut.install(with: fixture.options)
+
+        let tracker = try XCTUnwrap(Dynamic(sut).tracker.asObject as? SentryAppStartTracker, "SentryAppStartTrackingIntegration should have a tracker")
+        try assertTrackerSetupAndRunning(tracker)
+    }
+
+    func testUnistall_stopTracker() throws {
+        sut.install(with: fixture.options)
+
+        let tracker = try XCTUnwrap(Dynamic(sut).tracker.asObject as? SentryAppStartTracker, "SentryAppStartTrackingIntegration should have a tracker")
+        try assertTrackerSetupAndRunning(tracker)
+        sut.uninstall()
         
-        uiWindowDidBecomeVisible()
-        
-        XCTAssertNotNil(SentrySDK.getAppStartMeasurement())
+        let isRunning = Dynamic(tracker).isRunning.asBool ?? true
+        XCTAssertFalse(isRunning, "AppStartTracking should not be running")
     }
     
-    func testNoSampleRate_DoesNotUpdatesAppState() {
+    func testNoSampleRate_noTracker() {
         let options = fixture.options
         options.tracesSampleRate = 0.0
         options.tracesSampler = nil
         sut.install(with: options)
-        
-        uiWindowDidBecomeVisible()
-        
-        XCTAssertNil(SentrySDK.getAppStartMeasurement())
+
+        let tracker = Dynamic(sut).tracker.asAnyObject as? SentryAppStartTracker
+        XCTAssertNil(tracker)
     }
     
-    func testHybridSDKModeEnabled_DoesUpdatesAppState() {
+    func testHybridSDKModeEnabled_properlySetupTracker() throws {
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true
         
         let options = fixture.options
@@ -67,30 +76,27 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
         options.tracesSampler = nil
         sut.install(with: options)
         
-        uiWindowDidBecomeVisible()
-        
-        XCTAssertNotNil(SentrySDK.getAppStartMeasurement())
+        let tracker = try XCTUnwrap(Dynamic(sut).tracker.asObject as? SentryAppStartTracker, "SentryAppStartTrackingIntegration should have a tracker")
+        try assertTrackerSetupAndRunning(tracker)
     }
     
-    func testOnlyAppStartMeasuringEnabled_DoesNotUpdatesAppState() {
+    func testOnlyAppStartMeasuringEnabled_noTracker() {
         let options = fixture.options
         options.tracesSampleRate = 0.0
         options.tracesSampler = nil
         sut.install(with: options)
         
-        uiWindowDidBecomeVisible()
-        
-        XCTAssertNil(SentrySDK.getAppStartMeasurement())
+        let tracker = Dynamic(sut).tracker.asAnyObject as? SentryAppStartTracker
+        XCTAssertNil(tracker)
     }
     
-    func testAutoPerformanceTrackingDisabled_DoesNotUpdatesAppState() {
+    func testAutoPerformanceTrackingDisabled_noTracker() {
         let options = fixture.options
         options.enableAutoPerformanceTracing = false
         sut.install(with: options)
         
-        uiWindowDidBecomeVisible()
-        
-        XCTAssertNil(SentrySDK.getAppStartMeasurement())
+        let tracker = Dynamic(sut).tracker.asAnyObject as? SentryAppStartTracker
+        XCTAssertNil(tracker)
     }
     
     func test_PerformanceTrackingDisabled() {
@@ -99,6 +105,25 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
         let result = sut.install(with: options)
         
         XCTAssertFalse(result)
+    }
+
+    func assertTrackerSetupAndRunning(_ tracker: SentryAppStartTracker) throws {
+        let dateProvider = Dynamic(tracker).currentDate.asObject as? DefaultCurrentDateProvider
+
+        XCTAssertEqual(dateProvider, DefaultCurrentDateProvider.sharedInstance())
+
+        _ = try XCTUnwrap(Dynamic(tracker).dispatchQueue.asAnyObject as? SentryDispatchQueueWrapper, "Tracker does not have a dispatch queue.")
+
+        let appStateManager = Dynamic(tracker).appStateManager.asObject as? SentryAppStateManager
+
+        XCTAssertEqual(appStateManager, SentryDependencyContainer.sharedInstance().appStateManager)
+
+        _ = try XCTUnwrap(Dynamic(tracker).sysctl.asObject as? SentrySysctl, "Tracker does not have a Sysctl")
+
+        XCTAssertEqual(Dynamic(tracker).enablePreWarmedAppStartTracing.asBool, fixture.options.enablePreWarmedAppStartTracing)
+        let isRunning = Dynamic(tracker).isRunning.asBool ?? false
+
+        XCTAssertTrue(isRunning, "AppStartTracking should be running")
     }
     
 }

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -120,10 +120,7 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
 
         _ = try XCTUnwrap(Dynamic(tracker).sysctl.asObject as? SentrySysctl, "Tracker does not have a Sysctl")
 
-        XCTAssertEqual(Dynamic(tracker).enablePreWarmedAppStartTracing.asBool, fixture.options.enablePreWarmedAppStartTracing)
-        let isRunning = Dynamic(tracker).isRunning.asBool ?? false
-
-        XCTAssertTrue(isRunning, "AppStartTracking should be running")
+        XCTAssertTrue(tracker.isRunning, "AppStartTracking should be running")
     }
     
 }

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -2,6 +2,14 @@ import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+/**
+ * This test is making iOS 13 simulator hang in GH workflow,
+ * that why every test function needs to check for iOS 13 or later.
+ * By testing this in the other versions of iOS we guarantee the behavior
+ * mean while, running an iOS 13 sample with Saucelabs ensures this feature
+ * is not crashing the app.
+ */
 class SentryViewHierarchyTests: XCTestCase {
     private class Fixture {
 
@@ -26,7 +34,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_Multiple_Window() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             let secondWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
 
@@ -45,7 +53,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_ViewHierarchy_fetch() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             var window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             window.accessibilityIdentifier = "WindowId"
 
@@ -76,7 +84,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_Window_with_children() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             let childView = UIView(frame: CGRect(x: 1, y: 1, width: 8, height: 8))
             let secondChildView = UIView(frame: CGRect(x: 2, y: 2, width: 6, height: 6))
@@ -104,7 +112,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_ViewHierarchy_with_ViewController() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             let viewController = UIViewController()
             firstWindow.rootViewController = viewController
@@ -129,7 +137,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_ViewHierarchy_save() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             window.accessibilityIdentifier = "WindowId"
 
@@ -145,7 +153,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_invalidFilePath() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             window.accessibilityIdentifier = "WindowId"
 
@@ -156,7 +164,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_invalidSerialization() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let sut = TestSentryViewHierarchy()
             sut.viewHierarchyResult = -1
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
@@ -169,7 +177,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_fetchFromBackgroundTest() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let sut = TestSentryViewHierarchy()
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             fixture.uiApplication.windows = [window]
@@ -190,7 +198,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_fetch_usesMainThread() {
-        if #available(iOS 13, *) {
+        if #available(iOS 14, *) {
             let sut = TestSentryViewHierarchy()
             let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
             fixture.uiApplication.windows = [window]

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -2,7 +2,6 @@ import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-
 class SentryViewHierarchyTests: XCTestCase {
     private class Fixture {
         let uiApplication = TestSentryUIApplication()
@@ -16,6 +15,7 @@ class SentryViewHierarchyTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+
         fixture = Fixture()
         SentryDependencyContainer.sharedInstance().application = fixture.uiApplication
     }
@@ -30,7 +30,7 @@ class SentryViewHierarchyTests: XCTestCase {
          * mean while, running an iOS 12 sample with Saucelabs ensures this feature
          * is not crashing the app.
          */
-        if #available(iOS 13, *) {
+        guard #available(iOS 13, *) else {
             throw XCTSkip("Skipping for iOS < 13")
         }
     }

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -26,167 +26,185 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_Multiple_Window() {
-        let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        let secondWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+        if #available(iOS 13, *) {
+            let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            let secondWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
 
-        fixture.uiApplication.windows = [firstWindow, secondWindow]
+            fixture.uiApplication.windows = [firstWindow, secondWindow]
 
-        guard let descriptions = self.fixture.sut.fetch() else {
-            XCTFail("Could not serialize view hierarchy")
-            return
+            guard let descriptions = self.fixture.sut.fetch() else {
+                XCTFail("Could not serialize view hierarchy")
+                return
+            }
+
+            let object = try? JSONSerialization.jsonObject(with: descriptions) as? NSDictionary
+            let windows = object?["windows"] as? NSArray
+            XCTAssertNotNil(windows)
+            XCTAssertEqual(windows?.count, 2)
         }
-
-        let object = try? JSONSerialization.jsonObject(with: descriptions) as? NSDictionary
-        let windows = object?["windows"] as? NSArray
-        XCTAssertNotNil(windows)
-        XCTAssertEqual(windows?.count, 2)
     }
 
     func test_ViewHierarchy_fetch() {
-        var window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        window.accessibilityIdentifier = "WindowId"
+        if #available(iOS 13, *) {
+            var window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            window.accessibilityIdentifier = "WindowId"
 
-        fixture.uiApplication.windows = [window]
-        guard let data = self.fixture.sut.fetch()
-        else {
-            XCTFail("Could not serialize view hierarchy")
-            return
+            fixture.uiApplication.windows = [window]
+            guard let data = self.fixture.sut.fetch()
+            else {
+                XCTFail("Could not serialize view hierarchy")
+                return
+            }
+            var descriptions = String(data: data, encoding: .utf8) ?? ""
+
+            XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"WindowId\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
+
+            window = UIWindow(frame: CGRect(x: 1, y: 2, width: 20, height: 30))
+            window.accessibilityIdentifier = "IdWindow"
+
+            fixture.uiApplication.windows = [window]
+
+            guard let data = self.fixture.sut.fetch()
+            else {
+                XCTFail("Could not serialize view hierarchy")
+                return
+            }
+            descriptions = String(data: data, encoding: .utf8) ?? ""
+
+            XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"IdWindow\",\"width\":20,\"height\":30,\"x\":1,\"y\":2,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
         }
-        var descriptions = String(data: data, encoding: .utf8) ?? ""
-
-        XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"WindowId\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
-
-        window = UIWindow(frame: CGRect(x: 1, y: 2, width: 20, height: 30))
-        window.accessibilityIdentifier = "IdWindow"
-
-        fixture.uiApplication.windows = [window]
-
-        guard let data = self.fixture.sut.fetch()
-        else {
-            XCTFail("Could not serialize view hierarchy")
-            return
-        }
-        descriptions = String(data: data, encoding: .utf8) ?? ""
-
-        XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"IdWindow\",\"width\":20,\"height\":30,\"x\":1,\"y\":2,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
     }
 
     func test_Window_with_children() {
-        let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        let childView = UIView(frame: CGRect(x: 1, y: 1, width: 8, height: 8))
-        let secondChildView = UIView(frame: CGRect(x: 2, y: 2, width: 6, height: 6))
+        if #available(iOS 13, *) {
+            let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            let childView = UIView(frame: CGRect(x: 1, y: 1, width: 8, height: 8))
+            let secondChildView = UIView(frame: CGRect(x: 2, y: 2, width: 6, height: 6))
 
-        firstWindow.addSubview(childView)
-        firstWindow.addSubview(secondChildView)
+            firstWindow.addSubview(childView)
+            firstWindow.addSubview(secondChildView)
 
-        fixture.uiApplication.windows = [firstWindow]
+            fixture.uiApplication.windows = [firstWindow]
 
-        guard let descriptions = self.fixture.sut.fetch()
-        else {
-            XCTFail("Could not serialize view hierarchy")
-            return
+            guard let descriptions = self.fixture.sut.fetch()
+            else {
+                XCTFail("Could not serialize view hierarchy")
+                return
+            }
+
+            let object = try? JSONSerialization.jsonObject(with: descriptions) as? NSDictionary
+            let window = (object?["windows"] as? NSArray)?.firstObject as? NSDictionary
+            let children = window?["children"] as? NSArray
+
+            let firstChild = children?.firstObject as? NSDictionary
+
+            XCTAssertEqual(children?.count, 2)
+            XCTAssertEqual(firstChild?["type"] as? String, "UIView")
         }
-
-        let object = try? JSONSerialization.jsonObject(with: descriptions) as? NSDictionary
-        let window = (object?["windows"] as? NSArray)?.firstObject as? NSDictionary
-        let children = window?["children"] as? NSArray
-
-        let firstChild = children?.firstObject as? NSDictionary
-
-        XCTAssertEqual(children?.count, 2)
-        XCTAssertEqual(firstChild?["type"] as? String, "UIView")
     }
 
     func test_ViewHierarchy_with_ViewController() {
-        let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        let viewController = UIViewController()
-        firstWindow.rootViewController = viewController
-        firstWindow.addSubview(viewController.view)
+        if #available(iOS 13, *) {
+            let firstWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            let viewController = UIViewController()
+            firstWindow.rootViewController = viewController
+            firstWindow.addSubview(viewController.view)
 
-        fixture.uiApplication.windows = [firstWindow]
+            fixture.uiApplication.windows = [firstWindow]
 
-        guard let descriptions = self.fixture.sut.fetch()
-        else {
-            XCTFail("Could not serialize view hierarchy")
-            return
+            guard let descriptions = self.fixture.sut.fetch()
+            else {
+                XCTFail("Could not serialize view hierarchy")
+                return
+            }
+
+            let object = try? JSONSerialization.jsonObject(with: descriptions) as? NSDictionary
+            let window = (object?["windows"] as? NSArray)?.firstObject as? NSDictionary
+            let children = window?["children"] as? NSArray
+
+            let firstChild = children?.firstObject as? NSDictionary
+
+            XCTAssertEqual(firstChild?["view_controller"] as? String, "UIViewController")
         }
-
-        let object = try? JSONSerialization.jsonObject(with: descriptions) as? NSDictionary
-        let window = (object?["windows"] as? NSArray)?.firstObject as? NSDictionary
-        let children = window?["children"] as? NSArray
-
-        let firstChild = children?.firstObject as? NSDictionary
-
-        XCTAssertEqual(firstChild?["view_controller"] as? String, "UIViewController")
     }
 
     func test_ViewHierarchy_save() {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        window.accessibilityIdentifier = "WindowId"
+        if #available(iOS 13, *) {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            window.accessibilityIdentifier = "WindowId"
 
-        fixture.uiApplication.windows = [window]
+            fixture.uiApplication.windows = [window]
 
-        let path = FileManager.default.temporaryDirectory.appendingPathComponent("view.json").path
-        self.fixture.sut.save(path)
+            let path = FileManager.default.temporaryDirectory.appendingPathComponent("view.json").path
+            self.fixture.sut.save(path)
 
-        let descriptions = (try? String(contentsOfFile: path)) ?? ""
+            let descriptions = (try? String(contentsOfFile: path)) ?? ""
 
-        XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"WindowId\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
+            XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"WindowId\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
+        }
     }
 
     func test_invalidFilePath() {
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        window.accessibilityIdentifier = "WindowId"
+        if #available(iOS 13, *) {
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            window.accessibilityIdentifier = "WindowId"
 
-        fixture.uiApplication.windows = [window]
+            fixture.uiApplication.windows = [window]
 
-        XCTAssertFalse(self.fixture.sut.save(""))
+            XCTAssertFalse(self.fixture.sut.save(""))
+        }
     }
 
     func test_invalidSerialization() {
-        let sut = TestSentryViewHierarchy()
-        sut.viewHierarchyResult = -1
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        window.accessibilityIdentifier = "WindowId"
+        if #available(iOS 13, *) {
+            let sut = TestSentryViewHierarchy()
+            sut.viewHierarchyResult = -1
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            window.accessibilityIdentifier = "WindowId"
 
-        fixture.uiApplication.windows = [window]
-        let result = sut.fetch()
-        XCTAssertNil(result)
+            fixture.uiApplication.windows = [window]
+            let result = sut.fetch()
+            XCTAssertNil(result)
+        }
     }
 
     func test_fetchFromBackgroundTest() {
-        let sut = TestSentryViewHierarchy()
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        fixture.uiApplication.windows = [window]
+        if #available(iOS 13, *) {
+            let sut = TestSentryViewHierarchy()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            fixture.uiApplication.windows = [window]
 
-        let ex = expectation(description: "Running on Main Thread")
-        sut.processViewHierarchyCallback = {
-            ex.fulfill()
-            XCTAssertTrue(Thread.isMainThread)
-        }
-        
-        let dispatch = DispatchQueue(label: "background")
-        dispatch.async {
-            let _ = sut.fetch()
-        }
+            let ex = expectation(description: "Running on Main Thread")
+            sut.processViewHierarchyCallback = {
+                ex.fulfill()
+                XCTAssertTrue(Thread.isMainThread)
+            }
 
-        wait(for: [ex], timeout: 1)
+            let dispatch = DispatchQueue(label: "background")
+            dispatch.async {
+                let _ = sut.fetch()
+            }
+
+            wait(for: [ex], timeout: 1)
+        }
     }
 
     func test_fetch_usesMainThread() {
-        let sut = TestSentryViewHierarchy()
-        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
-        fixture.uiApplication.windows = [window]
-
-        let ex = expectation(description: "Running on background Thread")
-        let dispatch = DispatchQueue(label: "background")
-        dispatch.async {
-            let _ = sut.fetch()
-            ex.fulfill()
+        if #available(iOS 13, *) {
+            let sut = TestSentryViewHierarchy()
+            let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+            fixture.uiApplication.windows = [window]
+            
+            let ex = expectation(description: "Running on background Thread")
+            let dispatch = DispatchQueue(label: "background")
+            dispatch.async {
+                let _ = sut.fetch()
+                ex.fulfill()
+            }
+            
+            wait(for: [ex], timeout: 1)
+            XCTAssertTrue(fixture.uiApplication.calledOnMainThread, "fetchViewHierarchy is not using the main thread to get UI windows")
         }
-
-        wait(for: [ex], timeout: 1)
-        XCTAssertTrue(fixture.uiApplication.calledOnMainThread, "fetchViewHierarchy is not using the main thread to get UI windows")
     }
 
     class TestSentryUIApplication: SentryUIApplication {


### PR DESCRIPTION
This PR changes two things:

- Remove UITests for iOS 12 from running in the GH simulators. We still run it with SauceLabs.
- Remove Unit tests for view hierarchy from running on iOS 12 tests. GH is hanging when running this tests. We have view hierarchy enabled for UI tests that run in Saucelabs and iOS 12.


_#skip-changelog_