### PR TITLE
ref: Add availability comment for Swift Async

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -494,6 +494,9 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic) BOOL enableTimeToFullDisplayTracing;
 
 /**
+ * This feature is only available from Xcode 13 and from macOS 12.0, iOS 15.0, tvOS 15.0,
+ * watchOS 8.0.
+ *
  * @warning This is an experimental feature and may still have bugs.
  * @brief Stitches the call to Swift Async functions in one consecutive stack trace.
  * @note Default value is @c NO .


### PR DESCRIPTION
`backtrace_async` is only available from Xcode 13 and from macOS 12.0, iOS 15.0, tvOS 15.0,
 watchOS 8.0, see https://github.com/getsentry/sentry-cocoa/blob/de46f062cf2d18433c4d110b350dad14a67588bb/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m#L56-L59

#skip-changelog