### PR TITLE
test: fix dyld error causing tvOS tests to fail to launch

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -5217,6 +5217,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryTestUtils;
@@ -5370,6 +5371,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				MACH_O_TYPE = staticlib;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryTestUtils;
@@ -5400,6 +5402,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				MACH_O_TYPE = staticlib;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryTestUtils;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5429,6 +5432,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				MACH_O_TYPE = staticlib;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryTestUtils;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5458,6 +5462,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				MACH_O_TYPE = staticlib;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryTestUtils;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -5717,6 +5722,7 @@
 				DEVELOPMENT_TEAM = "";
 				EXECUTABLE_PREFIX = lib;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+				MACH_O_TYPE = staticlib;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryTestUtils;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
 I was seeing this runtime error trying to run tvOS tests locally: 
```
2023-11-06 17:07:22.055807-0900 xctest[3004:27207] [general] Error loading /Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/SentryProfilerTests.xctest/SentryProfilerTests (177):  dlopen(/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/SentryProfilerTests.xctest/SentryProfilerTests, 0x0109): Library not loaded: /Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a
  Referenced from: <2D742D1E-D6A4-37DB-88B5-1F09B59C9473> /Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/SentryProfilerTests.xctest/SentryProfilerTests
  Reason: tried: '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' (code signature in <BD2663C2-EC67-3F39-947C-38D605E44EF8> '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' not valid for use in process: Trying to load an unsigned library), '/Applications/Xcode15/Xcode.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/usr/lib/libSentryTestUtils.a' (no such file), '/Library/Developer/CoreSimulator/Volumes/tvOS_21J353/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS 17.0.simruntime/Contents/Resources/RuntimeRoot/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' (no such file), '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' (code signature in <BD2663C2-EC67-3F39-947C-38D605E44EF8> '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' not valid for use in process: Trying to load an unsigned library), '/Library/Developer/CoreSimulator/Volumes/tvOS_21J353/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS 17.0.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libSentryTestUtils.a' (no such file)
2023-11-06 17:07:22.177921-0900 xctest[3004:27207] [Default] The bundle “SentryProfilerTests.xctest” couldn’t be loaded. Try reinstalling the bundle.
2023-11-06 17:07:22.178012-0900 xctest[3004:27207] [Default] (dlopen(/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/SentryProfilerTests.xctest/SentryProfilerTests, 0x0109): Library not loaded: /Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a
  Referenced from: <2D742D1E-D6A4-37DB-88B5-1F09B59C9473> /Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/SentryProfilerTests.xctest/SentryProfilerTests
  Reason: tried: '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' (code signature in <BD2663C2-EC67-3F39-947C-38D605E44EF8> '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' not valid for use in process: Trying to load an unsigned library), '/Applications/Xcode15/Xcode.app/Contents/Developer/Platforms/AppleTVSimulator.platform/Developer/usr/lib/libSentryTestUtils.a' (no such file), '/Library/Developer/CoreSimulator/Volumes/tvOS_21J353/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS 17.0.simruntime/Contents/Resources/RuntimeRoot/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' (no such file), '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' (code signature in <BD2663C2-EC67-3F39-947C-38D605E44EF8> '/Users/andrewmcknight/Library/Developer/Xcode/DerivedData/Sentry-gnnqqmcfqpqmmhcjxfzwadgjajnt/Build/Products/Test-appletvsimulator/libSentryTestUtils.a' not valid for use in process: Trying to load an unsigned library), '/Library/Developer/CoreSimulator/Volumes/tvOS_21J353/Library/Developer/CoreSimulator/Profiles/Runtimes/tvOS 17.0.simruntime/Contents/Resources/RuntimeRoot/usr/lib/libSentryTestUtils.a' (no such file))
Program ended with exit code: 83
```

This overrides the default value for this setting which is "dynamic library", whereas this target is actually a static lib.