### PR TITLE
fix: testNoBreadcrumbForTextFieldEditingChanged flakiness 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -282,13 +282,13 @@ jobs:
   ui-tests:
     name: UI Tests for ${{matrix.target}} on Simulators
     runs-on: macos-13
-    strategy: 
+    strategy:
       matrix:
         target: ['ios_swift', 'ios_objc', 'tvos_swift']
 
     steps:
       - uses: actions/checkout@v3
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh  "14.3"
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,7 +247,7 @@ jobs:
   # that adds a significant overhead.
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
-        runs-on: macos-12
+    runs-on: macos-12
     # When there are threading issues the tests sometimes keep hanging
     timeout-minutes: 20
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,7 +247,7 @@ jobs:
   # that adds a significant overhead.
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
-    runs-on: macos-12
+        runs-on: macos-12
     # When there are threading issues the tests sometimes keep hanging
     timeout-minutes: 20
 
@@ -281,7 +281,7 @@ jobs:
 
   ui-tests:
     name: UI Tests for ${{matrix.target}} on Simulators
-    runs-on: macos-12
+    runs-on: macos-13
     strategy: 
       matrix:
         target: ['ios_swift', 'ios_objc', 'tvos_swift']

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
@@ -24,6 +24,8 @@ class UIEventBreadcrumbTests: XCTestCase {
 
         //Trigger a change in textfield
         app.buttons["editingChangedButton"].tap()
+
+        Thread.sleep(forTimeInterval: 0.5)
         //Check the last breadcrumb is the button being pressed
         XCTAssertEqual(app.staticTexts["breadcrumbLabel"].label, "performEditingChangedPressed:")
 

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
@@ -25,14 +25,13 @@ class UIEventBreadcrumbTests: XCTestCase {
         //Trigger a change in textfield
         app.buttons["editingChangedButton"].tap()
 
-        Thread.sleep(forTimeInterval: 0.5)
         //Check the last breadcrumb is the button being pressed
-        XCTAssertEqual(app.staticTexts["breadcrumbLabel"].label, "performEditingChangedPressed:")
+        app.staticTexts["performEditingChangedPressed:"].waitForExistence("performEditingChangedPressed: not called")
 
         //Trigger an endEditing in textfield
         app.buttons["editingDidEndButton"].tap()
         //Check the last breadcrumb is the endEditing from the textfield and not the button being pressed
-        XCTAssertEqual(app.staticTexts["breadcrumbLabel"].label, "textFieldEndChanging:")
+        app.staticTexts["textFieldEndChanging:"].waitForExistence("textFieldEndChanging: not called")
     }
 
     func waitForExistenceOfMainScreen() {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
@@ -22,17 +22,15 @@ class UIEventBreadcrumbTests: XCTestCase {
         app.buttons["Extra"].tap()
         app.buttons["UI event tests"].tap()
 
-        let label = app.staticTexts["breadcrumbLabel"]
-
         //Trigger a change in textfield
         app.buttons["editingChangedButton"].tap()
         //Check the last breadcrumb is the button being pressed
-        XCTAssertEqual(label.label, "performEditingChangedPressed:")
+        XCTAssertEqual(app.staticTexts["breadcrumbLabel"].label, "performEditingChangedPressed:")
 
         //Trigger an endEditing in textfield
         app.buttons["editingDidEndButton"].tap()
         //Check the last breadcrumb is the endEditing from the textfield and not the button being pressed
-        XCTAssertEqual(label.label, "textFieldEndChanging:")
+        XCTAssertEqual(app.staticTexts["breadcrumbLabel"].label, "textFieldEndChanging:")
     }
 
     func waitForExistenceOfMainScreen() {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
@@ -23,7 +23,7 @@ class UIEventBreadcrumbTests: XCTestCase {
         app.buttons["UI event tests"].tap()
 
         //Trigger a change in textfield
-        app.buttons["editingChangedButton"].tap()
+        app.buttons["editingChangedButton"].afterWaitingForExistence("Did not find editingChangedButton").tap()
 
         //Check the last breadcrumb is the button being pressed
         app.staticTexts["performEditingChangedPressed:"].waitForExistence("performEditingChangedPressed: not called")


### PR DESCRIPTION
Solving testNoBreadcrumbForTextFieldEditingChanged flakiness in the CI simulator.


_#skip-changelog_