### PR TITLE
ci: Skip CodeCov upload for scheduled jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -227,9 +227,10 @@ jobs:
       # See https://docs.codecov.io/docs/merging-reports
       # Checkout .codecov.yml to see the config of Codecov
       # We don't upload codecov for release branches, as we don't want a failing coverage check to block a release.
+      # We don't upload codecov for scheduled runs as CodeCov only accepts a limited amount of uploads per commit.
       - name: Push code coverage to codecov
         uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # pin@v3.1.3
-        if: ${{ contains(matrix.platform, 'iOS') && !contains(github.ref, 'release') }}
+        if: ${{ contains(matrix.platform, 'iOS') && !contains(github.ref, 'release') && github.event.schedule == '' }}
         with:
           # Although public repos should not have to specify a token there seems to be a bug with the Codecov GH action, which can
           # be solved by specifying the token, see https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469


### PR DESCRIPTION
To avoid failing CI jobs such as
https://github.com/getsentry/sentry-cocoa/actions/runs/4912764852/jobs/8772174301.

#skip-changelog