### PR TITLE
test: Set ui-tests environment

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -29,7 +29,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.profilesSampleRate = 1.0
             options.attachScreenshot = true
             options.attachViewHierarchy = true
-            options.environment = "test-app"
             options.enableTimeToFullDisplayTracing = true
             options.enablePerformanceV2 = true
             
@@ -65,7 +64,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             
             options.initialScope = { scope in
-                scope.setEnvironment("debug")
+                let processInfoEnvironment = ProcessInfo.processInfo.environment["io.sentry.sdk-environment"]
+                
+                if processInfoEnvironment != nil {
+                    scope.setEnvironment(processInfoEnvironment)
+                } else if isBenchmarking {
+                    scope.setEnvironment("benchmarking")
+                } else {
+                    scope.setEnvironment("debug")
+                }
+                
                 scope.setTag(value: "swift", key: "language")
                
                 let user = User(userId: "1")

--- a/Samples/iOS-Swift/iOS-SwiftUITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/BaseUITest.swift
@@ -8,6 +8,7 @@ class BaseUITest: XCTestCase {
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
         app.launchEnvironment["io.sentry.ui-test.test-name"] = name
+        app.launchEnvironment["io.sentry.sdk-environment"] = "ui-tests"
         app.launch()
         
         waitForExistenceOfMainScreen()


### PR DESCRIPTION
Set the up-tests environment when running UI tests in CI so that we can apply filters in Sentry.

#skip-changelog