### PR TITLE
Breaking: Remove stitchAsyncCode from SentryOption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@
 - Possible crash in Core Data tracking (#2865)
 - Ensure the current GPU frame rate is always reported for concurrent transaction profiling metrics (#2929)
 
+### Breaking Changes
+
+- Remove `stitchAsyncCode` from SentryOption
+
+The stitchAsyncCode option has been removed from the codebase as it was not behaving in a consistent way. Its behavior was unpredictable and resulted in unexpected errors.
+
+
 ## 8.5.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@
 
 - Remove `stitchAsyncCode` from SentryOption
 
-The stitchAsyncCode option has been removed from the codebase as it was not behaving in a consistent way. Its behavior was unpredictable and resulted in unexpected errors.
-
+The `stitchAsyncCode` option has been removed from `SentryOptions` as it was not behaving in a consistent way. Its behavior was unpredictable and resulted in unexpected errors. We plan to add it back once we fix it.
 
 ## 8.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,11 @@
 - Possible crash in Core Data tracking (#2865)
 - Ensure the current GPU frame rate is always reported for concurrent transaction profiling metrics (#2929)
 
-### Breaking Changes
+### Removed
 
-- Remove `stitchAsyncCode` from SentryOption
+- Remove `stitchAsyncCode` from SentryOption (#2973)
 
-The `stitchAsyncCode` option has been removed from `SentryOptions` as it was not behaving in a consistent way. Its behavior was unpredictable and resulted in unexpected errors. We plan to add it back once we fix it.
+The `stitchAsyncCode` experimental option has been removed from `SentryOptions` as it was not behaving in a consistent way. Its behavior was unpredictable and resulted in unexpected errors. We plan to add it back once we fix it.
 
 ## 8.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 - Create User and Breadcrumb from map (#2820)
 
-
 ### Fixes 
 
 - Improved performance serializing profiling data (#2863)

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -163,14 +163,6 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachStacktrace;
 
 /**
- * @warning This is an experimental feature and may still have bugs. Turning this feature on can
- * have an impact on the grouping of your issues.
- * @brief When enabled, the SDK stitches stack traces of asynchronous code together.
- * @note This feature is disabled by default.
- */
-@property (nonatomic, assign) BOOL stitchAsyncCode;
-
-/**
  * The maximum size for each attachment in bytes.
  * @note Default is 20 MiB (20 ✕ 1024 ✕ 1024 bytes).
  * @note Please also check the maximum attachment size of relay to make sure your attachments don't

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -688,10 +688,6 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
             [integrations addObject:trimmed];
         }
 
-        if (self.options.stitchAsyncCode) {
-            [integrations addObject:@"StitchAsyncCode"];
-        }
-
 #if SENTRY_HAS_UIKIT
         if (self.options.enablePreWarmedAppStartTracing) {
             [integrations addObject:@"PreWarmedAppStartTracing"];

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -84,10 +84,6 @@ SentryCrashIntegration ()
 
     [self startCrashHandler];
 
-    if (options.stitchAsyncCode) {
-        [self.crashAdapter installAsyncHooks];
-    }
-
     [self configureScope];
 
     return YES;

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -158,8 +158,6 @@ SentryCrashIntegration ()
         installationToken = 0;
     }
 
-    [self.crashAdapter uninstallAsyncHooks];
-
     [NSNotificationCenter.defaultCenter removeObserver:self
                                                   name:NSCurrentLocaleDidChangeNotification
                                                 object:nil];

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -53,7 +53,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)installAsyncHooks
 {
-    NSAssert(false, @"`installAsyncHooks` should not be called, as its behavior is unpredictable and sometimes resulted in unexpected errors.");
+    NSAssert(false,
+        @"`installAsyncHooks` should not be called, as its behavior is unpredictable and sometimes "
+        @"resulted in unexpected errors.");
     sentrycrash_install_async_hooks();
 }
 

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -53,11 +53,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)installAsyncHooks
 {
+    NSAssert(false, @"`installAsyncHooks` should not be called");
     sentrycrash_install_async_hooks();
 }
 
 - (void)uninstallAsyncHooks
 {
+    NSAssert(false, @"`uninstallAsyncHooks` should not be called");
     sentrycrash_deactivate_async_hooks();
 }
 

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)installAsyncHooks
 {
-    NSAssert(false, @"`installAsyncHooks` should not be called");
+    NSAssert(false, @"`installAsyncHooks` should not be called, as its behavior is unpredictable and sometimes resulted in unexpected errors.");
     sentrycrash_install_async_hooks();
 }
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -70,7 +70,6 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enableWatchdogTerminationTracking = YES;
         self.sessionTrackingIntervalMillis = [@30000 unsignedIntValue];
         self.attachStacktrace = YES;
-        self.stitchAsyncCode = NO;
         self.maxAttachmentSize = 20 * 1024 * 1024;
         self.sendDefaultPii = NO;
         self.enableAutoPerformanceTracing = YES;
@@ -320,9 +319,6 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[@"attachStacktrace"]
             block:^(BOOL value) { self->_attachStacktrace = value; }];
-
-    [self setBool:options[@"stitchAsyncCode"]
-            block:^(BOOL value) { self->_stitchAsyncCode = value; }];
 
     if ([options[@"maxAttachmentSize"] isKindOfClass:[NSNumber class]]) {
         self.maxAttachmentSize = [options[@"maxAttachmentSize"] unsignedIntValue];

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -185,17 +185,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         XCTAssertNil(fileManager.readCurrentSession())
         XCTAssertNil(fileManager.readCrashedSession())
     }
-    
-    func testInstall_WhenStitchAsyncCallsEnabled_CallsInstallAsyncHooks() {
-        let sut = fixture.getSut()
         
-        let options = Options()
-        options.stitchAsyncCode = true
-        sut.install(with: options)
-        
-        XCTAssertTrue(fixture.sentryCrash.installAsyncHooksCalled)
-    }
-    
     func testInstall_WhenStitchAsyncCallsDisabled_DoesNotCallInstallAsyncHooks() {
         fixture.getSut().install(with: Options())
         

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -185,23 +185,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         XCTAssertNil(fileManager.readCurrentSession())
         XCTAssertNil(fileManager.readCrashedSession())
     }
-        
-    func testInstall_WhenStitchAsyncCallsDisabled_DoesNotCallInstallAsyncHooks() {
-        fixture.getSut().install(with: Options())
-        
-        XCTAssertFalse(fixture.sentryCrash.installAsyncHooksCalled)
-    }
-
-    func testUninstall_CallsUninstallAsyncHooks() {
-        let sut = fixture.getSut()
-
-        sut.install(with: Options())
-
-        sut.uninstall()
-
-        XCTAssertTrue(fixture.sentryCrash.uninstallAsyncHooksCalled)
-    }
-    
+            
     func testUninstall_DoesNotUpdateLocale_OnLocaleDidChangeNotification() {
         let (sut, hub) = givenSutWithGlobalHubAndCrashWrapper()
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1133,12 +1133,6 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    func testTrackStitchAsyncCode() {        
-        testFeatureTrackingAsIntegration(integrationName: "StitchAsyncCode") {
-            $0.stitchAsyncCode = true
-        }
-    }
-
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func testTrackPreWarmedAppStartTracking() {
         testFeatureTrackingAsIntegration(integrationName: "PreWarmedAppStartTracing") {

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -67,22 +67,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
-    
-    func testAsyncStacktraces() throws {
-        SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
-            options.stitchAsyncCode = true
-        }
-        
-        let expect = expectation(description: "testAsyncStacktraces")
-
-        fixture.queue.async {
-            self.asyncFrame1(expect: expect)
-        }
-        
-        wait(for: [expect], timeout: 2)
-    }
-    
+     
     func asyncFrame1(expect: XCTestExpectation) {
         fixture.queue.asyncAfter(deadline: DispatchTime.now()) {
             self.asyncFrame2(expect: expect)

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -39,11 +39,6 @@ class SentryThreadInspectorTests: XCTestCase {
         XCTAssertTrue(30 < stacktrace?.frames.count ?? 0, "Not enough stacktrace frames.")
     }
     
-    func testStacktraceHasFrames_forEveryThread_withStitchAsyncOn() {
-        SentrySDK.start { $0.stitchAsyncCode = true }
-        assertStackForEveryThread()
-    }
-    
     func testStacktraceHasFrames_forEveryThread() {
         assertStackForEveryThread()
     }

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -478,11 +478,6 @@
     [self testBooleanField:@"attachStacktrace"];
 }
 
-- (void)testStitchAsyncCodeDisabledPerDefault
-{
-    [self testBooleanField:@"stitchAsyncCode" defaultValue:NO];
-}
-
 - (void)testEnableIOTracking
 {
     [self testBooleanField:@"enableFileIOTracing" defaultValue:YES];
@@ -517,7 +512,6 @@
         @"enableOutOfMemoryTracking" : [NSNull null],
         @"sessionTrackingIntervalMillis" : [NSNull null],
         @"attachStacktrace" : [NSNull null],
-        @"stitchAsyncCode" : [NSNull null],
         @"maxAttachmentSize" : [NSNull null],
         @"sendDefaultPii" : [NSNull null],
         @"enableAutoPerformanceTracing" : [NSNull null],

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -569,7 +569,6 @@
     XCTAssertEqual(YES, options.enableWatchdogTerminationTracking);
     XCTAssertEqual([@30000 unsignedIntValue], options.sessionTrackingIntervalMillis);
     XCTAssertEqual(YES, options.attachStacktrace);
-    XCTAssertEqual(NO, options.stitchAsyncCode);
     XCTAssertEqual(20 * 1024 * 1024, options.maxAttachmentSize);
     XCTAssertEqual(NO, options.sendDefaultPii);
     XCTAssertTrue(options.enableAutoPerformanceTracing);


### PR DESCRIPTION
## :scroll: Description

Removed `stitchAsyncCode` from SentryOption because it is not working. 

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
