### PR TITLE
ci: ThreadSanitizer validate test server runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -277,6 +277,9 @@ jobs:
 
       - run: ./test-server-exec &
 
+      - name: Check test-server runs
+        run: curl http://localhost:8080/echo-baggage-header
+
       - run: ./scripts/ci-select-xcode.sh
 
       - name: Running tests with ThreadSanitizer


### PR DESCRIPTION
Validate that the test server runs for ThreadSanitizer tests in CI cause the tests requiring the test server failed on main: https://github.com/getsentry/sentry-cocoa/actions/runs/7409955431/job/20162751416.

#skip-changelog