### PR TITLE
fix: TTFD waits for next drawn frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Add frames delay to transactions (#3487)
 - Add slow and frozen frames to spans (#3450, #3478)
+
+### Fixes
+
+- TTFD waits for next drawn frame (#3505)
+
 ## 8.17.2
 
 ### Fixes

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/LoremIpsumViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/LoremIpsumViewController.swift
@@ -14,7 +14,10 @@ class LoremIpsumViewController: UIViewController {
                 if let contents = FileManager.default.contents(atPath: path) {
                     DispatchQueue.main.async {
                         self.textView.text = String(data: contents, encoding: .utf8)
-                        SentrySDK.reportFullyDisplayed()
+                        
+                        dispatchQueue.asyncAfter(deadline: .now() + 0.1) {
+                            SentrySDK.reportFullyDisplayed()
+                        }
                     }
                 }
             }

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -26,7 +26,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
 
 @implementation SentryTimeToDisplayTracker {
     BOOL _waitForFullDisplay;
-    BOOL _isReadyToDisplay;
+    BOOL _initialDisplayReported;
     BOOL _fullyDisplayedReported;
     NSString *_controllerName;
 }
@@ -37,8 +37,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     if (self = [super init]) {
         _controllerName = [SwiftDescriptor getObjectClassName:controller];
         _waitForFullDisplay = waitForFullDisplay;
-
-        _isReadyToDisplay = NO;
+        _initialDisplayReported = NO;
         _fullyDisplayedReported = NO;
     }
     return self;
@@ -66,33 +65,26 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     self.initialDisplaySpan.startTimestamp = tracer.startTimestamp;
 
     [SentryDependencyContainer.sharedInstance.framesTracker addListener:self];
-    [tracer setFinishCallback:^(
-        SentryTracer *_tracer) { [self trimTTFDIdNecessaryForTracer:_tracer]; }];
+    [tracer setFinishCallback:^(SentryTracer *_tracer) {
+        if (self.fullDisplaySpan.status != kSentrySpanStatusDeadlineExceeded) {
+            return;
+        }
+
+        self.fullDisplaySpan.timestamp = self.initialDisplaySpan.timestamp;
+        self.fullDisplaySpan.spanDescription = [NSString
+            stringWithFormat:@"%@ - Deadline Exceeded", self.fullDisplaySpan.spanDescription];
+        [self addTimeToDisplayMeasurement:self.fullDisplaySpan name:@"time_to_full_display"];
+    }];
 }
 
-- (void)reportReadyToDisplay
+- (void)reportInitialDisplay
 {
-    _isReadyToDisplay = YES;
+    _initialDisplayReported = YES;
 }
 
 - (void)reportFullyDisplayed
 {
     _fullyDisplayedReported = YES;
-    if (self.waitForFullDisplay && _isReadyToDisplay) {
-        // We need the timestamp to be able to calculate the duration
-        // but we can't finish first and add measure later because
-        // finishing the span may trigger the tracer finishInternal.
-        self.fullDisplaySpan.timestamp =
-            [SentryDependencyContainer.sharedInstance.dateProvider date];
-        [self addTimeToDisplayMeasurement:self.fullDisplaySpan name:@"time_to_full_display"];
-        [self.fullDisplaySpan finish];
-    }
-}
-
-- (void)addTimeToDisplayMeasurement:(SentrySpan *)span name:(NSString *)name
-{
-    NSTimeInterval duration = [span.timestamp timeIntervalSinceDate:span.startTimestamp] * 1000;
-    [span setMeasurement:name value:@(duration) unit:SentryMeasurementUnitDuration.millisecond];
 }
 
 - (void)framesTrackerHasNewFrame
@@ -102,32 +94,35 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     // The purpose of TTID and TTFD is to measure how long
     // takes to the content of the screen to change.
     // Thats why we need to wait for the next frame to be drawn.
-    if (_isReadyToDisplay && self.initialDisplaySpan.isFinished == NO) {
+    if (_initialDisplayReported && self.initialDisplaySpan.isFinished == NO) {
         self.initialDisplaySpan.timestamp = finishTime;
 
         [self addTimeToDisplayMeasurement:self.initialDisplaySpan name:@"time_to_initial_display"];
 
         [self.initialDisplaySpan finish];
-        [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
+
+        if (!_waitForFullDisplay) {
+            [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
+        }
     }
-    if (_waitForFullDisplay && _fullyDisplayedReported && self.fullDisplaySpan.isFinished == NO) {
+    if (_waitForFullDisplay && _fullyDisplayedReported && self.fullDisplaySpan.isFinished == NO
+        && self.initialDisplaySpan.isFinished == YES) {
         self.fullDisplaySpan.timestamp = finishTime;
 
-        [self addTimeToDisplayMeasurement:self.initialDisplaySpan name:@"time_to_full_display"];
+        [self addTimeToDisplayMeasurement:self.fullDisplaySpan name:@"time_to_full_display"];
 
         [self.fullDisplaySpan finish];
     }
+
+    if (self.initialDisplaySpan.isFinished == YES && self.fullDisplaySpan.isFinished == YES) {
+        [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
+    }
 }
 
-- (void)trimTTFDIdNecessaryForTracer:(SentryTracer *)tracer
+- (void)addTimeToDisplayMeasurement:(SentrySpan *)span name:(NSString *)name
 {
-    if (self.fullDisplaySpan.status != kSentrySpanStatusDeadlineExceeded) {
-        return;
-    }
-
-    self.fullDisplaySpan.timestamp = self.initialDisplaySpan.timestamp;
-    self.fullDisplaySpan.spanDescription =
-        [NSString stringWithFormat:@"%@ - Deadline Exceeded", self.fullDisplaySpan.spanDescription];
+    NSTimeInterval duration = [span.timestamp timeIntervalSinceDate:span.startTimestamp] * 1000;
+    [span setMeasurement:name value:@(duration) unit:SentryMeasurementUnitDuration.millisecond];
 }
 
 @end

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -182,7 +182,7 @@ SentryUIViewControllerPerformanceTracker ()
 
         SentryTimeToDisplayTracker *ttdTracker
             = objc_getAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER);
-        [ttdTracker reportReadyToDisplay];
+        [ttdTracker reportInitialDisplay];
     };
 
     [self limitOverride:@"viewWillAppear"

--- a/Sources/Sentry/include/SentryTimeToDisplayTracker.h
+++ b/Sources/Sentry/include/SentryTimeToDisplayTracker.h
@@ -29,7 +29,7 @@ SENTRY_NO_INIT
 
 - (void)startForTracer:(SentryTracer *)tracer;
 
-- (void)reportReadyToDisplay;
+- (void)reportInitialDisplay;
 
 - (void)reportFullyDisplayed;
 

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -9,7 +10,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
     private class Fixture {
         let dateProvider: TestCurrentDateProvider = TestCurrentDateProvider()
-        var tracer: SentryTracer {  SentryTracer(transactionContext: TransactionContext(operation: "Test Operation"), hub: nil) }
+        let timerFactory = TestSentryNSTimerFactory()
 
         var displayLinkWrapper = TestDisplayLinkWrapper()
         var framesTracker: SentryFramesTracker
@@ -22,6 +23,16 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
         func getSut(for controller: UIViewController, waitForFullDisplay: Bool) -> SentryTimeToDisplayTracker {
             return SentryTimeToDisplayTracker(for: controller, waitForFullDisplay: waitForFullDisplay)
+        }
+        
+        func getTracer() throws -> SentryTracer {
+            let options = Options()
+            let hub = TestHub(client: SentryClient(options: options, fileManager: try TestFileManager(options: options), deleteOldEnvelopeItems: false), andScope: nil)
+            return SentryTracer(transactionContext: TransactionContext(operation: "Test Operation"), hub: hub, configuration: SentryTracerConfiguration(block: {
+                $0.waitForChildren = true
+                $0.timerFactory = self.timerFactory
+                $0.dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
+            }))
         }
     }
 
@@ -37,242 +48,246 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         clearTestState()
     }
 
-    func testReportInitialDisplay_notWaitingFullDisplay() throws {
+    func testReportInitialDisplay_notWaitingForFullDisplay() throws {
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: false)
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
-        let tracer = fixture.tracer
+        let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
-        XCTAssertEqual(tracer.children.count, 1)
-        XCTAssertEqual(Dynamic(fixture.framesTracker).listeners.count, 1)
+        expect(tracer.children.count) == 1
+        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 1
 
         let ttidSpan = try XCTUnwrap(tracer.children.first, "Expected a TTID span")
-        XCTAssertEqual(ttidSpan.startTimestamp, fixture.dateProvider.date())
+        expect(ttidSpan.startTimestamp) == fixture.dateProvider.date()
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
-        sut.reportReadyToDisplay()
+        sut.reportInitialDisplay()
+        expect(ttidSpan.timestamp) == nil
+        expect(ttidSpan.isFinished) == false
+        
         fixture.displayLinkWrapper.normalFrame()
 
-        XCTAssertEqual(ttidSpan.timestamp, fixture.dateProvider.date())
-        XCTAssertTrue(ttidSpan.isFinished)
-        XCTAssertEqual(ttidSpan.spanDescription, "UIViewController initial display")
-        XCTAssertEqual(ttidSpan.operation, SentrySpanOperationUILoadInitialDisplay)
-        XCTAssertEqual(ttidSpan.origin, "auto.ui.time_to_display")
+        expect(ttidSpan.timestamp) == fixture.dateProvider.date()
+        expect(ttidSpan.isFinished) == true
+        expect(ttidSpan.spanDescription) == "UIViewController initial display"
+        expect(ttidSpan.operation) == SentrySpanOperationUILoadInitialDisplay
+        expect(ttidSpan.origin) == "auto.ui.time_to_display"
 
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
 
-        XCTAssertEqual(Dynamic(fixture.framesTracker).listeners.count, 0)
+        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
     }
 
-    func testReportNewFrame_notReadyToDisplay() throws {
-        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: false)
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
-
-        let tracer = fixture.tracer
-
-        sut.start(for: tracer)
-        XCTAssertEqual(tracer.children.count, 1)
-
-        let ttidSpan = try XCTUnwrap(tracer.children.first, "Expected a TTID span")
-        XCTAssertEqual(ttidSpan.startTimestamp, fixture.dateProvider.date())
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
-        fixture.displayLinkWrapper.normalFrame()
-
-        XCTAssertNil(ttidSpan.timestamp)
-        XCTAssertFalse(ttidSpan.isFinished)
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 12))
-        sut.reportReadyToDisplay()
-        fixture.displayLinkWrapper.normalFrame()
-
-        XCTAssertEqual(ttidSpan.timestamp, fixture.dateProvider.date())
-        XCTAssertTrue(ttidSpan.isFinished)
-    }
-
-    func testreportInitialDisplay_waitForFullDisplay() {
+    func testReportInitialDisplay_waitForFullDisplay() throws {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
 
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
-        let tracer = fixture.tracer
+        let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
-        XCTAssertEqual(tracer.children.count, 2)
+        expect(tracer.children.count) == 2
 
-        let ttidSpan = tracer.children.first
-        XCTAssertEqual(ttidSpan?.startTimestamp, fixture.dateProvider.date())
+        let ttidSpan = sut.initialDisplaySpan
+        expect(ttidSpan?.startTimestamp) == fixture.dateProvider.date()
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
-        sut.reportReadyToDisplay()
+        sut.reportInitialDisplay()
         fixture.displayLinkWrapper.normalFrame()
 
-        XCTAssertEqual(ttidSpan?.timestamp, fixture.dateProvider.date())
-        XCTAssertTrue(ttidSpan?.isFinished ?? false)
+        expect(ttidSpan?.isFinished) == true
+        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 9)
+        
+        assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
         sut.reportFullyDisplayed()
-
-        assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
-        assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 4_000)
-
-        XCTAssertEqual(ttidSpan?.timestamp, Date(timeIntervalSince1970: 9))
-        XCTAssertTrue(ttidSpan?.isFinished ?? false)
-        XCTAssertEqual(tracer.children.count, 2)
+        
+        // TTFD not reported yet cause we wait for the next frame
+        expect(sut.fullDisplaySpan?.startTimestamp) == ttidSpan?.startTimestamp
+        expect(sut.fullDisplaySpan?.timestamp) == nil
+        expect(tracer.measurements["time_to_full_display"]) == nil
+        
+        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 1
     }
 
