### PR TITLE
ref: remove SENTRY_HAS_UIDEVICE in favor of identical SENTRY_HAS_UIKIT

### DIFF
--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -7,12 +7,6 @@
 #endif
 
 #if TARGET_OS_IOS || TARGET_OS_TV
-#    define SENTRY_HAS_UIDEVICE 1
-#else
-#    define SENTRY_HAS_UIDEVICE 0
-#endif
-
-#if SENTRY_HAS_UIDEVICE
 #    define SENTRY_HAS_UIKIT 1
 #else
 #    define SENTRY_HAS_UIKIT 0

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -209,7 +209,7 @@ SentryCrashIntegration ()
 
     // For MacCatalyst the UIDevice returns the current version of MacCatalyst and not the
     // macOSVersion. Therefore we have to use NSProcessInfo.
-#if SENTRY_HAS_UIDEVICE && !TARGET_OS_MACCATALYST
+#if SENTRY_HAS_UIKIT && !TARGET_OS_MACCATALYST
     [osData setValue:[UIDevice currentDevice].systemVersion forKey:@"version"];
 #else
     NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
@@ -267,7 +267,7 @@ SentryCrashIntegration ()
     NSString *locale = [[NSLocale autoupdatingCurrentLocale] objectForKey:NSLocaleIdentifier];
     [deviceData setValue:locale forKey:LOCALE_KEY];
 
-#if SENTRY_HAS_UIDEVICE
+#if SENTRY_HAS_UIKIT
 
     NSArray<UIWindow *> *appWindows = SentryDependencyContainer.sharedInstance.application.windows;
     if ([appWindows count] > 0) {

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -47,13 +47,13 @@ static NSString *const SentryConnectivityNone = @"none";
 BOOL
 SentryConnectivityShouldReportChange(SCNetworkReachabilityFlags flags)
 {
-#    if SENTRY_HAS_UIDEVICE
+#    if SENTRY_HAS_UIKIT
     // kSCNetworkReachabilityFlagsIsWWAN does not exist on macOS
     const SCNetworkReachabilityFlags importantFlags
         = kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsReachable;
-#    else
+#    else // !SENTRY_HAS_UIKIT
     const SCNetworkReachabilityFlags importantFlags = kSCNetworkReachabilityFlagsReachable;
-#    endif
+#    endif // SENTRY_HAS_UIKIT
     __block BOOL shouldReport = YES;
     // Check if the reported state is different from the last known state (if any)
     SCNetworkReachabilityFlags newFlags = flags & importantFlags;
@@ -80,13 +80,13 @@ NSString *
 SentryConnectivityFlagRepresentation(SCNetworkReachabilityFlags flags)
 {
     BOOL connected = (flags & kSCNetworkReachabilityFlagsReachable) != 0;
-#    if SENTRY_HAS_UIDEVICE
+#    if SENTRY_HAS_UIKIT
     return connected ? ((flags & kSCNetworkReachabilityFlagsIsWWAN) ? SentryConnectivityCellular
                                                                     : SentryConnectivityWiFi)
                      : SentryConnectivityNone;
-#    else
+#    else // !SENTRY_HAS_UIKIT
     return connected ? SentryConnectivityWiFi : SentryConnectivityNone;
-#    endif
+#    endif // SENTRY_HAS_UIKIT
 }
 
 /**

--- a/Tests/SentryTests/Networking/SentryReachabilityTests.m
+++ b/Tests/SentryTests/Networking/SentryReachabilityTests.m
@@ -23,14 +23,14 @@
     XCTAssertEqualObjects(@"none", SentryConnectivityFlagRepresentation(0));
     XCTAssertEqualObjects(
         @"none", SentryConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsIsDirect));
-#    if SENTRY_HAS_UIDEVICE
+#    if SENTRY_HAS_UIKIT
     // kSCNetworkReachabilityFlagsIsWWAN does not exist on macOS
     XCTAssertEqualObjects(
         @"none", SentryConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsIsWWAN));
     XCTAssertEqualObjects(@"cellular",
         SentryConnectivityFlagRepresentation(
             kSCNetworkReachabilityFlagsIsWWAN | kSCNetworkReachabilityFlagsReachable));
-#    endif
+#    endif // SENTRY_HAS_UIKIT
     XCTAssertEqualObjects(
         @"wifi", SentryConnectivityFlagRepresentation(kSCNetworkReachabilityFlagsReachable));
     XCTAssertEqualObjects(@"wifi",


### PR DESCRIPTION
One was defined in terms of the other, replicating it. Remove so there's just one.

#skip-changelog