### PR TITLE
ref: only declare conformance on SentryBaseIntegration superclass

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -10,6 +10,7 @@
 #import "SentryViewHierarchy.h"
 #import <SentryDependencyContainer.h>
 #import <SentryFramesTracker.h>
+#import <SentryOptions.h>
 #import <SentryScreenshot.h>
 
 @implementation PrivateSentrySDKOnly

--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import "SentryIntegrationProtocol.h"
 #import "SentrySpanProtocol.h"
 
 @class SentryEvent, SentryClient, SentryScope, SentryUser, SentryBreadcrumb, SentryId,

--- a/Sources/Sentry/Public/SentryIntegrationProtocol.h
+++ b/Sources/Sentry/Public/SentryIntegrationProtocol.h
@@ -1,14 +1,14 @@
+#import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
-#import "SentryDefines.h"
-#import "SentryOptions.h"
+@class SentryOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol SentryIntegrationProtocol <NSObject>
 
 /**
- * Installs the integration and returns YES if successful.
+ * Installs the integration and returns @c YES if successful.
  */
 - (BOOL)installWithOptions:(SentryOptions *)options;
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -1,4 +1,5 @@
 #import "SentryHub.h"
+#import "SentryBaseIntegration.h"
 #import "SentryClient+Private.h"
 #import "SentryCrashWrapper.h"
 #import "SentryCurrentDateProvider.h"
@@ -36,7 +37,7 @@ SentryHub ()
 @property (nonatomic, strong) SentryTracesSampler *tracesSampler;
 @property (nonatomic, strong) SentryProfilesSampler *profilesSampler;
 @property (nonatomic, strong) id<SentryCurrentDateProvider> currentDateProvider;
-@property (nonatomic, strong) NSMutableArray<id<SentryIntegrationProtocol>> *installedIntegrations;
+@property (nonatomic, strong) NSMutableArray<SentryBaseIntegration *> *installedIntegrations;
 @property (nonatomic, strong) NSMutableSet<NSString *> *installedIntegrationNames;
 @property (nonatomic) NSUInteger errorsBeforeSession;
 
