### PR TITLE
chore:  Remove "experimental" warning from SentryTracedView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- SwiftUI support is no longer in Beta (#3441) 
+
 ### Fixes
 
 - Fix inaccurate number of frames for transactions (#3439)

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -5,8 +5,6 @@ import SwiftUI
 import SentryInternal
 #endif
 
-/// - warning: This is an experimental feature and may still have bugs.
-///
 /// A control to measure the performance of your views and send the result as a transaction to Sentry.io.
 ///
 /// You create a transaction by wrapping your views with this.
@@ -96,7 +94,6 @@ public struct SentryTracedView<Content: View>: View {
 
 @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6.0, *)
 public extension View {
-    /// - warning: This is an experimental feature and may still have bugs.
     func sentryTrace(_ viewName: String? = nil) -> some View {
         return SentryTracedView(viewName) {
             return self


### PR DESCRIPTION
GA SwiftUI support

close #2572 

_#skip-changelog_