### PR TITLE
impr: Stop sending empty thread names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add thread id and name to span data (#3359)
 
+### Improvements
+
+- Stop sending empty thread names (#3361)
+
 ## 8.14.2
 
 ### Features

--- a/Sources/Sentry/SentryCrashDefaultMachineContextWrapper.m
+++ b/Sources/Sentry/SentryCrashDefaultMachineContextWrapper.m
@@ -41,11 +41,16 @@ SentryCrashThread mainThreadID;
     return thread;
 }
 
-- (void)getThreadName:(const SentryCrashThread)thread
+- (BOOL)getThreadName:(const SentryCrashThread)thread
             andBuffer:(char *const)buffer
          andBufLength:(int)bufLength;
 {
-    sentrycrashthread_getThreadName(thread, buffer, bufLength);
+    bool result = sentrycrashthread_getThreadName(thread, buffer, bufLength);
+    if (result == true) {
+        return YES;
+    } else {
+        return NO;
+    }
 }
 
 - (BOOL)isMainThread:(SentryCrashThread)thread

--- a/Sources/Sentry/SentryCrashDefaultMachineContextWrapper.m
+++ b/Sources/Sentry/SentryCrashDefaultMachineContextWrapper.m
@@ -45,12 +45,7 @@ SentryCrashThread mainThreadID;
             andBuffer:(char *const)buffer
          andBufLength:(int)bufLength;
 {
-    bool result = sentrycrashthread_getThreadName(thread, buffer, bufLength);
-    if (result == true) {
-        return YES;
-    } else {
-        return NO;
-    }
+    return sentrycrashthread_getThreadName(thread, buffer, bufLength) == true;
 }
 
 - (BOOL)isMainThread:(SentryCrashThread)thread

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -43,11 +43,8 @@ SentrySpan ()
         if ([NSThread isMainThread]) {
             _data[SPAN_DATA_THREAD_NAME] = @"main";
         } else {
-            NSString *threadName = [SentryDependencyContainer.sharedInstance.threadInspector
+            _data[SPAN_DATA_THREAD_NAME] = [SentryDependencyContainer.sharedInstance.threadInspector
                 getThreadName:currentThread];
-            if (threadName.length > 0) {
-                _data[SPAN_DATA_THREAD_NAME] = threadName;
-            }
         }
 
         _tags = [[NSMutableDictionary alloc] init];

--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -202,17 +202,24 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
     return threads;
 }
 
-- (NSString *)getThreadName:(SentryCrashThread)thread
+- (nullable NSString *)getThreadName:(SentryCrashThread)thread
 {
-    char buffer[128];
+    int bufferLength = 128;
+    char buffer[bufferLength];
     char *const pBuffer = buffer;
-    [self.machineContextWrapper getThreadName:thread andBuffer:pBuffer andBufLength:128];
 
-    NSString *threadName = [NSString stringWithCString:pBuffer encoding:NSUTF8StringEncoding];
-    if (nil == threadName) {
-        threadName = @"";
+    BOOL didGetThreadNameSucceed = [self.machineContextWrapper getThreadName:thread
+                                                                   andBuffer:pBuffer
+                                                                andBufLength:bufferLength];
+
+    if (didGetThreadNameSucceed == YES) {
+        NSString *threadName = [NSString stringWithCString:pBuffer encoding:NSUTF8StringEncoding];
+        if (threadName.length > 0) {
+            return threadName;
+        }
     }
-    return threadName;
+
+    return nil;
 }
 
 @end

--- a/Sources/Sentry/include/SentryCrashMachineContextWrapper.h
+++ b/Sources/Sentry/include/SentryCrashMachineContextWrapper.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (SentryCrashThread)getThread:(struct SentryCrashMachineContext *)context withIndex:(int)index;
 
-- (void)getThreadName:(const SentryCrashThread)thread
+- (BOOL)getThreadName:(const SentryCrashThread)thread
             andBuffer:(char *const)buffer
          andBufLength:(int)bufLength;
 

--- a/Sources/Sentry/include/SentryThreadInspector.h
+++ b/Sources/Sentry/include/SentryThreadInspector.h
@@ -31,7 +31,7 @@ SENTRY_NO_INIT
  */
 - (NSArray<SentryThread *> *)getCurrentThreadsWithStackTrace;
 
-- (NSString *)getThreadName:(SentryCrashThread)thread;
+- (nullable NSString *)getThreadName:(SentryCrashThread)thread;
 
 @end
 

--- a/Tests/SentryTests/Protocol/SentryThreadTests.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadTests.swift
@@ -18,6 +18,15 @@ class SentryThreadTests: XCTestCase {
         XCTAssertTrue(actual["main"] as! Bool)
     }
     
+    func testSerialize_ThreadNameNil() {
+        let thread = TestData.thread
+        thread.name = nil
+        
+        let actual = thread.serialize()
+        
+        XCTAssertNil(actual["name"])
+    }
+    
     func testSerialize_Bools() {
         let thread = SentryThread(threadId: 0)
         


### PR DESCRIPTION


## :scroll: Description

Set the thread name to nil when retrieving the thread name from the machine context wrapper in case it fails or the thread name is empty. This slightly reduces the payload size.

## :bulb: Motivation and Context

Came up here https://github.com/getsentry/sentry-cocoa/pull/3359#discussion_r1374232007.

## :green_heart: How did you test it?
Unit test and running the sample app on a simulator

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
