### PR TITLE
fix: symbolicate on mobile device always fail

### DIFF
--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
@@ -247,8 +247,15 @@ sentrycrashdl_dladdr(const uintptr_t address, Dl_info *const info)
                     uintptr_t symbolBase = symbolTable[iSym].n_value;
                     uintptr_t currentDistance = addressWithSlide - symbolBase;
                     if ((addressWithSlide >= symbolBase) && (currentDistance <= bestDistance)) {
-                        bestMatch = symbolTable + iSym;
-                        bestDistance = currentDistance;
+                        /*
+                        At runtime symbol table may have duplicate elements, all the value of these elments duplicate except n_un.n_strx
+                        Some of these elements whose name was empty (n_un.n_strx was 1) is not the symbol we want
+                        */
+                        char *symbol_name = (char *)((intptr_t)stringTable + (intptr_t)symbolTable[iSym].n_un.n_strx);
+                        if (strlen(symbol_name) > 0) {
+                            bestMatch = symbolTable + iSym;
+                            bestDistance = currentDistance;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## :scroll: Description
i find address symbolicate on mobile device always fail, so i debug the code , i find At runtime symbol table may have more than one element match the target address, elements whose n_strx is 1 was not the symbol we want, because it's name was empty, os ignore them , this change can fix the problem
## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

while crash occur, sentry upload the raw crash log, it's stack trace frame function content whether is empty
## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
