### PR TITLE
ref: Remove internal init of AppStartMeasurement

### DIFF
--- a/Sources/Sentry/SentryAppStartMeasurement.m
+++ b/Sources/Sentry/SentryAppStartMeasurement.m
@@ -20,27 +20,6 @@
 #    endif // SENTRY_HAS_UIKIT
 
 - (instancetype)initWithType:(SentryAppStartType)type
-              appStartTimestamp:(NSDate *)appStartTimestamp
-                       duration:(NSTimeInterval)duration
-           runtimeInitTimestamp:(NSDate *)runtimeInitTimestamp
-    didFinishLaunchingTimestamp:(NSDate *)didFinishLaunchingTimestamp
-{
-#    if SENTRY_HAS_UIKIT
-    return [self initWithType:type
-                          isPreWarmed:NO
-                    appStartTimestamp:appStartTimestamp
-                             duration:duration
-                 runtimeInitTimestamp:runtimeInitTimestamp
-        moduleInitializationTimestamp:[NSDate dateWithTimeIntervalSince1970:0]
-          didFinishLaunchingTimestamp:didFinishLaunchingTimestamp];
-#    else
-    SENTRY_LOG_DEBUG(@"SentryAppStartMeasurement only works with UIKit enabled. Ensure you're "
-                     @"using the right configuration of Sentry that links UIKit.");
-    return nil;
-#    endif // SENTRY_HAS_UIKIT
-}
-
-- (instancetype)initWithType:(SentryAppStartType)type
                       isPreWarmed:(BOOL)isPreWarmed
                 appStartTimestamp:(NSDate *)appStartTimestamp
                          duration:(NSTimeInterval)duration

--- a/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
+++ b/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
@@ -21,18 +21,6 @@ SENTRY_NO_INIT
  * Initializes SentryAppStartMeasurement with the given parameters.
  */
 - (instancetype)initWithType:(SentryAppStartType)type
-              appStartTimestamp:(NSDate *)appStartTimestamp
-                       duration:(NSTimeInterval)duration
-           runtimeInitTimestamp:(NSDate *)runtimeInitTimestamp
-    didFinishLaunchingTimestamp:(NSDate *)didFinishLaunchingTimestamp
-    DEPRECATED_MSG_ATTRIBUTE("Use "
-                             "initWithType:appStartTimestamp:duration:mainTimestamp:"
-                             "runtimeInitTimestamp:didFinishLaunchingTimestamp instead.");
-
-/**
- * Initializes SentryAppStartMeasurement with the given parameters.
- */
-- (instancetype)initWithType:(SentryAppStartType)type
                       isPreWarmed:(BOOL)isPreWarmed
                 appStartTimestamp:(NSDate *)appStartTimestamp
                          duration:(NSTimeInterval)duration


### PR DESCRIPTION
SentryAppStartMeasurement is only plublic for hybrid SDKs since https://github.com/getsentry/sentry-cocoa/pull/2458. Therefore, we can remove the deprecated init method.

#skip-changelog