### PR TITLE
ref: Add nanosecondsToTimeInterval

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */; };
 		62B86CFC29F052BB008F3947 /* SentryTestLogConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */; };
 		62C25C862B075F4900C68CBD /* TestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C25C852B075F4900C68CBD /* TestOptions.swift */; };
+		62C3168B2B1F865A000D7031 /* SentryTimeSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C3168A2B1F865A000D7031 /* SentryTimeSwiftTests.swift */; };
 		62E081A929ED4260000F69FC /* SentryBreadcrumbDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */; };
 		62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */; };
 		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
@@ -1002,6 +1003,7 @@
 		62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryUIEventTrackerTransactionMode.m; sourceTree = "<group>"; };
 		62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTestLogConfig.m; sourceTree = "<group>"; };
 		62C25C852B075F4900C68CBD /* TestOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestOptions.swift; sourceTree = "<group>"; };
+		62C3168A2B1F865A000D7031 /* SentryTimeSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTimeSwiftTests.swift; sourceTree = "<group>"; };
 		62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBreadcrumbDelegate.h; path = include/SentryBreadcrumbDelegate.h; sourceTree = "<group>"; };
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
 		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
@@ -2854,6 +2856,7 @@
 				84A8892028DBD8D600C51DFD /* SentryDeviceTests.mm */,
 				D85790282976A69F00C6AC1F /* TestDebugImageProvider.swift */,
 				8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */,
+				62C3168A2B1F865A000D7031 /* SentryTimeSwiftTests.swift */,
 				33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */,
 			);
 			path = Helper;
@@ -4403,6 +4406,7 @@
 				63EED6C32237989300E02400 /* SentryOptionsTest.m in Sources */,
 				7BBD18B22451804C00427C76 /* SentryRetryAfterHeaderParserTests.swift in Sources */,
 				7BD337E424A356180050DB6E /* SentryCrashIntegrationTests.swift in Sources */,
+				62C3168B2B1F865A000D7031 /* SentryTimeSwiftTests.swift in Sources */,
 				7BD4E8E827FD95900086C410 /* SentryMigrateSessionInitTests.m in Sources */,
 				7B6CC50224EE5A42001816D7 /* SentryHubTests.swift in Sources */,
 				7BF9EF882722D13000B5BBEF /* SentryTestObjCRuntimeWrapper.m in Sources */,

