### PR TITLE
Issue with relative path in import blocking me from integrating Sentry using Buck

### DIFF
--- a/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
@@ -1,4 +1,4 @@
-#import "../Public/SentryId.h"
+#import "SentryId.h"
 #import "SentryCompiler.h"
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>


### PR DESCRIPTION
## :scroll: Description

Remove relative path to `SentryId.h` in import in the file `SentryProfiledTracerConcurrency.h`

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This relative path in this particular import is causing our previously working buck builds to fail, and other files in the same folder seem fine to omit the relative path before the header name.
<img width="270" alt="Screenshot of error stating ../Public/SentryId.h file not found" src="https://github.com/getsentry/sentry-cocoa/assets/6633472/e86eab13-ee36-4d43-b744-4be613cbd803">

<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

I'm hoping your CI will do that for me, so I don't have to mess with my work computer's dev environment to make this change.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
