### PR TITLE
Fix case of SentryDsn.h import

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -2,7 +2,7 @@
 #import "SentryBaggage.h"
 #import "SentryBreadcrumb.h"
 #import "SentryClient+Private.h"
-#import "SentryDSN.h"
+#import "SentryDsn.h"
 #import "SentryEvent.h"
 #import "SentryException.h"
 #import "SentryHttpStatusCodeRange+Private.h"


### PR DESCRIPTION
## :scroll: Description

When reviewing build logs of my project I saw this flagged as an error (see screenshot)

<img width="703" alt="image" src="https://github.com/getsentry/sentry-cocoa/assets/2766321/8ee837b3-9efd-450e-8e6a-027737c7cb57">

## :bulb: Motivation and Context

This is a simple fix and eliminates build warnings

## :green_heart: How did you test it?

It builds and tests without issues

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

No further steps needed
