### PR TITLE
ci: Run linters on Gemfile.lock changes.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ on:
       - 'scripts/ci-select-xcode.sh'
       - 'Sentry.xcodeproj/**'
       - '*.podspec'
+      - 'Gemfile.lock'
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:


### PR DESCRIPTION
When updating the CocoaPods version we should run the CocoaPods linters.

#skip-changelog