### PR TITLE
test: Fix failing NSDataTracker tests

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/IO/SentryNSDataTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryNSDataTrackerTests.swift
@@ -316,7 +316,7 @@ class SentryNSDataTrackerTests: XCTestCase {
         if operation == SENTRY_FILE_READ_OPERATION {
             XCTAssertEqual(span?.spanDescription, lastComponent)
         } else {
-            let bytesDescription = ByteCountFormatter.string(fromByteCount: Int64(size), countStyle: .binary)
+            let bytesDescription = SentryByteCountFormatter.bytesCountDescription( UInt(size))
             XCTAssertEqual(span?.spanDescription ?? "", "\(lastComponent) (\(bytesDescription))")
         }
     }


### PR DESCRIPTION
When running the SentryNSDataTrackerTests locally they failed. This is fixed now by using the SentryByteCountFormatter instead of the NSByteCountFormatter.

Related to https://github.com/getsentry/sentry-cocoa/pull/2902.

#skip-changelog