### PR TITLE
test: use dispatch queue wrappers for all file managers in tests

### DIFF
--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -38,7 +38,7 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
             return name != "SentryAutoSessionTrackingIntegration"
         }
 
-        fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: DefaultCurrentDateProvider.sharedInstance())
+        fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: DefaultCurrentDateProvider.sharedInstance(), dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
         
         fileManager.deleteCurrentSession()
         fileManager.deleteCrashedSession()

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
@@ -18,7 +18,7 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
             
             crashWrapper = TestSentryCrashWrapper.sharedInstance()
             SentryDependencyContainer.sharedInstance().crashWrapper = crashWrapper
-            SentryDependencyContainer.sharedInstance().fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDate)
+            SentryDependencyContainer.sharedInstance().fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDate, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
 
             let hub = SentryHub(client: client, andScope: nil, andCrashWrapper: crashWrapper, andCurrentDateProvider: currentDate)
             SentrySDK.setCurrentHub(hub)

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsScopeObserverTests.swift
@@ -18,7 +18,7 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
 
             options = Options()
             options.dsn = SentryWatchdogTerminationScopeObserverTests.dsn
-            fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDate)
+            fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDate, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
         }
 
         func getSut() -> SentryWatchdogTerminationScopeObserver {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -33,7 +33,7 @@ class SentryHubTests: XCTestCase {
             event = Event()
             event.message = SentryMessage(formatted: message)
             
-            fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDateProvider)
+            fileManager = try! SentryFileManager(options: options, andCurrentDateProvider: currentDateProvider, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
             
             CurrentDate.setCurrentDateProvider(currentDateProvider)
             


### PR DESCRIPTION
#skip-changelog

Following a finding in #2906, init the remaining live file managers in the test suite with test dispatch queue wrappers, to keep them from delaying dispatches that cause issues in later test cases.

We should consider if some/all of these could also instead be converted to test file manager subclasses instead of the SDK file manager.