### PR TITLE
Avoid crashing in SentryCoreDataTracker

### DIFF
--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -67,7 +67,7 @@
             finishWithStatus:result == nil ? kSentrySpanStatusInternalError : kSentrySpanStatusOk];
 
         SENTRY_LOG_DEBUG(@"SentryCoreDataTracker automatically finished span with status: %@",
-            error == nil ? @"ok" : @"error");
+            result == nil ? @"error" : @"ok");
     }
 
     return result;
@@ -109,7 +109,7 @@
         [fetchSpan finishWithStatus:result ? kSentrySpanStatusOk : kSentrySpanStatusInternalError];
 
         SENTRY_LOG_DEBUG(@"SentryCoreDataTracker automatically finished span with status: %@",
-            *error == nil ? @"ok" : @"error");
+            result ? @"ok" : @"error");
     }
 
     return result;


### PR DESCRIPTION

## :scroll: Description

<!--- Describe your changes in detail -->

Users can pass in a `nil` error parameter when calling Core Data methods like `save:` and `executeFetchRequest:`. We were incorrectly handling that nil error parameter and trying to dereference it inside SENTRY_LOG_DEBUG calls. This commit fixes that by instead checking the *result* of the call, as recommended by the [Cocoa Error Handling Guide](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html#//apple_ref/doc/uid/TP40001806-CH204-BAJIIGCC).

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This fixes https://github.com/getsentry/sentry-cocoa/issues/3151.

## :green_heart: How did you test it?

Honestly, I didn't. But I'm making the logging logic match the same logic used in `[fetchSpan finishWithStatus:]`

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
