### PR TITLE
test: Clean up starting SDK in sample apps

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -17,17 +17,12 @@ AppDelegate ()
     [SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
         options.dsn = @"https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557";
         options.debug = YES;
-        options.sessionTrackingIntervalMillis = 5000UL;
-        // Sampling 100% - In Production you probably want to adjust this
         options.tracesSampleRate = @1.0;
-        options.enableFileIOTracing = YES;
         options.attachScreenshot = YES;
         options.attachViewHierarchy = YES;
-        options.enableUserInteractionTracing = YES;
         if ([NSProcessInfo.processInfo.arguments containsObject:@"--io.sentry.profiling.enable"]) {
             options.profilesSampleRate = @1;
         }
-        options.enableCaptureFailedRequests = YES;
         SentryHttpStatusCodeRange *httpStatusCodeRange =
             [[SentryHttpStatusCodeRange alloc] initWithMin:400 max:599];
         options.failedRequestStatusCodes = @[ httpStatusCodeRange ];

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -25,8 +25,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
             options.sessionTrackingIntervalMillis = 5_000
-            options.enableFileIOTracing = true
-            options.enableCoreDataTracing = true
             options.profilesSampleRate = 1.0
             options.attachScreenshot = true
             options.attachViewHierarchy = true

--- a/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
@@ -13,13 +13,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         SentrySDK.start { options in
             options.dsn = dsn
-            options.beforeSend = { event in
-                return event
-            }
             options.debug = true
-            // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
-            options.sessionTrackingIntervalMillis = 5_000
             if ProcessInfo.processInfo.arguments.contains("--io.sentry.profiling.enable") {
                 options.profilesSampleRate = 1
             }

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
@@ -8,12 +8,8 @@ struct SwiftUIApp: App {
         SentrySDK.start { options in
             options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
-            options.sessionTrackingIntervalMillis = 5_000
-            // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
-            options.enableFileIOTracing = true
             options.profilesSampleRate = 1.0
-            options.enableUserInteractionTracing = true
         }
     }
     

--- a/Samples/iOS15-SwiftUI/iOS15-SwiftUI/App.swift
+++ b/Samples/iOS15-SwiftUI/iOS15-SwiftUI/App.swift
@@ -7,12 +7,8 @@ struct SwiftUIApp: App {
         SentrySDK.start { options in
             options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
-            options.sessionTrackingIntervalMillis = 5_000
-            // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
-            options.enableFileIOTracing = true
             options.profilesSampleRate = 1.0
-            options.enableUserInteractionTracing = true
         }
     }
     

--- a/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
+++ b/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
@@ -9,10 +9,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         SentrySDK.start { options in
             options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
             options.debug = true
-            options.sessionTrackingIntervalMillis = 5_000
-            // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
-            options.enableFileIOTracing = true
             if ProcessInfo.processInfo.arguments.contains("--io.sentry.profiling.enable") {
                 options.profilesSampleRate = 1
             }

--- a/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
+++ b/Samples/tvOS-Swift/tvOS-Swift/AppDelegate.swift
@@ -15,8 +15,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.sessionTrackingIntervalMillis = 5_000
             // Sampling 100% - In Production you probably want to adjust this
             options.tracesSampleRate = 1.0
-            options.enableFileIOTracing = true
-            options.enableUserInteractionTracing = true
             options.enableAppHangTracking = true
         }
         

--- a/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ExtensionDelegate.swift
+++ b/Samples/watchOS-Swift/watchOS-Swift WatchKit Extension/ExtensionDelegate.swift
@@ -8,12 +8,7 @@ class ExtensionDelegate: NSObject, WKExtensionDelegate {
         
         SentrySDK.start { options in
             options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
-            options.beforeSend = { event in
-                return event
-            }
             options.debug = true
-            options.sessionTrackingIntervalMillis = 5_000
-            options.enableFileIOTracing = true
         }
         
         SentrySDK.configureScope { scope in


### PR DESCRIPTION
Remove turning on features that are on by default. Remove comment to adjust traces sample rate in production, as we recommend setting it to 1.0 anyways since having dynamic sampling.

#skip-changelog