### PR TITLE
chore: Fix decision log headings

### DIFF
--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -177,33 +177,33 @@ platform-specific framework bundles only works with Xcode 12.
 Carthage has encouraged its users [to use XCFrameworks](https://github.com/Carthage/Carthage/tree/a91d086ceaffef65c4a4a761108f3f32c519940c#getting-started)
 since version 0.37.0, released in January 2021. Therefore, it's acceptable to use XCFrameworks for Carthage users.
 
-## Remove the permissions feature
+### Remove the permissions feature
 
 Date: December 14, 2022
 
 We [removed](https://github.com/getsentry/sentry-cocoa/pull/2529) the permissions feature that we added in [7.24.0](https://github.com/getsentry/sentry-cocoa/releases/tag/7.24.0). Multiple people reported getting denied in app review because of permission access without the corresponding Info.plist entry: see [#2528](https://github.com/getsentry/sentry-cocoa/issues/2528) and [2065](https://github.com/getsentry/sentry-cocoa/issues/2065).
 
-## Rename master to main
+### Rename master to main
 
 Date: January 16th, 2023
 Contributors: @kahest, @brustolin and @philipphofmann
 
 With 8.0.0, we rename the default branch from `master` to `main`. We will keep the `master` branch for backwards compatibility for package managers pointing to the `master` branch.
 
-## SentrySwiftUI version
+### SentrySwiftUI version
 
 Date: January 18th, 2023
 Contributors: @brustolin and @philipphofmann
 
 We release experimental SentrySwiftUI cocoa package with the version 8.0.0 because all podspecs file in a repo need to have the same version. 
 
-## Tracking package managers
+### Tracking package managers
 
 To be able to identify the package manager(PM) being used by the user, we need that the PM identify itself.
 Luckily all of the 3 PMs we support do this in some way, mostly by exposing a compiler directive (SPM, COCOA)
 or a build setting (CARTHAGE). With this information we can create a conditional compilation that injects the name of
 the PM. You can find this in `SentrySDKInfo.m`.
 
-## Usage of `__has_include`
+### Usage of `__has_include`
 
 Some private headers add a dependency of a public header, when those private headers are used in a sample project, or referenced from a hybrid SDK, it is treated as part of the project using it, therefore, if it points to a header that is not part of said project, a compilation error will occur. To solve this we make use of `__has_include` to try to point to the SDK version of the header, or to fallback to the direct reference when compiling the SDK.


### PR DESCRIPTION
All headings in the decision log should be h3 and not h2.

#skip-changelog