### PR TITLE
test: clear test state in any test case using SentryDependencyContainer

### DIFF
--- a/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
@@ -46,6 +46,7 @@ class SentryAppStateManagerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         fixture.fileManager.deleteAppState()
+        clearTestState()
     }
 
     func testStartStoresAppState() {

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -94,6 +94,7 @@ class SentryFileManagerTests: XCTestCase {
         sut.deleteAllFolders()
         sut.deleteTimestampLastInForeground()
         sut.deleteAppState()
+        clearTestState()
     }
     
     func testInitDoesNotOverrideDirectories() {

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -1,3 +1,4 @@
+import SentryTestUtils
 import XCTest
 
 class SentryLogTests: XCTestCase {

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -45,6 +45,7 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
         
         wait(for: [fixture.threadWrapper.threadFinishedExpectation], timeout: 5)
         XCTAssertEqual(0, fixture.threadWrapper.threads.count)
+        clearTestState()
     }
     
     func start() {

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -30,6 +30,7 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
         fixture = Fixture()
         SentrySDK.setAppStartMeasurement(nil)
         sut = SentryAppStartTrackingIntegration()
+        clearTestState()
     }
 
     override func tearDown() {

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -27,6 +27,7 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
     
     override func tearDown() {
         PrivateSentrySDKOnly.framesTrackingMeasurementHybridSDKMode = false
+        clearTestState()
         super.tearDown()
     }
     

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -155,6 +155,7 @@ class SentryHttpTransportTests: XCTestCase {
         super.tearDown()
         fixture.fileManager.deleteAllEnvelopes()
         fixture.requestManager.waitForAllRequests()
+        clearTestState()
     }
 
     func testInitSendsCachedEnvelopes() {

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -56,16 +56,13 @@ class SentryEnvelopeTests: XCTestCase {
         SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
     }
     
-    override func tearDown() {
-        super.tearDown()
-        do {
-            let fileManager = FileManager.default
-            if fileManager.fileExists(atPath: fixture.path) {
-                try fileManager.removeItem(atPath: fixture.path)
-            }
-        } catch {
-            XCTFail("Couldn't delete files.")
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: fixture.path) {
+            try fileManager.removeItem(atPath: fixture.path)
         }
+        clearTestState()
     }
 
     private let defaultSdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, andVersion: SentryMeta.versionString)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -78,6 +78,7 @@ class SentryHubTests: XCTestCase {
         fixture.fileManager.deleteAppState()
         fixture.fileManager.deleteTimestampLastInForeground()
         fixture.fileManager.deleteAllEnvelopes()
+        clearTestState()
     }
     
     func testBeforeBreadcrumbWithoutCallbackStoresBreadcrumb() {


### PR DESCRIPTION
When looking at continued flakes of reachability tests, I noticed there are still dangling reachability observer instances when new test cases start (which I believe were coming from SentryHttpTransportTests). When I looked further I noticed that there were several tests that use SentryDependencyContainer, but never clean it up afterwards, so I added that call to each test suite's `tearDown` method.

Also changed one tearDown to tearDownWithError that did a manual XCTFail in a do/try/catch.

#skip-changelog