### PR TITLE
fix: additional profiling data races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fix crashes in profiling serialization race condition (#3018)
+- Fix crashes in profiling serialization race condition (#3018, #3035)
 
 ## 8.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Fixed
 
 - Fix crashes in profiling serialization race condition (#3018, #3035)
-- Fix crashes in profiling serialization race condition (#3018)
 - Fix a crash for user interaction transactions (#3036)
 
 ## 8.7.1

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0354A22B2A134D9C003C3A04 /* SentryProfiler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0354A22A2A134D9C003C3A04 /* SentryProfiler+Private.h */; };
 		0356A570288B4612008BF593 /* SentryProfilesSampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0356A56E288B4612008BF593 /* SentryProfilesSampler.h */; };
 		0356A571288B4612008BF593 /* SentryProfilesSampler.m in Sources */ = {isa = PBXBuildFile; fileRef = 0356A56F288B4612008BF593 /* SentryProfilesSampler.m */; };
 		03BCC38A27E1BF49003232C7 /* SentryTime.h in Headers */ = {isa = PBXBuildFile; fileRef = 03BCC38927E1BF49003232C7 /* SentryTime.h */; };
@@ -861,6 +862,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0354A22A2A134D9C003C3A04 /* SentryProfiler+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "SentryProfiler+Private.h"; path = "Sources/Sentry/include/SentryProfiler+Private.h"; sourceTree = SOURCE_ROOT; };
 		0356A56E288B4612008BF593 /* SentryProfilesSampler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilesSampler.h; path = Sources/Sentry/include/SentryProfilesSampler.h; sourceTree = SOURCE_ROOT; };
 		0356A56F288B4612008BF593 /* SentryProfilesSampler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SentryProfilesSampler.m; path = Sources/Sentry/SentryProfilesSampler.m; sourceTree = SOURCE_ROOT; };
 		035E73C727D56757005EEB11 /* SentryBacktraceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryBacktraceTests.mm; sourceTree = "<group>"; };
@@ -3064,6 +3066,7 @@
 				03F84D1127DD414C008FE43F /* SentryProfiler.h */,
 				844EDD6B2949387000C86F34 /* SentryMetricProfiler.h */,
 				8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */,
+				0354A22A2A134D9C003C3A04 /* SentryProfiler+Private.h */,
 				84A888FC28D9B11700C51DFD /* SentryProfiler+Test.h */,
 				844EDC7B2942843400C86F34 /* SentryProfiler+SwiftTest.h */,
 				03F84D2B27DD4191008FE43F /* SentryProfiler.mm */,
@@ -3515,6 +3518,7 @@
 				7BC8522F24581096005A70F0 /* SentryFileContents.h in Headers */,
 				7B30B67C26527886006B2752 /* SentryDisplayLinkWrapper.h in Headers */,
 				7BD86ECF264A7C77005439DB /* SentryAppStartMeasurement.h in Headers */,
+				0354A22B2A134D9C003C3A04 /* SentryProfiler+Private.h in Headers */,
 				7DC8310A2398283C0043DD9A /* SentryCrashIntegration.h in Headers */,
 				63FE718320DA4C1100CDBAE8 /* SentryCrashReportFixer.h in Headers */,
 				03F84D2027DD414C008FE43F /* SentryStackBounds.hpp in Headers */,

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -1,3 +1,4 @@
+#import "SentryProfiler+Private.h"
 #import "SentryProfiler+Test.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -49,7 +50,6 @@
 #    endif
 
 const int kSentryProfilerFrequencyHz = 101;
-NSString *const kTestStringConst = @"test";
 NSTimeInterval kSentryProfilerTimeoutInterval = 30;
 
 NSString *const kSentryProfilerSerializationKeySlowFrameRenders = @"slow_frame_renders";
@@ -77,108 +77,6 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         return symbolNSStr;
     }
     return [symbolNSStr substringWithRange:[match rangeAtIndex:1]];
-}
-
-std::mutex _gDataStructureLock;
-
-void
-processBacktrace(const Backtrace &backtrace,
-    NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata,
-    NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata,
-    NSMutableArray<SentrySample *> *samples, NSMutableArray<NSArray<NSNumber *> *> *stacks,
-    NSMutableArray<NSDictionary<NSString *, id> *> *frames,
-    NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup,
-    NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup)
-{
-    const auto stack = [NSMutableArray<NSNumber *> array];
-    const auto framesToAdd = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-    for (std::vector<uintptr_t>::size_type backtraceAddressIdx = 0;
-         backtraceAddressIdx < backtrace.addresses.size(); backtraceAddressIdx++) {
-        const auto instructionAddress
-            = sentry_formatHexAddressUInt64(backtrace.addresses[backtraceAddressIdx]);
-
-        const auto frameIndex = frameIndexLookup[instructionAddress];
-        if (frameIndex == nil) {
-            const auto frame = [NSMutableDictionary<NSString *, id> dictionary];
-            frame[@"instruction_addr"] = instructionAddress;
-#    if defined(DEBUG)
-            const auto symbols
-                = backtrace_symbols(reinterpret_cast<void *const *>(backtrace.addresses.data()),
-                    static_cast<int>(backtrace.addresses.size()));
-            frame[@"function"] = parseBacktraceSymbolsFunctionName(symbols[backtraceAddressIdx]);
-#    endif
-            [stack addObject:@(frames.count)];
-            frameIndexLookup[instructionAddress] = @(frames.count);
-            [framesToAdd addObject:frame];
-        } else {
-            [stack addObject:frameIndex];
-        }
-    }
-
-    const auto sample = [[SentrySample alloc] init];
-    sample.absoluteTimestamp = backtrace.absoluteTimestamp;
-    sample.threadID = backtrace.threadMetadata.threadID;
-
-    NSString *queueAddress = nil;
-    if (backtrace.queueMetadata.address != 0) {
-        queueAddress = sentry_formatHexAddressUInt64(backtrace.queueMetadata.address);
-    }
-    if (queueAddress != nil) {
-        sample.queueAddress = queueAddress;
-    }
-
-    const auto stackKey = [stack componentsJoinedByString:@"|"];
-    const auto stackIndex = stackIndexLookup[stackKey];
-    if (stackIndex) {
-        sample.stackIndex = stackIndex;
-    } else {
-        const auto nextStackIndex = @(stacks.count);
-        sample.stackIndex = nextStackIndex;
-        stackIndexLookup[stackKey] = nextStackIndex;
-    }
-
-    {
-        // critical section: here is where all mutable data structures are updated, which must be
-        // copied later during serialization, so we need enforce exclusive access
-        std::lock_guard<std::mutex> l(_gDataStructureLock);
-
-        // update queue metadata if we have any and it isn't already recorded from a previous sample
-        if (queueAddress != nil && queueMetadata[queueAddress] == nil
-            && backtrace.queueMetadata.label != nullptr) {
-            queueMetadata[queueAddress] = @ {
-                @"label" : [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()]
-            };
-        }
-
-        // The following can overwrite thread metadata that was previously recorded for a thread,
-        // when between samples if we find that the metadata is not present on one sample but is
-        // present for a subsequent sample on the same thread. This occasionally happens when we
-        // can't read the metadata for a thread (unclear why this happens but it tends to happen
-        // sometimes for a newly created thread).
-        const auto threadID = sentry_stringForUInt64(backtrace.threadMetadata.threadID);
-        NSMutableDictionary<NSString *, id> *metadata = threadMetadata[threadID];
-        if (metadata == nil) {
-            metadata = [NSMutableDictionary<NSString *, id> dictionary];
-            threadMetadata[threadID] = metadata;
-        }
-        if (!backtrace.threadMetadata.name.empty() && metadata[@"name"] == nil) {
-            metadata[@"name"] =
-                [NSString stringWithUTF8String:backtrace.threadMetadata.name.c_str()];
-        }
-        if (backtrace.threadMetadata.priority != -1 && metadata[@"priority"] == nil) {
-            metadata[@"priority"] = @(backtrace.threadMetadata.priority);
-        }
-
-        // add the new sample to the data structure
-        [samples addObject:sample];
-
-        // add the stack if it isn't already cached in the lookup index
-        if (stackIndex == nil) {
-            [stacks addObject:stack];
-        }
-
-        [frames addObjectsFromArray:framesToAdd];
-    }
 }
 
 std::mutex _gProfilerLock;
@@ -290,42 +188,25 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     SentryId *profileID, NSString *truncationReason, NSString *environment, NSString *release,
     NSDictionary<NSString *, id> *serializedMetrics, NSArray<SentryDebugMeta *> *debugMeta)
 {
-    NSArray<SentrySample *> *samplesCopy;
-    NSArray<NSArray<NSNumber *> *> *stacksCopy;
-    NSArray<NSDictionary<NSString *, id> *> *framesCopy;
-    NSMutableDictionary<NSString *, NSDictionary *> *threadMetadataCopy;
-    NSDictionary<NSString *, NSDictionary *> *queueMetadataCopy;
-    {
-        std::lock_guard<std::mutex> d(_gDataStructureLock);
-        samplesCopy = [profileData[@"profile"][@"samples"] copy];
-        stacksCopy = [profileData[@"profile"][@"stacks"] copy];
-        framesCopy = [profileData[@"profile"][@"frames"] copy];
-        queueMetadataCopy = [profileData[@"profile"][@"queue_metadata"] copy];
-
-        // thread metadata contains a mutable substructure, so it's not enough to perform a copy of
-        // the top-level dictionary, we need to go deeper to copy the mutable subdictionaries
-        threadMetadataCopy = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
-        [((NSDictionary<NSString *, NSDictionary *> *)profileData[@"profile"][@"thread_metadata"])
-            enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull key, NSDictionary *_Nonnull obj,
-                BOOL *_Nonnull stop) { threadMetadataCopy[key] = [obj copy]; }];
-    }
-
+    NSMutableArray<SentrySample *> *const samples = profileData[@"profile"][@"samples"];
     // We need at least two samples to be able to draw a stack frame for any given function: one
     // sample for the start of the frame and another for the end. Otherwise we would only have a
     // stack frame with 0 duration, which wouldn't make sense.
