### PR TITLE
build: Update Fastlane to 2.213.0

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - build/update-fastlane
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-      - build/update-fastlane
+
     paths:
       - 'Sources/**'
       - 'Samples/iOS-Swift/**'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,13 @@ repos:
       - id: end-of-file-fixer
       - id: no-commit-to-branch
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.0
+    hooks:
+    - id: check-github-actions
+    - id: check-github-workflows
+      args: [--verbose]
+
   - repo: local
     hooks:
       - id: format-clang

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,6 @@ repos:
       - id: end-of-file-fixer
       - id: no-commit-to-branch
 
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.23.0
-    hooks:
-    - id: check-github-actions
-    - id: check-github-workflows
-      args: [--verbose]
-
   - repo: local
     hooks:
       - id: format-clang

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,7 @@ source "https://rubygems.org"
 
 gem "bundler", ">= 2"
 gem "cocoapods", ">= 1.9.1"
-# Pin fastlane to 2.210.1 to avoid CI failure with "Could not install WWDR certificate".
-# Although https://github.com/fastlane/fastlane/issues/20960 was fixed with 
-# https://github.com/fastlane/fastlane/releases/tag/2.212.0 we still see it happening,
-# sometimes. We keep pinning to 2.210.1.
-gem "fastlane", "= 2.210.1" 
+gem "fastlane"
 gem "rest-client"
 gem "xcpretty"
 gem "slather"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,11 +3,12 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.4.3)
+    activesupport (6.1.7.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
@@ -16,16 +17,16 @@ GEM
     artifactory (3.0.15)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.723.0)
-    aws-sdk-core (3.170.0)
+    aws-partitions (1.769.0)
+    aws-sdk-core (3.173.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.63.0)
+    aws-sdk-kms (1.64.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.119.1)
+    aws-sdk-s3 (1.122.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.4)
@@ -115,8 +116,8 @@ GEM
     faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
-    fastimage (2.2.6)
-    fastlane (2.210.1)
+    fastimage (2.2.7)
+    fastlane (2.213.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -140,7 +141,7 @@ GEM
       json (< 3.0.0)
       jwt (>= 2.1.0, < 3)
       mini_magick (>= 4.9.4, < 5.0.0)
-      multipart-post (~> 2.0.0)
+      multipart-post (>= 2.0.0, < 3.0.0)
       naturally (~> 2.2)
       optparse (~> 0.1.1)
       plist (>= 3.1.0, < 4.0.0)
@@ -161,7 +162,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    google-apis-androidpublisher_v3 (0.35.0)
+    google-apis-androidpublisher_v3 (0.42.0)
       google-apis-core (>= 0.11.0, < 2.a)
     google-apis-core (0.11.0)
       addressable (~> 2.5, >= 2.5.1)
@@ -192,7 +193,7 @@ GEM
       google-cloud-core (~> 1.6)
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
-    googleauth (1.3.0)
+    googleauth (1.5.2)
       faraday (>= 0.17.3, < 3.a)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -219,12 +220,12 @@ GEM
     minitest (5.18.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
-    multipart-post (2.0.0)
+    multipart-post (2.3.0)
     nanaimo (0.3.0)
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.14.3)
+    nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     optparse (0.1.1)
@@ -293,6 +294,7 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby
@@ -300,11 +302,11 @@ PLATFORMS
 DEPENDENCIES
   bundler (>= 2)
   cocoapods (>= 1.9.1)
-  fastlane (= 2.210.1)
+  fastlane
   fastlane-plugin-sentry
   rest-client
   slather
   xcpretty
 
 BUNDLED WITH
-   2.3.26
+   2.4.7


### PR DESCRIPTION
Remove pinned Fastlane version as 2.213.0 contains a possible fix for WWDC
certificate error, see https://github.com/fastlane/fastlane/pull/21271.

Test run with fastlane 2.213.0 in CI: https://github.com/getsentry/sentry-cocoa/actions/runs/5081757057/jobs/9130562210

#skip-changelog