### PR TITLE
ci: Increase SauceLabs Concurrency to 4

### DIFF
--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -2,7 +2,7 @@ apiVersion: v1alpha
 kind: xcuitest
 sauce:
   region: us-west-1
-  concurrency: 2
+  concurrency: 4
 
 defaults:
   timeout: 20m

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -2,7 +2,7 @@ apiVersion: v1alpha
 kind: xcuitest
 sauce:
   region: us-west-1
-  concurrency: 2
+  concurrency: 4
 
 defaults:
   timeout: 20m


### PR DESCRIPTION
Our plan allows running 4 UI tests in parallel. This should speed up CI.

#skip-changelog