### PR TITLE
fix: Remove warning about non-portable path to file "SentryDsn.h"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Remove warning about non-portable path to file "SentryDsn.h" (#3270)x
+- Remove warning about non-portable path to file "SentryDsn.h" (#3270)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Remove warning about non-portable path to file "SentryDsn.h" (#3270)x
+
 ## 8.11.0
 
 ### Features

--- a/Sources/Sentry/SentryPropagationContext.m
+++ b/Sources/Sentry/SentryPropagationContext.m
@@ -1,5 +1,5 @@
 #import "SentryPropagationContext.h"
-#import "SentryDSN.h"
+#import "SentryDsn.h"
 #import "SentryHub+Private.h"
 #import "SentryId.h"
 #import "SentryOptions+Private.h"


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

closes #3269 

## :green_heart: How did you test it?

Manually

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
