### PR TITLE
test: Remove unnecessary check for macOS 10.12

### DIFF
--- a/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
@@ -87,9 +87,6 @@ class SentryConcurrentRateLimitsDictionaryTests: XCTestCase {
         }
     }
 
-    // Even if we don't run this test below OSX 10.12 we expect the actual
-    // implementation to be thread safe.
-    @available(OSX 10.12, *)
     private func getCategory(rawValue: NSNumber) -> SentryDataCategory {
         func failedToCreateCategory() -> SentryDataCategory {
             XCTFail("Could not create category from \(rawValue)")


### PR DESCRIPTION
As the minimum macOS version is 10.13, we can remove this unnecessary check for macOS 10.12.

#skip-changelog