### PR TITLE
fix: Crashed session not being reported as crashed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Reclaim memory used by profiler when transactions are discarded (#3154)
+- Crashed session not being reported as crashed (#3183)
 
 ## 8.9.2
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -56,6 +56,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 {
     NSMutableArray<NSString *> *defaultIntegrations =
         @[
+            NSStringFromClass([SentryCrashIntegration class]),
 #if SENTRY_HAS_UIKIT
             NSStringFromClass([SentryAppStartTrackingIntegration class]),
             NSStringFromClass([SentryFramesTrackingIntegration class]),
@@ -69,7 +70,6 @@ NSString *const kSentryDefaultEnvironment = @"production";
             NSStringFromClass([SentryAutoBreadcrumbTrackingIntegration class]),
             NSStringFromClass([SentryAutoSessionTrackingIntegration class]),
             NSStringFromClass([SentryCoreDataTrackingIntegration class]),
-            NSStringFromClass([SentryCrashIntegration class]),
             NSStringFromClass([SentryFileIOTrackingIntegration class]),
             NSStringFromClass([SentryNetworkTrackingIntegration class]),
             NSStringFromClass([SentrySwiftAsyncIntegration class])

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -54,6 +54,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
 + (NSArray<NSString *> *)defaultIntegrations
 {
+    // The order of integrations here is important.
+    // SentryCrashIntegration needs to be initialized before SentryAutoSessionTrackingIntegration.
     NSMutableArray<NSString *> *defaultIntegrations =
         @[
             NSStringFromClass([SentryCrashIntegration class]),

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -394,6 +394,11 @@
         @"Default integrations are not set correctly");
 }
 
+- (void)testSentryCrashIntegrationIsFirst
+{
+    XCTAssertEqualObjects(SentryOptions.defaultIntegrations.firstObject, NSStringFromClass([SentryCrashIntegration class]));
+}
+
 - (void)testSampleRateWithDict
 {
     NSNumber *sampleRate = @0.1;

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -396,7 +396,8 @@
 
 - (void)testSentryCrashIntegrationIsFirst
 {
-    XCTAssertEqualObjects(SentryOptions.defaultIntegrations.firstObject, NSStringFromClass([SentryCrashIntegration class]));
+    XCTAssertEqualObjects(SentryOptions.defaultIntegrations.firstObject,
+        NSStringFromClass([SentryCrashIntegration class]));
 }
 
 - (void)testSampleRateWithDict


### PR DESCRIPTION
## :scroll: Description

We [recently](https://github.com/getsentry/sentry-cocoa/pull/3157/files#diff-a29fc90c9efdf9bef7ce45c2687a50708114e90208d518b9fe3bad5ef8e0951b) changed the integration order, which is causing a problem to report crashed sessions.

This PR fix the order of integration.

## :bulb: Motivation and Context

close #3181 

## :green_heart: How did you test it?

Sample

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Investigate a way to update the integrations so they don't require a specific order.