-    if ([samplesCopy count] < 2) {
+    if ([samples count] < 2) {
         SENTRY_LOG_DEBUG(@"Not enough samples in profile");
         return nil;
     }
 
     // slice the profile data to only include the samples/metrics within the transaction
-    const auto slicedSamples = slicedProfileSamples(samplesCopy, transaction);
+    const auto slicedSamples = slicedProfileSamples(samples, transaction);
     if (slicedSamples.count < 2) {
         SENTRY_LOG_DEBUG(@"Not enough samples in profile during the transaction");
         return nil;
     }
-
     const auto payload = [NSMutableDictionary<NSString *, id> dictionary];
+    NSMutableDictionary<NSString *, id> *const profile = [profileData[@"profile"] mutableCopy];
+    profile[@"samples"] = serializedSamplesWithRelativeTimestamps(slicedSamples, transaction);
+    payload[@"profile"] = profile;
 
     payload[@"version"] = @"1";
     const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
@@ -366,15 +247,6 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     }
 
     payload[@"release"] = release;
-
-    payload[@"profile"] = @ {
-        @"samples" : serializedSamplesWithRelativeTimestamps(slicedSamples, transaction),
-        @"stacks" : stacksCopy,
-        @"frames" : framesCopy,
-        @"thread_metadata" : threadMetadataCopy,
-        @"queue_metadata" : queueMetadataCopy,
-    };
-
     payload[@"transaction"] = @ {
         @"id" : transaction.eventId.sentryIdString,
         @"trace_id" : transaction.trace.traceId.sentryIdString,
@@ -421,12 +293,150 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     return payload;
 }
 
