### PR TITLE
ref: Improve FileManager delete logs

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -239,13 +239,14 @@ SentryFileManager ()
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSError *error = nil;
     @synchronized(self) {
-        SENTRY_LOG_DEBUG(@"Deleting %@", path);
-
         if (![fileManager removeItemAtPath:path error:&error]) {
-            // We don't want to log an error if the file doesn't exist.
-            if (error.code != NSFileNoSuchFileError) {
-                SENTRY_LOG_ERROR(@"Couldn't delete file %@: %@", path, error);
+            if (error.code == NSFileNoSuchFileError) {
+                SENTRY_LOG_DEBUG(@"Tried to delete file but it doesn't exist at %@", path);
+            } else {
+                SENTRY_LOG_ERROR(@"Couldn't delete file at %@ because of %@", path, error);
             }
+        } else {
+            SENTRY_LOG_DEBUG(@"Deleted file at %@", path);
         }
     }
 }


### PR DESCRIPTION
Delete file log messages show whether a file was successfully deleted, it doesn't exist, or an error occurred.

When starting the SDK the logs print something like
```
[Sentry] [debug] [SentrySDK:145] Starting SDK...
[Sentry] [debug] [SentryFileManager:644] SentryFileManager.cachePath: /Users/philipp.hofmann/Library/Developer/CoreSimulator/Devices/E8ADA254-0887-4E90-AB61-3371BF009ED0/data/Containers/Data/Application/64FA3575-1E6F-4B2C-AA14-5587A6CBEE41/Library/Caches
[Sentry] [debug] [SentryFileManager:242] Deleting /Users/philipp.hofmann/Library/Developer/CoreSimulator/Devices/E8ADA254-0887-4E90-AB61-3371BF009ED0/data/Containers/Data/Application/64FA3575-1E6F-4B2C-AA14-5587A6CBEE41/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/events
```

When looking at the last log message, one could assume that SentryFileManager deleted a file or a folder, which it didn't.

Now they print 
```
[Sentry] [debug] [SentrySDK:145] Starting SDK...
[Sentry] [debug] [SentryFileManager:647] SentryFileManager.cachePath: /Users/philipp.hofmann/Library/Developer/CoreSimulator/Devices/E8ADA254-0887-4E90-AB61-3371BF009ED0/data/Containers/Data/Application/701E0A5E-E6D6-4120-A148-5111D62E36E3/Library/Caches
[Sentry] [debug] [SentryFileManager:246] Tried to delete file but it doesn't exist at /Users/philipp.hofmann/Library/Developer/CoreSimulator/Devices/E8ADA254-0887-4E90-AB61-3371BF009ED0/data/Containers/Data/Application/701E0A5E-E6D6-4120-A148-5111D62E36E3/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/events
```

#skip-changelog