### PR TITLE
test: Add periodic work to sample app

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -4,20 +4,52 @@ import UIKit
 class ViewController: UIViewController {
 
     private let dispatchQueue = DispatchQueue(label: "ViewController", attributes: .concurrent)
+    private var timer: Timer?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         SentrySDK.reportFullyDisplayed()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        periodicallyDoWork()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super .viewDidDisappear(animated)
+        self.timer?.invalidate()
+    }
+    
+    private func periodicallyDoWork() {
+
+        self.timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
+            self.dispatchQueue.async {
+                self.loadSentryBrandImage()
+                Thread.sleep(forTimeInterval: 1.0)
+                self.readLoremIpsumFile()
+            }
+        }
+        RunLoop.current.add(self.timer!, forMode: .common)
+        self.timer!.fire()
+    }
 
     @IBAction func uiClickTransaction(_ sender: UIButton) {
         highlightButton(sender)
+       
+        readLoremIpsumFile()
+        loadSentryBrandImage()
+    }
+    
+    private func readLoremIpsumFile() {
         dispatchQueue.async {
             if let path = Bundle.main.path(forResource: "LoremIpsum", ofType: "txt") {
                 _ = FileManager.default.contents(atPath: path)
             }
         }
-
+    }
+    
+    private func loadSentryBrandImage() {
         guard let imgUrl = URL(string: "https://sentry-brand.storage.googleapis.com/sentry-logo-black.png") else {
             return
         }


### PR DESCRIPTION
Periodically read a file and perform a network request in the iOS-Swift sample app, which will help test carrier transactions.

The flaky UI test is fixed in https://github.com/getsentry/sentry-cocoa/pull/3421 and therefore this PR is also based on https://github.com/getsentry/sentry-cocoa/pull/3421.

#skip-changelog