### PR TITLE
fix: SIGSEGV crash in profiler's queue metadata access

### DIFF
--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -137,8 +137,15 @@ namespace profiling {
         if (thread_info(handle_, THREAD_IDENTIFIER_INFO, info, &count) != KERN_SUCCESS) {
             return 0;
         }
+        if (info == nullptr) {
+            return 0;
+        }
+
         const auto idInfo = reinterpret_cast<thread_identifier_info_t>(info);
         if (!sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))) {
+            return 0;
+        }
+        if (idInfo->dispatch_qaddr == 0) {
             return 0;
         }
 
@@ -150,10 +157,16 @@ namespace profiling {
             return 0;
         }
 
+        if (idInfo == nullptr) {
+            return 0;
+        }
         if (idInfo->thread_handle == 0) {
             return 0;
         }
 
+        if (queuePtr == nullptr) {
+            return 0;
+        }
         if (*queuePtr == nullptr) {
             return 0;
         }


### PR DESCRIPTION
## :scroll: Description

Add more defensive checks to try to fix the third crasher in https://github.com/getsentry/sentry-cocoa/issues/3050

    the crash report shows line 141 as the culprit. there are two
    operations there:

    1. idInfo->thread_handle != 0
        this is already checked on line 138 with
    sentrycrashmem_isMemoryReadable(idInfo, sizeof(*idInfo))

    2. *queuePtr != nullptr
        queuePtr is checked on line 140 with
    sentrycrashmem_isMemoryReadable(queuePtr, sizeof(*queuePtr))

    I'm wondering if sentrycrashmem_isMemoryReadable is somehow
    leaving the memory in a bad state? but in any case, put some extra
    defensive checks before these operations. One of them is a check
    for queuePtr == nullptr which is already done right before the
    call to sentrycrashmem_isMemoryReadable(queuePtr,
    sizeof(*queuePtr)) but again, if that function is somehow causing
    a side effect on queuePtr, we need to check again.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

There is no repro so there's no way to test it currently.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
