### PR TITLE
fix(launch profiling): ensure launch profile can be uploaded

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -130,8 +130,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        print("[iOS-Swift] launch arguments: \(ProcessInfo.processInfo.arguments)")
-        print("[iOS-Swift] environment: \(ProcessInfo.processInfo.environment)")
+        print("[iOS-Swift] [debug] launch arguments: \(ProcessInfo.processInfo.arguments)")
+        print("[iOS-Swift] [debug] environment: \(ProcessInfo.processInfo.environment)")
         
         maybeWipeData()
         AppDelegate.startSentry()
@@ -168,7 +168,7 @@ private extension AppDelegate {
     // previously tried putting this in an AppDelegate.load override in ObjC, but it wouldn't run until after a launch profiler would have an opportunity to run, since SentryProfiler.load would always run first due to being dynamically linked in a framework module. it is sufficient to do it before calling SentrySDK.startWithOptions to clear state for testProfiledAppLaunches because we don't make any assertions on a launch profile the first launch of the app in that test 
     func maybeWipeData() {
         if ProcessInfo.processInfo.arguments.contains("--io.sentry.wipe-data") {
-            print("[iOS-Swift] removing app data")
+            print("[iOS-Swift] [debug] removing app data")
             let appSupport = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
             let cache = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
             for path in [appSupport, cache] {

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -46,7 +46,7 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
         let value = SentryBenchmarking.stopBenchmark()!
         valueTextField.isHidden = false
         valueTextField.text = value
-        print("[iOS-Swift] [ProfilingViewController] benchmarking results:\n\(value)")
+        print("[iOS-Swift] [debug] [ProfilingViewController] benchmarking results:\n\(value)")
     }
     
     @IBAction func startCPUWork(_ sender: UIButton) {
@@ -130,7 +130,7 @@ extension ProfilingViewController {
             let url = file as! URL
             if url.absoluteString.contains(fileName) {
                 block(url)
-                print("[iOS-Swift] [ProfilingViewController] removing file at \(url)")
+                print("[iOS-Swift] [debug] [ProfilingViewController] removing file at \(url)")
                 try! FileManager.default.removeItem(at: url)
                 return
             }
@@ -150,7 +150,7 @@ extension ProfilingViewController {
             return
         }
         let contents = data.base64EncodedString()
-        print("[iOS-Swift] [ProfilingViewController] contents of file at \(file): \(String(describing: String(data: data, encoding: .utf8)))")
+        print("[iOS-Swift] [debug] [ProfilingViewController] contents of file at \(file): \(String(describing: String(data: data, encoding: .utf8)))")
         profilingUITestDataMarshalingTextField.text = contents
         profilingUITestDataMarshalingStatus.text = "✅"
     }

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -15,7 +15,7 @@
 #    import "SentrySamplerDecision.h"
 #    import "SentrySampling.h"
 #    import "SentrySamplingContext.h"
-#    import "SentryTracer.h"
+#    import "SentryTracer+Private.h"
 #    import "SentryTracerConfiguration.h"
 #    import "SentryTransactionContext.h"
 
@@ -134,9 +134,10 @@ startLaunchProfile(void)
         appLaunchTraceId = [[SentryId alloc] init];
 
         SENTRY_LOG_INFO(@"Starting app launch profile at %llu", appLaunchSystemTime);
-
         SentryTransactionContext *context =
-            [[SentryTransactionContext alloc] initWithName:@"launch" operation:@"app.lifecycle"];
+            [[SentryTransactionContext alloc] initWithName:@"launch"
+                                                 operation:@"app.lifecycle"
+                                                   sampled:kSentrySampleDecisionYes];
         SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
         NSDictionary<NSString *, NSNumber *> *rates = appLaunchProfileConfiguration();
         NSNumber *profilesRate = rates[kSentryLaunchProfileConfigKeyProfilesSampleRate];
@@ -154,13 +155,15 @@ startLaunchProfile(void)
 }
 
 void
-stopLaunchProfile(void)
+stopLaunchProfile(SentryHub *hub)
 {
     if (launchTracer == nil) {
         SENTRY_LOG_DEBUG(@"No launch tracer present to stop.");
     }
 
     SENTRY_LOG_DEBUG(@"Finishing launch tracer.");
+
+    launchTracer.hub = hub;
     [launchTracer finish];
 }
 

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -15,17 +15,17 @@
 #    import "SentrySamplerDecision.h"
 #    import "SentrySampling.h"
 #    import "SentrySamplingContext.h"
+#    import "SentryTraceOrigins.h"
 #    import "SentryTracer+Private.h"
 #    import "SentryTracerConfiguration.h"
-#    import "SentryTransactionContext.h"
+#    import "SentryTransactionContext+Private.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 BOOL isTracingAppLaunch;
-SentryId *_Nullable appLaunchTraceId;
-NSObject *appLaunchTraceLock;
-uint64_t appLaunchSystemTime;
 NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate = @"traces";
 NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate = @"profiles";
-SentryTracer *_Nullable launchTracer;
+static SentryTracer *_Nullable launchTracer;
 
 #    pragma mark - Private
 
@@ -91,6 +91,29 @@ configureLaunchProfiling(SentryOptions *options)
     }];
 }
 
