### PR TITLE
test: Specify integrations when starting SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ Test guidelines:
 * We prefer using [Nimble](https://github.com/Quick/Nimble) over XCTest for test assertions. We can't use the latest Nimble version and are stuck
 with [v10.0.0](https://github.com/Quick/Nimble/releases/tag/v10.0.0), cause it's the latest one that still supports Xcode 13.2.1, which we use in CI for
 running our tests. [v11.0.0](https://github.com/Quick/Nimble/releases/tag/v11.0.0) already requires Swift 5.6 / Xcode 13.3.
+* When calling `SentrySDK.start` in a test, specify only the minimum integrations required to minimize side effects for tests and reduce flakiness.
 
 
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		62A456E32B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */; };
 		62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */; };
 		62B86CFC29F052BB008F3947 /* SentryTestLogConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */; };
+		62C25C862B075F4900C68CBD /* TestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C25C852B075F4900C68CBD /* TestOptions.swift */; };
 		62E081A929ED4260000F69FC /* SentryBreadcrumbDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */; };
 		62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */; };
 		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
@@ -973,6 +974,7 @@
 		62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUIEventTrackerTransactionMode.h; path = include/SentryUIEventTrackerTransactionMode.h; sourceTree = "<group>"; };
 		62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryUIEventTrackerTransactionMode.m; sourceTree = "<group>"; };
 		62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTestLogConfig.m; sourceTree = "<group>"; };
+		62C25C852B075F4900C68CBD /* TestOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestOptions.swift; sourceTree = "<group>"; };
 		62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBreadcrumbDelegate.h; path = include/SentryBreadcrumbDelegate.h; sourceTree = "<group>"; };
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
 		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
@@ -3210,6 +3212,7 @@
 				844EDC7829415AB300C86F34 /* TestSentrySystemWrapper.swift */,
 				844EDCE72947DCD700C86F34 /* TestSentryNSTimerFactory.swift */,
 				84B7FA3B29B2866200AD93B1 /* SentryTestUtils-ObjC-BridgingHeader.h */,
+				62C25C852B075F4900C68CBD /* TestOptions.swift */,
 			);
 			path = SentryTestUtils;
 			sourceTree = "<group>";
