### PR TITLE
test: use XCTUnwrap instead of force unwraps or unchecked array access

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -187,22 +187,20 @@ class SentryPerformanceTrackerTests: XCTestCase {
         wait(for: [expect], timeout: 0)
     }
     
-    func testNotSampled() {
+    func testNotSampled() throws {
         fixture.client.options.tracesSampleRate = 0
         let sut = fixture.getSut()
         let spanId = sut.startSpan(withName: fixture.someTransaction, nameSource: .custom, operation: fixture.someOperation, origin: fixture.origin)
-        let span = sut.getSpan(spanId)
-        
-        XCTAssertEqual(span!.sampled, .no)
+        let span = try XCTUnwrap(sut.getSpan(spanId))
+        XCTAssertEqual(span.sampled, .no)
     }
     
-    func testSampled() {
+    func testSampled() throws {
         fixture.client.options.tracesSampleRate = 1
         let sut = fixture.getSut()
         let spanId = sut.startSpan(withName: fixture.someTransaction, nameSource: .custom, operation: fixture.someOperation, origin: fixture.origin)
-        let span = sut.getSpan(spanId)
-        
-        XCTAssertEqual(span!.sampled, .yes)
+        let span = try XCTUnwrap(sut.getSpan(spanId))
+        XCTAssertEqual(span.sampled, .yes)
     }
     
     func testFinishSpan() {

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -113,7 +113,7 @@ class SentrySpanTests: XCTestCase {
         wait(for: [expect], timeout: 1.0)
     }
     
-    func testFinish() {
+    func testFinish() throws {
         let client = TestClient(options: fixture.options)!
         let span = fixture.getSut(client: client)
         
@@ -124,14 +124,14 @@ class SentrySpanTests: XCTestCase {
         XCTAssertTrue(span.isFinished)
         XCTAssertEqual(span.status, .ok)
         
-        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
+        let lastEvent = try XCTUnwrap(client.captureEventWithScopeInvocations.invocations.first).event
         XCTAssertEqual(lastEvent.transaction, fixture.someTransaction)
         XCTAssertEqual(lastEvent.timestamp, TestData.timestamp)
         XCTAssertEqual(lastEvent.startTimestamp, TestData.timestamp)
         XCTAssertEqual(lastEvent.type, SentryEnvelopeItemTypeTransaction)
     }
     
-    func testFinish_Custom_Timestamp() {
+    func testFinish_Custom_Timestamp() throws {
         let client = TestClient(options: fixture.options)!
         let span = fixture.getSut(client: client)
         
@@ -146,7 +146,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertTrue(span.isFinished)
         XCTAssertEqual(span.status, .ok)
         
-        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
+        let lastEvent = try XCTUnwrap(client.captureEventWithScopeInvocations.invocations.first).event
         XCTAssertEqual(lastEvent.transaction, fixture.someTransaction)
         XCTAssertEqual(lastEvent.timestamp, finishDate)
         XCTAssertEqual(lastEvent.startTimestamp, TestData.timestamp)
@@ -184,7 +184,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertTrue(span.isFinished)
     }
     
-    func testFinishWithChild() {
+    func testFinishWithChild() throws {
         let client = TestClient(options: fixture.options)!
         let span = fixture.getSut(client: client)
         let childSpan = span.startChild(operation: fixture.someOperation)
@@ -192,7 +192,7 @@ class SentrySpanTests: XCTestCase {
         childSpan.finish()
         span.finish()
         
-        let lastEvent = client.captureEventWithScopeInvocations.invocations[0].event
+        let lastEvent = try XCTUnwrap(client.captureEventWithScopeInvocations.invocations.first).event
         let serializedData = lastEvent.serialize()
         
         let spans = serializedData["spans"] as! [Any]


### PR DESCRIPTION
I changed these while investigating a broken assumption that were crashing the test run instead of just failing these cases. Helps with #3576.

#skip-changelog