### PR TITLE
ci: Fix Saucelabs  platform version

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -16,12 +16,12 @@ suites:
   - name: "iOS-16"
     devices:
       - name: "iPhone.*"
-        platformVersion: "16.4"
+        platformVersion: "16"
    
   - name: "iOS-15"
     devices:
       - name: "iPhone.*"
-        platformVersion: "15.4"
+        platformVersion: "15"
 
   - name: "iPhone-Pro"
     devices:
@@ -31,22 +31,22 @@ suites:
   - name: "iOS-14"
     devices:
       - name: "iPhone.*"
-        platformVersion: "14.8"
+        platformVersion: "14"
 
   - name: "iOS-13"
     devices:
       - name: "iPhone.*"
-        platformVersion: "13.7"
+        platformVersion: "13"
 
   - name: "iOS-12"
     devices:
       - name: "iPhone.*"
-        platformVersion: "12.5.7"
+        platformVersion: "12"
 
   - name: "iOS-11"
     devices:
       - name: "iPhone.*"
-        platformVersion: "11.4.1"
+        platformVersion: "11"
       
 artifacts:
   download:


### PR DESCRIPTION
Only specify major platform version, so CI doesn't break when Saucelabs update their devices.

#skip-changelog