### PR TITLE
chore: Rollback  profile-data-generator.yml macos version

### DIFF
--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'Sources/Sentry/Public/**'
       - 'Samples/TrendingMovies/**'
+      - '.github/workflows/profile-data-generator.yml'
 
 jobs:
   build-profile-data-generator-targets:

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-profile-data-generator-targets:
     name: Build app and test runner
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh

--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh '13.4.1'
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - name: Cache Carthage dependencies


### PR DESCRIPTION
Trending Movie uses a lib that can only be compiled with Swift 5.6, not available in the MacOS 13 image in GitHub.

_#skip-changelog_