### PR TITLE
ref: access SentrySwizzleWrapper via existing SentryDependencyContainer property

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -29,8 +29,8 @@ class TestCleanup: NSObject {
         setenv("ActivePrewarm", "0", 1)
         SentryAppStartTracker.load()
         SentryUIViewControllerPerformanceTracker.shared.enableWaitForFullDisplay = false
-        SentrySwizzleWrapper.sharedInstance.removeAllCallbacks()
-        #endif
+        SentryDependencyContainer.sharedInstance().swizzleWrapper.removeAllCallbacks()
+        #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
         SentryDependencyContainer.reset()
         Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -26,9 +26,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
     }
 
     [self installWithOptions:options
-             breadcrumbTracker:[[SentryBreadcrumbTracker alloc]
-                                   initWithSwizzleWrapper:[SentryDependencyContainer sharedInstance]
-                                                              .swizzleWrapper]
+             breadcrumbTracker:[[SentryBreadcrumbTracker alloc] init]
         systemEventBreadcrumbs:
             [[SentrySystemEventBreadcrumbs alloc]
                          initWithFileManager:[SentryDependencyContainer sharedInstance].fileManager

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -3,6 +3,7 @@
 #import "SentryBreadcrumbDelegate.h"
 #import "SentryClient.h"
 #import "SentryDefines.h"
+#import "SentryDependencyContainer.h"
 #import "SentryHub.h"
 #import "SentryLog.h"
 #import "SentrySDK+Private.h"
@@ -25,20 +26,11 @@ static NSString *const SentryBreadcrumbTrackerSwizzleSendAction
 @interface
 SentryBreadcrumbTracker ()
 
-@property (nonatomic, strong) SentrySwizzleWrapper *swizzleWrapper;
 @property (nonatomic, weak) id<SentryBreadcrumbDelegate> delegate;
 
 @end
 
 @implementation SentryBreadcrumbTracker
-
-- (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper
-{
-    if (self = [super init]) {
-        self.swizzleWrapper = swizzleWrapper;
-    }
-    return self;
-}
 
 - (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
 {
@@ -58,7 +50,8 @@ SentryBreadcrumbTracker ()
     // All breadcrumbs are guarded by checking the client of the current hub, which we remove when
     // uninstalling the SDK. Therefore, we don't clean up everything.
 #if SENTRY_HAS_UIKIT
-    [self.swizzleWrapper removeSwizzleSendActionForKey:SentryBreadcrumbTrackerSwizzleSendAction];
+    [SentryDependencyContainer.sharedInstance.swizzleWrapper
+        removeSwizzleSendActionForKey:SentryBreadcrumbTrackerSwizzleSendAction];
 #endif
     _delegate = nil;
 }
@@ -163,7 +156,7 @@ SentryBreadcrumbTracker ()
 - (void)swizzleSendAction
 {
 #if SENTRY_HAS_UIKIT
-    [self.swizzleWrapper
+    [SentryDependencyContainer.sharedInstance.swizzleWrapper
         swizzleSendAction:^(NSString *action, id target, id sender, UIEvent *event) {
             if ([SentryBreadcrumbTracker avoidSender:sender forTarget:target action:action]) {
                 return;

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -195,7 +195,7 @@ static NSObject *sentryDependencyContainerLock;
     if (_swizzleWrapper == nil) {
         @synchronized(sentryDependencyContainerLock) {
             if (_swizzleWrapper == nil) {
-                _swizzleWrapper = SentrySwizzleWrapper.sharedInstance;
+                _swizzleWrapper = [[SentrySwizzleWrapper alloc] init];
             }
         }
     }

--- a/Sources/Sentry/SentrySwizzleWrapper.m
+++ b/Sources/Sentry/SentrySwizzleWrapper.m
@@ -11,14 +11,6 @@ static NSMutableDictionary<NSString *, SentrySwizzleSendActionCallback>
     *sentrySwizzleSendActionCallbacks;
 #endif
 
-+ (SentrySwizzleWrapper *)sharedInstance
-{
-    static SentrySwizzleWrapper *instance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ instance = [[self alloc] init]; });
-    return instance;
-}
-
 #if SENTRY_HAS_UIKIT
 + (void)initialize
 {

--- a/Sources/Sentry/SentryUIEventTracker.m
+++ b/Sources/Sentry/SentryUIEventTracker.m
@@ -3,6 +3,7 @@
 #if SENTRY_HAS_UIKIT
 
 #    import "SentrySwizzleWrapper.h"
+#    import <SentryDependencyContainer.h>
 #    import <SentryHub+Private.h>
 #    import <SentryLog.h>
 #    import <SentrySDK+Private.h>
@@ -24,7 +25,6 @@ static NSString *const SentryUIEventTrackerSwizzleSendAction
 @interface
 SentryUIEventTracker ()
 
-@property (nonatomic, strong) SentrySwizzleWrapper *swizzleWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 @property (nonatomic, assign) NSTimeInterval idleTimeout;
 @property (nullable, nonatomic, strong) NSMutableArray<SentryTracer *> *activeTransactions;
@@ -33,12 +33,10 @@ SentryUIEventTracker ()
 
 @implementation SentryUIEventTracker
 
-- (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper
-                  dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-                           idleTimeout:(NSTimeInterval)idleTimeout
+- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
+                                 idleTimeout:(NSTimeInterval)idleTimeout
 {
     if (self = [super init]) {
-        self.swizzleWrapper = swizzleWrapper;
         self.dispatchQueueWrapper = dispatchQueueWrapper;
         self.idleTimeout = idleTimeout;
         self.activeTransactions = [NSMutableArray new];
@@ -48,7 +46,7 @@ SentryUIEventTracker ()
 
 - (void)start
 {
-    [self.swizzleWrapper
+    [SentryDependencyContainer.sharedInstance.swizzleWrapper
         swizzleSendAction:^(NSString *action, id target, id sender, UIEvent *event) {
             if (target == nil) {
                 SENTRY_LOG_DEBUG(@"Target was nil for action %@; won't capture in transaction "
@@ -165,7 +163,8 @@ SentryUIEventTracker ()
 
 - (void)stop
 {
-    [self.swizzleWrapper removeSwizzleSendActionForKey:SentryUIEventTrackerSwizzleSendAction];
+    [SentryDependencyContainer.sharedInstance.swizzleWrapper
+        removeSwizzleSendActionForKey:SentryUIEventTrackerSwizzleSendAction];
 }
 
 - (NSString *)getOperation:(id)sender

--- a/Sources/Sentry/SentryUIEventTrackingIntegration.m
+++ b/Sources/Sentry/SentryUIEventTrackingIntegration.m
@@ -25,10 +25,9 @@ SentryUIEventTrackingIntegration ()
     }
 
     SentryDependencyContainer *dependencies = [SentryDependencyContainer sharedInstance];
-    self.uiEventTracker = [[SentryUIEventTracker alloc]
-        initWithSwizzleWrapper:[SentryDependencyContainer sharedInstance].swizzleWrapper
-          dispatchQueueWrapper:dependencies.dispatchQueueWrapper
-                   idleTimeout:options.idleTimeout];
+    self.uiEventTracker =
+        [[SentryUIEventTracker alloc] initWithDispatchQueueWrapper:dependencies.dispatchQueueWrapper
+                                                       idleTimeout:options.idleTimeout];
 
     [self.uiEventTracker start];
 

--- a/Sources/Sentry/include/SentryBreadcrumbTracker.h
+++ b/Sources/Sentry/include/SentryBreadcrumbTracker.h
@@ -2,14 +2,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentrySwizzleWrapper;
-
 @protocol SentryBreadcrumbDelegate;
 
 @interface SentryBreadcrumbTracker : NSObject
-SENTRY_NO_INIT
-
-- (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper;
 
 - (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate;
 - (void)startSwizzle;

--- a/Sources/Sentry/include/SentrySwizzleWrapper.h
+++ b/Sources/Sentry/include/SentrySwizzleWrapper.h
@@ -17,8 +17,6 @@ typedef void (^SentrySwizzleSendActionCallback)(
  */
 @interface SentrySwizzleWrapper : NSObject
 
-@property (class, readonly, nonatomic) SentrySwizzleWrapper *sharedInstance;
-
 #if SENTRY_HAS_UIKIT
 - (void)swizzleSendAction:(SentrySwizzleSendActionCallback)callback forKey:(NSString *)key;
 

--- a/Sources/Sentry/include/SentryUIEventTracker.h
+++ b/Sources/Sentry/include/SentryUIEventTracker.h
@@ -4,14 +4,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentrySwizzleWrapper, SentryDispatchQueueWrapper;
+@class SentryDispatchQueueWrapper;
 
 @interface SentryUIEventTracker : NSObject
 SENTRY_NO_INIT
 
-- (instancetype)initWithSwizzleWrapper:(SentrySwizzleWrapper *)swizzleWrapper
-                  dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-                           idleTimeout:(NSTimeInterval)idleTimeout;
+- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
+                                 idleTimeout:(NSTimeInterval)idleTimeout;
 
 - (void)start;
 - (void)stop;

--- a/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
@@ -34,7 +34,7 @@ class SentrySwizzleWrapperTests: XCTestCase {
         super.setUp()
         
         fixture = Fixture()
-        sut = SentrySwizzleWrapper.sharedInstance
+        sut = SentryDependencyContainer.sharedInstance().swizzleWrapper
     }
     
     override func tearDown() {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
     
     private class Fixture {
-        let tracker = SentryTestBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper.sharedInstance)
+        let tracker = SentryTestBreadcrumbTracker()
         
         var systemEventBreadcrumbs: SentryTestSystemEventBreadcrumbs?
         

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -19,14 +19,13 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     
     func testStopRemovesSwizzleSendAction() {
-        let swizzleWrapper = SentrySwizzleWrapper.sharedInstance
-        let sut = SentryBreadcrumbTracker(swizzleWrapper: swizzleWrapper)
+        let sut = SentryBreadcrumbTracker()
 
         sut.start(with: delegate)
         sut.startSwizzle()
         sut.stop()
 
-        let dict = Dynamic(swizzleWrapper).swizzleSendActionCallbacks().asDictionary
+        let dict = Dynamic(SentryDependencyContainer.sharedInstance().swizzleWrapper).swizzleSendActionCallbacks().asDictionary
         XCTAssertEqual(0, dict?.count)
     }
 
@@ -36,7 +35,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let hub = TestHub(client: client, andScope: scope)
         SentrySDK.setCurrentHub(hub)
         
-        let sut = SentryBreadcrumbTracker(swizzleWrapper: SentrySwizzleWrapper.sharedInstance)
+        let sut = SentryBreadcrumbTracker()
         sut.start(with: delegate)
         sut.startSwizzle()
 

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -14,10 +14,11 @@ class SentryUIEventTrackerTests: XCTestCase {
 
         init () {
             dispatchQueue.blockBeforeMainBlock = { false }
+            SentryDependencyContainer.sharedInstance().swizzleWrapper = swizzleWrapper
         }
         
         func getSut() -> SentryUIEventTracker {
-            return SentryUIEventTracker(swizzleWrapper: swizzleWrapper, dispatchQueueWrapper: dispatchQueue, idleTimeout: 3.0)
+            return SentryUIEventTracker(dispatchQueueWrapper: dispatchQueue, idleTimeout: 3.0)
         }
     }
 

--- a/scripts/no-changes-in-high-risk-files.sh
+++ b/scripts/no-changes-in-high-risk-files.sh
@@ -10,7 +10,7 @@ EXPECTED="819d5ca5e3db2ac23c859b14c149b7f0754d3ae88bea1dba92c18f49a81da0e1  ./So
 e95e62ec7363984f20c78643bb7d992a41a740f97e1befb71525ac34caf88b37  ./Sources/Sentry/SentryNSDataSwizzling.m
 9ad05dd8dd29788cba994736fdcd3bbde59a94e32612640d11f4f9c38ad6610e  ./Sources/Sentry/SentrySubClassFinder.m
 59db11da66e6ac0058526be0be08b57cdccd3727033e85164a631b205e972134  ./Sources/Sentry/SentryCoreDataSwizzling.m
-c6fd5fb82863246c697f4913fdd03c09a18d1006d30322d375a66a0046e9c252  ./Sources/Sentry/SentrySwizzleWrapper.m
+4a041cf2704ca4a8cc1df76bc955781ddd29c3e515aef49898d248d4016e0315  ./Sources/Sentry/SentrySwizzleWrapper.m
 b1c642450170358cab39b4cc6cd546f27c41b12eacb90c3ad93f87733d46e56c  ./Sources/Sentry/include/SentrySwizzle.h
 f97128c823f92d1c2ec37e5e3b2914f7488a94043af6a8344e348f1a14425f47  ./Sources/Sentry/SentrySwizzle.m"
 


### PR DESCRIPTION
We already had a property on SentryDependencyContainer for this, but that still accessed SentrySwizzleWrapper.sharedInstance and we still also passed around the reference.

#skip-changelog