### PR TITLE
fix: Make SentryScope.useSpan non-blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix typo in BUILD_LIBRARY_FOR_DISTRIBUTION variable in Makefile (#3488)
 - Remove dispatch queue metadata collection to fix crash (#3522)
+- Make SentryScope.useSpan non-blocking (#3568)
 
 ## 8.18.0
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -141,9 +141,11 @@ SentryScope ()
 
 - (void)useSpan:(SentrySpanCallback)callback
 {
+    id<SentrySpan> localSpan = nil;
     @synchronized(_spanLock) {
-        callback(_span);
+        localSpan = _span;
     }
+    callback(localSpan);
 }
 
 - (void)clear


### PR DESCRIPTION

## :scroll: Description

Instead of calling the callback of useSpan within the spanLock, get a reference to the span inside the critical sector and pass this to the callback after the critical sector closes. This way, when the callback is a blocking call, useSpan doesn't block other invocations of itself and prevents potential deadlocks.

## :bulb: Motivation and Context

A customer reported a deadlock on macOS for which multiple threads pointed to acquiring locks to `SentryScope useSpan`.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
