### PR TITLE
test: Add periodic work to sample app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,13 @@ jobs:
             test-destination-os: "16.4"
             device: "iPhone 14"
 
+          # iOS 17
+          - runs-on: macos-13
+            platform: "iOS"
+            xcode: "15.0.1"
+            test-destination-os: "latest"
+            device: "iPhone 14"
+
           # macOS 11
           - runs-on: macos-11
             platform: "macOS"
@@ -120,10 +127,16 @@ jobs:
             xcode: "13.4.1"
             test-destination-os: "latest"
 
-            # macOS 13
+          # macOS 13
           - runs-on: macos-13
             platform: "macOS"
             xcode: "14.3"
+            test-destination-os: "latest"
+          
+          # macOS 14
+          - runs-on: macos-13
+            platform: "macOS"
+            xcode: "15.0.1"
             test-destination-os: "latest"
 
           # Catalyst. We only test the latest version, as
@@ -144,6 +157,12 @@ jobs:
           - runs-on: macos-13
             platform: "tvOS"
             xcode: "14.3"
+            test-destination-os: "latest"
+
+          # tvOS 17
+          - runs-on: macos-13
+            platform: "tvOS"
+            xcode: "15.0.1"
             test-destination-os: "latest"
 
     steps:

--- a/Samples/iOS-Swift/iOS-Swift/ViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewController.swift
@@ -4,20 +4,52 @@ import UIKit
 class ViewController: UIViewController {
 
     private let dispatchQueue = DispatchQueue(label: "ViewController", attributes: .concurrent)
+    private var timer: Timer?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         SentrySDK.reportFullyDisplayed()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        periodicallyDoWork()
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super .viewDidDisappear(animated)
+        self.timer?.invalidate()
+    }
+    
+    private func periodicallyDoWork() {
+
+        self.timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
+            self.dispatchQueue.async {
+                self.loadSentryBrandImage()
+                Thread.sleep(forTimeInterval: 1.0)
+                self.readLoremIpsumFile()
+            }
+        }
+        RunLoop.current.add(self.timer!, forMode: .common)
+        self.timer!.fire()
+    }
 
     @IBAction func uiClickTransaction(_ sender: UIButton) {
         highlightButton(sender)
+       
+        readLoremIpsumFile()
+        loadSentryBrandImage()
+    }
+    
+    private func readLoremIpsumFile() {
         dispatchQueue.async {
             if let path = Bundle.main.path(forResource: "LoremIpsum", ofType: "txt") {
                 _ = FileManager.default.contents(atPath: path)
             }
         }
-
+    }
+    
+    private func loadSentryBrandImage() {
         guard let imgUrl = URL(string: "https://sentry-brand.storage.googleapis.com/sentry-logo-black.png") else {
             return
         }

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -75,9 +75,16 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         sut.start(with: delegate)
         sut.startSwizzle()
 
+        // Using UINavigationController as a parent doesn't work on tvOS 17.0
+        // for an unknown reason. Therefore, we manually set the parent.
+        class ParentUIViewController: UIViewController {
+            
+        }
+        let parentController = ParentUIViewController()
         let viewController = UIViewController()
-        _ = UINavigationController(rootViewController: viewController)
+        parentController.addChild(viewController)
         viewController.title = "test title"
+        
         print("delegate: \(String(describing: delegate))")
         print("tracker: \(sut); SentryBreadcrumbTracker.delegate: \(String(describing: Dynamic(sut).delegate.asObject))")
         viewController.viewDidAppear(false)
@@ -97,7 +104,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         XCTAssertEqual("UIViewController", lifeCycleCrumb.data?["screen"] as? String)
         XCTAssertEqual("test title", lifeCycleCrumb.data?["title"] as? String)
         XCTAssertEqual("false", lifeCycleCrumb.data?["beingPresented"] as? String)
-        XCTAssertEqual("UINavigationController", lifeCycleCrumb.data?["parentViewController"] as? String)
+        XCTAssertEqual("ParentUIViewController", lifeCycleCrumb.data?["parentViewController"] as? String)
         
         clearTestState()
     }


### PR DESCRIPTION
Periodically read a file and perform a network request in the iOS-Swift sample app, which will help test carrier transactions.

The flaky UI test is fixed in https://github.com/getsentry/sentry-cocoa/pull/3421 and therefore this PR is also based on https://github.com/getsentry/sentry-cocoa/pull/3421.

#skip-changelog