### PR TITLE
fix(launch profiling): set a new trace origin for app launch profiles

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -130,8 +130,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        print("[iOS-Swift] launch arguments: \(ProcessInfo.processInfo.arguments)")
-        print("[iOS-Swift] environment: \(ProcessInfo.processInfo.environment)")
+        print("[iOS-Swift] [debug] launch arguments: \(ProcessInfo.processInfo.arguments)")
+        print("[iOS-Swift] [debug] environment: \(ProcessInfo.processInfo.environment)")
         
         maybeWipeData()
         AppDelegate.startSentry()
@@ -168,7 +168,7 @@ private extension AppDelegate {
     // previously tried putting this in an AppDelegate.load override in ObjC, but it wouldn't run until after a launch profiler would have an opportunity to run, since SentryProfiler.load would always run first due to being dynamically linked in a framework module. it is sufficient to do it  before calling SentrySDK.startWIthOptions to clear state for testProfiledAppLaunches because we don't make any assertions on a launch profile the first launch of the app in that test 
     func maybeWipeData() {
         if ProcessInfo.processInfo.arguments.contains("--io.sentry.wipe-data") {
-            print("[iOS-Swift] removing app data")
+            print("[iOS-Swift] [debug] removing app data")
             let appSupport = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
             let cache = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
             for path in [appSupport, cache] {

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -46,7 +46,7 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
         let value = SentryBenchmarking.stopBenchmark()!
         valueTextField.isHidden = false
         valueTextField.text = value
-        print("[iOS-Swift] [ProfilingViewController] benchmarking results:\n\(value)")
+        print("[iOS-Swift] [debug] [ProfilingViewController] benchmarking results:\n\(value)")
     }
     
     @IBAction func startCPUWork(_ sender: UIButton) {
@@ -130,7 +130,7 @@ extension ProfilingViewController {
             let url = file as! URL
             if url.absoluteString.contains(fileName) {
                 block(url)
-                print("[iOS-Swift] [ProfilingViewController] removing file at \(url)")
+                print("[iOS-Swift] [debug] [ProfilingViewController] removing file at \(url)")
                 try! FileManager.default.removeItem(at: url)
                 return
             }
@@ -150,7 +150,7 @@ extension ProfilingViewController {
             return
         }
         let contents = data.base64EncodedString()
-        print("[iOS-Swift] [ProfilingViewController] contents of file at \(file): \(String(describing: String(data: data, encoding: .utf8)))")
+        print("[iOS-Swift] [debug] [ProfilingViewController] contents of file at \(file): \(String(describing: String(data: data, encoding: .utf8)))")
         profilingUITestDataMarshalingTextField.text = contents
         profilingUITestDataMarshalingStatus.text = "✅"
     }

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -15,9 +15,10 @@
 #    import "SentrySamplerDecision.h"
 #    import "SentrySampling.h"
 #    import "SentrySamplingContext.h"
+#    import "SentryTraceOrigins.h"
 #    import "SentryTracer+Private.h"
 #    import "SentryTracerConfiguration.h"
-#    import "SentryTransactionContext.h"
+#    import "SentryTransactionContext+Private.h"
 
 BOOL isTracingAppLaunch;
 NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate = @"traces";
@@ -130,7 +131,9 @@ startLaunchProfile(void)
 
         SentryTransactionContext *context =
             [[SentryTransactionContext alloc] initWithName:@"launch"
+                                                nameSource:kSentryTransactionNameSourceCustom
                                                  operation:@"app.lifecycle"
+                                                    origin:SentryTraceOriginAutoAppStartProfile
                                                    sampled:kSentrySampleDecisionYes];
         SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
         NSDictionary<NSString *, NSNumber *> *rates = appLaunchProfileConfiguration();

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -107,6 +107,29 @@ configureLaunchProfiling(SentryOptions *options)
     }];
 }
 
+SentryTransactionContext *
+context(NSNumber *tracesRate)
+{
+    SentryTransactionContext *context =
+        [[SentryTransactionContext alloc] initWithName:@"launch"
+                                            nameSource:kSentryTransactionNameSourceCustom
+                                             operation:@"app.lifecycle"
+                                                origin:SentryTraceOriginAutoAppStartProfile
+                                               sampled:kSentrySampleDecisionYes];
+    context.sampleRate = tracesRate;
+    return context;
+}
+
+SentryTracerConfiguration *
+config(NSNumber *profilesRate)
+{
+    SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
+    config.profilesSamplerDecision =
+        [[SentrySamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
+                                          forSampleRate:profilesRate];
+    return config;
+}
+
 void
 startLaunchProfile(void)
 {
@@ -127,27 +150,19 @@ startLaunchProfile(void)
         [SentryLog configure:YES diagnosticLevel:kSentryLevelDebug];
 #    endif // defined(DEBUG)
 
-        SENTRY_LOG_INFO(@"Starting app launch profile.");
-
-        SentryTransactionContext *context =
-            [[SentryTransactionContext alloc] initWithName:@"launch"
-                                                nameSource:kSentryTransactionNameSourceCustom
-                                                 operation:@"app.lifecycle"
-                                                    origin:SentryTraceOriginAutoAppStartProfile
-                                                   sampled:kSentrySampleDecisionYes];
-        SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
         NSDictionary<NSString *, NSNumber *> *rates = appLaunchProfileConfiguration();
         NSNumber *profilesRate = rates[kSentryLaunchProfileConfigKeyProfilesSampleRate];
         NSNumber *tracesRate = rates[kSentryLaunchProfileConfigKeyTracesSampleRate];
-        if (profilesRate != nil && tracesRate != nil) {
-            config.profilesSamplerDecision =
-                [[SentrySamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
-                                                  forSampleRate:profilesRate];
-            context.sampleRate = tracesRate;
+        if (profilesRate == nil || tracesRate == nil) {
+            SENTRY_LOG_DEBUG(
+                @"Received a nil configured launch sample rate, will not trace or profile.");
+            return;
         }
-        launchTracer = [[SentryTracer alloc] initWithTransactionContext:context
+
+        SENTRY_LOG_INFO(@"Starting app launch profile.");
+        launchTracer = [[SentryTracer alloc] initWithTransactionContext:context(tracesRate)
                                                                     hub:nil
-                                                          configuration:config];
+                                                          configuration:config(profilesRate)];
     });
 }
 
@@ -156,6 +171,7 @@ stopLaunchProfile(SentryHub *hub)
 {
     if (launchTracer == nil) {
         SENTRY_LOG_DEBUG(@"No launch tracer present to stop.");
+        return;
     }
 
     SENTRY_LOG_DEBUG(@"Finishing launch tracer.");

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_EXTERN BOOL isTracingAppLaunch;
 
 /** Try to start a profiled trace for this app launch, if the configuration allows. */
-void startLaunchProfile(void);
+SENTRY_EXTERN void startLaunchProfile(void);
 
 /** Stop any profiled trace that may be in flight from the start of the app launch. */
 void stopLaunchProfile(SentryHub *hub);

--- a/Sources/Sentry/include/SentryTraceOrigins.h
+++ b/Sources/Sentry/include/SentryTraceOrigins.h
@@ -4,6 +4,7 @@ static NSString *const SentryTraceOriginManual = @"manual";
 static NSString *const SentryTraceOriginUIEventTracker = @"auto.ui.event_tracker";
 
 static NSString *const SentryTraceOriginAutoAppStart = @"auto.app.start";
+static NSString *const SentryTraceOriginAutoAppStartProfile = @"auto.app.start.profile";
 static NSString *const SentryTraceOriginAutoNSData = @"auto.file.ns_data";
 static NSString *const SentryTraceOriginAutoDBCoreData = @"auto.db.core_data";
 static NSString *const SentryTraceOriginAutoHttpNSURLSession = @"auto.http.ns_url_session";

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
@@ -3,6 +3,8 @@
 #import "SentryOptions+Private.h"
 #import "SentryProfilingConditionals.h"
 #import "SentrySDK+Tests.h"
+#import "SentryTraceOrigins.h"
+#import "SentryTransactionContext.h"
 #import <XCTest/XCTest.h>
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -11,6 +13,14 @@
 @end
 
 @implementation SentryAppLaunchProfilingTests
+
+- (void)testLaunchProfileTransactionContext
+{
+    SentryTransactionContext *actualContext = context(@1);
+    XCTAssertEqual(actualContext.nameSource, kSentryTransactionNameSourceCustom);
+    XCTAssert([actualContext.origin isEqualToString:SentryTraceOriginAutoAppStartProfile]);
+    XCTAssert(actualContext.sampled);
+}
 
 #    define SENTRY_OPTION(name, value)                                                             \
         NSStringFromSelector(@selector(name))                                                      \
@@ -145,6 +155,8 @@
         @"profiling");
 }
 #    endif // SENTRY_HAS_UIKIT
+
+#    pragma mark - Private
 
 - (SentryOptions *)defaultLaunchProfilingOptionsWithOverrides:
     (NSDictionary<NSString *, id> *)overrides

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -17,4 +17,7 @@ SENTRY_EXTERN SentryLaunchProfileConfig shouldProfileNextLaunch(SentryOptions *o
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 
+SENTRY_EXTERN SentryTransactionContext *context(NSNumber *tracesRate);
+SENTRY_EXTERN SentryTracerConfiguration *config(NSNumber *profilesRate);
+
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -1,6 +1,8 @@
 #import "SentryDefines.h"
 #import "SentryLaunchProfiling.h"
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
 @class SentrySamplerDecision;
 @class SentryOptions;
 
@@ -21,3 +23,5 @@ SENTRY_EXTERN SentryTransactionContext *context(NSNumber *tracesRate);
 SENTRY_EXTERN SentryTracerConfiguration *config(NSNumber *profilesRate);
 
 NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED


### PR DESCRIPTION
follows https://github.com/getsentry/sentry-cocoa/pull/3635

It was requested to make a new origin for these transactions: https://github.com/getsentry/sentry-cocoa/pull/3621#discussion_r1486012768

I wasn't sure what to do for `nameSource`, another parameter required on the init I needed to use, so I stuck with `custom` as that's the default value used in some of the other init implementations.

#skip-changelog