### PR TITLE
ref: access SentryUIDeviceWrapper from SentryDependencyContainer

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -8,7 +8,6 @@
 #import "SentryNSTimerFactory.h"
 #import "SentryRandom.h"
 #import "SentrySystemWrapper.h"
-#import "SentryUIApplication.h"
 #import "SentryUIDeviceWrapper.h"
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
@@ -18,15 +17,17 @@
 #import <SentryHub.h>
 #import <SentryNSNotificationCenterWrapper.h>
 #import <SentrySDK+Private.h>
-#import <SentryScreenshot.h>
 #import <SentrySwift.h>
 #import <SentrySwizzleWrapper.h>
 #import <SentrySysctl.h>
 #import <SentryThreadWrapper.h>
-#import <SentryViewHierarchy.h>
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryFramesTracker.h"
+#    import "SentryUIApplication.h"
+#    import "SentryUIDeviceWrapper.h"
+#    import <SentryScreenshot.h>
+#    import <SentryViewHierarchy.h>
 #endif // SENTRY_HAS_UIKIT
 
 @implementation SentryDependencyContainer
@@ -165,6 +166,7 @@ static NSObject *sentryDependencyContainerLock;
     }
     return _uiDeviceWrapper;
 }
+
 - (SentryScreenshot *)screenshot
 {
     if (_screenshot == nil) {

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -25,10 +25,13 @@
 #if SENTRY_HAS_UIKIT
 #    import "SentryFramesTracker.h"
 #    import "SentryUIApplication.h"
-#    import "SentryUIDeviceWrapper.h"
 #    import <SentryScreenshot.h>
 #    import <SentryViewHierarchy.h>
 #endif // SENTRY_HAS_UIKIT
+
+#if TARGET_OS_IOS
+#    import "SentryUIDeviceWrapper.h"
+#endif // TARGET_OS_IOS
 
 @implementation SentryDependencyContainer
 
@@ -154,7 +157,7 @@ static NSObject *sentryDependencyContainerLock;
     return _binaryImageCache;
 }
 
-#if SENTRY_HAS_UIKIT
+#if TARGET_OS_IOS
 - (SentryUIDeviceWrapper *)uiDeviceWrapper
 {
     if (_uiDeviceWrapper == nil) {
@@ -166,7 +169,9 @@ static NSObject *sentryDependencyContainerLock;
     }
     return _uiDeviceWrapper;
 }
+#endif // TARGET_OS_IOS
 
+#if SENTRY_HAS_UIKIT
 - (SentryScreenshot *)screenshot
 {
     if (_screenshot == nil) {

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -9,6 +9,7 @@
 #import "SentryRandom.h"
 #import "SentrySystemWrapper.h"
 #import "SentryUIApplication.h"
+#import "SentryUIDeviceWrapper.h"
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
 #import <SentryCrashWrapper.h>
@@ -153,6 +154,17 @@ static NSObject *sentryDependencyContainerLock;
 }
 
 #if SENTRY_HAS_UIKIT
+- (SentryUIDeviceWrapper *)uiDeviceWrapper
+{
+    if (_uiDeviceWrapper == nil) {
+        @synchronized(sentryDependencyContainerLock) {
+            if (_uiDeviceWrapper == nil) {
+                _uiDeviceWrapper = [[SentryUIDeviceWrapper alloc] init];
+            }
+        }
+    }
+    return _uiDeviceWrapper;
+}
 - (SentryScreenshot *)screenshot
 {
     if (_screenshot == nil) {

--- a/Sources/Sentry/SentryExtraContextProvider.h
+++ b/Sources/Sentry/SentryExtraContextProvider.h
@@ -1,6 +1,5 @@
 #import "SentryCrashWrapper.h"
 #import "SentryNSProcessInfoWrapper.h"
-#import "SentryUIDeviceWrapper.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -13,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)sharedInstance;
 
 - (instancetype)initWithCrashWrapper:(SentryCrashWrapper *)crashWrapper
-                       deviceWrapper:(SentryUIDeviceWrapper *)deviceWrapper
                   processInfoWrapper:(SentryNSProcessInfoWrapper *)processInfoWrapper;
 
 - (NSDictionary *)getExtraContext;

--- a/Sources/Sentry/SentryExtraContextProvider.m
+++ b/Sources/Sentry/SentryExtraContextProvider.m
@@ -9,7 +9,6 @@
 SentryExtraContextProvider ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
-@property (nonatomic, strong) SentryUIDeviceWrapper *deviceWrapper;
 @property (nonatomic, strong) SentryNSProcessInfoWrapper *processInfoWrapper;
 
 @end
@@ -28,17 +27,13 @@ SentryExtraContextProvider ()
 {
     return
         [self initWithCrashWrapper:[SentryCrashWrapper sharedInstance]
-                     deviceWrapper:[[SentryUIDeviceWrapper alloc] init]
                 processInfoWrapper:[SentryDependencyContainer.sharedInstance processInfoWrapper]];
 }
 
-- (instancetype)initWithCrashWrapper:(id)crashWrapper
-                       deviceWrapper:(id)deviceWrapper
-                  processInfoWrapper:(id)processInfoWrapper
+- (instancetype)initWithCrashWrapper:(id)crashWrapper processInfoWrapper:(id)processInfoWrapper
 {
     if (self = [super init]) {
         self.crashWrapper = crashWrapper;
-        self.deviceWrapper = deviceWrapper;
         self.processInfoWrapper = processInfoWrapper;
     }
     return self;
@@ -58,16 +53,16 @@ SentryExtraContextProvider ()
     extraDeviceContext[@"processor_count"] = @([self.processInfoWrapper processorCount]);
 
 #if TARGET_OS_IOS
-    if (self.deviceWrapper.orientation != UIDeviceOrientationUnknown) {
+    SentryUIDeviceWrapper *deviceWrapper = SentryDependencyContainer.sharedInstance.uiDeviceWrapper;
+    if (deviceWrapper.orientation != UIDeviceOrientationUnknown) {
         extraDeviceContext[@"orientation"]
-            = UIDeviceOrientationIsPortrait(self.deviceWrapper.orientation) ? @"portrait"
-                                                                            : @"landscape";
+            = UIDeviceOrientationIsPortrait(deviceWrapper.orientation) ? @"portrait" : @"landscape";
     }
 
-    if (self.deviceWrapper.isBatteryMonitoringEnabled) {
+    if (deviceWrapper.isBatteryMonitoringEnabled) {
         extraDeviceContext[@"charging"]
-            = self.deviceWrapper.batteryState == UIDeviceBatteryStateCharging ? @(YES) : @(NO);
-        extraDeviceContext[@"battery_level"] = @((int)(self.deviceWrapper.batteryLevel * 100));
+            = deviceWrapper.batteryState == UIDeviceBatteryStateCharging ? @(YES) : @(NO);
+        extraDeviceContext[@"battery_level"] = @((int)(deviceWrapper.batteryLevel * 100));
     }
 #endif
     return extraDeviceContext;

--- a/Sources/Sentry/SentryUIDeviceWrapper.m
+++ b/Sources/Sentry/SentryUIDeviceWrapper.m
@@ -8,7 +8,6 @@ NS_ASSUME_NONNULL_BEGIN
 SentryUIDeviceWrapper ()
 @property (nonatomic) BOOL cleanupDeviceOrientationNotifications;
 @property (nonatomic) BOOL cleanupBatteryMonitoring;
-@property (strong, nonatomic) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 @end
 
 @implementation SentryUIDeviceWrapper
@@ -17,15 +16,8 @@ SentryUIDeviceWrapper ()
 
 - (instancetype)init
 {
-    return [self initWithDispatchQueueWrapper:[SentryDependencyContainer sharedInstance]
-                                                  .dispatchQueueWrapper];
-}
-
-- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-{
     if (self = [super init]) {
-        self.dispatchQueueWrapper = dispatchQueueWrapper;
-        [self.dispatchQueueWrapper dispatchSyncOnMainQueue:^{
+        [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchSyncOnMainQueue:^{
             // Needed to read the device orientation on demand
             if (!UIDevice.currentDevice.isGeneratingDeviceOrientationNotifications) {
                 self.cleanupDeviceOrientationNotifications = YES;
@@ -44,7 +36,7 @@ SentryUIDeviceWrapper ()
 
 - (void)stop
 {
-    [self.dispatchQueueWrapper dispatchSyncOnMainQueue:^{
+    [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchSyncOnMainQueue:^{
         if (self.cleanupDeviceOrientationNotifications) {
             [UIDevice.currentDevice endGeneratingDeviceOrientationNotifications];
         }

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -25,9 +25,12 @@
 @class SentryFramesTracker;
 @class SentryScreenshot;
 @class SentryUIApplication;
-@class SentryUIDeviceWrapper;
 @class SentryViewHierarchy;
-#endif
+#endif // SENTRY_HAS_UIKIT
+
+#if TARGET_OS_IOS
+@class SentryUIDeviceWrapper;
+#endif // TARGET_OS_IOS
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -63,8 +66,11 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryScreenshot *screenshot;
 @property (nonatomic, strong) SentryViewHierarchy *viewHierarchy;
 @property (nonatomic, strong) SentryUIApplication *application;
+#endif // SENTRY_HAS_UIKIT
+
+#if TARGET_OS_IOS
 @property (nonatomic, strong) SentryUIDeviceWrapper *uiDeviceWrapper;
-#endif
+#endif // TARGET_OS_IOS
 
 - (SentryANRTracker *)getANRTracker:(NSTimeInterval)timeout;
 

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -57,13 +57,13 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryNSTimerFactory *timerFactory;
 @property (nonatomic, strong) SentryCurrentDateProvider *dateProvider;
 @property (nonatomic, strong) SentryBinaryImageCache *binaryImageCache;
-@property (nonatomic, strong) SentryUIDeviceWrapper *uiDeviceWrapper;
 
 #if SENTRY_HAS_UIKIT
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;
 @property (nonatomic, strong) SentryScreenshot *screenshot;
 @property (nonatomic, strong) SentryViewHierarchy *viewHierarchy;
 @property (nonatomic, strong) SentryUIApplication *application;
+@property (nonatomic, strong) SentryUIDeviceWrapper *uiDeviceWrapper;
 #endif
 
 - (SentryANRTracker *)getANRTracker:(NSTimeInterval)timeout;

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -15,7 +15,6 @@
 @class SentrySwizzleWrapper;
 @class SentrySystemWrapper;
 @class SentryThreadWrapper;
-@class SentryUIDeviceWrapper;
 @protocol SentryRandom;
 
 #if SENTRY_HAS_METRIC_KIT
@@ -26,6 +25,7 @@
 @class SentryFramesTracker;
 @class SentryScreenshot;
 @class SentryUIApplication;
+@class SentryUIDeviceWrapper;
 @class SentryViewHierarchy;
 #endif
 

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -15,6 +15,7 @@
 @class SentrySwizzleWrapper;
 @class SentrySystemWrapper;
 @class SentryThreadWrapper;
+@class SentryUIDeviceWrapper;
 @protocol SentryRandom;
 
 #if SENTRY_HAS_METRIC_KIT
@@ -56,6 +57,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryNSTimerFactory *timerFactory;
 @property (nonatomic, strong) SentryCurrentDateProvider *dateProvider;
 @property (nonatomic, strong) SentryBinaryImageCache *binaryImageCache;
+@property (nonatomic, strong) SentryUIDeviceWrapper *uiDeviceWrapper;
 
 #if SENTRY_HAS_UIKIT
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -12,7 +12,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_IOS
 - (instancetype)init;
-- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 - (void)stop;
 - (UIDeviceOrientation)orientation;
 - (BOOL)isBatteryMonitoringEnabled;

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -18,7 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isBatteryMonitoringEnabled;
 - (UIDeviceBatteryState)batteryState;
 - (float)batteryLevel;
-#endif
+#endif // TARGET_OS_IOS
 
 @end
 

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -6,6 +6,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SentryDispatchQueueWrapper;
+
 @interface SentryUIDeviceWrapper : NSObject
 
 #if TARGET_OS_IOS

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -6,8 +6,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryDispatchQueueWrapper;
-
 @interface SentryUIDeviceWrapper : NSObject
 
 #if TARGET_OS_IOS

--- a/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
+++ b/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
@@ -9,9 +9,9 @@ final class SentryExtraContextProviderTests: XCTestCase {
         let processWrapper = TestSentryNSProcessInfoWrapper()
         
         func getSut() -> SentryExtraContextProvider {
+            SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
             return SentryExtraContextProvider(
                     crashWrapper: crashWrapper,
-                    deviceWrapper: deviceWrapper,
                     processInfoWrapper: processWrapper)
         }
     }

--- a/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
+++ b/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
@@ -5,15 +5,15 @@ final class SentryExtraContextProviderTests: XCTestCase {
 
     private class Fixture {
         let crashWrapper = TestSentryCrashWrapper.sharedInstance()
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || targetEnvironment(macCatalyst)
         let deviceWrapper = TestSentryUIDeviceWrapper()
-#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#endif // os(iOS) || targetEnvironment(macCatalyst)
         let processWrapper = TestSentryNSProcessInfoWrapper()
         
         func getSut() -> SentryExtraContextProvider {
-            #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+            #if os(iOS) || targetEnvironment(macCatalyst)
             SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
-            #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+            #endif // os(iOS) || targetEnvironment(macCatalyst)
             return SentryExtraContextProvider(
                     crashWrapper: crashWrapper,
                     processInfoWrapper: processWrapper)
@@ -43,7 +43,7 @@ final class SentryExtraContextProviderTests: XCTestCase {
     }
     
     func testExtraDeviceInfo() {
-#if os(iOS)
+#if os(iOS) || targetEnvironment(macCatalyst)
         let sut = fixture.getSut()
         fixture.deviceWrapper.internalOrientation = .landscapeLeft
         fixture.deviceWrapper.internalBatteryState = .full
@@ -55,7 +55,7 @@ final class SentryExtraContextProviderTests: XCTestCase {
         XCTAssertEqual(device?["orientation"] as? String, "landscape")
         XCTAssertEqual(device?["charging"] as? Bool, false)
         XCTAssertEqual(device?["battery_level"] as? UInt, 44)
-#endif
+#endif // os(iOS) || targetEnvironment(macCatalyst)
     }
     
     func testExtraProcessInfo() {

--- a/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
+++ b/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
@@ -5,11 +5,15 @@ final class SentryExtraContextProviderTests: XCTestCase {
 
     private class Fixture {
         let crashWrapper = TestSentryCrashWrapper.sharedInstance()
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         let deviceWrapper = TestSentryUIDeviceWrapper()
+#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         let processWrapper = TestSentryNSProcessInfoWrapper()
         
         func getSut() -> SentryExtraContextProvider {
+            #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
             SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
+            #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
             return SentryExtraContextProvider(
                     crashWrapper: crashWrapper,
                     processInfoWrapper: processWrapper)

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -2,7 +2,10 @@
 #import "SentryRandom.h"
 #import "SentryTransport.h"
 
-@class SentryCrashWrapper, SentryThreadInspector, SentryTransportAdapter;
+@class SentryCrashWrapper;
+@class SentryDispatchQueueWrapper;
+@class SentryThreadInspector;
+@class SentryTransportAdapter;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -2,10 +2,7 @@
 #import "SentryRandom.h"
 #import "SentryTransport.h"
 
-@class SentryCrashWrapper;
-@class SentryDispatchQueueWrapper;
-@class SentryThreadInspector;
-@class SentryTransportAdapter;
+@class SentryCrashWrapper, SentryThreadInspector, SentryTransportAdapter;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -2,7 +2,7 @@
 #import "SentryRandom.h"
 #import "SentryTransport.h"
 
-@class SentryCrashWrapper, SentryThreadInspector, SentryTransportAdapter, SentryUIDeviceWrapper;
+@class SentryCrashWrapper, SentryThreadInspector, SentryTransportAdapter;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -62,8 +62,10 @@ class SentryClientTest: XCTestCase {
             crashWrapper.internalFreeMemorySize = 123_456
             crashWrapper.internalAppMemorySize = 234_567
             crashWrapper.internalFreeStorageSize = 345_678
+
+            SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
             
-            extraContentProvider = SentryExtraContextProvider(crashWrapper: crashWrapper, deviceWrapper: deviceWrapper, processInfoWrapper: processWrapper)
+            extraContentProvider = SentryExtraContextProvider(crashWrapper: crashWrapper, processInfoWrapper: processWrapper)
         }
 
         func getSut(configureOptions: (Options) -> Void = { _ in }) -> SentryClient {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -29,7 +29,9 @@ class SentryClientTest: XCTestCase {
         let trace = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
         let transaction: Transaction
         let crashWrapper = TestSentryCrashWrapper.sharedInstance()
+        #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         let deviceWrapper = TestSentryUIDeviceWrapper()
+        #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         let processWrapper = TestSentryNSProcessInfoWrapper()
         let extraContentProvider: SentryExtraContextProvider
         let locale = Locale(identifier: "en_US")
@@ -63,7 +65,9 @@ class SentryClientTest: XCTestCase {
             crashWrapper.internalAppMemorySize = 234_567
             crashWrapper.internalFreeStorageSize = 345_678
 
+            #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
             SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
+#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
             
             extraContentProvider = SentryExtraContextProvider(crashWrapper: crashWrapper, processInfoWrapper: processWrapper)
         }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -29,9 +29,9 @@ class SentryClientTest: XCTestCase {
         let trace = SentryTracer(transactionContext: TransactionContext(name: "SomeTransaction", operation: "SomeOperation"), hub: nil)
         let transaction: Transaction
         let crashWrapper = TestSentryCrashWrapper.sharedInstance()
-        #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        #if os(iOS) || targetEnvironment(macCatalyst)
         let deviceWrapper = TestSentryUIDeviceWrapper()
-        #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        #endif // os(iOS) || targetEnvironment(macCatalyst)
         let processWrapper = TestSentryNSProcessInfoWrapper()
         let extraContentProvider: SentryExtraContextProvider
         let locale = Locale(identifier: "en_US")
@@ -65,9 +65,9 @@ class SentryClientTest: XCTestCase {
             crashWrapper.internalAppMemorySize = 234_567
             crashWrapper.internalFreeStorageSize = 345_678
 
-            #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+            #if os(iOS) || targetEnvironment(macCatalyst)
             SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
-#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#endif // os(iOS) || targetEnvironment(macCatalyst)
             
             extraContentProvider = SentryExtraContextProvider(crashWrapper: crashWrapper, processInfoWrapper: processWrapper)
         }
@@ -714,7 +714,7 @@ class SentryClientTest: XCTestCase {
     }
 
     func testCaptureEvent_DeviceProperties_OtherValues() {
-#if os(iOS)
+#if os(iOS) || targetEnvironment(macCatalyst)
         fixture.deviceWrapper.internalOrientation = .landscapeLeft
         fixture.deviceWrapper.internalBatteryState = .full
 
@@ -727,7 +727,7 @@ class SentryClientTest: XCTestCase {
             let charging = actual.context?["device"]?["charging"] as? Bool
             XCTAssertEqual(charging, false)
         }
-#endif
+#endif // os(iOS) || targetEnvironment(macCatalyst)
     }
 
     func testCaptureEvent_AddCurrentCulture() {

--- a/Tests/SentryTests/SentryCrash/SentryUIDeviceWrapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryUIDeviceWrapperTests.swift
@@ -5,7 +5,8 @@ import XCTest
 class SentryUIDeviceWrapperTests: XCTestCase {
     func testExecutesLogicViaDispatchQueue() {
         let dispatchQueue = TestSentryDispatchQueueWrapper()
-        let sut = SentryUIDeviceWrapper(dispatchQueueWrapper: dispatchQueue)
+        SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueue
+        let sut = SentryUIDeviceWrapper()
         XCTAssertEqual(dispatchQueue.blockOnMainInvocations.count, 1)
 
         sut.stop()

--- a/Tests/SentryTests/SentryCrash/TestSentryUIDeviceWrapper.swift
+++ b/Tests/SentryTests/SentryCrash/TestSentryUIDeviceWrapper.swift
@@ -1,7 +1,7 @@
 import Sentry
 
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class TestSentryUIDeviceWrapper: SentryUIDeviceWrapper {
-#if os(iOS)
     var internalOrientation = UIDeviceOrientation.portrait
     var internalIsBatteryMonitoringEnabled = true
     var internalBatteryLevel: Float = 0.6
@@ -22,5 +22,5 @@ class TestSentryUIDeviceWrapper: SentryUIDeviceWrapper {
     override func batteryState() -> UIDevice.BatteryState {
         return internalBatteryState
     }
-#endif
 }
+#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/SentryCrash/TestSentryUIDeviceWrapper.swift
+++ b/Tests/SentryTests/SentryCrash/TestSentryUIDeviceWrapper.swift
@@ -1,6 +1,6 @@
 import Sentry
 
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#if os(iOS) || targetEnvironment(macCatalyst)
 class TestSentryUIDeviceWrapper: SentryUIDeviceWrapper {
     var internalOrientation = UIDeviceOrientation.portrait
     var internalIsBatteryMonitoringEnabled = true
@@ -23,4 +23,4 @@ class TestSentryUIDeviceWrapper: SentryUIDeviceWrapper {
         return internalBatteryState
     }
 }
-#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#endif // os(iOS) || targetEnvironment(macCatalyst)


### PR DESCRIPTION
Similar to https://github.com/getsentry/sentry-cocoa/pull/3242, there really only needs to ever be one instance of this.

#skip-changelog