### PR TITLE
fix: Start frame check removed

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.2, name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.2, name=iPhone 13 Pro" \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.2,name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.2,name=iPhone 13 Pro" \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -77,9 +77,6 @@
                   Identifier = "SentrySessionGeneratorTests/testSendSessions()">
                </Test>
                <Test
-                  Identifier = "SentryStacktraceBuilderTests/testAsyncStacktraces()">
-               </Test>
-               <Test
                   Identifier = "SentrySubClassFinderTests/testActOnSubclassesOfViewController()">
                </Test>
                <Test

--- a/Sources/Sentry/SentryStacktraceBuilder.m
+++ b/Sources/Sentry/SentryStacktraceBuilder.m
@@ -41,7 +41,8 @@ SentryStacktraceBuilder ()
             continue;
         }
         if (stackCursor.symbolicate(&stackCursor)) {
-            [frames addObject:[self.crashStackEntryMapper mapStackEntryWithCursor:stackCursor]];
+            frame = [self.crashStackEntryMapper mapStackEntryWithCursor:stackCursor];
+            [frames addObject:frame];
         }
     }
     sentrycrash_async_backtrace_decref(stackCursor.async_caller);


### PR DESCRIPTION
We stopped by mistake marking the start frame after an async frame marker.
Rolling back the code to fix this.

_#skip-changelog_