-    func testreportFullDisplay_notWaitingForFullDisplay() {
+    func testReportFullDisplay_notWaitingForFullDisplay() throws {
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: false)
-        let tracer = fixture.tracer
+        let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
 
-        sut.reportReadyToDisplay()
+        sut.reportInitialDisplay()
         fixture.displayLinkWrapper.normalFrame()
 
         sut.reportFullyDisplayed()
 
-        XCTAssertNil(sut.fullDisplaySpan)
-        XCTAssertEqual(tracer.children.count, 1)
+        expect(sut.fullDisplaySpan) == nil
+        expect(tracer.children.count) == 1
+        expect(tracer.measurements["time_to_full_display"]) == nil
+        
+        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
     }
-
-    func testreportFullDisplay_waitingForFullDisplay() {
+    
+    func testReportFullDisplay_waitingForFullDisplay() throws {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
 
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
-        let tracer = fixture.tracer
+        let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 10))
-        sut.reportReadyToDisplay()
+        sut.reportInitialDisplay()
         fixture.displayLinkWrapper.normalFrame()
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
         sut.reportFullyDisplayed()
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 12))
-        tracer.finish()
-
-        XCTAssertNotNil(sut.fullDisplaySpan)
-        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, Date(timeIntervalSince1970: 9))
-        XCTAssertEqual(sut.fullDisplaySpan?.timestamp, Date(timeIntervalSince1970: 11))
-        XCTAssertEqual(sut.fullDisplaySpan?.status, .ok)
-
-        XCTAssertEqual(sut.fullDisplaySpan?.spanDescription, "UIViewController full display")
-        XCTAssertEqual(sut.fullDisplaySpan?.operation, SentrySpanOperationUILoadFullDisplay)
-        XCTAssertEqual(sut.fullDisplaySpan?.origin, "manual.ui.time_to_display")
-    }
-
-    func testReportFullDisplay_waitingForFullDisplay_notReadyToDisplay() {
-        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
-        let tracer = fixture.tracer
-
-        sut.start(for: tracer)
-
         fixture.displayLinkWrapper.normalFrame()
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
-        sut.reportFullyDisplayed()
-
-        XCTAssertFalse(sut.fullDisplaySpan?.isFinished ?? true)
-    }
-
-    func testReportFullDisplay_expires() {
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
-
-        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
-        let tracer = fixture.tracer
-
-        sut.start(for: tracer)
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 10))
-        sut.reportReadyToDisplay()
-        fixture.displayLinkWrapper.normalFrame()
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
-        sut.fullDisplaySpan?.finish(status: .deadlineExceeded)
-
+        
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 13))
         tracer.finish()
 
