### PR TITLE
ref: Make allFilesInFolder internal

### DIFF
--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -69,8 +69,6 @@ SENTRY_NO_INIT
 
 - (void)removeFileAtPath:(NSString *)path;
 
-- (NSArray<NSString *> *)allFilesInFolder:(NSString *)path;
-
 - (void)storeAppState:(SentryAppState *)appState;
 - (void)moveAppStateToPreviousAppState;
 - (SentryAppState *_Nullable)readAppState;

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -206,11 +206,6 @@ class SentryFileManagerTests: XCTestCase {
         try SentryFileManager.createDirectory(atPath: "a")
     }
     
-    func testAllFilesInFolder() {
-        let files = sut.allFiles(inFolder: "x")
-        XCTAssertTrue(files.isEmpty)
-    }
-    
     func testDeleteFileNotExists() {
         let logOutput = TestLogOutput()
         SentryLog.setLogOutput(logOutput)


### PR DESCRIPTION
SentryFileManager.allFilesInFolder is only used by the SentryFileManager and can be internal. Furthermore, we can safely remove the test testAllFilesInFolder as that functionality is covered with other tests.

#skip-changelog