### PR TITLE
ci: Fix running profile data generator

### DIFF
--- a/.github/workflows/profile-data-generator.yml
+++ b/.github/workflows/profile-data-generator.yml
@@ -8,14 +8,15 @@ on:
     paths:
       - 'Sources/Sentry/Public/**'
       - 'Samples/TrendingMovies/**'
+      - '.github/workflows/profile-data-generator.yml'
 
 jobs:
   build-profile-data-generator-targets:
     name: Build app and test runner
-    runs-on: macos-13
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh 13.4.1
       - name: Install SentryCli
         run: brew install getsentry/tools/sentry-cli
       - name: Cache Carthage dependencies


### PR DESCRIPTION
Roll back to macos-12 with Xcode 13.4.1. Related to https://github.com/getsentry/sentry-cocoa/pull/3075.

#skip-changelog