### PR TITLE
fix: check for null value returned from pthread_mach_thread_np

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Crash when dereferencing an invalid thread pointer (#3443)
+
 ## 8.16.1
 
 ### Fixes

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -141,10 +141,11 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
     if (payload != nil) {
         payload[@"platform"] = SentryPlatformName;
-        payload[@"transaction"] = @{
-            @"active_thread_id" :
-                [NSNumber numberWithLongLong:sentry::profiling::ThreadHandle::current()->tid()]
-        };
+        const auto thread = sentry::profiling::ThreadHandle::current();
+        if (thread != nullptr) {
+            payload[@"transaction"] =
+                @{ @"active_thread_id" : [NSNumber numberWithLongLong:thread->tid()] };
+        }
     }
 
     return payload;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -428,12 +428,16 @@ serializedProfileData(
               forTransaction:(SentryTransaction *)transaction;
 {
     payload[@"platform"] = transaction.platform;
+
+    const auto activeThreadID =
+        [transaction.trace.transactionContext sentry_threadInfo].threadId ?: @(-1);
     payload[@"transaction"] = @{
         @"id" : transaction.eventId.sentryIdString,
         @"trace_id" : transaction.trace.traceId.sentryIdString,
         @"name" : transaction.transaction,
-        @"active_thread_id" : [transaction.trace.transactionContext sentry_threadInfo].threadId
+        @"active_thread_id" : activeThreadID
     };
+
     const auto timestamp = transaction.trace.originalStartTimestamp;
     if (UNLIKELY(timestamp == nil)) {
         SENTRY_LOG_WARN(@"There was no start timestamp on the provided transaction. Falling back "

--- a/Sources/Sentry/SentryThreadHandle.cpp
+++ b/Sources/Sentry/SentryThreadHandle.cpp
@@ -45,6 +45,9 @@ namespace profiling {
     ThreadHandle::current() noexcept
     {
         const auto thread = pthread_mach_thread_np(pthread_self());
+        if (thread == (mach_port_t)NULL) {
+            return nullptr;
+        }
         return std::make_unique<ThreadHandle>(thread);
     }
 

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -116,25 +116,31 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
         _name = [NSString stringWithString:name];
         _nameSource = source;
         self.parentSampled = parentSampled;
+#if SENTRY_TARGET_PROFILING_SUPPORTED
         [self getThreadInfo];
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
     return self;
 }
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
 - (void)getThreadInfo
 {
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-    const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
+    const auto thread = sentry::profiling::ThreadHandle::current();
+    if (thread == nullptr) {
+        return;
+    }
+    const auto threadID = thread->tid();
     self.threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
-#endif
 }
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-- (SentryThread *)sentry_threadInfo
+- (nullable SentryThread *)sentry_threadInfo
 {
     return self.threadInfo;
 }
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 - (void)commonInitWithName:(NSString *)name
                     source:(SentryTransactionNameSource)source
@@ -143,7 +149,9 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
     _name = [NSString stringWithString:name];
     _nameSource = source;
     self.parentSampled = parentSampled;
+#if SENTRY_TARGET_PROFILING_SUPPORTED
     [self getThreadInfo];
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
     SENTRY_LOG_DEBUG(@"Created transaction context with name %@", name);
 }
 

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -37,12 +37,15 @@ SentryTransactionContext ()
                parentSampled:(SentrySampleDecision)parentSampled;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-// This is currently only exposed for testing purposes, see -[SentryProfilerTests
-// testProfilerMutationDuringSerialization]
-@property (nonatomic, strong) SentryThread *threadInfo;
 
-- (SentryThread *)sentry_threadInfo;
-#endif
+// This is currently only exposed for testing purposes, see -[SentryProfilerTests
+// testProfilerMutationDuringSerialization]. Can be null if there was a problem
+// getting the current thread info from the underlying API.
+@property (nonatomic, strong, nullable) SentryThread *threadInfo;
+
+- (nullable SentryThread *)sentry_threadInfo;
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @end
 

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -826,7 +826,7 @@ private extension SentryProfilerSwiftTests {
         XCTAssertNotEqual(SentryId.empty, linkedTransactionTraceId)
 
         let activeThreadId = try XCTUnwrap(linkedTransactionInfo["active_thread_id"] as? NSNumber)
-        XCTAssertEqual(activeThreadId, latestTransaction.trace.transactionContext.sentry_threadInfo().threadId)
+        XCTAssertEqual(activeThreadId, try XCTUnwrap(latestTransaction.trace.transactionContext.sentry_threadInfo()).threadId)
 
         for sample in samples {
             let timestamp = try XCTUnwrap(sample["elapsed_since_start_ns"] as? NSString)


### PR DESCRIPTION
We didn't completely fix the problem reported in https://github.com/getsentry/sentry-cocoa/issues/3354 with https://github.com/getsentry/sentry-cocoa/pull/3364. This changes the callsites to check for `NULL` before dereferencing the pointer.

I checked the sources and it does appear that `NULL` is a possible return value from `pthread_mach_thread_np `: https://github.com/apple/darwin-libpthread/blob/2b46cbcc56ba33791296cd9714b2c90dae185ec7/src/pthread.c#L931-L937 and for `_pthread_is_valid `, https://opensource.apple.com/source/libpthread/libpthread-416.11.1/src/internal.h.