-        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, Date(timeIntervalSince1970: 9))
-        XCTAssertEqual(sut.fullDisplaySpan?.timestamp, Date(timeIntervalSince1970: 10))
-        XCTAssertEqual(sut.fullDisplaySpan?.spanDescription, "UIViewController full display - Deadline Exceeded")
+        expect(sut.fullDisplaySpan) != nil
+        expect(sut.fullDisplaySpan?.startTimestamp) == Date(timeIntervalSince1970: 9)
+        expect(sut.fullDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 12)
+        expect(sut.fullDisplaySpan?.status) == .ok
+
+        expect(sut.fullDisplaySpan?.spanDescription) == "UIViewController full display"
+        expect(sut.fullDisplaySpan?.operation) == SentrySpanOperationUILoadFullDisplay
+        expect(sut.fullDisplaySpan?.origin) == "manual.ui.time_to_display"
+        
+        assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)
+        
+        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+    }
+    
+    func testWaitingForFullDisplay_ReportFullDisplayBeforeInitialDisplay() throws {
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
+        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
+
+        let tracer = try fixture.getTracer()
+        sut.start(for: tracer)
+
+        fixture.displayLinkWrapper.normalFrame()
+
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
+        sut.reportFullyDisplayed()
+        
+        fixture.displayLinkWrapper.normalFrame()
+
+        expect(sut.fullDisplaySpan?.isFinished) == false
+        expect(sut.initialDisplaySpan?.isFinished) == false
+        
+        sut.reportInitialDisplay()
+        
+        expect(sut.fullDisplaySpan?.isFinished) == false
+        expect(sut.initialDisplaySpan?.isFinished) == false
+        
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 12))
+        fixture.displayLinkWrapper.normalFrame()
+        
+        expect(sut.initialDisplaySpan?.isFinished) == true
+        expect(sut.initialDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 12)
+        expect(sut.initialDisplaySpan?.status) == .ok
+        assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 3_000)
+        
+        expect(sut.fullDisplaySpan?.isFinished) == true
+        expect(sut.fullDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 12)
+        expect(sut.fullDisplaySpan?.status) == .ok
+        assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)
+        
+        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
     }
 
