### PR TITLE
ref: Reduce complexity for SentryDependencyContainer

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -58,7 +58,8 @@ static NSObject *sentryDependencyContainerLock;
     instance = [[SentryDependencyContainer alloc] init];
 }
 
-- (instancetype)init {
+- (instancetype)init
+{
     if (self = [super init]) {
         _dispatchQueueWrapper = [[SentryDispatchQueueWrapper alloc] init];
         _random = [[SentryRandom alloc] init];

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -44,24 +44,30 @@ static NSObject *sentryDependencyContainerLock;
 {
     if (self == [SentryDependencyContainer class]) {
         sentryDependencyContainerLock = [[NSObject alloc] init];
+        instance = [[SentryDependencyContainer alloc] init];
     }
 }
 
 + (instancetype)sharedInstance
 {
-    @synchronized(sentryDependencyContainerLock) {
-        if (instance == nil) {
-            instance = [[self alloc] init];
-        }
-        return instance;
-    }
+    return instance;
 }
 
 + (void)reset
 {
-    @synchronized(sentryDependencyContainerLock) {
-        instance = nil;
+    instance = [[SentryDependencyContainer alloc] init];
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _dispatchQueueWrapper = [[SentryDispatchQueueWrapper alloc] init];
+        _random = [[SentryRandom alloc] init];
+        _threadWrapper = [[SentryThreadWrapper alloc] init];
+        _binaryImageCache = [[SentryBinaryImageCache alloc] init];
+        _debugImageProvider = [[SentryDebugImageProvider alloc] init];
+        _dateProvider = [[SentryCurrentDateProvider alloc] init];
     }
+    return self;
 }
 
 - (SentryFileManager *)fileManager
@@ -126,28 +132,6 @@ static NSObject *sentryDependencyContainerLock;
     return _extraContextProvider;
 }
 
-- (SentryThreadWrapper *)threadWrapper
-{
-    if (_threadWrapper == nil) {
-        @synchronized(sentryDependencyContainerLock) {
-            if (_threadWrapper == nil) {
-                _threadWrapper = [[SentryThreadWrapper alloc] init];
-            }
-        }
-    }
-    return _threadWrapper;
-}
-
-- (SentryDispatchQueueWrapper *)dispatchQueueWrapper
-{
-    @synchronized(sentryDependencyContainerLock) {
-        if (_dispatchQueueWrapper == nil) {
-            _dispatchQueueWrapper = [[SentryDispatchQueueWrapper alloc] init];
-        }
-        return _dispatchQueueWrapper;
-    }
-}
-
 - (SentryNSNotificationCenterWrapper *)notificationCenterWrapper
 {
     @synchronized(sentryDependencyContainerLock) {
@@ -156,30 +140,6 @@ static NSObject *sentryDependencyContainerLock;
         }
         return _notificationCenterWrapper;
     }
-}
-
-- (id<SentryRandom>)random
-{
-    if (_random == nil) {
-        @synchronized(sentryDependencyContainerLock) {
-            if (_random == nil) {
-                _random = [[SentryRandom alloc] init];
-            }
-        }
-    }
-    return _random;
-}
-
-- (SentryBinaryImageCache *)binaryImageCache
-{
-    if (_binaryImageCache == nil) {
-        @synchronized(sentryDependencyContainerLock) {
-            if (_binaryImageCache == nil) {
-                _binaryImageCache = [[SentryBinaryImageCache alloc] init];
-            }
-        }
-    }
-    return _binaryImageCache;
 }
 
 #if TARGET_OS_IOS
@@ -259,19 +219,6 @@ static NSObject *sentryDependencyContainerLock;
     return _swizzleWrapper;
 }
 
-- (SentryDebugImageProvider *)debugImageProvider
-{
-    if (_debugImageProvider == nil) {
-        @synchronized(sentryDependencyContainerLock) {
-            if (_debugImageProvider == nil) {
-                _debugImageProvider = [[SentryDebugImageProvider alloc] init];
-            }
-        }
-    }
-
-    return _debugImageProvider;
-}
-
 - (SentryANRTracker *)getANRTracker:(NSTimeInterval)timeout
 {
     if (_anrTracker == nil) {
@@ -335,18 +282,6 @@ static NSObject *sentryDependencyContainerLock;
         }
     }
     return _timerFactory;
-}
-
-- (SentryCurrentDateProvider *)dateProvider
-{
-    if (_dateProvider == nil) {
-        @synchronized(sentryDependencyContainerLock) {
-            if (_dateProvider == nil) {
-                _dateProvider = [[SentryCurrentDateProvider alloc] init];
-            }
-        }
-    }
-    return _dateProvider;
 }
 
 #if SENTRY_HAS_METRIC_KIT

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -288,8 +288,8 @@ typedef struct __CFRuntimeBase {
 #    define __CF_BIG_ENDIAN__ 0
 #endif
 
-#define CF_INFO_BITS (!!(__CF_BIG_ENDIAN__)*3)
-#define CF_RC_BITS (!!(__CF_LITTLE_ENDIAN__)*3)
+#define CF_INFO_BITS (!!(__CF_BIG_ENDIAN__) * 3)
+#define CF_RC_BITS (!!(__CF_LITTLE_ENDIAN__) * 3)
 
 /* Bit manipulation macros */
 /* Bits are numbered from 31 on left to 0 on right */
@@ -299,7 +299,7 @@ typedef struct __CFRuntimeBase {
 /* In the following, N1 and N2 specify an inclusive range N2..N1 with N1 >= N2
  */
 #define __CFBitfieldMask(N1, N2) ((((UInt32)~0UL) << (31UL - (N1) + (N2))) >> (31UL - N1))
-#define __CFBitfieldGetValue(V, N1, N2) (((V)&__CFBitfieldMask(N1, N2)) >> (N2))
+#define __CFBitfieldGetValue(V, N1, N2) (((V) & __CFBitfieldMask(N1, N2)) >> (N2))
 
 // ======================================================================
 #pragma mark - CF-1153.18/CFString.c -

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -801,10 +801,8 @@
 - (void)testChanging_enableTracing_afterSetting_tracesSampler
 {
     SentryOptions *options = [[SentryOptions alloc] init];
-    options.tracesSampler = ^NSNumber *(SentrySamplingContext *__unused samplingContext)
-    {
-        return @0.1;
-    };
+    options.tracesSampler
+        = ^NSNumber *(SentrySamplingContext *__unused samplingContext) { return @0.1; };
     options.enableTracing = NO;
     XCTAssertNil(options.tracesSampleRate);
     options.enableTracing = FALSE;
@@ -1161,10 +1159,8 @@
 
 - (void)testInitialScope
 {
-    SentryScope * (^initialScope)(SentryScope *) = ^SentryScope *(SentryScope *scope)
-    {
-        return scope;
-    };
+    SentryScope * (^initialScope)(SentryScope *)
+        = ^SentryScope *(SentryScope *scope) { return scope; };
     SentryOptions *options = [self getValidOptions:@{ @"initialScope" : initialScope }];
     XCTAssertIdentical(initialScope, options.initialScope);
 }


### PR DESCRIPTION
Making `SentryDependencyContainer` less complex and more predictable by removing some unnecessary lazy loads.

The goal would be to have all necessary objects initialized according to SentryOptions and remove all the @syncronized locks.

_#skip-changelog_