### PR TITLE
impr: Add reason for NSPrivacyAccessedAPICategoryFileTimestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Cache installationID async to avoid file IO on the main thread when starting the SDK (#3601)
+- Add reason for NSPrivacyAccessedAPIType (#3626)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Improvements
 
 - Cache installationID async to avoid file IO on the main thread when starting the SDK (#3601)
-- Add reason for NSPrivacyAccessedAPIType (#3626)
+- Add reason for NSPrivacyAccessedAPICategoryFileTimestamp (#3626)
 
 ### Fixes
 

--- a/Sources/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/Resources/PrivacyInfo.xcprivacy
@@ -59,6 +59,14 @@
 				<string>35F9.1</string>
 			</array>
 		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## :scroll: Description

Add C617.1 as reason to use NSPrivacyAccessedAPICategoryFileTimestamp to PrivacyInfo.xcprivacy.

## :bulb: Motivation and Context

Fixes GH-3597

## :green_heart: How did you test it?

No test required.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
