### PR TITLE
ci: Fix skipping codecov2 upload for scheduled

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -251,7 +251,7 @@ jobs:
       - name: Push code coverage to codecov
         id: codecov_2
         uses: codecov/codecov-action@894ff025c7b54547a9a2a1e9f228beae737ad3c2 # pin@v3.1.3
-        if: steps.codecov_1.outcome == 'failure' && ${{ contains(matrix.platform, 'iOS') && !contains(github.ref, 'release') && github.event.schedule == '' }}
+        if: ${{ steps.codecov_1.outcome == 'failure' && contains(matrix.platform, 'iOS') && !contains(github.ref, 'release') && github.event.schedule == '' }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true


### PR DESCRIPTION
Scheduled runs try to upload coverage. I guess that's because the `${{` wasn't put at the beginning of the if statement in the yml.

https://github.com/getsentry/sentry-cocoa/actions/runs/4922793243/jobs/8793926172