### PR TITLE
fix: avoid inserting a nil into the gpu data dictionary literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Duplicated HTTP breadcrumbs (#3058)
 - Expose SentryPrivate and SentrySwiftUI schemes for cartahge clients that have `--no-use-binaries` option (#3071)
 - Convert last remaining `sprintf` call to `snprintf` (#3077)
+- Fix a crash when serializing profiling data (#3092)
 
 ### Breaking Changes
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -143,7 +143,7 @@ sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, SentryTransaction *transactio
             @"value" : obj[@"value"],
         }];
     }];
-    if (useMostRecentRecording && slicedGPUEntries.count == 0) {
+    if (useMostRecentRecording && slicedGPUEntries.count == 0 && nearestPredecessorValue != nil) {
         [slicedGPUEntries addObject:@ {
             @"elapsed_since_start_ns" : @"0",
             @"value" : nearestPredecessorValue,

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -143,7 +143,7 @@ sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, SentryTransaction *transactio
             @"value" : obj[@"value"],
         }];
     }];
-    if (useMostRecentRecording && slicedGPUEntries.count == 0) {
+    if (useMostRecentRecording && slicedGPUEntries.count == 0 && nearestPredecessorValue != nil) {
         [slicedGPUEntries addObject:@ {
             @"elapsed_since_start_ns" : @"0",
             @"value" : nearestPredecessorValue,
@@ -182,6 +182,41 @@ serializedSamplesWithRelativeTimestamps(
     }];
     return result;
 }
+
+#    if SENTRY_HAS_UIKIT
+NSDictionary<NSString *, id> *_Nullable serializedGPUMetrics(SentryTransaction *transaction)
+{
+    const auto mutableMetrics = [NSMutableDictionary<NSString *, id> dictionary];
+    const auto slowFrames = sliceGPUData(_gCurrentFramesTracker.currentFrames.slowFrameTimestamps,
+        transaction, /*useMostRecentRecording */ NO);
+    if (slowFrames.count > 0) {
+        mutableMetrics[@"slow_frame_renders"] =
+            @ { @"unit" : @"nanosecond", @"values" : slowFrames };
+    }
+
+    const auto frozenFrames
+        = sliceGPUData(_gCurrentFramesTracker.currentFrames.frozenFrameTimestamps, transaction,
+            /*useMostRecentRecording */ NO);
+    if (frozenFrames.count > 0) {
+        mutableMetrics[@"frozen_frame_renders"] =
+            @ { @"unit" : @"nanosecond", @"values" : frozenFrames };
+    }
+
+    if (slowFrames.count > 0 || frozenFrames.count > 0) {
+        const auto frameRates
+            = sliceGPUData(_gCurrentFramesTracker.currentFrames.frameRateTimestamps, transaction,
+                /*useMostRecentRecording */ YES);
+        if (frameRates.count > 0) {
+            mutableMetrics[@"screen_frame_rates"] = @ { @"unit" : @"hz", @"values" : frameRates };
+        } else {
+            // This shouldn't be possible, but is happening due to a data race so we must currently
+            // handle it
+            return nil;
+        }
+    }
+    return mutableMetrics;
+}
+#    endif // SENTRY_HAS_UIKIT
 
 NSDictionary<NSString *, id> *
 serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransaction *transaction,
@@ -258,32 +293,13 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
     auto metrics = serializedMetrics;
 
 #    if SENTRY_HAS_UIKIT
-    const auto mutableMetrics =
-        [NSMutableDictionary<NSString *, id> dictionaryWithDictionary:metrics];
-    const auto slowFrames = sliceGPUData(_gCurrentFramesTracker.currentFrames.slowFrameTimestamps,
-        transaction, /*useMostRecentRecording */ NO);
-    if (slowFrames.count > 0) {
-        mutableMetrics[@"slow_frame_renders"] =
-            @ { @"unit" : @"nanosecond", @"values" : slowFrames };
+    const auto gpuMetrics = serializedGPUMetrics(transaction);
+    if (gpuMetrics != nil) {
+        const auto mutableMetrics =
+            [NSMutableDictionary<NSString *, id> dictionaryWithDictionary:metrics];
+        [mutableMetrics addEntriesFromDictionary:gpuMetrics];
+        metrics = mutableMetrics;
     }
-
-    const auto frozenFrames
-        = sliceGPUData(_gCurrentFramesTracker.currentFrames.frozenFrameTimestamps, transaction,
-            /*useMostRecentRecording */ NO);
-    if (frozenFrames.count > 0) {
-        mutableMetrics[@"frozen_frame_renders"] =
-            @ { @"unit" : @"nanosecond", @"values" : frozenFrames };
-    }
-
-    if (slowFrames.count > 0 || frozenFrames.count > 0) {
-        const auto frameRates
-            = sliceGPUData(_gCurrentFramesTracker.currentFrames.frameRateTimestamps, transaction,
-                /*useMostRecentRecording */ YES);
-        if (frameRates.count > 0) {
-            mutableMetrics[@"screen_frame_rates"] = @ { @"unit" : @"hz", @"values" : frameRates };
-        }
-    }
-    metrics = mutableMetrics;
 #    endif // SENTRY_HAS_UIKIT
 
     if (metrics.count > 0) {


### PR DESCRIPTION
## :scroll: Description

Stops the crash from occurring that was reported in #3082 

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
~- [ ] I added tests to verify the changes.~
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
~- [ ] I updated the docs if needed.~
~- [ ] Review from the native team if needed.~
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
