### PR TITLE
ref: Delete envelopes folder instead of files

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -217,9 +217,8 @@ SentryFileManager ()
 
 - (void)deleteAllEnvelopes
 {
-    for (NSString *path in [self allFilesInFolder:self.envelopesPath]) {
-        [self removeFileAtPath:[self.envelopesPath stringByAppendingPathComponent:path]];
-    }
+    [self removeFileAtPath:self.envelopesPath];
+    [self createDirectoryIfNotExists:self.envelopesPath error:nil];
 }
 
 - (NSArray<NSString *> *)allFilesInFolder:(NSString *)path

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -218,7 +218,10 @@ SentryFileManager ()
 - (void)deleteAllEnvelopes
 {
     [self removeFileAtPath:self.envelopesPath];
-    [self createDirectoryIfNotExists:self.envelopesPath error:nil];
+    NSError *error;
+    if (![self createDirectoryIfNotExists:self.envelopesPath error:&error]) {
+        SENTRY_LOG_ERROR(@"Couldn't create envelopes path.");
+    }
 }
 
 - (NSArray<NSString *> *)allFilesInFolder:(NSString *)path

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -46,7 +46,11 @@ SENTRY_NO_INIT
 
 + (BOOL)createDirectoryAtPath:(NSString *)path withError:(NSError **)error;
 
+/**
+ * Only used for teting.
+ */
 - (void)deleteAllEnvelopes;
+
 - (void)deleteAllFolders;
 
 - (void)deleteOldEnvelopeItems;


### PR DESCRIPTION
Instead of deleting all the envelope items individually, delete the folder containing the envelope items to minimize the acquisition of locks. This change should speed up tests but has no performance impact on the SDK, as we use deleteAllEnvelopes only for tests.

#skip-changelog