### PR TITLE
feat: Experimental support for Swift Async stacktraces

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,14 +130,6 @@ jobs:
             xcode: '14.3'
             test-destination-os: 'latest'
 
-          # MetricKit doesn't exist for tvOS, so we can still run unit tests with
-          # Xcode 12 for it.
-          # tvOS 14
-          - runs-on: macos-11
-            platform: 'tvOS'
-            xcode: '12.5.1'
-            test-destination-os: 'latest'
-
           # tvOS 15
           - runs-on: macos-12
             platform: 'tvOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Support for stitching async Swift Concurrency frames (#3051)
+- Experimental support for Swift Async stacktraces (#3051)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Support for stitching async Swift Concurrency frames
+
 ### Fixes
 
 - Convert one of the two remaining usages of `sprintf` to `snprintf` (#2866)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Support for stitching async Swift Concurrency frames
+- Support for stitching async Swift Concurrency frames (#3051)
 
 ### Fixes
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -742,6 +742,8 @@
 		D8370B6C273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */; };
 		D84793262788737D00BE8E99 /* SentryByteCountFormatter.m in Sources */ = {isa = PBXBuildFile; fileRef = D84793242788737D00BE8E99 /* SentryByteCountFormatter.m */; };
 		D8479328278873A100BE8E99 /* SentryByteCountFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = D8479327278873A100BE8E99 /* SentryByteCountFormatter.h */; };
+		D84F833D2A1CC401005828E0 /* SentrySwiftAsyncIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = D84F833B2A1CC401005828E0 /* SentrySwiftAsyncIntegration.h */; };
+		D84F833E2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = D84F833C2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m */; };
 		D85596F3280580F10041FF8B /* SentryScreenshotIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = D85596F1280580F10041FF8B /* SentryScreenshotIntegration.m */; };
 		D855AD62286ED6A4002573E1 /* SentryCrashTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D855AD61286ED6A4002573E1 /* SentryCrashTests.m */; };
 		D855B3E827D652AF00BCED76 /* SentryCoreDataTrackingIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D855B3E727D652AF00BCED76 /* SentryCoreDataTrackingIntegrationTest.swift */; };
@@ -1671,6 +1673,8 @@
 		D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNSURLSessionTaskSearch.h; path = include/SentryNSURLSessionTaskSearch.h; sourceTree = "<group>"; };
 		D84793242788737D00BE8E99 /* SentryByteCountFormatter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryByteCountFormatter.m; sourceTree = "<group>"; };
 		D8479327278873A100BE8E99 /* SentryByteCountFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryByteCountFormatter.h; path = include/SentryByteCountFormatter.h; sourceTree = "<group>"; };
+		D84F833B2A1CC401005828E0 /* SentrySwiftAsyncIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySwiftAsyncIntegration.h; path = include/SentrySwiftAsyncIntegration.h; sourceTree = "<group>"; };
+		D84F833C2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySwiftAsyncIntegration.m; sourceTree = "<group>"; };
 		D85596F1280580F10041FF8B /* SentryScreenshotIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryScreenshotIntegration.m; sourceTree = "<group>"; };
 		D855AD61286ED6A4002573E1 /* SentryCrashTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashTests.m; sourceTree = "<group>"; };
 		D855B3E727D652AF00BCED76 /* SentryCoreDataTrackingIntegrationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCoreDataTrackingIntegrationTest.swift; sourceTree = "<group>"; };
@@ -2798,6 +2802,8 @@
 				7BCFBD6E2681D0EE00BC27D8 /* SentryCrashScopeObserver.m */,
 				7B96571F26830C9100C66E25 /* SentryScopeSyncC.h */,
 				7B96572126830D2400C66E25 /* SentryScopeSyncC.c */,
+				D84F833B2A1CC401005828E0 /* SentrySwiftAsyncIntegration.h */,
+				D84F833C2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m */,
 			);
 			name = SentryCrash;
 			sourceTree = "<group>";
@@ -3443,6 +3449,7 @@
 				7B98D7E425FB7A7200C5A389 /* SentryAppState.h in Headers */,
 				7BDEAA022632A4580001EA25 /* SentryOptions+Private.h in Headers */,
 				A8AFFCCD29069C3E00967CD7 /* SentryHttpStatusCodeRange.h in Headers */,
