### PR TITLE
fix: report energy usage in nanojoules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Distributed tracing without performance (#3196)
 - Report database backing store information for Core Data (#3231)
 
+### Fixes
+
+- Report correct units (nanojoules) for profiling energy metrics (#3262)
+
 ## 8.10.0
 
 ### Features

--- a/Sources/Sentry/SentryMetricProfiler.mm
+++ b/Sources/Sentry/SentryMetricProfiler.mm
@@ -32,7 +32,7 @@ NSString *const kSentryMetricProfilerSerializationKeyCPUEnergyUsage = @"cpu_ener
 
 NSString *const kSentryMetricProfilerSerializationUnitBytes = @"byte";
 NSString *const kSentryMetricProfilerSerializationUnitPercentage = @"percent";
-NSString *const kSentryMetricProfilerSerializationUnitNanoJoules = @"nanojoules";
+NSString *const kSentryMetricProfilerSerializationUnitNanoJoules = @"nanojoule";
 
 // Currently set to 10 Hz as we don't anticipate much utility out of a higher resolution when
 // sampling CPU usage and memory footprint, and we want to minimize the overhead of making the

--- a/Sources/Sentry/SentryMetricProfiler.mm
+++ b/Sources/Sentry/SentryMetricProfiler.mm
@@ -32,6 +32,7 @@ NSString *const kSentryMetricProfilerSerializationKeyCPUEnergyUsage = @"cpu_ener
 
 NSString *const kSentryMetricProfilerSerializationUnitBytes = @"byte";
 NSString *const kSentryMetricProfilerSerializationUnitPercentage = @"percent";
+NSString *const kSentryMetricProfilerSerializationUnitNanoJoules = @"nanojoules";
 
 // Currently set to 10 Hz as we don't anticipate much utility out of a higher resolution when
 // sampling CPU usage and memory footprint, and we want to minimize the overhead of making the
@@ -133,7 +134,7 @@ SentrySerializedMetricEntry *_Nullable serializeValuesWithNormalizedTime(
     if (cpuEnergyUsage.count > 0) {
         dict[kSentryMetricProfilerSerializationKeyCPUEnergyUsage]
             = serializeValuesWithNormalizedTime(cpuEnergyUsage,
-                kSentryMetricProfilerSerializationUnitBytes, startSystemTime, endSystemTime);
+                kSentryMetricProfilerSerializationUnitNanoJoules, startSystemTime, endSystemTime);
     }
 
     if (cpuUsage.count > 0) {

--- a/Sources/Sentry/include/SentryMetricProfiler.h
+++ b/Sources/Sentry/include/SentryMetricProfiler.h
@@ -14,6 +14,7 @@ SENTRY_EXTERN NSString *const kSentryMetricProfilerSerializationKeyCPUEnergyUsag
 
 SENTRY_EXTERN NSString *const kSentryMetricProfilerSerializationUnitBytes;
 SENTRY_EXTERN NSString *const kSentryMetricProfilerSerializationUnitPercentage;
+SENTRY_EXTERN NSString *const kSentryMetricProfilerSerializationUnitNanoJoules;
 
 // The next two types are technically the same as far as the type system is concerned, but they
 // actually contain different mixes of value types, so define them separately. If they ever change,


### PR DESCRIPTION
Copypasta in #3217 led to reporting the wrong units for energy profiling metrics.