### PR TITLE
ref: Move building app start spans

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		15E0A8F22411A45A00F044E3 /* SentrySession.m in Sources */ = {isa = PBXBuildFile; fileRef = 15E0A8F12411A45A00F044E3 /* SentrySession.m */; };
 		33042A0D29DAF79A00C60085 /* SentryExtraContextProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 33042A0C29DAF79A00C60085 /* SentryExtraContextProvider.m */; };
 		33042A1729DC2C4300C60085 /* SentryExtraContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */; };
+		620379DB2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h in Headers */ = {isa = PBXBuildFile; fileRef = 620379DA2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h */; };
+		620379DD2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m in Sources */ = {isa = PBXBuildFile; fileRef = 620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */; };
 		622C08D829E546F4002571D4 /* SentryTraceOrigins.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D729E546F4002571D4 /* SentryTraceOrigins.h */; };
 		622C08DB29E554B9002571D4 /* SentrySpanContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */; };
 		623C45B02A651D8200D9E88B /* SentryCoreDataTracker+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 623C45AF2A651D8200D9E88B /* SentryCoreDataTracker+Test.m */; };
@@ -953,6 +955,8 @@
 		33042A0B29DAF5F400C60085 /* SentryExtraContextProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryExtraContextProvider.h; sourceTree = "<group>"; };
 		33042A0C29DAF79A00C60085 /* SentryExtraContextProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryExtraContextProvider.m; sourceTree = "<group>"; };
 		33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExtraContextProviderTests.swift; sourceTree = "<group>"; };
+		620379DA2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBuildAppStartSpans.h; path = include/SentryBuildAppStartSpans.h; sourceTree = "<group>"; };
+		620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBuildAppStartSpans.m; sourceTree = "<group>"; };
 		622C08D729E546F4002571D4 /* SentryTraceOrigins.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTraceOrigins.h; path = include/SentryTraceOrigins.h; sourceTree = "<group>"; };
 		622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySpanContext+Private.h"; path = "include/SentrySpanContext+Private.h"; sourceTree = "<group>"; };
 		623C45AE2A651C4500D9E88B /* SentryCoreDataTracker+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryCoreDataTracker+Test.h"; sourceTree = "<group>"; };
@@ -3245,6 +3249,8 @@
 				D8B088B529C9E3FF00213258 /* SentryTracerConfiguration.m */,
 				8E8C57A525EEFC42001CEEFA /* SentryTracesSampler.h */,
 				8E8C57A025EEFC07001CEEFA /* SentryTracesSampler.m */,
+				620379DA2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h */,
+				620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */,
 				8E4A037725F6F52100000D77 /* SentrySampleDecision.h */,
 				D8757D142A209F7300BFEFCC /* SentrySampleDecision+Private.h */,
 				8453421128BE855D00C22EEC /* SentrySampleDecision.m */,
@@ -3472,6 +3478,7 @@
 				63FE716520DA4C1100CDBAE8 /* SentryCrashMemory.h in Headers */,
 				63FE713F20DA4C1100CDBAE8 /* SentryCrashStackCursor_SelfThread.h in Headers */,
 				639FCFA41EBC809A00778193 /* SentryStacktrace.h in Headers */,
+				620379DB2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h in Headers */,
 				63FE716320DA4C1100CDBAE8 /* SentryCrashDynamicLinker.h in Headers */,
 				639FCF981EBC7B9700778193 /* SentryEvent.h in Headers */,
 				03F84D2527DD414C008FE43F /* SentryThreadState.hpp in Headers */,
@@ -4190,6 +4197,7 @@
 				0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */,
 				639FCF991EBC7B9700778193 /* SentryEvent.m in Sources */,
 				632F43521F581D5400A18A36 /* SentryCrashExceptionApplication.m in Sources */,
+				620379DD2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m in Sources */,
 				7B77BE3727EC8460003C9020 /* SentryDiscardReasonMapper.m in Sources */,
 				63FE712520DA4C1000CDBAE8 /* SentryCrashSignalInfo.c in Sources */,
 				63FE70F320DA4C1000CDBAE8 /* SentryCrashMonitor_Signal.c in Sources */,

