### PR TITLE
feat: Double check-lock improvement

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -46,6 +46,16 @@
                </Test>
             </SkippedTests>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "63AA76641EB8CB2F00D153DE"
+               BuildableName = "SentryTests.xctest"
+               BlueprintName = "SentryTests"
+               ReferencedContainer = "container:../../Sentry.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 		D8CB742B294B1DD000A5F964 /* SentryUIApplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */; };
 		D8CB742E294B294B00A5F964 /* MockUIScene.m in Sources */ = {isa = PBXBuildFile; fileRef = D8CB742D294B294B00A5F964 /* MockUIScene.m */; };
 		D8CE69BC277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D8CE69BB277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m */; };
+		D8F01DE12A1219CF008F4996 /* SentrySingleExecution+assert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F01DDF2A1219C4008F4996 /* SentrySingleExecution+assert.swift */; };
 		D8F6A2472885512100320515 /* SentryPredicateDescriptor.m in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */; };
 		D8F6A24B2885515C00320515 /* SentryPredicateDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */; };
 		D8F6A24E288553A800320515 /* SentryPredicateDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */; };
@@ -1737,6 +1738,7 @@
 		D8CB742C294B294B00A5F964 /* MockUIScene.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MockUIScene.h; sourceTree = "<group>"; };
 		D8CB742D294B294B00A5F964 /* MockUIScene.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockUIScene.m; sourceTree = "<group>"; };
 		D8CE69BB277E39C700C6EC5C /* SentryFileIOTrackingIntegrationObjCTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryFileIOTrackingIntegrationObjCTests.m; sourceTree = "<group>"; };
+		D8F01DDF2A1219C4008F4996 /* SentrySingleExecution+assert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SentrySingleExecution+assert.swift"; sourceTree = "<group>"; };
 		D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryPredicateDescriptor.m; sourceTree = "<group>"; };
 		D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryPredicateDescriptor.h; path = include/SentryPredicateDescriptor.h; sourceTree = "<group>"; };
 		D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryPredicateDescriptorTests.swift; sourceTree = "<group>"; };
@@ -3274,6 +3276,7 @@
 				D8CB742C294B294B00A5F964 /* MockUIScene.h */,
 				D8CB742D294B294B00A5F964 /* MockUIScene.m */,
 				D83D805B2A0E476700F6A63A /* TestSentrySingleExecution.h */,
+				D8F01DDF2A1219C4008F4996 /* SentrySingleExecution+assert.swift */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -4317,6 +4320,7 @@
 				62B86CFC29F052BB008F3947 /* SentryTestLogConfig.m in Sources */,
 				D808FB92281BF6EC009A2A33 /* SentryUIEventTrackingIntegrationTests.swift in Sources */,
 				7BC6EC04255C235F0059822A /* SentryFrameTests.swift in Sources */,
+				D8F01DE12A1219CF008F4996 /* SentrySingleExecution+assert.swift in Sources */,
 				0AE455AD28F584D2006680E5 /* SentryReachabilityTests.m in Sources */,
 				63FE720420DA66EC00CDBAE8 /* SentryCrashString_Tests.m in Sources */,
 				849AC40029E0C1FF00889C16 /* SentryFormatterTests.swift in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -710,10 +710,10 @@
 		8ED3D306264DFE700049393B /* SwiftDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ED3D305264DFE700049393B /* SwiftDescriptorTests.swift */; };
 		8EE017A126704CD500470616 /* SentryUIViewControllerPerformanceTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA1ED0E2669152F00E62B98 /* SentryUIViewControllerPerformanceTrackerTests.swift */; };
 		92672BB629C9A2A9006B021C /* SentryBreadcrumb+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92672BB529C9A2A9006B021C /* SentryBreadcrumb+Private.h */; };
-		92F6726B29C8B7B100BFD34D /* SentryUser+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92F6726A29C8B7B000BFD34D /* SentryUser+Private.h */; };
 		9286059529A5096600F96038 /* SentryGeo.h in Headers */ = {isa = PBXBuildFile; fileRef = 9286059429A5096600F96038 /* SentryGeo.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9286059729A5098900F96038 /* SentryGeo.m in Sources */ = {isa = PBXBuildFile; fileRef = 9286059629A5098900F96038 /* SentryGeo.m */; };
 		9286059929A50BAB00F96038 /* SentryGeoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9286059829A50BAA00F96038 /* SentryGeoTests.swift */; };
