### PR TITLE
fix: un-invert compilation condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Infinite loop when parsing MetricKit data (#3395)
+- Fix incorrect implementation in #3398 to work around a profiling crash (#3405)
 
 ## 8.15.2
 

--- a/Sources/Sentry/SentryProfilingLogging.mm
+++ b/Sources/Sentry/SentryProfilingLogging.mm
@@ -1,6 +1,6 @@
 #include "SentryProfilingLogging.hpp"
 
-#if !defined(DEBUG)
+#if defined(DEBUG)
 
 #    import "SentryLog.h"
 
@@ -44,4 +44,4 @@ namespace profiling {
 } // namespace profiling
 } // namespace sentry
 
-#endif // !defined(DEBUG)
+#endif // defined(DEBUG)

--- a/Sources/Sentry/include/SentryProfilingLogging.hpp
+++ b/Sources/Sentry/include/SentryProfilingLogging.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#if !defined(DEBUG)
+#if defined(DEBUG)
 
 #    include <cerrno>
 #    include <cstring>
@@ -39,7 +39,7 @@ namespace profiling {
 #    define SENTRY_PROF_LOG_WARN(...)
 #    define SENTRY_PROF_LOG_ERROR(...)
 
-#endif // !defined(DEBUG)
+#endif // defined(DEBUG)
 
 /**
  * Logs the error code returned by executing `statement`, and returns the


### PR DESCRIPTION
#3390 attempted to compile some NSLogs out of production builds to avoid a crash, but the compilation condition was accidentally inverted, so that it was only compiled _into_ prod builds. This fixes that.