### PR TITLE
fix: Crash when UINavigationController without rootViewController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+
+### Fixes 
+
 - Crash when UINavigationController doesn't have rootViewController (#3455)
 
 ## 8.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Crash when UINavigationController doesn't have rootViewController (#3455)
+
 ## 8.17.0
 
 ### Features

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -204,7 +204,10 @@
     (UIViewController *)containerVC
 {
     if ([containerVC isKindOfClass:UINavigationController.class]) {
-        return @[ [(UINavigationController *)containerVC topViewController] ];
+        if ([(UINavigationController *)containerVC topViewController]) {
+            return @[ [(UINavigationController *)containerVC topViewController] ];
+        }
+        return nil;
     }
     if ([containerVC isKindOfClass:UITabBarController.class]) {
         UITabBarController *tbController = (UITabBarController *)containerVC;


### PR DESCRIPTION
When a UINavigationController is not initialized with initWithRootViewController, it leads to a crash.
like this: `self.window.rootViewController = [[UINavigationController alloc] init];`