### PR TITLE
ref: asserts and warnings

### DIFF
--- a/Sources/Sentry/SentryNSTimerFactory.m
+++ b/Sources/Sentry/SentryNSTimerFactory.m
@@ -8,7 +8,8 @@
                                       block:(void (^)(NSTimer *timer))block
 {
     SENTRY_ASSERT([NSThread isMainThread],
-        @"Timers must be scheduled from the main thread, or they may never fire.");
+        @"Timers must be scheduled from the main thread, or they may never fire. See the attribute "
+        @"on the declaration in NSTimer.h.");
     return [NSTimer scheduledTimerWithTimeInterval:interval repeats:repeats block:block];
 }
 
@@ -19,7 +20,8 @@
                                     repeats:(BOOL)yesOrNo
 {
     SENTRY_ASSERT([NSThread isMainThread],
-        @"Timers must be scheduled from the main thread, or they may never fire.");
+        @"Timers must be scheduled from the main thread, or they may never fire. See the attribute "
+        @"on the declaration in NSTimer.h.");
     return [NSTimer scheduledTimerWithTimeInterval:ti
                                             target:aTarget
                                           selector:aSelector

--- a/Sources/Sentry/SentryNSTimerFactory.m
+++ b/Sources/Sentry/SentryNSTimerFactory.m
@@ -1,4 +1,5 @@
 #import "SentryNSTimerFactory.h"
+#import "SentryInternalDefines.h"
 
 @implementation SentryNSTimerFactory
 
@@ -6,6 +7,8 @@
                                     repeats:(BOOL)repeats
                                       block:(void (^)(NSTimer *timer))block
 {
+    SENTRY_ASSERT([NSThread isMainThread],
+        @"Timers must be scheduled from the main thread, or they may never fire.");
     return [NSTimer scheduledTimerWithTimeInterval:interval repeats:repeats block:block];
 }
 
@@ -15,6 +18,8 @@
                                    userInfo:(nullable id)userInfo
                                     repeats:(BOOL)yesOrNo
 {
+    SENTRY_ASSERT([NSThread isMainThread],
+        @"Timers must be scheduled from the main thread, or they may never fire.");
     return [NSTimer scheduledTimerWithTimeInterval:ti
                                             target:aTarget
                                           selector:aSelector

--- a/Sources/Sentry/SentryNSTimerFactory.m
+++ b/Sources/Sentry/SentryNSTimerFactory.m
@@ -9,7 +9,9 @@
 {
     SENTRY_ASSERT([NSThread isMainThread],
         @"Timers must be scheduled from the main thread, or they may never fire. See the attribute "
-        @"on the declaration in NSTimer.h.");
+        @"on the declaration in NSTimer.h. See "
+        @"https://stackoverflow.com/questions/8304702/"
+        @"how-do-i-create-a-nstimer-on-a-background-thread for more info.");
     return [NSTimer scheduledTimerWithTimeInterval:interval repeats:repeats block:block];
 }
 
@@ -21,7 +23,9 @@
 {
     SENTRY_ASSERT([NSThread isMainThread],
         @"Timers must be scheduled from the main thread, or they may never fire. See the attribute "
-        @"on the declaration in NSTimer.h.");
+        @"on the declaration in NSTimer.h. See "
+        @"https://stackoverflow.com/questions/8304702/"
+        @"how-do-i-create-a-nstimer-on-a-background-thread for more info.");
     return [NSTimer scheduledTimerWithTimeInterval:ti
                                             target:aTarget
                                           selector:aSelector

--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -18,7 +18,8 @@ void
 logSlicingFailureWithArray(
     NSArray<SentrySample *> *array, SentryTransaction *transaction, BOOL start)
 {
-    if (!SENTRY_CASSERT(array.count > 0, @"Should not have attempted to slice an empty array.")) {
+    if (!SENTRY_CASSERT_RETURN(
+            array.count > 0, @"Should not have attempted to slice an empty array.")) {
         return;
     }
 

--- a/Sources/Sentry/SentryTracerConcurrency.mm
+++ b/Sources/Sentry/SentryTracerConcurrency.mm
@@ -3,6 +3,7 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryId.h"
+#    import "SentryInternalDefines.h"
 #    import "SentryLog.h"
 #    import "SentryProfiler+Private.h"
 #    import "SentryTracer.h"
@@ -41,7 +42,7 @@ trackProfilerForTracer(SentryProfiler *profiler, SentryTracer *tracer)
     SENTRY_LOG_DEBUG(
         @"Tracking relationship between profiler id %@ and tracer id %@", profilerKey, tracerKey);
 
-    NSCAssert((_gProfilersToTracers == nil && _gTracersToProfilers == nil)
+    SENTRY_CASSERT((_gProfilersToTracers == nil && _gTracersToProfilers == nil)
             || (_gProfilersToTracers != nil && _gTracersToProfilers != nil),
         @"Both structures must be initialized simultaneously.");
 
@@ -65,20 +66,26 @@ trackProfilerForTracer(SentryProfiler *profiler, SentryTracer *tracer)
     _gTracersToProfilers[tracerKey] = profiler;
 }
 
+SentryProfiler *_Nullable profilerForTracer(SentryTracer *tracer)
+{
+    std::lock_guard<std::mutex> l(_gStateLock);
+    SENTRY_CASSERT(_gTracersToProfilers != nil,
+        @"Structure should have already been initialized by the time it is being queried");
+    return _gTracersToProfilers[tracer.traceId.sentryIdString];
+}
+
 SentryProfiler *_Nullable profilerForFinishedTracer(SentryTracer *tracer)
 {
     std::lock_guard<std::mutex> l(_gStateLock);
 
-    NSCAssert(_gTracersToProfilers != nil && _gProfilersToTracers != nil,
+    SENTRY_CASSERT(_gTracersToProfilers != nil && _gProfilersToTracers != nil,
         @"Structures should have already been initialized by the time they are being queried");
 
     const auto tracerKey = tracer.traceId.sentryIdString;
     const auto profiler = _gTracersToProfilers[tracerKey];
 
-    NSCAssert(
-        profiler != nil, @"Expected a profiler to be associated with tracer id %@.", tracerKey);
-    if (profiler == nil) {
-        SENTRY_LOG_WARN(@"Could not find a profiler associated with tracer id %@.", tracerKey);
+    if (!SENTRY_CASSERT_RETURN(profiler != nil,
+            @"Expected a profiler to be associated with tracer id %@.", tracerKey)) {
         return nil;
     }
 

--- a/Sources/Sentry/SentryTracerConcurrency.mm
+++ b/Sources/Sentry/SentryTracerConcurrency.mm
@@ -66,14 +66,6 @@ trackProfilerForTracer(SentryProfiler *profiler, SentryTracer *tracer)
     _gTracersToProfilers[tracerKey] = profiler;
 }
 
-SentryProfiler *_Nullable profilerForTracer(SentryTracer *tracer)
-{
-    std::lock_guard<std::mutex> l(_gStateLock);
-    SENTRY_CASSERT(_gTracersToProfilers != nil,
-        @"Structure should have already been initialized by the time it is being queried");
-    return _gTracersToProfilers[tracer.traceId.sentryIdString];
-}
-
 SentryProfiler *_Nullable profilerForFinishedTracer(SentryTracer *tracer)
 {
     std::lock_guard<std::mutex> l(_gStateLock);

--- a/Sources/Sentry/include/SentryInternalDefines.h
+++ b/Sources/Sentry/include/SentryInternalDefines.h
@@ -1,13 +1,32 @@
+#import "SentryLog.h"
 #import <Foundation/Foundation.h>
 
 static NSString *const SentryDebugImageType = @"macho";
 
 /**
  * Abort if assertion fails in debug, and log a warning if it fails in production.
+ */
+#define SENTRY_ASSERT(cond, ...)                                                                   \
+    if (!(cond)) {                                                                                 \
+        SENTRY_LOG_WARN(__VA_ARGS__);                                                              \
+        NSAssert(NO, __VA_ARGS__);                                                                 \
+    }
+
+/**
+ * Abort if assertion fails in debug, and log a warning if it fails in production.
+ */
+#define SENTRY_CASSERT(cond, ...)                                                                  \
+    if (!(cond)) {                                                                                 \
+        SENTRY_LOG_WARN(__VA_ARGS__);                                                              \
+        NSCAssert(NO, __VA_ARGS__);                                                                \
+    }
+
+/**
+ * Abort if assertion fails in debug, and log a warning if it fails in production.
  * @return The result of the assertion condition, so it can be used to e.g. early return from the
  * point of it's check if that's also desirable in production.
  */
-#define SENTRY_ASSERT(cond, ...)                                                                   \
+#define SENTRY_ASSERT_RETURN(cond, ...)                                                            \
     ({                                                                                             \
         const auto __cond_result = (cond);                                                         \
         if (!__cond_result) {                                                                      \
@@ -22,7 +41,7 @@ static NSString *const SentryDebugImageType = @"macho";
  * @return The result of the assertion condition, so it can be used to e.g. early return from the
  * point of it's check if that's also desirable in production.
  */
-#define SENTRY_CASSERT(cond, ...)                                                                  \
+#define SENTRY_CASSERT_RETURN(cond, ...)                                                           \
     ({                                                                                             \
         const auto __cond_result = (cond);                                                         \
         if (!__cond_result) {                                                                      \


### PR DESCRIPTION
Add an assert/warning to timer factory if attempting to schedule a timer from a non-main context. Also add more macros that don't need to return the result of the condition if only a warning log is needed. Use in a couple other places.

#skip-changelog