### PR TITLE
ref: Add UIEventTracker Mode

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -84,6 +84,9 @@
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
+		62A456E12B03704A003F19A1 /* SentryUIEventTrackerMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E02B03704A003F19A1 /* SentryUIEventTrackerMode.h */; };
+		62A456E32B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */; };
+		62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */; };
 		62B86CFC29F052BB008F3947 /* SentryTestLogConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */; };
 		62E081A929ED4260000F69FC /* SentryBreadcrumbDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */; };
 		62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */; };
@@ -965,6 +968,9 @@
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
 		62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionContextTests.swift; sourceTree = "<group>"; };
 		629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReachabilitySwiftTests.swift; sourceTree = "<group>"; };
+		62A456E02B03704A003F19A1 /* SentryUIEventTrackerMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUIEventTrackerMode.h; path = include/SentryUIEventTrackerMode.h; sourceTree = "<group>"; };
+		62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUIEventTrackerTransactionMode.h; path = include/SentryUIEventTrackerTransactionMode.h; sourceTree = "<group>"; };
+		62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryUIEventTrackerTransactionMode.m; sourceTree = "<group>"; };
 		62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTestLogConfig.m; sourceTree = "<group>"; };
 		62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBreadcrumbDelegate.h; path = include/SentryBreadcrumbDelegate.h; sourceTree = "<group>"; };
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
@@ -2643,6 +2649,9 @@
 				7B63459A280EB9E200CFA05A /* SentryUIEventTrackingIntegration.m */,
 				7B63459C280EBA6300CFA05A /* SentryUIEventTracker.h */,
 				7B63459E280EBA7200CFA05A /* SentryUIEventTracker.m */,
+				62A456E02B03704A003F19A1 /* SentryUIEventTrackerMode.h */,
+				62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */,
+				62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */,
 			);
 			name = UIEvents;
 			sourceTree = "<group>";
@@ -3579,6 +3588,7 @@
 				7B31C291277B04A000337126 /* SentryCrashPlatformSpecificDefines.h in Headers */,
 				7B77BE3527EC8445003C9020 /* SentryDiscardReasonMapper.h in Headers */,
 				7B610D602512390E00B0B5D9 /* SentrySDK+Private.h in Headers */,
+				62A456E12B03704A003F19A1 /* SentryUIEventTrackerMode.h in Headers */,
 				03F84D2327DD414C008FE43F /* SentryThreadHandle.hpp in Headers */,
 				7B6C5EE0264E8E050010D138 /* SentryFramesTracker.h in Headers */,
 				63FE715720DA4C1100CDBAE8 /* SentryCrashThread.h in Headers */,
@@ -3698,6 +3708,7 @@
 				7BA61CB9247BC57B00C130A8 /* SentryCrashDefaultBinaryImageProvider.h in Headers */,
 				8E4E7C7D25DAB287006AB9E2 /* SentryTracer.h in Headers */,
 				7BC8523724588115005A70F0 /* SentryDataCategory.h in Headers */,
+				62A456E32B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h in Headers */,
 				63FE714B20DA4C1100CDBAE8 /* SentryCrashString.h in Headers */,
 				7BCFBD6D2681D0A900BC27D8 /* SentryCrashScopeObserver.h in Headers */,
 				63FE715320DA4C1100CDBAE8 /* SentryCrashObjCApple.h in Headers */,
@@ -4135,6 +4146,7 @@
 				7D65260E237F649E00113EA2 /* SentryScope.m in Sources */,
 				84281C472A57905700EE88F2 /* SentrySample.m in Sources */,
 				84AC61D329F7541E009EEF61 /* SentryDispatchSourceWrapper.m in Sources */,
