### PR TITLE
fix: Multiple issues in SentryReachability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - App hang with race condition for tick counter (#3290)
 - Remove "duplicate library" warning (#3312)
 - Remove unnecessaries build settings (#3325)
+- Fix multiple issues in Reachability (#3338)
 
 ## 8.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - App hang with race condition for tick counter (#3290)
 - Remove "duplicate library" warning (#3312)
-- Remove unnecessaries build settings (#3325)
 - Fix multiple issues in Reachability (#3338)
 - Remove unnecessary build settings (#3325)
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
+		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
 		62B86CFC29F052BB008F3947 /* SentryTestLogConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */; };
 		62E081A929ED4260000F69FC /* SentryBreadcrumbDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */; };
 		62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */; };
@@ -964,6 +965,7 @@
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
 		62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionContextTests.swift; sourceTree = "<group>"; };
+		629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReachabilitySwiftTests.swift; sourceTree = "<group>"; };
 		62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTestLogConfig.m; sourceTree = "<group>"; };
 		62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBreadcrumbDelegate.h; path = include/SentryBreadcrumbDelegate.h; sourceTree = "<group>"; };
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
@@ -2742,6 +2744,7 @@
 				7B5CAF7C27F5AD0600ED0DB6 /* TestNSURLRequestBuilder.h */,
 				7B5CAF7D27F5AD3500ED0DB6 /* TestNSURLRequestBuilder.m */,
 				0AE455AC28F584D2006680E5 /* SentryReachabilityTests.m */,
+				629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */,
 				0A9415B928F96CAC006A5DD1 /* TestSentryReachability.swift */,
 			);
 			path = Networking;
@@ -4209,6 +4212,7 @@
 				8ED3D306264DFE700049393B /* SwiftDescriptorTests.swift in Sources */,
 				7BFC16AD2524BCE700FF6266 /* SentryMessageTests.swift in Sources */,
 				7BF6505F292B77EC00BBA5A8 /* SentryMetricKitIntegrationTests.swift in Sources */,
+				629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */,
 				7BA61CC6247CFC5F00C130A8 /* SentryCrashDefaultBinaryImageProviderTests.swift in Sources */,
 				7BBC827925DFD7D7005F1ED8 /* SentryInAppLogicTests.swift in Sources */,
 				7BD7299A2463EA4A00EA3610 /* SentryDateUtilTests.swift in Sources */,

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -30,8 +30,13 @@ class TestCleanup: NSObject {
         SentryAppStartTracker.load()
         SentryUIViewControllerPerformanceTracker.shared.enableWaitForFullDisplay = false
         SentryDependencyContainer.sharedInstance().swizzleWrapper.removeAllCallbacks()
+        
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-
+        
+#if !os(watchOS)
+        SentryDependencyContainer.sharedInstance().reachability.removeAllObservers()
+#endif // !os(watchOS)
+        
         SentryDependencyContainer.reset()
         Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()
         SentryPerformanceTracker.shared.clear()

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -33,6 +33,7 @@
 #import "SentryNetworkTracker.h"
 #import "SentryPerformanceTracker+Testing.h"
 #import "SentryRandom.h"
+#import "SentryReachability.h"
 #import "SentrySDK+Private.h"
 #import "SentrySDK+Tests.h"
 #import "SentrySession.h"

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -92,28 +92,23 @@ SentryHttpTransport ()
         [self sendAllCachedEnvelopes];
 
 #if !TARGET_OS_WATCH
-        __weak SentryHttpTransport *weakSelf = self;
-        [SentryDependencyContainer.sharedInstance.reachability
-             addObserver:self
-            withCallback:^(BOOL connected, NSString *_Nonnull typeDescription) {
-                if (weakSelf == nil) {
-                    SENTRY_LOG_DEBUG(@"WeakSelf is nil. Not doing anything.");
-                    return;
-                }
-
-                if (connected) {
-                    SENTRY_LOG_DEBUG(@"Internet connection is back.");
-                    [weakSelf sendAllCachedEnvelopes];
-                } else {
-                    SENTRY_LOG_DEBUG(@"Lost internet connection.");
-                }
-            }];
+        [SentryDependencyContainer.sharedInstance.reachability addObserver:self];
 #endif // !TARGET_OS_WATCH
     }
     return self;
 }
 
 #if !TARGET_OS_WATCH