+@implementation SentryProfilingMutableState
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _samples = [NSMutableArray<SentrySample *> array];
+        _stacks = [NSMutableArray<NSArray<NSNumber *> *> array];
+        _frames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
+        _threadMetadata = [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
+        _queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
+        _frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
+        _stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
+    }
+    return self;
+}
+
+@end
+
+@implementation SentryProfilingState {
+    SentryProfilingMutableState *_mutableState;
+    std::mutex _lock;
+}
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _mutableState = [[SentryProfilingMutableState alloc] init];
+    }
+    return self;
+}
+
+- (void)mutate:(void (^)(SentryProfilingMutableState *))block
+{
+    NSParameterAssert(block);
+    std::lock_guard<std::mutex> l(_lock);
+    block(_mutableState);
+}
+
+- (void)appendBacktrace:(const Backtrace &)backtrace {
+    [self mutate:^(SentryProfilingMutableState *state) {
+        const auto threadID = sentry_stringForUInt64(backtrace.threadMetadata.threadID);
+        
+        NSString *queueAddress = nil;
+        if (backtrace.queueMetadata.address != 0) {
+            queueAddress = sentry_formatHexAddressUInt64(backtrace.queueMetadata.address);
+        }
+        NSMutableDictionary<NSString *, id> *metadata = state.threadMetadata[threadID];
+        if (metadata == nil) {
+            metadata = [NSMutableDictionary<NSString *, id> dictionary];
+            state.threadMetadata[threadID] = metadata;
+        }
+        if (!backtrace.threadMetadata.name.empty() && metadata[@"name"] == nil) {
+            metadata[@"name"] = [NSString stringWithUTF8String:backtrace.threadMetadata.name.c_str()];
+        }
+        if (backtrace.threadMetadata.priority != -1 && metadata[@"priority"] == nil) {
+            metadata[@"priority"] = @(backtrace.threadMetadata.priority);
+        }
+        if (queueAddress != nil && state.queueMetadata[queueAddress] == nil
+            && backtrace.queueMetadata.label != nullptr) {
+            state.queueMetadata[queueAddress] =
+                @ { @"label" : [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()] };
+        }
+    #    if defined(DEBUG)
+        const auto symbols
+            = backtrace_symbols(reinterpret_cast<void *const *>(backtrace.addresses.data()),
+                static_cast<int>(backtrace.addresses.size()));
+    #    endif
+
+        const auto stack = [NSMutableArray<NSNumber *> array];
+        for (std::vector<uintptr_t>::size_type backtraceAddressIdx = 0;
+             backtraceAddressIdx < backtrace.addresses.size(); backtraceAddressIdx++) {
+            const auto instructionAddress
+                = sentry_formatHexAddressUInt64(backtrace.addresses[backtraceAddressIdx]);
+
+            const auto frameIndex = state.frameIndexLookup[instructionAddress];
+            if (frameIndex == nil) {
+                const auto frame = [NSMutableDictionary<NSString *, id> dictionary];
+                frame[@"instruction_addr"] = instructionAddress;
+    #    if defined(DEBUG)
+                frame[@"function"] = parseBacktraceSymbolsFunctionName(symbols[backtraceAddressIdx]);
+    #    endif
+                const auto newFrameIndex = @(state.frames.count);
+                [stack addObject:newFrameIndex];
+                state.frameIndexLookup[instructionAddress] = newFrameIndex;
+                [state.frames addObject:frame];
+            } else {
+                [stack addObject:frameIndex];
+            }
+        }
+
+        const auto sample = [[SentrySample alloc] init];
+        sample.absoluteTimestamp = backtrace.absoluteTimestamp;
+        sample.threadID = backtrace.threadMetadata.threadID;
+        if (queueAddress != nil) {
+            sample.queueAddress = queueAddress;
+        }
+        
+        const auto stackKey = [stack componentsJoinedByString:@"|"];
+        const auto stackIndex = state.stackIndexLookup[stackKey];
+        if (stackIndex) {
+            sample.stackIndex = stackIndex;
+        } else {
+            const auto nextStackIndex = @(state.stacks.count);
+            sample.stackIndex = nextStackIndex;
+            state.stackIndexLookup[stackKey] = nextStackIndex;
+            [state.stacks addObject:stack];
+        }
+        
+        [state.samples addObject:sample];
+    }];
+}
+
+- (NSDictionary<NSString *,id> *)copyProfilingData {
+    std::lock_guard<std::mutex> l(_lock);
+    
+    NSMutableArray<SentrySample *> *const samples = [_mutableState.samples copy];
+    NSMutableArray<NSArray<NSNumber *> *> *const stacks = [_mutableState.stacks copy];
+    NSMutableArray<NSDictionary<NSString *, id> *> *const frames = [_mutableState.frames copy];
+    NSMutableDictionary<NSString *, NSDictionary *> *const queueMetadata = [_mutableState.queueMetadata copy];
+
+    // thread metadata contains a mutable substructure, so it's not enough to perform a copy of
+    // the top-level dictionary, we need to go deeper to copy the mutable subdictionaries
+    const auto threadMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
+    [_mutableState.threadMetadata
+        enumerateKeysAndObjectsUsingBlock:^(NSString *_Nonnull key, NSDictionary *_Nonnull obj,
+            BOOL *_Nonnull stop) { threadMetadata[key] = [obj copy]; }];
+    
+    return @{
+        @"profile": @{
+            @"samples": samples,
+            @"stacks": stacks,
+            @"frames": frames,
+            @"thread_metadata": threadMetadata,
+            @"queue_metadata": queueMetadata
+        }
+    };
+}
+
+@end
+
 @implementation SentryProfiler {
-    NSMutableDictionary<NSString *, id> *_profileData;
+    SentryProfilingState *_state;
     std::shared_ptr<SamplingProfiler> _profiler;
     SentryMetricProfiler *_metricProfiler;
     SentryDebugImageProvider *_debugImageProvider;
-    thread::TIDType _mainThreadID;
 
     SentryProfilerTruncationReason _truncationReason;
     NSTimer *_timeoutTimer;
@@ -442,7 +452,6 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     SENTRY_LOG_DEBUG(@"Initialized new SentryProfiler %@", self);
     _debugImageProvider = [SentryDependencyContainer sharedInstance].debugImageProvider;
     _hub = hub;
-    _mainThreadID = ThreadHandle::current()->tid();
     return self;
 }
 
