### PR TITLE
ci: Use non xl for UI tests with address sanitizer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -372,7 +372,7 @@ jobs:
 
   ui-tests-address-sanitizer:
     name: UI Tests with Address Sanitizer
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Roll back to macos-13 because macos-13-xlarge doesn't speed up CI, and is more expensive.

#skip-changelog

Other jobs show a clear trend when switching to xlarge
![CleanShot 2024-02-16 at 09 48 49@2x](https://github.com/getsentry/sentry-cocoa/assets/2443292/b4102e25-1413-4c40-bd53-a635df993eae)

but not UI tests with address sanitizer:

![CleanShot 2024-02-16 at 09 49 43@2x](https://github.com/getsentry/sentry-cocoa/assets/2443292/766a209e-bbb3-4926-b2f2-f172707b0c46)

