### PR TITLE
ci: archive any crash reports on test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -223,6 +223,14 @@ jobs:
           path: |
             raw-test-output.log
 
+      - name: Archiving Crash Logs
+        uses: actions/upload-artifact@v3
+        if: ${{  failure() || cancelled() }}
+        with:
+          name: crash-logs-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          path: |
+            ~/Library/Logs/DiagnosticReports/**
+
       # We can upload all coverage reports, because codecov merges them.
       # See https://docs.codecov.io/docs/merging-reports
       # Checkout .codecov.yml to see the config of Codecov

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -439,10 +439,6 @@ private extension SentryProfilerSwiftTests {
             try assertMetricValue(measurements: measurements, key: key, numberOfReadings: expectedUsageReadings, expectedValue: expectedUsage, transaction: transaction)
         }
 
-        let test: UInt? = nil
-        let crash = test!
-        print(crash)
-
         try assertMetricValue(measurements: measurements, key: kSentryMetricProfilerSerializationKeyMemoryFootprint, numberOfReadings: expectedUsageReadings, expectedValue: fixture.mockMemoryFootprint, transaction: transaction)
 
 #if !os(macOS)

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -439,6 +439,10 @@ private extension SentryProfilerSwiftTests {
             try assertMetricValue(measurements: measurements, key: key, numberOfReadings: expectedUsageReadings, expectedValue: expectedUsage, transaction: transaction)
         }
 
+        let test: UInt? = nil
+        let crash = test!
+        print(crash)
+
         try assertMetricValue(measurements: measurements, key: kSentryMetricProfilerSerializationKeyMemoryFootprint, numberOfReadings: expectedUsageReadings, expectedValue: fixture.mockMemoryFootprint, transaction: transaction)
 
 #if !os(macOS)


### PR DESCRIPTION
I got the idea because a test run recently failed with a crash that I don't expect, so I'd like more information on what happened: https://github.com/getsentry/sentry-cocoa/actions/runs/4913855191/jobs/8774525689?pr=2995

#skip-changelog

