### PR TITLE
feat: Split up UIKit and App Init App Start Spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add frames delay to transactions and spans (#3487, #3496)
 - Add slow and frozen frames to spans (#3450, #3478)
+- Split up UIKit and App Init App Start Span (#3534)
 
 ### Fixes
 

--- a/Sources/Sentry/SentryAppStartMeasurement.m
+++ b/Sources/Sentry/SentryAppStartMeasurement.m
@@ -15,6 +15,7 @@
     NSDate *_appStartTimestamp;
     NSDate *_runtimeInitTimestamp;
     NSDate *_moduleInitializationTimestamp;
+    NSDate *_sdkStartTimestamp;
     NSDate *_didFinishLaunchingTimestamp;
 }
 #    endif // SENTRY_HAS_UIKIT
@@ -25,6 +26,7 @@
                          duration:(NSTimeInterval)duration
              runtimeInitTimestamp:(NSDate *)runtimeInitTimestamp
     moduleInitializationTimestamp:(NSDate *)moduleInitializationTimestamp
+                sdkStartTimestamp:(NSDate *)sdkStartTimestamp
       didFinishLaunchingTimestamp:(NSDate *)didFinishLaunchingTimestamp
 {
 #    if SENTRY_HAS_UIKIT
@@ -35,6 +37,7 @@
         _duration = duration;
         _runtimeInitTimestamp = runtimeInitTimestamp;
         _moduleInitializationTimestamp = moduleInitializationTimestamp;
+        _sdkStartTimestamp = sdkStartTimestamp;
         _didFinishLaunchingTimestamp = didFinishLaunchingTimestamp;
     }
 

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -216,6 +216,7 @@ SentryAppStartTracker () <SentryFramesTrackerListener>
                                                    duration:appStartDuration
                                        runtimeInitTimestamp:runtimeInit
                               moduleInitializationTimestamp:sysctl.moduleInitializationTimestamp
+                                          sdkStartTimestamp:SentrySDK.startTimestamp
                                 didFinishLaunchingTimestamp:self.didFinishLaunchingTimestamp];
 
         SentrySDK.appStartMeasurement = appStartMeasurement;

--- a/Sources/Sentry/SentryBuildAppStartSpans.m
+++ b/Sources/Sentry/SentryBuildAppStartSpans.m
@@ -74,11 +74,17 @@ sentryBuildAppStartSpans(SentryTracer *tracer, SentryAppStartMeasurement *appSta
         [appStartSpans addObject:runtimeInitSpan];
     }
 
-    SentrySpan *appInitSpan = sentryBuildAppStartSpan(
-        tracer, appStartSpan.spanId, operation, @"UIKit and Application Init");
+    SentrySpan *appInitSpan
+        = sentryBuildAppStartSpan(tracer, appStartSpan.spanId, operation, @"UIKit Init");
     [appInitSpan setStartTimestamp:appStartMeasurement.moduleInitializationTimestamp];
-    [appInitSpan setTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
+    [appInitSpan setTimestamp:appStartMeasurement.sdkStartTimestamp];
     [appStartSpans addObject:appInitSpan];
+
+    SentrySpan *didFinishLaunching
+        = sentryBuildAppStartSpan(tracer, appStartSpan.spanId, operation, @"Application Init");
+    [didFinishLaunching setStartTimestamp:appStartMeasurement.sdkStartTimestamp];
+    [didFinishLaunching setTimestamp:appStartMeasurement.didFinishLaunchingTimestamp];
+    [appStartSpans addObject:didFinishLaunching];
 
     SentrySpan *frameRenderSpan
         = sentryBuildAppStartSpan(tracer, appStartSpan.spanId, operation, @"Initial Frame Render");

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -43,7 +43,7 @@ static NSObject *sentrySDKappStartMeasurementLock;
  * reenable the integrations.
  */
 static NSUInteger startInvocations;
-static NSDate *startTimestamp = nil;
+static NSDate *_Nullable startTimestamp = nil;
 
 + (void)initialize
 {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -7,6 +7,7 @@
 #import "SentryClient+Private.h"
 #import "SentryCrash.h"
 #import "SentryCrashWrapper.h"
+#import "SentryCurrentDateProvider.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryFileManager.h"
@@ -42,6 +43,7 @@ static NSObject *sentrySDKappStartMeasurementLock;
  * reenable the integrations.
  */
 static NSUInteger startInvocations;
+static NSDate *startTimestamp = nil;
 
 + (void)initialize
 {
@@ -135,6 +137,22 @@ static NSUInteger startInvocations;
     startInvocations = value;
 }
 
+/**
+ * Not public, only for internal use.
+ */
++ (nullable NSDate *)startTimestamp
+{
+    return startTimestamp;
+}
+
+/**
+ * Only needed for testing.
+ */
++ (void)setStartTimestamp:(NSDate *)value
+{
+    startTimestamp = value;
+}
+
 + (void)startWithOptions:(SentryOptions *)options
 {
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
@@ -145,6 +163,7 @@ static NSUInteger startInvocations;
     SENTRY_LOG_DEBUG(@"Starting SDK...");
 
     startInvocations++;
+    startTimestamp = [SentryDependencyContainer.sharedInstance.dateProvider date];
 
     SentryClient *newClient = [[SentryClient alloc] initWithOptions:options];
     [newClient.fileManager moveAppStateToPreviousAppState];
@@ -401,6 +420,8 @@ static NSUInteger startInvocations;
 + (void)close
 {
     SENTRY_LOG_DEBUG(@"Starting to close SDK.");
+
+    startTimestamp = nil;
 
     SentryHub *hub = SentrySDK.currentHub;
     [hub removeAllIntegrations];

--- a/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
+++ b/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
@@ -26,6 +26,7 @@ SENTRY_NO_INIT
                          duration:(NSTimeInterval)duration
              runtimeInitTimestamp:(NSDate *)runtimeInitTimestamp
     moduleInitializationTimestamp:(NSDate *)moduleInitializationTimestamp
+                sdkStartTimestamp:(NSDate *)sdkStartTimestamp
       didFinishLaunchingTimestamp:(NSDate *)didFinishLaunchingTimestamp;
 
 /**
@@ -57,6 +58,11 @@ SENTRY_NO_INIT
  * When application main function is called.
  */
 @property (readonly, nonatomic, strong) NSDate *moduleInitializationTimestamp;
+
+/**
+ * When the SentrySDK start method is called.
+ */
+@property (readonly, nonatomic, strong) NSDate *sdkStartTimestamp;
 
 /**
  * When OS posts UIApplicationDidFinishLaunchingNotification.

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -21,6 +21,7 @@ SentrySDK ()
 + (nullable SentryAppStartMeasurement *)getAppStartMeasurement;
 
 @property (nonatomic, class) NSUInteger startInvocations;
+@property (nullable, nonatomic, class) NSDate *startTimestamp;
 
 + (SentryHub *)currentHub;
 

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -228,7 +228,8 @@ class SentryProfilerSwiftTests: XCTestCase {
             appStart = preWarmed ? main : appStart
             appStartDuration = preWarmed ? appStartDuration - runtimeInitDuration - mainDuration : appStartDuration
             appStartEnd = appStart.addingTimeInterval(appStartDuration)
-            return SentryAppStartMeasurement(type: type, isPreWarmed: preWarmed, appStartTimestamp: appStart, duration: appStartDuration, runtimeInitTimestamp: runtimeInit, moduleInitializationTimestamp: main, didFinishLaunchingTimestamp: didFinishLaunching)
+            return SentryAppStartMeasurement(type: type, isPreWarmed: preWarmed, appStartTimestamp: appStart, duration: appStartDuration, runtimeInitTimestamp: runtimeInit, moduleInitializationTimestamp: main,
+                                             sdkStartTimestamp: appStart, didFinishLaunchingTimestamp: didFinishLaunching)
         }
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     }

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -24,6 +24,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
         let appStartDuration: TimeInterval = 0.4
         var runtimeInitTimestamp: Date
         var moduleInitializationTimestamp: Date
+        var sdkStartTimestamp: Date
         var didFinishLaunchingTimestamp: Date
         
         init() {
@@ -50,7 +51,10 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
             
             runtimeInitTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.2)
             moduleInitializationTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.1)
-            didFinishLaunchingTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.3)
+            sdkStartTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.1)
+            SentrySDK.startTimestamp = sdkStartTimestamp
+            
+            didFinishLaunchingTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.2)
         }
         
         var sut: SentryAppStartTracker {
@@ -440,10 +444,12 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
             XCTAssertEqual(fixture.sysctl.processStartTimestamp, appStartMeasurement.appStartTimestamp)
         }
 
-        XCTAssertEqual(fixture.sysctl.moduleInitializationTimestamp, appStartMeasurement.moduleInitializationTimestamp)
-        XCTAssertEqual(fixture.runtimeInitTimestamp, appStartMeasurement.runtimeInitTimestamp)
-        XCTAssertEqual(fixture.didFinishLaunchingTimestamp, appStartMeasurement.didFinishLaunchingTimestamp)
-        XCTAssertEqual(preWarmed, appStartMeasurement.isPreWarmed)
+        expect(appStartMeasurement.moduleInitializationTimestamp) == fixture.sysctl.moduleInitializationTimestamp
+        expect(appStartMeasurement.runtimeInitTimestamp) == fixture.runtimeInitTimestamp
+        
+        expect(appStartMeasurement.sdkStartTimestamp) == fixture.sdkStartTimestamp
+        expect(appStartMeasurement.didFinishLaunchingTimestamp) == fixture.didFinishLaunchingTimestamp
+        expect(appStartMeasurement.isPreWarmed) == preWarmed
     }
     
     private func assertValidHybridStart(type: SentryAppStartType) {

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -328,9 +328,10 @@ class TestData {
         let appStartDuration = 0.5
         let main = appStartTimestamp.addingTimeInterval(0.15)
         let runtimeInit = appStartTimestamp.addingTimeInterval(0.05)
-        let didFinishLaunching = appStartTimestamp.addingTimeInterval(0.3)
+        let sdkStart = appStartTimestamp.addingTimeInterval(0.1)
+        let didFinishLaunching = appStartTimestamp.addingTimeInterval(0.2)
         
-        return SentryAppStartMeasurement(type: type, isPreWarmed: false, appStartTimestamp: appStartTimestamp, duration: appStartDuration, runtimeInitTimestamp: runtimeInit, moduleInitializationTimestamp: main, didFinishLaunchingTimestamp: didFinishLaunching)
+        return SentryAppStartMeasurement(type: type, isPreWarmed: false, appStartTimestamp: appStartTimestamp, duration: appStartDuration, runtimeInitTimestamp: runtimeInit, moduleInitializationTimestamp: main, sdkStartTimestamp: sdkStart, didFinishLaunchingTimestamp: didFinishLaunching)
     }
 
     #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -502,6 +503,23 @@ class SentrySDKTests: XCTestCase {
         }
         
         XCTAssertEqual(1, SentrySDK.startInvocations)
+    }
+    
+    func testSDKStartTimestamp() {
+        let currentDateProvider = TestCurrentDateProvider()
+        SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
+        
+        expect(SentrySDK.startTimestamp) == nil
+        
+        SentrySDK.start { options in
+            options.dsn = SentrySDKTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+        
+        expect(SentrySDK.startTimestamp) == currentDateProvider.date()
+        
+        SentrySDK.close()
+        expect(SentrySDK.startTimestamp) == nil
     }
     
     func testIsEnabled() {


### PR DESCRIPTION

## :scroll: Description

Split the UIKit and Application Init span into one span for UIKit Init and another for Application Init. The UIKit Init span ends when the users start the SentrySDK. We recommend that the SentrySDK is the first to call in the UIApplication.didFinishLaunching method because otherwise, users won't receive any potential crash reports for code running before our SDK. Therefore, we pick the start time of our SDK as when the UIApplicationDelegate.didFinishLaunching is called.

### Before

![CleanShot 2024-01-04 at 10 43 21@2x](https://github.com/getsentry/sentry-cocoa/assets/2443292/379e10b9-b90b-4ded-973c-064a63979abc)


### Now

![CleanShot 2024-01-04 at 10 41 12@2x](https://github.com/getsentry/sentry-cocoa/assets/2443292/09795d7b-6445-4a58-a892-9d47ddf7580d)

## :bulb: Motivation and Context

Fixes GH-3345

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
