### PR TITLE
feat: Prewarmed App Start Tracing is stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add frames delay to transactions and spans (#3487, #3496)
 - Add slow and frozen frames to spans (#3450, #3478)
+- Prewarmed App Start Tracing is stable (#3535)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add frames delay to transactions and spans (#3487, #3496)
 - Add slow and frozen frames to spans (#3450, #3478)
-- Prewarmed App Start Tracing is stable (#3535)
+- Prewarmed App Start Tracing is stable (#3536)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -254,11 +254,12 @@ NS_SWIFT_NAME(Options)
  * @note The default is 3 seconds.
  */
 @property (nonatomic, assign) NSTimeInterval idleTimeout;
+
 /**
- * @warning This is an experimental feature and may still have bugs.
- * @brief Report pre-warmed app starts by dropping the first app start spans if pre-warming paused
+ * Report pre-warmed app starts by dropping the first app start spans if pre-warming paused
  * during these steps. This approach will shorten the app start duration, but it represents the
  * duration a user has to wait after clicking the app icon until the app is responsive.
+ *
  * @note You can filter for different app start types in Discover with
  * @c app_start_type:cold.prewarmed ,
  * @c app_start_type:warm.prewarmed , @c app_start_type:cold , and @c app_start_type:warm .


### PR DESCRIPTION


## :scroll: Description

Make the option enablePreWarmedAppStartTracing stable.

Docs PR https://github.com/getsentry/sentry-docs/pull/8812.

## :bulb: Motivation and Context

The option has been in beta for over a year. We didn't hear any complaints about the feature. Let's make it stable and fix problems if required. The plan is to turn this feature on by default in the next major https://github.com/getsentry/sentry-cocoa/issues/3535.

## :green_heart: How did you test it?
No complaints.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
