### PR TITLE
test: Make TestLogOutput thread safe

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -79,6 +79,7 @@
 		33042A0D29DAF79A00C60085 /* SentryExtraContextProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 33042A0C29DAF79A00C60085 /* SentryExtraContextProvider.m */; };
 		33042A1729DC2C4300C60085 /* SentryExtraContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */; };
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
+		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
 		630435FE1EBCA9D900C4D3FA /* SentryNSURLRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 630435FC1EBCA9D900C4D3FA /* SentryNSURLRequest.h */; };
 		630435FF1EBCA9D900C4D3FA /* SentryNSURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 630435FD1EBCA9D900C4D3FA /* SentryNSURLRequest.m */; };
@@ -926,6 +927,7 @@
 		33042A0C29DAF79A00C60085 /* SentryExtraContextProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryExtraContextProvider.m; sourceTree = "<group>"; };
 		33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExtraContextProviderTests.swift; sourceTree = "<group>"; };
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
+		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
 		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
 		62F226B829A37C270038080D /* SentryBooleanSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryBooleanSerialization.h; sourceTree = "<group>"; };
 		630435FC1EBCA9D900C4D3FA /* SentryNSURLRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNSURLRequest.h; path = include/SentryNSURLRequest.h; sourceTree = "<group>"; };
@@ -2963,6 +2965,7 @@
 		7BF536D224BEF240004FA6A2 /* TestUtils */ = {
 			isa = PBXGroup;
 			children = (
+				62885DA629E946B100554F38 /* TestConncurrentModifications.swift */,
 				7BF536D324BEF255004FA6A2 /* SentryAssertions.swift */,
 				7B6D98EC24C703F8005502FA /* Async.swift */,
 				7BF9EF712722A84800B5BBEF /* SentryClassRegistrator.h */,
@@ -4123,6 +4126,7 @@
 				63FE721F20DA66EC00CDBAE8 /* SentryCrashSignalInfo_Tests.m in Sources */,
 				0ADC33F128D9BE940078D980 /* TestSentryUIDeviceWrapper.swift in Sources */,
 				63FE721420DA66EC00CDBAE8 /* SentryCrashMemory_Tests.m in Sources */,
+				62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */,
 				63FE720520DA66EC00CDBAE8 /* FileBasedTestCase.m in Sources */,
 				0A6EEADD28A657970076B469 /* UIViewRecursiveDescriptionTests.swift in Sources */,
 				63EED6C32237989300E02400 /* SentryOptionsTest.m in Sources */,

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -317,28 +317,13 @@ class SentryScopeSwiftTests: XCTestCase {
     
     // With this test we test if modifications from multiple threads don't lead to a crash.
     func testModifyingFromMultipleThreads() {
-        let queue = DispatchQueue(label: "SentryScopeTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
-        let group = DispatchGroup()
-        
         let scope = fixture.scope
         
-        for _ in 0...2 {
-            group.enter()
-            queue.async {
-                
-                // The number is kept small for the CI to not take too long.
-                // If you really want to test this increase to 100_000 or so.
-                for _ in 0...10 {
-                    // Simulate some real world modifications of the user
-                    self.modifyScope(scope: scope)
-                }
-                
-                group.leave()
-            }
-        }
-        
-        queue.activate()
-        group.waitWithTimeout(timeout: 500)
+        // The number is kept small for the CI to not take too long.
+        // If you really want to test this increase to 100_000 or so.
+        testConcurrentModifications(asyncWorkItems: 2, writeLoopCount: 10, writeWork: { _ in
+            self.modifyScope(scope: scope)
+        })
     }
     
     func testScopeObserver_setUser() {

--- a/Tests/SentryTests/TestLogOutput.swift
+++ b/Tests/SentryTests/TestLogOutput.swift
@@ -1,9 +1,50 @@
 import Foundation
 
 class TestLogOutput: SentryLogOutput {
-    var loggedMessages: [String] = []
+    
+    private let queue = DispatchQueue(label: "TestLogOutput", attributes: .concurrent)
+    
+    private var _loggedMessages: [String] = []
+    
+    var loggedMessages: [String] {
+        get {
+            queue.sync {
+                return _loggedMessages
+            }
+        }
+    }
+    
     override func log(_ message: String) {
         super.log(message)
-        loggedMessages.append(message)
+        queue.async(flags: .barrier) {
+            self._loggedMessages.append(message)
+        }
+    }
+}
+
+class TestLogOutPutTests: XCTestCase {
+    
+    func testLoggingFromMulitpleThreads() {
+        let sut = TestLogOutput()
+        
+        let queue = DispatchQueue(label: "TestLogOutPutTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+        let group = DispatchGroup()
+        
+        for _ in 0...2 {
+            group.enter()
+            queue.async {
+                
+                for i in 0...1_000 {
+                    sut.log("Some message \(i)")
+                }
+                
+                XCTAssertNotNil(sut.loggedMessages)
+                
+                group.leave()
+            }
+        }
+        
+        queue.activate()
+        group.waitWithTimeout(timeout: 500)
     }
 }

--- a/Tests/SentryTests/TestLogOutput.swift
+++ b/Tests/SentryTests/TestLogOutput.swift
@@ -26,25 +26,10 @@ class TestLogOutPutTests: XCTestCase {
     
     func testLoggingFromMulitpleThreads() {
         let sut = TestLogOutput()
-        
-        let queue = DispatchQueue(label: "TestLogOutPutTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
-        let group = DispatchGroup()
-        
-        for _ in 0...2 {
-            group.enter()
-            queue.async {
-                
-                for i in 0...1_000 {
-                    sut.log("Some message \(i)")
-                }
-                
-                XCTAssertNotNil(sut.loggedMessages)
-                
-                group.leave()
-            }
-        }
-        
-        queue.activate()
-        group.waitWithTimeout(timeout: 500)
+        testConcurrentModifications(writeWork: { i in
+            sut.log("Some message \(i)")
+        }, readWork: {
+            XCTAssertNotNil(sut.loggedMessages)
+        })
     }
 }

--- a/Tests/SentryTests/TestUtils/TestConncurrentModifications.swift
+++ b/Tests/SentryTests/TestUtils/TestConncurrentModifications.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+func testConcurrentModifications(asyncWorkItems: Int = 5, writeLoopCount: Int = 1_000, writeWork: @escaping (Int) -> Void, readWork: @escaping () -> Void = {}) {
+    let queue = DispatchQueue(label: "testConcurrentModifications", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+    let group = DispatchGroup()
+    
+    for _ in 0..<asyncWorkItems {
+        group.enter()
+        queue.async {
+            
+            for i in 0...writeLoopCount {
+                writeWork(i)
+            }
+            
+            readWork()
+            
+            group.leave()
+        }
+    }
+    
+    queue.activate()
+    group.waitWithTimeout(timeout: 500)
+}


### PR DESCRIPTION
When running the tests locally, I got a SIGABRT in the TestLogOutput when writing to the loggedMessages. I added a test to reproduce the same error by writing and reading the loggedMessages from different threads. The problem is fixed now by using a dispatch queue.

#skip-changelog