### PR TITLE
test: remove live hub and client

### DIFF
--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -240,8 +240,11 @@ class SentryProfilerSwiftTests: XCTestCase {
         var spans = [Span]()
 
         func createConcurrentSpansWithMetrics() throws {
+            XCTAssertFalse(SentryProfiler.isCurrentlyProfiling())
+
             for _ in 0 ..< numberOfTransactions {
                 let span = try fixture.newTransaction()
+                XCTAssertTrue(SentryProfiler.isCurrentlyProfiling())
                 spans.append(span)
                 fixture.currentDateProvider.advanceBy(nanoseconds: 100)
             }
@@ -250,11 +253,14 @@ class SentryProfilerSwiftTests: XCTestCase {
 
             for (i, span) in spans.enumerated() {
                 try fixture.gatherMockedMetrics(span: span)
+                XCTAssertTrue(SentryProfiler.isCurrentlyProfiling())
                 span.finish()
 
                 try self.assertValidProfileData()
                 try self.assertMetricsPayload(metricsBatches: i + 1)
             }
+            
+            XCTAssertFalse(SentryProfiler.isCurrentlyProfiling())
         }
 
         try createConcurrentSpansWithMetrics()

--- a/Tests/SentryTests/Transaction/SentryTracerObjCTests.m
+++ b/Tests/SentryTests/Transaction/SentryTracerObjCTests.m
@@ -5,6 +5,7 @@
 #import "SentryProfilesSampler.h"
 #import "SentryProfilingConditionals.h"
 #import "SentrySpan.h"
+#import "SentryTests-Swift.h"
 #import "SentryTracer.h"
 #import "SentryTransactionContext.h"
 #import <XCTest/XCTest.h>
@@ -24,7 +25,7 @@
     SentrySpan *child;
     // To make sure the tracer is deallocated.
     @autoreleasepool {
-        SentryHub *hub = [[SentryHub alloc] initWithClient:nil andScope:nil];
+        SentryHub *hub = [[TestHub alloc] initWithClient:nil andScope:nil];
         SentryTransactionContext *context =
             [[SentryTransactionContext alloc] initWithOperation:@""];
         SentryTracer *tracer = [[SentryTracer alloc]
@@ -42,58 +43,5 @@
     XCTAssertNotNil(child);
     [child finish];
 }
-
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-- (void)testConcurrentTracerProfiling
-{
-    SentryOptions *options = [[SentryOptions alloc] init];
-    options.profilesSampleRate = @1;
-    SentryClient *client = [[SentryClient alloc] initWithOptions:options];
-    SentryHub *hub = [[SentryHub alloc] initWithClient:client andScope:nil];
-    SentryTransactionContext *context1 = [[SentryTransactionContext alloc] initWithName:@"name1"
-                                                                              operation:@"op1"];
-    SentryTransactionContext *context2 = [[SentryTransactionContext alloc] initWithName:@"name1"
-                                                                              operation:@"op2"];
-    SentryProfilesSamplerDecision *decision =
-        [[SentryProfilesSamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
-                                                  forSampleRate:@1];
-
-    SentryTracer *tracer1 = [[SentryTracer alloc]
-        initWithTransactionContext:context1
-                               hub:hub
-                     configuration:[SentryTracerConfiguration configurationWithBlock:^(
-                                       SentryTracerConfiguration *configuration) {
-                         configuration.profilesSamplerDecision = decision;
-                         configuration.waitForChildren = YES;
-                     }]];
-
-    SentryTracer *tracer2 = [[SentryTracer alloc]
-        initWithTransactionContext:context2
-                               hub:hub
-                     configuration:[SentryTracerConfiguration configurationWithBlock:^(
-                                       SentryTracerConfiguration *configuration) {
-                         configuration.profilesSamplerDecision = decision;
-                         configuration.waitForChildren = YES;
-                     }]];
-
-    XCTestExpectation *exp = [self expectationWithDescription:@"finishes tracers"];
-    dispatch_after(
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-            XCTAssert([SentryProfiler isCurrentlyProfiling]);
-
-            [tracer1 finish];
-
-            XCTAssert([SentryProfiler isCurrentlyProfiling]);
-
-            [tracer2 finish];
-
-            XCTAssertFalse([SentryProfiler isCurrentlyProfiling]);
-
-            [exp fulfill];
-        });
-
-    [self waitForExpectationsWithTimeout:2.0 handler:nil];
-}
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @end


### PR DESCRIPTION
Use mock hub in one test, remove the other test and use similar assertions in another test that already duplicates its logic.

#skip-changelog