### PR TITLE
ref: move decl/impl from SentryEvent (MetricKit) to SenryEvent .h/.m …

### DIFF
--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -17,6 +17,11 @@
 #import "SentryThread.h"
 #import "SentryUser.h"
 
+#if SENTRY_HAS_METRIC_KIT
+#    import "SentryMechanism.h"
+#    import "SentryMetricKitIntegration.h"
+#endif // SENTRY_HAS_METRIC_KIT
+
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryEvent
@@ -171,6 +176,30 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return crumbs;
 }
+
+#if SENTRY_HAS_METRIC_KIT
+
+- (BOOL)isMetricKitEvent
+{
+    if (self.exceptions == nil || self.exceptions.count != 1) {
+        return NO;
+    }
+
+    NSArray<NSString *> *metricKitMechanisms = @[
+        SentryMetricKitDiskWriteExceptionMechanism, SentryMetricKitCpuExceptionMechanism,
+        SentryMetricKitHangDiagnosticMechanism, @"MXCrashDiagnostic"
+    ];
+
+    SentryException *exception = self.exceptions[0];
+    if (exception.mechanism != nil &&
+        [metricKitMechanisms containsObject:exception.mechanism.type]) {
+        return YES;
+    } else {
+        return NO;
+    }
+}
+
+#endif // SENTRY_HAS_METRIC_KIT
 
 @end
 

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -449,31 +449,6 @@ SentryMetricKitIntegration ()
 
 @end
 
-@implementation
-SentryEvent (MetricKit)
-
-- (BOOL)isMetricKitEvent
-{
-    if (self.exceptions == nil || self.exceptions.count != 1) {
-        return NO;
-    }
-
-    NSArray<NSString *> *metricKitMechanisms = @[
-        SentryMetricKitDiskWriteExceptionMechanism, SentryMetricKitCpuExceptionMechanism,
-        SentryMetricKitHangDiagnosticMechanism, @"MXCrashDiagnostic"
-    ];
-
-    SentryException *exception = self.exceptions[0];
-    if (exception.mechanism != nil &&
-        [metricKitMechanisms containsObject:exception.mechanism.type]) {
-        return YES;
-    } else {
-        return NO;
-    }
-}
-
-@end
-
 NS_ASSUME_NONNULL_END
 
 #endif // SENTRY_HAS_METRIC_KIT

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -57,7 +57,7 @@ saveScreenShot(const char *path)
     // We don't take screenshots if the event is a crash or metric kit event.
     if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent
 #    if SENTRY_HAS_METRIC_KIT
-        || event.isMetricKitEvent
+        || [event isMetricKitEvent]
 #    endif // SENTRY_HAS_METRIC_KIT
     ) {
         return attachments;

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -63,7 +63,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
     // We don't attach the view hierarchy if the event is a crash or metric kit event.
     if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent
 #    if SENTRY_HAS_METRIC_KIT
-        || event.isMetricKitEvent
+        || [event isMetricKitEvent]
 #    endif // SENTRY_HAS_METRIC_KIT
     ) {
         return attachments;

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -1,3 +1,4 @@
+#import "SentryDefines.h"
 #import "SentryEvent.h"
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>
@@ -24,5 +25,9 @@ SentryEvent ()
 @property (nonatomic) uint64_t startSystemTime;
 @property (nonatomic) uint64_t endSystemTime;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+#if SENTRY_HAS_METRIC_KIT
+- (BOOL)isMetricKitEvent;
+#endif // SENTRY_HAS_METRIC_KIT
 
 @end

--- a/Sources/Sentry/include/SentryMetricKitIntegration.h
+++ b/Sources/Sentry/include/SentryMetricKitIntegration.h
@@ -26,13 +26,6 @@ API_UNAVAILABLE(tvos, watchos)
 
 @end
 
-@interface
-SentryEvent (MetricKit)
-
-@property (nonatomic, readonly) BOOL isMetricKitEvent;
-
-@end
-
 NS_ASSUME_NONNULL_END
 
 #endif // SENTRY_HAS_METRIC_KIT

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitEventTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitEventTests.swift
@@ -5,27 +5,27 @@ import XCTest
 final class SentryMetricKitEventTests: XCTestCase {
 
     func testMXCPUException_IsMetricKitEvent() {
-        XCTAssertTrue(TestData.metricKitEvent.isMetricKitEvent)
+        XCTAssertTrue(TestData.metricKitEvent.isMetricKitEvent())
     }
     
     func testMXDiskWriteException_IsMetricKitEvent() {        
-        XCTAssertTrue(createMetricKitEventWith(mechanismType: SentryMetricKitDiskWriteExceptionMechanism).isMetricKitEvent)
+        XCTAssertTrue(createMetricKitEventWith(mechanismType: SentryMetricKitDiskWriteExceptionMechanism).isMetricKitEvent())
     }
     
     func testMXHangDiagnostic_IsMetricKitEvent() {
-        XCTAssertTrue(createMetricKitEventWith(mechanismType: SentryMetricKitHangDiagnosticMechanism).isMetricKitEvent)
+        XCTAssertTrue(createMetricKitEventWith(mechanismType: SentryMetricKitHangDiagnosticMechanism).isMetricKitEvent())
     }
     
     func testWatchDogEvent_IsNotMetricKitEvent() {
-        XCTAssertFalse(TestData.oomEvent.isMetricKitEvent)
+        XCTAssertFalse(TestData.oomEvent.isMetricKitEvent())
     }
     
     func testNormalEvent_IsNotMetricKitEvent() {
-        XCTAssertFalse(TestData.event.isMetricKitEvent)
+        XCTAssertFalse(TestData.event.isMetricKitEvent())
     }
     
     func testEmptyEvent_IsNotMetricKitEvent() {
-        XCTAssertFalse(Event().isMetricKitEvent)
+        XCTAssertFalse(Event().isMetricKitEvent())
     }
     
     private func createMetricKitEventWith(mechanismType: String) -> Event {


### PR DESCRIPTION
Another conversion of a category to interface extension (see https://github.com/getsentry/sentry-cocoa/pull/3236 for elaboration)

This also moved the extension interface and implementation to SentryEvent instead of being hidden in SentryMetricKitIntegration. It also declared isMetricKitEvent as a method since that's what it actually is, and converted callsites to use method syntax.

#skip-changelog