### PR TITLE
chore: Ignore test folder for CodeCov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
   round: down
 
 ignore:
-  - "Tests/SentryTests" 
+  - "Tests/*" 
 
 comment:
   layout: "reach,diff,flags,files,footer"


### PR DESCRIPTION
SentryProfilerTests are [included in the CodeCov report](https://app.codecov.io/gh/getsentry/sentry-cocoa/commit/073b20d988681f2e34950fd5be347f291ce4196f/tree/Tests). To fix this, ignore the whole test folder.

#skip-changelog