### PR TITLE
fix: TARGET_OS_VISION not defined for macOS

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrashSystemCapabilities.h
+++ b/Sources/SentryCrash/Recording/SentryCrashSystemCapabilities.h
@@ -35,6 +35,10 @@
 #    define SentryCrashCRASH_HOST_ANDROID 1
 #endif
 
+#ifndef TARGET_OS_VISION
+#define TARGET_OS_VISION 0
+#endif
+
 #define SentryCrashCRASH_HOST_IOS (SentryCrashCRASH_HOST_APPLE && TARGET_OS_IOS)
 #define SentryCrashCRASH_HOST_TV (SentryCrashCRASH_HOST_APPLE && TARGET_OS_TV)
 #define SentryCrashCRASH_HOST_WATCH (SentryCrashCRASH_HOST_APPLE && TARGET_OS_WATCH)


### PR DESCRIPTION
Added

```objc
#ifndef TARGET_OS_VISION
#define TARGET_OS_VISION 0
#endif
```

to fix compilation on CI for macOS

_#skip-changelog_