### PR TITLE
ref: Remove redundant nonnull in FileManager

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -639,7 +639,7 @@ SentryFileManager ()
 
 #pragma mark private methods
 
-- (void)createPathsWithOptions:(SentryOptions *_Nonnull)options
+- (void)createPathsWithOptions:(SentryOptions *)options
 {
     NSString *cachePath = options.cacheDirectoryPath;
 


### PR DESCRIPTION
SentryFileManager has NS_ASSUME_NONNULL_BEGIN at the beginning. No need to specify nonnull for createPathsWithOptions.

#skip-changelog