### PR TITLE
replace NSLog with os_log

### DIFF
--- a/Sources/Sentry/SentryLogOutput.m
+++ b/Sources/Sentry/SentryLogOutput.m
@@ -1,12 +1,30 @@
 #import "SentryLogOutput.h"
 
+#if __has_include(<os/log.h>)
+#import <os/log.h>
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation SentryLogOutput
+@implementation SentryLogOutput {
+    id _os_log;
+}
 
-- (void)log:(NSString *)message
-{
-    NSLog(@"%@", message);
+- (instancetype)init {
+    if (self = [super init]) {
+        if (@available(iOS 10.0, macOS 10.12, macCatalyst 13.1, tvOS 10.0, watchOS 3.0, *)) {
+            _os_log = os_log_create("io.sentry.log", "any");
+        }
+    }
+    return self;
+}
+
+- (void)log:(NSString *)message {
+    if (_os_log && @available(iOS 10.0, macOS 10.12, macCatalyst 13.1, tvOS 10.0, watchOS 3.0, *)) {
+        os_log_debug(_os_log, "%{public}s", [message UTF8String]);
+    } else {
+        NSLog(@"%@", message);
+    }
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description

Replace NSLog with os_log 

## :bulb: Motivation and Context

It helps to keep Sentry debug mode on, and be able to filter log messages in Console app by Subsystem/Category.

## :green_heart: How did you test it?

Manually, need help here

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed. ???
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
