### PR TITLE
fix: Check for NULL in binary image cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 
 - Crash when UINavigationController doesn't have rootViewController (#3455)
 - Crash when synchronizing invalid JSON breadcrumbs to SentryWatchdogTermination (#3458)
-- Validate image name in binary image cache (#3469)
-- Check for NULL in binary image cache (#3468)
+- Check for NULL in binary image cache (#3469)
+- Threading issues in binary image cache (#3468)
 - Finish transaction for external view controllers (#3440)
 
 ## 8.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Crash when UINavigationController doesn't have rootViewController (#3455)
 - Crash when synchronizing invalid JSON breadcrumbs to SentryWatchdogTermination (#3458)
 - Validate image name in binary image cache (#3469)
-- Threading issues in binary image cache (#3468)
+- Check for NULL in binary image cache (#3468)
 - Finish transaction for external view controllers (#3440)
 
 ## 8.17.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 - Crash when UINavigationController doesn't have rootViewController (#3455)
 - Crash when synchronizing invalid JSON breadcrumbs to SentryWatchdogTermination (#3458)
+- Validate image name in binary image cache (#3469)
 
 ## 8.17.0
 

--- a/Sources/Sentry/SentryBinaryImageCache.m
+++ b/Sources/Sentry/SentryBinaryImageCache.m
@@ -2,6 +2,7 @@
 #import "SentryCrashBinaryImageCache.h"
 #import "SentryDependencyContainer.h"
 #import "SentryInAppLogic.h"
+#import "SentryLog.h"
 
 static void binaryImageWasAdded(const SentryCrashBinaryImage *image);
 
@@ -35,8 +36,21 @@ SentryBinaryImageCache ()
 
 - (void)binaryImageAdded:(const SentryCrashBinaryImage *)image
 {
+    if (image->name == NULL) {
+        SENTRY_LOG_WARN(@"The image name was NULL. Can't add image to cache.");
+        return;
+    }
+
+    NSString *imageName = [NSString stringWithCString:image->name encoding:NSUTF8StringEncoding];
+
+    if (imageName == nil) {
+        SENTRY_LOG_WARN(@"Couldn't convert the cString image name to an NSString. This could be "
+                        @"due to a different encoding than NSUTF8StringEncoding of the cString..");
+        return;
+    }
+
     SentryBinaryImageInfo *newImage = [[SentryBinaryImageInfo alloc] init];
-    newImage.name = [NSString stringWithCString:image->name encoding:NSUTF8StringEncoding];
+    newImage.name = imageName;
     newImage.address = image->address;
     newImage.size = image->size;
 

--- a/Sources/Sentry/SentryBinaryImageCache.m
+++ b/Sources/Sentry/SentryBinaryImageCache.m
@@ -40,6 +40,11 @@ SentryBinaryImageCache ()
 
 - (void)binaryImageAdded:(const SentryCrashBinaryImage *)image
 {
+    if (image == NULL) {
+        SENTRY_LOG_WARN(@"The image is NULL. Can't add NULL to cache.");
+        return;
+    }
+
     if (image->name == NULL) {
         SENTRY_LOG_WARN(@"The image name was NULL. Can't add image to cache.");
         return;
@@ -78,6 +83,11 @@ SentryBinaryImageCache ()
 
 - (void)binaryImageRemoved:(const SentryCrashBinaryImage *)image
 {
+    if (image == NULL) {
+        SENTRY_LOG_WARN(@"The image is NULL. Can't remove it from the cache.");
+        return;
+    }
+
     @synchronized(self) {
         NSInteger index = [self indexOfImage:image->address];
         if (index >= 0) {

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -157,7 +157,9 @@ class SentryBinaryImageCacheTests: XCTestCase {
     
     func testBinaryImageNameDifferentEncoding_DoesNotAddImage() {
         let name = NSString(string: "こんにちは") // "Hello" in Japanese
-        let nameCString = name.cString(using: NSShiftJISStringEncoding)
+        // 8 = NSShiftJISStringEncoding
+        // Passing NSShiftJISStringEncoding directly doesn't work on older Xcode versions.
+        let nameCString = name.cString(using: UInt(8))
         let address = UInt64(100)
     
         var binaryImage = SentryCrashBinaryImage(

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -42,6 +42,12 @@ class SentryBinaryImageCacheTests: XCTestCase {
         XCTAssertEqual(sut.cache.first?.name, "Expected Name at 0")
         XCTAssertEqual(sut.cache[1].name, "Expected Name at 100")
     }
+    
+    func testBinaryImageAdded_IsNull() {
+        sut.binaryImageAdded(nil)
+        
+        expect(self.sut.cache.count) == 0
+    }
 
     func testBinaryImageRemoved() {
         var binaryImage0 = createCrashBinaryImage(0)
@@ -74,6 +80,15 @@ class SentryBinaryImageCacheTests: XCTestCase {
         sut.binaryImageRemoved(&binaryImage2)
         XCTAssertEqual(sut.cache.count, 0)
         XCTAssertNil(sut.image(byAddress: 240))
+    }
+    
+    func testBinaryImageRemoved_IsNull() {
+        var binaryImage = createCrashBinaryImage(0)
+        sut.binaryImageAdded(&binaryImage)
+        
+        sut.binaryImageRemoved(nil)
+        
+        expect(self.sut.cache.count) == 1
     }
 
     func testImageNameByAddress() {


### PR DESCRIPTION


## :scroll: Description

Properly validate the binary image name when converting it to an NSString to avoid crashes.

## :bulb: Motivation and Context

I came across this when looking at https://github.com/getsentry/sentry-cocoa/pull/3468.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
