### PR TITLE
test: give the xcode 13 tests a little more time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,14 +87,14 @@ jobs:
             platform: 'iOS'
             xcode: '13.2.1'
             test-destination-os: '13.7'
-            timeout-minutes: 15
+            timeout-minutes: 20
 
           # iOS 14
           - runs-on: macos-11
             platform: 'iOS'
             xcode: '13.2.1'
             test-destination-os: '14.5'
-            timeout-minutes: 15
+            timeout-minutes: 20
 
           # iOS 15
           - runs-on: macos-12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,7 +202,6 @@ jobs:
 
       - name: Archiving DerivedData Logs
         uses: actions/upload-artifact@v3
-        if: failure()
         with:
           name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
@@ -210,7 +209,6 @@ jobs:
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v3
-        if: ${{  failure() || cancelled() }}
         with:
           name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,7 @@ jobs:
 
       - name: Archiving DerivedData Logs
         uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
@@ -209,6 +210,7 @@ jobs:
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v3
+        if: ${{  failure() || cancelled() }}
         with:
           name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,14 +87,14 @@ jobs:
             platform: 'iOS'
             xcode: '13.2.1'
             test-destination-os: '13.7'
-            timeout-minutes: 20
+            timeout-minutes: 25
 
           # iOS 14
           - runs-on: macos-11
             platform: 'iOS'
             xcode: '13.2.1'
             test-destination-os: '14.5'
-            timeout-minutes: 20
+            timeout-minutes: 25
 
           # iOS 15
           - runs-on: macos-12


### PR DESCRIPTION
#skip-changelog

These test jobs are just barely timing out, see the latest run against `main`: https://github.com/getsentry/sentry-cocoa/actions/runs/4698327161/jobs/8330707336

in one case the test even succeeded but timed out right before the script finished.