### PR TITLE
docs: Clarify no debugger for SentrySDK.crash

### DIFF
--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -269,7 +269,11 @@ SENTRY_NO_INIT
 + (void)endSession;
 
 /**
- * This forces a crash, useful to test the @c SentryCrash integration
+ * This forces a crash, useful to test the @c SentryCrash integration.
+ *
+ * @note The SDK can't report a crash when a debugger is attached. Your application needs to run
+ * without a debugger attached to capture the crash and send it to Sentry the next time you launch
+ * your application.
  */
 + (void)crash;
 


### PR DESCRIPTION
Clarify in code docs not to use a debugger attached when testing the SDK with SentrySDK.crash.

Came up in https://github.com/getsentry/sentry-cocoa/issues/2975.

#skip-changelog