### PR TITLE
fix: Crash in SentryFramesTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Infinite loop when parsing MetricKit data (#3395)
 - Fix incorrect implementation in #3398 to work around a profiling crash (#3405)
+- Fix crash in SentryFramesTracker (#3424)
 
 ### Improvements
 

--- a/SentryTestUtils/TestDisplayLinkWrapper.swift
+++ b/SentryTestUtils/TestDisplayLinkWrapper.swift
@@ -43,9 +43,11 @@ public class TestDisplayLinkWrapper: SentryDisplayLinkWrapper {
         return dateProvider.systemTime().toTimeInterval() + currentFrameRate.tickDuration
     }
 
+    public var invalidateInvocations = Invocations<Void>()
     public override func invalidate() {
         target = nil
         selector = nil
+        invalidateInvocations.record(Void())
     }
     
     public func call() {

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -209,12 +209,6 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
-- (void)stop
-{
-    _isRunning = NO;
-    [self.displayLinkWrapper invalidate];
-}
-
 - (void)addListener:(id<SentryFramesTrackerListener>)listener
 {
 
@@ -228,6 +222,17 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     @synchronized(self.listeners) {
         [self.listeners removeObject:listener];
     }
+}
+
+- (void)stop
+{
+    _isRunning = NO;
+    [self.displayLinkWrapper invalidate];
+}
+
+- (void)dealloc
+{
+    [self stop];
 }
 
 @end

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -143,6 +143,16 @@ class SentryFramesTrackerTests: XCTestCase {
 
         XCTAssertEqual(callbackCalls, 1)
     }
+    
+    func testDealloc_CallsStop() {
+        
+        func sutIsDeallocatedAfterCallingMe() {
+            _ = SentryFramesTracker(displayLinkWrapper: fixture.displayLinkWrapper)
+        }
+        sutIsDeallocatedAfterCallingMe()
+        
+        XCTAssertEqual(1, fixture.displayLinkWrapper.invalidateInvocations.count)
+    }
 }
 
 private class FrameTrackerListener: NSObject, SentryFramesTrackerListener {


### PR DESCRIPTION


## :scroll: Description

The SentryFramesTracker registers a callback to the CADisplayLink. While the SentryFramesTrackingIntegration keeps a reference to the SentryFramesTracker and calls SentryFramesTracker.stop on uninstall, there could be situations where the SentryFramesTracker is deallocated, but not calling invalidate on the CADisplayLink. Then the CADisplayLink still calls  and crashes with EXC_BAD_ACCESS cause the frames tracker is deallocated. To fix this problem SentryFramesTracker.dealloc now calls invalidate on the CADisplayLink.

## :bulb: Motivation and Context

A customer reported this crash, and we also see this in our [SDK crashes](https://sentry.sentry.io/issues/?project=4505469596663808&query=is%3Aunresolved+displaylinkcallback&referrer=issue-list&sort=user&statsPeriod=14d).

## :green_heart: How did you test it?
The actual crash is hard to reproduce, but I added a unit test to validate that dealloc calls invalidate.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
