### PR TITLE
test: reset file manager state in clearTestState()

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -31,6 +31,7 @@ class TestCleanup: NSObject {
         SentryAppStartTracker.load()
         SentryUIViewControllerPerformanceTracker.shared.enableWaitForFullDisplay = false
         SentryDependencyContainer.sharedInstance().swizzleWrapper.removeAllCallbacks()
+        SentryDependencyContainer.sharedInstance().fileManager.clearDiskState()
         
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         
@@ -51,7 +52,5 @@ class TestCleanup: NSObject {
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
         sentrycrash_scopesync_reset()
-        
-        SentryDependencyContainer.sharedInstance().fileManager.clearDiskState()
     }
 }

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -51,5 +51,7 @@ class TestCleanup: NSObject {
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
         sentrycrash_scopesync_reset()
+        
+        SentryDependencyContainer.sharedInstance().fileManager.clearDiskState()
     }
 }

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -31,7 +31,7 @@
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryDispatchSourceWrapper.h"
 #import "SentryEnvelope.h"
-#import "SentryFileManager+Test.h"
+#import "SentryFileManager+TestProperties.h"
 #import "SentryGlobalEventProcessor.h"
 #import "SentryLog.h"
 #import "SentryNSProcessInfoWrapper.h"

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -31,7 +31,7 @@
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryDispatchSourceWrapper.h"
 #import "SentryEnvelope.h"
-#import "SentryFileManager.h"
+#import "SentryFileManager+Test.h"
 #import "SentryGlobalEventProcessor.h"
 #import "SentryLog.h"
 #import "SentryNSProcessInfoWrapper.h"

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -710,6 +710,11 @@ SentryFileManager ()
     return YES;
 }
 
+- (void)clearDiskState
+{
+    [self removeFileAtPath:self.basePath];
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Helper/SentryFileManager+TestProperties.h
+++ b/Tests/SentryTests/Helper/SentryFileManager+TestProperties.h
@@ -9,6 +9,8 @@ SentryFileManager ()
 @property (nonatomic, copy) NSString *envelopesPath;
 @property (nonatomic, copy) NSString *timezoneOffsetFilePath;
 
+- (void)clearDiskState;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Noticed there was some stale state causing test failures in #3529. I don't think we ever had something that clears disk state in between tests.

#skip-changelog