### PR TITLE
ci: Use Xcode 15.2 for TestFlight upload

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh 15.2
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
Because: Starting April 29, 2024, all iOS and iPadOS apps must be built with the iOS 17 SDK or later, included in Xcode 15 or later, in order to be uploaded to App Store Connect or submitted for distribution.

#skip-changelog