### PR TITLE
impr: Cache installationID async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Cache installationID async to avoid file IO on the main thread when starting the SDK (#3601)
+
+
 ## 8.20.0
 
 ### Features

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -151,6 +151,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         self.timezone = timezone;
         self.attachmentProcessors = [[NSMutableArray alloc] init];
 
+        // The SDK stores the installationID in a file. The first call requires file IO. To avoid
+        // executing this on the main thread, we cache the installationID async here.
+        [SentryInstallation cacheIDAsyncWithCacheDirectoryPath:options.cacheDirectoryPath];
+
         if (deleteOldEnvelopeItems) {
             [fileManager deleteOldEnvelopeItems];
         }

--- a/Sources/Sentry/include/SentryInstallation.h
+++ b/Sources/Sentry/include/SentryInstallation.h
@@ -8,6 +8,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSString *)idWithCacheDirectoryPath:(NSString *)cacheDirectoryPath;
 
++ (nullable NSString *)idWithCacheDirectoryPathNonCached:(NSString *)cacheDirectoryPath;
+
++ (void)cacheIDAsyncWithCacheDirectoryPath:(NSString *)cacheDirectoryPath;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -163,6 +163,8 @@ class SentryClientTest: XCTestCase {
         
         let options = Options()
         options.dsn = SentryClientTest.dsn
+        // We have to put our cache into a subfolder of the default path, because on macOS we can't delete the default cache folder
+        options.cacheDirectoryPath = "\(options.cacheDirectoryPath)/cache"
         _ = SentryClient(options: options)
         
         expect(dispatchQueue.dispatchAsyncInvocations.count) == 1

--- a/Tests/SentryTests/State/SentryInstallationTests.swift
+++ b/Tests/SentryTests/State/SentryInstallationTests.swift
@@ -11,7 +11,6 @@ final class SentryInstallationTests: XCTestCase {
         try super.setUpWithError()
         
         try FileManager().createDirectory(atPath: basePath, withIntermediateDirectories: true)
-        print("base path: \(basePath)")
     }
     
     override func tearDownWithError() throws {

--- a/Tests/SentryTests/State/SentryInstallationTests.swift
+++ b/Tests/SentryTests/State/SentryInstallationTests.swift
@@ -1,19 +1,25 @@
+import Nimble
+import SentryTestUtils
 import XCTest
 
 final class SentryInstallationTests: XCTestCase {
-    var basePath: String!
+    
+    // FileManager().temporaryDirectory already has a trailing slash
+    let basePath = "\(FileManager().temporaryDirectory)\(UUID().uuidString)"
     
     override func setUpWithError() throws {
         try super.setUpWithError()
-        // FileManager().temporaryDirectory already has a trailting slash
-        basePath = "\(FileManager().temporaryDirectory)\(UUID().uuidString)"
+        
         try FileManager().createDirectory(atPath: basePath, withIntermediateDirectories: true)
-        print("base path: \(basePath!)")
+        print("base path: \(basePath)")
     }
     
     override func tearDownWithError() throws {
         super.tearDown()
-        try FileManager().removeItem(atPath: basePath)
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: basePath) {
+            try FileManager().removeItem(atPath: basePath)
+        }
     }
     
     func testSentryInstallationId() {
@@ -38,5 +44,34 @@ final class SentryInstallationTests: XCTestCase {
         let id1 = SentryInstallation.id(withCacheDirectoryPath: basePath)
         SentryInstallation.installationStringsByCacheDirectoryPaths.removeAllObjects()
         XCTAssertEqual(id1, SentryInstallation.id(withCacheDirectoryPath: basePath))
+    }
+    
+    func testCacheIDAsync_ExecutesOnBackgroundThread() {
+        let dispatchQueue = TestSentryDispatchQueueWrapper()
+        SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueue
+        
+        SentryInstallation.cacheIDAsync(withCacheDirectoryPath: basePath)
+        
+        expect(dispatchQueue.dispatchAsyncInvocations.count) == 1
+    }
+    
+    func testCacheIDAsync_CashesID() throws {
+        let dispatchQueue = TestSentryDispatchQueueWrapper()
+        SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueue
+        
+        SentryInstallation.cacheIDAsync(withCacheDirectoryPath: basePath)
+
+        let nonCachedID = SentryInstallation.id(withCacheDirectoryPathNonCached: basePath)
+        
+        // We remove the file containing the installation ID, but the cached ID is still in memory
+        try FileManager().removeItem(atPath: basePath)
+        
+        let nonCachedIDAfterDeletingFile = SentryInstallation.id(withCacheDirectoryPathNonCached: basePath)
+        expect(nonCachedIDAfterDeletingFile) == nil
+        
+        let cachedID = SentryInstallation.id(withCacheDirectoryPath: basePath)
+        
+        expect(cachedID) == nonCachedID
+
     }
 }


### PR DESCRIPTION




## :scroll: Description

The SDK stores the installationID in a file. When the SDK launches, it caches the installationID async to avoid file IO on the main thread.

## :bulb: Motivation and Context

Fixes GH-3575

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
