### PR TITLE
ref: remove setting timestamp boilderplate in SentryMetrickitIntegration

### DIFF
--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -203,7 +203,6 @@ SentryMetricKitIntegration ()
     if (callStackTree.callStackPerThread) {
         SentryEvent *event = [self createEvent:params];
 
-        event.timestamp = params.timeStampBegin;
         event.threads = [self convertToSentryThreads:callStackTree];
 
         SentryThread *crashedThread = event.threads[0];
@@ -322,7 +321,6 @@ SentryMetricKitIntegration ()
                           params:(SentryMXExceptionParams *)params
 {
     SentryEvent *event = [self createEvent:params];
-    event.timestamp = params.timeStampBegin;
 
     SentryThread *thread = [[SentryThread alloc] initWithThreadId:@0];
     thread.crashed = @(!params.handled);
@@ -341,6 +339,7 @@ SentryMetricKitIntegration ()
 - (SentryEvent *)createEvent:(SentryMXExceptionParams *)params
 {
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:params.level];
+    event.timestamp = params.timeStampBegin;
 
     SentryException *exception = [[SentryException alloc] initWithValue:params.exceptionValue
                                                                    type:params.exceptionType];


### PR DESCRIPTION
## :scroll: Description
Moved the duplicate timestamp setting logic to the createEvent function.

## :bulb: Motivation and Context
For reducing code comlexity. 
I've been using your library well. Thank you

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps


_#skip-changelog_