### PR TITLE
chore: Remove obsolete code in xcode-test.sh

### DIFF
--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -58,17 +58,7 @@ case $IS_LOCAL_BUILD in
         ;;
 esac
 
-if [ $PLATFORM == "iOS" -a $OS == "12.4" ]; then
-    # Skip some tests that fail on iOS 12.4.
-    env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
-        -scheme Sentry -configuration $CONFIGURATION \
-        -destination "$DESTINATION" \
-        -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfAddingBreadcrumbs" \
-        -skip-testing:"SentryTests/SentrySDKTests/testMemoryFootprintOfTransactions" \
-        test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}
-else
-    env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
-        -scheme Sentry -configuration $CONFIGURATION \
-        -destination "$DESTINATION" \
-        test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}
-fi
+env NSUnbufferedIO=YES xcodebuild -workspace Sentry.xcworkspace \
+    -scheme Sentry -configuration $CONFIGURATION \
+    -destination "$DESTINATION" \
+    test | tee raw-test-output.log | $RUBY_ENV_ARGS xcpretty -t && slather coverage --configuration $CONFIGURATION && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
Remove the check for iOS 12.4, as we aren't running unit tests on iOS 12 anymore
(https://github.com/getsentry/sentry-cocoa/pull/2891).

#skip-changelog