### PR TITLE
fix: import warning in package

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -2,7 +2,7 @@
 #import "SentryBaggage.h"
 #import "SentryBreadcrumb.h"
 #import "SentryClient+Private.h"
-#import "SentryDSN.h"
+#import "SentryDsn.h"
 #import "SentryEvent.h"
 #import "SentryException.h"
 #import "SentryHttpStatusCodeRange+Private.h"


### PR DESCRIPTION
## :scroll: Description

I have renamed the wrong header name to the correct one.

## :bulb: Motivation and Context

When integrating the latest release via SPM there is a new warning caused by wrong capitalization of one header name. Interestingly it's not happening when opening the workspace. The causing commit happened in #3058.
<img width="1840" alt="Screenshot 2023-06-17 at 15 04 28" src="https://github.com/getsentry/sentry-cocoa/assets/42500484/93e59ca6-7237-43f1-8365-afd89fa395fa">

## :green_heart: How did you test it?

When opening the project as a Package the error is now gone and everything compiles; related Unit tests are also working.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.