### PR TITLE
ci: set a path filter for codeql-analyze

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches:
+      - main
+      - release/**
     paths:
       - 'Sources/**'
       - '.github/workflows/codeql-analysis.yml'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
           -workspace Sentry.xcworkspace
           -scheme Sentry
           -configuration Release
-          -destination platform="iOS Simulator,OS=latest,name=iPhone 11 Pro"
+          -destination platform="iOS Simulator,OS=latest,name=iPhone 11 Pro" | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@7df0ce34898d659f95c0c4a09eaa8d4e32ee64db # pin@v2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches:
       - main
-      - release/**
     paths:
       - 'Sources/**'
       - '.github/workflows/codeql-analysis.yml'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'Sources/**'
-      - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '40 4 * * 6'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths:
+      - 'Sources/**'
+      - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '40 4 * * 6'
 


### PR DESCRIPTION
There's a warning in the codeql-analyze job because we have a pull_request trigger with no arguments. It still draws a notification on the job even though it passes, which is distracting.

![Screenshot 2023-04-21 at 4 15 37 PM](https://user-images.githubusercontent.com/3241469/233751482-6b2cd0ec-b36f-4861-b921-a6a77ef608ac.png)
![Screenshot 2023-04-21 at 4 15 28 PM](https://user-images.githubusercontent.com/3241469/233751486-7c19fd6e-0ce0-43a1-ae9f-76e1337b9a3c.png)


#skip-changelog