### PR TITLE
ref: convert SentryHttpStatusCodeRange (Private) category to an interface extension

### DIFF
--- a/Sources/Sentry/include/SentryHttpStatusCodeRange+Private.h
+++ b/Sources/Sentry/include/SentryHttpStatusCodeRange+Private.h
@@ -1,10 +1,9 @@
-#import "SentryDefines.h"
 #import "SentryHttpStatusCodeRange.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
-SentryHttpStatusCodeRange (Private)
+SentryHttpStatusCodeRange ()
 
 - (BOOL)isInRange:(NSInteger)statusCode;
 


### PR DESCRIPTION
Interface extensions > private categories (see https://github.com/getsentry/sentry-cocoa/pull/3236 for elaboration)

#skip-changelog