### PR TITLE
ref: FileManager remove redundant NS_SWIFT_NAME

### DIFF
--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -13,7 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryOptions;
 @class SentrySession;
 
-NS_SWIFT_NAME(SentryFileManager)
 @interface SentryFileManager : NSObject
 SENTRY_NO_INIT
 


### PR DESCRIPTION
`NS_SWIFT_NAME` is the same as ObjC. Therefore, we can safely remove it.

#skip-changelog