### PR TITLE
test: Set log level to error for spammy tests

### DIFF
--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -129,6 +129,9 @@ class SentryHubTests: XCTestCase {
     }
     
     func testBreadcrumbCapLimit() {
+        // To avoid spamming the test logs
+        SentryLog.configure(true, diagnosticLevel: .error)
+        
         let hub = fixture.getSut()
 
         for _ in 0...100 {
@@ -136,6 +139,8 @@ class SentryHubTests: XCTestCase {
         }
 
         assert(withScopeBreadcrumbsCount: 100, with: hub)
+        
+        setTestDefaultLogLevel()
     }
     
     func testBreadcrumbOverDefaultLimit() {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -1,3 +1,4 @@
+import SentryTestUtils
 import XCTest
 
 class SentryScopeSwiftTests: XCTestCase {
@@ -305,12 +306,17 @@ class SentryScopeSwiftTests: XCTestCase {
     }
     
     func testPeformanceOfSyncToSentryCrash() {
+        // To avoid spamming the test logs
+        SentryLog.configure(true, diagnosticLevel: .error)
+        
         let scope = fixture.scope
         scope.add(SentryCrashScopeObserver(maxBreadcrumbs: 100))
         
         self.measure {
             modifyScope(scope: scope)
         }
+        
+        setTestDefaultLogLevel()
     }
     
     func testPeformanceOfSyncToSentryCrash_OneCrumb() {


### PR DESCRIPTION
Set log level to error for testPeformanceOfSyncToSentryCrash and testBreadcrumbCapLimit to avoid spamming the raw test logs.

#skip-changelog