### PR TITLE
fix: Remove duplicate C++ lib for cocoapod

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,7 @@ on:
       - 'scripts/ci-select-xcode.sh'
       - 'scripts/no-changes-in-high-risk-files.sh'
       - 'Sentry.xcodeproj/**'
+      - '*.podspec'
 
 jobs:
   swift-lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Remove "duplicate library" warning (#3312)
+
 ## 8.13.0
 
 ### Fixes

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
   s.module_name  = "Sentry"
   s.requires_arc = true
   s.frameworks = 'Foundation'
-  s.libraries = 'z', 'c++'
   s.swift_versions = "5.5"
   s.pod_target_xcconfig = {
       'GCC_ENABLE_CPP_EXCEPTIONS' => 'YES',


### PR DESCRIPTION
## :scroll: Description

Xcode 15 automatically add libc++, we dont need to add it as well.

## :bulb: Motivation and Context

Removes a warning in the app compilation step.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
