### PR TITLE
fix: improvements resetting Reachability and other test state

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -33,10 +33,6 @@ class TestCleanup: NSObject {
         
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         
-#if !os(watchOS)
-        SentryDependencyContainer.sharedInstance().reachability.removeAllObservers()
-#endif // !os(watchOS)
-        
         SentryDependencyContainer.reset()
         Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()
         SentryPerformanceTracker.shared.clear()

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -60,6 +60,12 @@ static NSObject *sentryDependencyContainerLock;
 
 + (void)reset
 {
+#if !TARGET_OS_WATCH
+    if (instance) {
+        [instance->_reachability removeAllObservers];
+    }
+#endif // !TARGET_OS_WATCH
+
     instance = [[SentryDependencyContainer alloc] init];
 }
 

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -42,10 +42,13 @@ class SentrySessionTrackerTests: XCTestCase {
     private var fixture: Fixture!
     private var sut: SessionTracker!
     
+    override class func setUp() {
+        super.setUp()
+        clearTestState()
+    }
+    
     override func setUp() {
         super.setUp()
-        
-        clearTestState()
         
         fixture = Fixture()
         

--- a/Tests/SentryTests/Networking/SentryReachabilityTests.m
+++ b/Tests/SentryTests/Networking/SentryReachabilityTests.m
@@ -20,7 +20,8 @@
 
 - (void)connectivityChanged:(BOOL)connected typeDescription:(nonnull NSString *)typeDescription
 {
-    NSLog(@"Received connectivity notification: %i; type: %@", connected, typeDescription);
+    printf("Received connectivity notification: %i; type: %s\n", connected,
+        typeDescription.UTF8String);
     self.connectivityChangedInvocations++;
 }
 
@@ -69,41 +70,41 @@
 
 - (void)testMultipleReachabilityObservers
 {
-    NSLog(@"[Sentry] [TEST] creating observer A");
+    printf("[Sentry] [TEST] creating observer A\n");
     TestSentryReachabilityObserver *observerA = [[TestSentryReachabilityObserver alloc] init];
-    NSLog(@"[Sentry] [TEST] adding observer A as reachability observer");
+    printf("[Sentry] [TEST] adding observer A as reachability observer\n");
     [self.reachability addObserver:observerA];
 
-    NSLog(@"[Sentry] [TEST] throwaway reachability callback, setting to reachable");
+    printf("[Sentry] [TEST] throwaway reachability callback, setting to reachable\n");
     SentryConnectivityCallback(self.reachability.sentry_reachability_ref,
         kSCNetworkReachabilityFlagsReachable, nil); // ignored, as it's the first callback
-    NSLog(@"[Sentry] [TEST] reachability callback to set to intervention required");
+    printf("[Sentry] [TEST] reachability callback to set to intervention required\n");
     SentryConnectivityCallback(self.reachability.sentry_reachability_ref,
         kSCNetworkReachabilityFlagsInterventionRequired, nil);
 
-    NSLog(@"[Sentry] [TEST] creating observer B");
+    printf("[Sentry] [TEST] creating observer B\n");
     TestSentryReachabilityObserver *observerB = [[TestSentryReachabilityObserver alloc] init];
-    NSLog(@"[Sentry] [TEST] adding observer B as reachability observer");
+    printf("[Sentry] [TEST] adding observer B as reachability observer\n");
     [self.reachability addObserver:observerB];
 
-    NSLog(@"[Sentry] [TEST] reachability callback to set to back to reachable");
+    printf("[Sentry] [TEST] reachability callback to set to back to reachable\n");
     SentryConnectivityCallback(
         self.reachability.sentry_reachability_ref, kSCNetworkReachabilityFlagsReachable, nil);
-    NSLog(@"[Sentry] [TEST] reachability callback to set to back to intervention required");
+    printf("[Sentry] [TEST] reachability callback to set to back to intervention required\n");
     SentryConnectivityCallback(self.reachability.sentry_reachability_ref,
         kSCNetworkReachabilityFlagsInterventionRequired, nil);
 
-    NSLog(@"[Sentry] [TEST] removing observer B as reachability observer");
+    printf("[Sentry] [TEST] removing observer B as reachability observer\n");
     [self.reachability removeObserver:observerB];
 
-    NSLog(@"[Sentry] [TEST] reachability callback to set to back to reachable");
+    printf("[Sentry] [TEST] reachability callback to set to back to reachable\n");
     SentryConnectivityCallback(
         self.reachability.sentry_reachability_ref, kSCNetworkReachabilityFlagsReachable, nil);
 
     XCTAssertEqual(5, observerA.connectivityChangedInvocations);
     XCTAssertEqual(2, observerB.connectivityChangedInvocations);
 
-    NSLog(@"[Sentry] [TEST] removing observer A as reachability observer");
+    printf("[Sentry] [TEST] removing observer A as reachability observer\n");
     [self.reachability removeObserver:observerA];
 }
 

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -8,6 +8,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         let queue = DispatchQueue(label: "SentryStacktraceBuilderTests")
 
         var sut: SentryStacktraceBuilder {
+            SentryDependencyContainer.sharedInstance().reachability = TestSentryReachability()
             let res = SentryStacktraceBuilder(crashStackEntryMapper: SentryCrashStackEntryMapper(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])))
             res.symbolicate = true
             return res
@@ -15,11 +16,15 @@ class SentryStacktraceBuilderTests: XCTestCase {
     }
 
     private var fixture: Fixture!
+    
+    override class func setUp() {
+        super.setUp()
+        clearTestState()
+    }
 
     override func setUp() {
         super.setUp()
         fixture = Fixture()
-        clearTestState()
     }
 
     override func tearDown() {
@@ -70,48 +75,61 @@ class SentryStacktraceBuilderTests: XCTestCase {
         XCTAssertTrue(filteredFrames.count == 1, "The frames must be ordered from caller to callee, or oldest to youngest.")
     }
 
-    func testConcurrentStacktraces() {
-        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+    func testConcurrentStacktraces() throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("Not available for earlier platform versions")
+        }
 
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
             options.swiftAsyncStacktraces = true
+            options.debug = true
         }
 
         let waitForAsyncToRun = expectation(description: "Wait async functions")
         Task {
+            print("\(Date()) [Sentry] [TEST] running async task...")
             let filteredFrames = await self.firstFrame()
             waitForAsyncToRun.fulfill()
             XCTAssertGreaterThanOrEqual(filteredFrames, 3, "The Stacktrace must include the async callers.")
         }
-        wait(for: [waitForAsyncToRun], timeout: 1)
+
+        wait(for: [waitForAsyncToRun], timeout: 10)
     }
 
-    func testConcurrentStacktraces_noStitching() {
-        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else { return }
+    func testConcurrentStacktraces_noStitching() throws {
+        guard #available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *) else {
+            throw XCTSkip("Not available for earlier platform versions")
+        }
 
         SentrySDK.start { options in
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
             options.swiftAsyncStacktraces = false
+            options.debug = true
         }
 
         let waitForAsyncToRun = expectation(description: "Wait async functions")
         Task {
+            print("\(Date()) [Sentry] [TEST] running async task...")
             let filteredFrames = await self.firstFrame()
             waitForAsyncToRun.fulfill()
             XCTAssertGreaterThanOrEqual(filteredFrames, 1, "The Stacktrace must have only one function.")
         }
-        wait(for: [waitForAsyncToRun], timeout: 1)
+        wait(for: [waitForAsyncToRun], timeout: 10)
     }
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
     func firstFrame() async -> Int {
+        print("\(Date()) [Sentry] [TEST] first async frame about to await...")
         return await innerFrame1()
     }
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
     func innerFrame1() async -> Int {
-        await Task { @MainActor in }.value
+        print("\(Date()) [Sentry] [TEST] second async frame about to await on task...")
+        await Task { @MainActor in
+            print("\(Date()) [Sentry] [TEST] executing task inside second async frame...")
+        }.value
         return await innerFrame2()
     }
 
@@ -122,37 +140,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         let filteredFrames = actual.frames
             .compactMap({ $0.function })
             .filter { needed.contains(where: $0.contains) }
+        print("\(Date()) [Sentry] [TEST] returning filtered frames.")
         return filteredFrames.count
-
-    }
-
-    func asyncFrame1(expect: XCTestExpectation) {
-        fixture.queue.asyncAfter(deadline: DispatchTime.now()) {
-            self.asyncFrame2(expect: expect)
-        }
-    }
-    
-    func asyncFrame2(expect: XCTestExpectation) {
-        fixture.queue.async {
-            self.asyncAssertion(expect: expect)
-        }
-    }
-    
-    func asyncAssertion(expect: XCTestExpectation) {
-        let actual = fixture.sut.buildStacktraceForCurrentThread()
-
-        let filteredFrames = actual.frames.filter { frame in
-            return frame.function?.contains("testAsyncStacktraces") ?? false ||
-            frame.function?.contains("asyncFrame1") ?? false ||
-            frame.function?.contains("asyncFrame2") ?? false
-        }
-        let startFrames = actual.frames.filter { frame in
-            return frame.stackStart?.boolValue ?? false
-        }
-
-        XCTAssertTrue(filteredFrames.count >= 3, "The Stacktrace must include the async callers.")
-        XCTAssertTrue(startFrames.count >= 3, "The Stacktrace must have async continuation markers.")
-
-        expect.fulfill()
     }
 }


### PR DESCRIPTION
Noticed in some test logs that there were many instances of reachability observers being notified where it didn't make sense to have so many. I realized that as part of `clearTestState()`, we would try to access the dependency container's reachability singleton to reset observers, but if the test had never activated initializing the instance in the first place, then we'd allocate one as a side effect of trying to reset the observers. Those instances then hung around.

I reworked the reset pathway to always remove reachability observers on the reachability instance, if it exists, when calling SentryDependencyContainer.reset.

Also noticed there were some test cases that would call clearTestState in both setUp and tearDown. So we'd have a sequence like

clearTestState
test1
clearTestState
clearTestState
test2
clearTestState
clearTestState
....

I removed it from setUp to avoid the duplicate calls between test cases, but to be on the safe side, added it to the _class_ method setUp, so state would be cleared before the _set_ of test cases ran, just in case there was a legitimate reason to do so. There are probably plenty of test sets that don't call clearTestState in their teardown.

Also at some point I went looking for the logs I'd added to testMultipleReachabilityObservers but didn't see them; I'm not sure NSLog works from both the tests and system under test. I think printf fixes that so all the logs appear in CI.

#skip-changelog