### PR TITLE
ref: convert last sprintf call to snprintf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Changed `Trace` serialized value of `sampled` from string to boolean (#3067)
 - Duplicated HTTP breadcrumbs (#3058)
 - Expose SentryPrivate and SentrySwiftUI schemes for cartahge clients that have `--no-use-binaries` option (#3071)
+- Convert last remaining `sprintf` call to `snprintf` (#3077)
 
 ### Breaking Changes
 

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -917,7 +917,7 @@ writeNotableStackContents(const SentryCrashReportWriter *const writer,
     for (uintptr_t address = lowAddress; address < highAddress; address += sizeof(address)) {
         if (sentrycrashmem_copySafely(
                 (void *)address, &contentsAsPointer, sizeof(contentsAsPointer))) {
-            sprintf(nameBuffer, "stack@%p", (void *)address);
+            snprintf(nameBuffer, sizeof(nameBuffer), "stack@%p", (void *)address);
             writeMemoryContentsIfNotable(writer, nameBuffer, contentsAsPointer);
         }
     }


### PR DESCRIPTION
## :scroll: Description

Follows https://github.com/getsentry/sentry-cocoa/pull/2866 to convert potentially unsafe usage of `sprintf` to `snprintf`. See https://github.com/getsentry/sentry-cocoa/issues/2785.

## :bulb: Motivation and Context

This also causes Xcode 13+ builds to break when using address sanitizer after making the changes in https://github.com/getsentry/sentry-cocoa/pull/3075

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
~- [ ] I added tests to verify the changes.~ The tests required for this would require extensive effort disproportionate to the simplicity of the change.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
~- [ ] I updated the docs if needed.~
~- [ ] Review from the native team if needed.~
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
