### PR TITLE
fix: Dont take screenshot and view hierarchy for app hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,8 @@
 
 ### Fixes
 
-- Don't use main thread for app hang screenshot and view hierarchy (#3547)
 - Finish TTID span when transaction finishes (#3610)
-
+- Dont take screenshot and view hierarchy for app hanging (#3620)
 
 ## 8.20.0
 

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -64,17 +64,14 @@ saveScreenShot(const char *path)
         return attachments;
     }
 
-    NSArray *screenshot;
-
     // If the event is an App hanging event, we cant take the
-    // screenshot in the main thread because it's blocked.
+    // screenshot because the the main thread it's blocked.
     if (event.isAppHangEvent) {
-        screenshot = [SentryDependencyContainer.sharedInstance.screenshot appScreenshots];
-    } else {
-        screenshot =
-            [SentryDependencyContainer.sharedInstance.screenshot appScreenshotsFromMainThread];
+        return attachments;
     }
-
+    
+    NSArray * screenshot = [SentryDependencyContainer.sharedInstance.screenshot appScreenshotsFromMainThread];
+    
     NSMutableArray *result =
         [NSMutableArray arrayWithCapacity:attachments.count + screenshot.count];
     [result addObjectsFromArray:attachments];

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -69,19 +69,16 @@ saveViewHierarchy(const char *reportDirectoryPath)
         return attachments;
     }
 
-    NSMutableArray<SentryAttachment *> *result = [NSMutableArray arrayWithArray:attachments];
-
-    NSData *viewHierarchy;
-
     // If the event is an App hanging event, we cant take the
-    // view hierarchy in the main thread because it's blocked.
+    // view hierarchy because the main thread it's blocked.
     if (event.isAppHangEvent) {
-        viewHierarchy = [SentryDependencyContainer.sharedInstance.viewHierarchy appViewHierarchy];
-    } else {
-        viewHierarchy =
-            [SentryDependencyContainer.sharedInstance.viewHierarchy appViewHierarchyFromMainThread];
+        return attachments;
     }
-
+    
+    NSMutableArray<SentryAttachment *> *result = [NSMutableArray arrayWithArray:attachments];
+        
+    NSData * viewHierarchy = [SentryDependencyContainer.sharedInstance.viewHierarchy appViewHierarchyFromMainThread];
+    
     SentryAttachment *attachment =
         [[SentryAttachment alloc] initWithData:viewHierarchy
                                       filename:@"view-hierarchy.json"

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -181,13 +181,13 @@ class SentryScreenshotIntegrationTests: XCTestCase {
 
         let ex = expectation(description: "Attachment Added")
         
-        testVH.processViewHierarchyCallback = {
-            ex.fulfill()
-            XCTAssertFalse(Thread.isMainThread)
+        testVH.processScreenshotsCallback = {
+            XCTFail("Should not add screenshots to App Hanging events")
         }
         
         DispatchQueue.global().async {
             sut.processAttachments([], for: event)
+            ex.fulfill()
         }
         
         wait(for: [ex], timeout: 1)

--- a/Tests/SentryTests/Integrations/Screenshot/TestSentryScreenShot.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/TestSentryScreenShot.swift
@@ -3,10 +3,10 @@
 class TestSentryScreenshot: SentryScreenshot {
     
     var result: [Data] = []
-    var processViewHierarchyCallback: (() -> Void)?
+    var processScreenshotsCallback: (() -> Void)?
         
     override func appScreenshots() -> [Data] {
-        processViewHierarchyCallback?()
+        processScreenshotsCallback?()
         return result
     }
  

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -136,13 +136,13 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
         let ex = expectation(description: "Attachment Added")
         
         testVH.processViewHierarchyCallback = {
-            ex.fulfill()
-            expect(Thread.isMainThread) == false
+            XCTFail("Should not add view hierarchy to app hanging events")
         }
         
         let dispatch = DispatchQueue(label: "background")
         dispatch.async {
             sut.processAttachments([], for: event)
+            ex.fulfill()
         }
         
         wait(for: [ex], timeout: 1)


### PR DESCRIPTION
## :scroll: Description

We stop taking screenshot and view hierarchy during app hang events.

## :bulb: Motivation and Context

Main thread is blocked, and its not safe to use ui elements.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