+		92F6726B29C8B7B100BFD34D /* SentryUser+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 92F6726A29C8B7B000BFD34D /* SentryUser+Private.h */; };
 		A2475E1325FB63A3007D9080 /* fishhook.h in Headers */ = {isa = PBXBuildFile; fileRef = A2475E1225FB63A3007D9080 /* fishhook.h */; };
 		A2475E1725FB63AF007D9080 /* SentryHook.h in Headers */ = {isa = PBXBuildFile; fileRef = A2475E1625FB63AF007D9080 /* SentryHook.h */; };
 		A2475E1B25FB63D7007D9080 /* SentryHook.c in Sources */ = {isa = PBXBuildFile; fileRef = A2475E1A25FB63D7007D9080 /* SentryHook.c */; };
@@ -743,6 +743,8 @@
 		D81FDF12280EA1060045E0E4 /* SentryScreenShotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D81FDF10280EA0080045E0E4 /* SentryScreenShotTests.swift */; };
 		D8370B6A273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = D8370B68273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m */; };
 		D8370B6C273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */; };
+		D83D80592A0E36EA00F6A63A /* SentrySingleExecution.h in Headers */ = {isa = PBXBuildFile; fileRef = D83D80572A0E36EA00F6A63A /* SentrySingleExecution.h */; };
+		D83D805A2A0E36EA00F6A63A /* SentrySingleExecution.m in Sources */ = {isa = PBXBuildFile; fileRef = D83D80582A0E36EA00F6A63A /* SentrySingleExecution.m */; };
 		D84793262788737D00BE8E99 /* SentryByteCountFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = D84793242788737D00BE8E99 /* SentryByteCountFormatter.m */; };
 		D8479328278873A100BE8E99 /* SentryByteCountFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = D8479327278873A100BE8E99 /* SentryByteCountFormatter.h */; };
 		D85596F3280580F10041FF8B /* SentryScreenshotIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = D85596F1280580F10041FF8B /* SentryScreenshotIntegration.m */; };
@@ -1634,10 +1636,10 @@
 		8ED2D27F26A6581C00CA8329 /* NSURLProtocolSwizzle.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSURLProtocolSwizzle.m; sourceTree = "<group>"; };
 		8ED3D305264DFE700049393B /* SwiftDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDescriptorTests.swift; sourceTree = "<group>"; };
 		92672BB529C9A2A9006B021C /* SentryBreadcrumb+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SentryBreadcrumb+Private.h"; path = "include/HybridPublic/SentryBreadcrumb+Private.h"; sourceTree = "<group>"; };
-		92F6726A29C8B7B000BFD34D /* SentryUser+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SentryUser+Private.h"; path = "include/HybridPublic/SentryUser+Private.h"; sourceTree = "<group>"; };
 		9286059429A5096600F96038 /* SentryGeo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryGeo.h; path = Public/SentryGeo.h; sourceTree = "<group>"; };
 		9286059629A5098900F96038 /* SentryGeo.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryGeo.m; sourceTree = "<group>"; };
 		9286059829A50BAA00F96038 /* SentryGeoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryGeoTests.swift; sourceTree = "<group>"; };
+		92F6726A29C8B7B000BFD34D /* SentryUser+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SentryUser+Private.h"; path = "include/HybridPublic/SentryUser+Private.h"; sourceTree = "<group>"; };
 		A2475E1225FB63A3007D9080 /* fishhook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fishhook.h; sourceTree = "<group>"; };
 		A2475E1625FB63AF007D9080 /* SentryHook.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryHook.h; sourceTree = "<group>"; };
 		A2475E1A25FB63D7007D9080 /* SentryHook.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryHook.c; sourceTree = "<group>"; };
@@ -1674,6 +1676,9 @@
 		D81FDF10280EA0080045E0E4 /* SentryScreenShotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScreenShotTests.swift; sourceTree = "<group>"; };
 		D8370B68273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryNSURLSessionTaskSearch.m; sourceTree = "<group>"; };
 		D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNSURLSessionTaskSearch.h; path = include/SentryNSURLSessionTaskSearch.h; sourceTree = "<group>"; };
+		D83D80572A0E36EA00F6A63A /* SentrySingleExecution.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySingleExecution.h; path = include/SentrySingleExecution.h; sourceTree = "<group>"; };
+		D83D80582A0E36EA00F6A63A /* SentrySingleExecution.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySingleExecution.m; sourceTree = "<group>"; };
+		D83D805B2A0E476700F6A63A /* TestSentrySingleExecution.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSentrySingleExecution.h; sourceTree = "<group>"; };
 		D84793242788737D00BE8E99 /* SentryByteCountFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryByteCountFormatter.m; sourceTree = "<group>"; };
 		D8479327278873A100BE8E99 /* SentryByteCountFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryByteCountFormatter.h; path = include/SentryByteCountFormatter.h; sourceTree = "<group>"; };
 		D85596F1280580F10041FF8B /* SentryScreenshotIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryScreenshotIntegration.m; sourceTree = "<group>"; };
@@ -3162,6 +3167,8 @@
 				D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */,
 				0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */,
 				0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */,