@@ -519,7 +520,7 @@ SentryHub ()
 - (BOOL)isIntegrationInstalled:(Class)integrationClass
 {
     @synchronized(_integrationsLock) {
-        for (id<SentryIntegrationProtocol> item in _installedIntegrations) {
+        for (SentryBaseIntegration *item in _installedIntegrations) {
             if ([item isKindOfClass:integrationClass]) {
                 return YES;
             }
@@ -537,7 +538,7 @@ SentryHub ()
     }
 }
 
-- (void)addInstalledIntegration:(id<SentryIntegrationProtocol>)integration name:(NSString *)name
+- (void)addInstalledIntegration:(SentryBaseIntegration *)integration name:(NSString *)name
 {
     @synchronized(_integrationsLock) {
         [_installedIntegrations addObject:integration];
@@ -553,7 +554,7 @@ SentryHub ()
     }
 }
 
-- (NSArray<id<SentryIntegrationProtocol>> *)installedIntegrations
+- (NSArray<SentryBaseIntegration *> *)installedIntegrations
 {
     @synchronized(_integrationsLock) {
         return _installedIntegrations.copy;

--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -7,6 +7,7 @@
 #import "SentryHub.h"
 #import "SentryLog.h"
 #import "SentryMeta.h"
+#import "SentryOptions.h"
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -10,6 +10,7 @@
 #import "SentryLog.h"
 #import "SentryMechanism.h"
 #import "SentryNoOpSpan.h"
+#import "SentryOptions.h"
 #import "SentryRequest.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope+Private.h"

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -22,6 +22,7 @@
 #    import "SentryMetricProfiler.h"
 #    import "SentryNSProcessInfoWrapper.h"
 #    import "SentryNSTimerWrapper.h"
+#    import "SentryOptions.h"
 #    import "SentryProfileTimeseries.h"
 #    import "SentrySamplingProfiler.hpp"
 #    import "SentryScope+Private.h"

--- a/Sources/Sentry/SentryRequestOperation.m
+++ b/Sources/Sentry/SentryRequestOperation.m
@@ -3,6 +3,7 @@
 #import "SentryError.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
+#import "SentryOptions.h"
 #import "SentrySDK+Private.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -381,7 +381,7 @@ static NSUInteger startInvocations;
     SentryHub *hub = SentrySDK.currentHub;
 
     // Uninstall all the integrations
-    for (NSObject<SentryIntegrationProtocol> *integration in hub.installedIntegrations) {
+    for (SentryBaseIntegration *integration in hub.installedIntegrations) {
         if ([integration respondsToSelector:@selector(uninstall)]) {
             [integration uninstall];
         }

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -351,7 +351,8 @@ static NSUInteger startInvocations;
                 integrationName);
             continue;
         }
-        SentryBaseIntegration *integrationInstance = [[integrationClass alloc] init];
+        SentryBaseIntegration *integrationInstance = [integrationClass alloc];
+        integrationInstance = [integrationInstance init];
         BOOL shouldInstall = [integrationInstance installWithOptions:options];
 
         if (shouldInstall) {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -2,6 +2,7 @@
 #import "PrivateSentrySDKOnly.h"
 #import "SentryAppStartMeasurement.h"
 #import "SentryAppStateManager.h"
+#import "SentryBaseIntegration.h"
 #import "SentryBreadcrumb.h"
 #import "SentryClient+Private.h"
 #import "SentryCrash.h"
@@ -350,7 +351,7 @@ static NSUInteger startInvocations;
                 integrationName);
             continue;
         }
-        id<SentryIntegrationProtocol> integrationInstance = [[integrationClass alloc] init];
+        SentryBaseIntegration *integrationInstance = [[integrationClass alloc] init];
         BOOL shouldInstall = [integrationInstance installWithOptions:options];
 
         if (shouldInstall) {

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -6,6 +6,7 @@
 #import "SentryInternalNotificationNames.h"
 #import "SentryLog.h"
 #import "SentryNSNotificationCenterWrapper.h"
+#import "SentryOptions.h"
 #import "SentrySDK+Private.h"
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -2,6 +2,7 @@
 #import "SentryFramesTracker.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
+#import "SentryOptions.h"
 #import "SentryPerformanceTracker.h"
 #import "SentrySDK+Private.h"
 #import "SentryScope.h"

--- a/Sources/Sentry/include/SentryANRTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryANRTrackingIntegration.h
@@ -1,12 +1,10 @@
 #import "SentryANRTracker.h"
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryANRTrackingIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerDelegate>
+@interface SentryANRTrackingIntegration : SentryBaseIntegration <SentryANRTrackerDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentryAppStartTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAppStartTrackingIntegration.h
@@ -1,5 +1,4 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -7,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Tracks cold and warm app start time for iOS, tvOS, and Mac Catalyst.
  */
-@interface SentryAppStartTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryAppStartTrackingIntegration : SentryBaseIntegration
 
 - (void)stop;
 

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,6 +1,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentryBreadcrumbDelegate.h"
-#import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This automatically adds breadcrumbs for different user actions.
  */
 @interface SentryAutoBreadcrumbTrackingIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryBreadcrumbDelegate>
+    : SentryBaseIntegration <SentryBreadcrumbDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
@@ -1,5 +1,4 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -7,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Automatically tracks session start and end.
  */
-@interface SentryAutoSessionTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryAutoSessionTrackingIntegration : SentryBaseIntegration
 
 - (void)stop;
 

--- a/Sources/Sentry/include/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/SentryBaseIntegration.h
@@ -1,3 +1,4 @@
+#import "SentryIntegrationProtocol.h"
 #import "SentryOptions.h"
 #import <Foundation/Foundation.h>
 
@@ -25,7 +26,7 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
     kIntegrationOptionEnableMetricKit = 1 << 17,
 };
 
-@interface SentryBaseIntegration : NSObject
+@interface SentryBaseIntegration : NSObject <SentryIntegrationProtocol>
 
 - (NSString *)integrationName;
 - (BOOL)installWithOptions:(SentryOptions *)options;

--- a/Sources/Sentry/include/SentryCoreDataTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryCoreDataTrackingIntegration.h
@@ -1,9 +1,8 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryCoreDataTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryCoreDataTrackingIntegration : SentryBaseIntegration
 
 @end
 

--- a/Sources/Sentry/include/SentryCrashIntegration.h
+++ b/Sources/Sentry/include/SentryCrashIntegration.h
@@ -1,5 +1,4 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -9,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const SentryDeviceContextFreeMemoryKey = @"free_memory";
 static NSString *const SentryDeviceContextAppMemoryKey = @"app_memory";
 
-@interface SentryCrashIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryCrashIntegration : SentryBaseIntegration
 
 + (void)enrichScope:(SentryScope *)scope crashWrapper:(SentryCrashWrapper *)crashWrapper;
 

--- a/Sources/Sentry/include/SentryFileIOTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryFileIOTrackingIntegration.h
@@ -1,9 +1,8 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryFileIOTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryFileIOTrackingIntegration : SentryBaseIntegration
 
 @end
 

--- a/Sources/Sentry/include/SentryFramesTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryFramesTrackingIntegration.h
@@ -1,10 +1,9 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryFramesTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryFramesTrackingIntegration : SentryBaseIntegration
 
 - (void)stop;
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -2,17 +2,17 @@
 #import "SentryTracer.h"
 
 @class SentryEnvelopeItem, SentryId, SentryScope, SentryTransaction, SentryDispatchQueueWrapper,
-    SentryEnvelope, SentryNSTimerWrapper;
+    SentryEnvelope, SentryNSTimerWrapper, SentryBaseIntegration;
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
 SentryHub (Private)
 
-@property (nonatomic, strong) NSArray<id<SentryIntegrationProtocol>> *installedIntegrations;
+@property (nonatomic, strong) NSArray<SentryBaseIntegration *> *installedIntegrations;
 @property (nonatomic, strong) NSSet<NSString *> *installedIntegrationNames;
 
-- (void)addInstalledIntegration:(id<SentryIntegrationProtocol>)integration name:(NSString *)name;
+- (void)addInstalledIntegration:(SentryBaseIntegration *)integration name:(NSString *)name;
 - (void)removeAllIntegrations;
 
 - (SentryClient *_Nullable)client;

--- a/Sources/Sentry/include/SentryMetricKitIntegration.h
+++ b/Sources/Sentry/include/SentryMetricKitIntegration.h
@@ -1,6 +1,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentryEvent.h"
-#import "SentryIntegrationProtocol.h"
 #import "SentrySwift.h"
 #import <Foundation/Foundation.h>
 
@@ -19,8 +18,7 @@ static NSString *const SentryMetricKitHangDiagnosticMechanism = @"mx_hang_diagno
 
 API_AVAILABLE(ios(15.0), macos(12.0), macCatalyst(15.0))
 API_UNAVAILABLE(tvos, watchos)
-@interface SentryMetricKitIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryMXManagerDelegate>
+@interface SentryMetricKitIntegration : SentryBaseIntegration <SentryMXManagerDelegate>
 
 @end
 

--- a/Sources/Sentry/include/SentryNetworkTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryNetworkTrackingIntegration.h
@@ -1,9 +1,8 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryNetworkTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryNetworkTrackingIntegration : SentryBaseIntegration
 
 @end
 

--- a/Sources/Sentry/include/SentryPerformanceTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryPerformanceTrackingIntegration.h
@@ -1,5 +1,4 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -9,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Automatic UI performance setup can be avoided by setting @c enableAutoPerformanceTracing to @c NO
  * in @c SentryOptions during SentrySDK initialization.
  */
-@interface SentryPerformanceTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryPerformanceTrackingIntegration : SentryBaseIntegration
 
 @end
 

--- a/Sources/Sentry/include/SentryScreenshotIntegration.h
+++ b/Sources/Sentry/include/SentryScreenshotIntegration.h
@@ -1,14 +1,12 @@
 #import "SentryBaseIntegration.h"
 #import "SentryClient+Private.h"
-#import "SentryIntegrationProtocol.h"
 #import "SentryScreenshot.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT
 
-@interface SentryScreenshotIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryClientAttachmentProcessor>
+@interface SentryScreenshotIntegration : SentryBaseIntegration <SentryClientAttachmentProcessor>
 
 @end
 

--- a/Sources/Sentry/include/SentryUIEventTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryUIEventTrackingIntegration.h
@@ -1,10 +1,9 @@
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT
-@interface SentryUIEventTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentryUIEventTrackingIntegration : SentryBaseIntegration
 
 @end
 #endif

--- a/Sources/Sentry/include/SentryViewHierarchyIntegration.h
+++ b/Sources/Sentry/include/SentryViewHierarchyIntegration.h
@@ -1,13 +1,11 @@
 #import "SentryBaseIntegration.h"
 #import "SentryClient+Private.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT
 
-@interface SentryViewHierarchyIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryClientAttachmentProcessor>
+@interface SentryViewHierarchyIntegration : SentryBaseIntegration <SentryClientAttachmentProcessor>
 
 @end
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
@@ -1,12 +1,11 @@
 #import "SentryANRTracker.h"
 #import "SentryBaseIntegration.h"
-#import "SentryIntegrationProtocol.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryWatchdogTerminationTrackingIntegration
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerDelegate>
+    : SentryBaseIntegration <SentryANRTrackerDelegate>
 
 @end
 

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryTestIntegration.h
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryTestIntegration.h
@@ -1,11 +1,11 @@
-#import "SentryIntegrationProtocol.h"
+#import "SentryBaseIntegration.h"
 #import <Foundation/Foundation.h>
 
 @class SentryOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryTestIntegration : NSObject <SentryIntegrationProtocol>
+@interface SentryTestIntegration : SentryBaseIntegration
 
 @property (nonatomic, strong) SentryOptions *options;
 

--- a/Tests/SentryTests/TestUtils/EmptyIntegration.swift
+++ b/Tests/SentryTests/TestUtils/EmptyIntegration.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-class EmptyIntegration: NSObject, SentryIntegrationProtocol {
-    func install(with options: Options) -> Bool {
+class EmptyIntegration: SentryBaseIntegration {
+    override func install(with options: Options) -> Bool {
         return true
     }
 }


### PR DESCRIPTION
I am working on converting SentryCrashWrapper from a singleton to fully dependency-injected (#2942). This involves changing SentryBaseIntegration.init to accept it as an argument, since it needs to use it in its implementation.

I noticed that all of our integration classes both subclass SentryBaseIntegration and conform to SentryIntegrationProtocol at their declarations. I lifted the protocol conformance declaration out of the subclasses and to the superclass, where it applies to any future subclass for free.

I also converted all the generic `id<SentryIntegrationProtocol>` to polymorphic declarations of `SentryBaseIntegration *` instead, like in array types. It would only really make sense to use the type-erased version if customers are able to create their own integrations conforming to `SentryIntegrationProtocol`, but as far as I can tell we don't support that kind of plug-in architecture. **Let me know if I've missed anything here and am wrong about this.**

Finally, I changed the implicit header import of SentryOptions from SentryIntegrationProtocol.h to a forward class declaration, and added the necessary missing imports of SentryOptions in the necessary places.

#skip-changelog