### PR TITLE
test: Fix TestDisplayLink rounding issues

### DIFF
--- a/SentryTestUtils/TestDisplayLinkWrapper.swift
+++ b/SentryTestUtils/TestDisplayLinkWrapper.swift
@@ -23,11 +23,19 @@ public class TestDisplayLinkWrapper: SentryDisplayLinkWrapper {
     public var target: AnyObject!
     public var selector: Selector!
     public var currentFrameRate: FrameRate = .low
-    let frozenFrameThreshold = 0.7
+    
+    private let frozenFrameThreshold = 0.7
+    private let slowestSlowFrameDuration: Double
+    private let fastestFrozenFrameDuration: Double
+    
     public var dateProvider: TestCurrentDateProvider
 
     public init(dateProvider: TestCurrentDateProvider = TestCurrentDateProvider()) {
         self.dateProvider = dateProvider
+        // The test date provider converts the duration from UInt64 to a double back and forth.
+        // Therefore we have rounding issues, and subtract or add the timeEpsilon.
+        slowestSlowFrameDuration = frozenFrameThreshold - timeEpsilon
+        fastestFrozenFrameDuration = frozenFrameThreshold + timeEpsilon
     }
 
     public var linkInvocations = Invocations<Void>()
@@ -80,16 +88,15 @@ public class TestDisplayLinkWrapper: SentryDisplayLinkWrapper {
     }
     
     public func slowestSlowFrame() -> CFTimeInterval {
-        dateProvider.advance(by: frozenFrameThreshold)
+        dateProvider.advance(by: slowestSlowFrameDuration)
         call()
-        return frozenFrameThreshold
+        return slowestSlowFrameDuration
     }
 
     public func fastestFrozenFrame() -> CFTimeInterval {
-        let duration: Double = frozenFrameThreshold + timeEpsilon
-        dateProvider.advance(by: duration)
+        dateProvider.advance(by: fastestFrozenFrameDuration)
         call()
-        return duration
+        return fastestFrozenFrameDuration
     }
 
     /// There's no upper bound for a frozen frame, except maybe for the watchdog time limit.

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -84,6 +84,20 @@ class SentryFramesTrackerTests: XCTestCase {
 
         try assert(slow: 2, frozen: 0, total: 3)
     }
+    
+    func testMultipleSlowestSlowFrames() throws {
+        let sut = fixture.sut
+        sut.start()
+
+        fixture.displayLinkWrapper.call()
+        
+        let slowFramesCount: UInt = 20
+        for _ in 0..<slowFramesCount {
+            _ = fixture.displayLinkWrapper.slowestSlowFrame()
+        }
+
+        try assert(slow: slowFramesCount, frozen: 0, total: slowFramesCount)
+    }
 
     func testFrozenFrame() throws {
         let sut = fixture.sut
@@ -94,6 +108,20 @@ class SentryFramesTrackerTests: XCTestCase {
         _ = fixture.displayLinkWrapper.fastestFrozenFrame()
 
         try assert(slow: 1, frozen: 1, total: 2)
+    }
+    
+    func testMultipleFastestFrozenFrames() throws {
+        let sut = fixture.sut
+        sut.start()
+
+        fixture.displayLinkWrapper.call()
+        
+        let frozenFramesCount: UInt = 20
+        for _ in 0..<frozenFramesCount {
+            _ = fixture.displayLinkWrapper.fastestFrozenFrame()
+        }
+
+        try assert(slow: 0, frozen: frozenFramesCount, total: frozenFramesCount)
     }
 
     func testFrameRateChange() throws {


### PR DESCRIPTION


## :scroll: Description

Calling the TestDisplayLinkWrapper with multiple slowestSlowFrames or fastestFrozenFrames in tests leads to wrong results. This is fixed now by adding and subtracting the timeEpsilon for these.

## :bulb: Motivation and Context

This came up when implementing frame delay https://github.com/getsentry/sentry-cocoa/issues/3481.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