+				D83D80572A0E36EA00F6A63A /* SentrySingleExecution.h */,
+				D83D80582A0E36EA00F6A63A /* SentrySingleExecution.m */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -3266,6 +3273,7 @@
 				D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */,
 				D8CB742C294B294B00A5F964 /* MockUIScene.h */,
 				D8CB742D294B294B00A5F964 /* MockUIScene.m */,
+				D83D805B2A0E476700F6A63A /* TestSentrySingleExecution.h */,
 			);
 			name = Tools;
 			sourceTree = "<group>";
@@ -3458,6 +3466,7 @@
 				8E4E7C6E25DAAAFE006AB9E2 /* SentrySpan.h in Headers */,
 				D8ACE3CE2762187D00F5A213 /* SentryNSDataTracker.h in Headers */,
 				03F84D2427DD414C008FE43F /* SentryCompiler.h in Headers */,
+				D83D80592A0E36EA00F6A63A /* SentrySingleExecution.h in Headers */,
 				631E6D331EBC679C00712345 /* SentryQueueableRequestManager.h in Headers */,
 				7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */,
 				6304360A1EC0595B00C4D3FA /* NSData+SentryCompression.h in Headers */,
@@ -4091,6 +4100,7 @@
 				63FE711520DA4C1000CDBAE8 /* SentryCrashJSONCodec.c in Sources */,
 				03F84D3327DD4191008FE43F /* SentryMachLogging.cpp in Sources */,
 				D85852BA27EDDC5900C6D8AE /* SentryUIApplication.m in Sources */,
+				D83D805A2A0E36EA00F6A63A /* SentrySingleExecution.m in Sources */,
 				7B4E375F258231FC00059C93 /* SentryAttachment.m in Sources */,
 				636085141ED47BE600E8599E /* SentryFileManager.m in Sources */,
 				0356A571288B4612008BF593 /* SentryProfilesSampler.m in Sources */,

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -51,7 +51,7 @@ SentryHttpTransport ()
  */
 @property (atomic) BOOL isSending;
 
-@property (nonatomic) SentrySingleExecution* flushSingleExecution;
+@property (nonatomic) SentrySingleExecution *flushSingleExecution;
 
 @end
 
