### PR TITLE
ci: Run unit tests on macOS 14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,13 @@ jobs:
             test-destination-os: "16.4"
             device: "iPhone 14"
 
+          # iOS 17
+          - runs-on: macos-14-xlarge
+            platform: "iOS"
+            xcode: "15.2"
+            test-destination-os: "17.2"
+            device: "iPhone 15"
+
           # macOS 11
           - runs-on: macos-11
             platform: "macOS"
@@ -131,12 +138,18 @@ jobs:
             xcode: "14.3"
             test-destination-os: "latest"
 
+          # macOS 14
+          - runs-on: macos-14-xlarge
+            platform: "macOS"
+            xcode: "15.2"
+            test-destination-os: "latest"
+
           # Catalyst. We only test the latest version, as
           # the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
-          - runs-on: macos-13
+          - runs-on: macos-14-xlarge
             platform: "Catalyst"
-            xcode: "14.3"
+            xcode: "15.2"
             test-destination-os: "latest"
 
           # tvOS 15
@@ -149,6 +162,12 @@ jobs:
           - runs-on: macos-13
             platform: "tvOS"
             xcode: "14.3"
+            test-destination-os: "latest"
+
+          # tvOS 17
+          - runs-on: macos-14-xlarge
+            platform: "tvOS"
+            xcode: "15.2"
             test-destination-os: "latest"
 
     steps:


### PR DESCRIPTION
Add tvOS 17, iOS 17, and macOS 14. Run Catalyst on Xcode 15.2.

Fixes GH-3329

#skip-changelog