### PR TITLE
test: Fix flaky Reachability test

### DIFF
--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -165,6 +165,10 @@ SentryConnectivityCallback(
 
         sentry_reachability_queue
             = dispatch_queue_create("io.sentry.cocoa.connectivity", DISPATCH_QUEUE_SERIAL);
+        // Ensure to call CFRelease for the return value of SCNetworkReachabilityCreateWithName, see
+        // https://developer.apple.com/documentation/systemconfiguration/1514904-scnetworkreachabilitycreatewithn?language=objc
+        // and
+        // https://developer.apple.com/documentation/systemconfiguration/scnetworkreachability?language=objc
         _sentry_reachability_ref = SCNetworkReachabilityCreateWithName(NULL, "sentry.io");
         if (!_sentry_reachability_ref) { // Can be null if a bad hostname was specified
             return;
@@ -208,6 +212,7 @@ SentryConnectivityCallback(
         SENTRY_LOG_DEBUG(@"removing callback for reachability ref %@", _sentry_reachability_ref);
         SCNetworkReachabilitySetCallback(_sentry_reachability_ref, NULL, NULL);
         SCNetworkReachabilitySetDispatchQueue(_sentry_reachability_ref, NULL);
+        CFRelease(_sentry_reachability_ref);
         _sentry_reachability_ref = nil;
     }
 

--- a/Tests/SentryTests/Networking/SentryReachabilityTests.m
+++ b/Tests/SentryTests/Networking/SentryReachabilityTests.m
@@ -69,30 +69,41 @@
 
 - (void)testMultipleReachabilityObservers
 {
+    NSLog(@"[Sentry] [TEST] creating observer A");
     TestSentryReachabilityObserver *observerA = [[TestSentryReachabilityObserver alloc] init];
+    NSLog(@"[Sentry] [TEST] adding observer A as reachability observer");
     [self.reachability addObserver:observerA];
 
+    NSLog(@"[Sentry] [TEST] throwaway reachability callback, setting to reachable");
     SentryConnectivityCallback(self.reachability.sentry_reachability_ref,
         kSCNetworkReachabilityFlagsReachable, nil); // ignored, as it's the first callback
+    NSLog(@"[Sentry] [TEST] reachability callback to set to intervention required");
     SentryConnectivityCallback(self.reachability.sentry_reachability_ref,
         kSCNetworkReachabilityFlagsInterventionRequired, nil);
 
+    NSLog(@"[Sentry] [TEST] creating observer B");
     TestSentryReachabilityObserver *observerB = [[TestSentryReachabilityObserver alloc] init];
+    NSLog(@"[Sentry] [TEST] adding observer B as reachability observer");
     [self.reachability addObserver:observerB];
 
+    NSLog(@"[Sentry] [TEST] reachability callback to set to back to reachable");
     SentryConnectivityCallback(
         self.reachability.sentry_reachability_ref, kSCNetworkReachabilityFlagsReachable, nil);
+    NSLog(@"[Sentry] [TEST] reachability callback to set to back to intervention required");
     SentryConnectivityCallback(self.reachability.sentry_reachability_ref,
         kSCNetworkReachabilityFlagsInterventionRequired, nil);
 
+    NSLog(@"[Sentry] [TEST] removing observer B as reachability observer");
     [self.reachability removeObserver:observerB];
 
+    NSLog(@"[Sentry] [TEST] reachability callback to set to back to reachable");
     SentryConnectivityCallback(
         self.reachability.sentry_reachability_ref, kSCNetworkReachabilityFlagsReachable, nil);
 
     XCTAssertEqual(5, observerA.connectivityChangedInvocations);
     XCTAssertEqual(2, observerB.connectivityChangedInvocations);
 
+    NSLog(@"[Sentry] [TEST] removing observer A as reachability observer");
     [self.reachability removeObserver:observerA];
 }
 


### PR DESCRIPTION
The testMultipleReachabilityObservers sometimes times out in CI. As no threading is involved, there is no need for test expectations. So we can replace these expectations by an int keeping track of how often the connectivity changes. This speeds up the tests significantly and reduces the complexity. Furthermore, the reset of SentryReachbility can now only be achieved by calling removeAllObservers.

#skip-changelog