### PR TITLE
ref: Add some log messages when closing the SDK

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -492,6 +492,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 {
     _isEnabled = NO;
     [self flush:self.options.shutdownTimeInterval];
+    SENTRY_LOG_DEBUG(@"Closed the Client.");
 }
 
 - (SentryEvent *_Nullable)prepareEvent:(SentryEvent *)event

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -640,6 +640,7 @@ SentryHub ()
 - (void)close
 {
     [_client close];
+    SENTRY_LOG_DEBUG(@"Closed the Hub.");
 }
 
 @end

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -375,16 +375,18 @@ static NSUInteger startInvocations;
  */
 + (void)close
 {
+    SENTRY_LOG_DEBUG(@"Starting to close SDK.");
     // pop the hub and unset
     SentryHub *hub = SentrySDK.currentHub;
 
-    // uninstall all the integrations
+    // Uninstall all the integrations
     for (NSObject<SentryIntegrationProtocol> *integration in hub.installedIntegrations) {
         if ([integration respondsToSelector:@selector(uninstall)]) {
             [integration uninstall];
         }
     }
     [hub removeAllIntegrations];
+    SENTRY_LOG_DEBUG(@"Uninstalled all integrations.");
 
 #if SENTRY_HAS_UIKIT
     // force the AppStateManager to unsubscribe, see


### PR DESCRIPTION
Add some extra log messages when closing the SDK in the client, hub, and SDK.

#skip-changelog