### PR TITLE
ci: Speed up upload to TestFlight

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - ci/speed-up-fastlane
 
     paths:
       - 'Sources/**'

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - ci/speed-up-fastlane
 
     paths:
       - 'Sources/**'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -215,7 +215,9 @@ platform :ios do
       key_content: ENV["APP_STORE_CONNECT_KEY"]
     )
 
-    testflight
+    testflight(
+      skip_waiting_for_build_processing: true,
+    )
 
     sentry_upload_dif(
       auth_token: ENV["SENTRY_AUTH_TOKEN"],


### PR DESCRIPTION
Speed up upload to TestFlight by skipping waiting for the build to be
processed, which isn't required anymore as we don't have bitcode
enabled.

Previously, the upload took from around 10 up to 20 minutes, depending on how fast AppStoreConnect is with processing the build. Now CI takes around 5 minutes.

Successful CI run https://github.com/getsentry/sentry-cocoa/actions/runs/5476620487