### PR TITLE
test: Add missing test for transaction name

### DIFF
--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -85,7 +85,7 @@ SentryTransaction ()
     }
 
     if (self.trace) {
-        [serializedData setValue:self.trace.transactionContext.name forKey:@"transaction"];
+        serializedData[@"transaction"] = self.trace.transactionContext.name;
 
         serializedData[@"transaction_info"] =
             @{ @"source" : [self stringForNameSource:self.trace.transactionContext.nameSource] };

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -169,4 +169,13 @@ class SentryTransactionTests: XCTestCase {
         let actualTransactionInfo = actual["transaction_info"] as? [String: String]
         XCTAssertEqual(actualTransactionInfo?["source"], "component")
     }
+    
+    func testSerialize_TransactionName() {
+        let scope = Scope()
+        let transaction = fixture.getTransactionWith(scope: scope)
+        let actual = transaction.serialize()
+
+        let actualTransaction = actual["transaction"] as? String
+        XCTAssertEqual(actualTransaction, fixture.transactionName)
+    }
 }


### PR DESCRIPTION
The serialization of `transactionContext.name` was missing a test case.

#skip-changelog