+				D84F833D2A1CC401005828E0 /* SentrySwiftAsyncIntegration.h in Headers */,
 				15E0A8EA240F2C9000F044E3 /* SentrySerialization.h in Headers */,
 				63FE70EF20DA4C1000CDBAE8 /* SentryCrashMonitor_AppState.h in Headers */,
 				635B3F381EBC6E2500A6176D /* SentryAsynchronousOperation.h in Headers */,
@@ -3896,6 +3903,7 @@
 				7B8713B426415BAA006D6004 /* SentryAppStartTracker.m in Sources */,
 				7BDB03BB2513652900BAE198 /* SentryDispatchQueueWrapper.m in Sources */,
 				7B6C5EDE264E8DF00010D138 /* SentryFramesTracker.m in Sources */,
+				D84F833E2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m in Sources */,
 				7B6438AB26A70F24000D0F65 /* UIViewController+Sentry.m in Sources */,
 				63AA76A31EB9CBAA00D153DE /* SentryDsn.m in Sources */,
 				63B818FA1EC34639002FDF4C /* SentryDebugMeta.m in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -190,7 +190,7 @@
 		63FE710120DA4C1000CDBAE8 /* SentryCrashDate.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE700720DA4C1000CDBAE8 /* SentryCrashDate.h */; };
 		63FE710320DA4C1000CDBAE8 /* SentryCrashMachineContext_Apple.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE700820DA4C1000CDBAE8 /* SentryCrashMachineContext_Apple.h */; };
 		63FE710520DA4C1000CDBAE8 /* SentryCrashLogger.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700920DA4C1000CDBAE8 /* SentryCrashLogger.c */; };
-		63FE710720DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700A20DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.c */; };
+		63FE710720DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700A20DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m */; };
 		63FE710920DA4C1000CDBAE8 /* SentryCrashFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE700B20DA4C1000CDBAE8 /* SentryCrashFileUtils.h */; };
 		63FE710B20DA4C1000CDBAE8 /* SentryCrashMach.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700C20DA4C1000CDBAE8 /* SentryCrashMach.c */; };
 		63FE710D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c */; };
@@ -1060,7 +1060,7 @@
 		63FE700720DA4C1000CDBAE8 /* SentryCrashDate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashDate.h; sourceTree = "<group>"; };
 		63FE700820DA4C1000CDBAE8 /* SentryCrashMachineContext_Apple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashMachineContext_Apple.h; sourceTree = "<group>"; };
 		63FE700920DA4C1000CDBAE8 /* SentryCrashLogger.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashLogger.c; sourceTree = "<group>"; };
-		63FE700A20DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashStackCursor_SelfThread.c; sourceTree = "<group>"; };
+		63FE700A20DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashStackCursor_SelfThread.m; sourceTree = "<group>"; };
 		63FE700B20DA4C1000CDBAE8 /* SentryCrashFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashFileUtils.h; sourceTree = "<group>"; };
 		63FE700C20DA4C1000CDBAE8 /* SentryCrashMach.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashMach.c; sourceTree = "<group>"; };
 		63FE700D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashStackCursor_MachineContext.c; sourceTree = "<group>"; };
@@ -2435,7 +2435,7 @@
 				63FE702B20DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.h */,
 				63FE700D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c */,
 				63FE703120DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.h */,
-				63FE700A20DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.c */,
+				63FE700A20DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m */,
 				63FE702620DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.h */,
 				63FE703B20DA4C1000CDBAE8 /* SentryCrashStackCursor.c */,
 				63FE701C20DA4C1000CDBAE8 /* SentryCrashStackCursor.h */,
@@ -3972,7 +3972,7 @@
 				D8F6A2472885512100320515 /* SentryPredicateDescriptor.m in Sources */,
 				A839D89A24864BA8003B7AFD /* SentrySystemEventBreadcrumbs.m in Sources */,
 				7D082B8323C628790029866B /* SentryMeta.m in Sources */,
