### PR TITLE
fix: FileManager log info when path doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Clarify FramesTracker log message (#3570)
 - Fix rare battery breadcrumbs crash (#3582)
 - Fix synchronization issue in FramesTracker (#3571)
+- Fix FileManager logs info instead of error when a path doesn't exist (#3594)
 
 ## 8.19.0
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -225,11 +225,16 @@ SentryFileManager ()
 - (NSArray<NSString *> *)allFilesInFolder:(NSString *)path
 {
     NSFileManager *fileManager = [NSFileManager defaultManager];
+    if (![fileManager fileExistsAtPath:path]) {
+        SENTRY_LOG_INFO(@"Returning empty files list, as folder doesn't exist at path: %@", path);
+        return @[];
+    }
+
     NSError *error = nil;
     NSArray<NSString *> *storedFiles = [fileManager contentsOfDirectoryAtPath:path error:&error];
-    if (nil != error) {
+    if (error != nil) {
         SENTRY_LOG_ERROR(@"Couldn't load files in folder %@: %@", path, error);
-        return [NSArray new];
+        return @[];
     }
     return [storedFiles sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)];
 }

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -476,6 +477,22 @@ class SentryFileManagerTests: XCTestCase {
         sut.deleteAllEnvelopes()
 
         XCTAssertEqual(0, sut.getAllEnvelopes().count)
+    }
+    
+    func testGetAllEnvelopesWhenNoEnvelopesPath_LogsInfoMessage() {
+        let logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+        SentryLog.configure(true, diagnosticLevel: .debug)
+        
+        sut.deleteAllFolders()
+        sut.getAllEnvelopes()
+        
+        let debugLogMessages = logOutput.loggedMessages.filter { $0.contains("[Sentry] [info]") && $0.contains("Returning empty files list, as folder doesn't exist at path:") }
+        expect(debugLogMessages.count) == 1
+        
+        let errorMessages = logOutput.loggedMessages.filter { $0.contains("[Sentry] [error]") }
+        
+        expect(errorMessages.count) == 0
     }
     
     func testReadStoreDeleteAppState() {


### PR DESCRIPTION


## :scroll: Description

Logging an error when getting all files for a folder that doesn't exist confuses users; see GH-3577. Instead, log an info message that the SentryFileManager tried getting a list of files for a folder that doesn't exist. We chose info because it's still an edge case that shouldn't occur often, but it doesn't break any functionality. If a path was deleted manually by the user that the SDK requires, the SDK will create the path on next launch. We don't want to add checks if all the necessary paths exist every time the SDK stores an envelope cause this adds some overhead. If users manually remove the required paths, we accept that they have to wait until the next time the SDK launches.

## :bulb: Motivation and Context

Fixes GH-3577

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
