### PR TITLE
ci: always run setup_ci

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -263,8 +263,9 @@ platform :ios do
 
   desc "Build Perf-test app without Sentry"
   lane :build_perf_test_app_plain do
-
-    setup_ci
+    setup_ci(
+      force: true
+    )
 
     sync_code_signing(
       type: "development",
@@ -287,7 +288,9 @@ platform :ios do
 
   desc "Build Perf-test app with Sentry"
   lane :build_perf_test_app_sentry do
-    setup_ci
+    setup_ci(
+      force: true
+    )
 
     sync_code_signing(
       type: "development",


### PR DESCRIPTION
For some reason if these jobs are both run on ci sequentially, the second one fails in the match phase. I think setup_ci lets the previous run's keychain get used for the subsequent run's, and then something fails. In any case, these are the only jobs that don't call this with force: true.

This is also failing nondeterminstically; sometimes it works on PRs, sometimes not.

#skip-changelog