### PR TITLE
feat: Send debug meta for app start transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Send debug meta for app start transactions (#3543)
+
 ## 8.18.0
 
 ### Features

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -71,6 +71,7 @@ SentryTracer ()
 @property (nonatomic, nullable, strong) NSTimer *deadlineTimer;
 @property (nonnull, strong) SentryTracerConfiguration *configuration;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
+@property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 @property (nonatomic) BOOL isProfiling;
@@ -134,6 +135,7 @@ static BOOL appStartMeasurementRead;
     _startSystemTime = SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
     _configuration = configuration;
     _dispatchQueue = SentryDependencyContainer.sharedInstance.dispatchQueueWrapper;
+    _debugImageProvider = SentryDependencyContainer.sharedInstance.debugImageProvider;
 
     self.transactionContext = transactionContext;
     _children = [[NSMutableArray alloc] init];
@@ -751,6 +753,10 @@ static BOOL appStartMeasurementRead;
             NSDictionary *appContext = @{ @"app" : @ { @"start_type" : appStartType } };
             [context mergeEntriesFromDictionary:appContext];
             [transaction setContext:context];
+
+            // The backend calculates statistics on the number and size of debug images for app
+            // start transactions. Therefore, we add all debug images here.
+            transaction.debugMeta = [self.debugImageProvider getDebugImagesCrashed:NO];
         }
     }
 }


### PR DESCRIPTION




## :scroll: Description

Send the complete list of debug meta for app start transactions so we can calculate statistics on the number and size of libraries loaded on the backend when the app starts.

## :bulb: Motivation and Context

Fixes GH-3541

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
