### PR TITLE
ci: Remove UI test schedule

### DIFF
--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -1,9 +1,5 @@
 name: Sauce Labs UI Tests
 on:
-  # Schedule the UI tests so we can see in Sentry how the duration of transactions
-  # changes over time.
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
We once scheduled UI tests in CI to identify patterns in their duration because they often timed out. As they are currently stable, we can remove the unnecessary schedule.

#skip-changelog