### PR TITLE
test: Add BaseUITest class

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0AAAB8572887F7C60011845C /* PermissionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2E928855FF80057ED69 /* PermissionsViewController.swift */; };
 		0AABE2EA28855FF80057ED69 /* PermissionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AABE2E928855FF80057ED69 /* PermissionsViewController.swift */; };
+		62C07D5C2AF3E3F500894688 /* BaseUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C07D5B2AF3E3F500894688 /* BaseUITest.swift */; };
 		630853532440C60F00DDE4CE /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 630853322440C44F00DDE4CE /* Sentry.framework */; };
 		637AFDAA243B02760034958B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637AFDA9243B02760034958B /* AppDelegate.swift */; };
 		637AFDAE243B02760034958B /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 637AFDAD243B02760034958B /* ViewController.swift */; };
@@ -270,6 +271,7 @@
 
 /* Begin PBXFileReference section */
 		0AABE2E928855FF80057ED69 /* PermissionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsViewController.swift; sourceTree = "<group>"; };
+		62C07D5B2AF3E3F500894688 /* BaseUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUITest.swift; sourceTree = "<group>"; };
 		6308532C2440C44F00DDE4CE /* Sentry.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sentry.xcodeproj; path = ../../Sentry.xcodeproj; sourceTree = "<group>"; };
 		637AFDA6243B02760034958B /* iOS-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		637AFDA9243B02760034958B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -478,6 +480,7 @@
 			isa = PBXGroup;
 			children = (
 				D83A30DF279F1F5C00372D0A /* fatal-error-binary-images-message2.json */,
+				62C07D5B2AF3E3F500894688 /* BaseUITest.swift */,
 				7B64386A26A6C544000D0F65 /* LaunchUITests.swift */,
 				D8C33E2529FBB8D90071B75A /* UIEventBreadcrumbTests.swift */,
 				84A5D72C29D2708D00388BFA /* UITestHelpers.swift */,
@@ -929,6 +932,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62C07D5C2AF3E3F500894688 /* BaseUITest.swift in Sources */,
 				84A5D72629D2705000388BFA /* ProfilingUITests.swift in Sources */,
 				84A5D72D29D2708D00388BFA /* UITestHelpers.swift in Sources */,
 				84B527B928DD24BA00475E8D /* SentryDeviceTests.mm in Sources */,

--- a/Samples/iOS-Swift/iOS-SwiftUITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/BaseUITest.swift
@@ -1,0 +1,25 @@
+import XCTest
+
+class BaseUITest: XCTestCase {
+    internal let app: XCUIApplication = XCUIApplication()
+    
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        XCUIDevice.shared.orientation = .portrait
+        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
+        app.launch()
+        
+        waitForExistenceOfMainScreen()
+    }
+    
+    override func tearDown() {
+        app.terminate()
+        super.tearDown()
+    }
+    
+    func waitForExistenceOfMainScreen() {
+        app.waitForExistence( "Home Screen doesn't exist.")
+    }
+    
+}

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -1,22 +1,6 @@
 import XCTest
 
-class LaunchUITests: XCTestCase {
-    private let app: XCUIApplication = XCUIApplication()
-
-    override func setUp() {
-        super.setUp()
-        continueAfterFailure = false
-        XCUIDevice.shared.orientation = .portrait
-        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
-        app.launch()
-        
-        waitForExistenceOfMainScreen()
-    }
-    
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
+class LaunchUITests: BaseUITest {
 
     func testCrashRecovery() {
         //We will be removing this test from iOS 12 because it fails during CI, which looks like a bug that we cannot reproduce.
@@ -120,9 +104,6 @@ class LaunchUITests: XCTestCase {
 }
 
 private extension LaunchUITests {
-    func waitForExistenceOfMainScreen() {
-        app.waitForExistence( "Home Screen doesn't exist.")
-    }
     
     func checkSlowAndFrozenFrames() {
         let frameStatsLabel = app.staticTexts["framesStatsLabel"]

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -1,15 +1,6 @@
 import XCTest
 
-final class ProfilingUITests: XCTestCase {
-    private let app: XCUIApplication = XCUIApplication()
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        continueAfterFailure = false
-        XCUIDevice.shared.orientation = .portrait
-        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
-        app.launch()
-    }
+final class ProfilingUITests: BaseUITest {
 
     /**
      * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
@@ -1,22 +1,6 @@
 import XCTest
 
-class UIEventBreadcrumbTests: XCTestCase {
-    private let app: XCUIApplication = XCUIApplication()
-
-    override func setUp() {
-        super.setUp()
-        continueAfterFailure = false
-        XCUIDevice.shared.orientation = .portrait
-        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
-        app.launch()
-
-        waitForExistenceOfMainScreen()
-    }
-
-    override func tearDown() {
-        app.terminate()
-        super.tearDown()
-    }
+class UIEventBreadcrumbTests: BaseUITest {
 
     func testNoBreadcrumbForTextFieldEditingChanged() {
         app.buttons["Extra"].tap()
@@ -43,9 +27,5 @@ class UIEventBreadcrumbTests: XCTestCase {
         let info = app.staticTexts["infoLabel"].label
 
         XCTAssertNotEqual(info, "ERROR")
-    }
-
-    func waitForExistenceOfMainScreen() {
-        app.waitForExistence( "Home Screen doesn't exist.")
     }
 }


### PR DESCRIPTION
Add a base class for UITests for the iOSSwift to remove some redundant code.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/3370.