### PR TITLE
ref: centralize frames tracker access in SentryDependencyContainer

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -25,7 +25,7 @@ class TestCleanup: NSObject {
         setTestDefaultLogLevel()
 
         #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-        let framesTracker = SentryFramesTracker.sharedInstance()
+        let framesTracker = SentryDependencyContainer.sharedInstance().framesTracker
         framesTracker.stop()
         framesTracker.resetFrames()
 

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -131,12 +131,12 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (BOOL)isFramesTrackingRunning
 {
-    return [SentryFramesTracker sharedInstance].isRunning;
+    return SentryDependencyContainer.sharedInstance.framesTracker.isRunning;
 }
 
 + (SentryScreenFrames *)currentScreenFrames
 {
-    return [SentryFramesTracker sharedInstance].currentFrames;
+    return SentryDependencyContainer.sharedInstance.framesTracker.currentFrames;
 }
 
 + (NSArray<NSData *> *)captureScreenshots

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -1,6 +1,8 @@
 #import "SentryANRTracker.h"
 #import "SentryDefaultCurrentDateProvider.h"
 #import "SentryDispatchQueueWrapper.h"
+#import "SentryDisplayLinkWrapper.h"
+#import "SentryFramesTracker.h"
 #import "SentryNSProcessInfoWrapper.h"
 #import "SentryUIApplication.h"
 #import <SentryAppStateManager.h>
@@ -168,7 +170,20 @@ static NSObject *sentryDependencyContainerLock;
     }
     return _application;
 }
-#endif
+
+- (SentryFramesTracker *)framesTracker
+{
+    if (_framesTracker == nil) {
+        @synchronized(sentryDependencyContainerLock) {
+            if (_framesTracker == nil) {
+                _framesTracker = [[SentryFramesTracker alloc]
+                    initWithDisplayLinkWrapper:[[SentryDisplayLinkWrapper alloc] init]];
+            }
+        }
+    }
+    return _framesTracker;
+}
+#endif // SENTRY_HAS_UIKIT
 
 - (SentrySwizzleWrapper *)swizzleWrapper
 {
@@ -242,6 +257,6 @@ static NSObject *sentryDependencyContainerLock;
     return _metricKitManager;
 }
 
-#endif
+#endif // SENTRY_HAS_METRIC_KIT
 
 @end

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -50,18 +50,6 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     unsigned int _frozenFrames;
 }
 
-+ (instancetype)sharedInstance
-{
-    static SentryFramesTracker *sharedInstance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedInstance =
-            [[self alloc] initWithDisplayLinkWrapper:[[SentryDisplayLinkWrapper alloc] init]];
-    });
-    return sharedInstance;
-}
-
-/** Internal constructor for testing */
 - (instancetype)initWithDisplayLinkWrapper:(SentryDisplayLinkWrapper *)displayLinkWrapper
 {
     if (self = [super init]) {

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -1,5 +1,6 @@
 #import "SentryFramesTrackingIntegration.h"
 #import "PrivateSentrySDKOnly.h"
+#import "SentryDependencyContainer.h"
 #import "SentryFramesTracker.h"
 #import "SentryLog.h"
 
@@ -24,7 +25,7 @@ SentryFramesTrackingIntegration ()
         return NO;
     }
 
-    self.tracker = [SentryFramesTracker sharedInstance];
+    self.tracker = SentryDependencyContainer.sharedInstance.framesTracker;
     [self.tracker start];
 
     return YES;

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -1,5 +1,6 @@
 #import "SentryTimeToDisplayTracker.h"
 #import "SentryCurrentDate.h"
+#import "SentryDependencyContainer.h"
 #import "SentryFramesTracker.h"
 #import "SentryMeasurementValue.h"
 #import "SentrySpan.h"
@@ -24,18 +25,15 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     BOOL _waitForFullDisplay;
     BOOL _isReadyToDisplay;
     BOOL _fullyDisplayedReported;
-    SentryFramesTracker *_frameTracker;
     NSString *_controllerName;
 }
 
 - (instancetype)initForController:(UIViewController *)controller
