### PR TITLE
feat: Close session for unhandled error

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -594,14 +594,14 @@ SentryHub ()
     BOOL handled = YES;
     if ([self envelopeContainsEventWithErrorOrHigher:envelope.items wasHandled:&handled]) {
         SentrySession *currentSession;
-        @synchronized (_sessionLock) {
+        @synchronized(_sessionLock) {
             currentSession = handled ? [self incrementSessionErrors] : [_session copy];
             if (currentSession == nil) {
                 return envelope;
             }
             if (!handled) {
                 [currentSession endSessionCrashedWithTimestamp:[_currentDateProvider date]];
-                //Setting _session to nil so starSession dont capture it again
+                // Setting _session to nil so starSession dont capture it again
                 _session = nil;
                 [self startSession];
             }
@@ -609,10 +609,9 @@ SentryHub ()
 
         // Create a new envelope with the session update
         NSMutableArray<SentryEnvelopeItem *> *itemsToSend =
-        [[NSMutableArray alloc] initWithArray:envelope.items];
+            [[NSMutableArray alloc] initWithArray:envelope.items];
         [itemsToSend addObject:[[SentryEnvelopeItem alloc] initWithSession:currentSession]];
         return [[SentryEnvelope alloc] initWithHeader:envelope.header items:itemsToSend];
-        
     }
     return envelope;
 }

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -620,14 +620,14 @@ SentryHub ()
     for (SentryEnvelopeItem *item in items) {
         if ([item.header.type isEqualToString:SentryEnvelopeItemTypeEvent]) {
             // If there is no level the default is error
-            NSDictionary *eventJson = [SentrySerialization eventEnvelopeItemJson:item.data];
+            NSDictionary *eventJson = [SentrySerialization deserializeEventEnvelopeItem:item.data];
             if (eventJson == nil) {
                 return NO;
             }
 
             SentryLevel level = sentryLevelForString(eventJson[@"level"]);
             if (level >= kSentryLevelError) {
-                *handled = [self envelopeEventItemContainsUnhandledError:eventJson];
+                *handled = [self eventContainsUnhandledError:eventJson];
                 return YES;
             }
         }
@@ -635,7 +635,7 @@ SentryHub ()
     return NO;
 }
 
-- (BOOL)envelopeEventItemContainsUnhandledError:(NSDictionary *)eventDictionary
+- (BOOL)eventContainsUnhandledError:(NSDictionary *)eventDictionary
 {
     NSArray *exceptions = eventDictionary[@"exception"][@"values"];
     for (NSDictionary *exception in exceptions) {

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -593,23 +593,26 @@ SentryHub ()
 {
     BOOL handled = YES;
     if ([self envelopeContainsEventWithErrorOrHigher:envelope.items wasHandled:&handled]) {
-        SentrySession *currentSession = [self incrementSessionErrors];
-
-        if (currentSession != nil) {
+        SentrySession *currentSession;
+        @synchronized (_sessionLock) {
+            currentSession = handled ? [self incrementSessionErrors] : [_session copy];
+            if (currentSession == nil) {
+                return envelope;
+            }
             if (!handled) {
                 [currentSession endSessionCrashedWithTimestamp:[_currentDateProvider date]];
-
-                _session = [[SentrySession alloc] initWithReleaseName:_client.options.releaseName];
-                _session.environment = _client.options.environment;
-                [self.scope applyToSession:_session];
+                //Setting _session to nil so starSession dont capture it again
+                _session = nil;
+                [self startSession];
             }
-
-            // Create a new envelope with the session update
-            NSMutableArray<SentryEnvelopeItem *> *itemsToSend =
-                [[NSMutableArray alloc] initWithArray:envelope.items];
-            [itemsToSend addObject:[[SentryEnvelopeItem alloc] initWithSession:currentSession]];
-            return [[SentryEnvelope alloc] initWithHeader:envelope.header items:itemsToSend];
         }
+
+        // Create a new envelope with the session update
+        NSMutableArray<SentryEnvelopeItem *> *itemsToSend =
+        [[NSMutableArray alloc] initWithArray:envelope.items];
+        [itemsToSend addObject:[[SentryEnvelopeItem alloc] initWithSession:currentSession]];
+        return [[SentryEnvelope alloc] initWithHeader:envelope.header items:itemsToSend];
+        
     }
     return envelope;
 }

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -601,7 +601,7 @@ SentryHub ()
             }
             if (!handled) {
                 [currentSession endSessionCrashedWithTimestamp:[_currentDateProvider date]];
-                // Setting _session to nil so starSession dont capture it again
+                // Setting _session to nil so startSession doesn't capture it again
                 _session = nil;
                 [self startSession];
             }

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -339,6 +339,24 @@ NS_ASSUME_NONNULL_BEGIN
     return [[SentryAppState alloc] initWithJSONObject:appSateDictionary];
 }
 
++ (NSDictionary *)eventEnvelopeItemJson:(NSData *)eventEnvelopeItemData
+{
+    NSError *error = nil;
+    NSDictionary *eventDictionary = [NSJSONSerialization JSONObjectWithData:eventEnvelopeItemData
+                                                                    options:0
+                                                                      error:&error];
+    if (nil != error) {
+        [SentryLog
+            logWithMessage:
+                [NSString
+                    stringWithFormat:@"Failed to retrieve event level from envelope item data: %@",
+                    error]
+                  andLevel:kSentryLevelError];
+    }
+
+    return eventDictionary;
+}
+
 + (SentryLevel)levelFromData:(NSData *)eventEnvelopeItemData
 {
     NSError *error = nil;

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -339,7 +339,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [[SentryAppState alloc] initWithJSONObject:appSateDictionary];
 }
 
-+ (NSDictionary *)eventEnvelopeItemJson:(NSData *)eventEnvelopeItemData
++ (NSDictionary *)deserializeEventEnvelopeItem:(NSData *)eventEnvelopeItemData
 {
     NSError *error = nil;
     NSDictionary *eventDictionary = [NSJSONSerialization JSONObjectWithData:eventEnvelopeItemData
@@ -349,7 +349,7 @@ NS_ASSUME_NONNULL_BEGIN
         [SentryLog
             logWithMessage:
                 [NSString
-                    stringWithFormat:@"Failed to retrieve event level from envelope item data: %@",
+                    stringWithFormat:@"Failed to deserialize envelope item data: %@",
                     error]
                   andLevel:kSentryLevelError];
     }

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -347,10 +347,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                                       error:&error];
     if (nil != error) {
         [SentryLog
-            logWithMessage:
-                [NSString
-                    stringWithFormat:@"Failed to deserialize envelope item data: %@",
-                    error]
+            logWithMessage:[NSString
+                               stringWithFormat:@"Failed to deserialize envelope item data: %@",
+                               error]
                   andLevel:kSentryLevelError];
     }
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -2,7 +2,7 @@
 #import "SentryTracer.h"
 
 @class SentryEnvelopeItem, SentryId, SentryScope, SentryTransaction, SentryDispatchQueueWrapper,
-    SentryEnvelope, SentryNSTimerWrapper;
+    SentryEnvelope, SentryNSTimerWrapper, SentrySession;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,6 +11,7 @@ SentryHub (Private)
 
 @property (nonatomic, strong) NSArray<id<SentryIntegrationProtocol>> *installedIntegrations;
 @property (nonatomic, strong) NSSet<NSString *> *installedIntegrationNames;
+@property (nullable, nonatomic, strong) SentrySession *session;
 
 - (void)addInstalledIntegration:(id<SentryIntegrationProtocol>)integration name:(NSString *)name;
 - (void)removeAllIntegrations;

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -25,6 +25,11 @@ static int const SENTRY_BAGGAGE_MAX_SIZE = 8192;
 + (SentryAppState *_Nullable)appStateWithData:(NSData *)sessionData;
 
 /**
+ * Retrieves the json object from an event envelope item data.
+ */
++ (NSDictionary *)eventEnvelopeItemJson:(NSData *)eventEnvelopeItemData;
+
+/**
  * Extract the level from data of an envelopte item containing an event. Default is the 'error'
  * level, see https://develop.sentry.dev/sdk/event-payloads/#optional-attributes
  */

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -27,7 +27,7 @@ static int const SENTRY_BAGGAGE_MAX_SIZE = 8192;
 /**
  * Retrieves the json object from an event envelope item data.
  */
-+ (NSDictionary *)eventEnvelopeItemJson:(NSData *)eventEnvelopeItemData;
++ (NSDictionary *)deserializeEventEnvelopeItem:(NSData *)eventEnvelopeItemData;
 
 /**
  * Extract the level from data of an envelopte item containing an event. Default is the 'error'

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -723,7 +723,7 @@ class SentryHubTests: XCTestCase {
           let event = TestData.event
           event.level = .error
           event.exceptions = [TestData.exception]
-          event.exceptions?.first?.mechanism?.handled = NSNumber(booleanLiteral: false)
+          event.exceptions?.first?.mechanism?.handled = false
           sut.capture(SentryEnvelope(event: event))
 
           let endSession = sut.session

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -720,17 +720,12 @@ class SentryHubTests: XCTestCase {
         
         fixture.currentDateProvider.setDate(date: Date(timeIntervalSince1970: 2))
         
-        let beginSession = sut.session
-        
         let event = TestData.event
         event.level = .error
         event.exceptions = [TestData.exception]
         event.exceptions?.first?.mechanism?.handled = false
         sut.capture(SentryEnvelope(event: event))
-        
-        let endSession = sut.session
-        XCTAssertNotEqual(beginSession, endSession)
-        
+
         //Check whether session was finished as crashed
         let envelope = fixture.client.captureEnvelopeInvocations.first
         let sessionEnvelopeItem = envelope?.items.first(where: { $0.header.type == "session" })

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -715,6 +715,45 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(envelope, fixture.client.captureEnvelopeInvocations.first)
     }
 
+    func testCaptureEnvelope_WithUnhandledException() {
+          sut.startSession()
+
+          let beginSession = sut.session
+
+          let event = TestData.event
+          event.level = .error
+          event.exceptions = [TestData.exception]
+          event.exceptions?.first?.mechanism?.handled = NSNumber(booleanLiteral: false)
+          sut.capture(SentryEnvelope(event: event))
+
+          let endSession = sut.session
+          XCTAssertNotEqual(beginSession, endSession)
+
+          //Check whether session was finished as crashed
+          let envelope = fixture.client.captureEnvelopeInvocations.first
+          let sessionEnvelopeItem = envelope?.items.first(where: { $0.header.type == "session" })
+
+          let json = (try! JSONSerialization.jsonObject(with: sessionEnvelopeItem!.data)) as! [String: Any]
+
+          XCTAssertNotNil(json["timestamp"])
+          XCTAssertEqual(json["status"] as? String, "crashed")
+      }
+
+      func testCaptureEnvelope_WithHandledException() {
+          sut.startSession()
+
+          let beginSession = sut.session
+
+          let event = TestData.event
+          event.level = .error
+          event.exceptions = [TestData.exception]
+          sut.capture(SentryEnvelope(event: event))
+
+          let endSession = sut.session
+
+          XCTAssertEqual(beginSession, endSession)
+      }
+
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func test_reportFullyDisplayed_enableTimeToFullDisplay_YES() {
         fixture.options.enableTimeToFullDisplay = true


### PR DESCRIPTION
## :scroll: Description

Closes session as crashed for hybrids SDK when a new envelope with unhandled crashed event is captured, and start a new session.

## :bulb: Motivation and Context

closes #2593 

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

_#skip-changelog_
