### PR TITLE
ci: Address Sanitizer tests use Xcode 15.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -361,7 +361,7 @@ jobs:
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"$iPhone 14 (17.2)" address_sanitizer:true && break ; done
+        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"iPhone 14 (17.2)" address_sanitizer:true && break ; done
         shell: sh
 
       - name: Archiving Raw Test Logs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -357,11 +357,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh 15.2
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"$iPhone 8 (15.5)" address_sanitizer:true && break ; done
+        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"$iPhone 14 (17.2)" address_sanitizer:true && break ; done
         shell: sh
 
       - name: Archiving Raw Test Logs


### PR DESCRIPTION
Address Sanitizer tests use Xcode 15.2 with iPhone 14 and iOS 17.2 instead of Xcode 14.3 with iPhone 8 and iOS 15.5.

#skip-changelog