### PR TITLE
test: speed up some profiling tests

### DIFF
--- a/Tests/SentryProfilerTests/SentryBacktraceTests.mm
+++ b/Tests/SentryProfilerTests/SentryBacktraceTests.mm
@@ -235,7 +235,7 @@ countof(Array &)
             break;
         }
         std::this_thread::sleep_for(
-            std::chrono::milliseconds(static_cast<long long>(std::pow(2, i + 1)) * 1000));
+            std::chrono::milliseconds(static_cast<long long>(std::pow(2, i + 1))));
     }
 
     XCTAssertEqual(pthread_cancel(thread1), 0);

--- a/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
@@ -44,14 +44,16 @@ using namespace sentry::profiling;
     profiler->startSampling([&start] { start = getAbsoluteTime(); });
     XCTAssertTrue(profiler->isSampling());
 
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+    // sleep long enough for 2 samples to be collected
+    const auto sleep = (uint64_t)(2.0 / samplingRateHz * 1000);
+    std::this_thread::sleep_for(std::chrono::milliseconds(sleep));
+
     profiler->stopSampling();
 
     XCTAssertFalse(profiler->isSampling());
 
-    const auto duration = std::chrono::nanoseconds(getDurationNs(start, getAbsoluteTime()));
     XCTAssertGreaterThan(start, static_cast<std::uint64_t>(0));
-    XCTAssertGreaterThan(std::chrono::duration_cast<std::chrono::seconds>(duration).count(), 0);
+    XCTAssertGreaterThan(getDurationNs(start, getAbsoluteTime()), 0ULL);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(numIdleSamples, 0);
 }

--- a/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
@@ -47,6 +47,10 @@ threadSpin(void *name)
         SENTRY_PROF_LOG_ERROR_RETURN(pthread_setschedparam(thread, policy, &param));
     }
 
+    // give the other thread a little time to spawn, otherwise its name comes back as an empty
+    // string and the isSentryOwnedThreadName check will fail
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
     const auto cache = std::make_shared<ThreadMetadataCache>();
     ThreadHandle handle(pthread_mach_thread_np(thread));
     const auto metadata = cache->metadataForThread(handle);
@@ -69,6 +73,10 @@ threadSpin(void *name)
         param.sched_priority = 50;
         SENTRY_PROF_LOG_ERROR_RETURN(pthread_setschedparam(thread, policy, &param));
     }
+
+    // give the other thread a little time to spawn, otherwise its metadata doesn't come back as
+    // expected
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     const auto cache = std::make_shared<ThreadMetadataCache>();
     ThreadHandle handle(pthread_mach_thread_np(thread));

--- a/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
@@ -90,9 +90,13 @@ threadSpin(void *name)
     char name[] = "io.sentry.SentryThreadMetadataCacheTests";
     XCTAssertEqual(pthread_create(&thread, nullptr, threadSpin, reinterpret_cast<void *>(name)), 0);
 
+    // give the other thread a little time to spawn, otherwise its name comes back as an empty
+    // string and the isSentryOwnedThreadName check will fail
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
     const auto cache = std::make_shared<ThreadMetadataCache>();
     ThreadHandle handle(pthread_mach_thread_np(thread));
-    XCTAssertEqual(cache->metadataForThread(handle).threadID, static_cast<unsigned long long>(0));
+    XCTAssertEqual(cache->metadataForThread(handle).threadID, 0ULL);
 
     XCTAssertEqual(pthread_cancel(thread), 0);
     XCTAssertEqual(pthread_join(thread, nullptr), 0);
@@ -114,7 +118,7 @@ threadSpin(void *name)
     const auto cache = std::make_shared<ThreadMetadataCache>();
     const auto metadata = cache->metadataForQueue(0);
 
-    XCTAssertEqual(metadata.address, static_cast<unsigned long long>(0));
+    XCTAssertEqual(metadata.address, 0ULL);
     XCTAssertEqual(metadata.label, nullptr);
 }
 

--- a/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
@@ -47,8 +47,6 @@ threadSpin(void *name)
         SENTRY_PROF_LOG_ERROR_RETURN(pthread_setschedparam(thread, policy, &param));
     }
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
     const auto cache = std::make_shared<ThreadMetadataCache>();
     ThreadHandle handle(pthread_mach_thread_np(thread));
     const auto metadata = cache->metadataForThread(handle);
@@ -72,8 +70,6 @@ threadSpin(void *name)
         SENTRY_PROF_LOG_ERROR_RETURN(pthread_setschedparam(thread, policy, &param));
     }
 
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
     const auto cache = std::make_shared<ThreadMetadataCache>();
     ThreadHandle handle(pthread_mach_thread_np(thread));
     XCTAssertEqual(cache->metadataForThread(handle).priority, 50);
@@ -93,8 +89,6 @@ threadSpin(void *name)
     pthread_t thread;
     char name[] = "io.sentry.SentryThreadMetadataCacheTests";
     XCTAssertEqual(pthread_create(&thread, nullptr, threadSpin, reinterpret_cast<void *>(name)), 0);
-
-    std::this_thread::sleep_for(std::chrono::seconds(1));
 
     const auto cache = std::make_shared<ThreadMetadataCache>();
     ThreadHandle handle(pthread_mach_thread_np(thread));


### PR DESCRIPTION
After looking at the list of 20 slowest tests for a [recent CI run](https://github.com/getsentry/sentry-cocoa/actions/runs/5483115319/jobs/9989134033?pr=3132#step:13:7), I realized some of the sleeps in profiler tests are unnecessary, and others are unnecessarily long.

#skip-changelog