### PR TITLE
ref: Ignore getFramesDelay for ThreadSanitizer

### DIFF
--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -234,6 +234,17 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
+/**
+ * The ThreadSanitizer ignores this method; see ThreadSanitizer.sup.
+ *
+ * We accept the data race of the two properties _currentFrameRate and previousFrameSystemTimestamp,
+ * that are updated on the main thread in the displayLinkCallback. This method only reads these
+ * properties. In most scenarios, this method will be called on the main thread, for which no
+ * synchronization is needed. When calling this function from a background thread, the frames delay
+ * statistics don't need to be that accurate because background spans contribute less to delayed
+ * frames. We prefer having not 100% correct frames delay numbers for background spans instead of
+ * adding the overhead of synchronization.
+ */
 - (CFTimeInterval)getFramesDelay:(uint64_t)startSystemTimestamp
               endSystemTimestamp:(uint64_t)endSystemTimestamp
 {

--- a/Tests/ThreadSanitizer.sup
+++ b/Tests/ThreadSanitizer.sup
@@ -23,3 +23,6 @@ race:disable
 race:URLSessionDataTaskMock
 race:getOriginalImplementation
 race:SentrySpanContext
+
+# Ignore SentryFramesTracer:getFramesDelay. Visit the method for the explanation.
+race:getFramesDelay


### PR DESCRIPTION
The ThreadSanitizer now ignores SentryFramesTracker:getFramesDelay. 

$#skip-changelog