+				62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */,
 				63FE712D20DA4C1100CDBAE8 /* SentryCrashJSONCodecObjC.m in Sources */,
 				7BBD18932449BEDD00427C76 /* SentryDefaultRateLimits.m in Sources */,
 				7BD729982463E93500EA3610 /* SentryDateUtil.m in Sources */,

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -1,0 +1,124 @@
+#import <SentryUIEventTrackerTransactionMode.h>
+
+#if SENTRY_HAS_UIKIT
+
+#    import <SentryDependencyContainer.h>
+#    import <SentryHub+Private.h>
+#    import <SentryLog.h>
+#    import <SentrySDK+Private.h>
+#    import <SentrySDK.h>
+#    import <SentryScope.h>
+#    import <SentrySpanId.h>
+#    import <SentrySpanOperations.h>
+#    import <SentryTraceOrigins.h>
+#    import <SentryTracer.h>
+#    import <SentryTransactionContext+Private.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface
+SentryUIEventTrackerTransactionMode ()
+
+@property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
+@property (nonatomic, assign) NSTimeInterval idleTimeout;
+@property (nullable, nonatomic, strong) NSMutableArray<SentryTracer *> *activeTransactions;
+
+@end
+
+@implementation SentryUIEventTrackerTransactionMode
+
+- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
+                                 idleTimeout:(NSTimeInterval)idleTimeout
+{
+    if (self = [super init]) {
+        self.dispatchQueueWrapper = dispatchQueueWrapper;
+        self.idleTimeout = idleTimeout;
+        self.activeTransactions = [NSMutableArray new];
+    }
+    return self;
+}
+
+- (void)handleUIEvent:(NSString *)action
+                  operation:(NSString *)operation
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier
+{
+
+    // There might be more active transactions stored, but only the last one might still be
+    // active with a timeout. The others are already waiting for their children to finish
+    // without a timeout.
+    SentryTracer *currentActiveTransaction;
+    @synchronized(self.activeTransactions) {
+        currentActiveTransaction = self.activeTransactions.lastObject;
+    }
+
+    BOOL sameAction = [currentActiveTransaction.transactionContext.name isEqualToString:action];
+    if (sameAction) {
+        SENTRY_LOG_DEBUG(@"Dispatching idle timeout for transaction with span id %@",
+            currentActiveTransaction.spanId.sentrySpanIdString);
+        [currentActiveTransaction dispatchIdleTimeout];
+        return;
+    }
+
+    [currentActiveTransaction finish];
+
+    if (currentActiveTransaction) {
+        SENTRY_LOG_DEBUG(@"Finished transaction %@ (span ID %@)",
+            currentActiveTransaction.transactionContext.name,
+            currentActiveTransaction.spanId.sentrySpanIdString);
+    }
+
+    SentryTransactionContext *context =
+        [[SentryTransactionContext alloc] initWithName:action
+                                            nameSource:kSentryTransactionNameSourceComponent
+                                             operation:operation
+                                                origin:SentryTraceOriginUIEventTracker];
+
+    __block SentryTracer *transaction;
+    [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
+        BOOL ongoingScreenLoadTransaction
+            = span != nil && [span.operation isEqualToString:SentrySpanOperationUILoad];
+        BOOL ongoingManualTransaction = span != nil
+            && ![span.operation isEqualToString:SentrySpanOperationUILoad]
+            && ![span.operation containsString:SentrySpanOperationUIAction];
+
+        BOOL bindToScope = !ongoingScreenLoadTransaction && !ongoingManualTransaction;
+
+        transaction = [SentrySDK.currentHub
+            startTransactionWithContext:context
+                            bindToScope:bindToScope
+                  customSamplingContext:@{}
+                          configuration:[SentryTracerConfiguration configurationWithBlock:^(
+                                            SentryTracerConfiguration *config) {
+                              config.idleTimeout = self.idleTimeout;
+                              config.waitForChildren = YES;
+                              config.dispatchQueueWrapper = self.dispatchQueueWrapper;
+                          }]];
+
+        SENTRY_LOG_DEBUG(@"Automatically started a new transaction with name: "
+                         @"%@, bindToScope: %@",
+            action, bindToScope ? @"YES" : @"NO");
+    }];
+
+    if (accessibilityIdentifier) {
+        [transaction setTagValue:accessibilityIdentifier forKey:@"accessibilityIdentifier"];
+    }
+
+    transaction.finishCallback = ^(SentryTracer *tracer) {
+        @synchronized(self.activeTransactions) {
+            [self.activeTransactions removeObject:tracer];
+            SENTRY_LOG_DEBUG(@"Active transactions after removing tracer for span ID %@: %@",
+                tracer.spanId.sentrySpanIdString, self.activeTransactions);
+        }
+    };
+    @synchronized(self.activeTransactions) {
+        SENTRY_LOG_DEBUG(@"Adding transaction %@ to list of active transactions (currently %@)",
+            transaction.spanId.sentrySpanIdString, self.activeTransactions);
+        [self.activeTransactions addObject:transaction];
+    }
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryUIEventTrackingIntegration.m
+++ b/Sources/Sentry/SentryUIEventTrackingIntegration.m
@@ -8,6 +8,7 @@
 #    import <SentryOptions+Private.h>
 #    import <SentryOptions.h>
 #    import <SentryUIEventTracker.h>
