### PR TITLE
ci: Remove iOS 12 simulator

### DIFF
--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -106,6 +106,9 @@ jobs:
           - xcode: '13.4.1'
             suite: 'iOS-13'
 
+          - xcode: '13.4.1'
+            suite: 'iOS-12'
+
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,13 +81,6 @@ jobs:
         # we get the error 'XCTest/XCTest.h' not found. Setting ENABLE_TESTING_SEARCH_PATH=YES
         # doesn't work.
         include:
-          # iOS 12.4
-          - runs-on: macos-11
-            platform: 'iOS'
-            xcode: '13.2.1'
-            test-destination-os: '12.4'
-            # This job needs to install the simulator which can take a couple of minutes
-            timeout-minutes: 25 
 
           # iOS 13.7
           - runs-on: macos-11
@@ -166,14 +159,6 @@ jobs:
       - run: ./test-server-exec &
 
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
-
-      # GH action images don't have an iOS 12.4 simulator. Therefore we have to download and install the simulator manually.
-      - name: Install iOS 12.4 simulator
-        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '12.4'}}
-        run: |
-          gem install xcode-install
-          xcversion simulators --install='iOS 12.4'
-          xcrun simctl create custom-test-device "iPhone 8" "com.apple.CoreSimulator.SimRuntime.iOS-12-4"
 
       # Workaround with a symlink pointed out in: https://github.com/actions/virtual-environments/issues/551#issuecomment-637344435
       - name: Prepare iOS 13.7 simulator

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -36,7 +36,7 @@ suites:
   - name: "iOS-12"
     devices:
       - name: "iPhone.*"
-        platformVersion: "12.5.5"
+        platformVersion: "12.5.7"
 
   - name: "iOS-11"
     devices:

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -22,6 +22,15 @@
 #import "SentryTracer.h"
 #import <objc/runtime.h>
 
+/**
+ * WARNING: We had issues in the past with this code on older iOS versions. We don't run unit tests
+ * on all the iOS versions our SDK supports. When adding this comment on April 12th, 2023, we
+ * decided to remove running unit tests on iOS 12 simulators. Check the develop-docs decision log
+ * for more information https://github.com/getsentry/sentry-cocoa/blob/main/develop-docs/README.md.
+ * Back then, the code worked correctly on all iOS versions. Please evaluate if your changes could
+ * break on specific iOS versions to ensure it works properly when modifying this file. If they
+ * could, please add UI tests and run them on older iOS versions.
+ */
 @interface
 SentryNetworkTracker ()
 

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -130,10 +130,12 @@ Contributors: @marandaneto, @brustolin and @philipphofmann
 
 We decided not to use the `NSRange` type for the `failedRequestStatusCodes` property of the `SentryNetworkTracker` class because it's not compatible with the specification, which requires the type to be a range of `from` -> `to` integers. The `NSRange` type is a range of `location` -> `length` integers. We decided to use a custom type instead of `NSRange` to avoid confusion. The custom type is called `SentryHttpStatusCodeRange`.
 
-### Manually installing iOS 12 simulators
+### Manually installing iOS 12 simulators  <a name="ios-12-simulators"></a>
 
 Date: October 21st 2022
 Contributors: @philipphofmann
+
+We reverted this decision with [remove running unit tests on iOS 12 simulators](#remove-ios-12-simulators).
 
 GH actions will remove the macOS-10.15 image, which contains an iOS 12 simulator on 12/1/22; see https://github.com/actions/runner-images/issues/5583.
 Neither the [macOS-11](https://github.com/actions/runner-images/blob/main/images/macos/macos-11-Readme.md#installed-sdks) nor the
@@ -207,3 +209,19 @@ the PM. You can find this in `SentrySDKInfo.m`.
 ## Usage of `__has_include`
 
 Some private headers add a dependency of a public header, when those private headers are used in a sample project, or referenced from a hybrid SDK, it is treated as part of the project using it, therefore, if it points to a header that is not part of said project, a compilation error will occur. To solve this we make use of `__has_include` to try to point to the SDK version of the header, or to fallback to the direct reference when compiling the SDK.
+
+### Remove running unit tests on iOS 12 simulators <a name="remove-ios-12-simulators"></a>
+
+Date: April 12th 2023
+Contributors: @philipphofmann
+
+We use [`xcode-install`](https://github.com/xcpretty/xcode-install) to install some older iOS simulators for test runs [here](https://github.com/getsentry/sentry-cocoa/blob/ff5c1d83bf601bbcd0f5f1070c3abf05310881bd/.github/workflows/test.yml#L174) and [here](https://github.com/getsentry/sentry-cocoa/blob/ff5c1d83bf601bbcd0f5f1070c3abf05310881bd/.github/workflows/test.yml#L343). That project is being sunset, so we would have to find an alternative.
+
+Installing the simulator can take up to 15 minutes, so the current solution slows CI and sometimes leads to timeouts.
+We want our CI to be fast and reliable. Instead of running the unit tests on iOS 12, we run UI tests on an iPhone with iOS 12,
+which reduces the risk of breaking users on iOS 12. Our unit tests should primarily focus on business logic and shouldn't depend
+on specific iOS versions. If we have functionality that risks breaking on older iOS versions, we should write UI tests instead.
+For the swizzling of UIViewControllers and NSURLSession, we have UI tests running on iOS 12. Therefore, dropping running unit
+tests on iOS 12 simulators is acceptable. This decision reverts [manually installing iOS 12 simulators](#ios-12-simulators).
+
+Related to [GH-2862](https://github.com/getsentry/sentry-cocoa/issues/2862) and 

--- a/scripts/no-changes-in-high-risk-files.sh
+++ b/scripts/no-changes-in-high-risk-files.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# To update the sha run shasum -a 256 ./Sources/Sentry/SentryNSURLSessionTaskSearch.m and copy the result in EXPECTED.
+# To update the sha run the command in ACTUAL and copy the result in EXPECTED.
 
-ACTUAL=$(shasum -a 256 ./Sources/Sentry/SentryNSURLSessionTaskSearch.m)
-EXPECTED="819d5ca5e3db2ac23c859b14c149b7f0754d3ae88bea1dba92c18f49a81da0e1  ./Sources/Sentry/SentryNSURLSessionTaskSearch.m"
+ACTUAL=$(shasum -a 256 ./Sources/Sentry/SentryNSURLSessionTaskSearch.m ./Sources/Sentry/SentryNetworkTracker.m)
+EXPECTED="819d5ca5e3db2ac23c859b14c149b7f0754d3ae88bea1dba92c18f49a81da0e1  ./Sources/Sentry/SentryNSURLSessionTaskSearch.m
+58d5414b4f0a4c821b20fc1a16f88bda3116401e905b7bc1d18af828be75e431  ./Sources/Sentry/SentryNetworkTracker.m"
 
 if [ "$ACTUAL" = "$EXPECTED" ]; then
     echo "No changes in high risk files."


### PR DESCRIPTION
Remove running unit tests on iOS 12 simulator as the xcode-install tool is being sunset. Instead, we now run UI tests in saucelabs on iOS 12.

Other usages of iOS 12 simulators are removed with https://github.com/getsentry/sentry-cocoa/pull/2889.

Fixes GH-2862

#skip-changelog