### PR TITLE
fix: profiling memory growth fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Renamed `enableTimeToFullDisplay` to `enableTimeToFullDisplayTracing` (#3106)
     - This is an experimental feature and may change at any time without a major revision.
+    
+### Fixes
+
+- Fix potential unbounded memory growth when starting profiled transactions from non-main contexts (#3135)
 
 ## 8.9.0-beta.1
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -3112,7 +3112,6 @@
 				8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */,
 				03F84D1127DD414C008FE43F /* SentryProfiler.h */,
 				03F84D2B27DD4191008FE43F /* SentryProfiler.mm */,
-				84A888FC28D9B11700C51DFD /* SentryProfiler+Test.h */,
 				84A888FC28D9B11700C51DFD /* SentryProfiler+Private.h */,
 				0354A22A2A134D9C003C3A04 /* SentryProfilerState.h */,
 				84281C642A57D36100EE88F2 /* SentryProfilerState+ObjCpp.h */,

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -42,6 +42,7 @@ class TestCleanup: NSObject {
         SentryTracer.resetAppStartMeasurementRead()
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+        SentryProfiler.getCurrent().stop(for: .normal)
         SentryTracer.resetConcurrencyTracking()
 #endif
     }

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -21,6 +21,7 @@
 #import "SentryNSTimerFactory.h"
 #import "SentryNetworkTracker.h"
 #import "SentryPerformanceTracker+Testing.h"
+#import "SentryProfiler+Test.h"
 #import "SentryRandom.h"
 #import "SentrySDK+Private.h"
 #import "SentrySDK+Tests.h"

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -123,7 +123,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     }
 
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-    if ([SentryProfiler isRunning]) {
+    if ([SentryProfiler isCurrentlyProfiling]) {
         BOOL hasNoFrameRatesYet = self.frameRateTimestamps.count == 0;
         uint64_t previousFrameRate
             = self.frameRateTimestamps.lastObject[@"value"].unsignedLongLongValue;
@@ -179,7 +179,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
 - (void)recordTimestamp:(uint64_t)timestamp value:(NSNumber *)value array:(NSMutableArray *)array
 {
-    BOOL shouldRecord = [SentryProfiler isRunning];
+    BOOL shouldRecord = [SentryProfiler isCurrentlyProfiling];
 #        if defined(TEST) || defined(TESTCI)
     shouldRecord = YES;
 #        endif

--- a/Sources/Sentry/SentryNSNotificationCenterWrapper.m
+++ b/Sources/Sentry/SentryNSNotificationCenterWrapper.m
@@ -46,7 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addObserver:(id)observer
            selector:(SEL)aSelector
                name:(NSNotificationName)aName
-             object:(id)anObject
+             object:(nullable id)anObject
 {
     [NSNotificationCenter.defaultCenter addObserver:observer
                                            selector:aSelector
@@ -67,7 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
     [NSNotificationCenter.defaultCenter removeObserver:observer name:aName object:nil];
 }
 
-- (void)removeObserver:(id)observer name:(NSNotificationName)aName object:(id)anObject
+- (void)removeObserver:(id)observer name:(NSNotificationName)aName object:(nullable id)anObject
 {
     [NSNotificationCenter.defaultCenter removeObserver:observer name:aName object:anObject];
 }
@@ -77,7 +77,7 @@ NS_ASSUME_NONNULL_BEGIN
     [NSNotificationCenter.defaultCenter removeObserver:observer];
 }
 
-- (void)postNotificationName:(NSNotificationName)aName object:(id)anObject
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject
 {
     [NSNotificationCenter.defaultCenter postNotificationName:aName object:anObject];
 }

--- a/Sources/Sentry/SentryScreenFrames.m
+++ b/Sources/Sentry/SentryScreenFrames.m
@@ -43,6 +43,17 @@
 
     return self;
 }
+
+- (nonnull id)copyWithZone:(nullable NSZone *)zone
+{
+    return [[SentryScreenFrames allocWithZone:zone] initWithTotal:_total
+                                                           frozen:_frozen
+                                                             slow:_slow
+                                              slowFrameTimestamps:[_slowFrameTimestamps copy]
+                                            frozenFrameTimestamps:[_frozenFrameTimestamps copy]
+                                              frameRateTimestamps:[_frameRateTimestamps copy]];
+}
+
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @end

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -151,8 +151,7 @@ static BOOL appStartMeasurementRead;
     if (_configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes) {
         _isProfiling = YES;
         _startSystemTime = SentryCurrentDate.systemTime;
-        [SentryProfiler startWithHub:hub];
-        trackTracerWithID(self.traceId);
+        [SentryProfiler startWithHub:hub tracer:self];
     }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -515,12 +514,11 @@ static BOOL appStartMeasurementRead;
 {
     SentryEnvelopeItem *profileEnvelopeItem =
         [SentryProfiler createProfilingEnvelopeItemForTransaction:transaction];
+
     if (!profileEnvelopeItem) {
         [_hub captureTransaction:transaction withScope:_hub.scope];
         return;
     }
-
-    stopTrackingTracerWithID(self.traceId, ^{ [SentryProfiler stop]; });
 
     SENTRY_LOG_DEBUG(@"Capturing transaction with profiling data attached.");
     [_hub captureTransaction:transaction
@@ -806,9 +804,9 @@ static BOOL appStartMeasurementRead;
 }
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED && (defined(TEST) || defined(TESTCI))
-// this just calls through to SentryTracerConcurrency.resetConcurrencyTracking(). we have to do this
-// through SentryTracer because SentryTracerConcurrency cannot be included in test targets via ObjC
-// bridging headers because it contains C++.
+// this just calls through to SentryTracerConcurrency.resetConcurrencyTracking(). we have to
+// do this through SentryTracer because SentryTracerConcurrency cannot be included in test
+// targets via ObjC bridging headers because it contains C++.
 + (void)resetConcurrencyTracking
 {
     resetConcurrencyTracking();

--- a/Sources/Sentry/SentryTracerConcurrency.mm
+++ b/Sources/Sentry/SentryTracerConcurrency.mm
@@ -1,41 +1,107 @@
 #import "SentryTracerConcurrency.h"
-#import "SentryId.h"
-#import "SentryLog.h"
-#include <mutex>
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-static NSMutableSet<NSString *> *_gInFlightTraceIDs;
+#    import "SentryId.h"
+#    import "SentryLog.h"
+#    import "SentryProfiler+Private.h"
+#    import "SentryTracer.h"
+#    include <mutex>
+
+#    if SENTRY_HAS_UIKIT
+#        import "SentryDependencyContainer.h"
+#        import "SentryFramesTracker.h"
+#        import "SentryScreenFrames.h"
+#    endif // SENTRY_HAS_UIKIT
+
+/**
+ * a mapping of profilers to the tracers that started them that are still in-flight and will need to
+ * query them for their profiling data when they finish. this helps resolve the incongruity between
+ * the different timeout durations between tracers (500s) and profilers (30s), where a transaction
+ * may start a profiler that then times out, and then a new transaction starts a new profiler, and
+ * we must keep the aborted one around until its associated transaction finishes.
+ */
+static NSMutableDictionary</* SentryProfiler.profileId */ NSString *,
+    NSMutableSet<SentryTracer *> *> *_gProfilersToTracers;
+
+/** provided for fast access to a profiler given a tracer */
+static NSMutableDictionary</* SentryTracer.tracerId */ NSString *, SentryProfiler *>
+    *_gTracersToProfilers;
+
 std::mutex _gStateLock;
 
 void
-trackTracerWithID(SentryId *traceID)
+trackProfilerForTracer(SentryProfiler *profiler, SentryTracer *tracer)
 {
     std::lock_guard<std::mutex> l(_gStateLock);
 
-    if (_gInFlightTraceIDs == nil) {
-        _gInFlightTraceIDs = [NSMutableSet<NSString *> set];
+    const auto profilerKey = profiler.profileId.sentryIdString;
+    const auto tracerKey = tracer.traceId.sentryIdString;
+
+    SENTRY_LOG_DEBUG(
+        @"Tracking relationship between profiler id %@ and tracer id %@", profilerKey, tracerKey);
+
+    NSCAssert((_gProfilersToTracers == nil && _gTracersToProfilers == nil)
+            || (_gProfilersToTracers != nil && _gTracersToProfilers != nil),
+        @"Both structures must be initialized simultaneously.");
+
+    if (_gProfilersToTracers == nil) {
+        _gProfilersToTracers = [NSMutableDictionary</* SentryProfiler.profileId */ NSString *,
+            NSMutableSet<SentryTracer *> *> dictionaryWithObject:[NSMutableSet setWithObject:tracer]
+                                                          forKey:profilerKey];
+        _gTracersToProfilers =
+            [NSMutableDictionary</* SentryTracer.tracerId */ NSString *, SentryProfiler *>
+                dictionaryWithObject:profiler
+                              forKey:tracerKey];
+        return;
     }
-    const auto idString = traceID.sentryIdString;
-    SENTRY_LOG_DEBUG(@"Adding tracer id %@", idString);
-    [_gInFlightTraceIDs addObject:idString];
+
+    if (_gProfilersToTracers[profilerKey] == nil) {
+        _gProfilersToTracers[profilerKey] = [NSMutableSet setWithObject:tracer];
+    } else {
+        [_gProfilersToTracers[profilerKey] addObject:tracer];
+    }
+
+    _gTracersToProfilers[tracerKey] = profiler;
 }
 
-void
-stopTrackingTracerWithID(SentryId *traceID, SentryConcurrentTransactionCleanupBlock cleanup)
+SentryProfiler *_Nullable profilerForFinishedTracer(SentryTracer *tracer)
 {
     std::lock_guard<std::mutex> l(_gStateLock);
 
-    const auto idString = traceID.sentryIdString;
-    SENTRY_LOG_DEBUG(@"Removing trace id %@", idString);
-    [_gInFlightTraceIDs removeObject:idString];
-    if (_gInFlightTraceIDs.count == 0) {
-        SENTRY_LOG_DEBUG(@"Last in flight tracer completed, performing cleanup.");
-        cleanup();
-    } else {
-        SENTRY_LOG_DEBUG(@"Waiting on %lu other tracers to complete: %@.", _gInFlightTraceIDs.count,
-            _gInFlightTraceIDs);
+    NSCAssert(_gTracersToProfilers != nil && _gProfilersToTracers != nil,
+        @"Structures should have already been initialized by the time they are being queried");
+
+    const auto tracerKey = tracer.traceId.sentryIdString;
+    const auto profiler = _gTracersToProfilers[tracerKey];
+
+    NSCAssert(
+        profiler != nil, @"Expected a profiler to be associated with tracer id %@.", tracerKey);
+    if (profiler == nil) {
+        SENTRY_LOG_WARN(@"Could not find a profiler associated with tracer id %@.", tracerKey);
+        return nil;
     }
+
+    const auto profilerKey = profiler.profileId.sentryIdString;
+
+    [_gTracersToProfilers removeObjectForKey:tracerKey];
+    [_gProfilersToTracers[profilerKey] removeObject:tracer];
+    if ([_gProfilersToTracers[profilerKey] count] == 0) {
+        [_gProfilersToTracers removeObjectForKey:profilerKey];
+        if ([profiler isRunning]) {
+            [profiler stopForReason:SentryProfilerTruncationReasonNormal];
+        }
+    }
+
+#    if SENTRY_HAS_UIKIT
+    profiler._screenFrameData =
+        [SentryDependencyContainer.sharedInstance.framesTracker.currentFrames copy];
+    if (_gProfilersToTracers.count == 0) {
+        [SentryDependencyContainer.sharedInstance.framesTracker resetProfilingTimestamps];
+    }
+#    endif // SENTRY_HAS_UIKIT
+
+    return profiler;
 }
 
 #    if defined(TEST) || defined(TESTCI)
@@ -43,7 +109,8 @@ void
 resetConcurrencyTracking()
 {
     std::lock_guard<std::mutex> l(_gStateLock);
-    [_gInFlightTraceIDs removeAllObjects];
+    [_gTracersToProfilers removeAllObjects];
+    [_gProfilersToTracers removeAllObjects];
 }
 #    endif // defined(TEST) || defined(TESTCI)
 

--- a/Sources/Sentry/include/HybridPublic/SentryScreenFrames.h
+++ b/Sources/Sentry/include/HybridPublic/SentryScreenFrames.h
@@ -10,6 +10,9 @@ typedef NSArray<NSDictionary<NSString *, NSNumber *> *> SentryFrameInfoTimeSerie
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @interface SentryScreenFrames : NSObject
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
+                                <NSCopying>
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 SENTRY_NO_INIT
 
 - (instancetype)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow;

--- a/Sources/Sentry/include/SentryNSNotificationCenterWrapper.h
+++ b/Sources/Sentry/include/SentryNSNotificationCenterWrapper.h
@@ -21,17 +21,17 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addObserver:(id)observer
            selector:(SEL)aSelector
                name:(NSNotificationName)aName
-             object:(id)anObject;
+             object:(nullable id)anObject;
 
 - (void)addObserver:(id)observer selector:(SEL)aSelector name:(NSNotificationName)aName;
 
-- (void)removeObserver:(id)observer name:(NSNotificationName)aName object:(id)anObject;
+- (void)removeObserver:(id)observer name:(NSNotificationName)aName object:(nullable id)anObject;
 
 - (void)removeObserver:(id)observer name:(NSNotificationName)aName;
 
 - (void)removeObserver:(id)observer;
 
-- (void)postNotificationName:(NSNotificationName)aName object:(id)anObject;
+- (void)postNotificationName:(NSNotificationName)aName object:(nullable id)anObject;
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -7,6 +7,9 @@
 @class SentryId;
 @class SentryProfilerState;
 @class SentrySample;
+#    if SENTRY_HAS_UIKIT
+@class SentryScreenFrames;
+#    endif // SENTRY_HAS_UIKIT
 @class SentryTransaction;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -14,12 +17,20 @@ NS_ASSUME_NONNULL_BEGIN
 NSDictionary<NSString *, id> *serializedProfileData(NSDictionary<NSString *, id> *profileData,
     SentryTransaction *transaction, SentryId *profileID, NSString *truncationReason,
     NSString *environment, NSString *release, NSDictionary<NSString *, id> *serializedMetrics,
-    NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub);
+    NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
+#    if SENTRY_HAS_UIKIT
+    ,
+    SentryScreenFrames *gpuData
+#    endif // SENTRY_HAS_UIKIT
+);
 
 @interface
 SentryProfiler ()
 
 @property (strong, nonatomic) SentryProfilerState *_state;
+#    if SENTRY_HAS_UIKIT
+@property (strong, nonatomic) SentryScreenFrames *_screenFrameData;
+#    endif // SENTRY_HAS_UIKIT
 
 @end
 

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -39,17 +39,30 @@ SENTRY_EXTERN_C_END
  */
 @interface SentryProfiler : NSObject
 
+@property (strong, nonatomic) SentryId *profileId;
+
 /**
- * Start the profiler, if it isn't already running.
+ * Start a profiler, if one isn't already running.
  */
-+ (void)startWithHub:(SentryHub *)hub;
++ (void)startWithHub:(SentryHub *)hub tracer:(SentryTracer *)tracer;
 
 /**
  * Stop the profiler if it is running.
  */
-+ (void)stop;
+- (void)stopForReason:(SentryProfilerTruncationReason)reason;
 
-+ (BOOL)isRunning;
+/**
+ * Whether the profiler instance is currently running. If not, then it probably timed out or aborted
+ * due to app backgrounding and is being kept alive while its associated transactions finish so they
+ * can query for its profile data. */
+- (BOOL)isRunning;
+
+/**
+ * Whether there is any profiler that is currently running. A convenience method to query for this
+ * information from other SDK components that don't have access to specific @c SentryProfiler
+ * instances.
+ */
++ (BOOL)isCurrentlyProfiling;
 
 /**
  * Given a transaction, return an envelope item containing any corresponding profile data to be

--- a/Sources/Sentry/include/SentryTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryTracerConcurrency.h
@@ -2,7 +2,8 @@
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>
 
-@class SentryId;
+@class SentryProfiler;
+@class SentryTracer;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -10,17 +11,19 @@ NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN_C_BEGIN
 
-typedef void (^SentryConcurrentTransactionCleanupBlock)(void);
-
-/** Track the tracer with specified ID to help with operations that need to know about all in-flight
- * concurrent tracers. */
-void trackTracerWithID(SentryId *traceID);
+/**
+ * Associate the provided profiler and tracer so that profiling data may be retrieved by the tracer
+ * when it is ready to transmit its envelope.
+ */
+void trackProfilerForTracer(SentryProfiler *profiler, SentryTracer *tracer);
 
 /**
- * Stop tracking the tracer with the specified ID, and if it was the last concurrent tracer in
- * flight, perform the cleanup actions.
+ * Return the profiler instance associated with the tracer. If it was the last tracer for the
+ * associated profiler, stop that profiler. Copy any recorded @c SentryScreenFrames data into the
+ * profiler instance, and if this is the last profiler being tracked, reset the
+ * @c SentryFramesTracker data.
  */
-void stopTrackingTracerWithID(SentryId *traceID, SentryConcurrentTransactionCleanupBlock cleanup);
+SentryProfiler *_Nullable profilerForFinishedTracer(SentryTracer *tracer);
 
 #    if defined(TEST) || defined(TESTCI)
 void resetConcurrencyTracking(void);

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -584,7 +584,7 @@ private extension SentryProfilerSwiftTests {
         let threadMetadata = try XCTUnwrap(sampledProfile["thread_metadata"] as? [String: [String: Any]])
         let queueMetadata = try XCTUnwrap(sampledProfile["queue_metadata"] as? [String: [String: Any]])
         XCTAssertFalse(threadMetadata.isEmpty)
-        if let expectedThreadMetadata {
+        if let expectedThreadMetadata = expectedThreadMetadata {
             try expectedThreadMetadata.forEach {
                 let actualThreadMetadata = try XCTUnwrap(threadMetadata["\($0.id)"])
                 let actualThreadPriority = try XCTUnwrap(actualThreadMetadata["priority"] as? Int32)
@@ -596,7 +596,7 @@ private extension SentryProfilerSwiftTests {
             XCTAssertFalse(try threadMetadata.values.compactMap { $0["priority"] }.filter { try XCTUnwrap($0 as? Int) > 0 }.isEmpty)
         }
         XCTAssertFalse(queueMetadata.isEmpty)
-        if let expectedQueueMetadata {
+        if let expectedQueueMetadata = expectedQueueMetadata {
             try expectedQueueMetadata.forEach {
                 let actualQueueMetadata = try XCTUnwrap(queueMetadata[sentry_formatHexAddressUInt64($0.address)])
                 let actualQueueLabel = try XCTUnwrap(actualQueueMetadata["label"] as? String)

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -7,6 +7,7 @@
 #import "SentryProfilerMocks.h"
 #import "SentryProfilerState+ObjCpp.h"
 #import "SentryProfilingConditionals.h"
+#import "SentryScreenFrames.h"
 #import "SentryThread.h"
 #import "SentryTransaction.h"
 #import "SentryTransactionContext+Private.h"
@@ -189,7 +190,17 @@ using namespace sentry::profiling;
     const auto profileID = [[SentryId alloc] init];
     const auto serialization = serializedProfileData(profileData, transaction, profileID,
         profilerTruncationReasonName(SentryProfilerTruncationReasonNormal), @"test", @"someRelease",
-        @{}, @[], [[SentryHub alloc] initWithClient:nil andScope:nil]);
+        @{}, @[], [[SentryHub alloc] initWithClient:nil andScope:nil]
+#    if SENTRY_HAS_UIKIT
+        ,
+        [[SentryScreenFrames alloc] initWithTotal:5
+                                           frozen:6
+                                             slow:7
+                              slowFrameTimestamps:@[]
+                            frozenFrameTimestamps:@[]
+                              frameRateTimestamps:@[]]
+#    endif // SENTRY_HAS_UIKIT
+    );
 
     // cause the data structures to be modified again: add new addresses
     {

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -8,6 +8,8 @@ class SentryFramesTrackerTests: XCTestCase {
         
         var displayLinkWrapper: TestDisplayLinkWrapper
         var queue: DispatchQueue
+        lazy var hub = TestHub(client: nil, andScope: nil)
+        lazy var tracer = SentryTracer(transactionContext: TransactionContext(name: "test transaction", operation: "test operation"), hub: hub)
         
         init() {
             displayLinkWrapper = TestDisplayLinkWrapper()
@@ -25,15 +27,13 @@ class SentryFramesTrackerTests: XCTestCase {
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
         // the profiler must be running for the frames tracker to record frame rate info etc, validated in assertProfilingData()
-        SentryProfiler.start(with: TestHub(client: nil, andScope: nil))
+        SentryProfiler.start(with: fixture.hub, tracer: fixture.tracer)
 #endif
     }
 
     override func tearDown() {
         super.tearDown()
-#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-        SentryProfiler.stop()
-#endif
+        clearTestState()
     }
     
     func testIsNotRunning_WhenNotStarted() {

--- a/Tests/SentryTests/Transaction/SentryTracerObjCTests.m
+++ b/Tests/SentryTests/Transaction/SentryTracerObjCTests.m
@@ -79,15 +79,15 @@
     XCTestExpectation *exp = [self expectationWithDescription:@"finishes tracers"];
     dispatch_after(
         dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            XCTAssert([SentryProfiler isRunning]);
+            XCTAssert([SentryProfiler isCurrentlyProfiling]);
 
             [tracer1 finish];
 
-            XCTAssert([SentryProfiler isRunning]);
+            XCTAssert([SentryProfiler isCurrentlyProfiling]);
 
             [tracer2 finish];
 
-            XCTAssertFalse([SentryProfiler isRunning]);
+            XCTAssertFalse([SentryProfiler isCurrentlyProfiling]);
 
             [exp fulfill];
         });


### PR DESCRIPTION
Following on from #3133, write a test that exercises the situation that is causing the memory growth bug. We actually already had a test that sets up the scenario, but prior to being able to mock backtraces, which that linked PR provides the ability to do, we were not able to distinguish which profile data comes from which profiler–and therefore tell that one had been lost. Now that we can disambiguate them with different mock data, we can ensure both are preserved. This test should fail in this PR and then pass in #3135 with the fixes.

#skip-changelog