### PR TITLE
ref: Replace deprecated function

### DIFF
--- a/Sources/Sentry/SentryDevice.mm
+++ b/Sources/Sentry/SentryDevice.mm
@@ -185,7 +185,7 @@ sentry_getOSVersion(void)
 #else
     const auto version = [[NSProcessInfo processInfo] operatingSystemVersion];
     return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion,
-            (long)version.minorVersion, (long)version.patchVersion];
+                     (long)version.minorVersion, (long)version.patchVersion];
 #endif // SENTRY_HAS_UIKIT
 }
 

--- a/Sources/Sentry/SentryDevice.mm
+++ b/Sources/Sentry/SentryDevice.mm
@@ -183,24 +183,9 @@ sentry_getOSVersion(void)
 #elif SENTRY_HAS_UIKIT
     return UIDevice.currentDevice.systemVersion;
 #else
-    // based off of
-    // https://github.com/lmirosevic/GBDeviceInfo/blob/98dd3c75bb0e1f87f3e0fd909e52dcf0da4aa47d/GBDeviceInfo/GBDeviceInfo_OSX.m#L107-L133
-    if ([[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)]) {
-        const auto version = [[NSProcessInfo processInfo] operatingSystemVersion];
-        return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion,
-                         (long)version.minorVersion, (long)version.patchVersion];
-    } else {
-        SInt32 major, minor, patch;
-
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        Gestalt(gestaltSystemVersionMajor, &major);
-        Gestalt(gestaltSystemVersionMinor, &minor);
-        Gestalt(gestaltSystemVersionBugFix, &patch);
-#    pragma clang diagnostic pop
-
-        return [NSString stringWithFormat:@"%d.%d.%d", major, minor, patch];
-    }
+    const auto version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion,
+            (long)version.minorVersion, (long)version.patchVersion];
 #endif // SENTRY_HAS_UIKIT
 }
 


### PR DESCRIPTION
Replaced macOS OS version retrieval from a deprecated API to a new one.

closes #3317

_#skip-changelog_