### PR TITLE
ci: Remove Xcode 15.0.1 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,13 +108,6 @@ jobs:
             test-destination-os: "16.4"
             device: "iPhone 14"
 
-          # iOS 17
-          - runs-on: macos-13
-            platform: "iOS"
-            xcode: "15.0.1"
-            test-destination-os: "latest"
-            device: "iPhone 14"
-
           # macOS 11
           - runs-on: macos-11
             platform: "macOS"
@@ -131,12 +124,6 @@ jobs:
           - runs-on: macos-13
             platform: "macOS"
             xcode: "14.3"
-            test-destination-os: "latest"
-          
-          # macOS 14
-          - runs-on: macos-13
-            platform: "macOS"
-            xcode: "15.0.1"
             test-destination-os: "latest"
 
           # Catalyst. We only test the latest version, as
@@ -157,12 +144,6 @@ jobs:
           - runs-on: macos-13
             platform: "tvOS"
             xcode: "14.3"
-            test-destination-os: "latest"
-
-          # tvOS 17
-          - runs-on: macos-13
-            platform: "tvOS"
-            xcode: "15.0.1"
             test-destination-os: "latest"
 
     steps:


### PR DESCRIPTION
Unit tests with Xcode 15.0.1 are more flaky compared to other Xcode versions. This could be due to a problem with GH action runners; see https://github.com/actions/runner-images/issues/8693. We will add Xcode 15 back once the next bugfix for Xcode 15.1 is released.

#skip-changelog