+- (void)connectivityChanged:(BOOL)connected typeDescription:(nonnull NSString *)typeDescription
+{
+    if (connected) {
+        SENTRY_LOG_DEBUG(@"Internet connection is back.");
+        [self sendAllCachedEnvelopes];
+    } else {
+        SENTRY_LOG_DEBUG(@"Lost internet connection.");
+    }
+}
+
 - (void)dealloc
 {
     [SentryDependencyContainer.sharedInstance.reachability removeObserver:self];

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -96,7 +96,7 @@ SentryConnectivityCallback(
         @"SentryConnectivityCallback called with target: %@; flags: %u", target, flags);
 
     @synchronized(sentry_reachability_observers) {
-        SENTRY_LOG_DEBUG(@"Entered synchronized region of SentryConnectivityCallback");
+        SENTRY_LOG_DEBUG(@"Entered synchronized region of SentryConnectivityCallback with target: %@; flags: %u", target, flags);
 
         if (sentry_reachability_observers.count == 0) {
             SENTRY_LOG_DEBUG(@"No reachability observers registered. Nothing to do.");
@@ -149,7 +149,9 @@ SentryConnectivityReset(void)
 
 - (void)addObserver:(id<SentryReachabilityObserver>)observer;
 {
+    SENTRY_LOG_DEBUG(@"Adding observer: %@", observer);
     @synchronized(sentry_reachability_observers) {
+        SENTRY_LOG_DEBUG(@"Synchronized to add observer: %@", observer);
         if ([sentry_reachability_observers containsObject:observer]) {
             SENTRY_LOG_DEBUG(@"Observer already added. Doing nothing.");
             return;
@@ -184,7 +186,7 @@ SentryConnectivityReset(void)
 {
     SENTRY_LOG_DEBUG(@"Removing observer: %@", observer);
     @synchronized(sentry_reachability_observers) {
-        SENTRY_LOG_DEBUG(@"Entered synchronized region of removeObserver");
+        SENTRY_LOG_DEBUG(@"Synchronized to remove observer: %@", observer);
         [sentry_reachability_observers removeObject:observer];
 
         [self unsetReachabilityCallbackIfNeeded];
@@ -193,7 +195,9 @@ SentryConnectivityReset(void)
 
 - (void)removeAllObservers
 {
+    SENTRY_LOG_DEBUG(@"Removing all observers.");
     @synchronized(sentry_reachability_observers) {
+        SENTRY_LOG_DEBUG(@"Synchronized to remove all observers.");
         [sentry_reachability_observers removeAllObjects];
         [self unsetReachabilityCallbackIfNeeded];
     }

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -94,12 +94,15 @@ SentryConnectivityCallback(
 {
     SENTRY_LOG_DEBUG(
         @"SentryConnectivityCallback called with target: %@; flags: %u", target, flags);
+
     @synchronized(sentry_reachability_observers) {
         SENTRY_LOG_DEBUG(@"Entered synchronized region of SentryConnectivityCallback");
+
         if (!sentry_reachability_observers) {
             SENTRY_LOG_DEBUG(@"No reachability observers registered. Nothing to do.");
             return;
         }
+
         if (!SentryConnectivityShouldReportChange(flags)) {
             SENTRY_LOG_DEBUG(@"SentryConnectivityShouldReportChange returned NO for flags %u, will "
                              @"not report change to observers.",
@@ -117,6 +120,13 @@ SentryConnectivityCallback(
         }
         SENTRY_LOG_DEBUG(@"Finished notifying observers.");
     }
+}
+
+void
+SentryConnectivityReset(void)
+{
+    [sentry_reachability_observers removeAllObjects];
+    sentry_current_reachability_state = kSCNetworkReachabilityFlagsUninitialized;
 }
 
 @implementation SentryReachability

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -119,13 +119,6 @@ SentryConnectivityCallback(
     }
 }
 
-void
-SentryConnectivityReset(void)
-{
-    [sentry_reachability_change_blocks removeAllObjects];
-    sentry_current_reachability_state = kSCNetworkReachabilityFlagsUninitialized;
-}
-
 @implementation SentryReachability
 
 + (void)initialize

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -96,7 +96,9 @@ SentryConnectivityCallback(
         @"SentryConnectivityCallback called with target: %@; flags: %u", target, flags);
 
     @synchronized(sentry_reachability_observers) {
-        SENTRY_LOG_DEBUG(@"Entered synchronized region of SentryConnectivityCallback with target: %@; flags: %u", target, flags);
+        SENTRY_LOG_DEBUG(
+            @"Entered synchronized region of SentryConnectivityCallback with target: %@; flags: %u",
+            target, flags);
 
         if (sentry_reachability_observers.count == 0) {
             SENTRY_LOG_DEBUG(@"No reachability observers registered. Nothing to do.");

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -98,7 +98,7 @@ SentryConnectivityCallback(
     @synchronized(sentry_reachability_observers) {
         SENTRY_LOG_DEBUG(@"Entered synchronized region of SentryConnectivityCallback");
 
-        if (!sentry_reachability_observers) {
+        if (sentry_reachability_observers.count == 0) {
             SENTRY_LOG_DEBUG(@"No reachability observers registered. Nothing to do.");
             return;
         }
@@ -179,7 +179,7 @@ SentryConnectivityReset(void)
         SENTRY_LOG_DEBUG(@"Entered synchronized region of removeObserver");
         [sentry_reachability_observers removeObject:observer];
 
-        [self unsetCallbackIfNeeded];
+        [self unsetReachabilityCallbackIfNeeded];
     }
 }
 
@@ -187,11 +187,11 @@ SentryConnectivityReset(void)
 {
     @synchronized(sentry_reachability_observers) {
         [sentry_reachability_observers removeAllObjects];
-        [self unsetCallbackIfNeeded];
+        [self unsetReachabilityCallbackIfNeeded];
     }
 }
 
-- (void)unsetCallbackIfNeeded
+- (void)unsetReachabilityCallbackIfNeeded
 {
     if (sentry_reachability_observers.count > 0) {
         SENTRY_LOG_DEBUG(
@@ -199,11 +199,6 @@ SentryConnectivityReset(void)
         return;
     }
 
-    [self removeReachabilityNotification];
-}
-
-- (void)removeReachabilityNotification
-{
     sentry_current_reachability_state = kSCNetworkReachabilityFlagsUninitialized;
 
     if (_sentry_reachability_ref != nil) {

--- a/Sources/Sentry/include/SentryReachability.h
+++ b/Sources/Sentry/include/SentryReachability.h
@@ -64,7 +64,7 @@ SENTRY_EXTERN NSString *const SentryConnectivityNone;
 /**
  * Only needed for testing.
  */
-@property (nonatomic) BOOL setReachabilityCallback;
+@property (nonatomic, assign) BOOL setReachabilityCallback;
 
 /**
  * Add an observer which is called each time network connectivity changes.

--- a/Sources/Sentry/include/SentryReachability.h
+++ b/Sources/Sentry/include/SentryReachability.h
@@ -43,14 +43,16 @@ SENTRY_EXTERN NSString *const SentryConnectivityCellular;
 SENTRY_EXTERN NSString *const SentryConnectivityWiFi;
 SENTRY_EXTERN NSString *const SentryConnectivityNone;
 
+@protocol SentryReachabilityObserver <NSObject>
+
 /**
- * Function signature to connectivity monitoring callback of @c SentryReachability
+ * Called when network connectivity changes.
+ *
  * @param connected @c YES if the monitored URL is reachable
  * @param typeDescription a textual representation of the connection type
  */
-typedef void (^SentryConnectivityChangeBlock)(BOOL connected, NSString *typeDescription);
+- (void)connectivityChanged:(BOOL)connected typeDescription:(NSString *)typeDescription;
 
-@protocol SentryReachabilityObserver <NSObject>
 @end
 
 /**
@@ -60,16 +62,21 @@ typedef void (^SentryConnectivityChangeBlock)(BOOL connected, NSString *typeDesc
 @interface SentryReachability : NSObject
 
 /**
- * Invoke a block each time network connectivity changes
- * @param block The block called when connectivity changes
+ * Only needed for testing.
  */
-- (void)addObserver:(id<SentryReachabilityObserver>)observer
-       withCallback:(SentryConnectivityChangeBlock)block;
+@property (nonatomic) BOOL setReachabilityCallback;
+
+/**
+ * Add an observer which is called each time network connectivity changes.
+ */
+- (void)addObserver:(id<SentryReachabilityObserver>)observer;
 
 /**
  * Stop monitoring the URL previously configured with @c monitorURL:usingCallback:
  */
 - (void)removeObserver:(id<SentryReachabilityObserver>)observer;
+
+- (void)removeAllObservers;
 
 @end
 

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -55,6 +55,9 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
     }
 
     func testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb() {
+        let testReachability = TestSentryReachability()
+        SentryDependencyContainer.sharedInstance().reachability = testReachability
+        
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
@@ -74,12 +77,12 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let crumbs = delegate.addCrumbInvocations.invocations
 
         // one breadcrumb for starting the tracker, one for the first reachability breadcrumb and one final one for the swizzled viewDidAppear
-        guard crumbs.count == 3 else {
-            XCTFail("Expected exactly 3 breadcrumbs, got: \(crumbs)")
+        guard crumbs.count == 2 else {
+            XCTFail("Expected exactly 2 breadcrumbs, got: \(crumbs)")
             return
         }
 
-        let lifeCycleCrumb = crumbs[2]
+        let lifeCycleCrumb = crumbs[1]
         XCTAssertEqual("navigation", lifeCycleCrumb.type)
         XCTAssertEqual("ui.lifecycle", lifeCycleCrumb.category)
         XCTAssertEqual("false", lifeCycleCrumb.data?["beingPresented"] as? String)

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -31,7 +31,9 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
 
     func testNetworkConnectivityChangeBreadcrumbs() throws {
         let testReachability = TestSentryReachability()
+        
         SentryDependencyContainer.sharedInstance().reachability = testReachability
+        
         let sut = SentryBreadcrumbTracker()
         sut.start(with: delegate)
         let states = [SentryConnectivityCellular,
@@ -56,6 +58,12 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
 
     func testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb() {
         let testReachability = TestSentryReachability()
+        
+        // We already test the network breadcrumbs in a test above. Using the `TestReachability`
+        // makes this test more stable, as using the real implementation sometimes leads to
+        // test failure, cause sometimes the dispatch queue responsible for reporting the reachability
+        // status takes some time and then there isn't a network breadcrumb available. This test
+        // doesn't validate the network breadcrumb anyways.
         SentryDependencyContainer.sharedInstance().reachability = testReachability
         
         let scope = Scope()

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -800,7 +800,10 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testDealloc_StopsReachabilityMonitoring() {
-        _ = fixture.sut
+        func deallocSut() {
+            _ = fixture.sut
+        }
+        deallocSut()
 
         XCTAssertEqual(1, fixture.reachability.stopMonitoringInvocations.count)
     }

--- a/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
+++ b/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+
+final class SentryReachabilitySwiftTests: XCTestCase, SentryReachabilityObserver {
+
+    func testAddRemoveFromMultipleThreads() throws {
+        let sut = SentryReachability()
+        testConcurrentModifications(writeWork: {_ in
+            sut.add(self)
+        }, readWork: {
+            sut.remove(self)
+        })
+        
+        sut.removeAllObservers()
+    }
+    
+    func connectivityChanged(_ connected: Bool, typeDescription: String) {
+        // Do nothing
+    }
+
+}

--- a/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
+++ b/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
@@ -1,20 +1,19 @@
 import XCTest
 
-final class SentryReachabilitySwiftTests: XCTestCase, SentryReachabilityObserver {
+final class SentryReachabilitySwiftTests: XCTestCase {
 
     func testAddRemoveFromMultipleThreads() throws {
         let sut = SentryReachability()
         testConcurrentModifications(writeWork: {_ in
-            sut.add(self)
+            sut.add(TestReachabilityObserver())
         }, readWork: {
-            sut.remove(self)
+            sut.removeAllObservers()
         })
-        
-        sut.removeAllObservers()
     }
-    
+}
+
+class TestReachabilityObserver: NSObject, SentryReachabilityObserver {
     func connectivityChanged(_ connected: Bool, typeDescription: String) {
         // Do nothing
     }
-
 }

--- a/Tests/SentryTests/Networking/SentryReachabilityTests.m
+++ b/Tests/SentryTests/Networking/SentryReachabilityTests.m
@@ -1,3 +1,4 @@
+#import "SentryLog.h"
 #import "SentryReachability+Private.h"
 #import "SentryReachability.h"
 #import <XCTest/XCTest.h>
@@ -19,6 +20,7 @@
 
 - (void)connectivityChanged:(BOOL)connected typeDescription:(nonnull NSString *)typeDescription
 {
+    NSLog(@"Received connectivity notification: %i; type: %@", connected, typeDescription);
     [self.expectation fulfill];
 }
 

--- a/Tests/SentryTests/Networking/SentryReachabilityTests.m
+++ b/Tests/SentryTests/Networking/SentryReachabilityTests.m
@@ -69,8 +69,8 @@ void SentryConnectivityReset(void);
 - (void)testMultipleReachabilityObservers
 {
     SentryReachability *reachability = [[SentryReachability alloc] init];
-    // Disable the rechability callbacks, cause we call the callbacks manually.
-    // Otherwise, the rechability callbacks kick it at some point and make the tests flaky.
+    // Disable the reachability callbacks, cause we call the callbacks manually.
+    // Otherwise, the reachability callbacks are called during later unrelated tests causing flakes.
     reachability.setReachabilityCallback = NO;
 
     XCTestExpectation *aExp =

--- a/Tests/SentryTests/Networking/TestSentryReachability.swift
+++ b/Tests/SentryTests/Networking/TestSentryReachability.swift
@@ -3,18 +3,24 @@
 import SentryTestUtils
 
 class TestSentryReachability: SentryReachability {
-    var block: SentryConnectivityChangeBlock?
+    
+    private var observers: NSHashTable<SentryReachabilityObserver> = NSHashTable.weakObjects()
 
-    override func add(_ observer: SentryReachabilityObserver, withCallback block: @escaping SentryConnectivityChangeBlock) {
-        self.block = block
+    override func add(_ observer: SentryReachabilityObserver) {
+        observers.add(observer)
     }
 
     func setReachabilityState(state: String) {
-        block?(state != SentryConnectivityNone, state)
+        for observer in observers.allObjects {
+            observer.connectivityChanged(state != SentryConnectivityNone, typeDescription: state)
+        }
+        
     }
 
     func triggerNetworkReachable() {
-        block?(true, SentryConnectivityWiFi)
+        for observer in observers.allObjects {
+            observer.connectivityChanged(true, typeDescription: SentryConnectivityWiFi)
+        }
     }
     
     var stopMonitoringInvocations = Invocations<Void>()

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -150,6 +150,7 @@
 #import "SentryRandom.h"
 #import "SentryRateLimitParser.h"
 #import "SentryRateLimits.h"
+#import "SentryReachability.h"
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentrySDK+Private.h"
 #import "SentrySDK+Tests.h"


### PR DESCRIPTION

## :scroll: Description

The tests can launch multiple threads of the ANR tracker, which call dealloc of SentryReachability simultaneously, leading to a segfault while iterating over the observers in SentryReachability. This is fixed now by using some synchronization around the observer's access. Furthermore, the bookkeeping of the observers is implemented now with weak references using an NSHashTable. Instead of relying on dealloc to be called for removing the observers, each observer must now call removeObserver after subscribing. If an observer doesn't call removeObserver no memory is leaked cause the SentryReachability uses weak references. Previously, the list of observers used a dictionary with the description method of Objective-C as the key, which is suboptimal cause the description could change between adding and removing the observer, leading to memory leaks when the observer's description changed between invocations.

## :bulb: Motivation and Context

A test in CI contained the following crash report.

<details><summary>Crash Report</summary>
<p>

```
Process:               xctest [2374]
Path:                  /Applications/Xcode_13.2.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Xcode/Agents/xctest
Identifier:            xctest
Version:               13.2.1 (19566)
Code Type:             X86-64 (Native)
Parent Process:        xcodebuild [2361]
Responsible:           xctest [2374]
User ID:               501

Date/Time:             2023-10-04 08:54:45.554 +0000
OS Version:            macOS 11.7.10 (20G1427)
Report Version:        12
Anonymous UUID:        28C488D7-2871-0137-7EA3-2D329D89124C


Time Awake Since Boot: 1000 seconds

System Integrity Protection: enabled

Crashed Thread:        15  io.sentry.app-hang-tracker

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       EXC_I386_GPFLT
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Segmentation fault: 11
Termination Reason:    Namespace SIGNAL, Code 0xb
Terminating Process:   exc handler [2374]

Thread 0:: Dispatch queue: com.apple.main-thread
0   com.apple.CoreFoundation      	0x00007fff205dd1a0 -[NSDictionary allValues] + 146
1   io.sentry.Sentry              	0x000000010b2ad45b -[SentryReachability removeObserver:] + 155 (SentryReachability.m:146)
2   io.sentry.Sentry              	0x000000010b2a8722 -[SentryHttpTransport dealloc] + 114 (SentryHttpTransport.m:119)
3   io.sentry.Sentry              	0x000000010b25c5d9 -[SentryTransportAdapter .cxx_destruct] + 57 (SentryTransportAdapter.m:18)
4   libobjc.A.dylib               	0x00007fff2038ea04 object_cxxDestructFromClass(objc_object*, objc_class*) + 83
5   libobjc.A.dylib               	0x00007fff203875a1 objc_destructInstance + 94
6   libobjc.A.dylib               	0x00007fff20387505 _objc_rootDealloc + 62
7   io.sentry.Sentry              	0x000000010b242bef -[SentryClient .cxx_destruct] + 159 (SentryClient.m:72)
8   libobjc.A.dylib               	0x00007fff2038ea04 object_cxxDestructFromClass(objc_object*, objc_class*) + 83
9   libobjc.A.dylib               	0x00007fff203875a1 objc_destructInstance + 94
10  libobjc.A.dylib               	0x00007fff20387505 _objc_rootDealloc + 62
11  io.sentry.Sentry              	0x000000010b28edb5 -[SentryHub setClient:] + 37
12  io.sentry.Sentry              	0x000000010b28cc63 -[SentryHub bindClient:] + 83 (SentryHub.m:497)
13  io.sentry.Sentry              	0x000000010b2e4269 +[SentrySDK close] + 761 (SentrySDK.m:404)
14  libSentryTestUtils.a          	0x000000010b103cfe static TestCleanup.clearTestState() + 78 (ClearTestState.swift:15)
15  libSentryTestUtils.a          	0x000000010b103c7a clearTestState() + 42 (ClearTestState.swift:5)
16  io.sentry.Sentry.tests        	0x000000010f431109 SentryNetworkTrackerIntegrationTests.tearDown() + 105 (SentryNetworkTrackerIntegrationTests.swift:35)
17  io.sentry.Sentry.tests        	0x000000010f43112c @objc SentryNetworkTrackerIntegrationTests.tearDown() + 28
18  com.apple.dt.XCTestCore       	0x000000010a8d2348 __86-[XCTestCase _performTearDownSequenceWithSelector:permittingControlFlowInterruptions:]_block_invoke_2 + 21
19  com.apple.dt.XCTestCore       	0x000000010a8d25a0 __79-[XCTestCase _performFailableTearDownBlock:permittingControlFlowInterruptions:]_block_invoke + 38
20  com.apple.dt.XCTestCore       	0x000000010a896b86 -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] + 179
21  com.apple.dt.XCTestCore       	0x000000010a8d23cf -[XCTestCase _performFailableTearDownBlock:permittingControlFlowInterruptions:] + 131
22  com.apple.dt.XCTestCore       	0x000000010a8d1fa5 __86-[XCTestCase _performTearDownSequenceWithSelector:permittingControlFlowInterruptions:]_block_invoke + 126
23  com.apple.dt.XCTestCore       	0x000000010a8b6483 -[XCTContext _runActivityNamed:type:block:] + 301
24  com.apple.dt.XCTestCore       	0x000000010a8da513 -[XCTestCase startActivityWithTitle:type:block:] + 186
25  com.apple.dt.XCTestCore       	0x000000010a8d0c64 -[XCTestCase _performTearDownSequenceWithSelector:] + 90
26  com.apple.dt.XCTestCore       	0x000000010a8d0129 -[XCTestCase invokeTest] + 1205
27  com.apple.dt.XCTestCore       	0x000000010a8d190b __26-[XCTestCase performTest:]_block_invoke.379 + 38
28  com.apple.dt.XCTestCore       	0x000000010a896b86 -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] + 179
29  com.apple.dt.XCTestCore       	0x000000010a8d1288 __26-[XCTestCase performTest:]_block_invoke.358 + 523
30  com.apple.dt.XCTestCore       	0x000000010a8b6afb +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
31  com.apple.dt.XCTestCore       	0x000000010a8d0e9a -[XCTestCase performTest:] + 287
32  com.apple.dt.XCTestCore       	0x000000010a8850c5 -[XCTest runTest] + 57
33  com.apple.dt.XCTestCore       	0x000000010a8b9d0f -[XCTestSuite runTestBasedOnRepetitionPolicy:testRun:] + 156
34  com.apple.dt.XCTestCore       	0x000000010a8b9b85 __27-[XCTestSuite performTest:]_block_invoke + 252
35  com.apple.dt.XCTestCore       	0x000000010a8b9484 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 24
36  com.apple.dt.XCTestCore       	0x000000010a8b6afb +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
37  com.apple.dt.XCTestCore       	0x000000010a8b943b -[XCTestSuite _performProtectedSectionForTest:testSection:] + 159
38  com.apple.dt.XCTestCore       	0x000000010a8b9730 -[XCTestSuite performTest:] + 222
39  com.apple.dt.XCTestCore       	0x000000010a8850c5 -[XCTest runTest] + 57
40  com.apple.dt.XCTestCore       	0x000000010a8b9d0f -[XCTestSuite runTestBasedOnRepetitionPolicy:testRun:] + 156
41  com.apple.dt.XCTestCore       	0x000000010a8b9b85 __27-[XCTestSuite performTest:]_block_invoke + 252
42  com.apple.dt.XCTestCore       	0x000000010a8b9484 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 24
43  com.apple.dt.XCTestCore       	0x000000010a8b6afb +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
44  com.apple.dt.XCTestCore       	0x000000010a8b943b -[XCTestSuite _performProtectedSectionForTest:testSection:] + 159
45  com.apple.dt.XCTestCore       	0x000000010a8b9730 -[XCTestSuite performTest:] + 222
46  com.apple.dt.XCTestCore       	0x000000010a8850c5 -[XCTest runTest] + 57
47  com.apple.dt.XCTestCore       	0x000000010a8b9d0f -[XCTestSuite runTestBasedOnRepetitionPolicy:testRun:] + 156
48  com.apple.dt.XCTestCore       	0x000000010a8b9b85 __27-[XCTestSuite performTest:]_block_invoke + 252
49  com.apple.dt.XCTestCore       	0x000000010a8b9484 __59-[XCTestSuite _performProtectedSectionForTest:testSection:]_block_invoke + 24
50  com.apple.dt.XCTestCore       	0x000000010a8b6afb +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
51  com.apple.dt.XCTestCore       	0x000000010a8b943b -[XCTestSuite _performProtectedSectionForTest:testSection:] + 159
52  com.apple.dt.XCTestCore       	0x000000010a8b9730 -[XCTestSuite performTest:] + 222
53  com.apple.dt.XCTestCore       	0x000000010a8850c5 -[XCTest runTest] + 57
54  com.apple.dt.XCTestCore       	0x000000010a886725 __89-[XCTTestRunSession executeTestsWithIdentifiers:skippingTestsWithIdentifiers:completion:]_block_invoke + 374
55  com.apple.dt.XCTestCore       	0x000000010a8b6afb +[XCTContext runInContextForTestCase:markAsReportingBase:block:] + 220
56  com.apple.dt.XCTestCore       	0x000000010a886544 -[XCTTestRunSession executeTestsWithIdentifiers:skippingTestsWithIdentifiers:completion:] + 212
57  com.apple.dt.XCTestCore       	0x000000010a8f205c __72-[XCTExecutionWorker enqueueTestIdentifiersToRun:testIdentifiersToSkip:]_block_invoke_2 + 119
58  com.apple.dt.XCTestCore       	0x000000010a8f21a4 -[XCTExecutionWorker runWithError:] + 112
59  com.apple.dt.XCTestCore       	0x000000010a8b3ee5 __25-[XCTestDriver _runTests]_block_invoke + 61
60  com.apple.dt.XCTestCore       	0x000000010a88f25b -[XCTestObservationCenter _observeTestExecutionForBlock:] + 325
61  com.apple.dt.XCTestCore       	0x000000010a8b3c46 -[XCTestDriver _runTests] + 1397
62  com.apple.dt.XCTestCore       	0x000000010a88566a _XCTestMain + 125
63  xctest                        	0x000000010a3f1571 main + 355
64  libdyld.dylib                 	0x00007fff20502f3d start + 1

Thread 1:: SentryCrash Exception Handler (Secondary)
0   libsystem_kernel.dylib        	0x00007fff204b229a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff204b260c mach_msg + 60
2   libsystem_kernel.dylib        	0x00007fff204d197b thread_suspend + 80
3   io.sentry.Sentry              	0x000000010b29479a handleExceptions + 186 (SentryCrashMonitor_MachException.c:306)
4   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
5   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 2:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 3:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 4:
0   libsystem_kernel.dylib        	0x00007fff204b229a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff204b260c mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff205dfc45 __CFRunLoopServiceMachPort + 316
3   com.apple.CoreFoundation      	0x00007fff205de30b __CFRunLoopRun + 1332
4   com.apple.CoreFoundation      	0x00007fff205dd710 CFRunLoopRunSpecific + 567
5   com.apple.CoreFoundation      	0x00007fff20663fa8 CFRunLoopRun + 40
6   com.apple.DebugSymbols        	0x000000010af81e98 SpotlightQueryThread(void*) + 472
7   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
8   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 5:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 6:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 7:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 8:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 9:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 10:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 11:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 12:
0   libsystem_pthread.dylib       	0x00007fff204e3420 start_wqthread + 0

Thread 13:: io.sentry.app-hang-tracker
0   libsystem_kernel.dylib        	0x00007fff204b4b92 __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff20434c1a nanosleep + 196
2   com.apple.Foundation          	0x00007fff21326bc8 +[NSThread sleepForTimeInterval:] + 170
3   io.sentry.Sentry              	0x000000010b2ae650 -[SentryThreadWrapper sleepForTimeInterval:] + 64 (SentryThreadWrapper.m:9)
4   io.sentry.Sentry              	0x000000010b263816 -[SentryANRTracker detectANRs] + 1526 (SentryANRTracker.m:103)
5   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
6   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
7   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 14:: io.sentry.app-hang-tracker
0   com.apple.CoreFoundation      	0x00007fff205dd19c -[NSDictionary allValues] + 142
1   io.sentry.Sentry              	0x000000010b2ad45b -[SentryReachability removeObserver:] + 155 (SentryReachability.m:146)
2   io.sentry.Sentry              	0x000000010b2acf59 -[SentryReachability dealloc] + 361 (SentryReachability.m:113)
3   io.sentry.Sentry              	0x000000010b2fc78f -[SentryDependencyContainer .cxx_destruct] + 63 (SentryDependencyContainer.m:42)
4   libobjc.A.dylib               	0x00007fff2038ea04 object_cxxDestructFromClass(objc_object*, objc_class*) + 83
5   libobjc.A.dylib               	0x00007fff203875a1 objc_destructInstance + 94
6   libobjc.A.dylib               	0x00007fff20387505 _objc_rootDealloc + 62
7   libobjc.A.dylib               	0x00007fff203a5343 AutoreleasePoolPage::releaseUntil(objc_object**) + 167
8   libobjc.A.dylib               	0x00007fff20387d94 objc_autoreleasePoolPop + 161
9   libobjc.A.dylib               	0x00007fff203a54b5 AutoreleasePoolPage::tls_dealloc(void*) + 91
10  libsystem_pthread.dylib       	0x00007fff204e598d _pthread_tsd_cleanup + 487
11  libsystem_pthread.dylib       	0x00007fff204e7f65 _pthread_exit + 70
12  libsystem_pthread.dylib       	0x00007fff204e5763 pthread_exit + 42
13  com.apple.Foundation          	0x00007fff21303aec +[NSThread exit] + 11
14  com.apple.Foundation          	0x00007fff2129349b __NSThread__start__ + 1088
15  libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
16  libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 15 Crashed:: io.sentry.app-hang-tracker
0   libobjc.A.dylib               	0x00007fff20385613 objc_retain + 19
1   com.apple.CoreFoundation      	0x00007fff205dd1a5 -[NSDictionary allValues] + 151
2   io.sentry.Sentry              	0x000000010b2ad45b -[SentryReachability removeObserver:] + 155 (SentryReachability.m:146)
3   io.sentry.Sentry              	0x000000010b2acf59 -[SentryReachability dealloc] + 361 (SentryReachability.m:113)
4   io.sentry.Sentry              	0x000000010b2fc78f -[SentryDependencyContainer .cxx_destruct] + 63 (SentryDependencyContainer.m:42)
5   libobjc.A.dylib               	0x00007fff2038ea04 object_cxxDestructFromClass(objc_object*, objc_class*) + 83
6   libobjc.A.dylib               	0x00007fff203875a1 objc_destructInstance + 94
7   libobjc.A.dylib               	0x00007fff20387505 _objc_rootDealloc + 62
8   libobjc.A.dylib               	0x00007fff203a5343 AutoreleasePoolPage::releaseUntil(objc_object**) + 167
9   libobjc.A.dylib               	0x00007fff20387d94 objc_autoreleasePoolPop + 161
10  libobjc.A.dylib               	0x00007fff203a54b5 AutoreleasePoolPage::tls_dealloc(void*) + 91
11  libsystem_pthread.dylib       	0x00007fff204e598d _pthread_tsd_cleanup + 487
12  libsystem_pthread.dylib       	0x00007fff204e7f65 _pthread_exit + 70
13  libsystem_pthread.dylib       	0x00007fff204e5763 pthread_exit + 42
14  com.apple.Foundation          	0x00007fff21303aec +[NSThread exit] + 11
15  com.apple.Foundation          	0x00007fff2129349b __NSThread__start__ + 1088
16  libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
17  libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 16:: io.sentry.app-hang-tracker
0   libobjc.A.dylib               	0x00007fff20385600 objc_retain + 0
1   com.apple.CoreFoundation      	0x00007fff205cfbbf -[NSDictionary allKeys] + 151
2   io.sentry.Sentry              	0x000000010b2ace53 -[SentryReachability dealloc] + 99 (SentryReachability.m:112)
3   io.sentry.Sentry              	0x000000010b2fc78f -[SentryDependencyContainer .cxx_destruct] + 63 (SentryDependencyContainer.m:42)
4   libobjc.A.dylib               	0x00007fff2038ea04 object_cxxDestructFromClass(objc_object*, objc_class*) + 83
5   libobjc.A.dylib               	0x00007fff203875a1 objc_destructInstance + 94
6   libobjc.A.dylib               	0x00007fff20387505 _objc_rootDealloc + 62
7   libobjc.A.dylib               	0x00007fff203a5343 AutoreleasePoolPage::releaseUntil(objc_object**) + 167
8   libobjc.A.dylib               	0x00007fff20387d94 objc_autoreleasePoolPop + 161
9   libobjc.A.dylib               	0x00007fff203a54b5 AutoreleasePoolPage::tls_dealloc(void*) + 91
10  libsystem_pthread.dylib       	0x00007fff204e598d _pthread_tsd_cleanup + 487
11  libsystem_pthread.dylib       	0x00007fff204e7f65 _pthread_exit + 70
12  libsystem_pthread.dylib       	0x00007fff204e5763 pthread_exit + 42
13  com.apple.Foundation          	0x00007fff21303aec +[NSThread exit] + 11
14  com.apple.Foundation          	0x00007fff2129349b __NSThread__start__ + 1088
15  libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
16  libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 17:: io.sentry.app-hang-tracker
0   com.apple.CoreFoundation      	0x00007fff205cfbbf -[NSDictionary allKeys] + 151
1   io.sentry.Sentry              	0x000000010b2ace53 -[SentryReachability dealloc] + 99 (SentryReachability.m:112)
2   io.sentry.Sentry              	0x000000010b2fc78f -[SentryDependencyContainer .cxx_destruct] + 63 (SentryDependencyContainer.m:42)
3   libobjc.A.dylib               	0x00007fff2038ea04 object_cxxDestructFromClass(objc_object*, objc_class*) + 83
4   libobjc.A.dylib               	0x00007fff203875a1 objc_destructInstance + 94
5   libobjc.A.dylib               	0x00007fff20387505 _objc_rootDealloc + 62
6   libobjc.A.dylib               	0x00007fff203a5343 AutoreleasePoolPage::releaseUntil(objc_object**) + 167
7   libobjc.A.dylib               	0x00007fff20387d94 objc_autoreleasePoolPop + 161
8   libobjc.A.dylib               	0x00007fff203a54b5 AutoreleasePoolPage::tls_dealloc(void*) + 91
9   libsystem_pthread.dylib       	0x00007fff204e598d _pthread_tsd_cleanup + 487
10  libsystem_pthread.dylib       	0x00007fff204e7f65 _pthread_exit + 70
11  libsystem_pthread.dylib       	0x00007fff204e5763 pthread_exit + 42
12  com.apple.Foundation          	0x00007fff21303aec +[NSThread exit] + 11
13  com.apple.Foundation          	0x00007fff2129349b __NSThread__start__ + 1088
14  libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
15  libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 18:: io.sentry.app-hang-tracker
0   libsystem_kernel.dylib        	0x00007fff204b4b92 __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff20434c1a nanosleep + 196
2   com.apple.Foundation          	0x00007fff21326bc8 +[NSThread sleepForTimeInterval:] + 170
3   io.sentry.Sentry              	0x000000010b2ae650 -[SentryThreadWrapper sleepForTimeInterval:] + 64 (SentryThreadWrapper.m:9)
4   io.sentry.Sentry              	0x000000010b263816 -[SentryANRTracker detectANRs] + 1526 (SentryANRTracker.m:103)
5   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
6   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
7   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 19:: io.sentry.app-hang-tracker
0   libsystem_kernel.dylib        	0x00007fff204b4b92 __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff20434c1a nanosleep + 196
2   com.apple.Foundation          	0x00007fff21326bc8 +[NSThread sleepForTimeInterval:] + 170
3   io.sentry.Sentry              	0x000000010b2ae650 -[SentryThreadWrapper sleepForTimeInterval:] + 64 (SentryThreadWrapper.m:9)
4   io.sentry.Sentry              	0x000000010b263816 -[SentryANRTracker detectANRs] + 1526 (SentryANRTracker.m:103)
5   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
6   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
7   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 20:: com.apple.CFNetwork.CustomProtocols
0   libsystem_kernel.dylib        	0x00007fff204b229a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff204b260c mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff205dfc45 __CFRunLoopServiceMachPort + 316
3   com.apple.CoreFoundation      	0x00007fff205de30b __CFRunLoopRun + 1332
4   com.apple.CoreFoundation      	0x00007fff205dd710 CFRunLoopRunSpecific + 567
5   com.apple.CFNetwork           	0x00007fff249b1290 0x7fff24772000 + 2355856
6   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
7   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
8   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 21:: io.sentry.app-hang-tracker
0   libsystem_kernel.dylib        	0x00007fff204b4b92 __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff20434c1a nanosleep + 196
2   com.apple.Foundation          	0x00007fff21326bc8 +[NSThread sleepForTimeInterval:] + 170
3   io.sentry.Sentry              	0x000000010b2ae650 -[SentryThreadWrapper sleepForTimeInterval:] + 64 (SentryThreadWrapper.m:9)
4   io.sentry.Sentry              	0x000000010b263816 -[SentryANRTracker detectANRs] + 1526 (SentryANRTracker.m:103)
5   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
6   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
7   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 22:: io.sentry.app-hang-tracker
0   libsystem_kernel.dylib        	0x00007fff204b4b92 __semwait_signal + 10
1   libsystem_c.dylib             	0x00007fff20434c1a nanosleep + 196
2   com.apple.Foundation          	0x00007fff21326bc8 +[NSThread sleepForTimeInterval:] + 170
3   io.sentry.Sentry              	0x000000010b2ae650 -[SentryThreadWrapper sleepForTimeInterval:] + 64 (SentryThreadWrapper.m:9)
4   io.sentry.Sentry              	0x000000010b263816 -[SentryANRTracker detectANRs] + 1526 (SentryANRTracker.m:103)
5   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
6   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
7   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 23:: com.apple.NSURLConnectionLoader
0   libsystem_kernel.dylib        	0x00007fff204b229a mach_msg_trap + 10
1   libsystem_kernel.dylib        	0x00007fff204b260c mach_msg + 60
2   com.apple.CoreFoundation      	0x00007fff205dfc45 __CFRunLoopServiceMachPort + 316
3   com.apple.CoreFoundation      	0x00007fff205de30b __CFRunLoopRun + 1332
4   com.apple.CoreFoundation      	0x00007fff205dd710 CFRunLoopRunSpecific + 567
5   com.apple.CFNetwork           	0x00007fff249b1290 0x7fff24772000 + 2355856
6   com.apple.Foundation          	0x00007fff21293487 __NSThread__start__ + 1068
7   libsystem_pthread.dylib       	0x00007fff204e78fc _pthread_start + 224
8   libsystem_pthread.dylib       	0x00007fff204e3443 thread_start + 15

Thread 15 crashed with X86 Thread State (64-bit):
  rax: 0x0000000000000000  rbx: 0x0000000000000005  rcx: 0x000000000000fffe  rdx: 0x00000000c300000c
  rdi: 0x0061007200650070  rsi: 0x00007fff7baaaf79  rbp: 0x000070000483a980  rsp: 0x000070000483a948
   r8: 0x00007fa6abf89978   r9: 0x000000000000d80c  r10: 0x00007fff807de050  r11: 0x00007fff202206b2
  r12: 0x0000000000000007  r13: 0x00007fff2038650c  r14: 0x00007fa6ab9dc100  r15: 0x00007fa6aba6b150
  rip: 0x00007fff20385613  rfl: 0x0000000000010246  cr2: 0x00007fff2488d075
  
Logical CPU:     0
Error Code:      0x0100001f
Trap Number:     133

Thread 15 instruction stream not available.

Thread 15 last branch register state not available.
```

</p>
</details> 

Some links to crash reports with the same root cause:
* https://github.com/getsentry/sentry-cocoa/suites/16943969041/artifacts/971940882
* https://github.com/getsentry/sentry-cocoa/suites/16964012836/artifacts/969277370

## :green_heart: How did you test it?
Unit tests and on a real device to ensure the logic of reachability is still working.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
