### PR TITLE
ref: Send frames for all spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- Add slow and frozen frames to spans (#3450)
+- Add slow and frozen frames to spans (#3450, #3478)
 
 ## 8.17.1
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -57,21 +57,20 @@ SentrySpan ()
 
         if ([NSThread isMainThread]) {
             _data[SPAN_DATA_THREAD_NAME] = @"main";
-
-#if SENTRY_HAS_UIKIT
-            // Only track frames if running on main thread.
-            _framesTracker = framesTracker;
-            if (_framesTracker.isRunning) {
-                SentryScreenFrames *currentFrames = _framesTracker.currentFrames;
-                initTotalFrames = currentFrames.total;
-                initSlowFrames = currentFrames.slow;
-                initFrozenFrames = currentFrames.frozen;
-            }
-#endif // SENTRY_HAS_UIKIT
         } else {
             _data[SPAN_DATA_THREAD_NAME] = [SentryDependencyContainer.sharedInstance.threadInspector
                 getThreadName:currentThread];
         }
+
+#if SENTRY_HAS_UIKIT
+        _framesTracker = framesTracker;
+        if (_framesTracker.isRunning) {
+            SentryScreenFrames *currentFrames = _framesTracker.currentFrames;
+            initTotalFrames = currentFrames.total;
+            initSlowFrames = currentFrames.slow;
+            initFrozenFrames = currentFrames.frozen;
+        }
+#endif // SENTRY_HAS_UIKIT
 
         _tags = [[NSMutableDictionary alloc] init];
         _stateLock = [[NSObject alloc] init];

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -499,7 +499,7 @@ class SentrySpanTests: XCTestCase {
         expect(sut.data["frames.frozen"]) == nil
     }
     
-    func testDontAddZeroSlowFrozenFrames_WhenSpanStartedBackgroundThread() {
+    func testAddZeroSlowFrozenFrames_WhenSpanStartedBackgroundThread() {
         let (displayLinkWrapper, framesTracker) = givenFramesTracker()
         
         let expectation = expectation(description: "SpanStarted on a background thread")
@@ -513,10 +513,9 @@ class SentrySpanTests: XCTestCase {
             
             sut.finish()
             
-            expect(sut.data["frames.total"]) == nil
-            expect(sut.data["frames.slow"]) == nil
-            expect(sut.data["frames.frozen"]) == nil
-            
+            expect(sut.data["frames.total"] as? NSNumber) == NSNumber(value: slow + frozen + normal)
+            expect(sut.data["frames.slow"] as? NSNumber) == NSNumber(value: slow)
+            expect(sut.data["frames.frozen"] as? NSNumber) == NSNumber(value: frozen)
             expectation.fulfill()
         }
         


### PR DESCRIPTION
Initially, we wanted to send frame data only for spans started on the main thread, but we decided that the frame data makes sense for all spans. This PR fixes that.
