### PR TITLE
test: Assert clearTestState on main thread

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "Sources/**"
       - "Tests/**"
+      - "SentryTestUtils/**"
       - "test-server/**"
       - "Samples/**"
       - ".github/workflows/test.yml"

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -12,6 +12,10 @@ public func setTestDefaultLogLevel() {
 @objcMembers
 class TestCleanup: NSObject {
     static func clearTestState() {
+        // You must call clearTestState on the main thread. Calling it on a background thread
+        // could interfere with another currently running test, making the tests flaky.
+        assert(Thread.isMainThread, "You must call clearTestState on the main thread.")
+        
         SentrySDK.close()
         SentrySDK.setCurrentHub(nil)
         SentrySDK.crashedLastRunCalled = false


### PR DESCRIPTION
Add an assert for checking clearTestState executed on the main thread. I suspected one of our tests was flaky because we weren't running clearTestState on the main thread, which was a false assumption. I added this assert to avoid any future problems caused by running clearTestState on a background thread.

#skip-changelog