-                    framesTracker:(SentryFramesTracker *)framestracker
                waitForFullDisplay:(BOOL)waitForFullDisplay
 {
     if (self = [super init]) {
         _controllerName = [SwiftDescriptor getObjectClassName:controller];
         _waitForFullDisplay = waitForFullDisplay;
-        _frameTracker = framestracker;
 
         _isReadyToDisplay = NO;
         _fullyDisplayedReported = NO;
@@ -64,7 +62,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
 
     self.initialDisplaySpan.startTimestamp = tracer.startTimestamp;
 
-    [_frameTracker addListener:self];
+    [SentryDependencyContainer.sharedInstance.framesTracker addListener:self];
     [tracer setFinishCallback:^(
         SentryTracer *_tracer) { [self trimTTFDIdNecessaryForTracer:_tracer]; }];
 }
@@ -106,7 +104,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
         [self addTimeToDisplayMeasurement:self.initialDisplaySpan name:@"time_to_initial_display"];
 
         [self.initialDisplaySpan finish];
-        [_frameTracker removeListener:self];
+        [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
     }
     if (_waitForFullDisplay && _fullyDisplayedReported && self.fullDisplaySpan.isFinished == NO) {
         self.fullDisplaySpan.timestamp = finishTime;

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -138,7 +138,7 @@ static BOOL appStartMeasurementRead;
 #if SENTRY_HAS_UIKIT
     // Store current amount of frames at the beginning to be able to calculate the amount of
     // frames at the end of the transaction.
-    SentryFramesTracker *framesTracker = [SentryFramesTracker sharedInstance];
+    SentryFramesTracker *framesTracker = SentryDependencyContainer.sharedInstance.framesTracker;
     if (framesTracker.isRunning) {
         SentryScreenFrames *currentFrames = framesTracker.currentFrames;
         initTotalFrames = currentFrames.total;
@@ -737,7 +737,7 @@ static BOOL appStartMeasurementRead;
 
 #if SENTRY_HAS_UIKIT
     // Frames
-    SentryFramesTracker *framesTracker = [SentryFramesTracker sharedInstance];
+    SentryFramesTracker *framesTracker = SentryDependencyContainer.sharedInstance.framesTracker;
     if (framesTracker.isRunning && !_startTimeChanged) {
 
         SentryScreenFrames *currentFrames = framesTracker.currentFrames;

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -1,5 +1,4 @@
 #import "SentryUIViewControllerPerformanceTracker.h"
-#import "SentryDependencyContainer.h"
 #import "SentryFramesTracker.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
@@ -139,10 +138,9 @@ SentryUIViewControllerPerformanceTracker ()
         return;
     }
 
-    SentryTimeToDisplayTracker *ttdTracker = [[SentryTimeToDisplayTracker alloc]
-         initForController:controller
-             framesTracker:SentryDependencyContainer.sharedInstance.framesTracker
-        waitForFullDisplay:self.enableWaitForFullDisplay];
+    SentryTimeToDisplayTracker *ttdTracker =
+        [[SentryTimeToDisplayTracker alloc] initForController:controller
+                                           waitForFullDisplay:self.enableWaitForFullDisplay];
 
     objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER, ttdTracker,
         OBJC_ASSOCIATION_ASSIGN);

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -1,4 +1,5 @@
 #import "SentryUIViewControllerPerformanceTracker.h"
+#import "SentryDependencyContainer.h"
 #import "SentryFramesTracker.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
@@ -138,10 +139,10 @@ SentryUIViewControllerPerformanceTracker ()
         return;
     }
 
-    SentryTimeToDisplayTracker *ttdTracker =
-        [[SentryTimeToDisplayTracker alloc] initForController:controller
-                                                framesTracker:SentryFramesTracker.sharedInstance
-                                           waitForFullDisplay:self.enableWaitForFullDisplay];
+    SentryTimeToDisplayTracker *ttdTracker = [[SentryTimeToDisplayTracker alloc]
+         initForController:controller
+             framesTracker:SentryDependencyContainer.sharedInstance.framesTracker
+        waitForFullDisplay:self.enableWaitForFullDisplay];
 
     objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER, ttdTracker,
         OBJC_ASSOCIATION_ASSIGN);

--- a/Sources/Sentry/include/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/SentryDependencyContainer.h
@@ -2,12 +2,22 @@
 #import "SentryFileManager.h"
 #import "SentryRandom.h"
 
-@class SentryAppStateManager, SentryCrashWrapper, SentryThreadWrapper, SentrySwizzleWrapper,
-    SentryDispatchQueueWrapper, SentryDebugImageProvider, SentryANRTracker,
-    SentryNSNotificationCenterWrapper, SentryMXManager, SentryNSProcessInfoWrapper;
+@class SentryANRTracker;
+@class SentryAppStateManager;
+@class SentryCrashWrapper;
+@class SentryDebugImageProvider;
+@class SentryDispatchQueueWrapper;
+@class SentryFramesTracker;
+@class SentryMXManager;
+@class SentryNSNotificationCenterWrapper;
+@class SentryNSProcessInfoWrapper;
+@class SentrySwizzleWrapper;
+@class SentryThreadWrapper;
 
 #if SENTRY_HAS_UIKIT
