### PR TITLE
ci: Stop running iOSSwift tests on simulator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -289,7 +289,7 @@ jobs:
     runs-on: macos-13
     strategy:
       matrix:
-        target: ["ios_swift", "ios_objc", "tvos_swift"]
+        target: ["ios_objc", "tvos_swift"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
We run the iOSSwift tests on SauceLabs and also with the address sanitizer. Therefore, we can remove running them on a simulator without address sanitizer.

#skip-changelog