### PR TITLE
Fix: SDK detects OutOfMemory after device reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Improve OOM detection by ignoring system reboot (#3352)
+
 ## 8.14.1
 
 ### Fixes

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -62,7 +62,7 @@ SentryWatchdogTerminationLogic ()
 
     // The app may have been terminated due to device reboot
     if (previousAppState.systemBootTimestamp != currentAppState.systemBootTimestamp) {
-      return NO;
+        return NO;
     }
 
     // This value can change when installing test builds using Xcode or when installing an app

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -60,6 +60,11 @@ SentryWatchdogTerminationLogic ()
         return NO;
     }
 
+    // The app may have been terminated due to device reboot
+    if (previousAppState.systemBootTimestamp != currentAppState.systemBootTimestamp) {
+      return NO;
+    }
+
     // This value can change when installing test builds using Xcode or when installing an app
     // on a device using ad-hoc distribution.
     if (![currentAppState.vendorId isEqualToString:previousAppState.vendorId]) {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -13,6 +13,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         let sentryCrash: TestSentryCrashWrapper
         
         init() {
+            SentryDependencyContainer.sharedInstance().sysctlWrapper = TestSysctl()
             sentryCrash = TestSentryCrashWrapper.sharedInstance()
             sentryCrash.internalActiveDurationSinceLastCrash = 5.0
             sentryCrash.internalCrashedLastLaunch = true

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
@@ -216,7 +216,18 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         sut.start()
         assertNoOOMSent()
     }
-    
+
+    func testDifferentBootTime_NoOOM() {
+        sut = fixture.getSut(usingRealFileManager: true)
+        sut.start()
+        let appState = SentryAppState(releaseName: fixture.options.releaseName ?? "", osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: fixture.sysctl.systemBootTimestamp.addingTimeInterval(1))
+
+        givenPreviousAppState(appState: appState)
+        fixture.mockFileManager.moveAppStateToPreviousAppState()
+        sut.start()
+        assertNoOOMSent()
+    }
+
     func testAppWasInForeground_OOM() {
         sut = fixture.getSut(usingRealFileManager: true)
 


### PR DESCRIPTION
## :scroll: Description

If the host app has been terminated due to device reboot, SentrySDK assumes it as a WatchdogTermination crash. In such cases, mostly, the boot time will be mentioned as "a few seconds before this event". 

![Screenshot 2023-10-19 at 09 52 27](https://github.com/getsentry/sentry-cocoa/assets/1960884/c66f778a-cb4e-4687-991b-646de004b194)

The idea behind this fix is that if the system boot time has been changed since the previous app launch, most likely the app has been terminated due to the reboot and the SentrySDK should not consider it as a WatchdogTermination crash.

## :bulb: Motivation and Context

This change helps reducing the amount of false WatchdogTermination events detected by the SDK.

## :green_heart: How did you test it?

There's a new test case added in the `SentryWatchdogTerminationsTrackerTests.swift` file, which sets the previous app-launch time to different value and expects not sending any OOM event.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
