### PR TITLE
test: Remove subclass of NSTimer

### DIFF
--- a/SentryTestUtils/TestSentryNSTimerWrapper.swift
+++ b/SentryTestUtils/TestSentryNSTimerWrapper.swift
@@ -9,14 +9,15 @@ public class TestSentryNSTimerWrapper: SentryNSTimerWrapper {
     
     public var timer: Timer {
         get {
-            _timer!
+            _timer ?? Timer()
         }
     }
 
     public override func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Void) -> Timer {
-        _timer = Timer.scheduledTimer(withTimeInterval: TimeInterval.infinity, repeats: repeats, block: block)
+        let timer = Timer.scheduledTimer(withTimeInterval: TimeInterval.infinity, repeats: repeats, block: block)
+        _timer = timer
         
-        return _timer!
+        return timer
     }
 
     public func fire() {

--- a/SentryTestUtils/TestSentryNSTimerWrapper.swift
+++ b/SentryTestUtils/TestSentryNSTimerWrapper.swift
@@ -1,31 +1,25 @@
 import Foundation
 import Sentry
 
-public class TestTimer: Timer {
-    public var invalidateCount = 0
-
-    public override func invalidate() {
-        // no-op as this timer doesn't actually schedule anything on a runloop
-        invalidateCount += 1
-    }
-}
-
+// We must not subclass NSTimer, see https://developer.apple.com/documentation/foundation/nstimer#1770465.
+// Therefore we return a NSTimer instance here with TimeInterval.infinity.
 public class TestSentryNSTimerWrapper: SentryNSTimerWrapper {
-    public struct Overrides {
-        public var timer: TestTimer!
-        var block: ((Timer) -> Void)?
-    }
 
-    public var overrides = Overrides()
+    private var _timer: Timer?
+    
+    public var timer: Timer {
+        get {
+            _timer!
+        }
+    }
 
     public override func scheduledTimer(withTimeInterval interval: TimeInterval, repeats: Bool, block: @escaping (Timer) -> Void) -> Timer {
-        let timer = TestTimer()
-        overrides.timer = timer
-        overrides.block = block
-        return timer
+        _timer = Timer.scheduledTimer(withTimeInterval: TimeInterval.infinity, repeats: repeats, block: block)
+        
+        return _timer!
     }
 
     public func fire() {
-        overrides.block?(overrides.timer)
+        _timer?.fire()
     }
 }

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -209,7 +209,7 @@ class SentryTracerTests: XCTestCase {
         let sut = fixture.getSut()
         sut.finish()
 
-        XCTAssertEqual(fixture.timerWrapper.overrides.timer.invalidateCount, 1)
+        XCTAssertFalse(fixture.timerWrapper.timer.isValid)
     }
 
     func testFinish_CheckDefaultStatus() {


### PR DESCRIPTION
We subclassed NSTimer, which is not allowed see:
https://developer.apple.com/documentation/foundation/nstimer#1770465.
This sometimes leads to crashes in TestSentryNSTimerWrapper with EXC_BAD_ACCESS.
The subclass is now removed.

#skip-changelog