### PR TITLE
meta: mention experimental nature of UIKitless feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,8 @@ The XCFramework attached to GitHub releases is now built with Xcode 15.
 
 ### Features
 
-- Sentry can now be used without linking UIKit; this is helpful for using the SDK in certain app extension contexts (#3175)  
+- Sentry can now be used without linking UIKit; this is helpful for using the SDK in certain app extension contexts (#3175)
+**Note:** this is an experimental feature not yet available for with SPM.
 **Warning:** this breaks some SPM integrations. Use 8.14.1 if you integrate using SPM.
 
 - GA of MetricKit integration (#3340)


### PR DESCRIPTION
There is some confusion over the availability of the UIKitless feature, like in https://github.com/getsentry/sentry-cocoa/issues/3460

Point out this is still an experimental feature not yet compatible with SPM.