-@class SentryScreenshot, SentryUIApplication, SentryViewHierarchy;
+@class SentryScreenshot;
+@class SentryUIApplication;
+@class SentryViewHierarchy;
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -35,6 +45,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryNSProcessInfoWrapper *processInfoWrapper;
 
 #if SENTRY_HAS_UIKIT
+@property (nonatomic, strong) SentryFramesTracker *framesTracker;
 @property (nonatomic, strong) SentryScreenshot *screenshot;
 @property (nonatomic, strong) SentryViewHierarchy *viewHierarchy;
 @property (nonatomic, strong) SentryUIApplication *application;

--- a/Sources/Sentry/include/SentryFramesTracker.h
+++ b/Sources/Sentry/include/SentryFramesTracker.h
@@ -19,9 +19,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Tracks total, frozen and slow frames for iOS, tvOS, and Mac Catalyst.
  */
 @interface SentryFramesTracker : NSObject
-SENTRY_NO_INIT
 
-+ (instancetype)sharedInstance;
+- (instancetype)initWithDisplayLinkWrapper:(SentryDisplayLinkWrapper *)displayLinkWrapper;
 
 @property (nonatomic, assign, readonly) SentryScreenFrames *currentFrames;
 @property (nonatomic, assign, readonly) BOOL isRunning;

--- a/Sources/Sentry/include/SentryTimeToDisplayTracker.h
+++ b/Sources/Sentry/include/SentryTimeToDisplayTracker.h
@@ -4,7 +4,8 @@
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
 
-@class SentrySpan, SentryTracer, SentryFramesTracker;
+@class SentrySpan;
+@class SentryTracer;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,7 +26,6 @@ SENTRY_NO_INIT
 @property (nonatomic, readonly) BOOL waitForFullDisplay;
 
 - (instancetype)initForController:(UIViewController *)controller
-                    framesTracker:(SentryFramesTracker *)framestracker
                waitForFullDisplay:(BOOL)waitForFullDisplay;
 
 - (void)startForTracer:(SentryTracer *)tracer;
@@ -38,4 +38,4 @@ SENTRY_NO_INIT
 
 NS_ASSUME_NONNULL_END
 
-#endif
+#endif // SENTRY_HAS_UIKIT

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -56,7 +56,7 @@ class SentryProfilerSwiftTests: XCTestCase {
             systemWrapper.overrides.memoryFootprintBytes = mockMemoryFootprint
 
 #if !os(macOS)
-            SentryProfiler.useFramesTracker(framesTracker)
+            SentryDependencyContainer.sharedInstance().framesTracker = framesTracker
             framesTracker.start()
             displayLinkWrapper.call()
 #endif

--- a/Tests/SentryTests/Helper/SentryProfiler+SwiftTest.h
+++ b/Tests/SentryTests/Helper/SentryProfiler+SwiftTest.h
@@ -27,10 +27,6 @@ SentryProfiler ()
 + (void)useTimeoutTimerWrapper:(SentryNSTimerWrapper *)timerWrapper
     NS_SWIFT_NAME(useTimeoutTimerWrapper(_:));
 
-#    if SENTRY_HAS_UIKIT
-+ (void)useFramesTracker:(SentryFramesTracker *)framesTracker NS_SWIFT_NAME(useFramesTracker(_:));
-#    endif // SENTRY_HAS_UIKIT
-
 @end
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -76,7 +76,7 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
     func testUninstall() {
         sut.install(with: fixture.options)
         
-        SentryFramesTracker.sharedInstance().setDisplayLinkWrapper(fixture.displayLink)
+        SentryDependencyContainer.sharedInstance().framesTracker.setDisplayLinkWrapper(fixture.displayLink)
         
         sut.uninstall()
         

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -17,7 +17,6 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         init() {
             framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper)
             SentryDependencyContainer.sharedInstance().framesTracker = framesTracker
-            print("Fixture.init.SentryDependencyContainer.sharedInstance().framesTracker = \(SentryDependencyContainer.sharedInstance().framesTracker)")
             framesTracker.start()
         }
 
@@ -46,7 +45,6 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
         sut.start(for: tracer)
         XCTAssertEqual(tracer.children.count, 1)
-        print("testReportInitialDisplay_notWaitingFullDisplay.SentryDependencyContainer.sharedInstance().framesTracker = \(SentryDependencyContainer.sharedInstance().framesTracker)")
         XCTAssertEqual(Dynamic(fixture.framesTracker).listeners.count, 1)
 
         let ttidSpan = try XCTUnwrap(tracer.children.first, "Expected a TTID span")

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -20,7 +20,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         }
 
         func getSut(for controller: UIViewController, waitForFullDisplay: Bool) -> SentryTimeToDisplayTracker {
-            return SentryTimeToDisplayTracker(for: controller, framesTracker: framesTracker, waitForFullDisplay: waitForFullDisplay)
+            return SentryTimeToDisplayTracker(for: controller, waitForFullDisplay: waitForFullDisplay)
         }
     }
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -16,6 +16,8 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
         init() {
             framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper)
