### PR TITLE
Revert "Fix: App hang being reported from background"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@
 
 ### Fixes
 
-- Reporting app hangs from background (#3298)
 - Missing `mechanism.handled` is not considered crash (#3353)
 
 ## 8.14.1
@@ -45,7 +44,6 @@ Once enabled, this feature subscribes to [MetricKit's](https://developer.apple.c
 The MetricKit integration subscribes to [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic),
 [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic),
 and [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic).
-
 
 ## 8.13.1
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -3,7 +3,6 @@
 #import "SentryClient+Private.h"
 #import "SentryCrashMachineContext.h"
 #import "SentryCrashWrapper.h"
-#import "SentryDependencyContainer.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryEvent.h"
 #import "SentryException.h"
@@ -15,12 +14,8 @@
 #import "SentryThread.h"
 #import "SentryThreadInspector.h"
 #import "SentryThreadWrapper.h"
-#import "SentryUIApplication.h"
+#import <SentryDependencyContainer.h>
 #import <SentryOptions+Private.h>
-
-#if SENTRY_HAS_UIKIT
-#    import <UIKit/UIKit.h>
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -66,14 +61,6 @@ SentryANRTrackingIntegration ()
 
 - (void)anrDetected
 {
-#if SENTRY_HAS_UIKIT
-    // If the app is not active, the main thread may be blocked or too busy.
-    // Since there is no UI for the user to interact, there is no need to report app hang.
-    if (SentryDependencyContainer.sharedInstance.application.applicationState
-        != UIApplicationStateActive) {
-        return;
-    }
-#endif
     SentryThreadInspector *threadInspector = SentrySDK.currentHub.getClient.threadInspector;
 
     NSArray<SentryThread *> *threads = [threadInspector getCurrentThreadsWithStackTrace];

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -56,11 +56,6 @@
     return result;
 }
 
-- (UIApplicationState)applicationState
-{
-    return self.sharedApplication.applicationState;
-}
-
 @end
 
 #endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryUIApplication.h
+++ b/Sources/Sentry/include/SentryUIApplication.h
@@ -7,19 +7,12 @@
 @class UIWindow;
 @protocol UIApplicationDelegate;
 
-typedef NS_ENUM(NSInteger, UIApplicationState);
-
 NS_ASSUME_NONNULL_BEGIN
 
 /**
  * A helper tool to retrieve informations from the application instance.
  */
 @interface SentryUIApplication : NSObject
-
-/**
- * Returns the application state available at @c NSApplication.sharedApplication.applicationState
- */
-@property (nonatomic, readonly) UIApplicationState applicationState;
 
 /**
  * Application shared UIApplication instance.

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -108,23 +108,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         
         assertNoEventCaptured()
     }
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-    func testANRDetected_ButBackground_EventNotCaptured() {
-
-        class BackgroundSentryUIApplication: SentryUIApplication {
-            override var applicationState: UIApplication.State { .background }
-        }
-
-        givenInitializedTracker()
-        setUpThreadInspector()
-        SentryDependencyContainer.sharedInstance().application = BackgroundSentryUIApplication()
-
-        Dynamic(sut).anrDetected()
-
-        assertNoEventCaptured()
-    }
-#endif
-
+    
     func testDealloc_CallsUninstall() {
         givenInitializedTracker()
         
@@ -153,7 +137,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
     
     private func setUpThreadInspector(addThreads: Bool = true) {
         let threadInspector = TestThreadInspector.instance
-
+        
         if addThreads {
             
             let frame1 = Sentry.Frame()


### PR DESCRIPTION
Revert #3298 because `ProfilingUITests.testProfilingGPUInfo` continuously fails after merging #3298 to the main branch.

I could reproduce `ProfilingUITests.testProfilingGPUInfo` failing when running all UITests locally. Only running `ProfilingUITests.testProfilingGPUInfo` succeeds. Commenting out the following code made the test work again.

https://github.com/getsentry/sentry-cocoa/blob/dd0557fb0fec40f5527e4f40ead6f82e092fde0f/Sources/Sentry/SentryANRTrackingIntegration.m#L69-L76

#skip-changelog