### PR TITLE
ci: only archive derived data logs if the build step fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,16 @@ jobs:
 
       # We split building and running tests in two steps so we know how long running the tests takes.
       - name: Build tests
+        id: build_tests
         run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME ci build-for-testing
+
+      - name: Archiving DerivedData Logs
+        uses: actions/upload-artifact@v3
+        if: steps.build_tests.outcome == 'failure'
+        with:
+          name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          path: |
+            /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
       
       - name: Run tests
         # We call a script with the platform so the destination
@@ -206,14 +215,6 @@ jobs:
       - name: Slowest Tests
         if: ${{ always() }}
         run: ./scripts/xcode-slowest-tests.sh
-
-      - name: Archiving DerivedData Logs
-        uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
-          path: |
-            /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -196,14 +196,6 @@ jobs:
       - name: Build tests
         id: build_tests
         run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME ci build-for-testing
-
-      - name: Archiving DerivedData Logs
-        uses: actions/upload-artifact@v3
-        if: steps.build_tests.outcome == 'failure'
-        with:
-          name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
-          path: |
-            /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
       
       - name: Run tests
         # We call a script with the platform so the destination
@@ -215,6 +207,14 @@ jobs:
       - name: Slowest Tests
         if: ${{ always() }}
         run: ./scripts/xcode-slowest-tests.sh
+
+      - name: Archiving DerivedData Logs
+        uses: actions/upload-artifact@v3
+        if: steps.build_tests.outcome == 'failure'
+        with:
+          name: derived-data-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          path: |
+            /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
I noticed a case where it took several minutes to archive derived data logs [here](https://github.com/getsentry/sentry-cocoa/actions/runs/4914931513/jobs/8777452063?pr=3009): 
![image](https://user-images.githubusercontent.com/3241469/236831513-5fb156c7-b0fa-4a5a-b059-a323942da597.png)

This happened due to a test failure. Now that we've split up the build and runtest steps, I think we only need derived data logs if the build step fails. Once the build succeeds, these logs can't help for test run failures, so the step linked above didn't actually need to run.

#skip-changelog