### PR TITLE
test: Remove Dynamic for BreadcrumbTrackerTests

### DIFF
--- a/Sources/Sentry/include/SentryBreadcrumbTracker.h
+++ b/Sources/Sentry/include/SentryBreadcrumbTracker.h
@@ -15,6 +15,13 @@ SENTRY_NO_INIT
 - (void)startSwizzle;
 - (void)stop;
 
+#if SENTRY_HAS_UIKIT
+/**
+ * For testing.
+ */
++ (BOOL)avoidSender:(id)sender forTarget:(id)target action:(NSString *)action;
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -108,7 +108,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let viewController = ViewControllerForBreadcrumbTest()
         textField.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .editingChanged)
 
-        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(textField, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldTextChanged(_:))) ).asBool ?? false
+        let result = SentryBreadcrumbTracker.avoidSender(textField, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldTextChanged(_:))))
 
         XCTAssertTrue(result)
     }
@@ -119,7 +119,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         textField.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .editingChanged)
         textField.addTarget(viewController, action: #selector(viewController.textFieldEndChange(_:)), for: .editingDidEnd)
 
-        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(textField, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) ).asBool ?? false
+        let result = SentryBreadcrumbTracker.avoidSender(textField, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) )
 
         XCTAssertFalse(result)
     }
@@ -129,7 +129,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let viewController = ViewControllerForBreadcrumbTest()
         button.addTarget(viewController, action: #selector(viewController.textFieldTextChanged(_:)), for: .touchUpInside)
 
-        let result = Dynamic(SentryBreadcrumbTracker.self).avoidSender(button, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))) ).asBool ?? false
+        let result = SentryBreadcrumbTracker.avoidSender(button, forTarget: viewController, action: NSStringFromSelector(#selector(viewController.textFieldEndChange(_:))))
 
         XCTAssertFalse(result)
     }


### PR DESCRIPTION
Removing the Dynamic usage for the BreadcrumbTrackerTests (added in https://github.com/getsentry/sentry-cocoa/pull/2686) seems to solve the hanging test test_avoidSender.

The failing tests of https://github.com/getsentry/sentry-cocoa/actions/runs/4730099718 time out cause of `PrivateSentrySDKOnlyTests testCaptureEnvelope`, also mentioned in GH-2911.

This partly fixes GH-2911.

#skip-changelog