@@ -4491,6 +4494,7 @@
 			files = (
 				8431F01629B2851500D8DC56 /* TestSentryNSProcessInfoWrapper.swift in Sources */,
 				84B7FA4229B28CDE00AD93B1 /* TestCurrentDateProvider.swift in Sources */,
+				62C25C862B075F4900C68CBD /* TestOptions.swift in Sources */,
 				84B7FA3F29B28BAD00AD93B1 /* TestTransport.swift in Sources */,
 				84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */,
 				84AC61D929F7643B009EEF61 /* TestDispatchFactory.swift in Sources */,

--- a/SentryTestUtils/TestOptions.swift
+++ b/SentryTestUtils/TestOptions.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Sentry
+
+public extension Options {
+    func setIntegrations(_ integrations: [AnyClass]) {
+        self.integrations = integrations.map {
+            String(describing: $0)
+        }
+    }
+    
+    func removeAllIntegrations() {
+        self.integrations = []
+    }
+}

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryNSDataTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryNSDataTrackerTests.swift
@@ -34,7 +34,9 @@ class SentryNSDataTrackerTests: XCTestCase {
         super.setUp()
         fixture = Fixture()
         fixture.getSut().enable()
-        SentrySDK.start { $0.enableFileIOTracing = true }
+        SentrySDK.start {
+            $0.removeAllIntegrations()
+        }
     }
     
     override func tearDown() {

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -36,19 +36,28 @@ class SentryScreenshotIntegrationTests: XCTestCase {
     }
 
     func test_attachScreenshot_disabled() {
-        SentrySDK.start { $0.attachScreenshot = false }
+        SentrySDK.start {
+            $0.attachScreenshot = false
+            $0.setIntegrations([SentryScreenshotIntegration.self])
+        }
         XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
         XCTAssertFalse(sentrycrash_hasSaveScreenshotCallback())
     }
     
     func test_attachScreenshot_enabled() {
-        SentrySDK.start { $0.attachScreenshot = true }
+        SentrySDK.start {
+            $0.attachScreenshot = true
+            $0.setIntegrations([SentryScreenshotIntegration.self])
+        }
         XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
         XCTAssertTrue(sentrycrash_hasSaveScreenshotCallback())
     }
     
     func test_uninstall() {
-        SentrySDK.start { $0.attachScreenshot = true }
+        SentrySDK.start {
+            $0.attachScreenshot = true
+            $0.setIntegrations([SentryScreenshotIntegration.self])
+        }
         SentrySDK.close()
         
         XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -77,6 +77,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
             options.dsn = SentryCrashIntegrationTests.dsnAsString
             options.releaseName = releaseName
             options.dist = dist
+            options.setIntegrations([SentryCrashIntegration.self])
         }
         
         // To test this properly we need SentryCrash and SentryCrashIntegration installed and registered on the current hub of the SDK.
@@ -89,6 +90,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     func testContext_IsPassedToSentryCrash() throws {
         SentrySDK.start { options in
             options.dsn = SentryCrashIntegrationTests.dsnAsString
+            options.setIntegrations([SentryCrashIntegration.self])
         }
         
         let userInfo = try XCTUnwrap(SentryDependencyContainer.sharedInstance().crashReporter.userInfo)

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -36,26 +36,38 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
     }
 
     func test_attachViewHierarchy() {
-        SentrySDK.start { $0.attachViewHierarchy = false }
+        SentrySDK.start {
+            $0.attachViewHierarchy = false
+            $0.setIntegrations([SentryViewHierarchyIntegration.self])
+        }
         XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
         XCTAssertFalse(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
     func test_attachViewHierarchy_enabled() {
-        SentrySDK.start { $0.attachViewHierarchy = true }
+        SentrySDK.start {
+            $0.attachViewHierarchy = true
+            $0.setIntegrations([SentryViewHierarchyIntegration.self])
+        }
         XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
         XCTAssertTrue(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
     func test_uninstall() {
-        SentrySDK.start { $0.attachViewHierarchy = true }
+        SentrySDK.start {
+            $0.attachViewHierarchy = true
+            $0.setIntegrations([SentryViewHierarchyIntegration.self])
+        }
         SentrySDK.close()
         XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
         XCTAssertFalse(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
     func test_integrationAddFileName() {
-        SentrySDK.start { $0.attachViewHierarchy = true }
+        SentrySDK.start {
+            $0.attachViewHierarchy = true
+            $0.setIntegrations([SentryViewHierarchyIntegration.self])
+        }
         saveViewHierarchy("/test/path")
         XCTAssertEqual("/test/path/view-hierarchy.json", fixture.viewHierarchy.saveFilePathUsed)
     }

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -51,6 +51,7 @@ class SentryCrashInstallationReporterTests: XCTestCase {
     private func sdkStarted() {
         SentrySDK.start { options in
             options.dsn = SentryCrashInstallationReporterTests.dsnAsString
+            options.setIntegrations([SentryCrashIntegration.self])
         }
         let options = Options()
         options.dsn = SentryCrashInstallationReporterTests.dsnAsString

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -84,6 +84,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
             options.swiftAsyncStacktraces = true
             options.debug = true
+            options.setIntegrations([SentryCrashIntegration.self, SentrySwiftAsyncIntegration.self])
         }
 
         let waitForAsyncToRun = expectation(description: "Wait async functions")
@@ -113,6 +114,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
             options.dsn = TestConstants.dsnAsString(username: "SentryStacktraceBuilderTests")
             options.swiftAsyncStacktraces = false
             options.debug = true
+            options.setIntegrations([SentryCrashIntegration.self, SentrySwiftAsyncIntegration.self])
         }
 
         let waitForAsyncToRun = expectation(description: "Wait async functions")

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -80,6 +80,7 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
             options.maxBreadcrumbs = 0
+            options.setIntegrations([])
         }
 
         SentrySDK.addBreadcrumb(Breadcrumb(level: SentryLevel.warning, category: "test"))
@@ -123,6 +124,7 @@ class SentrySDKTests: XCTestCase {
     func testStartStopBinaryImageCache() {
         SentrySDK.start { options in
             options.debug = true
+            options.removeAllIntegrations()
         }
 
         XCTAssertNotNil(SentryDependencyContainer.sharedInstance().binaryImageCache.cache)
@@ -136,6 +138,7 @@ class SentrySDKTests: XCTestCase {
     func testStartWithConfigureOptions_NoDsn() throws {
         SentrySDK.start { options in
             options.debug = true
+            options.removeAllIntegrations()
         }
         
         let options = SentrySDK.currentHub().getClient()?.options
@@ -148,6 +151,7 @@ class SentrySDKTests: XCTestCase {
     func testStartWithConfigureOptions_WrongDsn() throws {
         SentrySDK.start { options in
             options.dsn = "wrong"
+            options.removeAllIntegrations()
         }
         
         let options = SentrySDK.currentHub().getClient()?.options
@@ -164,6 +168,7 @@ class SentrySDKTests: XCTestCase {
                 wasBeforeSendCalled = true
                 return event
             }
+            options.removeAllIntegrations()
         }
         
         SentrySDK.capture(message: "")
@@ -181,6 +186,7 @@ class SentrySDKTests: XCTestCase {
                 XCTAssertEqual(123, Dynamic(suggested).maxBreadcrumbs)
                 return scope
             }
+            options.removeAllIntegrations()
         }
         XCTAssertEqual("me", SentrySDK.currentHub().scope.userObject?.userId)
         XCTAssertIdentical(scope, SentrySDK.currentHub().scope)
@@ -412,7 +418,7 @@ class SentrySDKTests: XCTestCase {
     
     func testInstallIntegrations_NoIntegrations() {
         SentrySDK.start { options in
-            options.integrations = []
+            options.removeAllIntegrations()
         }
         
         assertIntegrationsInstalled(integrations: [])
@@ -491,6 +497,7 @@ class SentrySDKTests: XCTestCase {
         
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         
         XCTAssertEqual(1, SentrySDK.startInvocations)
@@ -504,6 +511,7 @@ class SentrySDKTests: XCTestCase {
         
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         XCTAssertTrue(SentrySDK.isEnabled)
         
@@ -515,6 +523,7 @@ class SentrySDKTests: XCTestCase {
         
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         XCTAssertTrue(SentrySDK.isEnabled)
     }
@@ -522,6 +531,7 @@ class SentrySDKTests: XCTestCase {
     func testClose_ResetsDependencyContainer() {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         
         let first = SentryDependencyContainer.sharedInstance()
@@ -536,9 +546,12 @@ class SentrySDKTests: XCTestCase {
     func testClose_ClearsIntegrations() {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.swiftAsyncStacktraces = true
+            options.setIntegrations([SentrySwiftAsyncIntegration.self])
         }
         
         let hub = SentrySDK.currentHub()
+        XCTAssertEqual(1, hub.installedIntegrations().count)
         SentrySDK.close()
         XCTAssertEqual(0, hub.installedIntegrations().count)
         assertIntegrationsInstalled(integrations: [])
@@ -549,6 +562,7 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
             options.tracesSampleRate = 1
+            options.removeAllIntegrations()
         }
 
         let appStateManager = SentryDependencyContainer.sharedInstance().appStateManager
@@ -557,6 +571,7 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
             options.tracesSampleRate = 1
+            options.removeAllIntegrations()
         }
 
         XCTAssertEqual(appStateManager.startCount, 2)
@@ -606,6 +621,7 @@ class SentrySDKTests: XCTestCase {
     func testClose_SetsClientToNil() {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         
         SentrySDK.close()
@@ -616,6 +632,7 @@ class SentrySDKTests: XCTestCase {
     func testClose_ClosesClient() {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         
         let client = SentrySDK.currentHub().client()
@@ -627,6 +644,7 @@ class SentrySDKTests: XCTestCase {
     func testClose_CallsFlushCorrectlyOnTransport() throws {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         
         let transport = TestTransport()
@@ -641,6 +659,7 @@ class SentrySDKTests: XCTestCase {
     func testFlush_CallsFlushCorrectlyOnTransport() throws {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
         }
         
         let transport = TestTransport()

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -164,6 +164,7 @@
 #import "SentryScreenshot.h"
 #import "SentryScreenshotIntegration.h"
 #import "SentrySdkInfo.h"
+#import "SentrySwiftAsyncIntegration.h"
 
 #import "SentrySerialization.h"
 #import "SentrySession+Private.h"


### PR DESCRIPTION
Specify the minimum integrations required for every test case using SentrySDK.start to minimize side effects for tests and reduce flakiness.

While investigating why `testConcurrentStacktraces_noStitching` was failing in [CI](https://github.com/getsentry/sentry-cocoa/actions/runs/6896421341/job/18762544285), I saw that the test logs print that the test is calling classes not required for the test to succeed when starting the SDK. That's how I came up with the idea for this PR.

<details><summary>Test Logs for failing testConcurrentStacktraces_noStitching</summary>
<p>

```sh
Test Case '-[SentryTests.SentryStacktraceBuilderTests testConcurrentStacktraces_noStitching]' started.
2023-11-16 21:08:28.145977+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:145] Starting SDK...
2023-11-16 21:08:28.146343+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:645] SentryFileManager.cachePath: /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches
2023-11-16 21:08:28.146688+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/events
2023-11-16 21:08:28.147694+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:268] sendAllCachedEnvelopes start.
2023-11-16 21:08:28.147934+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:280] No envelopes left to send.
2023-11-16 21:08:28.148332+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:362] Finished sending.
2023-11-16 21:08:28.148530+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:180] Adding observer: <SentryHttpTransport: 0x600014fb1da0>
2023-11-16 21:08:28.148679+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:182] Synchronized to add observer: <SentryHttpTransport: 0x600014fb1da0>
2023-11-16 21:08:28.148982+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:212] registering callback for reachability ref <SCNetworkReachability 0x7f98a27fa590 [0x10c8911d0]> {name = sentry.io}
2023-11-16 21:08:28.149627+0000 xctest[6477:36822] [Sentry] [debug] [SentryFileManager:93] Dispatched deletion of old envelopes from <SentryFileManager: 0x600001a71040>
2023-11-16 21:08:28.149569+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:476] Moving state /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/app.state to previous /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.app.state.
2023-11-16 21:08:28.150855+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.app.state
2023-11-16 21:08:28.151000+0000 xctest[6477:36822] [Sentry] [warning] [SentryFileManager:175] Could not get NSFileTypeDirectory from /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/timezone.offset
2023-11-16 21:08:28.151774+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:476] Moving state /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/breadcrumbs.1.state to previous /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.breadcrumbs.1.state.
2023-11-16 21:08:28.152614+0000 xctest[6477:36440] [Sentry] [debug] [SentryReachability:138] SentryConnectivityCallback called with target: <SCNetworkReachability 0x7f98a27fa590 [0x10c8911d0]> {name = sentry.io (complete, 35.186.247.156), flags = 0x00000002, if_index = 5}; flags: 2
2023-11-16 21:08:28.152932+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.breadcrumbs.1.state
2023-11-16 21:08:28.153478+0000 xctest[6477:36440] [Sentry] [debug] [SentryReachability:103] Entered synchronized region of SentryConnectivityCallback with flags: 2
2023-11-16 21:08:28.154177+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:476] Moving state /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/breadcrumbs.2.state to previous /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.breadcrumbs.2.state.
2023-11-16 21:08:28.154292+0000 xctest[6477:36440] [Sentry] [debug] [SentryReachability:119] Notifying observers...
2023-11-16 21:08:28.154998+0000 xctest[6477:36440] [Sentry] [debug] [SentryReachability:121] Notifying <SentryHttpTransport: 0x600014fb1da0>
2023-11-16 21:08:28.155593+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:242] Deleting /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.breadcrumbs.2.state
2023-11-16 21:08:28.155851+0000 xctest[6477:36440] [Sentry] [debug] [SentryHttpTransport:106] Internet connection is back.
2023-11-16 21:08:28.156759+0000 xctest[6477:36440] [Sentry] [debug] [SentryHttpTransport:268] sendAllCachedEnvelopes start.
2023-11-16 21:08:28.156966+0000 xctest[6477:36440] [Sentry] [debug] [SentryHttpTransport:280] No envelopes left to send.
2023-11-16 21:08:28.157113+0000 xctest[6477:36440] [Sentry] [debug] [SentryHttpTransport:362] Finished sending.
2023-11-16 21:08:28.157284+0000 xctest[6477:36440] [Sentry] [debug] [SentryReachability:125] Finished notifying observers.
2023-11-16 21:08:28.157500+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:158] SDK initialized! Version: 8.15.2
2023-11-16 21:08:28.157902+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:160] Dispatching init work required to run on main thread.
2023-11-16 21:08:28.158301+0000 xctest[6477:33127] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2023-11-16 21:08:28.158691+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:162] SDK main thread init started...
2023-11-16 21:08:28.160332+0000 xctest[6477:33127] [Sentry] [warning] [SentryFileManager:570] No app state data found at /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/previous.app.state
2023-11-16 21:08:28.163474+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:381] Integration installed: SentryCrashIntegration
2023-11-16 21:08:28.164200+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryAppStartTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.164744+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryFramesTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.165338+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryPerformanceTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.165943+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryScreenshotIntegration because attachScreenshot is disabled.
2023-11-16 21:08:28.166481+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryUIEventTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.167205+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryViewHierarchyIntegration because attachViewHierarchy is disabled.
2023-11-16 21:08:28.168097+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:381] Integration installed: SentryANRTrackingIntegration
2023-11-16 21:08:28.168697+0000 xctest[6477:33127] [Sentry] [debug] [SentryScope:122] Add breadcrumb: <SentryBreadcrumb: 0x60001f359740, {
    category = started;
    level = info;
    message = "Breadcrumb Tracking";
    timestamp = "2023-11-16T21:08:28.169Z";
    type = debug;
}>
2023-11-16 21:08:28.169615+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:180] Adding observer: <SentryBreadcrumbTracker: 0x60000295ba40>
2023-11-16 21:08:28.170830+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:182] Synchronized to add observer: <SentryBreadcrumbTracker: 0x60000295ba40>
2023-11-16 21:08:28.171470+0000 xctest[6477:33127] [Sentry] [debug] [SentrySwizzleWrapper:26] Swizzling sendAction for SentryBreadcrumbTrackerSwizzleSendAction
2023-11-16 21:08:28.173060+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:591] Reading timezone offset
2023-11-16 21:08:28.173861+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:598] No timezone offset found.
2023-11-16 21:08:28.174776+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:613] Persisting timezone offset: 0
2023-11-16 21:08:28.177171+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:381] Integration installed: SentryAutoBreadcrumbTrackingIntegration
2023-11-16 21:08:28.177722+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:412] Reading timestamp of last in foreground at: /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/lastInForeground.timestamp
2023-11-16 21:08:28.179334+0000 xctest[6477:33127] [Sentry] [debug] [SentryFileManager:419] No lastInForeground found.
2023-11-16 21:08:28.179905+0000 xctest[6477:33127] [Sentry] [debug] Reading from session: /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/session.current
2023-11-16 21:08:28.180582+0000 xctest[6477:33127] [Sentry] [warning] [SentryFileManager:376] No data found at /Users/runner/Library/Developer/CoreSimulator/Devices/25300F54-86DE-4AC7-B194-A9DD4CBF3B76/data/Library/Caches/io.sentry/437aa95453fb4e35989a3ebf0b6137c082038d93/session.current
2023-11-16 21:08:28.181121+0000 xctest[6477:33127] [Sentry] [debug] [SentryHub:165] No cached session to close.
2023-11-16 21:08:28.181966+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:381] Integration installed: SentryAutoSessionTrackingIntegration
2023-11-16 21:08:28.182588+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryCoreDataTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.183169+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryFileIOTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.183918+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryNetworkTrackingIntegration because isTracingEnabled is disabled.
2023-11-16 21:08:28.184803+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:381] Integration installed: SentryNetworkTrackingIntegration
2023-11-16 21:08:28.185338+0000 xctest[6477:33127] [Sentry] [debug] [SentryBaseIntegration:29] Not going to enable SentryMetricKitIntegration because enableMetricKit is disabled.
2023-11-16 21:08:28.189222+0000 xctest[6477:33127] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2023-11-16 21:08:28 +0000 [Sentry] [TEST] running async task...
2023-11-16 21:08:28 +0000 [Sentry] [TEST] first async frame about to await...
2023-11-16 21:08:28 +0000 [Sentry] [TEST] second async frame about to await on task...
2023-11-16 21:08:28.190799+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799657461883 (frame tracker: <SentryFramesTracker: 0x600000826c10>).
2023-11-16 21:08:28.191051+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799657870698 (frame tracker: <SentryFramesTracker: 0x60000080c050>).
2023-11-16 21:08:28.191619+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799658189739 (frame tracker: <SentryFramesTracker: 0x60000080c280>).
2023-11-16 21:08:28.191942+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799658780223 (frame tracker: <SentryFramesTracker: 0x600004aff5c0>).
2023-11-16 21:08:28.192534+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799659367250 (frame tracker: <SentryFramesTracker: 0x600004b536b0>).
2023-11-16 21:08:28.192961+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799659635934 (frame tracker: <SentryFramesTracker: 0x600004b538e0>).
2023-11-16 21:08:28.193962+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799660796033 (frame tracker: <SentryFramesTracker: 0x600004b53840>).
2023-11-16 21:08:28.194548+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799661382930 (frame tracker: <SentryFramesTracker: 0x600004affc00>).
2023-11-16 21:08:28.195125+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799661962087 (frame tracker: <SentryFramesTracker: 0x600004b14190>).
2023-11-16 21:08:28.195302+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799662131982 (frame tracker: <SentryFramesTracker: 0x600004b53c50>).
2023-11-16 21:08:28.195566+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799662403564 (frame tracker: <SentryFramesTracker: 0x600004affed0>).
2023-11-16 21:08:28.196372+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799662940243 (frame tracker: <SentryFramesTracker: 0x600004afee40>).
2023-11-16 21:08:28.196891+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799663724230 (frame tracker: <SentryFramesTracker: 0x600004aff480>).
2023-11-16 21:08:28.197151+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799663986315 (frame tracker: <SentryFramesTracker: 0x600004b54410>).
2023-11-16 21:08:28.197469+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799664291673 (frame tracker: <SentryFramesTracker: 0x600004b58190>).
2023-11-16 21:08:28.198159+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799664796574 (frame tracker: <SentryFramesTracker: 0x600004b584b0>).
2023-11-16 21:08:28.198686+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799665520544 (frame tracker: <SentryFramesTracker: 0x600004b14be0>).
2023-11-16 21:08:28 +0000 [Sentry] [TEST] executing task inside second async frame...
2023-11-16 21:08:28.199453+0000 xctest[6477:36822] [Sentry] [debug] [SentryStacktraceBuilder:110] Building async-unsafe stack trace...
2023-11-16 21:08:28.199603+0000 xctest[6477:36822] [Sentry] [debug] [SentryCrashStackCursor_SelfThread:65] Retrieving backtrace without async swift stitching...
2023-11-16 21:08:28.199770+0000 xctest[6477:36822] [Sentry] [debug] [SentryCrashStackCursor_SelfThread:78] Finished retrieving backtrace.
2023-11-16 21:08:28.220583+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799687387790 (frame tracker: <SentryFramesTracker: 0x600000826c10>).
2023-11-16 21:08:28.222061+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799688727995 (frame tracker: <SentryFramesTracker: 0x60000080c050>).
2023-11-16 21:08:28.222853+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799689681185 (frame tracker: <SentryFramesTracker: 0x60000080c280>).
2023-11-16 21:08:28.223558+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799690393377 (frame tracker: <SentryFramesTracker: 0x600004aff5c0>).
2023-11-16 21:08:28.224256+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799690933592 (frame tracker: <SentryFramesTracker: 0x600004b536b0>).
2023-11-16 21:08:28.224897+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799691731021 (frame tracker: <SentryFramesTracker: 0x600004b538e0>).
2023-11-16 21:08:28.225422+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799692258554 (frame tracker: <SentryFramesTracker: 0x600004b53840>).
2023-11-16 21:08:28.225973+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799692806558 (frame tracker: <SentryFramesTracker: 0x600004affc00>).
2023-11-16 21:08:28.226555+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799693392069 (frame tracker: <SentryFramesTracker: 0x600004b14190>).
2023-11-16 21:08:28.227175+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799694012544 (frame tracker: <SentryFramesTracker: 0x600004b53c50>).
2023-11-16 21:08:28.227872+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799694706867 (frame tracker: <SentryFramesTracker: 0x600004affed0>).
2023-11-16 21:08:28.228159+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799694996271 (frame tracker: <SentryFramesTracker: 0x600004afee40>).
2023-11-16 21:08:28.229086+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799695917978 (frame tracker: <SentryFramesTracker: 0x600004aff480>).
2023-11-16 21:08:28.229756+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799696592028 (frame tracker: <SentryFramesTracker: 0x600004b54410>).
2023-11-16 21:08:28.230544+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799697378788 (frame tracker: <SentryFramesTracker: 0x600004b58190>).
2023-11-16 21:08:28.231163+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799697998143 (frame tracker: <SentryFramesTracker: 0x600004b584b0>).
2023-11-16 21:08:28.231727+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:151] Capturing slow frame starting at 1799698563434 (frame tracker: <SentryFramesTracker: 0x600004b14be0>).
/Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift:133: error: -[SentryTests.SentryStacktraceBuilderTests testConcurrentStacktraces_noStitching] : Asynchronous wait failed: Exceeded timeout of 1 seconds, with unfulfilled expectations: "Wait async functions".
2023-11-16 21:08:29.206072+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:402] Starting to close SDK.
2023-11-16 21:08:29.206418+0000 xctest[6477:33127] [Sentry] [info] [SentryANRTracker:203] Stopping ANR detection
2023-11-16 21:08:29.206634+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:407] Uninstalled all integrations.
2023-11-16 21:08:29.206801+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:191] Start flushing.
2023-11-16 21:08:29.206970+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:268] sendAllCachedEnvelopes start.
2023-11-16 21:08:29.207226+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:280] No envelopes left to send.
2023-11-16 21:08:29.207568+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:362] Finished sending.
2023-11-16 21:08:29.207734+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:366] Stop flushing.
2023-11-16 21:08:29.207900+0000 xctest[6477:33127] [Sentry] [debug] [SentryHttpTransport:211] Finished flushing.
2023-11-16 21:08:29.208070+0000 xctest[6477:33127] [Sentry] [debug] [SentryClient:532] Closed the Client.
2023-11-16 21:08:29.208231+0000 xctest[6477:33127] [Sentry] [debug] [SentryHub:690] Closed the Hub.
2023-11-16 21:08:29.208779+0000 xctest[6477:33127] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2023-11-16 21:08:29.209255+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:234] Removing all observers.
2023-11-16 21:08:29.209729+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:236] Synchronized to remove all observers.
2023-11-16 21:08:29.209997+0000 xctest[6477:33127] [Sentry] [debug] [SentryReachability:260] Cleaning up reachability queue.
2023-11-16 21:08:29.210476+0000 xctest[6477:33127] [Sentry] [debug] [SentrySDK:428] SDK closed!
2023-11-16 21:08:29.210996+0000 xctest[6477:33127] [Sentry] [debug] [SentryFramesTracker:61] Initialized frame tracker <SentryFramesTracker: 0x60000488e170>
2023-11-16 21:08:29.215657+0000 xctest[6477:33127] [Sentry] [warning] [SentryProfiler:492] Profiler is not currently running.
2023-11-16 21:08:29.216315+0000 xctest[6477:33127] [Sentry] [info] [SentryANRTracker:203] Stopping ANR detection
Test Case '-[SentryTests.SentryStacktraceBuilderTests testConcurrentStacktraces_noStitching]' failed (1.073 seconds).
```

</p>
</details> 