### PR TITLE
test: add triggers to build/test if a change occurs in the sentry xcode project

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
       - 'fastlane/**'
       - 'scripts/ci-select-xcode.sh'
       - Sentry.xcworkspace
+      - Sentry.xcodeproj
       - Gemfile.lock
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ on:
       - 'scripts/ci-select-xcode.sh'
       - 'scripts/xcode-test.sh'
       - '.codecov.yml'
+      - Sentry.xcodeproj
 
-      # run the workflow any time an Xcode scheme changes for any tested target
-      - 'Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme'
+      # run the workflow any time an Xcode scheme changes for a sample app
       - 'Samples/tvOS-Swift/tvOS-Swift.xcodeproj/xcshareddata/xcschemes/tvOS-Swift.xcscheme'
       - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS13-Swift.xcscheme'
       - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-SwiftUITests.xcscheme'


### PR DESCRIPTION
I noticed that https://github.com/getsentry/sentry-cocoa/pull/3071 didn't run build or test checks, which probably should've happened. We didn't actually configure those checks to run those on a project config change.

#skip-changelog