### PR TITLE
fix(breadcrumbs): Check for valid JSON in SentryWatchdogTerminationScopeObserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Fixes 
 
 - Crash when UINavigationController doesn't have rootViewController (#3455)
+- Crash when synchronizing invalid JSON breadcrumbs to SentryWatchdogTermination (#3458)
 
 ## 8.17.0
 

--- a/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
+++ b/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
@@ -101,6 +101,11 @@ SentryWatchdogTerminationScopeObserver ()
 
 - (void)addSerializedBreadcrumb:(NSDictionary *)crumb
 {
+    if (![NSJSONSerialization isValidJSONObject:crumb]) {
+        SENTRY_LOG_ERROR(@"Breadcrumb is not a valid JSON object: %@", crumb);
+        return;
+    }
+
     NSError *error;
     NSData *jsonData = [NSJSONSerialization dataWithJSONObject:crumb options:0 error:&error];
 

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsScopeObserverTests.swift
@@ -9,6 +9,7 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
     
     private class Fixture {
         let breadcrumb: Breadcrumb
+        let invalidJSONbreadcrumb: [String: Double]
         let options: Options
         let fileManager: SentryFileManager
         let currentDate = TestCurrentDateProvider()
@@ -17,6 +18,8 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
         init() {
             breadcrumb = TestData.crumb
             breadcrumb.data = nil
+          
+            invalidJSONbreadcrumb = [ "invalid": Double.infinity ]
 
             options = Options()
             options.dsn = SentryWatchdogTerminationScopeObserverTests.dsn
@@ -47,6 +50,17 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
         fixture.fileManager.deleteAllFolders()
     }
 
+    // Test that we're storing the serialized breadcrumb in a proper JSON string
+    func testStoreInvalidJSONBreadcrumb() throws {
+        let breadcrumb = fixture.invalidJSONbreadcrumb
+
+        sut.addSerializedBreadcrumb(breadcrumb)
+
+        let fileOneContents = try String(contentsOfFile: fixture.fileManager.breadcrumbsFilePathOne)
+        let firstLine = fileOneContents.split(separator: "\n").first
+        XCTAssertNil(firstLine)
+    }
+  
     // Test that we're storing the serialized breadcrumb in a proper JSON string
     func testStoreBreadcrumb() throws {
         let breadcrumb = fixture.breadcrumb.serialize() as! [String: String]


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

This PR adds a check for valid JSON to prevent crashes during the breadcrumbs sync.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes: https://github.com/getsentry/sentry-react-native/issues/3421

## :green_heart: How did you test it?

integration test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
