### PR TITLE
feat: Add thread id and name to span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add thread id and name to span data (#3359)
+
 ## 8.14.2
 
 ### Features

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -114,7 +114,7 @@
 {
     BOOL isMainThread = [NSThread isMainThread];
 
-    [span setDataValue:@(isMainThread) forKey:BLOCKED_MAIN_THREAD];
+    [span setDataValue:@(isMainThread) forKey:SPAN_DATA_BLOCKED_MAIN_THREAD];
     NSMutableArray<NSString *> *systems = [NSMutableArray<NSString *> array];
     NSMutableArray<NSString *> *names = [NSMutableArray<NSString *> array];
     [context.persistentStoreCoordinator.persistentStores enumerateObjectsUsingBlock:^(

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -11,6 +11,7 @@
 #import "SentryRandom.h"
 #import "SentrySysctl.h"
 #import "SentrySystemWrapper.h"
+#import "SentryThreadInspector.h"
 #import "SentryUIDeviceWrapper.h"
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
@@ -130,6 +131,19 @@ static NSObject *sentryDependencyContainerLock;
         }
     }
     return _sysctlWrapper;
+}
+
+- (SentryThreadInspector *)threadInspector
+{
+    if (_threadInspector == nil) {
+        @synchronized(sentryDependencyContainerLock) {
+            if (_threadInspector == nil) {
+                SentryOptions *options = [[[SentrySDK currentHub] getClient] options];
+                _threadInspector = [[SentryThreadInspector alloc] initWithOptions:options];
+            }
+        }
+    }
+    return _threadInspector;
 }
 
 - (SentryExtraContextProvider *)extraContextProvider

--- a/Sources/Sentry/SentryNSDataTracker.m
+++ b/Sources/Sentry/SentryNSDataTracker.m
@@ -190,7 +190,7 @@ SentryNSDataTracker ()
 {
     BOOL isMainThread = [NSThread isMainThread];
 
-    [span setDataValue:@(isMainThread) forKey:BLOCKED_MAIN_THREAD];
+    [span setDataValue:@(isMainThread) forKey:SPAN_DATA_BLOCKED_MAIN_THREAD];
 
     if (!isMainThread) {
         return;
@@ -210,7 +210,7 @@ SentryNSDataTracker ()
         // and only the 'main' frame remains in the stack
         // therefore, there is nothing to do about it
         // and we should not report it as an issue.
-        [span setDataValue:@(NO) forKey:BLOCKED_MAIN_THREAD];
+        [span setDataValue:@(NO) forKey:SPAN_DATA_BLOCKED_MAIN_THREAD];
     } else {
         [((SentrySpan *)span) setFrames:frames];
     }

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -45,7 +45,9 @@ SentrySpan ()
         } else {
             NSString *threadName = [SentryDependencyContainer.sharedInstance.threadInspector
                 getThreadName:currentThread];
-            _data[SPAN_DATA_THREAD_NAME] = threadName;
+            if (threadName.length > 0) {
+                _data[SPAN_DATA_THREAD_NAME] = threadName;
+            }
         }
 
         _tags = [[NSMutableDictionary alloc] init];

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -1,10 +1,12 @@
 #import "SentrySpan.h"
 #import "NSDate+SentryExtras.h"
 #import "NSDictionary+SentrySanitize.h"
+#import "SentryCrashThread.h"
 #import "SentryCurrentDateProvider.h"
 #import "SentryDependencyContainer.h"
 #import "SentryFrame.h"
 #import "SentryId.h"
+#import "SentryInternalDefines.h"
 #import "SentryLog.h"
 #import "SentryMeasurementValue.h"
 #import "SentryNoOpSpan.h"
@@ -12,6 +14,7 @@
 #import "SentrySerializable.h"
 #import "SentrySpanContext.h"
 #import "SentrySpanId.h"
+#import "SentryThreadInspector.h"
 #import "SentryTime.h"
 #import "SentryTraceHeader.h"
 #import "SentryTracer.h"
@@ -33,6 +36,18 @@ SentrySpan ()
     if (self = [super init]) {
         self.startTimestamp = [SentryDependencyContainer.sharedInstance.dateProvider date];
         _data = [[NSMutableDictionary alloc] init];
+
+        SentryCrashThread currentThread = sentrycrashthread_self();
+        _data[SPAN_DATA_THREAD_ID] = @(currentThread);
+
+        if ([NSThread isMainThread]) {
+            _data[SPAN_DATA_THREAD_NAME] = @"main";
+        } else {
+            NSString *threadName = [SentryDependencyContainer.sharedInstance.threadInspector
+                getThreadName:currentThread];
+            _data[SPAN_DATA_THREAD_NAME] = threadName;
+        }
+
         _tags = [[NSMutableDictionary alloc] init];
         _isFinished = NO;
 

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -17,6 +17,7 @@
 @class SentrySysctl;
 @class SentrySystemWrapper;
 @class SentryThreadWrapper;
+@class SentryThreadInspector;
 @protocol SentryRandom;
 
 #if SENTRY_HAS_METRIC_KIT
@@ -68,6 +69,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryBinaryImageCache *binaryImageCache;
 @property (nonatomic, strong) SentryExtraContextProvider *extraContextProvider;
 @property (nonatomic, strong) SentrySysctl *sysctlWrapper;
+@property (nonatomic, strong) SentryThreadInspector *threadInspector;
 
 #if SENTRY_UIKIT_AVAILABLE
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;

--- a/Sources/Sentry/include/SentryInternalDefines.h
+++ b/Sources/Sentry/include/SentryInternalDefines.h
@@ -59,4 +59,6 @@ static NSString *const SentryPlatformName = @"cocoa";
         (__cond_result);                                                                           \
     })
 