+            SentryDependencyContainer.sharedInstance().framesTracker = framesTracker
+            print("Fixture.init.SentryDependencyContainer.sharedInstance().framesTracker = \(SentryDependencyContainer.sharedInstance().framesTracker)")
             framesTracker.start()
         }
 
@@ -24,7 +26,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         }
     }
 
-    private let fixture = Fixture()
+    private lazy var fixture = Fixture()
 
     override func setUp() {
         super.setUp()
@@ -44,6 +46,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
         sut.start(for: tracer)
         XCTAssertEqual(tracer.children.count, 1)
+        print("testReportInitialDisplay_notWaitingFullDisplay.SentryDependencyContainer.sharedInstance().framesTracker = \(SentryDependencyContainer.sharedInstance().framesTracker)")
         XCTAssertEqual(Dynamic(fixture.framesTracker).listeners.count, 1)
 
         let ttidSpan = try XCTUnwrap(tracer.children.first, "Expected a TTID span")

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -621,7 +621,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     }
 
     private func reportFrame() {
-        Dynamic(SentryFramesTracker.sharedInstance()).displayLinkCallback()
+        Dynamic(SentryDependencyContainer.sharedInstance().framesTracker).displayLinkCallback()
     }
 }
 #endif

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -122,12 +122,12 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     
     func testIsFramesTrackingRunning() {
         XCTAssertFalse(PrivateSentrySDKOnly.isFramesTrackingRunning)
-        SentryFramesTracker.sharedInstance().start()
+        SentryDependencyContainer.sharedInstance().framesTracker.start()
         XCTAssertTrue(PrivateSentrySDKOnly.isFramesTrackingRunning)
     }
     
     func testGetFrames() {
-        let tracker = SentryFramesTracker.sharedInstance()
+        let tracker = SentryDependencyContainer.sharedInstance().framesTracker
         let displayLink = TestDisplayLinkWrapper()
         
         tracker.setDisplayLinkWrapper(displayLink)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -982,7 +982,7 @@ class SentryHubTests: XCTestCase {
 class TestTimeToDisplayTracker: SentryTimeToDisplayTracker {
     
     init() {
-        super.init(for: UIViewController(), framesTracker: SentryDependencyContainer.sharedInstance().framesTracker, waitForFullDisplay: false)
+        super.init(for: UIViewController(), waitForFullDisplay: false)
     }
     
     var registerFullDisplayCalled = false

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -982,7 +982,7 @@ class SentryHubTests: XCTestCase {
 class TestTimeToDisplayTracker: SentryTimeToDisplayTracker {
     
     init() {
-        super.init(for: UIViewController(), framesTracker: SentryFramesTracker.sharedInstance(), waitForFullDisplay: false)
+        super.init(for: UIViewController(), framesTracker: SentryDependencyContainer.sharedInstance().framesTracker, waitForFullDisplay: false)
     }
     
     var registerFullDisplayCalled = false

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -64,8 +64,8 @@ class SentryTracerTests: XCTestCase {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
             displayLinkWrapper = TestDisplayLinkWrapper()
             
-            SentryFramesTracker.sharedInstance().setDisplayLinkWrapper(displayLinkWrapper)
-            SentryFramesTracker.sharedInstance().start()
+            SentryDependencyContainer.sharedInstance().framesTracker.setDisplayLinkWrapper(displayLinkWrapper)
+            SentryDependencyContainer.sharedInstance().framesTracker.start()
             displayLinkWrapper.call()
 #endif
         }
@@ -985,7 +985,7 @@ class SentryTracerTests: XCTestCase {
         
         let sut = fixture.getSut()
         
-        SentryFramesTracker.sharedInstance().resetFrames()
+        SentryDependencyContainer.sharedInstance().framesTracker.resetFrames()
         
         sut.finish()
         


### PR DESCRIPTION
In service of reworking SentryProfiler's management of GPU frame data in https://github.com/getsentry/sentry-cocoa/pull/3090, I need to simplify how it keeps a reference to the frames tracker. 

This has bugged me for some time because we vend a singleton of the frames tracker, but then various other objects keep and pass references to it, which is unnecessary; it can just be accessed via SentryDependencyContainer. This seemed like a good opportunity to fix it everywhere.

#skip-changelog

