### PR TITLE
chore: Remove precommit GH actions check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,6 @@ repos:
       - id: end-of-file-fixer
       - id: no-commit-to-branch
 
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.23.0
-    hooks:
-    - id: check-github-actions
-    - id: check-github-workflows
-      args: [--verbose]
-
   - repo: local
     hooks:
       - id: format-clang


### PR DESCRIPTION
The precommit check fails when adding a valid macos-13 as a runner.

We can add the check back once https://github.com/SchemaStore/schemastore/pull/2979 is merged and `check-jsonschema` starts using the new schema as pointed out in https://github.com/python-jsonschema/check-jsonschema/pull/268.

#skip-changelog