### PR TITLE
fix: Use "__has_include" instead of platform check

### DIFF
--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -6,13 +6,13 @@
 #    define SENTRY_EXTERN extern __attribute__((visibility("default")))
 #endif
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if __has_include(<UIKit/UIKit.h>)
 #    define SENTRY_HAS_UIKIT 1
 #else
 #    define SENTRY_HAS_UIKIT 0
 #endif
 
-#if TARGET_OS_IOS || TARGET_OS_OSX || TARGET_OS_MACCATALYST
+#if __has_include(<MetricKit/MetricKit.h>)
 #    define SENTRY_HAS_METRIC_KIT 1
 #else
 #    define SENTRY_HAS_METRIC_KIT 0


### PR DESCRIPTION
Instead of filtering features out by platform directives, I believe we should check whether the framework we need exists with `__has_include`.

_#skip-changelog_

