### PR TITLE
ref: Add multiple transports to TransportAdapter

### DIFF
--- a/SentryTestUtils/TestClient.swift
+++ b/SentryTestUtils/TestClient.swift
@@ -2,11 +2,11 @@ import Foundation
 
 public class TestClient: SentryClient {
     public override init?(options: Options) {
-        super.init(options: options, fileManager: try! TestFileManager(options: options), deleteOldEnvelopeItems: false, transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
+        super.init(options: options, fileManager: try! TestFileManager(options: options), deleteOldEnvelopeItems: false, transportAdapter: TestTransportAdapter(transports: [TestTransport()], options: options))
     }
 
     public override init?(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool) {
-        super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: TestTransportAdapter(transport: TestTransport(), options: options))
+        super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: TestTransportAdapter(transports: [TestTransport()], options: options))
     }
     
     public override init(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, transportAdapter: SentryTransportAdapter) {

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -98,11 +98,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                     fileManager:(SentryFileManager *)fileManager
          deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
 {
-    id<SentryTransport> transport = [SentryTransportFactory initTransport:options
-                                                        sentryFileManager:fileManager];
+    NSArray<id<SentryTransport>> *transports = [SentryTransportFactory initTransports:options
+                                                                    sentryFileManager:fileManager];
 
     SentryTransportAdapter *transportAdapter =
-        [[SentryTransportAdapter alloc] initWithTransport:transport options:options];
+        [[SentryTransportAdapter alloc] initWithTransports:transports options:options];
 
     return [self initWithOptions:options
                      fileManager:fileManager

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -10,17 +10,18 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryTransportAdapter ()
 
-@property (nonatomic, strong) id<SentryTransport> transport;
+@property (nonatomic, strong) NSArray<id<SentryTransport>> *transports;
 @property (nonatomic, strong) SentryOptions *options;
 
 @end
 
 @implementation SentryTransportAdapter
 
-- (instancetype)initWithTransport:(id<SentryTransport>)transport options:(SentryOptions *)options
+- (instancetype)initWithTransports:(NSArray<id<SentryTransport>> *)transports
+                           options:(SentryOptions *)options
 {
     if (self = [super init]) {
-        self.transport = transport;
+        self.transports = transports;
         self.options = options;
     }
 
@@ -89,17 +90,23 @@ SentryTransportAdapter ()
 
 - (void)sendEnvelope:(SentryEnvelope *)envelope
 {
-    [self.transport sendEnvelope:envelope];
+    for (id<SentryTransport> transport in self.transports) {
+        [transport sendEnvelope:envelope];
+    }
 }
 
 - (void)recordLostEvent:(SentryDataCategory)category reason:(SentryDiscardReason)reason
 {
-    [self.transport recordLostEvent:category reason:reason];
+    for (id<SentryTransport> transport in self.transports) {
+        [transport recordLostEvent:category reason:reason];
+    }
 }
 
 - (void)flush:(NSTimeInterval)timeout
 {
-    [self.transport flush:timeout];
+    for (id<SentryTransport> transport in self.transports) {
+        [transport flush:timeout];
+    }
 }
 
 - (NSMutableArray<SentryEnvelopeItem *> *)buildEnvelopeItems:(SentryEvent *)event

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -23,8 +23,8 @@ SentryTransportFactory ()
 
 @implementation SentryTransportFactory
 
-+ (id<SentryTransport>)initTransport:(SentryOptions *)options
-                   sentryFileManager:(SentryFileManager *)sentryFileManager
++ (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
+                               sentryFileManager:(SentryFileManager *)sentryFileManager
 {
     NSURLSessionConfiguration *configuration =
         [NSURLSessionConfiguration ephemeralSessionConfiguration];
@@ -51,13 +51,16 @@ SentryTransportFactory ()
         [[SentryDispatchQueueWrapper alloc] initWithName:"sentry-http-transport"
                                               attributes:attributes];
 
-    return [[SentryHttpTransport alloc] initWithOptions:options
-                                            fileManager:sentryFileManager
-                                         requestManager:requestManager
-                                         requestBuilder:[[SentryNSURLRequestBuilder alloc] init]
-                                             rateLimits:rateLimits
-                                      envelopeRateLimit:envelopeRateLimit
-                                   dispatchQueueWrapper:dispatchQueueWrapper];
+    SentryHttpTransport *httpTransport =
+        [[SentryHttpTransport alloc] initWithOptions:options
+                                         fileManager:sentryFileManager
+                                      requestManager:requestManager
+                                      requestBuilder:[[SentryNSURLRequestBuilder alloc] init]
+                                          rateLimits:rateLimits
+                                   envelopeRateLimit:envelopeRateLimit
+                                dispatchQueueWrapper:dispatchQueueWrapper];
+
+    return @[ httpTransport ];
 }
 
 @end

--- a/Sources/Sentry/include/SentryTransportAdapter.h
+++ b/Sources/Sentry/include/SentryTransportAdapter.h
@@ -16,7 +16,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryTransportAdapter : NSObject
 SENTRY_NO_INIT
 
-- (instancetype)initWithTransport:(id<SentryTransport>)transport options:(SentryOptions *)options;
+- (instancetype)initWithTransports:(NSArray<id<SentryTransport>> *)transports
+                           options:(SentryOptions *)options;
 
 - (void)sendEvent:(SentryEvent *)event
           session:(SentrySession *)session

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -9,8 +9,8 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(TransportInitializer)
 @interface SentryTransportFactory : NSObject
 
-+ (id<SentryTransport>)initTransport:(SentryOptions *)options
-                   sentryFileManager:(SentryFileManager *)sentryFileManager;
++ (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
+                               sentryFileManager:(SentryFileManager *)sentryFileManager;
 
 @end
 

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -248,7 +248,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         
         let transport = TestTransport()
         let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
-        Dynamic(client).transportAdapter = TestTransportAdapter(transport: transport, options: fixture.options)
+        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
         hub.bindClient(client)
         
         delayNonBlocking(timeout: 0.01)

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -19,8 +19,9 @@ class SentryTransportFactoryTests: XCTestCase {
         options.urlSessionDelegate = urlSessionDelegateSpy
         
         let fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
-        let transport = TransportInitializer.initTransport(options, sentryFileManager: fileManager)
-        let requestManager = Dynamic(transport).requestManager.asObject as! SentryQueueableRequestManager
+        let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager)
+        let httpTransport = transports.first
+        let requestManager = Dynamic(httpTransport).requestManager.asObject as! SentryQueueableRequestManager
         
         let imgUrl = URL(string: "https://github.com")!
         let request = URLRequest(url: imgUrl)

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -17,9 +18,11 @@ class SentryTransportInitializerTests: XCTestCase {
 
     func testDefault() throws {
         let options = try Options(dict: ["dsn": SentryTransportInitializerTests.dsnAsString])
+    
+        let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager)
+        expect(result.count) == 1
         
-        let result = TransportInitializer.initTransport(options, sentryFileManager: fileManager)
-        
-        XCTAssertTrue(result.isKind(of: SentryHttpTransport.self))
+        let firstTransport = result.first
+        expect(firstTransport?.isKind(of: SentryHttpTransport.self)) == true
     }
 }

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -60,7 +60,7 @@ class SentryClientTest: XCTestCase {
             transaction = Transaction(trace: trace, children: [])
             
             transport = TestTransport()
-            transportAdapter = TestTransportAdapter(transport: transport, options: options)
+            transportAdapter = TestTransportAdapter(transports: [transport], options: options)
             
             crashWrapper.internalFreeMemorySize = 123_456
             crashWrapper.internalAppMemorySize = 234_567

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -668,7 +668,7 @@ class SentrySDKTests: XCTestCase {
         
         let transport = TestTransport()
         let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
-        Dynamic(client).transportAdapter = TestTransportAdapter(transport: transport, options: fixture.options)
+        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
         SentrySDK.currentHub().bindClient(client)
         SentrySDK.close()
         
@@ -683,7 +683,7 @@ class SentrySDKTests: XCTestCase {
         
         let transport = TestTransport()
         let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
-        Dynamic(client).transportAdapter = TestTransportAdapter(transport: transport, options: fixture.options)
+        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
         SentrySDK.currentHub().bindClient(client)
         
         let flushTimeout = 10.0


### PR DESCRIPTION
Add the possibility to add multiple transports in the TransportAdapter, which is internal. This is a preparation for adding support for Spotlight.

#skip-changelog