-    func testCheckInitialTime() {
+    func testCheckInitialTime() throws {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
         fixture.dateProvider.driftTimeForEveryRead = true
 
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
-        let tracer = fixture.tracer
+        let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
 
-        XCTAssertNotNil(sut.fullDisplaySpan)
-        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, tracer.startTimestamp)
-        XCTAssertEqual(sut.initialDisplaySpan?.startTimestamp, tracer.startTimestamp)
+        expect(sut.fullDisplaySpan) != nil
+        expect(sut.fullDisplaySpan?.startTimestamp) == tracer.startTimestamp
+        expect(sut.initialDisplaySpan?.startTimestamp) == tracer.startTimestamp
     }
-
-    func testFullDisplay_reportedBefore_initialDisplay() {
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
-
-        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
-        let tracer = fixture.tracer
-        sut.start(for: tracer)
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
-        sut.reportFullyDisplayed()
-
-        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
-        sut.reportReadyToDisplay()
-        fixture.displayLinkWrapper.normalFrame()
-
-        assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 4_000)
-        assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 4_000)
-
-        XCTAssertEqual(sut.initialDisplaySpan?.timestamp, fixture.dateProvider.date())
-        XCTAssertEqual(sut.fullDisplaySpan?.timestamp, sut.initialDisplaySpan?.timestamp)
-    }
-
-    func testReportFullyDisplayed_afterFinishingTracer_withWaitForChildren() throws {
+    
+    func testReportFullyDisplayed_AfterTracerTimesOut() throws {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
 
-        let options = Options()
-        let hub = TestHub(client: SentryClient(options: options, fileManager: try TestFileManager(options: options), deleteOldEnvelopeItems: false), andScope: nil)
-        let tracer = SentryTracer(transactionContext: TransactionContext(operation: "Test Operation"), hub: hub, configuration: SentryTracerConfiguration(block: { config in
-            config.waitForChildren = true
-        }))
+        let tracer = try fixture.getTracer()
+        
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: true)
 
         sut.start(for: tracer)
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 10))
-        sut.reportReadyToDisplay()
+        sut.reportInitialDisplay()
         fixture.displayLinkWrapper.normalFrame()
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
 
