### PR TITLE
feat(internal): change collectProfilerForTrace result to mutable

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -129,9 +129,9 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
 }
 
-+ (nullable NSDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
-                                                             and:(uint64_t)endSystemTime
-                                                        forTrace:(SentryId *)traceId;
++ (nullable NSMutableDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
+                                                                    and:(uint64_t)endSystemTime
+                                                               forTrace:(SentryId *)traceId;
 {
     NSMutableDictionary<NSString *, id> *payload =
         [SentryProfiler collectProfileBetween:startSystemTime

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -91,9 +91,9 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * Collect a profiler session data associated with the given @c SentryId.
  * This also discards the profiler.
  */
-+ (nullable NSDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
-                                                             and:(uint64_t)endSystemTime
-                                                        forTrace:(SentryId *)traceId;
++ (nullable NSMutableDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
+                                                                    and:(uint64_t)endSystemTime
+                                                               forTrace:(SentryId *)traceId;
 
 /**
  * Discard profiler session data associated with the given @c SentryId.


### PR DESCRIPTION
When testing the native profiling integration for iOS in .NET, same way I've done it in Flutter, I've found I could use the collectProfileOutput directly without copying, which would, just if it was exposed as the NSMutableDictionary that it actually is.

See https://github.com/getsentry/sentry-dotnet/pull/2930/files#diff-1b71762e3c3bd42c9d55060467f9fcbc82b733f625ee6310ee76a6ff35a9e2d1R39

#skip-changelog - this probably doesn't make sense to mention to standard SDK consumers


