### PR TITLE
ref: Extract checking image name inApp

### DIFF
--- a/Sources/Sentry/SentryBinaryImageCache.m
+++ b/Sources/Sentry/SentryBinaryImageCache.m
@@ -1,6 +1,7 @@
 #import "SentryBinaryImageCache.h"
 #import "SentryCrashBinaryImageCache.h"
 #import "SentryDependencyContainer.h"
+#import "SentryInAppLogic.h"
 
 static void binaryImageWasAdded(const SentryCrashBinaryImage *image);
 
@@ -99,12 +100,11 @@ SentryBinaryImageCache ()
     return -1; // Address not found
 }
 
-- (nullable NSString *)pathForImage:(NSString *)binaryName
+- (nullable NSString *)pathForInAppInclude:(NSString *)inAppInclude
 {
     @synchronized(self) {
         for (SentryBinaryImageInfo *info in _cache) {
-            if ([[info.name.lastPathComponent lowercaseString]
-                    hasPrefix:binaryName.lowercaseString]) {
+            if ([SentryInAppLogic isImageNameInApp:info.name inAppInclude:inAppInclude]) {
                 return info.name;
             }
         }

--- a/Sources/Sentry/SentryInAppLogic.m
+++ b/Sources/Sentry/SentryInAppLogic.m
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     for (NSString *inAppInclude in self.inAppIncludes) {
-        if ([imageName.lastPathComponent.lowercaseString hasPrefix:inAppInclude.lowercaseString])
+        if ([SentryInAppLogic isImageNameInApp:imageName inAppInclude:inAppInclude])
             return YES;
     }
 
@@ -44,6 +44,15 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSString *classImageName = [NSString stringWithCString:imageName encoding:NSUTF8StringEncoding];
     return [self isInApp:classImageName];
+}
+
++ (BOOL)isImageNameInApp:(NSString *)imageName inAppInclude:(NSString *)inAppInclude
+{
+    if ([imageName.lastPathComponent.lowercaseString hasPrefix:inAppInclude.lowercaseString]) {
+        return YES;
+    }
+
+    return NO;
 }
 
 @end

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -74,14 +74,14 @@ SentryUIViewControllerSwizzling ()
 
 - (void)start
 {
-    for (NSString *include in self.inAppLogic.inAppIncludes) {
-        NSString *pathToImage = [self.binaryImageCache pathForImage:include];
+    for (NSString *inAppInclude in self.inAppLogic.inAppIncludes) {
+        NSString *pathToImage = [self.binaryImageCache pathForInAppInclude:inAppInclude];
         if (pathToImage != nil) {
             [self swizzleUIViewControllersOfImage:pathToImage];
         } else {
             SENTRY_LOG_WARN(@"Failed to find the binary image for inAppInclude <%@> and, therefore "
                             @"can't instrument UIViewControllers in that binary",
-                include);
+                inAppInclude);
         }
     }
 

--- a/Sources/Sentry/include/HybridPublic/SentryBinaryImageCache.h
+++ b/Sources/Sentry/include/HybridPublic/SentryBinaryImageCache.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SentryBinaryImageInfo *)imageByAddress:(const uint64_t)address;
 
-- (nullable NSString *)pathForImage:(NSString *)binaryName;
+- (nullable NSString *)pathForInAppInclude:(NSString *)inAppInclude;
 
 @end
 

--- a/Sources/Sentry/include/SentryInAppLogic.h
+++ b/Sources/Sentry/include/SentryInAppLogic.h
@@ -76,6 +76,8 @@ SENTRY_NO_INIT
  */
 - (BOOL)isClassInApp:(Class)targetClass;
 
++ (BOOL)isImageNameInApp:(NSString *)imageName inAppInclude:(NSString *)inAppInclude;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -103,16 +103,16 @@ class SentryBinaryImageCacheTests: XCTestCase {
         sut.binaryImageAdded(&binaryImage)
         sut.binaryImageAdded(&binaryImage2)
         
-        let path = sut.path(forImage: "Expected Name at 0")
+        let path = sut.pathFor(inAppInclude: "Expected Name at 0")
         expect(path) == "Expected Name at 0"
         
-        let path2 = sut.path(forImage: "Expected Name at 1")
+        let path2 = sut.pathFor(inAppInclude: "Expected Name at 1")
         expect(path2) == "Expected Name at 1"
         
-        let path3 = sut.path(forImage: "Expected")
+        let path3 = sut.pathFor(inAppInclude: "Expected")
         expect(path3) == "Expected Name at 0"
         
-        let didNotFind = sut.path(forImage: "Name at 0")
+        let didNotFind = sut.pathFor(inAppInclude: "Name at 0")
         expect(didNotFind) == nil
     }
 

--- a/scripts/no-changes-in-high-risk-files.sh
+++ b/scripts/no-changes-in-high-risk-files.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 ACTUAL=$(shasum -a 256 ./Sources/Sentry/SentryNSURLSessionTaskSearch.m ./Sources/Sentry/SentryNetworkTracker.m ./Sources/Sentry/SentryUIViewControllerSwizzling.m ./Sources/Sentry/SentryNSDataSwizzling.m ./Sources/Sentry/SentrySubClassFinder.m ./Sources/Sentry/SentryCoreDataSwizzling.m ./Sources/Sentry/SentrySwizzleWrapper.m ./Sources/Sentry/include/SentrySwizzle.h ./Sources/Sentry/SentrySwizzle.m)
 EXPECTED="819d5ca5e3db2ac23c859b14c149b7f0754d3ae88bea1dba92c18f49a81da0e1  ./Sources/Sentry/SentryNSURLSessionTaskSearch.m
 2f9ea6984ff32b53fc03c386b648f4f1bdf8737ce69050d25ce6d1307f8d1672  ./Sources/Sentry/SentryNetworkTracker.m
-de3bcc594035e578c0012c0369759587f16106510390c99d2fc70b37637c2d00  ./Sources/Sentry/SentryUIViewControllerSwizzling.m
+40f476800b32cf885dba9ac3de75d93b6f536e819fe8e51d071b4610c879b416  ./Sources/Sentry/SentryUIViewControllerSwizzling.m
 e95e62ec7363984f20c78643bb7d992a41a740f97e1befb71525ac34caf88b37  ./Sources/Sentry/SentryNSDataSwizzling.m
 cc3849725bd1733515c71742872bed94ca47d2c115ef9d8c98383eae2e171925  ./Sources/Sentry/SentrySubClassFinder.m
 59db11da66e6ac0058526be0be08b57cdccd3727033e85164a631b205e972134  ./Sources/Sentry/SentryCoreDataSwizzling.m


### PR DESCRIPTION
Add method isImageNameInApp to SentryInAppLogic, so both SentryInAppLogic and SentryBinaryImageCache use the same code.

#skip-changelog