### PR TITLE
ci: Run Catalyst tests on macOS 13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,9 +133,9 @@ jobs:
           # Catalyst. We only test the latest version, as
           # the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
-          - runs-on: macos-12
+          - runs-on: macos-13
             platform: 'Catalyst'
-            xcode: '13.4.1'
+            xcode: '14.3'
             test-destination-os: 'latest'
 
           # MetricKit doesn't exist for tvOS, so we can still run unit tests with


### PR DESCRIPTION
Cause building catalyst took more than 14 minutes on this [CI job](https://github.com/getsentry/sentry-cocoa/actions/runs/4891384756/jobs/8731849536). Let's use the macOS 13 image, which is way faster.