### PR TITLE
ref: Move storeData into storeEnvelope

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches:
+      - main
   schedule:
     - cron: '40 4 * * 6'
 
@@ -32,7 +34,7 @@ jobs:
           -workspace Sentry.xcworkspace
           -scheme Sentry
           -configuration Release
-          -destination platform="iOS Simulator,OS=latest,name=iPhone 11 Pro"
+          -destination platform="iOS Simulator,OS=latest,name=iPhone 11 Pro" | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@b2c19fb9a2a485599ccf4ed5d65527d94bc57226 # pin@v2


### PR DESCRIPTION
The storeData method was only used by storeEnvelope. Both methods used @synchronized. Now the storeData is moved into storeEnvelope and only one invocation of @ synchronized is needed.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/2965.

#skip-changelog