### PR TITLE
fix: avoid call to possibly crashing `mach_thread_deallocate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Stop sending empty thread names (#3361)
-- Work around edge case with a thread info syscall sometimes returning an invalid pointer, leading to a crash (#3364)
+- Work around edge case with a thread info kernel call sometimes returning invalid data, leading to a crash (#3364)
 
 ## 8.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add thread id and name to span data (#3359)
 
+### Fixes
+
+- Work around edge case with a thread info syscall sometimes returning an invalid pointer, leading to a crash (#3364)
+
 ## 8.14.2
 
 ### Features

--- a/Sources/Sentry/SentryBacktrace.cpp
+++ b/Sources/Sentry/SentryBacktrace.cpp
@@ -68,6 +68,7 @@ namespace profiling {
         } else {
             current = getFrameAddress(&machineContext);
         }
+
         // Even if this bounds check passes, the frame pointer address could still be invalid if the
         // thread was suspended in an inconsistent state. The best we can do is to detect these
         // situations at symbolication time on the server and filter them out -- there's not an easy
@@ -76,6 +77,7 @@ namespace profiling {
         if (UNLIKELY(!isValidFrame(current, bounds))) {
             return 0;
         }
+
         bool reachedEndOfStack = false;
         while (depth < maxDepth) {
             const auto frame = reinterpret_cast<StackFrame *>(current);
@@ -92,6 +94,7 @@ namespace profiling {
                 break;
             }
         }
+
         if (LIKELY(reachedEndOfStackPtr != nullptr)) {
             *reachedEndOfStackPtr = reachedEndOfStack;
         }

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -44,9 +44,8 @@ namespace profiling {
     std::unique_ptr<ThreadHandle>
     ThreadHandle::current() noexcept
     {
-        const auto port = mach_thread_self();
-        SENTRY_PROF_LOG_KERN_RETURN(mach_port_deallocate(mach_task_self(), port));
-        return std::make_unique<ThreadHandle>(port);
+        const auto thread = pthread_mach_thread_np(pthread_self());
+        return std::make_unique<ThreadHandle>(thread);
     }
 
     std::vector<std::unique_ptr<ThreadHandle>>


### PR DESCRIPTION
In an attempt to fix https://github.com/getsentry/sentry-cocoa/issues/3354, but unverified because we have no repro.

The crash report in the attached issue points to line 49 in SentryThreadHandle.cpp, but that is not actually the line crashing if you look at the source code, which is constructing a C++ unique pointer, the line above that is actually a macro: when it expands in place, the actual line of code crashing on line 49 is actually the call to mach_port_deallocate wrapped in the macro–see the definition for SENTRY_PROF_LOG_KERN_RETURN: https://github.com/getsentry/sentry-cocoa/blob/2124551ae0a2da085c69d3f0838e9be646fa4a70/Sources/Sentry/include/SentryMachLogging.hpp#L30-L38) 

We hope that avoiding the call to mach_port_deallocate avoids the whatever issue is occurring, and also that the new logic is potentially more efficient. See https://codereview.chromium.org/276043002/ for more information.