### PR TITLE
test: Improve SentryReachabilityTests

### DIFF
--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -44,6 +44,7 @@ NSString *const SentryConnectivityNone = @"none";
 void
 SentrySetReachabilityIgnoreActualCallback(BOOL value)
 {
+    SENTRY_LOG_DEBUG(@"Setting ignore actual callback to %@", value ? @"YES" : @"NO");
     sentry_reachability_ignore_actual_callback = value;
 }
 
@@ -155,6 +156,15 @@ SentryReachability ()
     }
 }
 
+- (instancetype)init
+{
+    if (self = [super init]) {
+        self.skipRegisteringActualCallbacks = NO;
+    }
+
+    return self;
+}
+
 - (void)addObserver:(id<SentryReachabilityObserver>)observer;
 {
     SENTRY_LOG_DEBUG(@"Adding observer: %@", observer);
@@ -168,6 +178,11 @@ SentryReachability ()
         [sentry_reachability_observers addObject:observer];
 
         if (sentry_reachability_observers.count > 1) {
+            return;
+        }
+
+        if (self.skipRegisteringActualCallbacks) {
+            SENTRY_LOG_DEBUG(@"Skip registering actual callbacks");
             return;
         }
 
@@ -214,6 +229,10 @@ SentryReachability ()
 
 - (void)unsetReachabilityCallback
 {
+    if (self.skipRegisteringActualCallbacks) {
+        SENTRY_LOG_DEBUG(@"Skip unsetting actual callbacks");
+    }
+
     sentry_current_reachability_state = kSCNetworkReachabilityFlagsUninitialized;
 
     if (_sentry_reachability_ref != nil) {

--- a/Sources/Sentry/include/SentryReachability.h
+++ b/Sources/Sentry/include/SentryReachability.h
@@ -66,6 +66,12 @@ SENTRY_EXTERN NSString *const SentryConnectivityNone;
 @interface SentryReachability : NSObject
 
 /**
+ * Only needed for testing. Use this flag to skip registering and unregistering the actual callbacks
+ * to SCNetworkReachability to minimize side effects.
+ */
+@property (nonatomic, assign) BOOL skipRegisteringActualCallbacks;
+
+/**
  * Add an observer which is called each time network connectivity changes.
  */
 - (void)addObserver:(id<SentryReachabilityObserver>)observer;

--- a/Tests/SentryTests/Networking/SentryReachabilityTests.m
+++ b/Tests/SentryTests/Networking/SentryReachabilityTests.m
@@ -35,11 +35,13 @@
 
 - (void)setUp
 {
-    self.reachability = [[SentryReachability alloc] init];
     // Ignore the actual reachability callbacks, cause we call the callbacks manually.
     // Otherwise, the actual reachability callbacks are called during later unrelated tests causing
     // flakes.
     SentrySetReachabilityIgnoreActualCallback(YES);
+
+    self.reachability = [[SentryReachability alloc] init];
+    self.reachability.skipRegisteringActualCallbacks = YES;
 }
 
 - (void)tearDown
@@ -142,6 +144,20 @@
 
     XCTAssertEqual(1, observer.connectivityChangedInvocations);
 
+    [self.reachability removeObserver:observer];
+}
+
+/**
+ * We only want to make sure running the actual registering and unregistering callbacks doesn't
+ * crash.
+ */
+- (void)testRegisteringActualCallbacks
+{
+    self.reachability.skipRegisteringActualCallbacks = NO;
+
+    TestSentryReachabilityObserver *observer = [[TestSentryReachabilityObserver alloc] init];
+
+    [self.reachability addObserver:observer];
     [self.reachability removeObserver:observer];
 }
 


### PR DESCRIPTION
The SentryReachabilityTests are still sometimes failing in CI. We now skip registering and unregistering the actual callbacks to SCNetworkReachability for all tests except one to minimize side effects.

#skip-changelog

