### PR TITLE
ref: Remove SentrySwizzleWrapper.sharedInstance

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -175,7 +175,7 @@ static NSObject *sentryDependencyContainerLock;
     if (_swizzleWrapper == nil) {
         @synchronized(sentryDependencyContainerLock) {
             if (_swizzleWrapper == nil) {
-                _swizzleWrapper = SentrySwizzleWrapper.sharedInstance;
+                _swizzleWrapper = [[SentrySwizzleWrapper alloc] init];
             }
         }
     }

--- a/Sources/Sentry/SentrySwizzleWrapper.m
+++ b/Sources/Sentry/SentrySwizzleWrapper.m
@@ -11,14 +11,6 @@ static NSMutableDictionary<NSString *, SentrySwizzleSendActionCallback>
     *sentrySwizzleSendActionCallbacks;
 #endif
 
-+ (SentrySwizzleWrapper *)sharedInstance
-{
-    static SentrySwizzleWrapper *instance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ instance = [[self alloc] init]; });
-    return instance;
-}
-
 + (void)initialize
 {
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentrySwizzleWrapper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapper.h
@@ -17,8 +17,6 @@ typedef void (^SentrySwizzleSendActionCallback)(
  */
 @interface SentrySwizzleWrapper : NSObject
 
-@property (class, readonly, nonatomic) SentrySwizzleWrapper *sharedInstance;
-
 #if SENTRY_HAS_UIKIT
 - (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key;
 


### PR DESCRIPTION
Only the dependency container uses the shared instance. Therefore, we can remove it as the dependency container keeps track of the single instance.

#skip-changelog