### PR TITLE
chore: Add high risk files check to pre commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,11 @@ repos:
         types_or: ["swift" ]
         args:
           - "format-swift"
+
+      - id: no-changes-in-high-risk-files
+        name: No Changes in High Risk Files
+        entry: make
+        language: system
+        types_or: ["swift","objective-c", "objective-c++", "c", "c++"]
+        args:
+          - "no-changes-in-high-risk-files"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,10 @@ lint:
 	swiftlint
 .PHONY: lint
 
+no-changes-in-high-risk-files:
+	@echo "--> Checking if there are changes in high risk files"
+	./scripts/no-changes-in-high-risk-files.sh
+
 format: format-clang format-swift
 
 # Format ObjC, ObjC++, C, and C++


### PR DESCRIPTION
Add validating no changes in high-risk files to the pre-commit hook.

#skip-changelog