### PR TITLE
ci: Fix running web request tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -31,21 +31,24 @@ jobs:
           repository: 'Alamofire/Alamofire'
           ref: 'f82c23a8a7ef8dc1a49a8bfc6a96883e79121864'
 
-      - run: ./scripts/ci-select-xcode.sh 14.2
-
       # Use github.event.pull_request.head.sha instead of github.sha when available as
       # the github.sha is the pre merge commit id for PRs.
       # See https://github.community/t/github-sha-isnt-the-value-expected/17903/17906.
-      - name: Download Apply Patch Script
+      - name: Download Scripts
         run: >-
           if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/apply-patch.sh --output apply-patch.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh
           else
-            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.sha }}/scripts/apply-patch.sh --output apply-patch.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/apply-patch.sh --output apply-patch.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh
           fi
 
           chmod +x apply-patch.sh
+          chmod +x ci-select-xcode.sh
         shell: bash
+
+      - run: ./scripts/ci-select-xcode.sh 14.2
 
       - name: Download and Apply Patch
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - ci/fix-web-request-tests
 
   pull_request:
     paths:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -44,8 +44,7 @@ jobs:
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.sha }}/scripts/ci-select-xcode.sh --output ci-select-xcode.sh
           fi
 
-          chmod +x apply-patch.sh
-          chmod +x ci-select-xcode.sh
+          chmod +x apply-patch.sh ci-select-xcode.sh
         shell: bash
 
       - name: Select Xcode Version

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,12 +68,14 @@ jobs:
       - name: Run tests
         # Run the tests twice, because they are sometimes flaky.
         # We skip two tests because they even fail sometimes when not adding Sentry to Alamofire.
+        # testReleasingManagerWithPendingRequestDeinitializesSuccessfully also fails without Sentry.
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
           xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=16.2,name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
-          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
+          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \ 
+          -skip-testing:"Alamofire iOS Tests/SessionTestCase/testReleasingManagerWithPendingRequestDeinitializesSuccessfully" \ 
           test | xcpretty \
           && break ; done
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,8 +40,8 @@ jobs:
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/apply-patch.sh --output apply-patch.sh
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh --output ci-select-xcode.sh
           else
-            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/apply-patch.sh --output apply-patch.sh
-            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh --output ci-select-xcode.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.sha }}/scripts/apply-patch.sh --output apply-patch.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.sha }}/scripts/ci-select-xcode.sh --output ci-select-xcode.sh
           fi
 
           chmod +x apply-patch.sh

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,7 +24,7 @@ jobs:
   web-request-tests:
     name: Integration Web Requests
     runs-on: macos-12
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -38,17 +38,18 @@ jobs:
         run: >-
           if [[ "${{ github.event.pull_request.head.sha }}" != "" ]]; then
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/apply-patch.sh --output apply-patch.sh
-            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh --output ci-select-xcode.sh
           else
             curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/apply-patch.sh --output apply-patch.sh
-            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh
+            curl https://raw.githubusercontent.com/getsentry/sentry-cocoa/${{ github.event.pull_request.head.sha }}/scripts/ci-select-xcode.sh --output ci-select-xcode.sh
           fi
 
           chmod +x apply-patch.sh
           chmod +x ci-select-xcode.sh
         shell: bash
 
-      - run: ./scripts/ci-select-xcode.sh 14.2
+      - name: Select Xcode Version
+        run: ./ci-select-xcode.sh 14.2
 
       - name: Download and Apply Patch
         run: ./apply-patch.sh "${{ github.event.pull_request.head.sha }}" "${{ github.sha }}" add-sentry-to-alamofire

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,8 +74,8 @@ jobs:
           set -o pipefail && env NSUnbufferedIO=YES \
           xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=16.2,name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
-          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \ 
-          -skip-testing:"Alamofire iOS Tests/SessionTestCase/testReleasingManagerWithPendingRequestDeinitializesSuccessfully" \ 
+          -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
+          -skip-testing:"Alamofire iOS Tests/SessionTestCase/testReleasingManagerWithPendingRequestDeinitializesSuccessfully" \
           test | xcpretty \
           && break ; done
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - ci/fix-web-request-tests
 
   pull_request:
     paths:
@@ -22,13 +23,15 @@ jobs:
   # doesn't break web requests.
   web-request-tests:
     name: Integration Web Requests
-    runs-on: macos-11
+    runs-on: macos-12
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v3
         with:
           repository: 'Alamofire/Alamofire'
           ref: 'f82c23a8a7ef8dc1a49a8bfc6a96883e79121864'
+
+      - run: ./scripts/ci-select-xcode.sh 14.2
 
       # Use github.event.pull_request.head.sha instead of github.sha when available as
       # the github.sha is the pre merge commit id for PRs.
@@ -61,11 +64,11 @@ jobs:
 
       - name: Run tests
         # Run the tests twice, because they are sometimes flaky.
-        # We skip two tests because it also fails sometimes when not adding Sentry to Alamofire.
+        # We skip two tests because they even fail sometimes when not adding Sentry to Alamofire.
         run: |
           for i in {1..2}; do \
           set -o pipefail && env NSUnbufferedIO=YES \
-          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=15.2,name=iPhone 13 Pro" \
+          xcodebuild -project "Alamofire.xcodeproj" -scheme "Alamofire iOS" -destination "OS=16.2,name=iPhone 13 Pro" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorThrowsMissingCredentialErrorWhenCredentialIsNilAndRequestShouldBeRetried" \
           -skip-testing:"Alamofire iOS Tests/AuthenticationInterceptorTestCase/testThatInterceptorRetriesRequestThatFailedWithOutdatedCredential" \
           test | xcpretty \


### PR DESCRIPTION
This PRs fixes an error when running the web request integration tests by using the latest Xcode version and ignoring one failing test.

```
023-04-17 09:39:17.400 xcodebuild[1031:6745] [MT] IDEResultKit: Warning: While writing a result bundle to /Users/runner/Library/Developer/Xcode/DerivedData/Alamofire-fdzsmdexoebjaihelbilprzgjoup/Logs/Test/Test-Alamofire iOS-2023.04.17_09-30-11-+0000.xcresult, not all contents have been imported, as the Staging directory still contains the following files/directories: ["1_Test"]
Testing failed:
	Alamofire iOS Tests:
		xctest (4215) encountered an error (Test runner never began executing tests after launching. If you believe this error represents a bug, please attach the result bundle at /Users/runner/Library/Developer/Xcode/DerivedData/Alamofire-fdzsmdexoebjaihelbilprzgjoup/Logs/Test/Test-Alamofire iOS-2023.04.17_09-30-11-+0000.xcresult)
```

It doesn't fix failing tests in web request integration tests. This will be done in a subsequent PR.