### PR TITLE
Fix: `remove_preview_version_suffixes` Lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,7 +36,7 @@ platform :ios do
       value: new_version
     )
 
-    sentryInfoPlistPath = "./Sources/Sentry/Info.plist"
+    sentryInfoPlistPath = "./Sources/Resources/Info.plist"
     set_info_plist_value(
       path: sentryInfoPlistPath,
       key: "CFBundleShortVersionString",


### PR DESCRIPTION
Fixes an error on CI to bump the version.

_#skip-changelog_