### PR TITLE
chore: Run Linters as pre commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
     - id: check-github-workflows
       args: [--verbose]
 
+  - repo: https://github.com/realm/SwiftLint
+    ## Use same version as GH actions macos-13 https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+    rev: 0.51.0
+    hooks:
+      - id: swiftlint
+        entry: swiftlint --fix --strict
+
   - repo: local
     hooks:
       - id: format-clang

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,13 +20,6 @@ repos:
     - id: check-github-workflows
       args: [--verbose]
 
-  - repo: https://github.com/realm/SwiftLint
-    ## Use same version as GH actions macos-13 https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-    rev: 0.51.0
-    hooks:
-      - id: swiftlint
-        entry: swiftlint --fix --strict
-
   - repo: local
     hooks:
       - id: format-clang
@@ -44,6 +37,14 @@ repos:
         types_or: ["swift" ]
         args:
           - "format-swift"
+
+      - id: lint
+        name: Run Linters
+        entry: make
+        language: system
+        types_or: ["swift", "objective-c", "objective-c++", "c", "c++" ]
+        args:
+          - "lint"
 
       - id: no-changes-in-high-risk-files
         name: No Changes in High Risk Files


### PR DESCRIPTION
Run `make lint` as a pre-commit check.

#skip-changelog