### PR TITLE
fix: use correct format specifier for NSInteger (either an int or a long int)

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -611,7 +611,7 @@ SentryFileManager ()
 
 - (void)storeTimezoneOffset:(NSInteger)offset
 {
-    NSString *timezoneOffsetString = [NSString stringWithFormat:@"%zd", offset];
+    NSString *timezoneOffsetString = [NSString stringWithFormat:@"%ld", (long)offset];
     SENTRY_LOG_DEBUG(@"Persisting timezone offset: %@", timezoneOffsetString);
     @synchronized(self.timezoneOffsetFilePath) {
         if (![self writeData:[timezoneOffsetString dataUsingEncoding:NSUTF8StringEncoding]

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -551,6 +551,11 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(sut.readTimezoneOffset(), 7_200)
     }
 
+    func testtestStoreAndReadNegativeTimezoneOffset() {
+        sut.storeTimezoneOffset(-1_000)
+        XCTAssertEqual(sut.readTimezoneOffset(), -1_000)
+    }
+
     func testStoreDeleteTimezoneOffset() {
         sut.storeTimezoneOffset(7_200)
         sut.deleteTimezoneOffset()


### PR DESCRIPTION
Saw this when debugging a test failure. `%zd` specifies a `size_t`, but this is formatting an amount of seconds. It seemed inappropriate to mix a value of time type with a type meant for memory values.

#skip-changelog