### PR TITLE
ci: Print hardware info for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: test-server
+
+      - name: Print hardware info
+        run: system_profiler SPHardwareDataType
+
       - name: Allow test-server to run
         run: chmod +x ./test-server-exec
       - run: ./test-server-exec &


### PR DESCRIPTION
Print hardware info for tests to determine if our tests are slow or fail on a specific hardware type.

Tests will print now something like
```
Hardware Overview:

      Model Name: Mac
      Model Identifier: VMware[7](https://github.com/getsentry/sentry-cocoa/actions/runs/4869504613/jobs/8684174080?pr=2988#step:4:8),1
      Processor Name: Unknown
      Processor Speed: 3.33 GHz
      Number of Processors: 1
      Total Number of Cores: 3
      L2 Cache (per Core): 256 KB
      L3 Cache: 12 MB
      Memory: 14 GB
      System Firmware Version: VMW71.00V.139[8](https://github.com/getsentry/sentry-cocoa/actions/runs/4869504613/jobs/8684174080?pr=2988#step:4:9)[9](https://github.com/getsentry/sentry-cocoa/actions/runs/4869504613/jobs/8684174080?pr=2988#step:4:10)454.B64.1906190538
      Apple ROM Info: [MS_VM_CERT/SHA1/27d66596a61c48dd3dc7216fd715[12](https://github.com/getsentry/sentry-cocoa/actions/runs/4869504613/jobs/8684174080?pr=2988#step:4:13)6e33f59ae7]Welcome to the Virtual Machine
      SMC Version (system): 2.8f0
      Serial Number (system): VM65MSZP+CpC
      Hardware UUID: 42030[18](https://github.com/getsentry/sentry-cocoa/actions/runs/4869504613/jobs/8684174080?pr=2988#step:4:19)E-580F-C1B5-9525-B745CECA79EB
      Provisioning UDID: 4[20](https://github.com/getsentry/sentry-cocoa/actions/runs/4869504613/jobs/8684174080?pr=2988#step:4:21)3018E-580F-C1B5-9525-B745CECA79EB
```

#skip-changelog