-        tracer.finish()
+        // Timeout for tracer times out
+        fixture.timerFactory.fire()
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 12))
         sut.reportFullyDisplayed()
+        
+        let ttidSpan = sut.initialDisplaySpan
+        expect(ttidSpan?.startTimestamp) == Date(timeIntervalSince1970: 9)
+        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 10)
+        expect(ttidSpan?.status) == .ok
+        assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 1_000)
+        
+        let ttfdSpan = sut.fullDisplaySpan
+        expect(ttfdSpan?.startTimestamp) == ttidSpan?.startTimestamp
+        expect(ttfdSpan?.timestamp) == ttidSpan?.timestamp
+        expect(ttfdSpan?.status) == .deadlineExceeded
+        expect(ttfdSpan?.spanDescription) == "UIViewController full display - Deadline Exceeded"
+        expect(ttfdSpan?.operation) == SentrySpanOperationUILoadFullDisplay
+        expect(ttfdSpan?.origin) == "manual.ui.time_to_display"
+        
+        assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 1_000)
+    }
+    
+    func testNotWaitingForFullyDisplayed_AfterTracerTimesOut() throws {
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
 
-        let transaction = hub.capturedTransactionsWithScope.first?.transaction
-        let measurements = transaction?["measurements"] as? [String: Any]
-        let ttid = measurements?["time_to_initial_display"] as? [String: Any]
-        let ttfd = measurements?["time_to_full_display"] as? [String: Any]
+        let tracer = try fixture.getTracer()
+        
+        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: false)
 