-				63FE710720DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.c in Sources */,
+				63FE710720DA4C1000CDBAE8 /* SentryCrashStackCursor_SelfThread.m in Sources */,
 				63FE711120DA4C1000CDBAE8 /* SentryCrashDebug.c in Sources */,
 				7B883F49253D714C00879E62 /* SentryCrashUUIDConversion.c in Sources */,
 				63FE716720DA4C1100CDBAE8 /* SentryCrashCPU.c in Sources */,

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -482,6 +482,13 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic) BOOL enableTimeToFullDisplay;
 
+
+/**
+ * @warning This is an experimental feature and may still have bugs.
+ * @brief Stitches the call to Swift Async functions in one consecutive stack trace.
+ * @note Default value is @c NO .
+ */
+@property (nonatomic, assign) BOOL stitchSwiftAsync;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -487,7 +487,7 @@ NS_SWIFT_NAME(Options)
  * @brief Stitches the call to Swift Async functions in one consecutive stack trace.
  * @note Default value is @c NO .
  */
-@property (nonatomic, assign) BOOL stitchSwiftAsync;
+@property (nonatomic, assign) BOOL swiftAsyncStacktraces;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -107,7 +107,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;
         self.sendClientReports = YES;
-        self.stitchSwiftAsync = NO;
+        self.swiftAsyncStacktraces = NO;
 
 #if TARGET_OS_OSX
         NSString *dsn = [[[NSProcessInfo processInfo] environment] objectForKey:@"SENTRY_DSN"];
@@ -317,8 +317,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
     [self setBool:options[@"enableWatchdogTerminationTracking"]
             block:^(BOOL value) { self->_enableWatchdogTerminationTracking = value; }];
 
-    [self setBool:options[@"stitchSwiftAsync"]
-            block:^(BOOL value) { self->_stitchSwiftAsync = value; }];
+    [self setBool:options[@"swiftAsyncStacktraces"]
+            block:^(BOOL value) { self->_swiftAsyncStacktraces = value; }];
 
     if ([options[@"sessionTrackingIntervalMillis"] isKindOfClass:[NSNumber class]]) {
         self.sessionTrackingIntervalMillis =

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -43,7 +43,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
             @"SentryAutoBreadcrumbTrackingIntegration", @"SentryAutoSessionTrackingIntegration",
             @"SentryAppStartTrackingIntegration", @"SentryWatchdogTerminationTrackingIntegration",
             @"SentryPerformanceTrackingIntegration", @"SentryNetworkTrackingIntegration",
-            @"SentryFileIOTrackingIntegration", @"SentryCoreDataTrackingIntegration"
+            @"SentryFileIOTrackingIntegration", @"SentryCoreDataTrackingIntegration",
+            @"SentrySwiftAsyncIntegration"
         ]
             .mutableCopy;
 
@@ -106,6 +107,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;
         self.sendClientReports = YES;
+        self.stitchSwiftAsync = NO;
 
 #if TARGET_OS_OSX
         NSString *dsn = [[[NSProcessInfo processInfo] environment] objectForKey:@"SENTRY_DSN"];
@@ -314,6 +316,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[@"enableWatchdogTerminationTracking"]
             block:^(BOOL value) { self->_enableWatchdogTerminationTracking = value; }];
