### PR TITLE
ref: convert simple private category to interface extensions

### DIFF
--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -1,4 +1,3 @@
-#import "SentryOptions.h"
 #import "SentryANRTracker.h"
 #import "SentryANRTrackingIntegration.h"
 #import "SentryAutoBreadcrumbTrackingIntegration.h"
@@ -12,6 +11,7 @@
 #import "SentryLog.h"
 #import "SentryMeta.h"
 #import "SentryNetworkTrackingIntegration.h"
+#import "SentryOptions+Private.h"
 #import "SentrySDK.h"
 #import "SentryScope.h"
 #import "SentrySwiftAsyncIntegration.h"
@@ -34,12 +34,7 @@
 SentryOptions ()
 
 @property (nullable, nonatomic, copy, readonly) NSNumber *defaultSampleRate;
-@property (nullable, nonatomic, copy, readonly) NSNumber *defaultTracesSampleRate;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-@property (nullable, nonatomic, copy, readonly) NSNumber *defaultProfilesSampleRate;
-@property (nonatomic, assign) BOOL enableProfiling_DEPRECATED_TEST_ONLY;
-#endif
 @end
 
 NSString *const kSentryDefaultEnvironment = @"production";

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -600,7 +600,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
     return self.enableProfiling;
 }
 #    pragma clang diagnostic pop
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 /**
  * Checks if the passed in block is actually of type block. We can't check if the block matches a

--- a/Sources/Sentry/include/HybridPublic/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/HybridPublic/SentryBreadcrumb+Private.h
@@ -1,9 +1,7 @@
 #import "SentryBreadcrumb.h"
-#import "SentryDefines.h"
-#import "SentrySerializable.h"
 
 @interface
-SentryBreadcrumb (Private)
+SentryBreadcrumb ()
 
 /**
  * Initializes a SentryBreadcrumb from a JSON object.

--- a/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
+++ b/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
@@ -7,7 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
-SentryOptions (HybridSDKs)
+SentryOptions ()
 
 - (_Nullable instancetype)initWithDict:(NSDictionary<NSString *, id> *)options
                       didFailWithError:(NSError *_Nullable *_Nullable)error;

--- a/Sources/Sentry/include/HybridPublic/SentryUser+Private.h
+++ b/Sources/Sentry/include/HybridPublic/SentryUser+Private.h
@@ -1,9 +1,7 @@
-#import "SentryDefines.h"
-#import "SentrySerializable.h"
 #import "SentryUser.h"
 
 @interface
-SentryUser (Private)
+SentryUser ()
 
 /**
  * Initializes a SentryUser from a dictionary.

--- a/Sources/Sentry/include/SentryEnvelope+Private.h
+++ b/Sources/Sentry/include/SentryEnvelope+Private.h
@@ -1,11 +1,9 @@
-#import "SentryAttachment+Private.h"
 #import "SentryEnvelope.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
-SentryEnvelopeItem (Private)
+SentryEnvelopeItem ()
 
 - (instancetype)initWithClientReport:(SentryClientReport *)clientReport;
 

--- a/Sources/Sentry/include/SentryHttpStatusCodeRange+Private.h
+++ b/Sources/Sentry/include/SentryHttpStatusCodeRange+Private.h
@@ -1,10 +1,9 @@
-#import "SentryDefines.h"
 #import "SentryHttpStatusCodeRange.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
-SentryHttpStatusCodeRange (Private)
+SentryHttpStatusCodeRange ()
 
 - (BOOL)isInRange:(NSInteger)statusCode;
 

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
 
 @interface
-SentryOptions (Private)
+SentryOptions ()
 
 @property (nullable, nonatomic, copy, readonly) NSNumber *defaultTracesSampleRate;
 

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -12,13 +12,15 @@ SentryOptions ()
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 @property (nullable, nonatomic, copy, readonly) NSNumber *defaultProfilesSampleRate;
 @property (nonatomic, assign) BOOL enableProfiling_DEPRECATED_TEST_ONLY;
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 - (BOOL)isValidSampleRate:(NSNumber *)sampleRate;
 
 - (BOOL)isValidTracesSampleRate:(NSNumber *)tracesSampleRate;
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
 - (BOOL)isValidProfilesSampleRate:(NSNumber *)profilesSampleRate;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @end
 

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -5,7 +5,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
-SentrySDK (Private)
+SentrySDK ()
 
 + (void)captureCrashEvent:(SentryEvent *)event;
 

--- a/Sources/Sentry/include/SentrySpanContext+Private.h
+++ b/Sources/Sentry/include/SentrySpanContext+Private.h
@@ -1,10 +1,9 @@
-#import <SentryDefines.h>
 #import <SentrySpanContext.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface
-SentrySpanContext (Private)
+SentrySpanContext ()
 
 - (instancetype)initWithOperation:(NSString *)operation
                            origin:(NSString *)origin

--- a/Tests/SentryTests/SentryCrash/SentryCrashTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashTests.m
@@ -6,7 +6,8 @@
 
 @end
 
-@interface SentryCrash (private)
+@interface
+SentryCrash ()
 
 - (NSString *)clearBundleName:(NSString *)filename;
 

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -10,7 +10,7 @@
 #import <XCTest/XCTest.h>
 
 @interface
-SentryBreadcrumbTracker (Private)
+SentryBreadcrumbTracker ()
 
 + (NSString *)sanitizeViewControllerName:(NSString *)controller;
 


### PR DESCRIPTION
Interface extensions > private categories (see https://github.com/getsentry/sentry-cocoa/pull/3236 for elaboration)

This PR collects all such changes that didn't involve any other code changes other than removing the category name to make it anonymous.

#skip-changelog