### PR TITLE
meta: fix changelog entry that was added to stale diff after 8.18.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix typo in BUILD_LIBRARY_FOR_DISTRIBUTION variable in Makefile (#3488)
 - Remove dispatch queue metadata collection to fix crash (#3522)
 - Make SentryScope.useSpan non-blocking (#3568)
+- Don't override `sentry-trace` and `baggage` headers (#3540)
 
 ## 8.18.0
 
@@ -31,7 +32,6 @@
 - Use correct rendered frames timestamp for TTID/TTFD and app start (#3531)
 
 - Missing transactions when not calling `reportFullyDisplayed` (#3477)
-- Don't override `sentry-trace` and `baggage` headers (#3540)
 
 ## 8.17.2
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-cocoa/pull/3540 was opened before the 8.18.0 release. After the release ran, the PR was not caught up to `main`, so the diff was stale and its changelog entry went in under the 8.18.0 heading.

#skip-changelog