### PR TITLE
fix: indicate api key in sample project is a test key

### DIFF
--- a/Samples/TrendingMovies/TrendingMovies/TMDb/TMDbCredentials.swift
+++ b/Samples/TrendingMovies/TrendingMovies/TMDb/TMDbCredentials.swift
@@ -1,5 +1,5 @@
 /// Credentials for accessing The Movie Database API
 struct TMDbCredentials {
     /// Key for version 3 of the API.
-    static let apiKey = "b753b3593b6183f4d68afada9720fff1"
+    static let apiKey = "testb753b3593b61testd68afada972test"
 }


### PR DESCRIPTION
The security team received a report concerning the API key in the TMDb sample application. The API key is invalid, but it's not immediately clear.

_#skip-changelog_