### PR TITLE
feat: Add frames delay to span data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- Add frames delay to transactions and spans (#3487, #3495)
+- Add frames delay to transactions and spans (#3487, #3496)
 - Add slow and frozen frames to spans (#3450, #3478)
 
 ## 8.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Features
 
-- Add frames delay to transactions (#3487)
+- Add frames delay to transactions and spans (#3487, #3495)
 - Add slow and frozen frames to spans (#3450, #3478)
 
 ## 8.17.1

--- a/Sources/Sentry/SentryDelayedFramesTracker.m
+++ b/Sources/Sentry/SentryDelayedFramesTracker.m
@@ -174,14 +174,6 @@ SentryDelayedFramesTracker ()
         delay = delay + [self calculateDelay:frame queryDateInterval:queryDateInterval];
     }
 
-    uint64_t queryTimeDuration = endSystemTimestamp - startSystemTimestamp;
-    if (queryTimeDuration < timeIntervalToNanoseconds(delay)) {
-        SENTRY_LOG_ERROR(
-            @"Not calculating frames delay because delay %f is longer than query time: %llu.",
-            delay, queryTimeDuration);
-        return cantCalculateFrameDelayReturnValue;
-    }
-
     return delay;
 }
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -240,8 +240,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     return [self.delayedFramesTracker getFramesDelay:startSystemTimestamp
                                   endSystemTimestamp:endSystemTimestamp
                                            isRunning:_isRunning
-                                  thisFrameTimestamp:self.displayLinkWrapper.timestamp
-                              previousFrameTimestamp:self.previousFrameTimestamp
+                        previousFrameSystemTimestamp:self.previousFrameSystemTimestamp
                                   slowFrameThreshold:slowFrameThreshold(_currentFrameRate)];
 }
 

--- a/Sources/Sentry/include/SentryDelayedFramesTracker.h
+++ b/Sources/Sentry/include/SentryDelayedFramesTracker.h
@@ -45,8 +45,7 @@ SENTRY_NO_INIT
  * delay.
  * @param endSystemTimestamp The end system time stamp for the time interval to query frames delay.
  * @param isRunning Wether the frames tracker is running or not.
- * @param thisFrameTimestamp The timestamp of the current frame.
- * @param previousFrameTimestamp The timestamp of the previous frame.
+ * @param previousFrameSystemTimestamp The system timestamp of the previous frame.
  * @param slowFrameThreshold The threshold for a slow frame. For 60 fps this is roughly 16.67 ms.
  *
  * @return the frames delay duration or -1 if it can't calculate the frames delay.
@@ -54,8 +53,7 @@ SENTRY_NO_INIT
 - (CFTimeInterval)getFramesDelay:(uint64_t)startSystemTimestamp
               endSystemTimestamp:(uint64_t)endSystemTimestamp
                        isRunning:(BOOL)isRunning
-              thisFrameTimestamp:(CFTimeInterval)thisFrameTimestamp
-          previousFrameTimestamp:(CFTimeInterval)previousFrameTimestamp
+    previousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp
               slowFrameThreshold:(CFTimeInterval)slowFrameThreshold;
 
 @end

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -310,12 +310,37 @@ class SentryFramesTrackerTests: XCTestCase {
         
         let startSystemTime = fixture.dateProvider.systemTime()
         
-        let delay = 0.5
+        let delay = 0.02
         fixture.dateProvider.advance(by: delay)
         
         let endSystemTime = fixture.dateProvider.systemTime()
         
         let expectedDelay = delay - slowFrameThreshold(fixture.displayLinkWrapper.currentFrameRate.rawValue)
+        
+        let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
+        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+    }
+    
+    func testDelayedFrames_FrameIsDelayedSmallerThanSlowFrameThreshold_ReturnsDelay() {
+        fixture.dateProvider.advance(by: 2.0)
+        
+        let sut = fixture.sut
+        sut.start()
+        
+        let displayLink = fixture.displayLinkWrapper
+        displayLink.call()
+        displayLink.normalFrame()
+        
+        fixture.dateProvider.advance(by: slowFrameThreshold(fixture.displayLinkWrapper.currentFrameRate.rawValue))
+        
+        let startSystemTime = fixture.dateProvider.systemTime()
+        
+        let delay = 0.0001
+        fixture.dateProvider.advance(by: delay)
+        
+        let endSystemTime = fixture.dateProvider.systemTime()
+        
+        let expectedDelay = delay
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
         expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))


### PR DESCRIPTION


## :scroll: Description

Also fix a couple of edge cases when calculating the frames delay when an ongoing delayed frame is not yet recorded.

## :bulb: Motivation and Context

Fixes GH-3481

## :green_heart: How did you test it?
Unit tests and with the simulator

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Update the docs once we show the feature in mobile starfish.