### PR TITLE
ref: add method to SentryThreadWrapper to ensure code runs on main thread

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -639,6 +639,7 @@
 		8453421228BE855D00C22EEC /* SentrySampleDecision.m in Sources */ = {isa = PBXBuildFile; fileRef = 8453421128BE855D00C22EEC /* SentrySampleDecision.m */; };
 		8453421628BE8A9500C22EEC /* SentrySpanStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 8453421528BE8A9500C22EEC /* SentrySpanStatus.m */; };
 		8454CF8D293EAF9A006AC140 /* SentryMetricProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */; };
+		8489B8882A5F7905009A055A /* SentryThreadWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8489B8872A5F7905009A055A /* SentryThreadWrapperTests.swift */; };
 		849AC40029E0C1FF00889C16 /* SentryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AC3FF29E0C1FF00889C16 /* SentryFormatterTests.swift */; };
 		84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */; };
 		84A888FD28D9B11700C51DFD /* SentryProfiler+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A888FC28D9B11700C51DFD /* SentryProfiler+Private.h */; };
@@ -1577,6 +1578,7 @@
 		8453421128BE855D00C22EEC /* SentrySampleDecision.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySampleDecision.m; sourceTree = "<group>"; };
 		8453421528BE8A9500C22EEC /* SentrySpanStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpanStatus.m; sourceTree = "<group>"; };
 		8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryMetricProfiler.mm; path = Sources/Sentry/SentryMetricProfiler.mm; sourceTree = SOURCE_ROOT; };
+		8489B8872A5F7905009A055A /* SentryThreadWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SentryThreadWrapperTests.swift; path = Helper/SentryThreadWrapperTests.swift; sourceTree = "<group>"; };
 		849472802971C107002603DE /* SentrySystemWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySystemWrapperTests.swift; sourceTree = "<group>"; };
 		849472822971C2CD002603DE /* SentryNSProcessInfoWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSProcessInfoWrapperTests.swift; sourceTree = "<group>"; };
 		849472842971C41A002603DE /* SentryNSTimerFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSTimerFactoryTest.swift; sourceTree = "<group>"; };
@@ -2238,6 +2240,7 @@
 				632331F52404FFA8008D91D6 /* SentryScopeTests.m */,
 				7B0002312477F0520035FEF1 /* SentrySessionTests.m */,
 				63AA75951EB8AEDB00D153DE /* SentryTests.m */,
+				8489B8872A5F7905009A055A /* SentryThreadWrapperTests.swift */,
 				63AA75941EB8AEDB00D153DE /* Info.plist */,
 				7B6D1262265F7CC600C9BE4B /* PrivateSentrySDKOnlyTests.swift */,
 				7B4260332630315C00B36EDD /* SampleError.swift */,
@@ -4249,6 +4252,7 @@
 				7BFAA6E7297AA16A00E7E02E /* SentryCrashMonitor_CppException_Tests.mm in Sources */,
 				9286059929A50BAB00F96038 /* SentryGeoTests.swift in Sources */,
 				D8B76B0828081461000A58C4 /* TestSentryScreenShot.swift in Sources */,
+				8489B8882A5F7905009A055A /* SentryThreadWrapperTests.swift in Sources */,
 				A8AFFCD22907DA7600967CD7 /* SentryHttpStatusCodeRangeTests.swift in Sources */,
 				7BE2C7F8257000A4003B66C7 /* SentryTestIntegration.m in Sources */,
 				84A8892128DBD8D600C51DFD /* SentryDeviceTests.mm in Sources */,

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -32,6 +32,7 @@
 #    import "SentrySpanId.h"
 #    import "SentrySystemWrapper.h"
 #    import "SentryThread.h"
+#    import "SentryThreadWrapper.h"
 #    import "SentryTime.h"
 #    import "SentryTracer.h"
 #    import "SentryTracerConcurrency.h"
@@ -312,7 +313,8 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
 - (void)scheduleTimeoutTimer
 {
     __weak SentryProfiler *weakSelf = self;
-    void (^block)(void) = ^(void) {
+
+    [SentryThreadWrapper onMainThread:^{
         if (![weakSelf isRunning]) {
             return;
         }
@@ -324,13 +326,7 @@ serializedProfileData(NSDictionary<NSString *, id> *profileData, SentryTransacti
                                   selector:@selector(timeoutAbort)
                                   userInfo:nil
                                    repeats:NO];
-    };
-
-    if (NSThread.isMainThread) {
-        block();
-    } else {
-        dispatch_async(dispatch_get_main_queue(), block);
-    }
+    }];
 }
 
 #    pragma mark - Public

--- a/Sources/Sentry/SentryThreadWrapper.m
+++ b/Sources/Sentry/SentryThreadWrapper.m
@@ -19,6 +19,15 @@ NS_ASSUME_NONNULL_BEGIN
     // No op. Only needed for testing.
 }
 
++ (void)onMainThread:(void (^)(void))block
+{
+    if ([NSThread isMainThread]) {
+        block();
+    } else {
+        dispatch_async(dispatch_get_main_queue(), block);
+    }
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryThreadWrapper.h
+++ b/Sources/Sentry/include/SentryThreadWrapper.h
@@ -13,6 +13,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)threadFinished:(NSUUID *)threadID;
 
+/**
+ * Ensure a block runs on the main thread. If called from the main thread, execute the block
+ * synchronously. If called from a non-main thread, then dispatch the block to the main queue
+ * asynchronously.
+ * @warning The block will not execute until the main queue is freed by the caller. Try to return up
+ * the call stack as soon as possible after calling this method if you need the block to execute in
+ * a timely manner.
+ */
++ (void)onMainThread:(void (^)(void))block;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Helper/SentryThreadWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryThreadWrapperTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+final class SentryThreadWrapperTests: XCTestCase {
+    func testOnMainThreadFromMainThread() {
+        let e = expectation(description: "Asserted that execution happened on main thread")
+        SentryThreadWrapper.onMainThread {
+            XCTAssertTrue(Thread.isMainThread)
+            e.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testOnMainThreadFromNonmainContext() {
+        let e = expectation(description: "Asserted that execution happened on main thread")
+        let q = DispatchQueue(label: "a nonmain queue", qos: .background)
+        q.async {
+            XCTAssertFalse(Thread.isMainThread)
+            SentryThreadWrapper.onMainThread {
+                XCTAssertTrue(Thread.isMainThread)
+                e.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Tests/SentryTests/Helper/SentryThreadWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryThreadWrapperTests.swift
@@ -10,7 +10,7 @@ final class SentryThreadWrapperTests: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testOnMainThreadFromNonmainContext() {
+    func testOnMainThreadFromNonMainContext() {
         let e = expectation(description: "Asserted that execution happened on main thread")
         let q = DispatchQueue(label: "a nonmain queue", qos: .background)
         q.async {


### PR DESCRIPTION
And use to schedule the NSTimer in SentryTracer on the main thread.

#skip-changelog