@@ -568,7 +577,7 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
         return nil;
     }
 
-    return serializedProfileData(_gCurrentProfiler->_profileData, transaction, profileID,
+    return serializedProfileData([_gCurrentProfiler->_state copyProfilingData], transaction, profileID,
         profilerTruncationReasonName(_gCurrentProfiler->_truncationReason),
         _gCurrentProfiler->_hub.scope.environmentString
             ?: _gCurrentProfiler->_hub.getClient.options.environment,
@@ -678,83 +687,24 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
 
     SENTRY_LOG_DEBUG(@"Starting profiler.");
 
-    _profileData = [NSMutableDictionary<NSString *, id> dictionary];
-    const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
-
-    /*
-     * Maintain an index of unique frames to avoid duplicating large amounts of data. Every
-     * unique frame is stored in an array, and every time a stack trace is captured for a
-     * sample, the stack is stored as an array of integers indexing into the array of frames.
-     * Stacks are thusly also stored as unique elements in their own index, an array of arrays
-     * of frame indices, and each sample references a stack by index, to deduplicate common
-     * stacks between samples, such as when the same deep function call runs across multiple
-     * samples.
-     *
-     * E.g. if we have the following samples in the following function call stacks:
-     *
-     *              v sample1    v sample2               v sample3    v sample4
-     * |-foo--------|------------|-----|    |-abc--------|------------|-----|
-     *    |-bar-----|------------|--|          |-def-----|------------|--|
-     *      |-baz---|------------|-|             |-ghi---|------------|-|
-     *
-     * Then we'd wind up with the following structures:
-     *
-     * frames: [
-     *   { function: foo, instruction_addr: ... },
-     *   { function: bar, instruction_addr: ... },
-     *   { function: baz, instruction_addr: ... },
-     *   { function: abc, instruction_addr: ... },
-     *   { function: def, instruction_addr: ... },
-     *   { function: ghi, instruction_addr: ... }
-     * ]
-     * stacks: [ [0, 1, 2], [3, 4, 5] ]
-     * samples: [
-     *   { stack_id: 0, ... },
-     *   { stack_id: 0, ... },
-     *   { stack_id: 1, ... },
-     *   { stack_id: 1, ... }
-     * ]
-     */
-    const auto samples = [NSMutableArray<SentrySample *> array];
-    const auto stacks = [NSMutableArray<NSArray<NSNumber *> *> array];
-    const auto frames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-    const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-    const auto stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-    sampledProfile[@"samples"] = samples;
-    sampledProfile[@"stacks"] = stacks;
-    sampledProfile[@"frames"] = frames;
-
-    const auto threadMetadata = [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
-    const auto queueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
-    sampledProfile[@"thread_metadata"] = threadMetadata;
-    sampledProfile[@"queue_metadata"] = queueMetadata;
-    _profileData[@"profile"] = sampledProfile;
-
-    __weak const auto weakSelf = self;
-    _profiler = std::make_shared<SamplingProfiler>(
-        [weakSelf, threadMetadata, queueMetadata, samples, mainThreadID = _mainThreadID, frames,
-            frameIndexLookup, stacks, stackIndexLookup](auto &backtrace) {
-            const auto strongSelf = weakSelf;
-            if (strongSelf == nil) {
-                SENTRY_LOG_WARN(@"Profiler instance no longer exists, cannot process next sample.");
-                return;
-            }
-
-        // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate etal.
-        // Doing this in a unified way between tests and production required extensive changes to
-        // the C++ layer, so we opted for this solution to avoid any potential breakages or
-        // performance hits there.
-#    if defined(TEST) || defined(TESTCI)
+    SentryProfilingState *const state = [[SentryProfilingState alloc] init];
+    _state = state;
+    _profiler = std::make_shared<SamplingProfiler>([state](auto &backtrace) {
+        @autoreleasepool {
+            // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate etal.
+            // Doing this in a unified way between tests and production required extensive changes to
+            // the C++ layer, so we opted for this solution to avoid any potential breakages or
+            // performance hits there.
+    #    if defined(TEST) || defined(TESTCI)
             Backtrace backtraceCopy = backtrace;
             backtraceCopy.absoluteTimestamp = SentryCurrentDate.systemTime;
-            processBacktrace(backtraceCopy, threadMetadata, queueMetadata, samples, stacks, frames,
-                frameIndexLookup, stackIndexLookup);
-#    else
-            processBacktrace(backtrace, threadMetadata, queueMetadata, samples, stacks, frames,
-                frameIndexLookup, stackIndexLookup);
-#    endif // defined(TEST) || defined(TESTCI)
-        },
-        kSentryProfilerFrequencyHz);
+            [state appendBacktrace:backtraceCopy];
+    #    else
+            [state appendBacktrace:backtrace];
+    #    endif // defined(TEST) || defined(TESTCI)
+        }
+    },
+    kSentryProfilerFrequencyHz);
     _profiler->startSampling();
 
     [self startMetricProfiler];

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -697,10 +697,10 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     _state = state;
     _profiler = std::make_shared<SamplingProfiler>(
         [state](auto &backtrace) {
-        // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate
-        // etal. Doing this in a unified way between tests and production required extensive
-        // changes to the C++ layer, so we opted for this solution to avoid any potential
-        // breakages or performance hits there.
+    // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate
+    // etal. Doing this in a unified way between tests and production required extensive
+    // changes to the C++ layer, so we opted for this solution to avoid any potential
+    // breakages or performance hits there.
 #    if defined(TEST) || defined(TESTCI)
             Backtrace backtraceCopy = backtrace;
             backtraceCopy.absoluteTimestamp = SentryCurrentDate.systemTime;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -697,19 +697,17 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     _state = state;
     _profiler = std::make_shared<SamplingProfiler>(
         [state](auto &backtrace) {
-            @autoreleasepool {
-            // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate
-            // etal. Doing this in a unified way between tests and production required extensive
-            // changes to the C++ layer, so we opted for this solution to avoid any potential
-            // breakages or performance hits there.
+        // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate
+        // etal. Doing this in a unified way between tests and production required extensive
+        // changes to the C++ layer, so we opted for this solution to avoid any potential
+        // breakages or performance hits there.
 #    if defined(TEST) || defined(TESTCI)
-                Backtrace backtraceCopy = backtrace;
-                backtraceCopy.absoluteTimestamp = SentryCurrentDate.systemTime;
-                [state appendBacktrace:backtraceCopy];
+            Backtrace backtraceCopy = backtrace;
+            backtraceCopy.absoluteTimestamp = SentryCurrentDate.systemTime;
+            [state appendBacktrace:backtraceCopy];
 #    else
-                [state appendBacktrace:backtrace];
+            [state appendBacktrace:backtrace];
 #    endif // defined(TEST) || defined(TESTCI)
-            }
         },
         kSentryProfilerFrequencyHz);
     _profiler->startSampling();

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -1,6 +1,6 @@
-#import <Foundation/Foundation.h>
 #import "SentryBacktrace.hpp"
 #import "SentryProfilingConditionals.h"
+#import <Foundation/Foundation.h>
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -12,8 +12,10 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) NSMutableArray<SentrySample *> *samples;
 @property (nonatomic, strong, readonly) NSMutableArray<NSArray<NSNumber *> *> *stacks;
 @property (nonatomic, strong, readonly) NSMutableArray<NSDictionary<NSString *, id> *> *frames;
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata;
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata;
+@property (nonatomic, strong, readonly)
+    NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata;
+@property (nonatomic, strong, readonly)
+    NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata;
 
 /*
  * Maintain an index of unique frames to avoid duplicating large amounts of data. Every
@@ -49,8 +51,10 @@ NS_ASSUME_NONNULL_BEGIN
  *   { stack_id: 1, ... }
  * ]
  */
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup;
-@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup;
+@property (nonatomic, strong, readonly)
+    NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup;
+@property (nonatomic, strong, readonly)
+    NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup;
 @end
 
 @interface SentryProfilingState : NSObject

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -1,0 +1,65 @@
+#import <Foundation/Foundation.h>
+#import "SentryBacktrace.hpp"
+#import "SentryProfilingConditionals.h"
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SentrySample;
+
+@interface SentryProfilingMutableState : NSObject
+@property (nonatomic, strong, readonly) NSMutableArray<SentrySample *> *samples;
+@property (nonatomic, strong, readonly) NSMutableArray<NSArray<NSNumber *> *> *stacks;
+@property (nonatomic, strong, readonly) NSMutableArray<NSDictionary<NSString *, id> *> *frames;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata;
+
+/*
+ * Maintain an index of unique frames to avoid duplicating large amounts of data. Every
+ * unique frame is stored in an array, and every time a stack trace is captured for a
+ * sample, the stack is stored as an array of integers indexing into the array of frames.
+ * Stacks are thusly also stored as unique elements in their own index, an array of arrays
+ * of frame indices, and each sample references a stack by index, to deduplicate common
+ * stacks between samples, such as when the same deep function call runs across multiple
+ * samples.
+ *
+ * E.g. if we have the following samples in the following function call stacks:
+ *
+ *              v sample1    v sample2               v sample3    v sample4
+ * |-foo--------|------------|-----|    |-abc--------|------------|-----|
+ *    |-bar-----|------------|--|          |-def-----|------------|--|
+ *      |-baz---|------------|-|             |-ghi---|------------|-|
+ *
+ * Then we'd wind up with the following structures:
+ *
+ * frames: [
+ *   { function: foo, instruction_addr: ... },
+ *   { function: bar, instruction_addr: ... },
+ *   { function: baz, instruction_addr: ... },
+ *   { function: abc, instruction_addr: ... },
+ *   { function: def, instruction_addr: ... },
+ *   { function: ghi, instruction_addr: ... }
+ * ]
+ * stacks: [ [0, 1, 2], [3, 4, 5] ]
+ * samples: [
+ *   { stack_id: 0, ... },
+ *   { stack_id: 0, ... },
+ *   { stack_id: 1, ... },
+ *   { stack_id: 1, ... }
+ * ]
+ */
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup;
+@property (nonatomic, strong, readonly) NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup;
+@end
+
+@interface SentryProfilingState : NSObject
+// All functions are safe to call from multiple threads concurrently
+- (void)mutate:(void (^)(SentryProfilingMutableState *))block;
+- (void)appendBacktrace:(const sentry::profiling::Backtrace &)backtrace;
+- (NSDictionary<NSString *, id> *)copyProfilingData;
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif

--- a/Sources/Sentry/include/SentryProfiler+Test.h
+++ b/Sources/Sentry/include/SentryProfiler+Test.h
@@ -1,5 +1,6 @@
 #include "SentryBacktrace.hpp"
 #import "SentryProfiler.h"
+#import "SentryProfiler+Private.h"
 #import "SentryProfilingConditionals.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -10,14 +11,6 @@
 @class SentryTransaction;
 
 NS_ASSUME_NONNULL_BEGIN
-
-void processBacktrace(const sentry::profiling::Backtrace &backtrace,
-    NSMutableDictionary<NSString *, NSMutableDictionary *> *threadMetadata,
-    NSMutableDictionary<NSString *, NSDictionary *> *queueMetadata,
-    NSMutableArray<SentrySample *> *samples, NSMutableArray<NSArray<NSNumber *> *> *stacks,
-    NSMutableArray<NSDictionary<NSString *, id> *> *frames,
-    NSMutableDictionary<NSString *, NSNumber *> *frameIndexLookup,
-    NSMutableDictionary<NSString *, NSNumber *> *stackIndexLookup);
 
 NSDictionary<NSString *, id> *serializedProfileData(NSDictionary<NSString *, id> *profileData,
     SentryTransaction *transaction, SentryId *profileID, NSString *truncationReason,

--- a/Sources/Sentry/include/SentryProfiler+Test.h
+++ b/Sources/Sentry/include/SentryProfiler+Test.h
@@ -1,6 +1,6 @@
 #include "SentryBacktrace.hpp"
-#import "SentryProfiler.h"
 #import "SentryProfiler+Private.h"
+#import "SentryProfiler.h"
 #import "SentryProfilingConditionals.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -21,7 +21,6 @@ typedef NS_ENUM(NSUInteger, SentryProfilerTruncationReason) {
 NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN const int kSentryProfilerFrequencyHz;
-SENTRY_EXTERN NSString *const kTestStringConst;
 
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -145,9 +145,8 @@ using namespace sentry::profiling;
     mutateExpectation.expectedFulfillmentCount = operations;
 
     void (^mutateBlock)(void) = ^(void) {
-        [state mutate:^(__unused SentryProfilingMutableState *mutableState) {
-            [mutateExpectation fulfill];
-        }];
+        [state mutate:^(
+            __unused SentryProfilingMutableState *mutableState) { [mutateExpectation fulfill]; }];
     };
 
     const auto sliceOperations = [[NSOperationQueue alloc] init]; // concurrent queue
@@ -195,7 +194,7 @@ using namespace sentry::profiling;
 
         backtrace.absoluteTimestamp = 1;
         [state appendBacktrace:backtrace];
-        
+
         backtrace.absoluteTimestamp = 2;
         [state appendBacktrace:backtrace];
     }
@@ -335,18 +334,19 @@ using namespace sentry::profiling;
     // record a third backtrace that's identical to the second to test stack/frame deduplication
 
     [state appendBacktrace:backtrace2];
-    
+
     [state mutate:^(SentryProfilingMutableState *mutableState) {
         XCTAssertEqual(mutableState.frames.count, 5UL);
         const auto expectedOrdered = @[
-            @"0x0000000000000123", @"0x0000000000000456", @"0x0000000000000789", @"0x0000000000000777",
-            @"0x0000000000000888"
+            @"0x0000000000000123", @"0x0000000000000456", @"0x0000000000000789",
+            @"0x0000000000000777", @"0x0000000000000888"
         ];
-        [mutableState.frames enumerateObjectsUsingBlock:^(NSDictionary<NSString *, id> *_Nonnull actualFrame,
-            NSUInteger idx, __unused BOOL *_Nonnull stop) {
-            XCTAssert([actualFrame[@"instruction_addr"] isEqualToString:expectedOrdered[idx]]);
-        }];
-        
+        [mutableState.frames
+            enumerateObjectsUsingBlock:^(NSDictionary<NSString *, id> *_Nonnull actualFrame,
+                NSUInteger idx, __unused BOOL *_Nonnull stop) {
+                XCTAssert([actualFrame[@"instruction_addr"] isEqualToString:expectedOrdered[idx]]);
+            }];
+
         XCTAssertEqual(mutableState.stacks.count, 2UL);
         XCTAssertEqual(mutableState.samples.count, 3UL);
     }];

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -60,15 +60,7 @@ using namespace sentry::profiling;
 
 - (void)testProfilerMutationDuringSlicing
 {
-    const auto resolvedThreadMetadata =
-        [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
-    const auto resolvedQueueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
-    const auto resolvedStacks = [NSMutableArray<NSArray<NSNumber *> *> array];
-    const auto resolvedSamples = [NSMutableArray<SentrySample *> array];
-    const auto resolvedFrames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-    const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-    const auto stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-
+    SentryProfilingState *state = [[SentryProfilingState alloc] init];
     // generate a large timeseries of simulated data
 
     const auto threads = 5;
@@ -100,9 +92,7 @@ using namespace sentry::profiling;
 
         for (auto sample = 0; sample < samplesPerThread; sample++) {
             backtrace.absoluteTimestamp = sampleIdx; // simulate 1 sample per nanosecond
-            processBacktrace(backtrace, resolvedThreadMetadata, resolvedQueueMetadata,
-                resolvedSamples, resolvedStacks, resolvedFrames, frameIndexLookup,
-                stackIndexLookup);
+            [state appendBacktrace:backtrace];
             ++sampleIdx;
         }
     }
@@ -127,8 +117,10 @@ using namespace sentry::profiling;
     sliceExpectation.expectedFulfillmentCount = operations;
 
     void (^sliceBlock)(void) = ^(void) {
-        __unused const auto slice = slicedProfileSamples(resolvedSamples, transaction);
-        [sliceExpectation fulfill];
+        [state mutate:^(SentryProfilingMutableState *mutableState) {
+            __unused const auto slice = slicedProfileSamples(mutableState.samples, transaction);
+            [sliceExpectation fulfill];
+        }];
     };
 
     ThreadMetadata threadMetadata;
@@ -153,9 +145,9 @@ using namespace sentry::profiling;
     mutateExpectation.expectedFulfillmentCount = operations;
 
     void (^mutateBlock)(void) = ^(void) {
-        processBacktrace(backtrace, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-            resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
-        [mutateExpectation fulfill];
+        [state mutate:^(__unused SentryProfilingMutableState *mutableState) {
+            [mutateExpectation fulfill];
+        }];
     };
 
     const auto sliceOperations = [[NSOperationQueue alloc] init]; // concurrent queue
@@ -184,15 +176,7 @@ using namespace sentry::profiling;
  */
 - (void)testProfilerMutationDuringSerialization
 {
-    const auto resolvedThreadMetadata =
-        [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
-    const auto resolvedQueueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
-    const auto resolvedStacks = [NSMutableArray<NSArray<NSNumber *> *> array];
-    const auto resolvedSamples = [NSMutableArray<SentrySample *> array];
-    const auto resolvedFrames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-    const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-    const auto stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-
+    SentryProfilingState *state = [[SentryProfilingState alloc] init];
     // initialize the data structures with some simulated data
     {
         ThreadMetadata threadMetadata;
@@ -210,22 +194,14 @@ using namespace sentry::profiling;
         backtrace.addresses = std::vector<std::uintptr_t>({ 0x4, 0x5, 0x6 });
 
         backtrace.absoluteTimestamp = 1;
-        processBacktrace(backtrace, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-            resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
-
+        [state appendBacktrace:backtrace];
+        
         backtrace.absoluteTimestamp = 2;
-        processBacktrace(backtrace, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-            resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
+        [state appendBacktrace:backtrace];
     }
 
     // serialize the data as if it were captured in a transaction envelope
-    const auto sampledProfile = [NSMutableDictionary<NSString *, id> dictionary];
-    sampledProfile[@"samples"] = resolvedSamples;
-    sampledProfile[@"stacks"] = resolvedStacks;
-    sampledProfile[@"frames"] = resolvedFrames;
-    sampledProfile[@"thread_metadata"] = resolvedThreadMetadata;
-    sampledProfile[@"queue_metadata"] = resolvedQueueMetadata;
-    const auto profileData = @{ @"profile" : sampledProfile };
+    const auto profileData = [state copyProfilingData];
 
     const auto context = [[SentrySpanContext alloc] initWithOperation:@"test trace"];
     const auto trace = [[SentryTracer alloc] initWithContext:context];
@@ -260,8 +236,7 @@ using namespace sentry::profiling;
         backtrace.absoluteTimestamp = 5;
         backtrace.addresses = std::vector<std::uintptr_t>({ 0x777, 0x888, 0x999 });
 
-        processBacktrace(backtrace, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-            resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
+        [state appendBacktrace:backtrace];
     }
 
     // cause the data structures to be modified again: overwrite previous thread metadata
@@ -282,8 +257,7 @@ using namespace sentry::profiling;
         backtrace.absoluteTimestamp = 6;
         backtrace.addresses = std::vector<std::uintptr_t>({ 0x4, 0x5, 0x6 });
 
-        processBacktrace(backtrace, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-            resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
+        [state appendBacktrace:backtrace];
     }
 
     // ensure the serialization's copied data structures don't contain the new addresses
@@ -314,14 +288,7 @@ using namespace sentry::profiling;
 
 - (void)testProfilerPayload
 {
-    const auto resolvedThreadMetadata =
-        [NSMutableDictionary<NSString *, NSMutableDictionary *> dictionary];
-    const auto resolvedQueueMetadata = [NSMutableDictionary<NSString *, NSDictionary *> dictionary];
-    const auto resolvedStacks = [NSMutableArray<NSArray<NSNumber *> *> array];
-    const auto resolvedSamples = [NSMutableArray<SentrySample *> array];
-    const auto resolvedFrames = [NSMutableArray<NSDictionary<NSString *, id> *> array];
-    const auto frameIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
-    const auto stackIndexLookup = [NSMutableDictionary<NSString *, NSNumber *> dictionary];
+    SentryProfilingState *state = [[SentryProfilingState alloc] init];
 
     // record an initial backtrace
 
@@ -342,8 +309,7 @@ using namespace sentry::profiling;
     backtrace1.absoluteTimestamp = 5;
     backtrace1.addresses = addresses1;
 
-    processBacktrace(backtrace1, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-        resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
+    [state appendBacktrace:backtrace1];
 
     // record a second backtrace with some common addresses to test frame deduplication
 
@@ -364,26 +330,26 @@ using namespace sentry::profiling;
     backtrace2.absoluteTimestamp = 5;
     backtrace2.addresses = addresses2;
 
-    processBacktrace(backtrace2, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-        resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
+    [state appendBacktrace:backtrace2];
 
     // record a third backtrace that's identical to the second to test stack/frame deduplication
 
-    processBacktrace(backtrace2, resolvedThreadMetadata, resolvedQueueMetadata, resolvedSamples,
-        resolvedStacks, resolvedFrames, frameIndexLookup, stackIndexLookup);
-
-    XCTAssertEqual(resolvedFrames.count, 5UL);
-    const auto expectedOrdered = @[
-        @"0x0000000000000123", @"0x0000000000000456", @"0x0000000000000789", @"0x0000000000000777",
-        @"0x0000000000000888"
-    ];
-    [resolvedFrames enumerateObjectsUsingBlock:^(NSDictionary<NSString *, id> *_Nonnull actualFrame,
-        NSUInteger idx, __unused BOOL *_Nonnull stop) {
-        XCTAssert([actualFrame[@"instruction_addr"] isEqualToString:expectedOrdered[idx]]);
+    [state appendBacktrace:backtrace2];
+    
+    [state mutate:^(SentryProfilingMutableState *mutableState) {
+        XCTAssertEqual(mutableState.frames.count, 5UL);
+        const auto expectedOrdered = @[
+            @"0x0000000000000123", @"0x0000000000000456", @"0x0000000000000789", @"0x0000000000000777",
+            @"0x0000000000000888"
+        ];
+        [mutableState.frames enumerateObjectsUsingBlock:^(NSDictionary<NSString *, id> *_Nonnull actualFrame,
+            NSUInteger idx, __unused BOOL *_Nonnull stop) {
+            XCTAssert([actualFrame[@"instruction_addr"] isEqualToString:expectedOrdered[idx]]);
+        }];
+        
+        XCTAssertEqual(mutableState.stacks.count, 2UL);
+        XCTAssertEqual(mutableState.samples.count, 3UL);
     }];
-
-    XCTAssertEqual(resolvedStacks.count, 2UL);
-    XCTAssertEqual(resolvedSamples.count, 3UL);
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description

While debugging the memory leaks reported in #2980 I found additional data race issues on top of the ones fixed in #3018. This is a larger refactor that fixes those issues but also simplifies the way that synchronization works.

In #3018, there was a change to add locking where `processBacktrace` mutated data structures that could be accessed concurrently. It attempted to separate the code that did not access the shared data structures, and moved all mutating code to a section at the end of the function. However, it missed a few reads from those data structures that also needed to be synchronized (e.g. `frames.count` and `stacks.count`). Generally, separating the critical section from the rest of the logic in that function is not worth the pain because the taking the lock for the entire duration of the function is not expensive.

This refactor adds a new type, `SentryProfilingState`, that centralizes all logic for reading/writing the shared data structures. This has the additional benefit that you no longer need a `processBacktrace` function that takes many parameters where the lifetime of those parameters is unclear (this will be helpful for fixing the memory leaks in a subsequent PR).

All notable changes have been commented on inline.

## :green_heart: How did you test it?

Ran all existing tests, they pass.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
