### PR TITLE
test: Use accessibility id for breadcrumb UI test

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -791,6 +791,7 @@
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FfQ-2y-q0S">
                                                         <rect key="frame" x="0.0" y="28" width="152" height="28"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="uiEventTests"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="UI event tests"/>
                                                         <connections>

--- a/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/UIEventBreadcrumbTests.swift
@@ -4,7 +4,7 @@ class UIEventBreadcrumbTests: BaseUITest {
 
     func testNoBreadcrumbForTextFieldEditingChanged() {
         app.buttons["Extra"].tap()
-        app.buttons["UI event tests"].tap()
+        app.buttons["uiEventTests"].tap()
 
         //Trigger a change in textfield
         app.buttons["editingChangedButton"].afterWaitingForExistence("Did not find editingChangedButton").tap()


### PR DESCRIPTION
This [SauceLabs test run](https://app.saucelabs.com/tests/db0632ba709947cc997bda7f59c74e27#15) navigated to the breadcrumb info test instead of the U event tests for the `testNoBreadcrumbForTextFieldEditingChanged`. Using an accessibility identifier should mitigate this problem.

#skip-changelog