### PR TITLE
fix: Fix FileManager logs warning for .DS_Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Move header reference out of "extern C" (#3538)
 - Clarify FramesTracker log message (#3570)
 - Fix synchronization issue in FramesTracker (#3571)
+- Fix SentryFileManager logs warning for .DS_Files (#3584)
 
 ## 8.19.0
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -189,7 +189,8 @@ SentryFileManager ()
     NSDictionary *dict = [[NSFileManager defaultManager] attributesOfItemAtPath:fullPath
                                                                           error:&error];
     if (error != nil) {
-        SENTRY_LOG_WARN(@"Could not get attributes of item at path %@. Error: %@", fullPath, error);
+        SENTRY_LOG_WARN(
+            @"Could not get attributes of item at path: %@. Error: %@", fullPath, error);
         return nil;
     }
 

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -17,6 +17,7 @@ NS_SWIFT_NAME(SentryFileManager)
 @interface SentryFileManager : NSObject
 SENTRY_NO_INIT
 
+@property (nonatomic, readonly) NSString *basePath;
 @property (nonatomic, readonly) NSString *sentryPath;
 @property (nonatomic, readonly) NSString *breadcrumbsFilePathOne;
 @property (nonatomic, readonly) NSString *breadcrumbsFilePathTwo;
@@ -54,6 +55,11 @@ SENTRY_NO_INIT
 - (void)deleteAllFolders;
 
 - (void)deleteOldEnvelopeItems;
+
+/**
+ * Only used for testing.
+ */
+- (nullable NSString *)getEnvelopesPath:(NSString *)filePath;
 
 /**
  * Get all envelopes sorted ascending by the @c timeIntervalSince1970 the envelope was stored and if

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -157,7 +157,10 @@ class SentryFileManagerTests: XCTestCase {
         
         sut.deleteOldEnvelopeItems()
         
-        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring .DS_Store file when building envelopes path at path: \(dsStoreFile)") }
+        let logMessages = logOutput.loggedMessages.filter {
+            $0.contains("[Sentry] [debug]") &&
+            $0.contains("Ignoring .DS_Store file when building envelopes path at path: \(dsStoreFile)")
+        }
         expect(logMessages.count) == 1
         
         try FileManager.default.removeItem(atPath: dsStoreFile)
@@ -177,7 +180,10 @@ class SentryFileManagerTests: XCTestCase {
         
         sut.deleteOldEnvelopeItems()
         
-        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring non directory when deleting old envelopes at path: \(textFilePath)") }
+        let logMessages = logOutput.loggedMessages.filter {
+            $0.contains("[Sentry] [debug]") &&
+            $0.contains("Ignoring non directory when deleting old envelopes at path: \(textFilePath)")
+        }
         expect(logMessages.count) == 1
         
         try FileManager.default.removeItem(atPath: textFilePath)
@@ -195,7 +201,10 @@ class SentryFileManagerTests: XCTestCase {
         
         expect(sut.getEnvelopesPath(nonExistentFile)) == nil
         
-        let logMessages = logOutput.loggedMessages.filter { $0.contains("Could not get attributes of item at path: \(nonExistentFileFullPath)") }
+        let logMessages = logOutput.loggedMessages.filter {
+            $0.contains("[Sentry] [warning]") &&
+            $0.contains("Could not get attributes of item at path: \(nonExistentFileFullPath)")
+        }
         expect(logMessages.count) == 1
     }
     

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -148,7 +148,7 @@ class SentryFileManagerTests: XCTestCase {
     func testDeleteOldEnvelopes_LogsIgnoreDSStoreFiles() throws {
         let logOutput = TestLogOutput()
         SentryLog.setLogOutput(logOutput)
-        SentryLog.configure(true, diagnosticLevel: .warning)
+        SentryLog.configure(true, diagnosticLevel: .debug)
         
         let dsStoreFile = "\(sut.basePath)/.DS_Store"
         
@@ -157,7 +157,8 @@ class SentryFileManagerTests: XCTestCase {
         
         sut.deleteOldEnvelopeItems()
         
-        expect(logOutput.loggedMessages.count) == 1
+        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring .DS_Store file when building envelopes path at path") }
+        expect(logMessages.count) == 1
         
         try FileManager.default.removeItem(atPath: dsStoreFile)
     }

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -157,7 +157,7 @@ class SentryFileManagerTests: XCTestCase {
         
         sut.deleteOldEnvelopeItems()
         
-        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring .DS_Store file when building envelopes path at path") }
+        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring .DS_Store file when building envelopes path at path: \(dsStoreFile)") }
         expect(logMessages.count) == 1
         
         try FileManager.default.removeItem(atPath: dsStoreFile)
@@ -177,7 +177,7 @@ class SentryFileManagerTests: XCTestCase {
         
         sut.deleteOldEnvelopeItems()
         
-        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring non directory when deleting old envelopes at path") }
+        let logMessages = logOutput.loggedMessages.filter { $0.contains("Ignoring non directory when deleting old envelopes at path: \(textFilePath)") }
         expect(logMessages.count) == 1
         
         try FileManager.default.removeItem(atPath: textFilePath)
@@ -190,11 +190,12 @@ class SentryFileManagerTests: XCTestCase {
         
         let sut = fixture.getSut()
         
-        let textFilePath = "\(sut.basePath)/something.txt"
+        let nonExistentFile = "nonExistentFile.txt"
+        let nonExistentFileFullPath = "\(sut.basePath)/\(nonExistentFile)"
         
-        expect(sut.getEnvelopesPath(textFilePath)) == nil
+        expect(sut.getEnvelopesPath(nonExistentFile)) == nil
         
-        let logMessages = logOutput.loggedMessages.filter { $0.contains("Could not get attributes of item at path") }
+        let logMessages = logOutput.loggedMessages.filter { $0.contains("Could not get attributes of item at path: \(nonExistentFileFullPath)") }
         expect(logMessages.count) == 1
     }
     


### PR DESCRIPTION


## :scroll: Description

Don't log a warning in SentryFileManager for .DS_Store files.

## :bulb: Motivation and Context

Fixes one part of GH-3577

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
