### PR TITLE
fix: Profiling memory leaks

### DIFF
--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -354,9 +354,13 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
         }
         if (queueAddress != nil && state.queueMetadata[queueAddress] == nil
             && backtrace.queueMetadata.label != nullptr) {
-            state.queueMetadata[queueAddress] = @ {
-                @"label" : [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()]
-            };
+            NSString *const labelNSStr = [NSString stringWithUTF8String:backtrace.queueMetadata.label->c_str()];
+            // -[NSString stringWithUTF8String:] can return `nil` for malformed string data
+            if (labelNSStr != nil) {
+                state.queueMetadata[queueAddress] = @ {
+                    @"label" : labelNSStr
+                };
+            }
         }
 #    if defined(DEBUG)
         const auto symbols

--- a/Sources/Sentry/SentrySamplingProfiler.cpp
+++ b/Sources/Sentry/SentrySamplingProfiler.cpp
@@ -24,7 +24,7 @@ namespace profiling {
 
         void *
         samplingThreadMain(mach_port_t port, clock_serv_t clock, mach_timespec_t delaySpec,
-            std::shared_ptr<ThreadMetadataCache> cache,
+            const std::shared_ptr<ThreadMetadataCache> &cache,
             const std::function<void(const Backtrace &)> &callback, std::atomic_uint64_t &numSamples,
             std::function<void()> onThreadStart)
         {
@@ -107,7 +107,7 @@ namespace profiling {
         }
         isSampling_ = true;
         numSamples_ = 0;
-        thread_ = std::thread(samplingThreadMain, port_, clock_, delaySpec_, cache_, std::cref(callback_),
+        thread_ = std::thread(samplingThreadMain, port_, clock_, delaySpec_, std::cref(cache_), std::cref(callback_),
             std::ref(numSamples_), onThreadStart);
 
         int policy;

--- a/Sources/Sentry/SentrySamplingProfiler.cpp
+++ b/Sources/Sentry/SentrySamplingProfiler.cpp
@@ -25,7 +25,7 @@ namespace profiling {
         void *
         samplingThreadMain(mach_port_t port, clock_serv_t clock, mach_timespec_t delaySpec,
             std::shared_ptr<ThreadMetadataCache> cache,
-            std::function<void(const Backtrace &)> callback, std::atomic_uint64_t &numSamples,
+            const std::function<void(const Backtrace &)> &callback, std::atomic_uint64_t &numSamples,
             std::function<void()> onThreadStart)
         {
             SENTRY_PROF_LOG_ERROR_RETURN(pthread_setname_np("io.sentry.SamplingProfiler"));
@@ -107,7 +107,7 @@ namespace profiling {
         }
         isSampling_ = true;
         numSamples_ = 0;
-        thread_ = std::thread(samplingThreadMain, port_, clock_, delaySpec_, cache_, callback_,
+        thread_ = std::thread(samplingThreadMain, port_, clock_, delaySpec_, cache_, std::cref(callback_),
             std::ref(numSamples_), onThreadStart);
 
         int policy;


### PR DESCRIPTION
## :scroll: Description

This fixes most of the memory leaks reported in #2980. I checked before/after the fixes using Instruments.

**Before:**
<img width="1624" alt="CleanShot 2023-05-23 at 23 33 23@2x" src="https://github.com/getsentry/sentry-cocoa/assets/353158/4563e88b-59f6-42a0-bdf6-8a5ee7369d77">

**After:**
<img width="1624" alt="CleanShot 2023-05-23 at 23 33 28@2x" src="https://github.com/getsentry/sentry-cocoa/assets/353158/72666b93-7dfc-40b3-b372-7087368a7240">

There is 1 memory leak left to fix that I couldn't find a solution for yet, but the other leaks are fixed.

The root of the problem seems to be that `std::thread` does not correctly deallocate parameters that are passed to the newly spawned thread. It's unclear if this is expected behavior or not, but the fix was simple: pass parameters that were being copied (and leaked) by reference.

There's also one more unrelated fix to a crash that I found while debugging the leaks - it turns out `-[NSString stringWithUTF8String:]` can return `nil` for malformed data and we weren't checking for nil.

## :green_heart: How did you test it?

Check before/after the fix in Instruments, run all existing unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