@@ -159,7 +159,7 @@ SentryHttpTransport ()
 
 - (BOOL)flush:(NSTimeInterval)timeout
 {
-    __block intptr_t result = NO;
+    __block intptr_t result;
     BOOL executed = [self.flushSingleExecution standaloneExecution:^{
         dispatch_time_t delta = (int64_t)(timeout * (NSTimeInterval)NSEC_PER_SEC);
         dispatch_time_t dispatchTimeout = dispatch_time(DISPATCH_TIME_NOW, delta);
@@ -178,9 +178,10 @@ SentryHttpTransport ()
 
     if (executed == NO) {
         SENTRY_LOG_DEBUG(@"Already flushing.");
+        return NO;
     }
 
-    return result != 0;
+    return result == 0;
 }
 
 /**

--- a/Sources/Sentry/SentrySingleExecution.m
+++ b/Sources/Sentry/SentrySingleExecution.m
@@ -1,28 +1,32 @@
 #import "SentrySingleExecution.h"
 
 #if TEST || TESTCI
-//We dont need this extra code for release
-@interface SentrySingleExecution ()
+// We dont need this extra code for release
+@interface
+SentrySingleExecution ()
 
 @property (nonatomic, strong) void (^willSkip)(void);
 @property (nonatomic, strong) void (^willExecute)(void);
 
-
 @end
 
-#define CALL_FOR_TEST(BLOCK) if (BLOCK != nil) { BLOCK(); }
+#    define CALL_FOR_TEST(BLOCK)                                                                   \
+        if (BLOCK != nil) {                                                                        \
+            BLOCK();                                                                               \
+        }
 #else
-#define CALL_FOR_TEST(...)
+#    define CALL_FOR_TEST(...)
 #endif
 
 @implementation SentrySingleExecution
 
-- (BOOL)standaloneExecution:(void (^)(void))block {
+- (BOOL)standaloneExecution:(void (^)(void))block
+{
     if (_isRunning) {
         CALL_FOR_TEST(self.willSkip);
         return NO;
     }
-    @synchronized (self) {
+    @synchronized(self) {
         if (_isRunning) {
             CALL_FOR_TEST(self.willSkip);
             return NO;

--- a/Sources/Sentry/SentrySingleExecution.m
+++ b/Sources/Sentry/SentrySingleExecution.m
@@ -1,0 +1,39 @@
+#import "SentrySingleExecution.h"
+
+#if TEST || TESTCI
+//We dont need this extra code for release
+@interface SentrySingleExecution ()
+
+@property (nonatomic, strong) void (^willSkip)(void);
+@property (nonatomic, strong) void (^willExecute)(void);
+
+
+@end
+
+#define CALL_FOR_TEST(BLOCK) if (BLOCK != nil) { BLOCK(); }
+#else
+#define CALL_FOR_TEST(...)
+#endif
+
+@implementation SentrySingleExecution
+
+- (BOOL)standaloneExecution:(void (^)(void))block {
+    if (_isRunning) {
+        CALL_FOR_TEST(self.willSkip);
+        return NO;
+    }
+    @synchronized (self) {
+        if (_isRunning) {
+            CALL_FOR_TEST(self.willSkip);
+            return NO;
+        }
+        _isRunning = YES;
+    }
+
+    CALL_FOR_TEST(self.willExecute);
+    block();
+
+    return YES;
+}
+
+@end

--- a/Sources/Sentry/include/SentrySingleExecution.h
+++ b/Sources/Sentry/include/SentrySingleExecution.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentrySingleExecution : NSObject
+
+@property (nonatomic, readonly) BOOL isRunning;
+
+/**
+ * Execute the block and avoid any other parallel call
+ * to @c standaloneExecution while the first call is in execution.
+ *
+ * @return Whether the block was executed or not.
+ */
+- (BOOL)standaloneExecution:(void (^)(void))block;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentrySingleExecution+assert.swift
+++ b/Tests/SentryTests/SentrySingleExecution+assert.swift
@@ -1,0 +1,36 @@
+import Foundation
+import XCTest
+
+extension XCTestCase {
+
+    func assertRaceConditon(target: SentrySingleExecution, firstCall: @escaping () -> Void, subsequentCall: () -> Void) {
+        let semaphore = DispatchSemaphore(value: 0)
+
+        let beginOFExecuteExpectation = expectation(description: "Will Execute Begin")
+        let endOFExecuteExpectation = expectation(description: "Will Execute End")
+        let willSkipExpectation = expectation(description: "WillSkip")
+
+        target.willExecute = {
+            beginOFExecuteExpectation.fulfill()
+            //Hold the execution to test race condition
+            semaphore.wait()
+        }
+
+        target.willSkip = {
+            willSkipExpectation.fulfill()
+            semaphore.signal()
+        }
+
+        DispatchQueue.global().async {
+            firstCall()
+            endOFExecuteExpectation.fulfill()
+        }
+
+        wait(for: [beginOFExecuteExpectation], timeout: 1)
+
+        subsequentCall()
+
+        wait(for: [endOFExecuteExpectation, willSkipExpectation], timeout: 1)
+    }
+
+}

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -197,6 +197,7 @@
 #import "SentryTimeToDisplayTracker.h"
 #import "SentryTracerConfiguration.h"
 #import "TestSentryViewHierarchy.h"
+#import "TestSentrySingleExecution.h"
 #if SENTRY_HAS_UIKIT
 #    import "MockUIScene.h"
 #    import "SentryUIEventTracker.h"

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -196,8 +196,8 @@
 #import "SentrySpanOperations.h"
 #import "SentryTimeToDisplayTracker.h"
 #import "SentryTracerConfiguration.h"
-#import "TestSentryViewHierarchy.h"
 #import "TestSentrySingleExecution.h"
+#import "TestSentryViewHierarchy.h"
 #if SENTRY_HAS_UIKIT
 #    import "MockUIScene.h"
 #    import "SentryUIEventTracker.h"

--- a/Tests/SentryTests/TestSentrySingleExecution.h
+++ b/Tests/SentryTests/TestSentrySingleExecution.h
@@ -1,5 +1,6 @@
 #import "SentrySingleExecution.h"
-@interface SentrySingleExecution ()
+@interface
+SentrySingleExecution ()
 
 @property (nonatomic, strong) void (^willSkip)(void);
 

--- a/Tests/SentryTests/TestSentrySingleExecution.h
+++ b/Tests/SentryTests/TestSentrySingleExecution.h
@@ -1,0 +1,8 @@
+#import "SentrySingleExecution.h"
+@interface SentrySingleExecution ()
+
+@property (nonatomic, strong) void (^willSkip)(void);
+
+@property (nonatomic, strong) void (^willExecute)(void);
+
+@end


### PR DESCRIPTION
## :scroll: Description

Created a class to help with a double-checking and blocking approach to avoiding race condition.
It also makes it easier to test for such a condition.

## :bulb: Motivation and Context

`testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse` was Flaky, as most of the tests trying to simulate race condition.

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
