### PR TITLE
fix: Reading applicationState in the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 - Stop sending empty thread names (#3361)
 - Work around edge case with a thread info kernel call sometimes returning invalid data, leading to a crash (#3364)
-- Reading applicationState in the background (#3372)
 
 ## 8.14.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Stop sending empty thread names (#3361)
 - Work around edge case with a thread info kernel call sometimes returning invalid data, leading to a crash (#3364)
+- Reading applicationState in the background (#3372)
 
 ## 8.14.2
 

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -8,20 +8,21 @@
     UIApplicationState appState;
 }
 
-- (instancetype)init{
+- (instancetype)init
+{
     if (self = [super init]) {
         [NSNotificationCenter.defaultCenter addObserver:self
                                                selector:@selector(didEnterBackground)
                                                    name:UIApplicationDidEnterBackgroundNotification
                                                  object:nil];
-        
+
         [NSNotificationCenter.defaultCenter addObserver:self
                                                selector:@selector(didBecomeActive)
                                                    name:UIApplicationDidBecomeActiveNotification
                                                  object:nil];
-        //We store the application state when the app is initialized
-        //and we keep track of its changes by the notifications
-        //this way we avoid calling sharedApplication in a background thread
+        // We store the application state when the app is initialized
+        // and we keep track of its changes by the notifications
+        // this way we avoid calling sharedApplication in a background thread
         appState = self.sharedApplication.applicationState;
     }
     return self;
@@ -87,11 +88,13 @@
     return appState;
 }
 
-- (void)didEnterBackground {
+- (void)didEnterBackground
+{
     appState = UIApplicationStateBackground;
 }
 
-- (void)didBecomeActive {
+- (void)didBecomeActive
+{
     appState = UIApplicationStateActive;
 }
 

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -4,7 +4,33 @@
 
 #    import <UIKit/UIKit.h>
 
-@implementation SentryUIApplication
+@implementation SentryUIApplication {
+    UIApplicationState appState;
+}
+
+- (instancetype)init{
+    if (self = [super init]) {
+        [NSNotificationCenter.defaultCenter addObserver:self
+                                               selector:@selector(didEnterBackground)
+                                                   name:UIApplicationDidEnterBackgroundNotification
+                                                 object:nil];
+        
+        [NSNotificationCenter.defaultCenter addObserver:self
+                                               selector:@selector(didBecomeActive)
+                                                   name:UIApplicationDidBecomeActiveNotification
+                                                 object:nil];
+        //We store the application state when the app is initialized
+        //and we keep track of its changes by the notifications
+        //this way we avoid calling sharedApplication in a background thread
+        appState = self.sharedApplication.applicationState;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [NSNotificationCenter.defaultCenter removeObserver:self];
+}
 
 - (UIApplication *)sharedApplication
 {
@@ -58,7 +84,15 @@
 
 - (UIApplicationState)applicationState
 {
-    return self.sharedApplication.applicationState;
+    return appState;
+}
+
+- (void)didEnterBackground {
+    appState = UIApplicationStateBackground;
+}
+
+- (void)didBecomeActive {
+    appState = UIApplicationStateActive;
 }
 
 @end

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -1,4 +1,6 @@
 #import "SentryUIApplication.h"
+#import "SentryDependencyContainer.h"
+#import "SentryNSNotificationCenterWrapper.h"
 
 #if SENTRY_HAS_UIKIT
 
@@ -11,15 +13,16 @@
 - (instancetype)init
 {
     if (self = [super init]) {
-        [NSNotificationCenter.defaultCenter addObserver:self
-                                               selector:@selector(didEnterBackground)
-                                                   name:UIApplicationDidEnterBackgroundNotification
-                                                 object:nil];
 
-        [NSNotificationCenter.defaultCenter addObserver:self
-                                               selector:@selector(didBecomeActive)
-                                                   name:UIApplicationDidBecomeActiveNotification
-                                                 object:nil];
+        [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
+            addObserver:self
+               selector:@selector(didEnterBackground)
+                   name:UIApplicationDidEnterBackgroundNotification];
+
+        [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
+            addObserver:self
+               selector:@selector(didBecomeActive)
+                   name:UIApplicationDidBecomeActiveNotification];
         // We store the application state when the app is initialized
         // and we keep track of its changes by the notifications
         // this way we avoid calling sharedApplication in a background thread
@@ -30,7 +33,7 @@
 
 - (void)dealloc
 {
-    [NSNotificationCenter.defaultCenter removeObserver:self];
+    [SentryDependencyContainer.sharedInstance.notificationCenterWrapper removeObserver:self];
 }
 
 - (UIApplication *)sharedApplication

--- a/Tests/SentryTests/Helper/TestNSNotificationCenterWrapper.swift
+++ b/Tests/SentryTests/Helper/TestNSNotificationCenterWrapper.swift
@@ -2,6 +2,9 @@ import Foundation
 import SentryTestUtils
 
 @objcMembers public class TestNSNotificationCenterWrapper: SentryNSNotificationCenterWrapper {
+    
+    var ignoreRemoveObserver = false
+    
     var addObserverInvocations = Invocations<(observer: Any, selector: Selector, name: NSNotification.Name)>()
     public var addObserverInvocationsCount: Int {
         return addObserverInvocations.count
@@ -24,6 +27,8 @@ import SentryTestUtils
         return removeObserverInvocations.count
     }
     public override func removeObserver(_ observer: Any) {
-        removeObserverInvocations.record(observer)
+        if ignoreRemoveObserver == false {
+            removeObserverInvocations.record(observer)
+        }
     }
 }

--- a/Tests/SentryTests/SentryUIApplicationTests.swift
+++ b/Tests/SentryTests/SentryUIApplicationTests.swift
@@ -45,6 +45,32 @@ class SentryUIApplicationTests: XCTestCase {
 
         XCTAssertEqual(sut.windows?.count, 0)
     }
+    
+    @available(iOS 13.0, tvOS 13.0, *)
+    func test_ApplicationState() {
+        let notificationCenter = TestNSNotificationCenterWrapper()
+        notificationCenter.ignoreRemoveObserver = true
+        SentryDependencyContainer.sharedInstance().notificationCenterWrapper = notificationCenter
+        
+        let sut = MockSentryUIApplicationTests()
+        XCTAssertEqual(sut.applicationState, .active)
+        
+        notificationCenter.addObserverInvocations.invocations.forEach { (observer: Any, selector: Selector, name: NSNotification.Name) in
+            if name == UIApplication.didEnterBackgroundNotification {
+                sut.perform(selector, with: observer)
+            }
+        }
+        
+        XCTAssertEqual(sut.applicationState, .background)
+        
+        notificationCenter.addObserverInvocations.invocations.forEach { (observer: Any, selector: Selector, name: NSNotification.Name) in
+            if name == UIApplication.didBecomeActiveNotification {
+                sut.perform(selector, with: observer)
+            }
+        }
+        
+        XCTAssertEqual(sut.applicationState, .active)
+    }
 
     private class TestApplicationDelegate: NSObject, UIApplicationDelegate {
         var window: UIWindow?


### PR DESCRIPTION
Keep track of application state by notification instead of reading directly from UIApplication. This way we avoid using UIApplication in the background thread when detecting an ANR.

_#skip-changelog_ 