+#    import <SentryUIEventTrackerTransactionMode.h>
 
 @interface
 SentryUIEventTrackingIntegration ()
@@ -25,9 +26,11 @@ SentryUIEventTrackingIntegration ()
     }
 
     SentryDependencyContainer *dependencies = [SentryDependencyContainer sharedInstance];
-    self.uiEventTracker =
-        [[SentryUIEventTracker alloc] initWithDispatchQueueWrapper:dependencies.dispatchQueueWrapper
-                                                       idleTimeout:options.idleTimeout];
+    SentryUIEventTrackerTransactionMode *mode = [[SentryUIEventTrackerTransactionMode alloc]
+        initWithDispatchQueueWrapper:dependencies.dispatchQueueWrapper
+                         idleTimeout:options.idleTimeout];
+
+    self.uiEventTracker = [[SentryUIEventTracker alloc] initWithMode:mode];
 
     [self.uiEventTracker start];
 

--- a/Sources/Sentry/include/SentryUIEventTracker.h
+++ b/Sources/Sentry/include/SentryUIEventTracker.h
@@ -5,12 +5,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryDispatchQueueWrapper;
+@protocol SentryUIEventTrackerMode;
 
 @interface SentryUIEventTracker : NSObject
 SENTRY_NO_INIT
 
-- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-                                 idleTimeout:(NSTimeInterval)idleTimeout;
+- (instancetype)initWithMode:(id<SentryUIEventTrackerMode>)mode;
 
 - (void)start;
 - (void)stop;

--- a/Sources/Sentry/include/SentryUIEventTrackerMode.h
+++ b/Sources/Sentry/include/SentryUIEventTrackerMode.h
@@ -1,0 +1,17 @@
+#import "SentryDefines.h"
+
+#if SENTRY_HAS_UIKIT
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SentryUIEventTrackerMode <NSObject>
+
+- (void)handleUIEvent:(NSString *)action
+                  operation:(NSString *)operation
+    accessibilityIdentifier:(NSString *)accessibilityIdentifier;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryUIEventTrackerTransactionMode.h
+++ b/Sources/Sentry/include/SentryUIEventTrackerTransactionMode.h
@@ -1,0 +1,19 @@
+#import "SentryUIEventTrackerMode.h"
+
+#if SENTRY_HAS_UIKIT
+
+@class SentryDispatchQueueWrapper;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryUIEventTrackerTransactionMode : NSObject <SentryUIEventTrackerMode>
+SENTRY_NO_INIT
+
+- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
+                                 idleTimeout:(NSTimeInterval)idleTimeout;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_HAS_UIKIT

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -16,6 +16,7 @@
 #    import "SentryUIApplication.h"
 #    import "SentryUIDeviceWrapper.h"
 #    import "SentryUIEventTracker.h"
+#    import "SentryUIEventTrackerTransactionMode.h"
 #    import "SentryUIEventTrackingIntegration.h"
 #    import "SentryUIViewControllerPerformanceTracker.h"
 #    import "SentryUIViewControllerSwizzling+Test.h"
@@ -163,6 +164,7 @@
 #import "SentryScreenshot.h"
 #import "SentryScreenshotIntegration.h"
 #import "SentrySdkInfo.h"
+
 #import "SentrySerialization.h"
 #import "SentrySession+Private.h"
 #import "SentrySessionTracker.h"


### PR DESCRIPTION

## :scroll: Description

Carrier transactions are going to replace UI event transactions in the future. When users enable carrier transactions, UI event transactions must be disabled because both would interfere. Therefore, prepare the SentryUIEventTracker to be able to handle two different modes—one for the existing functionality of UI event transactions and one for adding spans to carrier transactions.

#skip-changelog

## :bulb: Motivation and Context

Preparation for carrier transactions https://github.com/getsentry/team-mobile/issues/157.

## :green_heart: How did you test it?
The unit tests are still all green—no change in functionality.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
