### PR TITLE
test: Increase timeout for SpanTests

### DIFF
--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -93,7 +93,7 @@ class SentrySpanTests: XCTestCase {
             expect.fulfill()
         }
         
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 1.0)
     }
     
     func testInit_SetsThreadInfoAsSpanData_FromBackgroundThreadWithNoName() {
@@ -110,7 +110,7 @@ class SentrySpanTests: XCTestCase {
             expect.fulfill()
         }
         
-        wait(for: [expect], timeout: 0.1)
+        wait(for: [expect], timeout: 1.0)
     }
     
     func testFinish() {


### PR DESCRIPTION
The SentrySpanTests sometimes fail because the expectations sometimes time out. To fix this, we increase the value so the tests don't fail when CI is busy.

#skip-changelog