### PR TITLE
ref: Use sample decision instead of bool

### DIFF
--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithOperation:(NSString *)operation
 {
-    return [self initWithOperation:operation sampled:NO];
+    return [self initWithOperation:operation sampled:kSentrySampleDecisionUndecided];
 }
 
 - (instancetype)initWithOperation:(NSString *)operation sampled:(SentrySampleDecision)sampled


### PR DESCRIPTION
Use sample decision instead of bool in SentrySpanContext.

#skip-changelog