### PR TITLE
chore: Add note on improvement of #3135

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
 ### Features
 
 - Symbolicate locally only when debug is enabled (#3079)
+
+This change considerably speeds up retrieving stacktraces, which the SDK uses for captureMessage, captureError and also for reporting file IO or DB operation on the main thread.
+
 - Sanitize HTTP info from breadcrumbs, spans and events (#3094)
 
 ### Breaking change


### PR DESCRIPTION
Explain that not symbolicating locally speeds up certain SDK actions.

#skip-changelog

Came up in https://github.com/getsentry/sentry-cocoa/issues/3167#issuecomment-1641789633.