### PR TITLE
fix: Free memory returned by backtrace_symbols() in debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes
  
 - Remove linker settings from Package.swift (#3188)
+- Free memory returned by backtrace_symbols() in debug builds ([#3202](https://github.com/getsentry/sentry-cocoa/pull/3202))
 
 ## 8.9.3
 

--- a/Sources/Sentry/Profiling/SentryProfilerState.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerState.mm
@@ -129,6 +129,9 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
                 [stack addObject:frameIndex];
             }
         }
+#    if defined(DEBUG)
+        free(symbols);
+#    endif
 
         const auto sample = [[SentrySample alloc] init];
         sample.absoluteTimestamp = backtrace.absoluteTimestamp;


### PR DESCRIPTION
## :scroll: Description

This code is only compiled in debug builds, but we were forgetting to `free` the pointer returned by `backtrace_symbols`. The documentation (https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/backtrace_symbols.3.html)  says:

> It is allocated using malloc() and should be released using free()

## :bulb: Motivation and Context

Customer reported a memory leak in a call to `backtrace_symbols`, this is the cause.

## :green_heart: How did you test it?

Verify that the memory is freed and does not leak in a debug build.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