--- a/Sources/Sentry/SentryTime.mm
+++ b/Sources/Sentry/SentryTime.mm
@@ -10,9 +10,15 @@ uint64_t
 timeIntervalToNanoseconds(double seconds)
 {
     NSCAssert(seconds >= 0, @"Seconds must be a positive value");
-    NSCAssert(seconds <= UINT64_MAX / 1e9,
+    NSCAssert(seconds <= (double)UINT64_MAX / (double)NSEC_PER_SEC,
         @"Value of seconds is too great; will overflow if casted to a uint64_t");
-    return (uint64_t)(seconds * 1e9);
+    return (uint64_t)(seconds * NSEC_PER_SEC);
+}
+
+double
+nanosecondsToTimeInterval(uint64_t nanoseconds)
+{
+    return (double)nanoseconds / NSEC_PER_SEC;
 }
 
 uint64_t

--- a/Sources/Sentry/include/SentryTime.h
+++ b/Sources/Sentry/include/SentryTime.h
@@ -12,6 +12,12 @@ SENTRY_EXTERN_C_BEGIN
 uint64_t timeIntervalToNanoseconds(double seconds);
 
 /**
+ * Converts nanoseconds to a @c double from a Cocoa API like @c -[NSDate
+ * @c timeIntervalSinceDate:] .
+ */
+double nanosecondsToTimeInterval(uint64_t nanoseconds);
+
+/**
  * Returns the absolute timestamp, which has no defined reference point or unit
  * as it is platform dependent.
  */

--- a/Sources/Sentry/include/SentryTime.h
+++ b/Sources/Sentry/include/SentryTime.h
@@ -12,7 +12,7 @@ SENTRY_EXTERN_C_BEGIN
 uint64_t timeIntervalToNanoseconds(double seconds);
 
 /** Converts integer nanoseconds to a @c NSTimeInterval. */
-NSTimeInterval nanosecondsToTimeInterval(uint64_t nanoseconds);
+double nanosecondsToTimeInterval(uint64_t nanoseconds);
 
 /**
  * Returns the absolute timestamp, which has no defined reference point or unit

--- a/Sources/Sentry/include/SentryTime.h
+++ b/Sources/Sentry/include/SentryTime.h
@@ -11,11 +11,8 @@ SENTRY_EXTERN_C_BEGIN
  */
 uint64_t timeIntervalToNanoseconds(double seconds);
 
-/**
- * Converts nanoseconds to a @c double from a Cocoa API like @c -[NSDate
- * @c timeIntervalSinceDate:] .
- */
-double nanosecondsToTimeInterval(uint64_t nanoseconds);
+/** Converts integer nanoseconds to a @c NSTimeInterval. */
+NSTimeInterval nanosecondsToTimeInterval(uint64_t nanoseconds);
 
 /**
  * Returns the absolute timestamp, which has no defined reference point or unit

--- a/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
+++ b/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
@@ -7,13 +7,13 @@ final class SentryTimeSwiftTests: XCTestCase {
         expect(timeIntervalToNanoseconds(0.0)) == UInt64(0)
         expect(timeIntervalToNanoseconds(0.5)) == UInt64(500_000_000)
         expect(timeIntervalToNanoseconds(1.0)) == UInt64(1_000_000_000)
-        expect(timeIntervalToNanoseconds(18_446_744_073.709553)) == UInt64.max
+        let maxTimeInterval = nanosecondsToTimeInterval(UInt64.max)
+        expect(timeIntervalToNanoseconds(maxTimeInterval)) == UInt64.max
     }
 
     func testNanosecondsToTimeInterval() {
         expect(nanosecondsToTimeInterval(0)).to(beCloseTo(0.0, within: 1e-9))
         expect(nanosecondsToTimeInterval(500_000_000)).to(beCloseTo(0.5, within: 1e-9))
         expect(nanosecondsToTimeInterval(1_000_000_000)).to(beCloseTo(1.0, within: 1e-9))
-        expect(nanosecondsToTimeInterval(UInt64.max - 1)).to(beCloseTo(18_446_744_073.709551614, within: 1e-9))
     }
 }

--- a/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
+++ b/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
@@ -7,13 +7,15 @@ final class SentryTimeSwiftTests: XCTestCase {
         expect(timeIntervalToNanoseconds(0.0)) == UInt64(0)
         expect(timeIntervalToNanoseconds(0.5)) == UInt64(500_000_000)
         expect(timeIntervalToNanoseconds(1.0)) == UInt64(1_000_000_000)
-        let maxTimeInterval = nanosecondsToTimeInterval(UInt64.max)
-        expect(timeIntervalToNanoseconds(maxTimeInterval)) == UInt64.max
+        expect(timeIntervalToNanoseconds(1.123456789)) == UInt64(1_123_456_789)
+        expect(timeIntervalToNanoseconds(123_456_789.123456)) == UInt64(123_456_789_123_456_000)
     }
 
     func testNanosecondsToTimeInterval() {
         expect(nanosecondsToTimeInterval(0)).to(beCloseTo(0.0, within: 1e-9))
         expect(nanosecondsToTimeInterval(500_000_000)).to(beCloseTo(0.5, within: 1e-9))
         expect(nanosecondsToTimeInterval(1_000_000_000)).to(beCloseTo(1.0, within: 1e-9))
+        expect(nanosecondsToTimeInterval(1_123_456_789)).to(beCloseTo(1.123456789, within: 1e-9))
+        expect(nanosecondsToTimeInterval(123_456_789_123_456_000)).to(beCloseTo(123_456_789.123456, within: 1e-9))
     }
 }

--- a/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
+++ b/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
@@ -1,0 +1,19 @@
+import Nimble
+import XCTest
+
+final class SentryTimeSwiftTests: XCTestCase {
+    
+    func testTimeIntervalToNanoseconds() {
+        expect(timeIntervalToNanoseconds(0.0)) == UInt64(0)
+        expect(timeIntervalToNanoseconds(0.5)) == UInt64(500_000_000)
+        expect(timeIntervalToNanoseconds(1.0)) == UInt64(1_000_000_000)
+        expect(timeIntervalToNanoseconds(18_446_744_073.709553)) == UInt64.max
+    }
+
+    func testNanosecondsToTimeInterval() {
+        expect(nanosecondsToTimeInterval(0)).to(beCloseTo(0.0, within: 1e-9))
+        expect(nanosecondsToTimeInterval(500_000_000)).to(beCloseTo(0.5, within: 1e-9))
+        expect(nanosecondsToTimeInterval(1_000_000_000)).to(beCloseTo(1.0, within: 1e-9))
+        expect(nanosecondsToTimeInterval(UInt64.max - 1)).to(beCloseTo(18_446_744_073.709551614, within: 1e-9))
+    }
+}


### PR DESCRIPTION
SentryTime has timeIntervalToNanoseconds but not nanosecondsToTimeInterval. This PR adds nanosecondsToTimeInterval. 
Furthermore, added some tests for timeIntervalToNanoseconds  and fixed the max value check. This method is required for frame delay https://github.com/getsentry/sentry-cocoa/issues/3481.

#skip-changelog