### PR TITLE
Fix: Remove linker settings from Package.swift

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
       - Sentry.xcworkspace
       - Sentry.xcodeproj
       - Gemfile.lock
+      - 'Package.swift'
 
 jobs:
   # We had issues that the release build was broken on main.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## Unreleased
+
+### Fixes
+ 
+- Remove linker settings from Package.swift (#3188)
+
 ## 8.9.3
 
 ### Fixes

--- a/Package.swift
+++ b/Package.swift
@@ -31,10 +31,6 @@ let package = Package(
                 .headerSearchPath("SentryCrash/Reporting/Filters"),
                 .headerSearchPath("SentryCrash/Reporting/Filters/Tools"),
                 .headerSearchPath("SentryCrash/Reporting/Tools")
-            ],
-            linkerSettings: [
-                .linkedLibrary("z"),
-                .linkedLibrary("c++")
             ]
         ),
         .target( name: "SentryPrivate",


### PR DESCRIPTION
## :scroll: Description

Removes `C++` and `Z` linker settings from Package.swift.
It seems this is not necessary since it don't break the build for Xcode 14,
also this will be necessary for Xcode 15.

## :bulb: Motivation and Context

closes #3122

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