-#define BLOCKED_MAIN_THREAD @"blocked_main_thread"
+#define SPAN_DATA_BLOCKED_MAIN_THREAD @"blocked_main_thread"
+#define SPAN_DATA_THREAD_ID @"thread.id"
+#define SPAN_DATA_THREAD_NAME @"thread.name"

--- a/Sources/Sentry/include/SentryThreadInspector.h
+++ b/Sources/Sentry/include/SentryThreadInspector.h
@@ -31,6 +31,8 @@ SENTRY_NO_INIT
  */
 - (NSArray<SentryThread *> *)getCurrentThreadsWithStackTrace;
 
+- (NSString *)getThreadName:(SentryCrashThread)thread;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -61,7 +61,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(NSNumber(value: threadId), span.data["thread.id"] as! NSNumber)
     }
     
-    func testInit_SetsThreadInfoAsSpanData_FromBackGroundThread() {
+    func testInit_SetsThreadInfoAsSpanData_FromBackgroundThread() {
         let expect = expectation(description: "Thread must be called.")
         
         Thread.detachNewThread {
@@ -70,6 +70,23 @@ class SentrySpanTests: XCTestCase {
             
             let span = self.fixture.getSut()
             XCTAssertEqual(threadName, span.data["thread.name"] as! String)
+            let threadId = sentrycrashthread_self()
+            XCTAssertEqual(NSNumber(value: threadId), span.data["thread.id"] as! NSNumber)
+            
+            expect.fulfill()
+        }
+        
+        wait(for: [expect], timeout: 0.1)
+    }
+    
+    func testInit_SetsThreadInfoAsSpanData_FromBackgroundThreadWithNoName() {
+        let expect = expectation(description: "Thread must be called.")
+        
+        Thread.detachNewThread {
+            Thread.current.name = ""
+            
+            let span = self.fixture.getSut()
+            XCTAssertNil(span.data["thread.name"])
             let threadId = sentrycrashthread_self()
             XCTAssertEqual(NSNumber(value: threadId), span.data["thread.id"] as! NSNumber)
             

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -1097,7 +1097,8 @@ class SentryTracerTests: XCTestCase {
         let sut = fixture.getSut()
         sut.setExtra(value: 0, key: "key")
         
-        XCTAssertEqual(["key": 0], sut.data as! [String: Int])
+        let data = sut.data as [String: Any]
+        XCTAssertEqual(0, data["key"] as? Int)
     }
 
     private func advanceTime(bySeconds: TimeInterval) {

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -139,10 +139,10 @@ class SentryTransactionTests: XCTestCase {
         
         // when
         let serializedTransaction = sut.serialize()
-        let serializedTransactionExtra = try! XCTUnwrap(serializedTransaction["extra"] as? [String: String])
+        let serializedTransactionExtra = try! XCTUnwrap(serializedTransaction["extra"] as? [String: Any])
         
         // then
-        XCTAssertEqual(serializedTransactionExtra, [fixture.testKey: fixture.testValue])
+        XCTAssertEqual(serializedTransactionExtra[fixture.testKey] as! String, fixture.testValue)
     }
     
     func testSerialize_shouldPreserveExtraFromScope() {
@@ -156,10 +156,10 @@ class SentryTransactionTests: XCTestCase {
 
         // when
         let serializedTransaction = sut.serialize()
-        let serializedTransactionExtra = try! XCTUnwrap(serializedTransaction["extra"] as? [String: String])
+        let serializedTransactionExtra = try! XCTUnwrap(serializedTransaction["extra"] as? [String: Any])
         
         // then
-        XCTAssertEqual(serializedTransactionExtra, [fixture.testKey: fixture.testValue])
+        XCTAssertEqual(serializedTransactionExtra[fixture.testKey] as! String, fixture.testValue)
     }
     
     func testSerializeOrigin() throws {


### PR DESCRIPTION
## :scroll: Description

Add current thread name and thread id to every span when the SDK initializes the span.

## :bulb: Motivation and Context

Fixes GH-3355

## :green_heart: How did you test it?
Unit tests and with the sample app.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
