### PR TITLE
ci: install/cache bundle for other jobs needing it

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Git checkout
         uses: actions/checkout@v3
       - run: ./scripts/ci-select-xcode.sh
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
       - uses: actions/cache@v3
         id: app-plain-cache
         with:


### PR DESCRIPTION
Missed this job in #3257. This will un-break this benchmark job.

#skip-changelog