--- a/Sources/Sentry/SentryBuildAppStartSpans.m
+++ b/Sources/Sentry/SentryBuildAppStartSpans.m
@@ -1,0 +1,92 @@
+#import "SentryAppStartMeasurement.h"
+#import "SentrySpan.h"
+#import "SentrySpanContext+Private.h"
+#import "SentrySpanId.h"
+#import "SentryTraceOrigins.h"
+#import "SentryTracer.h"
+#import <Foundation/Foundation.h>
+#import <SentryBuildAppStartSpans.h>
+
+#if SENTRY_HAS_UIKIT
+
+id<SentrySpan>
+sentryBuildAppStartSpan(
+    SentryTracer *tracer, SentrySpanId *parentId, NSString *operation, NSString *description)
+{
+    SentrySpanContext *context =
+        [[SentrySpanContext alloc] initWithTraceId:tracer.traceId
+                                            spanId:[[SentrySpanId alloc] init]
+                                          parentId:parentId
+                                         operation:operation
+                                   spanDescription:description
+                                            origin:SentryTraceOriginAutoAppStart
+                                           sampled:tracer.sampled];
+
+    return [[SentrySpan alloc] initWithTracer:tracer context:context];
+}
+
+NSArray<SentrySpan *> *
+sentryBuildAppStartSpans(SentryTracer *tracer, SentryAppStartMeasurement *appStartMeasurement)
+{
+
+    if (appStartMeasurement == nil) {
+        return @[];
+    }
+
+    NSString *operation;
+    NSString *type;
+
+    switch (appStartMeasurement.type) {
+    case SentryAppStartTypeCold:
+        operation = @"app.start.cold";
+        type = @"Cold Start";
+        break;
+    case SentryAppStartTypeWarm:
+        operation = @"app.start.warm";
+        type = @"Warm Start";
+        break;
+    default:
+        return @[];
+    }
+
+    NSMutableArray<SentrySpan *> *appStartSpans = [NSMutableArray array];
+
+    NSDate *appStartEndTimestamp = [appStartMeasurement.appStartTimestamp
+        dateByAddingTimeInterval:appStartMeasurement.duration];
+
+    SentrySpan *appStartSpan = sentryBuildAppStartSpan(tracer, tracer.spanId, operation, type);
+    [appStartSpan setStartTimestamp:appStartMeasurement.appStartTimestamp];
+    [appStartSpan setTimestamp:appStartEndTimestamp];
+
+    [appStartSpans addObject:appStartSpan];
+
+    if (!appStartMeasurement.isPreWarmed) {
+        SentrySpan *premainSpan
+            = sentryBuildAppStartSpan(tracer, appStartSpan.spanId, operation, @"Pre Runtime Init");
+        [premainSpan setStartTimestamp:appStartMeasurement.appStartTimestamp];
+        [premainSpan setTimestamp:appStartMeasurement.runtimeInitTimestamp];
+        [appStartSpans addObject:premainSpan];
+
+        SentrySpan *runtimeInitSpan = sentryBuildAppStartSpan(
+            tracer, appStartSpan.spanId, operation, @"Runtime Init to Pre Main Initializers");
+        [runtimeInitSpan setStartTimestamp:appStartMeasurement.runtimeInitTimestamp];
+        [runtimeInitSpan setTimestamp:appStartMeasurement.moduleInitializationTimestamp];
+        [appStartSpans addObject:runtimeInitSpan];
+    }
+
+    SentrySpan *appInitSpan = sentryBuildAppStartSpan(
+        tracer, appStartSpan.spanId, operation, @"UIKit and Application Init");
+    [appInitSpan setStartTimestamp:appStartMeasurement.moduleInitializationTimestamp];
+    [appInitSpan setTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
+    [appStartSpans addObject:appInitSpan];
+
+    SentrySpan *frameRenderSpan
+        = sentryBuildAppStartSpan(tracer, appStartSpan.spanId, operation, @"Initial Frame Render");
+    [frameRenderSpan setStartTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
+    [frameRenderSpan setTimestamp:appStartEndTimestamp];
+    [appStartSpans addObject:frameRenderSpan];
+
+    return appStartSpans;
+}
+
+#endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -1,5 +1,6 @@
 #import "NSDictionary+SentrySanitize.h"
 #import "PrivateSentrySDKOnly.h"
+#import "SentryBuildAppStartSpans.h"
 #import "SentryClient.h"
 #import "SentryCurrentDateProvider.h"
 #import "SentryDebugImageProvider.h"
@@ -595,7 +596,7 @@ static BOOL appStartMeasurementRead;
 {
     NSUInteger capacity;
 #if SENTRY_HAS_UIKIT
-    NSArray<id<SentrySpan>> *appStartSpans = [self buildAppStartSpans];
+    NSArray<id<SentrySpan>> *appStartSpans = sentryBuildAppStartSpans(self, appStartMeasurement);
     capacity = _children.count + appStartSpans.count;
 #else
     capacity = _children.count;
@@ -696,72 +697,6 @@ static BOOL appStartMeasurementRead;
     return measurement;
 }
 
-- (NSArray<SentrySpan *> *)buildAppStartSpans
-{
-    if (appStartMeasurement == nil) {
-        return @[];
-    }
-
-    NSString *operation;
-    NSString *type;
-
-    switch (appStartMeasurement.type) {
-    case SentryAppStartTypeCold:
-        operation = @"app.start.cold";
-        type = @"Cold Start";
-        break;
-    case SentryAppStartTypeWarm:
-        operation = @"app.start.warm";
-        type = @"Warm Start";
-        break;
-    default:
-        return @[];
-    }
-
-    NSMutableArray<SentrySpan *> *appStartSpans = [NSMutableArray array];
-
-    NSDate *appStartEndTimestamp = [appStartMeasurement.appStartTimestamp
-        dateByAddingTimeInterval:appStartMeasurement.duration];
-
-    SentrySpan *appStartSpan = [self buildSpan:self.spanId operation:operation description:type];
-    [appStartSpan setStartTimestamp:appStartMeasurement.appStartTimestamp];
-    [appStartSpan setTimestamp:appStartEndTimestamp];
-
-    [appStartSpans addObject:appStartSpan];
-
-    if (!appStartMeasurement.isPreWarmed) {
-        SentrySpan *premainSpan = [self buildSpan:appStartSpan.spanId
-                                        operation:operation
-                                      description:@"Pre Runtime Init"];
-        [premainSpan setStartTimestamp:appStartMeasurement.appStartTimestamp];
-        [premainSpan setTimestamp:appStartMeasurement.runtimeInitTimestamp];
-        [appStartSpans addObject:premainSpan];
-
-        SentrySpan *runtimeInitSpan = [self buildSpan:appStartSpan.spanId
-                                            operation:operation
-                                          description:@"Runtime Init to Pre Main Initializers"];
-        [runtimeInitSpan setStartTimestamp:appStartMeasurement.runtimeInitTimestamp];
-        [runtimeInitSpan setTimestamp:appStartMeasurement.moduleInitializationTimestamp];
-        [appStartSpans addObject:runtimeInitSpan];
-    }
-
-    SentrySpan *appInitSpan = [self buildSpan:appStartSpan.spanId
-                                    operation:operation
-                                  description:@"UIKit and Application Init"];
-    [appInitSpan setStartTimestamp:appStartMeasurement.moduleInitializationTimestamp];
-    [appInitSpan setTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
-    [appStartSpans addObject:appInitSpan];
-
-    SentrySpan *frameRenderSpan = [self buildSpan:appStartSpan.spanId
-                                        operation:operation
-                                      description:@"Initial Frame Render"];
-    [frameRenderSpan setStartTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
-    [frameRenderSpan setTimestamp:appStartEndTimestamp];
-    [appStartSpans addObject:frameRenderSpan];
-
-    return appStartSpans;
-}
-
 - (void)addMeasurements:(SentryTransaction *)transaction
 {
     if (appStartMeasurement != nil && appStartMeasurement.type != SentryAppStartTypeUnknown) {
@@ -813,22 +748,6 @@ static BOOL appStartMeasurementRead;
 }
 
 #endif // SENTRY_HAS_UIKIT
-
-- (id<SentrySpan>)buildSpan:(SentrySpanId *)parentId
-                  operation:(NSString *)operation
-                description:(NSString *)description
-{
-    SentrySpanContext *context =
-        [[SentrySpanContext alloc] initWithTraceId:self.traceId
-                                            spanId:[[SentrySpanId alloc] init]
-                                          parentId:parentId
-                                         operation:operation
-                                   spanDescription:description
-                                            origin:SentryTraceOriginAutoAppStart
-                                           sampled:self.sampled];
-
-    return [[SentrySpan alloc] initWithTracer:self context:context];
-}
 
 /**
  * Internal. Only needed for testing.

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -1,6 +1,5 @@
 #import "NSDictionary+SentrySanitize.h"
 #import "PrivateSentrySDKOnly.h"
-#import "SentryBuildAppStartSpans.h"
 #import "SentryClient.h"
 #import "SentryCurrentDateProvider.h"
 #import "SentryDebugImageProvider.h"
@@ -37,6 +36,7 @@
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryAppStartMeasurement.h"
+#    import "SentryBuildAppStartSpans.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryUIViewControllerPerformanceTracker.h"
 #    import <SentryScreenFrames.h>

--- a/Sources/Sentry/include/SentryBuildAppStartSpans.h
+++ b/Sources/Sentry/include/SentryBuildAppStartSpans.h
@@ -1,0 +1,16 @@
+#import "SentryDefines.h"
+
+@class SentryTracer;
+@class SentrySpan;
+@class SentryAppStartMeasurement;
+
+NS_ASSUME_NONNULL_BEGIN
+
+#if SENTRY_HAS_UIKIT
+
+NSArray<SentrySpan *> *sentryBuildAppStartSpans(
+    SentryTracer *tracer, SentryAppStartMeasurement *appStartMeasurement);
+
+#endif // SENTRY_HAS_UIKIT
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Move building app start spans to an extra file to shrink the code in SentryTracer. The SentryTracer previously had around 850 LOC and now about 750 LOC.



#skip-changelog