### PR TITLE
chore: Bump saucectl from 0.107.2 to 0.171.0

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: DerivedData-Xcode
-      - run: npm install -g saucectl@0.107.2
+      - run: npm install -g saucectl@0.171.0
       - name: Run Benchmarks in SauceLab
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           name: DerivedData-Xcode-${{ matrix.xcode }}
 
-      - run: npm install -g saucectl@0.107.2
+      - run: npm install -g saucectl@0.171.0
 
       # As Sauce Labs is a bit flaky we retry 5 times
       - name: Run Tests in SauceLab


### PR DESCRIPTION
0.107.2 was released in Sep 2022. Let's bump to the latest version.

#skip-changelog