### PR TITLE
fix: remove relative component of import

### DIFF
--- a/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
@@ -1,5 +1,5 @@
-#import "../Public/SentryId.h"
 #import "SentryCompiler.h"
+#import "SentryId.h"
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>
 


### PR DESCRIPTION
Reported with a proposed fix in https://github.com/getsentry/sentry-cocoa/pull/3331, but that can't run all the necessary CI checks

#skip-changelog