### PR TITLE
test: add a test that stops the SDK on a nonmain thread

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -220,7 +220,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="hFG-bX-qLp">
-                                <rect key="frame" x="10" y="174" width="300" height="159.5"/>
+                                <rect key="frame" x="10" y="174" width="300" height="194"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Work threads:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t2C-jL-6qO">
                                         <rect key="frame" x="97" y="0.0" width="106.5" height="20.5"/>
@@ -306,6 +306,14 @@
                                             <action selector="bgBrightnessChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="HTb-Ef-kcz"/>
                                         </connections>
                                     </slider>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XJf-Vq-id8">
+                                        <rect key="frame" x="37.5" y="159.5" width="225" height="34.5"/>
+                                        <state key="normal" title="Button"/>
+                                        <buttonConfiguration key="configuration" style="plain" title="Close SDK on New Thread"/>
+                                        <connections>
+                                            <action selector="closeSDKOnNewThread:" destination="NZr-bH-g9o" eventType="touchUpInside" id="ASJ-50-JAt"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="rJh-QS-fAl" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" id="jbh-kK-Uqg"/>

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -119,4 +119,10 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
         let maxInterval = (maxWorkIntensityTextField.text! as NSString).integerValue
         workIntervalMicros = UInt32(_projectedRange(factor: workIntervalSlider.value, min: minInterval, max: maxInterval))
     }
+    
+    @IBAction func closeSDKOnNewThread(_ sender: Any) {
+        Thread.detachNewThread {
+            SentrySDK.close()
+        }
+    }
 }

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -38,4 +38,14 @@ final class ProfilingUITests: BaseUITest {
         let frameRateValues = try XCTUnwrap(frameRates["values"] as? [[String: Any]])
         XCTAssertFalse(frameRateValues.isEmpty)
     }
+    
+    func testInvalidPointerToFrameRateTimestampsInDisplayLinkCallback() {
+        let app = XCUIApplication()
+        let tabBar = app.tabBars["Tab Bar"]
+        tabBar.buttons["Transactions"].tap()
+        app.staticTexts["Start transaction (main thread)"].tap()
+        tabBar.buttons["Profiling"].tap()
+        app.staticTexts["Close SDK on New Thread"].tap()
+        tabBar.buttons["Transactions"].tap()
+    }
 }


### PR DESCRIPTION
Trying to find a repro for a crash we're observing in `SentryFramesTracker` when accessing `self.frameRateTimestamps`. See [here](https://sentry.sentry.io/issues/4391703480/?project=4505469596663808&query=is%3Aunresolved+SentryFramesTracker&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=3) and [here](https://sentry.sentry.io/issues/4617044928/?project=4505469596663808&query=is%3Aunresolved+SentryFramesTracker&referrer=issue-stream&sort=freq&statsPeriod=14d&stream_index=6) for internal SDK crash reports.

My guess so far was that the frames tracker could have become deallocated and the memory previously allocated to it reallocated somewhere else. I thought if `SentryDependencyContainer.reset` were called this would happen, so I tried to create a test that would cause that to be called from a different thread while `displayLinkCallback` is executing, but before the ivar in question is accessed. Running this UI test repeatedly didn't repro the issue, but if that's actually what's happening, it would be very unlikely to happen. We'd need to mock this in a unit test somehow.