### PR TITLE
ci: Build test server on Ubuntu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,10 +37,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./test-server/.build
-          key: test-server-${{ hashFiles('./test-server') }}
+          key: ubuntu-test-server-${{ hashFiles('./test-server') }}
           restore-keys: |
-            test-server-${{ hashFiles('./test-server') }}
-            test-server-
+            ubuntu-test-server-${{ hashFiles('./test-server') }}
+            ubuntu-test-server-
 
       - name: Build Test Server
         if: steps.cache_test_server.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   build-test-server:
     name: Build test server
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Cache for Test Server


### PR DESCRIPTION
As Ubuntu runners are cheaper and usually faster, build the test server on Ubuntu.

#skip-changelog