### PR TITLE
fix: dont call through to NSLog from profiler sampling thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Crash when logging from certain profiling contexts (#3390)
+
 ## 8.15.1
 
 ### Fixes

--- a/Sources/Sentry/SentryProfilingLogging.mm
+++ b/Sources/Sentry/SentryProfilingLogging.mm
@@ -1,6 +1,8 @@
 #include "SentryProfilingLogging.hpp"
 
-#import "SentryLog.h"
+#if !defined(DEBUG)
+
+#    import "SentryLog.h"
 
 namespace sentry {
 namespace profiling {
@@ -41,3 +43,5 @@ namespace profiling {
 
 } // namespace profiling
 } // namespace sentry
+
+#endif // !defined(DEBUG)

--- a/Sources/Sentry/include/SentryProfilingLogging.hpp
+++ b/Sources/Sentry/include/SentryProfilingLogging.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include <cerrno>
-#include <cstring>
-#include <string>
-#include <unistd.h>
-#include <vector>
+#if !defined(DEBUG)
+
+#    include <cerrno>
+#    include <cstring>
+#    include <string>
+#    include <unistd.h>
+#    include <vector>
 
 namespace sentry {
 namespace profiling {
@@ -19,12 +21,22 @@ namespace profiling {
 } // namespace profiling
 } // namespace sentry
 
-#define SENTRY_PROF_LOG_DEBUG(...)                                                                 \
-    sentry::profiling::log(sentry::profiling::LogLevel::Debug, __VA_ARGS__)
-#define SENTRY_PROF_LOG_WARN(...)                                                                  \
-    sentry::profiling::log(sentry::profiling::LogLevel::Warning, __VA_ARGS__)
-#define SENTRY_PROF_LOG_ERROR(...)                                                                 \
-    sentry::profiling::log(sentry::profiling::LogLevel::Error, __VA_ARGS__)
+#    define SENTRY_PROF_LOG_DEBUG(...)                                                             \
+        sentry::profiling::log(sentry::profiling::LogLevel::Debug, __VA_ARGS__)
+#    define SENTRY_PROF_LOG_WARN(...)                                                              \
+        sentry::profiling::log(sentry::profiling::LogLevel::Warning, __VA_ARGS__)
+#    define SENTRY_PROF_LOG_ERROR(...)                                                             \
+        sentry::profiling::log(sentry::profiling::LogLevel::Error, __VA_ARGS__)
+
+#else
+
+// don't do anything with these in production until we can get a logging solution in place that
+// doesn't use NSLog
+#    define SENTRY_PROF_LOG_DEBUG(...)
+#    define SENTRY_PROF_LOG_WARN(...)
+#    define SENTRY_PROF_LOG_ERROR(...)
+
+#endif // !defined(DEBUG)
 
 /**
  * Logs the error code returned by executing `statement`, and returns the

--- a/Sources/Sentry/include/SentryProfilingLogging.hpp
+++ b/Sources/Sentry/include/SentryProfilingLogging.hpp
@@ -30,8 +30,11 @@ namespace profiling {
 
 #else
 
-// don't do anything with these in production until we can get a logging solution in place that
-// doesn't use NSLog
+// Don't do anything with these in production until we can get a logging solution in place that
+// doesn't use NSLog. We can't use NSLog in these codepaths because it takes a lock, and if the
+// profiler's sampling thread is terminated before it can release that lock, then subsequent
+// attempts to acquire it can cause a crash.
+// See https://github.com/getsentry/sentry-cocoa/issues/3336#issuecomment-1802892052 for more info.
 #    define SENTRY_PROF_LOG_DEBUG(...)
 #    define SENTRY_PROF_LOG_WARN(...)
 #    define SENTRY_PROF_LOG_ERROR(...)


### PR DESCRIPTION
fixes #3336 

Let's just avoid calling through to NSLog from the profiler's sampling thread until we can get a different logging solution in place, if we decide we need these logs at some point in the future.