### PR TITLE
ref: remove header import in header, in favor of fcd already present

### DIFF
--- a/Sources/Sentry/SentryEnvelopeRateLimit.m
+++ b/Sources/Sentry/SentryEnvelopeRateLimit.m
@@ -1,6 +1,7 @@
 #import "SentryEnvelopeRateLimit.h"
 #import "SentryDataCategoryMapper.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
 #import "SentryRateLimits.h"
 #import <Foundation/Foundation.h>
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -7,6 +7,7 @@
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryDsn.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
 #import "SentryError.h"
 #import "SentryEvent.h"
 #import "SentryFileContents.h"

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -9,6 +9,7 @@
 #import "SentryDsn.h"
 #import "SentryEnvelope+Private.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryEnvelopeRateLimit.h"
 #import "SentryEvent.h"

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -3,6 +3,7 @@
 #import "SentryCurrentDateProvider.h"
 #import "SentryDependencyContainer.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryEvent+Private.h"
 #import "SentryFileManager.h"

--- a/Sources/Sentry/SentryMigrateSessionInit.m
+++ b/Sources/Sentry/SentryMigrateSessionInit.m
@@ -1,5 +1,6 @@
 #import "SentryMigrateSessionInit.h"
 #import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryLog.h"
 #import "SentrySerialization.h"

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -12,7 +12,7 @@
 #    import "SentryDispatchFactory.h"
 #    import "SentryDispatchSourceWrapper.h"
 #    import "SentryEnvelope.h"
-#import "SentryEnvelopeItemHeader.h"
+#    import "SentryEnvelopeItemHeader.h"
 #    import "SentryEnvelopeItemType.h"
 #    import "SentryEvent+Private.h"
 #    import "SentryFormatter.h"

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -12,6 +12,7 @@
 #    import "SentryDispatchFactory.h"
 #    import "SentryDispatchSourceWrapper.h"
 #    import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
 #    import "SentryEnvelopeItemType.h"
 #    import "SentryEvent+Private.h"
 #    import "SentryFormatter.h"

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
@@ -1,9 +1,4 @@
 #import "PrivatesHeader.h"
-#if __has_include(<Sentry/SentryEnvelopeItemHeader.h>)
-#    import <Sentry/SentryEnvelopeItemHeader.h>
-#else
-#    import "SentryEnvelopeItemHeader.h"
-#endif
 
 #if COCOAPODS
 @class SentrySdkInfo, SentryTraceContext;


### PR DESCRIPTION
This prevented Sentry from being build on an Intel mac, causing weird errors in the umbrella header until i made this change, then it built.

In general we should not import a header in another header unless we need to subclass an interface defined in it, etc.

#skip-changelog

