### PR TITLE
ref: Add delegate to SentryBreadcrumbTracker

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -80,6 +80,8 @@
 		33042A1729DC2C4300C60085 /* SentryExtraContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */; };
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
+		62E081A929ED4260000F69FC /* SentryBreadcrumbDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */; };
+		62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */; };
 		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
 		630435FE1EBCA9D900C4D3FA /* SentryNSURLRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 630435FC1EBCA9D900C4D3FA /* SentryNSURLRequest.h */; };
 		630435FF1EBCA9D900C4D3FA /* SentryNSURLRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 630435FD1EBCA9D900C4D3FA /* SentryNSURLRequest.m */; };
@@ -928,6 +930,8 @@
 		33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExtraContextProviderTests.swift; sourceTree = "<group>"; };
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
+		62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBreadcrumbDelegate.h; path = include/SentryBreadcrumbDelegate.h; sourceTree = "<group>"; };
+		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
 		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
 		62F226B829A37C270038080D /* SentryBooleanSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryBooleanSerialization.h; sourceTree = "<group>"; };
 		630435FC1EBCA9D900C4D3FA /* SentryNSURLRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNSURLRequest.h; path = include/SentryNSURLRequest.h; sourceTree = "<group>"; };
@@ -2734,6 +2738,7 @@
 				A839D89924864BA8003B7AFD /* SentrySystemEventBreadcrumbs.m */,
 				639889B51EDECFA800EA7442 /* SentryBreadcrumbTracker.h */,
 				639889B61EDECFA800EA7442 /* SentryBreadcrumbTracker.m */,
+				62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */,
 			);
 			name = Breadcrumbs;
 			sourceTree = "<group>";
@@ -2863,6 +2868,7 @@
 				7BE0DC30272ABCEC004FA8B7 /* SentryAutoBreadcrumbTrackingIntegration+Test.h */,
 				7BE0DC28272A9E1C004FA8B7 /* SentryBreadcrumbTrackerTests.swift */,
 				A811D866248E2770008A41EA /* SentrySystemEventBreadcrumbsTest.swift */,
+				62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */,
 			);
 			path = Breadcrumbs;
 			sourceTree = "<group>";
@@ -3526,6 +3532,7 @@
 				7B3B83722833832B0001FDEB /* SentrySpanOperations.h in Headers */,
 				7BF9EF722722A84800B5BBEF /* SentryClassRegistrator.h in Headers */,
 				63FE715520DA4C1100CDBAE8 /* SentryCrashStackCursor_MachineContext.h in Headers */,
+				62E081A929ED4260000F69FC /* SentryBreadcrumbDelegate.h in Headers */,
 				15360CF02433A16D00112302 /* SentryInstallation.h in Headers */,
 				63FE714720DA4C1100CDBAE8 /* SentryCrashMachineContext.h in Headers */,
 				7BA61CAB247BA98100C130A8 /* SentryDebugImageProvider.h in Headers */,
@@ -4139,6 +4146,7 @@
 				7BE912AF272166DD00E49E62 /* SentryNoOpSpanTests.swift in Sources */,
 				7B56D73524616E5600B842DA /* SentryConcurrentRateLimitsDictionaryTests.swift in Sources */,
 				7B7D8730248648AD00D2ECFF /* SentryStacktraceBuilderTests.swift in Sources */,
+				62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */,
 				D8751FA5274743710032F4DE /* SentryNSURLSessionTaskSearchTests.swift in Sources */,
 				D86F419827C8FEFA00490520 /* SentryCoreDataMiddleware+Extension.swift in Sources */,
 				7B944FB32469C02900A10721 /* TestHub.swift in Sources */,

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -53,7 +53,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
     systemEventBreadcrumbs:(SentrySystemEventBreadcrumbs *)systemEventBreadcrumbs
 {
     self.breadcrumbTracker = breadcrumbTracker;
-    [self.breadcrumbTracker start];
+    [self.breadcrumbTracker startWithDelegate:self];
 
     if (options.enableSwizzling) {
         [self.breadcrumbTracker startSwizzle];

--- a/Sources/Sentry/SentrySystemEventBreadcrumbs.m
+++ b/Sources/Sentry/SentrySystemEventBreadcrumbs.m
@@ -1,5 +1,6 @@
 #import "SentrySystemEventBreadcrumbs.h"
 #import "SentryBreadcrumb.h"
+#import "SentryBreadcrumbDelegate.h"
 #import "SentryCurrentDateProvider.h"
 #import "SentryDependencyContainer.h"
 #import "SentryLog.h"
@@ -12,7 +13,7 @@
 
 @interface
 SentrySystemEventBreadcrumbs ()
-@property (nonatomic, weak) id<SentrySystemEventBreadcrumbsDelegate> delegate;
+@property (nonatomic, weak) id<SentryBreadcrumbDelegate> delegate;
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) id<SentryCurrentDateProvider> currentDateProvider;
 @property (nonatomic, strong) SentryNSNotificationCenterWrapper *notificationCenterWrapper;
@@ -32,7 +33,7 @@ SentrySystemEventBreadcrumbs ()
     return self;
 }
 