-        XCTAssertEqual(ttid?["value"] as? Int, 1_000)
-        XCTAssertEqual(ttfd?["value"] as? Int, 3_000)
+        sut.start(for: tracer)
+
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 10))
+        sut.reportInitialDisplay()
+        fixture.displayLinkWrapper.normalFrame()
+
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
+
+        // Timeout for tracer times out
+        fixture.timerFactory.fire()
+
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 12))
+        sut.reportFullyDisplayed()
+        
+        assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 1_000)
+        let ttidSpan = sut.initialDisplaySpan
+        expect(ttidSpan?.startTimestamp) == Date(timeIntervalSince1970: 9)
+        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 10)
+        expect(ttidSpan?.status) == .ok
+        
+        expect(sut.fullDisplaySpan) == nil
+        expect(tracer.measurements["time_to_full_display"]) == nil
     }
 
     func assertMeasurement(tracer: SentryTracer, name: String, duration: TimeInterval) {
-        XCTAssertEqual(tracer.measurements[name]?.value, NSNumber(value: duration))
-        XCTAssertEqual(tracer.measurements[name]?.unit?.unit, "millisecond")
-
+        expect(tracer.measurements[name]?.value) == NSNumber(value: duration)
+        expect(tracer.measurements[name]?.unit?.unit) == "millisecond"
     }
 }
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -1,5 +1,6 @@
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
+import Nimble
 import ObjectiveC
 import SentryTestUtils
 import XCTest
@@ -21,6 +22,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     let spanName = "spanName"
     let spanOperation = "spanOperation"
     let origin = "auto.ui.view_controller"
+    let frameDuration = 0.0016
     
     private class Fixture {
         
@@ -251,11 +253,11 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             callbackExpectation.fulfill()
         }
         try assertSpanDuration(span: lastSpan, expectedDuration: 5)
-        try assertSpanDuration(span: transactionSpan, expectedDuration: 22)
+        try assertSpanDuration(span: transactionSpan, expectedDuration: 22 + frameDuration)
         
         wait(for: [callbackExpectation], timeout: 0)
     }
-
+    
     func testReportFullyDisplayed() {
         let sut = fixture.getSut()
         sut.enableWaitForFullDisplay = true
@@ -267,11 +269,17 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             let spans = self.getStack(tracker)
             tracer = spans.first as? SentryTracer
         }
+        sut.viewControllerViewWillAppear(viewController) {
+            self.advanceTime(bySeconds: 0.1)
+        }
 
         sut.reportFullyDisplayed()
         reportFrame()
+        let expectedTTFDTimestamp = fixture.dateProvider.date()
 
-        XCTAssertTrue(tracer?.children[1].isFinished ?? false)
+        let ttfdSpan = tracer?.children[1]
+        expect(ttfdSpan?.isFinished) == true
+        expect(ttfdSpan?.timestamp) == expectedTTFDTimestamp
     }
 
     func testSecondViewController() {
@@ -598,7 +606,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         let timestamp = try XCTUnwrap(span.timestamp)
         let startTimestamp = try XCTUnwrap(span.startTimestamp)
         let duration = timestamp.timeIntervalSince(startTimestamp)
-        XCTAssertEqual(duration, expectedDuration)
+        expect(duration).to(beCloseTo(expectedDuration, within: 0.001))
     }
     
     private func assertTrackerIsEmpty(_ tracker: SentryPerformanceTracker) {
@@ -621,6 +629,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     }
 
     private func reportFrame() {
+        advanceTime(bySeconds: self.frameDuration)
         Dynamic(SentryDependencyContainer.sharedInstance().framesTracker).displayLinkCallback()
     }
 }


### PR DESCRIPTION

## :scroll: Description

The SDK waits for the next drawn frame after users call reportFullyDisplayed to reflect when UI changes are visible to the user correctly.

## :bulb: Motivation and Context

Preparation for https://github.com/getsentry/sentry-cocoa/issues/3471.

## :green_heart: How did you test it?

Unit tests and simulator.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
