### PR TITLE
fix: Use cocoapod resource_bundles for PrivacyInfo

### DIFF
--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -34,7 +34,7 @@ Pod::Spec.new do |s|
         "Sources/SentryCrash/**/*.{h,hpp,m,mm,c,cpp}", "Sources/Swift/Sentry.swift"
       sp.public_header_files =
         "Sources/Sentry/Public/*.h"
-      sp.resource = "Sources/Resources/PrivacyInfo.xcprivacy"
+      sp.resource_bundles = { "Sentry" => "Sources/Resources/PrivacyInfo.xcprivacy" }
   end
   
   s.subspec 'HybridSDK' do |sp|
@@ -44,6 +44,6 @@ Pod::Spec.new do |s|
       sp.public_header_files =
         "Sources/Sentry/Public/*.h", "Sources/Sentry/include/HybridPublic/*.h"
 
-      sp.resource = "Sources/Resources/PrivacyInfo.xcprivacy"
+      sp.resource_bundles = { "Sentry" => "Sources/Resources/PrivacyInfo.xcprivacy" }
   end
 end


### PR DESCRIPTION
## :scroll: Description

Changed the inclusion of `PrivacyInfo.xcprivacy` to `resource_bundles` for cocoapod to avoid resource name collision when the user uses cocoapod as static library.

## :bulb: Motivation and Context

Fixes https://github.com/getsentry/sentry-react-native/issues/3599

## :green_heart: How did you test it?

Sample

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
