### PR TITLE
fix: remove redundant nilcheck

### DIFF
--- a/Sources/Sentry/Public/SentryMechanism.h
+++ b/Sources/Sentry/Public/SentryMechanism.h
@@ -33,7 +33,7 @@ SENTRY_NO_INIT
  * Flag indicating whether the exception has been handled by the user
  * (e.g. via @c try..catch )
  */
-@property (nonatomic, copy) NSNumber *_Nullable handled;
+@property (nonatomic, copy) NSNumber *handled;
 
 /**
  * An optional flag indicating a synthetic exception. For more info visit

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -262,11 +262,12 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     SentryException *exception = [[SentryException alloc] initWithValue:exceptionValue
                                                                    type:error.domain];
 
-    // Sentry uses the error domain and code on the mechanism for gouping
+    // Sentry uses the error domain and code on the mechanism for grouping
     SentryMechanism *mechanism = [[SentryMechanism alloc] initWithType:@"NSError"];
     SentryMechanismMeta *mechanismMeta = [[SentryMechanismMeta alloc] init];
     mechanismMeta.error = [[SentryNSError alloc] initWithDomain:error.domain code:error.code];
     mechanism.meta = mechanismMeta;
+    mechanism.handled = @YES;
     // The description of the error can be especially useful for error from swift that
     // use a simple enum.
     mechanism.desc = error.description;

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -642,7 +642,7 @@ SentryHub ()
 
             SentryLevel level = sentryLevelForString(eventJson[@"level"]);
             if (level >= kSentryLevelError) {
-                *handled = [self eventContainsOnlyHandledErrors:eventJson];
+                *handled = [self eventContainsUnhandledError:eventJson];
                 return YES;
             }
         }
@@ -650,14 +650,14 @@ SentryHub ()
     return NO;
 }
 
-- (BOOL)eventContainsOnlyHandledErrors:(NSDictionary *)eventDictionary
+- (BOOL)eventContainsUnhandledError:(NSDictionary *)eventDictionary
 {
     NSArray *exceptions = eventDictionary[@"exception"][@"values"];
     for (NSDictionary *exception in exceptions) {
         NSDictionary *mechanism = exception[@"mechanism"];
         NSNumber *handled = mechanism[@"handled"];
 
-        if (handled != nil && [handled boolValue] == NO) {
+        if ([handled boolValue] == NO) {
             return NO;
         }
     }

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -642,7 +642,7 @@ SentryHub ()
 
             SentryLevel level = sentryLevelForString(eventJson[@"level"]);
             if (level >= kSentryLevelError) {
-                *handled = [self eventContainsUnhandledError:eventJson];
+                *handled = [self eventContainsOnlyHandledErrors:eventJson];
                 return YES;
             }
         }
@@ -650,14 +650,14 @@ SentryHub ()
     return NO;
 }
 
-- (BOOL)eventContainsUnhandledError:(NSDictionary *)eventDictionary
+- (BOOL)eventContainsOnlyHandledErrors:(NSDictionary *)eventDictionary
 {
     NSArray *exceptions = eventDictionary[@"exception"][@"values"];
     for (NSDictionary *exception in exceptions) {
         NSDictionary *mechanism = exception[@"mechanism"];
         NSNumber *handled = mechanism[@"handled"];
 
-        if ([handled boolValue] == NO) {
+        if (!handled.boolValue) {
             return NO;
         }
     }

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -657,7 +657,7 @@ SentryHub ()
         NSDictionary *mechanism = exception[@"mechanism"];
         NSNumber *handled = mechanism[@"handled"];
 
-        if (!handled.boolValue) {
+        if (handled.boolValue == NO) {
             return NO;
         }
     }

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -269,7 +269,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertEqual(exceptionType, exception.type)
         XCTAssertEqual(exceptionValue, exception.value)
         XCTAssertEqual(exceptionMechanism, exception.mechanism?.type)
-        XCTAssertEqual(handled, exception.mechanism?.handled?.boolValue)
+        XCTAssertEqual(handled, exception.mechanism?.handled.boolValue)
         XCTAssertEqual(true, exception.mechanism?.synthetic)
         XCTAssertEqual(event?.threads?.first?.threadId, exception.threadId)
         


### PR DESCRIPTION
Just a small thing I noticed and figured could be improved. Sending `boolValue` to `nil` will result in a falsy value.

#skip-changelog