### PR TITLE
test: Skip callbacks for Swift Reachability Tests

### DIFF
--- a/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
+++ b/Tests/SentryTests/Networking/SentryReachabilitySwiftTests.swift
@@ -4,6 +4,12 @@ final class SentryReachabilitySwiftTests: XCTestCase {
 
     func testAddRemoveFromMultipleThreads() throws {
         let sut = SentryReachability()
+        // Calling the methods of SCNetworkReachability in a tight loop from
+        // multiple threads is not an actual use case, and it leads to flaky test
+        // results. With this test, we want to test if the adding and removing
+        // observers are adequately synchronized and not if we call
+        // SCNetworkReachability correctly.
+        sut.skipRegisteringActualCallbacks = true
         testConcurrentModifications(writeWork: {_ in
             sut.add(TestReachabilityObserver())
         }, readWork: {


### PR DESCRIPTION
Calling the methods of SCNetworkReachability in a tight loop from multiple threads is not an actual use case, and it leads to flaky test results. With this test, we want to test if the adding and removing observers are adequately synchronized and not if we call SCNetworkReachability correctly.

The reason for this PR is that testNoObservers still is flaky sometimes. See https://github.com/getsentry/sentry-cocoa/actions/runs/6888982334.

#skip-changelog