### PR TITLE
fix: A crash for user interaction transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fix crashes in profiling serialization race condition (#3018)
+- Fix a crash for user interaction transactions (#3036)
 
 ## 8.7.1
 

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -211,6 +211,15 @@ class SentryTracerTests: XCTestCase {
 
         XCTAssertFalse(fixture.timerWrapper.overrides.timer.isValid)
     }
+    
+    func testDeadlineTimer_MultipleSpansFinishedInParallel() {
+        let sut = fixture.getSut(idleTimeout: 0.01, dispatchQueueWrapper: SentryDispatchQueueWrapper())
+        
+        testConcurrentModifications(writeWork: { _ in
+            let child = sut.startChild(operation: self.fixture.transactionOperation)
+            child.finish()
+        })
+    }
 
     func testFinish_CheckDefaultStatus() {
         let sut = fixture.getSut()


### PR DESCRIPTION




## :scroll: Description

Finishing multiple spans on different threads that cancel and reschedule the idle timeout for user interaction transactions could lead to EXC_BAD_ACCESS crashes. This is fixed now by synchronizing the access to the idleTimeout block.

## :bulb: Motivation and Context

Fixes GH-3002

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
