### PR TITLE
chore: Readd precommit GH actions check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,13 @@ repos:
       - id: end-of-file-fixer
       - id: no-commit-to-branch
 
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.23.1
+    hooks:
+    - id: check-github-actions
+    - id: check-github-workflows
+      args: [--verbose]
+
   - repo: local
     hooks:
       - id: format-clang


### PR DESCRIPTION
Was removed with https://github.com/getsentry/sentry-cocoa/pull/3064, cause it caused problems. Which are fixed now with v 0.23.01.

#skip-changelog