### PR TITLE
feat: Add SENTRY_IGNORE_UIKIT compiler directive to avoid linking with UIKIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Reduced macOS SDK footprint by 2% (#3157) with similar changes for tvOS and watchOS (#3158, #3159, #3161)
 
+### Features
+
+- Add SENTRY_IGNORE_UIKIT compiler directive to avoid linking with UIKIT (#3178)
+
 ### Fixes
 
 - Fix a crash in SentryCoreDataTracker for nil error params (#3152)

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -6,7 +6,7 @@
 #    define SENTRY_EXTERN extern __attribute__((visibility("default")))
 #endif
 
-#if TARGET_OS_IOS || TARGET_OS_TV
+#if (TARGET_OS_IOS || TARGET_OS_TV) && !SENTRY_IGNORE_UIKIT
 #    define SENTRY_HAS_UIKIT 1
 #else
 #    define SENTRY_HAS_UIKIT 0

--- a/Sources/Sentry/SentryDevice.mm
+++ b/Sources/Sentry/SentryDevice.mm
@@ -181,7 +181,7 @@ sentry_getOSVersion(void)
 {
 #if TARGET_OS_WATCH
     return WKInterfaceDevice.currentDevice.systemVersion;
-#elif TARGET_OS_IOS
+#elif TARGET_OS_IOS || TARGET_OS_TV
 #    if SENTRY_HAS_UIKIT
     return UIDevice.currentDevice.systemVersion;
 #    else

--- a/Sources/Sentry/SentryExtraContextProvider.m
+++ b/Sources/Sentry/SentryExtraContextProvider.m
@@ -57,7 +57,7 @@ SentryExtraContextProvider ()
     extraDeviceContext[@"free_storage"] = @(self.crashWrapper.freeStorageSize);
     extraDeviceContext[@"processor_count"] = @([self.processInfoWrapper processorCount]);
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {
         extraDeviceContext[@"orientation"]
             = UIDeviceOrientationIsPortrait(self.deviceWrapper.orientation) ? @"portrait"

--- a/Sources/Sentry/SentrySystemEventBreadcrumbs.m
+++ b/Sources/Sentry/SentrySystemEventBreadcrumbs.m
@@ -7,7 +7,7 @@
 #import "SentryNSNotificationCenterWrapper.h"
 
 // all those notifications are not available for tvOS
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
 #endif
 
@@ -32,7 +32,7 @@ SentrySystemEventBreadcrumbs ()
 
 - (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
 {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     UIDevice *currentDevice = [UIDevice currentDevice];
     [self startWithDelegate:delegate currentDevice:currentDevice];
 #else
@@ -42,7 +42,7 @@ SentrySystemEventBreadcrumbs ()
 
 - (void)stop
 {
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     // Remove the observers with the most specific detail possible, see
     // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
     [self.notificationCenterWrapper removeObserver:self name:UIKeyboardDidShowNotification];
@@ -67,7 +67,7 @@ SentrySystemEventBreadcrumbs ()
     [self.notificationCenterWrapper removeObserver:self];
 }
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 /**
  * Only used for testing, call startWithDelegate instead.
  */
@@ -88,7 +88,7 @@ SentrySystemEventBreadcrumbs ()
 }
 #endif
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 - (void)initBatteryObserver:(UIDevice *)currentDevice
 {
     if (currentDevice.batteryMonitoringEnabled == NO) {

--- a/Sources/Sentry/SentryUIDeviceWrapper.m
+++ b/Sources/Sentry/SentryUIDeviceWrapper.m
@@ -13,7 +13,7 @@ SentryUIDeviceWrapper ()
 
 @implementation SentryUIDeviceWrapper
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 - (instancetype)init
 {

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -1,7 +1,6 @@
 #import "SentryUIViewControllerPerformanceTracker.h"
 
 #if SENTRY_HAS_UIKIT
-
 #    import "SentryFramesTracker.h"
 #    import "SentryHub.h"
 #    import "SentryLog.h"

--- a/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
@@ -1,7 +1,7 @@
 #import "SentryFileManager.h"
 #import <Foundation/Foundation.h>
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
 #endif
 
@@ -19,7 +19,7 @@ SENTRY_NO_INIT
 
 - (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate;
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 - (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
             currentDevice:(nullable UIDevice *)currentDevice;
 - (void)timezoneEventTriggered;

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryUIDeviceWrapper : NSObject
 
-#if TARGET_OS_IOS
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 - (instancetype)init;
 - (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 - (void)stop;

--- a/Sources/SentryCrash/Recording/SentryCrashSystemCapabilities.h
+++ b/Sources/SentryCrash/Recording/SentryCrashSystemCapabilities.h
@@ -68,13 +68,13 @@
 #    define SentryCrashCRASH_HAS_STRNSTR 0
 #endif
 
-#if SentryCrashCRASH_HOST_IOS || SentryCrashCRASH_HOST_TV || SentryCrashCRASH_HOST_WATCH
+#if (SentryCrashCRASH_HOST_IOS || SentryCrashCRASH_HOST_TV || SentryCrashCRASH_HOST_WATCH) && !SENTRY_IGNORE_UIKIT
 #    define SentryCrashCRASH_HAS_UIKIT 1
 #else
 #    define SentryCrashCRASH_HAS_UIKIT 0
 #endif
 
-#if SentryCrashCRASH_HOST_IOS || SentryCrashCRASH_HOST_TV
+#if (SentryCrashCRASH_HOST_IOS || SentryCrashCRASH_HOST_TV) && !SENTRY_IGNORE_UIKIT
 #    define SentryCrashCRASH_HAS_UIAPPLICATION 1
 #else
 #    define SentryCrashCRASH_HAS_UIAPPLICATION 0
@@ -92,7 +92,7 @@
 #    define SentryCrashCRASH_HAS_MESSAGEUI 0
 #endif
 
-#if SentryCrashCRASH_HOST_IOS || SentryCrashCRASH_HOST_TV
+#if (SentryCrashCRASH_HOST_IOS || SentryCrashCRASH_HOST_TV) && !SENTRY_IGNORE_UIKIT
 #    define SentryCrashCRASH_HAS_UIDEVICE 1
 #else
 #    define SentryCrashCRASH_HAS_UIDEVICE 0


### PR DESCRIPTION
## :scroll: Description

Added SENTRY_IGNORE_UIKIT compiler directive in order to remove from the build everything related to UIKIT. 

## :bulb: Motivation and Context

Users will be able to add the `-DSENTRY_IGNORE_UIKIT` compiler flag, or add a preprocessor macro `SENTRY_IGNORE_UIKIT=1` to their Sentry build step to avoid linking with UIKIT and saving a few bytes from the SDK.

![image](https://github.com/getsentry/sentry-cocoa/assets/28265868/db45cab0-a6bc-428c-a936-c854fefaf88e)
_Only one of these two options required_

This could be the solution for #3174

## :green_heart: How did you test it?

Manual test with `otool`

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
