### PR TITLE
fix: changelog entries after 8.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,6 @@
 ### Features
 
 - Enrich error events with any underlying NSErrors reported by Cocoa APIs (#3230)
-
-### Features
-
 - Improve OOM detection by ignoring system reboot (#3352)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,23 @@
 
 ### Features
 
+- Enrich error events with any underlying NSErrors reported by Cocoa APIs (#3230)
 - Add experimental visionOS support (#3328)
+- Improve OOM detection by ignoring system reboot (#3352)
 - Add thread id and name to span data (#3359)
 
 ### Fixes
 
+- Reporting app hangs from background (#3298)
+- Thread sanitizer data race warnings in ANR tracker, network tracker and span finish (#3303)
 - Stop sending empty thread names (#3361)
 - Work around edge case with a thread info kernel call sometimes returning invalid data, leading to a crash (#3364)
-- Thread sanitizer data race warnings in ANR tracker, network tracker and span finish (#3303)
 - Crashes when trace ID is externally modified or profiler fails to initialize (#3365)
 
 ## 8.14.2
 
-### Features
-
-- Enrich error events with any underlying NSErrors reported by Cocoa APIs (#3230)
-- Improve OOM detection by ignoring system reboot (#3352)
-
 ### Fixes
 
-- Reporting app hangs from background (#3298)
 - Missing `mechanism.handled` is not considered crash (#3353)
 
 ## 8.14.1


### PR DESCRIPTION
After releasing 8.14.2, other PRs were merged without first merging in `main` again, so their stale diffs didn't appear to be adding their changelog entries under 8.14.2 instead of Unreleased, but that's what wound up happening.

And also one made it in in between us updating changelog for 8.14.2 and actually merging that release branch back into main: 
![image](https://github.com/getsentry/sentry-cocoa/assets/3241469/e34146d5-9575-44ec-9be2-8051de9d7d80)

I still think that craft should not be renaming `Unreleased` to whatever version is being released; instead inserting the section header for the release underneath `Unreleased`, leaving that unreleased section header always. I think the way git diffs work would avoid some of this issue: https://github.com/getsentry/craft/issues/422

#skip-changelog