### PR TITLE
Fix no-changes-in-high-risk-files.sh

### DIFF
--- a/scripts/no-changes-in-high-risk-files.sh
+++ b/scripts/no-changes-in-high-risk-files.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 ACTUAL=$(shasum -a 256 ./Sources/Sentry/SentryNSURLSessionTaskSearch.m ./Sources/Sentry/SentryNetworkTracker.m ./Sources/Sentry/SentryUIViewControllerSwizzling.m ./Sources/Sentry/SentryNSDataSwizzling.m ./Sources/Sentry/SentrySubClassFinder.m ./Sources/Sentry/SentryCoreDataSwizzling.m ./Sources/Sentry/SentrySwizzleWrapper.m ./Sources/Sentry/include/SentrySwizzle.h ./Sources/Sentry/SentrySwizzle.m)
 EXPECTED="819d5ca5e3db2ac23c859b14c149b7f0754d3ae88bea1dba92c18f49a81da0e1  ./Sources/Sentry/SentryNSURLSessionTaskSearch.m
-44267c2a4798e76dd019bfe5d24db229f4a712cfef0d5415e3670e24bb0996d4  ./Sources/Sentry/SentryNetworkTracker.m
+797f1e4f1f4d0986770c749c6614243417373d3858044a0aa6e16bd4a52533ed  ./Sources/Sentry/SentryNetworkTracker.m
 52cb473dcc8d13c0d4f6cd1429c3fc6e8588521660b714f4a2edb4eaf1401e9f  ./Sources/Sentry/SentryUIViewControllerSwizzling.m
 e95e62ec7363984f20c78643bb7d992a41a740f97e1befb71525ac34caf88b37  ./Sources/Sentry/SentryNSDataSwizzling.m
 9ad05dd8dd29788cba994736fdcd3bbde59a94e32612640d11f4f9c38ad6610e  ./Sources/Sentry/SentrySubClassFinder.m


### PR DESCRIPTION
An [user PR](https://github.com/getsentry/sentry-cocoa/pull/3109) changed `SentryNetworkTracker.m`, so we need to fix `no-changes-in-high-risk-files.sh`


_#skip-changelog_