### PR TITLE
fix: data race collecting GPU slow/frozen frames and framerates

### DIFF
--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -555,9 +555,6 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
 {
     const auto profileID = [[SentryId alloc] init];
     const auto payload = [self serializeForTransaction:transaction profileID:profileID];
-#    if SENTRY_HAS_UIKIT
-    [_gCurrentFramesTracker resetProfilingTimestamps];
-#    endif // SENTRY_HAS_UIKIT
 
 #    if defined(TEST) || defined(TESTCI)
     [NSNotificationCenter.defaultCenter postNotificationName:@"SentryProfileCompleteNotification"

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -192,6 +192,7 @@ serializedSamplesWithRelativeTimestamps(
     return result;
 }
 
+#    if SENTRY_HAS_UIKIT
 NSMutableDictionary<NSString *, id> *_Nullable serializeGPUMetrics(SentryTransaction *transaction)
 {
     const auto gpuMetrics = [NSMutableDictionary<NSString *, id> dictionary];
@@ -230,6 +231,7 @@ NSMutableDictionary<NSString *, id> *_Nullable serializeGPUMetrics(SentryTransac
     }
     return gpuMetrics;
 }
+#    endif // SENTRY_HAS_UIKIT
 
 NSDictionary<NSString *, id> *
 serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransaction *transaction,

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -150,6 +150,7 @@ static BOOL appStartMeasurementRead;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if (_configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes) {
         _isProfiling = YES;
+        [[SentryFramesTracker sharedInstance] recordCurrentFrameRate];
         _startSystemTime = SentryCurrentDate.systemTime;
         [SentryProfiler startWithHub:hub];
         trackTracerWithID(self.traceId);

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -150,7 +150,9 @@ static BOOL appStartMeasurementRead;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if (_configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes) {
         _isProfiling = YES;
+#    if SENTRY_HAS_UIKIT
         [[SentryFramesTracker sharedInstance] recordCurrentFrameRate];
+#    endif // SENTRY_HAS_UIKIT
         _startSystemTime = SentryCurrentDate.systemTime;
         [SentryProfiler startWithHub:hub];
         trackTracerWithID(self.traceId);

--- a/Sources/Sentry/include/SentryFramesTracker.h
+++ b/Sources/Sentry/include/SentryFramesTracker.h
@@ -29,6 +29,7 @@ SENTRY_NO_INIT
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
 /** Remove previously recorded timestamps in preparation for a later profiled transaction. */
 - (void)resetProfilingTimestamps;
+- (void)recordCurrentFrameRate;
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 - (void)start;


### PR DESCRIPTION
## :scroll: Description

Adds some extra guards in the case where we don't have all the data we expect, which is when we do have frozen/slow frame info but seem to not have any frame rate info. This avoids some unnecessary work and of course the attempt to insert nil into a dictionary literal, which is causing a crash.

Also fixes a small bug where we clear the profiling GPU frame rate data structure when we stop the profiler due to timing out or going to the background; in these cases, we don't want to throw those away until after the associated span has finished and we serialize the profiler data for it. So we only clear the data when stopping normally, which is whenever the last in-flight span has finished in SentryTracer.

## :bulb: Motivation and Context

To fix https://github.com/getsentry/sentry-cocoa/issues/3082

## :green_heart: How did you test it?

I was unable to reproduce. One theory was that if was a data race between a timed out profiler (since the customer's stack trace shows the span actually timed out as well) and another subsequent profiler, but I don't see a data race because reads and writes to SentryFramesTracker's profiling timestamp data structures are all synchronized with lock_guard.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
