### PR TITLE
test: Increase timeout for CoreData tests

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -64,7 +64,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
             expect.fulfill()
         }
 
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 1.0)
     }
     
     func test_FetchRequest_WithPredicate() {
@@ -111,7 +111,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
             expect.fulfill()
         }
 
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 1.0)
     }
     
     func test_Save_2Insert_1Entity() {


### PR DESCRIPTION
The tests [sometimes timeout in CI](https://github.com/getsentry/sentry-cocoa/actions/runs/4948424425/jobs/8849165677). 1.0 seconds is still reasonable.

#skip-changelog