### PR TITLE
test: Specify integrations when starting SDK

### DIFF
--- a/SentryTestUtils/TestOptions.swift
+++ b/SentryTestUtils/TestOptions.swift
@@ -11,4 +11,10 @@ public extension Options {
     func removeAllIntegrations() {
         self.integrations = []
     }
+    
+    static func noIntegrations() -> Options {
+        let options = Options()
+        options.removeAllIntegrations()
+        return options
+    }
 }

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -13,6 +13,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
             options = Options()
             options.enableCoreDataTracing = true
             options.tracesSampleRate = 1
+            options.setIntegrations([SentryCoreDataTrackingIntegration.self])
         }
         
         func getSut() -> SentryCoreDataTrackingIntegration {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -17,6 +17,7 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
             result.enableFileIOTracing = enableFileIOTracing
             result.enableSwizzling = enableSwizzling
             result.tracesSampleRate = tracesSampleRate
+            result.setIntegrations([SentryFileIOTrackingIntegration.self])
             return result
         }
         

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -20,6 +20,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
             options = Options()
             options.dsn = SentryNetworkTrackerIntegrationTests.dsnAsString
             options.tracesSampleRate = 1.0
+            options.setIntegrations([SentryNetworkTrackingIntegration.self])
         }
     }
     

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -25,7 +25,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     private class Fixture {
         
         var options: Options {
-            let options = Options()
+            let options = Options.noIntegrations()
             let imageName = String(
                 cString: class_getImageName(SentryUIViewControllerSwizzlingTests.self)!,
                 encoding: .utf8)! as NSString

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -17,7 +17,7 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         }
         
         var options: Options {
-            let options = Options()
+            let options = Options.noIntegrations()
             let imageName = String(
                 cString: class_getImageName(SentryUIViewControllerSwizzlingTests.self)!,
                 encoding: .utf8)! as NSString

--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -25,7 +25,7 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
     override func setUp() {
         super.setUp()
         
-        options = Options()
+        options = Options.noIntegrations()
         options.dsn = TestConstants.realDSN
         
         options.releaseName = "Release Health"

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -79,6 +79,7 @@ class SentryClientTest: XCTestCase {
                 let options = try Options(dict: [
                     "dsn": SentryClientTest.dsn
                 ])
+                options.removeAllIntegrations()
                 configureOptions(options)
 
                 client = SentryClient(

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -41,9 +41,10 @@ class SentrySDKTests: XCTestCase {
             scope = Scope()
             scope.setTag(value: "value", key: "key")
             
-            options = Options()
+            options = Options.noIntegrations()
             options.dsn = SentrySDKTests.dsnAsString
             options.releaseName = "1.0.0"
+            
             client = TestClient(options: options)!
             hub = SentryHub(client: client, andScope: scope, andCrashWrapper: TestSentryCrashWrapper.sharedInstance())
             


### PR DESCRIPTION
I missed some test cases in https://github.com/getsentry/sentry-cocoa/pull/3427. This is a follow-up PR.

Specify the minimum integrations required for more test cases using SentrySDK.start.

#skip-changelog

