### PR TITLE
fix: use-after-free ASAN warning

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      enableAddressSanitizer = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -52,6 +53,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableAddressSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -359,10 +359,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="fn9-mQ-2PY">
-                                <rect key="frame" x="25" y="235.5" width="270" height="112"/>
+                                <rect key="frame" x="25" y="232.5" width="270" height="118.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Q2k-6Y-RnD">
-                                        <rect key="frame" x="0.0" y="0.0" width="135" height="112"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="135" height="118.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NFC-V3-lgW">
                                                 <rect key="frame" x="0.0" y="0.0" width="135" height="28"/>
@@ -373,7 +373,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Llv-Yz-cwF">
-                                                <rect key="frame" x="0.0" y="28" width="135" height="28"/>
+                                                <rect key="frame" x="0.0" y="30" width="135" height="28"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <state key="normal" title="Capture NSException"/>
                                                 <connections>
@@ -381,7 +381,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJ4-gS-64G" userLabel="fatalError">
-                                                <rect key="frame" x="0.0" y="56" width="135" height="28"/>
+                                                <rect key="frame" x="0.0" y="60" width="135" height="28"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <state key="normal" title="Throw FatalError"/>
                                                 <connections>
@@ -389,7 +389,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NYx-6R-0bb">
-                                                <rect key="frame" x="0.0" y="84" width="135" height="28"/>
+                                                <rect key="frame" x="0.0" y="90.5" width="135" height="28"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <state key="normal" title="OOM crash"/>
                                                 <connections>
@@ -399,7 +399,7 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="2CV-VI-MDY">
-                                        <rect key="frame" x="135" y="0.0" width="135" height="112"/>
+                                        <rect key="frame" x="135" y="0.0" width="135" height="118.5"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zbo-2T-1Zm">
                                                 <rect key="frame" x="0.0" y="0.0" width="135" height="28"/>
@@ -411,7 +411,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s6w-E3-5yE" userLabel="DiskWriteException">
-                                                <rect key="frame" x="0.0" y="42" width="135" height="28"/>
+                                                <rect key="frame" x="0.0" y="28" width="135" height="28"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <state key="normal" title="DiskWriteException"/>
                                                 <connections>
@@ -419,28 +419,48 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NNd-Ec-zXw">
-                                                <rect key="frame" x="0.0" y="84" width="135" height="28"/>
+                                                <rect key="frame" x="0.0" y="56" width="135" height="28"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <state key="normal" title="Crash the app"/>
                                                 <connections>
                                                     <action selector="crash:" destination="QmU-DD-itF" eventType="touchUpInside" id="qlZ-bL-KUT"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJs-Av-cg2">
+                                                <rect key="frame" x="0.0" y="84" width="135" height="34.5"/>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="Use-after-free"/>
+                                                <connections>
+                                                    <action selector="useAfterFree:" destination="QmU-DD-itF" eventType="touchUpInside" id="CBM-tY-0bu"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                     </stackView>
                                 </subviews>
                             </stackView>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1zm-ho-TCr">
+                                <rect key="frame" x="40" y="227.5" width="240" height="128"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="240" id="5Ge-8E-fcn"/>
+                                    <constraint firstAttribute="height" constant="128" id="lc6-97-p3W"/>
+                                </constraints>
+                            </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="RXi-Ac-EvL"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="fn9-mQ-2PY" firstAttribute="centerX" secondItem="RXi-Ac-EvL" secondAttribute="centerX" id="6Jl-qx-lzY"/>
+                            <constraint firstItem="1zm-ho-TCr" firstAttribute="centerY" secondItem="RXi-Ac-EvL" secondAttribute="centerY" id="JyK-Aq-Hqe"/>
                             <constraint firstItem="fn9-mQ-2PY" firstAttribute="centerY" secondItem="RXi-Ac-EvL" secondAttribute="centerY" id="UYM-w4-XaB"/>
+                            <constraint firstItem="1zm-ho-TCr" firstAttribute="centerX" secondItem="RXi-Ac-EvL" secondAttribute="centerX" id="z3k-vH-nPR"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Errors" image="exclamationmark.triangle.fill" catalog="system" id="u05-ZO-4bg">
                         <imageReference key="selectedImage" image="exclamationmark.triangle.fill" catalog="system"/>
                     </tabBarItem>
+                    <connections>
+                        <outlet property="imageView" destination="1zm-ho-TCr" id="JvD-Tf-Vwc"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0Fg-3B-Ecy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
@@ -4,12 +4,17 @@ import UIKit
 
 class ErrorsViewController: UIViewController {
 
+    @IBOutlet weak var imageView: UIImageView!
     private let dispatchQueue = DispatchQueue(label: "ErrorsViewController", attributes: .concurrent)
     private let diskWriteException = DiskWriteException()
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         SentrySDK.reportFullyDisplayed()
+    }
+
+    @IBAction func useAfterFree(_ sender: UIButton) {
+        imageView.image = UIImage(named: "")
     }
 
     @IBAction func diskWriteException(_ sender: UIButton) {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -98,6 +98,21 @@ class LaunchUITests: XCTestCase {
         app.buttons["Extra"].tap()
         checkSlowAndFrozenFrames()
     }
+
+    /**
+     * We received a customer report that ASAN reports a use-after-free error after
+     * calling UIImage(named:) with an empty string argument. Recording another
+     * transaction leads to the ASAN error.
+     */
+    func testUseAfterFreeAfterUIImageNamedEmptyString() {
+        let app = XCUIApplication()
+
+        // this primes the state required according to the customer report, by setting a UIImageView.image property to a UIImage(named: "")
+        app/*@START_MENU_TOKEN@*/.staticTexts["Use-after-free"]/*[[".buttons[\"Use-after-free\"].staticTexts[\"Use-after-free\"]",".staticTexts[\"Use-after-free\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+
+        // this causes another transaction to be recorded which hits the codepath necessary for the ASAN to trip
+        app.tabBars["Tab Bar"].buttons["Extra"].tap()
+    }
 }
 
 private extension LaunchUITests {

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -917,7 +917,7 @@ writeNotableStackContents(const SentryCrashReportWriter *const writer,
     for (uintptr_t address = lowAddress; address < highAddress; address += sizeof(address)) {
         if (sentrycrashmem_copySafely(
                 (void *)address, &contentsAsPointer, sizeof(contentsAsPointer))) {
-            sprintf(nameBuffer, "stack@%p", (void *)address);
+            //            sprintf(nameBuffer, "stack@%p", (void *)address);
             writeMemoryContentsIfNotable(writer, nameBuffer, contentsAsPointer);
         }
     }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

A customer reported that ASAN reports a use-after-free in Sentry code after assigning a UIImage to an image view, which is initialized with an empty string for the asset name. This draft PR so far reproduces the issue in a test case for further investigation. 

<img width="1812" alt="image" src="https://github.com/getsentry/sentry-cocoa/assets/3241469/63085779-556d-4acb-ae77-8ee23804d2f3">


## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
