### PR TITLE
chore: Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,15 @@
 ### Fixes
 
 - Fix a data race for `SentryId.empty` (#3072)
-- Changed `Trace` serialized value of `sampled` from string to boolean (#3067)
 - Duplicated HTTP breadcrumbs (#3058)
 - Expose SentryPrivate and SentrySwiftUI schemes for cartahge clients that have `--no-use-binaries` option (#3071)
 - Convert last remaining `sprintf` call to `snprintf` (#3077)
+
+## 8.7.4
+
+### Fixes
+
+- Changed `Trace` serialized value of `sampled` from string to boolean (#3067)
 
 ### Breaking Changes
 


### PR DESCRIPTION
Update CHANGELOG based on the released of 8.7.4

_#skip-changelog_ 