### PR TITLE
chore: Removing SentryFrameTracker atomic operation

### DIFF
--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -211,7 +211,9 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
                                frozenFrameTimestamps:self.frozenFrameTimestamps
                                  frameRateTimestamps:self.frameRateTimestamps];
 #    else
-    return [[SentryScreenFrames alloc] initWithTotal:_totalFrames frozen:_frozenFrames slow:_slowFrames];
+    return [[SentryScreenFrames alloc] initWithTotal:_totalFrames
+                                              frozen:_frozenFrames
+                                                slow:_slowFrames];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -203,19 +203,15 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
 - (SentryScreenFrames *)currentFrames
 {
-    NSUInteger total = _totalFrames;
-    NSUInteger slow = _slowFrames;
-    NSUInteger frozen = _frozenFrames;
-
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-    return [[SentryScreenFrames alloc] initWithTotal:total
-                                              frozen:frozen
-                                                slow:slow
+    return [[SentryScreenFrames alloc] initWithTotal:_totalFrames
+                                              frozen:_frozenFrames
+                                                slow:_slowFrames
                                  slowFrameTimestamps:self.slowFrameTimestamps
                                frozenFrameTimestamps:self.frozenFrameTimestamps
                                  frameRateTimestamps:self.frameRateTimestamps];
 #    else
-    return [[SentryScreenFrames alloc] initWithTotal:total frozen:frozen slow:slow];
+    return [[SentryScreenFrames alloc] initWithTotal:_totalFrames frozen:_frozenFrames slow:_slowFrames];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -21,12 +21,6 @@ typedef NSMutableArray<NSDictionary<NSString *, NSNumber *> *> SentryMutableFram
 static CFTimeInterval const SentryFrozenFrameThreshold = 0.7;
 static CFTimeInterval const SentryPreviousFrameInitialValue = -1;
 
-/**
- * Relaxed memoring ordering is typical for incrementing counters. This operation only requires
- * atomicity but not ordering or synchronization.
- */
-static memory_order const SentryFramesMemoryOrder = memory_order_relaxed;
-
 @interface
 SentryFramesTracker ()
 
@@ -51,14 +45,9 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 }
 
 @implementation SentryFramesTracker {
-
-    /**
-     * With 32 bit we can track frames with 120 fps for around 414 days (2^32 / (120* 60 * 60 *
-     * 24)).
-     */
-    atomic_uint_fast32_t _totalFrames;
-    atomic_uint_fast32_t _slowFrames;
-    atomic_uint_fast32_t _frozenFrames;
+    unsigned int _totalFrames;
+    unsigned int _slowFrames;
+    unsigned int _frozenFrames;
 }
 
 + (instancetype)sharedInstance
@@ -93,9 +82,9 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 /** Internal for testing */
 - (void)resetFrames
 {
-    atomic_store_explicit(&_totalFrames, 0, SentryFramesMemoryOrder);
-    atomic_store_explicit(&_frozenFrames, 0, SentryFramesMemoryOrder);
-    atomic_store_explicit(&_slowFrames, 0, SentryFramesMemoryOrder);
+    _totalFrames = 0;
+    _frozenFrames = 0;
+    _slowFrames = 0;
 
     self.previousFrameTimestamp = SentryPreviousFrameInitialValue;
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -165,7 +154,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
     if (frameDuration > slowFrameThreshold(currentFrameRate)
         && frameDuration <= SentryFrozenFrameThreshold) {
-        atomic_fetch_add_explicit(&_slowFrames, 1, SentryFramesMemoryOrder);
+        _slowFrames++;
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
         SENTRY_LOG_DEBUG(@"Capturing slow frame starting at %llu.", thisFrameSystemTimestamp);
         [self recordTimestamp:thisFrameSystemTimestamp
@@ -173,7 +162,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
                         array:self.slowFrameTimestamps];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
     } else if (frameDuration > SentryFrozenFrameThreshold) {
-        atomic_fetch_add_explicit(&_frozenFrames, 1, SentryFramesMemoryOrder);
+        _frozenFrames++;
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
         SENTRY_LOG_DEBUG(@"Capturing frozen frame starting at %llu.", thisFrameSystemTimestamp);
         [self recordTimestamp:thisFrameSystemTimestamp
@@ -181,8 +170,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
                         array:self.frozenFrameTimestamps];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
-
-    atomic_fetch_add_explicit(&_totalFrames, 1, SentryFramesMemoryOrder);
+    _totalFrames++;
     self.previousFrameTimestamp = thisFrameTimestamp;
     self.previousFrameSystemTimestamp = thisFrameSystemTimestamp;
     [self reportNewFrame];
@@ -215,9 +203,9 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
 - (SentryScreenFrames *)currentFrames
 {
-    NSUInteger total = atomic_load_explicit(&_totalFrames, SentryFramesMemoryOrder);
-    NSUInteger slow = atomic_load_explicit(&_slowFrames, SentryFramesMemoryOrder);
-    NSUInteger frozen = atomic_load_explicit(&_frozenFrames, SentryFramesMemoryOrder);
+    NSUInteger total = _totalFrames;
+    NSUInteger slow = _slowFrames;
+    NSUInteger frozen = _frozenFrames;
 
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
     return [[SentryScreenFrames alloc] initWithTotal:total


### PR DESCRIPTION
SentryFrameTracker makes uses of CADisplayLink to increment the number of slow and frozen frames.
CADisplayLink only uses the main thread, we dont need to worry about a variable increment discrepancy. 

This also removes the slowest Test in our CI, responsible for almost 15% of unit test time alone.

_#skip-changelog_