### PR TITLE
feat: Swift error names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Features
 
+- Swift Error Names (#2958)
+
+Instead of only the Swift error name and error code, the SDK now sends the Swift error name for enum-based errors.
+
+```Swift
+enum LoginError: Error {
+    case wrongUser
+    case wrongPassword
+}
+
+SentrySDK.capture(error: LoginError.wrongPassword)
+```
+
+Capturing the above Swift error will now result in the following error message in Sentry: `wrongPassword (Code: 1)` instead of only `(Code: 1)`.
+[Customized error descriptions](https://docs.sentry.io/platforms/apple/usage/#customizing-error-descriptions) have precedence over this feature.
+To avoid sending PII by accident, the SDK doesn't send the Swift error name for struct-based Swift errors, and the SDK drops the values of enums.
+
 - Create User and Breadcrumb from map (#2820)
 
 ### Fixes 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ SentrySDK.capture(error: LoginError.wrongPassword)
 Capturing the above Swift error will now result in the following error message in Sentry: `wrongPassword (Code: 1)` instead of only `(Code: 1)`.
 [Customized error descriptions](https://docs.sentry.io/platforms/apple/usage/#customizing-error-descriptions) have precedence over this feature.
 To avoid sending PII by accident, the SDK doesn't send the Swift error name for struct-based Swift errors, and the SDK drops the values of enums.
+This change has no impact on grouping of the issues in Sentry.
 
 - Create User and Breadcrumb from map (#2820)
 

--- a/Samples/iOS-Swift/iOS-Swift/Tools/RandomErrors.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/RandomErrors.swift
@@ -6,23 +6,6 @@ enum SampleError: Error {
     case awesomeCentaur
 }
 
-extension SampleError: CustomNSError {
-    var errorUserInfo: [String: Any] {
-        func getDebugDescription() -> String {
-            switch self {
-            case SampleError.bestDeveloper:
-                return  "bestDeveloper"
-            case .happyCustomer:
-                return  "happyCustomer"
-            case .awesomeCentaur:
-                return "awesomeCentaur"
-            }
-        }
-        
-        return [NSDebugDescriptionErrorKey: getDebugDescription()]
-    }
-}
-
 class RandomErrorGenerator {
     
     static func generate() throws {

--- a/Sources/Swift/SwiftDescriptor.swift
+++ b/Sources/Swift/SwiftDescriptor.swift
@@ -8,4 +8,20 @@ public class SwiftDescriptor: NSObject {
         return String(describing: type(of: object))
     }
     
+    @objc
+    public static func getSwiftErrorDescription(_ error: Error) -> String? {
+        let description = String(describing: error)
+        
+        // We can't reliably detect what is PII in a struct and what is not.
+        // Furthermore, we can't detect which property contains the error enum.
+        if description.contains(":") || description.contains(",") {
+            return nil
+        }
+        
+        // For error enums the description could contain PII in between (). Therefore,
+        // we strip the data.
+        let index = description.firstIndex(of: "(") ?? description.endIndex
+        return String(description[..<index])
+    }
+    
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -415,7 +415,7 @@ class SentryClientTest: XCTestCase {
         eventId.assertIsNotEmpty()
         let error = TestError.invalidTest as NSError
         assertLastSentEvent { actual in
-            assertValidErrorEvent(actual, error)
+            assertValidErrorEvent(actual, error, exceptionValue: "invalidTest (Code: 0)")
         }
     }
 
@@ -451,6 +451,63 @@ class SentryClientTest: XCTestCase {
             do {
                 let exceptions = try XCTUnwrap(actual.exceptions)
                 XCTAssertEqual("Code: 999", try XCTUnwrap(exceptions.first).value)
+            } catch {
+                XCTFail("Exception expected but was nil")
+            }
+        }
+    }
+    
+    func testCaptureSwiftError_UsesSwiftStringDescription() {
+        let eventId = fixture.getSut().capture(error: SentryClientError.someError)
+
+        eventId.assertIsNotEmpty()
+        assertLastSentEvent { actual in
+            do {
+                let exceptions = try XCTUnwrap(actual.exceptions)
+                XCTAssertEqual("someError (Code: 1)", try XCTUnwrap(exceptions.first).value)
+            } catch {
+                XCTFail("Exception expected but was nil")
+            }
+        }
+    }
+    
+    func testCaptureSwiftErrorStruct_DoesNotUseDescriptionToAvoidPII() {
+        let eventId = fixture.getSut().capture(error: XMLParsingError(line: 10, column: 12, kind: .internalError))
+
+        eventId.assertIsNotEmpty()
+        assertLastSentEvent { actual in
+            do {
+                let exceptions = try XCTUnwrap(actual.exceptions)
+                XCTAssertEqual("Code: 1", try XCTUnwrap(exceptions.first).value)
+            } catch {
+                XCTFail("Exception expected but was nil")
+            }
+        }
+    }
+    
+    func testCaptureSwiftErrorWithData_UsesSwiftStringDescriptionStripped() {
+        let eventId = fixture.getSut().capture(error: SentryClientError.invalidInput("hello"))
+
+        eventId.assertIsNotEmpty()
+        assertLastSentEvent { actual in
+            do {
+                let exceptions = try XCTUnwrap(actual.exceptions)
+                XCTAssertEqual("invalidInput (Code: 0)", try XCTUnwrap(exceptions.first).value)
+            } catch {
+                XCTFail("Exception expected but was nil")
+            }
+        }
+    }
+    
+    func testCaptureSwiftErrorWithDebugDescription_UsesDebugDescription() {
+        
+        let eventId = fixture.getSut().capture(error: SentryClientErrorWithDebugDescription.someError)
+
+        eventId.assertIsNotEmpty()
+        assertLastSentEvent { actual in
+            do {
+                let exceptions = try XCTUnwrap(actual.exceptions)
+                XCTAssertEqual("anotherError (Code: 0)", try XCTUnwrap(exceptions.first).value)
             } catch {
                 XCTFail("Exception expected but was nil")
             }
@@ -1464,7 +1521,7 @@ class SentryClientTest: XCTestCase {
         }
     }
     
-    private func assertValidErrorEvent(_ event: Event, _ error: NSError) {
+    private func assertValidErrorEvent(_ event: Event, _ error: NSError, exceptionValue: String? = nil) {
         XCTAssertEqual(SentryLevel.error, event.level)
         XCTAssertEqual(error, event.error as NSError?)
         
@@ -1475,7 +1532,7 @@ class SentryClientTest: XCTestCase {
         let exception = exceptions[0]
         XCTAssertEqual(error.domain, exception.type)
         
-        XCTAssertEqual("Code: \(error.code)", exception.value)
+        XCTAssertEqual(exceptionValue ?? "Code: \(error.code)", exception.value)
         
         XCTAssertNil(exception.threadId)
         XCTAssertNil(exception.stacktrace)
@@ -1563,6 +1620,28 @@ class SentryClientTest: XCTestCase {
         }
     }
     
+}
+
+enum SentryClientError: Error {
+    case someError
+    case invalidInput(String)
+}
+
+enum SentryClientErrorWithDebugDescription: Error {
+    case someError
+}
+
+extension SentryClientErrorWithDebugDescription: CustomNSError {
+    var errorUserInfo: [String: Any] {
+        func getDebugDescription() -> String {
+            switch self {
+            case .someError:
+                return  "anotherError"
+            }
+        }
+
+        return [NSDebugDescriptionErrorKey: getDebugDescription()]
+    }
 }
 
 // swiftlint:enable file_length

--- a/Tests/SentryTests/SwiftDescriptorTests.swift
+++ b/Tests/SentryTests/SwiftDescriptorTests.swift
@@ -28,7 +28,61 @@ class SwiftDescriptorTests: XCTestCase {
         XCTAssertEqual(name, "InnerClass")
     }
     
+    func testgetSwiftErrorDescription_EnumValue() {
+        let actual = SwiftDescriptor.getSwiftErrorDescription(SentryTestError.someError)
+        XCTAssertEqual("someError", actual)
+    }
+    
+    func testgetSwiftErrorDescription_EnumValueWithData() {
+        let actual = SwiftDescriptor.getSwiftErrorDescription(SentryTestError.someOhterError(10))
+        XCTAssertEqual("someOhterError", actual)
+    }
+    
+    func testgetSwiftErrorDescription_StructWithData() {
+        let actual = SwiftDescriptor.getSwiftErrorDescription(XMLParsingError(line: 10, column: 12, kind: .internalError))
+        XCTAssertNil(actual)
+        
+        SentrySDK.capture(error: LoginError.wrongPassword)
+    }
+    
+    func testgetSwiftErrorDescription_StructWithOneParam() {
+        let actual = SwiftDescriptor.getSwiftErrorDescription(StructWithOneParam(line: 10))
+        XCTAssertNil(actual)
+    }
+    
     private func sanitize(_ name: AnyObject) -> String {
         return SwiftDescriptor.getObjectClassName(name)
     }
+}
+
+enum SentryTestError: Error {
+    case someError
+    case someOhterError(Int)
+}
+
+enum LoginError: Error {
+    case wrongUser
+    case wrongPassword
+}
+
+struct XMLParsingError: Error {
+    enum ErrorKind {
+        case invalidCharacter
+        case mismatchedTag
+        case internalError
+    }
+
+    let line: Int
+    let column: Int
+    let kind: ErrorKind
+}
+
+struct StructWithOneParam: Error {
+    enum ErrorKind {
+        case invalidCharacter
+        case mismatchedTag
+        case internalError
+    }
+
+    let line: Int
 }


### PR DESCRIPTION




## :scroll: Description

Call into Swift to get the error description for Swift errors to get meaningful error names instead of only the error enum code. To avoid sending PII, the SDK strips parameter values and doesn't send the Swift error name for struct-based Swift errors.
This change has no impact on grouping.

I'm unsure about my data stripping approach in `SwiftDescriptor.getSwiftErrorDescription` to avoid sending PII. Maybe it's also OK to just attach the description. On the other hand, I feel safer changing that behavior in the next major.

## :bulb: Motivation and Context

Fixes GH-2958

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
