### PR TITLE
test: Add biometric prompt to permissions

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Info.plist
+++ b/Samples/iOS-Swift/iOS-Swift/Info.plist
@@ -2,6 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+
+	<key>NSFaceIDUsageDescription</key>
+	<string>$(PRODUCT_NAME) Authentication with TouchId or FaceID for testing purposes of the Sentry Cocoa SDK.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Add a button to trigger a biometric prompt for the iOS-Swift test app.

For investigating https://github.com/getsentry/sentry-cocoa/issues/3472.