### PR TITLE
test: Add Nimble for test assertions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Test guidelines:
 * Make use of the fixture pattern for test setup code. For examples, checkout [SentryClientTest](/Tests/SentryTests/SentryClientTest.swift) or [SentryHttpTransportTests](/Tests/SentryTests/SentryHttpTransportTests.swift).
 * Use [TestData](/Tests/SentryTests/Protocol/TestData.swift) when possible to avoid setting up data classes with test values.
 * Name the variable of the class you are testing `sut`, which stands for [system under test](https://en.wikipedia.org/wiki/System_under_test).
+* We prefer using [Nimble](https://github.com/Quick/Nimble) over XCTest for test assertions.
 
 Test can either be ran inside from Xcode or via
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
+		62986F032B03D250008E2D62 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 62986F022B03D250008E2D62 /* Nimble */; };
 		62A456E12B03704A003F19A1 /* SentryUIEventTrackerMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E02B03704A003F19A1 /* SentryUIEventTrackerMode.h */; };
 		62A456E32B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */; };
 		62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */; };
@@ -1799,6 +1800,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				62986F032B03D250008E2D62 /* Nimble in Frameworks */,
 				8431F01C29B2854200D8DC56 /* libSentryTestUtils.a in Frameworks */,
 				63AA766A1EB8CB2F00D153DE /* Sentry.framework in Frameworks */,
 			);
@@ -3794,6 +3796,9 @@
 				63AA766C1EB8CB2F00D153DE /* PBXTargetDependency */,
 			);
 			name = SentryTests;
+			packageProductDependencies = (
+				62986F022B03D250008E2D62 /* Nimble */,
+			);
 			productName = "Tests-iOS";
 			productReference = 63AA76651EB8CB2F00D153DE /* SentryTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -3921,6 +3926,9 @@
 				Base,
 			);
 			mainGroup = 6327C5C91EB8A783004E799B;
+			packageReferences = (
+				62986F012B03D250008E2D62 /* XCRemoteSwiftPackageReference "Nimble" */,
+			);
 			productRefGroup = 6327C5D41EB8A783004E799B /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -4779,6 +4787,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/SentryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4793,6 +4802,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug;
 		};
@@ -4810,6 +4820,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/SentryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4823,6 +4834,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/SentryTests/SentryTests-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release;
 		};
@@ -4948,6 +4960,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/SentryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4962,6 +4975,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = TestCI;
 		};
@@ -5084,6 +5098,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/SentryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5097,6 +5112,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Debug_without_UIKit;
 		};
@@ -5596,6 +5612,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/SentryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5609,6 +5626,7 @@
 				SWIFT_OBJC_BRIDGING_HEADER = "Tests/SentryTests/SentryTests-Bridging-Header.h";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Release_without_UIKit;
 		};
@@ -5861,6 +5879,7 @@
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/SentryTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5875,6 +5894,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
 				SWIFT_VERSION = 5.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 			};
 			name = Test;
 		};
@@ -6279,6 +6299,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		62986F012B03D250008E2D62 /* XCRemoteSwiftPackageReference "Nimble" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Quick/Nimble";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 13.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		62986F022B03D250008E2D62 /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 62986F012B03D250008E2D62 /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6327C5CA1EB8A783004E799B /* Project object */;
 }

--- a/Tests/SentryTests/Protocol/SentryUserFeedbackTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserFeedbackTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 import XCTest
 
 class SentryUserFeedbackTests: XCTestCase {
@@ -5,9 +6,9 @@ class SentryUserFeedbackTests: XCTestCase {
     func testPropertiesAreSetToEmptyString() {
         let userFeedback = UserFeedback(eventId: SentryId())
         
-        XCTAssertEqual("", userFeedback.comments)
-        XCTAssertEqual("", userFeedback.email)
-        XCTAssertEqual("", userFeedback.name)
+        expect(userFeedback.comments).to(beEmpty())
+        expect(userFeedback.email).to(beEmpty())
+        expect(userFeedback.name).to(beEmpty())
     }
     
     func testSerialize() {
@@ -18,10 +19,10 @@ class SentryUserFeedbackTests: XCTestCase {
         
         let actual = userFeedback.serialize()
         
-        XCTAssertEqual(userFeedback.eventId.sentryIdString, actual["event_id"] as? String)
-        XCTAssertEqual(userFeedback.comments, actual["comments"] as? String)
-        XCTAssertEqual(userFeedback.email, actual["email"] as? String)
-        XCTAssertEqual(userFeedback.name, actual["name"] as? String)
+        expect(actual["event_id"] as? String).to(match(userFeedback.eventId.sentryIdString))
+        expect(actual["comments"] as? String).to(match(userFeedback.comments))
+        expect(actual["email"] as? String).to(match(userFeedback.email))
+        expect(actual["name"] as? String).to(match(userFeedback.name))
     }
     
     func testSerialize_WithoutSettingProperties_AllAreEmptyStrings() {
@@ -29,8 +30,8 @@ class SentryUserFeedbackTests: XCTestCase {
         
         let actual = userFeedback.serialize()
         
-        XCTAssertEqual("", actual["comments"] as? String)
-        XCTAssertEqual("", actual["email"] as? String)
-        XCTAssertEqual("", actual["name"] as? String)
+        expect(actual["comments"] as? String).to(beEmpty())
+        expect(actual["email"] as? String).to(beEmpty())
+        expect(actual["name"] as? String).to(beEmpty())
     }
 }


### PR DESCRIPTION
Convert user feedback tests to see them in action. I had to increase the deployment target for tests to iOS 13 cause Nimble requires a minimum version of iOS 13 or higher. That shouldn't be a problem because we can only run unit tests on iOS 13 or higher on GH actions, see https://github.com/getsentry/sentry-cocoa/blob/1ce939e8ac0eb2a9c3ced2d46fbaeee39351b758/.github/workflows/test.yml#L83-L88

