### PR TITLE
fix: Race condition in SentryTracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - TTFD waits for next drawn frame (#3505)
 - Fix TTID/TTFD for app start transactions (#3512): TTID/TTFD spans and measurements for app start transaction now include the app start duration.
+- Fix a race condition in SentryTracer (#3523)
 
 ## 8.17.2
 

--- a/Tests/ThreadSanitizer.sup
+++ b/Tests/ThreadSanitizer.sup
@@ -10,9 +10,17 @@ race:monitorCachedData
 race:TestThread.m
 race:uninstallExceptionHandler
 
-# These methods use Double-Checked Locking and ThreadSanitizers produces
-# false alarms for them.
+# ------------------ Double Checked Locks ------------------ #
+# ThreadSanitizers produces false alarms for double-checked
+# locks.
+
 race:getAppStartMeasurement
+
+# SentryDependencyContainer
+race:application
+race:threadInspector
+
+# ------------------ End: Double Checked Locks -------------- #
 
 # Races to fix
 race:returnResponse


### PR DESCRIPTION


## :scroll: Description

Fix a race condition of the wasFinishCalled property in SentryTracer by using two extra synchronized blocks.

## :bulb: Motivation and Context

The thread sanitizer tests fail on the main branch.

## :green_heart: How did you test it?
Thread sanitizer tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
