### PR TITLE
fix: nil-check values being added to dictionaries

### DIFF
--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -107,8 +107,11 @@ processBacktrace(const Backtrace &backtrace,
     }
     if (queueAddress != nil && queueMetadata[queueAddress] == nil
         && backtrace.queueMetadata.label != nullptr) {
-        queueMetadata[queueAddress] =
-            @ { @"label" : [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()] };
+        const auto labelCString = backtrace.queueMetadata.label->c_str();
+        if (labelCString != nullptr) {
+            queueMetadata[queueAddress] =
+                @ { @"label" : [NSString stringWithUTF8String:labelCString] };
+        }
     }
 #    if defined(DEBUG)
     const auto symbols


### PR DESCRIPTION
## :scroll: Description

Check any values that might possibly be `nil` before adding them to a dictionary [literal].

## :bulb: Motivation and Context

Fixes some potential crashes in https://github.com/getsentry/sentry-cocoa/issues/2993.
## :green_heart: How did you test it?

I don't have a repro, but these are easy checks to add and shouldn't change any behavior/functionality.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