-- (void)startWithDelegate:(id<SentrySystemEventBreadcrumbsDelegate>)delegate
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
 {
 #if TARGET_OS_IOS
     UIDevice *currentDevice = [UIDevice currentDevice];
@@ -73,7 +74,7 @@ SentrySystemEventBreadcrumbs ()
 /**
  * Only used for testing, call startWithDelegate instead.
  */
-- (void)startWithDelegate:(id<SentrySystemEventBreadcrumbsDelegate>)delegate
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
             currentDevice:(nullable UIDevice *)currentDevice
 {
     _delegate = delegate;

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,6 +1,6 @@
 #import "SentryBaseIntegration.h"
+#import "SentryBreadcrumbDelegate.h"
 #import "SentryIntegrationProtocol.h"
-#import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This automatically adds breadcrumbs for different user actions.
  */
 @interface SentryAutoBreadcrumbTrackingIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentrySystemEventBreadcrumbsDelegate>
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentryBreadcrumbDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentryBreadcrumbDelegate.h
+++ b/Sources/Sentry/include/SentryBreadcrumbDelegate.h
@@ -1,0 +1,11 @@
+#import "SentryInternalDefines.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SentryBreadcrumbDelegate <NSObject>
+
+- (void)addBreadcrumb:(SentryBreadcrumb *)crumb;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryBreadcrumbTracker.h
+++ b/Sources/Sentry/include/SentryBreadcrumbTracker.h
@@ -4,12 +4,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SentrySwizzleWrapper;
 
+@protocol SentryBreadcrumbDelegate;
+
 @interface SentryBreadcrumbTracker : NSObject
 SENTRY_NO_INIT
 
 - (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper;
 
-- (void)start;
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate;
 - (void)startSwizzle;
 - (void)stop;
 

--- a/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SentryNSNotificationCenterWrapper;
 
-@protocol SentrySystemEventBreadcrumbsDelegate;
+@protocol SentryBreadcrumbDelegate;
 
 @interface SentrySystemEventBreadcrumbs : NSObject
 SENTRY_NO_INIT
@@ -19,21 +19,15 @@ SENTRY_NO_INIT
              andCurrentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider
        andNotificationCenterWrapper:(SentryNSNotificationCenterWrapper *)notificationCenterWrapper;
 
-- (void)startWithDelegate:(id<SentrySystemEventBreadcrumbsDelegate>)delegate;
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate;
 
 #if TARGET_OS_IOS
-- (void)startWithDelegate:(id<SentrySystemEventBreadcrumbsDelegate>)delegate
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
             currentDevice:(nullable UIDevice *)currentDevice;
 - (void)timezoneEventTriggered;
 #endif
 
 - (void)stop;
-
-@end
-
-@protocol SentrySystemEventBreadcrumbsDelegate <NSObject>
-
-- (void)addBreadcrumb:(SentryBreadcrumb *)crumb;
 
 @end
 

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -93,9 +93,9 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
 
 private class SentryTestBreadcrumbTracker: SentryBreadcrumbTracker {
     
-    let startInvocations = Invocations<Void>()
-    override func start() {
-        startInvocations.record(Void())
+    let startInvocations = Invocations<SentryBreadcrumbDelegate>()
+    override func start(with delegate: SentryBreadcrumbDelegate) {
+        startInvocations.record(delegate)
     }
     
     let startSwizzleInvocations = Invocations<Void>()

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -107,8 +107,8 @@ private class SentryTestBreadcrumbTracker: SentryBreadcrumbTracker {
 
 private class SentryTestSystemEventBreadcrumbs: SentrySystemEventBreadcrumbs {
     
-    let startWithdelegateInvocations = Invocations<SentrySystemEventBreadcrumbsDelegate>()
-    override func start(with delegate: SentrySystemEventBreadcrumbsDelegate) {
+    let startWithdelegateInvocations = Invocations<SentryBreadcrumbDelegate>()
+    override func start(with delegate: SentryBreadcrumbDelegate) {
         startWithdelegateInvocations.record(delegate)
     }
 }

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTestDelegate.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTestDelegate.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SentryTestUtils
+
+class SentryBreadcrumbTestDelegate: NSObject, SentryBreadcrumbDelegate {
+    
+    var addCrumbInvocations = Invocations<Breadcrumb>()
+    func add(_ crumb: Breadcrumb) {
+        addCrumbInvocations.record(crumb)
+    }
+}

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -9,7 +9,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
     
     private class Fixture {
         let options: Options
-        let delegate = SentrySystemEventBreadcrumbTestDelegate()
+        let delegate = SentryBreadcrumbTestDelegate()
         let fileManager: TestFileManager
         var currentDateProvider = TestCurrentDateProvider()
         let notificationCenterWrapper = TestNSNotificationCenterWrapper()
@@ -281,12 +281,4 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
     }
     
     #endif
-}
-
-class SentrySystemEventBreadcrumbTestDelegate: NSObject, SentrySystemEventBreadcrumbsDelegate {
-    
-    var addCrumbInvocations = Invocations<Breadcrumb>()
-    func add(_ crumb: Breadcrumb) {
-        addCrumbInvocations.record(crumb)
-    }
 }

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -22,6 +22,7 @@
 #import "SentryAutoSessionTrackingIntegration.h"
 #import "SentryBaggage.h"
 #import "SentryBooleanSerialization.h"
+#import "SentryBreadcrumbDelegate.h"
 #import "SentryBreadcrumbTracker.h"
 #import "SentryByteCountFormatter.h"
 #import "SentryClassRegistrator.h"


### PR DESCRIPTION


## :scroll: Description

Replace usages of SentrySDK.addBreadcrumb with delegate except one usage inside of swizzling, which can't be easily replaced cause we can't reference an instance of SentryBreadcrumbTracker inside SwizzleInstanceMethod. To get rid of SentrySDK we need to add swizzling viewDidAppear to swizzleWrapper, which we are going to do in a subsequent PR.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/2913.

#skip-changelog

## :bulb: Motivation and Context

It partly tackles https://github.com/getsentry/sentry-cocoa/issues/2911.

## :green_heart: How did you test it?
Breadcrumbs are still working see https://sentry-sdks.sentry.io/issues/2895893229/events/d3022f614ada4bb8a567af3954d77762/.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