+SentryTransactionContext *
+context(NSNumber *tracesRate)
+{
+    SentryTransactionContext *context =
+        [[SentryTransactionContext alloc] initWithName:@"launch"
+                                            nameSource:kSentryTransactionNameSourceCustom
+                                             operation:@"app.lifecycle"
+                                                origin:SentryTraceOriginAutoAppStartProfile
+                                               sampled:kSentrySampleDecisionYes];
+    context.sampleRate = tracesRate;
+    return context;
+}
+
+SentryTracerConfiguration *
+config(NSNumber *profilesRate)
+{
+    SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
+    config.profilesSamplerDecision =
+        [[SentrySamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
+                                          forSampleRate:profilesRate];
+    return config;
+}
+
 void
 startLaunchProfile(void)
 {
@@ -111,28 +134,19 @@ startLaunchProfile(void)
         [SentryLog configure:YES diagnosticLevel:kSentryLevelDebug];
 #    endif // defined(DEBUG)
 
-        appLaunchSystemTime = SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
-        appLaunchTraceLock = [[NSObject alloc] init];
-        appLaunchTraceId = [[SentryId alloc] init];
-
-        SENTRY_LOG_INFO(@"Starting app launch profile at %llu", appLaunchSystemTime);
-        SentryTransactionContext *context =
-            [[SentryTransactionContext alloc] initWithName:@"launch"
-                                                 operation:@"app.lifecycle"
-                                                   sampled:kSentrySampleDecisionYes];
-        SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
         NSDictionary<NSString *, NSNumber *> *rates = appLaunchProfileConfiguration();
         NSNumber *profilesRate = rates[kSentryLaunchProfileConfigKeyProfilesSampleRate];
         NSNumber *tracesRate = rates[kSentryLaunchProfileConfigKeyTracesSampleRate];
-        if (profilesRate != nil && tracesRate != nil) {
-            config.profilesSamplerDecision =
-                [[SentrySamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
-                                                  forSampleRate:profilesRate];
-            context.sampleRate = tracesRate;
+        if (profilesRate == nil || tracesRate == nil) {
+            SENTRY_LOG_DEBUG(
+                @"Received a nil configured launch sample rate, will not trace or profile.");
+            return;
         }
-        launchTracer = [[SentryTracer alloc] initWithTransactionContext:context
+
+        SENTRY_LOG_INFO(@"Starting app launch profile.");
+        launchTracer = [[SentryTracer alloc] initWithTransactionContext:context(tracesRate)
                                                                     hub:nil
-                                                          configuration:config];
+                                                          configuration:config(profilesRate)];
     });
 }
 
@@ -141,6 +155,7 @@ stopLaunchProfile(SentryHub *hub)
 {
     if (launchTracer == nil) {
         SENTRY_LOG_DEBUG(@"No launch tracer present to stop.");
+        return;
     }
 
     SENTRY_LOG_DEBUG(@"Finishing launch tracer.");
@@ -148,5 +163,7 @@ stopLaunchProfile(SentryHub *hub)
     launchTracer.hub = hub;
     [launchTracer finish];
 }
+
+NS_ASSUME_NONNULL_END
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -463,18 +463,19 @@ writeProfileFile(NSDictionary<NSString *, id> *payload)
     if (isTracingAppLaunch) {
         SENTRY_LOG_DEBUG(@"Writing app launch profile.");
         pathToWrite = [appSupportDirPath stringByAppendingPathComponent:@"launchProfile"];
-        if (!SENTRY_CASSERT_RETURN(![fm fileExistsAtPath:pathToWrite],
-                @"Already a launch profile file present; make sure to remove them right after "
-                @"using them, and that tests clean state in between so there isn't leftover config "
-                @"producing one when it isn't expected.")) {
-            return;
-        }
     } else {
         SENTRY_LOG_DEBUG(@"Overwriting last non-launch profile.");
         pathToWrite = [appSupportDirPath stringByAppendingPathComponent:@"profile"];
     }
 
-    SENTRY_LOG_DEBUG(@"Writing app launch profile to file.");
+    if ([fm fileExistsAtPath:pathToWrite]) {
+        SENTRY_LOG_DEBUG(@"Already a%@ profile file present; make sure to remove them right after "
+                         @"using them, and that tests clean state in between so there isn't "
+                         @"leftover config producing one when it isn't expected.",
+            isTracingAppLaunch ? @" launch" : @"");
+    }
+
+    SENTRY_LOG_DEBUG(@"Writing%@ profile to file.", isTracingAppLaunch ? @" launch" : @"");
     SENTRY_CASSERT(
         [data writeToFile:pathToWrite atomically:YES], @"Failed to write profile to test file");
 }

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -164,10 +164,6 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)startWithOptions:(SentryOptions *)options
 {
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-    stopLaunchProfile();
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
-
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
     // We accept the tradeoff that the SDK might not be fully initialized directly after
@@ -190,7 +186,8 @@ static NSDate *_Nullable startTimestamp = nil;
         = options.initialScope([[SentryScope alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs]);
     // The Hub needs to be initialized with a client so that closing a session
     // can happen.
-    [SentrySDK setCurrentHub:[[SentryHub alloc] initWithClient:newClient andScope:scope]];
+    SentryHub *hub = [[SentryHub alloc] initWithClient:newClient andScope:scope];
+    [SentrySDK setCurrentHub:hub];
     SENTRY_LOG_DEBUG(@"SDK initialized! Version: %@", SentryMeta.versionString);
 
     SENTRY_LOG_DEBUG(@"Dispatching init work required to run on main thread.");
@@ -204,11 +201,14 @@ static NSDate *_Nullable startTimestamp = nil;
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
         [SentryDependencyContainer.sharedInstance.uiDeviceWrapper start];
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
-    }];
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    configureLaunchProfiling(options);
+        [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchAsyncWithBlock:^{
+            stopLaunchProfile(hub);
+            configureLaunchProfiling(options);
+        }];
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
+    }];
 }
 
 + (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -609,15 +609,6 @@ static BOOL appStartMeasurementRead;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if (self.isProfiling) {
         [self captureTransactionWithProfile:transaction];
-
-        // as long as this isn't used for any conditional branching logic, and is just being set to
-        // NO, we don't need to synchronize the read here
-        if (isTracingAppLaunch) {
-            @synchronized(appLaunchTraceLock) {
-                isTracingAppLaunch = NO;
-            }
-        }
-
         return;
     }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -124,20 +124,6 @@ SENTRY_EXTERN void writeAppLaunchProfilingConfigFile(
  */
 SENTRY_EXTERN void removeAppLaunchProfilingConfigFile(void);
 
-/**
- * Save a current launch profile config file for use when the associated transaction needs to be
- * started. This is when checking @c SentryOptions for whether to write a config for the next
- * launch; if there's no current app launch profile going, then we'd simply remove whatever config
- * file may exist, but if there is a launch profile going, we need to save the config that it used.
- */
-SENTRY_EXTERN void backupAppLaunchProfilingConfigFile(void);
-
-/**
- * Clean up the backup file saved off in the case that an app launch is in-flight when the SDK
- * configures subsequent launches not to profile, requiring the current config to be saved for the
- * associated transaction. This can be cleaned up when that transaction is started.
- */
-SENTRY_EXTERN void removeAppLaunchProfilingConfigBackupFile(void);
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @end

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -13,12 +13,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN BOOL isTracingAppLaunch;
-SENTRY_EXTERN SentryId *_Nullable appLaunchTraceId;
-SENTRY_EXTERN uint64_t appLaunchSystemTime;
-SENTRY_EXTERN NSObject *appLaunchTraceLock;
 
 /** Try to start a profiled trace for this app launch, if the configuration allows. */
-void startLaunchProfile(void);
+SENTRY_EXTERN void startLaunchProfile(void);
 
 /** Stop any profiled trace that may be in flight from the start of the app launch. */
 void stopLaunchProfile(SentryHub *hub);

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -4,6 +4,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
+@class SentryHub;
 @class SentryId;
 @class SentryOptions;
 @class SentryTracerConfiguration;
@@ -20,7 +21,7 @@ SENTRY_EXTERN NSObject *appLaunchTraceLock;
 void startLaunchProfile(void);
 
 /** Stop any profiled trace that may be in flight from the start of the app launch. */
-void stopLaunchProfile(void);
+void stopLaunchProfile(SentryHub *hub);
 
 /**
  * Write a file to disk containing sample rates for profiles and traces. The presence of this file

--- a/Sources/Sentry/include/SentryTraceOrigins.h
+++ b/Sources/Sentry/include/SentryTraceOrigins.h
@@ -4,6 +4,7 @@ static NSString *const SentryTraceOriginManual = @"manual";
 static NSString *const SentryTraceOriginUIEventTracker = @"auto.ui.event_tracker";
 
 static NSString *const SentryTraceOriginAutoAppStart = @"auto.app.start";
+static NSString *const SentryTraceOriginAutoAppStartProfile = @"auto.app.start.profile";
 static NSString *const SentryTraceOriginAutoNSData = @"auto.file.ns_data";
 static NSString *const SentryTraceOriginAutoDBCoreData = @"auto.db.core_data";
 static NSString *const SentryTraceOriginAutoHttpNSURLSession = @"auto.http.ns_url_session";

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
@@ -3,6 +3,8 @@
 #import "SentryOptions+Private.h"
 #import "SentryProfilingConditionals.h"
 #import "SentrySDK+Tests.h"
+#import "SentryTraceOrigins.h"
+#import "SentryTransactionContext.h"
 #import <XCTest/XCTest.h>
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -11,6 +13,14 @@
 @end
 
 @implementation SentryAppLaunchProfilingTests
+
+- (void)testLaunchProfileTransactionContext
+{
+    SentryTransactionContext *actualContext = context(@1);
+    XCTAssertEqual(actualContext.nameSource, kSentryTransactionNameSourceCustom);
+    XCTAssert([actualContext.origin isEqualToString:SentryTraceOriginAutoAppStartProfile]);
+    XCTAssert(actualContext.sampled);
+}
 
 #    define SENTRY_OPTION(name, value)                                                             \
         NSStringFromSelector(@selector(name))                                                      \
@@ -106,6 +116,8 @@
         @"Default options with app launch profiling and tracing enabled, traces sample rate of 1, "
         @"but profiles sample rate of 0 should not enable launch profiling");
 }
+
+#    pragma mark - Private
 
 - (SentryOptions *)defaultLaunchProfilingOptionsWithOverrides:
     (NSDictionary<NSString *, id> *)overrides

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -1,6 +1,8 @@
 #import "SentryDefines.h"
 #import "SentryLaunchProfiling.h"
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
 @class SentrySamplerDecision;
 @class SentryOptions;
 
@@ -17,4 +19,9 @@ SENTRY_EXTERN SentryLaunchProfileConfig shouldProfileNextLaunch(SentryOptions *o
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 
+SENTRY_EXTERN SentryTransactionContext *context(NSNumber *tracesRate);
+SENTRY_EXTERN SentryTracerConfiguration *config(NSNumber *profilesRate);
+
 NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED


### PR DESCRIPTION
follows https://github.com/getsentry/sentry-cocoa/pull/3633 and followed by https://github.com/getsentry/sentry-cocoa/pull/3635

The dedicated trace was being created with a nil hub, so we need to inject it when it becomes available, before it is transmitted, or it will simply be lost. Also needed to inject the sampling decision in another parameter in the transaction context.

#skip-changelog