### PR TITLE
fix(profiling): don't use concurrent enumeration when slicing samples

### DIFF
--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -46,13 +46,11 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
         return nil;
     }
 
-    const auto firstIndex =
-        [samples indexOfObjectWithOptions:NSEnumerationConcurrent
-                              passingTest:^BOOL(SentrySample *_Nonnull sample, NSUInteger idx,
-                                  BOOL *_Nonnull stop) {
-                                  *stop = sample.absoluteTimestamp >= startSystemTime;
-                                  return *stop;
-                              }];
+    const auto firstIndex = [samples indexOfObjectPassingTest:^BOOL(
+        SentrySample *_Nonnull sample, NSUInteger idx, BOOL *_Nonnull stop) {
+        *stop = sample.absoluteTimestamp >= startSystemTime;
+        return *stop;
+    }];
 
     if (firstIndex == NSNotFound) {
         logSlicingFailureWithArray(samples, startSystemTime, endSystemTime, /*start*/ YES);
@@ -62,7 +60,7 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
     }
 
     const auto lastIndex =
-        [samples indexOfObjectWithOptions:NSEnumerationConcurrent | NSEnumerationReverse
+        [samples indexOfObjectWithOptions:NSEnumerationReverse
                               passingTest:^BOOL(SentrySample *_Nonnull sample, NSUInteger idx,
                                   BOOL *_Nonnull stop) {
                                   *stop = sample.absoluteTimestamp <= endSystemTime;


### PR DESCRIPTION
Something I noticed while debugging for launch profiling. It's possible with concurrency that an index beyond the first may be selected. These arrays are in chronological order, so searching just for the first instance and stopping should be performant enough. Concurrency seems like overkill and overcomplicating.

#skip-changelog