+
+    [self setBool:options[@"stitchSwiftAsync"]
+            block:^(BOOL value) { self->_stitchSwiftAsync = value; }];
 
     if ([options[@"sessionTrackingIntervalMillis"] isKindOfClass:[NSNumber class]]) {
         self.sessionTrackingIntervalMillis =

--- a/Sources/Sentry/SentrySwiftAsyncIntegration.m
+++ b/Sources/Sentry/SentrySwiftAsyncIntegration.m
@@ -1,0 +1,16 @@
+#import "SentrySwiftAsyncIntegration.h"
+#import "SentryCrashStackCursor_SelfThread.h"
+
+@implementation SentrySwiftAsyncIntegration
+
+- (BOOL)installWithOptions:(nonnull SentryOptions *)options
+{
+    sentrycrashsc_setSwiftAsyncStitching(options.stitchSwiftAsync);
+    return options.stitchSwiftAsync;
+}
+
+- (void)uninstall {
+    sentrycrashsc_setSwiftAsyncStitching(NO);
+}
+
+@end

--- a/Sources/Sentry/SentrySwiftAsyncIntegration.m
+++ b/Sources/Sentry/SentrySwiftAsyncIntegration.m
@@ -5,8 +5,8 @@
 
 - (BOOL)installWithOptions:(nonnull SentryOptions *)options
 {
-    sentrycrashsc_setSwiftAsyncStitching(options.stitchSwiftAsync);
-    return options.stitchSwiftAsync;
+    sentrycrashsc_setSwiftAsyncStitching(options.swiftAsyncStacktraces);
+    return options.swiftAsyncStacktraces;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/include/SentrySwiftAsyncIntegration.h
+++ b/Sources/Sentry/include/SentrySwiftAsyncIntegration.h
@@ -1,0 +1,11 @@
+#import "SentryBaseIntegration.h"
+#import "SentryIntegrationProtocol.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentrySwiftAsyncIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.h
@@ -42,6 +42,9 @@ extern "C" {
  */
 void sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries);
 
+
+void sentrycrashsc_setSwiftAsyncStitching(bool enabled);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -34,8 +34,6 @@
     (SentryCrashSC_CONTEXT_SIZE                                                                    \
         - sizeof(SentryCrashStackCursor_Backtrace_Context) / sizeof(void *) - 1)
 
-size_t backtrace_async(void **array, size_t length, uint32_t *task_id);
-
 typedef struct {
     SentryCrashStackCursor_Backtrace_Context SelfThreadContextSpacer;
     uintptr_t backtrace[0];
@@ -46,6 +44,8 @@ sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
 
+//backtrace_async api is not available for xcode 12
+#if __clang_major__ > 13
     int backtraceLength;
     if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
         backtraceLength
@@ -53,6 +53,9 @@ sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
     } else {
         backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
     }
+#else
+    int backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+#endif
 
     sentrycrashsc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -43,6 +43,14 @@ void
 sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
-    int backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+
+    int backtraceLength;
+    if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
+        backtraceLength
+            = (int)backtrace_async((void **)context->backtrace, MAX_BACKTRACE_LENGTH, NULL);
+    } else {
+        backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
+    }
+
     sentrycrashsc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -44,8 +44,8 @@ sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
 
-//backtrace_async api is not available for xcode 12
-#if __clang_major__ > 13
+//backtrace_async api is only available from xcode 13
+#if __clang_major__ >= 13
     int backtraceLength;
     if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
         backtraceLength

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -44,7 +44,7 @@ sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
 {
     SelfThreadContext *context = (SelfThreadContext *)cursor->context;
 
-//backtrace_async api is only available from xcode 13
+// backtrace_async api is only available from xcode 13
 #if __clang_major__ >= 13
     int backtraceLength;
     if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -34,6 +34,8 @@
     (SentryCrashSC_CONTEXT_SIZE                                                                    \
         - sizeof(SentryCrashStackCursor_Backtrace_Context) / sizeof(void *) - 1)
 
+size_t backtrace_async(void** array, size_t length, uint32_t *task_id);
+
 typedef struct {
     SentryCrashStackCursor_Backtrace_Context SelfThreadContextSpacer;
     uintptr_t backtrace[0];

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -68,30 +68,30 @@ class SentryStacktraceBuilderTests: XCTestCase {
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
 
-//    func testConcurrentStacktraces() async throws {
-//        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
-//        SentrySDK.start { options in
-//            options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
-//        }
-//
-//        await Task { await innerFrame1() }.value
-//    }
-//
-//    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-//    func innerFrame1() async {
-//        await Task { @MainActor in }.value
-//        await innerFrame2()
-//    }
-//
-//    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-//    func innerFrame2() async {
-//        let needed = ["testConcurrentStacktraces", "innerFrame1", "innerFrame2"]
-//        let actual = fixture.sut.buildStacktraceForCurrentThreadAsyncUnsafe()!
-//        let filteredFrames = actual.frames
-//            .compactMap(\.function)
-//            .filter { needed.contains(where: $0.contains) }
-//        XCTAssertGreaterThanOrEqual(filteredFrames.count, 3, "The Stacktrace must include the async callers.")
-//    }
+    func testConcurrentStacktraces() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        SentrySDK.start { options in
+            options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
+        }
+
+        await Task { await innerFrame1() }.value
+    }
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func innerFrame1() async {
+        await Task { @MainActor in }.value
+        await innerFrame2()
+    }
+
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func innerFrame2() async {
+        let needed = ["testConcurrentStacktraces", "innerFrame1", "innerFrame2"]
+        let actual = fixture.sut.buildStacktraceForCurrentThreadAsyncUnsafe()!
+        let filteredFrames = actual.frames
+            .compactMap({ $0.function })
+            .filter { needed.contains(where: $0.contains) }
+        XCTAssertGreaterThanOrEqual(filteredFrames.count, 3, "The Stacktrace must include the async callers.")
+    }
 
     func asyncFrame1(expect: XCTestExpectation) {
         fixture.queue.asyncAfter(deadline: DispatchTime.now()) {

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -68,7 +68,6 @@ class SentryStacktraceBuilderTests: XCTestCase {
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
 
-
     func testConcurrentStacktraces() {
         guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         let waitForAsyncToRun = expectation(description: "Wait async functions")

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -6,20 +6,20 @@ class SentryStacktraceBuilderTests: XCTestCase {
     
     private class Fixture {
         let queue = DispatchQueue(label: "SentryStacktraceBuilderTests")
-        
+
         var sut: SentryStacktraceBuilder {
             return SentryStacktraceBuilder(crashStackEntryMapper: SentryCrashStackEntryMapper(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])))
         }
     }
-    
+
     private var fixture: Fixture!
-    
+
     override func setUp() {
         super.setUp()
         fixture = Fixture()
         clearTestState()
     }
-    
+
     override func tearDown() {
         super.tearDown()
         clearTestState()
@@ -67,32 +67,32 @@ class SentryStacktraceBuilderTests: XCTestCase {
         
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
-    
-    func testConcurrentStacktraces() async throws {
-        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
-        SentrySDK.start { options in
-            options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
-        }
-        
-        await Task { await innerFrame1() }.value
-    }
-    
-    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func innerFrame1() async {
-        await Task { @MainActor in }.value
-        await innerFrame2()
-    }
-    
-    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func innerFrame2() async {
-        let needed = ["testConcurrentStacktraces", "innerFrame1", "innerFrame2"]
-        let actual = fixture.sut.buildStacktraceForCurrentThreadAsyncUnsafe()!
-        let filteredFrames = actual.frames
-            .compactMap(\.function)
-            .filter { needed.contains(where: $0.contains) }
-        XCTAssertGreaterThanOrEqual(filteredFrames.count, 3, "The Stacktrace must include the async callers.")
-    }
-    
+
+//    func testConcurrentStacktraces() async throws {
+//        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+//        SentrySDK.start { options in
+//            options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
+//        }
+//
+//        await Task { await innerFrame1() }.value
+//    }
+//
+//    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+//    func innerFrame1() async {
+//        await Task { @MainActor in }.value
+//        await innerFrame2()
+//    }
+//
+//    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+//    func innerFrame2() async {
+//        let needed = ["testConcurrentStacktraces", "innerFrame1", "innerFrame2"]
+//        let actual = fixture.sut.buildStacktraceForCurrentThreadAsyncUnsafe()!
+//        let filteredFrames = actual.frames
+//            .compactMap(\.function)
+//            .filter { needed.contains(where: $0.contains) }
+//        XCTAssertGreaterThanOrEqual(filteredFrames.count, 3, "The Stacktrace must include the async callers.")
+//    }
+
     func asyncFrame1(expect: XCTestExpectation) {
         fixture.queue.asyncAfter(deadline: DispatchTime.now()) {
             self.asyncFrame2(expect: expect)
@@ -107,7 +107,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
     
     func asyncAssertion(expect: XCTestExpectation) {
         let actual = fixture.sut.buildStacktraceForCurrentThread()
-        
+
         let filteredFrames = actual.frames.filter { frame in
             return frame.function?.contains("testAsyncStacktraces") ?? false ||
             frame.function?.contains("asyncFrame1") ?? false ||
@@ -116,10 +116,10 @@ class SentryStacktraceBuilderTests: XCTestCase {
         let startFrames = actual.frames.filter { frame in
             return frame.stackStart?.boolValue ?? false
         }
-        
+
         XCTAssertTrue(filteredFrames.count >= 3, "The Stacktrace must include the async callers.")
         XCTAssertTrue(startFrames.count >= 3, "The Stacktrace must have async continuation markers.")
-        
+
         expect.fulfill()
     }
 }

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -2,6 +2,7 @@
 import SentryTestUtils
 import XCTest
 
+@available(tvOS 15.0, *)
 class SentryStacktraceBuilderTests: XCTestCase {
     
     private class Fixture {
@@ -75,7 +76,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
             await self.firstFrame()
             waitForAsyncToRun.fulfill()
         }
-        wait(for: [waitForAsyncToRun], timeout: 100)
+        wait(for: [waitForAsyncToRun], timeout: 1)
     }
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -68,8 +68,8 @@ class SentryStacktraceBuilderTests: XCTestCase {
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
 
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
     func testConcurrentStacktraces() async throws {
-        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
         }

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -6,20 +6,20 @@ class SentryStacktraceBuilderTests: XCTestCase {
     
     private class Fixture {
         let queue = DispatchQueue(label: "SentryStacktraceBuilderTests")
-
+        
         var sut: SentryStacktraceBuilder {
             return SentryStacktraceBuilder(crashStackEntryMapper: SentryCrashStackEntryMapper(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])))
         }
     }
-
+    
     private var fixture: Fixture!
-
+    
     override func setUp() {
         super.setUp()
         fixture = Fixture()
         clearTestState()
     }
-
+    
     override func tearDown() {
         super.tearDown()
         clearTestState()
@@ -67,7 +67,32 @@ class SentryStacktraceBuilderTests: XCTestCase {
         
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
-     
+    
+    func testConcurrentStacktraces() async throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+        SentrySDK.start { options in
+            options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
+        }
+        
+        await Task { await innerFrame1() }.value
+    }
+    
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func innerFrame1() async {
+        await Task { @MainActor in }.value
+        await innerFrame2()
+    }
+    
+    @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
+    func innerFrame2() async {
+        let needed = ["testConcurrentStacktraces", "innerFrame1", "innerFrame2"]
+        let actual = fixture.sut.buildStacktraceForCurrentThreadAsyncUnsafe()!
+        let filteredFrames = actual.frames
+            .compactMap(\.function)
+            .filter { needed.contains(where: $0.contains) }
+        XCTAssertGreaterThanOrEqual(filteredFrames.count, 3, "The Stacktrace must include the async callers.")
+    }
+    
     func asyncFrame1(expect: XCTestExpectation) {
         fixture.queue.asyncAfter(deadline: DispatchTime.now()) {
             self.asyncFrame2(expect: expect)
@@ -82,7 +107,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
     
     func asyncAssertion(expect: XCTestExpectation) {
         let actual = fixture.sut.buildStacktraceForCurrentThread()
-
+        
         let filteredFrames = actual.frames.filter { frame in
             return frame.function?.contains("testAsyncStacktraces") ?? false ||
             frame.function?.contains("asyncFrame1") ?? false ||
@@ -91,10 +116,10 @@ class SentryStacktraceBuilderTests: XCTestCase {
         let startFrames = actual.frames.filter { frame in
             return frame.stackStart?.boolValue ?? false
         }
-
+        
         XCTAssertTrue(filteredFrames.count >= 3, "The Stacktrace must include the async callers.")
         XCTAssertTrue(startFrames.count >= 3, "The Stacktrace must have async continuation markers.")
-
+        
         expect.fulfill()
     }
 }

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -73,7 +73,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
 
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
-            options.stitchSwiftAsync = true
+            options.swiftAsyncStacktraces = true
         }
 
         let waitForAsyncToRun = expectation(description: "Wait async functions")
@@ -90,7 +90,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
 
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
-            options.stitchSwiftAsync = false
+            options.swiftAsyncStacktraces = false
         }
 
         let waitForAsyncToRun = expectation(description: "Wait async functions")

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -587,7 +587,7 @@
     XCTAssertEqual(YES, options.enableSwizzling);
     XCTAssertEqual(YES, options.enableFileIOTracing);
     XCTAssertEqual(YES, options.enableAutoBreadcrumbTracking);
-    XCTAssertTrue(options.swiftAsyncStacktraces);
+    XCTAssertFalse(options.swiftAsyncStacktraces);
 
 #if SENTRY_HAS_METRIC_KIT
     if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -534,7 +534,8 @@
         @"enableCaptureFailedRequests" : [NSNull null],
         @"failedRequestStatusCodes" : [NSNull null],
         @"enableTimeToFullDisplay" : [NSNull null],
-        @"enableTracing" : [NSNull null]
+        @"enableTracing" : [NSNull null],
+        @"swiftAsyncStacktraces" : [NSNull null]
     }
                                                 didFailWithError:nil];
 
@@ -586,6 +587,7 @@
     XCTAssertEqual(YES, options.enableSwizzling);
     XCTAssertEqual(YES, options.enableFileIOTracing);
     XCTAssertEqual(YES, options.enableAutoBreadcrumbTracking);
+    XCTAssertTrue(options.swiftAsyncStacktraces);
 
 #if SENTRY_HAS_METRIC_KIT
     if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {
@@ -1183,6 +1185,21 @@
     SentryOptions *options = [self getValidOptions:@{ @"urlSessionDelegate" : urlSessionDelegate }];
 
     XCTAssertNotNil(options.urlSessionDelegate);
+}
+
+- (void)testDefaultSwiftAsyncStacktraces {
+    SentryOptions * options = [[SentryOptions alloc] init];
+    XCTAssertFalse(options.swiftAsyncStacktraces);
+}
+
+- (void)testInitialSwiftAsyncStacktraces {
+    SentryOptions *options = [self getValidOptions:@{}];
+    XCTAssertFalse(options.swiftAsyncStacktraces);
+}
+
+- (void)testInitialSwiftAsyncStacktracesYes {
+    SentryOptions *options = [self getValidOptions:@{@"swiftAsyncStacktraces": @YES}];
+    XCTAssertTrue(options.swiftAsyncStacktraces);
 }
 
 - (void)assertArrayEquals:(NSArray<NSString *> *)expected actual:(NSArray<NSString *> *)actual

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1187,18 +1187,21 @@
     XCTAssertNotNil(options.urlSessionDelegate);
 }
 
-- (void)testDefaultSwiftAsyncStacktraces {
-    SentryOptions * options = [[SentryOptions alloc] init];
+- (void)testDefaultSwiftAsyncStacktraces
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
     XCTAssertFalse(options.swiftAsyncStacktraces);
 }
 
-- (void)testInitialSwiftAsyncStacktraces {
+- (void)testInitialSwiftAsyncStacktraces
+{
     SentryOptions *options = [self getValidOptions:@{}];
     XCTAssertFalse(options.swiftAsyncStacktraces);
 }
 
-- (void)testInitialSwiftAsyncStacktracesYes {
-    SentryOptions *options = [self getValidOptions:@{@"swiftAsyncStacktraces": @YES}];
+- (void)testInitialSwiftAsyncStacktracesYes
+{
+    SentryOptions *options = [self getValidOptions:@{ @"swiftAsyncStacktraces" : @YES }];
     XCTAssertTrue(options.swiftAsyncStacktraces);
 }
 


### PR DESCRIPTION
## :scroll: Description

> This PR was created By [kabiroberai](https://github.com/kabiroberai) at #2983, but CI was strange and I wanted to test this properly.

Adds support for stitching async Swift Concurrency frames using [backtrace_async](https://keith.github.io/xcode-man-pages/backtrace.3.html#backtrace_async).

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

Switching from `backtrace` to `backtrace_async` is super trivial and gets Sentry 90% of the way to offering good Swift Concurrency support. The man page mentions that backtrace_async is identical to backtrace in all circumstances except when Swift Concurrency `Task`s are involved, so IMO it's a no-brainer to make the jump.

Unfortunately the story isn't as easy for profiling, since the code there manually walks the stack — I think a good approach there could be to mimic how backtrace_async is [implemented](https://github.com/apple-oss-distributions/Libc/blob/dbde50970329ace8793fca2b63d708d280c33d88/gen/backtrace.c#L47-L53) in Darwin's libc.

Fixes #1919.

## :green_heart: How did you test it?

Unit tests + a production app

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

After this, it'd be amazing to see support for Swift Concurrency in profiling — though I suspect that requires a greater eng lift.