### PR TITLE
ci: Use macos-13-xlarge

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build-benchmark-test-target:
     name: Build app and test runner
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh
@@ -102,7 +102,7 @@ jobs:
 
   app-metrics:
     name: Collect app metrics
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,7 +39,7 @@ jobs:
 
   xcode-analyze:
     name: Xcode Analyze
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,7 +107,7 @@ jobs:
             device: "iPhone 8"
 
           # iOS 16
-          - runs-on: macos-13
+          - runs-on: macos-13-xlarge
             platform: "iOS"
             xcode: "14.3"
             test-destination-os: "16.4"
@@ -126,7 +126,7 @@ jobs:
             test-destination-os: "latest"
 
           # macOS 13
-          - runs-on: macos-13
+          - runs-on: macos-13-xlarge
             platform: "macOS"
             xcode: "14.3"
             test-destination-os: "latest"
@@ -134,7 +134,7 @@ jobs:
           # Catalyst. We only test the latest version, as
           # the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
-          - runs-on: macos-13
+          - runs-on: macos-13-xlarge
             platform: "Catalyst"
             xcode: "14.3"
             test-destination-os: "latest"
@@ -146,7 +146,7 @@ jobs:
             test-destination-os: "latest"
 
           # tvOS 16
-          - runs-on: macos-13
+          - runs-on: macos-13-xlarge
             platform: "tvOS"
             xcode: "14.3"
             test-destination-os: "latest"
@@ -258,7 +258,7 @@ jobs:
   # that adds a significant overhead.
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     timeout-minutes: 20
     needs: [build-test-server]
     
@@ -353,7 +353,7 @@ jobs:
 
   ui-tests-address-sanitizer:
     name: UI Tests with Address Sanitizer
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -258,7 +258,7 @@ jobs:
   # that adds a significant overhead.
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     timeout-minutes: 20
     needs: [build-test-server]
     


### PR DESCRIPTION
Use macos-13-xlarge for slow GH jobs to speed up CI.

#skip-changelog