### PR TITLE
feat: GA MetricKit integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- GA of MetricKit integration (#3340)
+
+Once enabled, this feature subscribes to [MetricKit's](https://developer.apple.com/documentation/metrickit) [MXDiagnosticPayload](https://developer.apple.com/documentation/metrickit/mxdiagnosticpayload) data, converts it to events, and sends it to Sentry.
+The MetricKit integration subscribes to [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic),
+[MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic),
+and [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic).
+
 ## 8.13.1
 
 ### Fixes

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -457,7 +457,8 @@ NS_SWIFT_NAME(Options)
 #if SENTRY_HAS_METRIC_KIT
 
 /**
- * @warning This is an experimental feature and may still have bugs.
+ * Use this feature to enable the Sentry MetricKit integration.
+ *
  * @brief When enabled, the SDK sends @c MXDiskWriteExceptionDiagnostic, @c MXCPUExceptionDiagnostic
  * and
  * @c MXHangDiagnostic to Sentry. The SDK supports this feature from iOS 15 and later and macOS 12


### PR DESCRIPTION




## :scroll: Description

Remove experimental note on options to make the MetricKit integration GA.

## :bulb: Motivation and Context

Fixes GH-2585

## :green_heart: How did you test it?
Nothing to test for removing code comments.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs: https://github.com/getsentry/sentry-docs/pull/8186.
- [x] Review from the native team if needed. 
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
