### PR TITLE
ci: Change to SauceLabs Retry

### DIFF
--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -124,9 +124,8 @@ jobs:
 
       - run: npm install -g saucectl@0.171.0
 
-      # As Sauce Labs is a bit flaky we retry 5 times
       - name: Run Tests in SauceLab
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: for i in {1..5}; do saucectl run --select-suite ${{ matrix.suite }} && break ; done
+        run: do saucectl run --select-suite ${{ matrix.suite }}

--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -128,4 +128,4 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: do saucectl run --select-suite ${{ matrix.suite }}
+        run: saucectl run --select-suite ${{ matrix.suite }}

--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -3,6 +3,7 @@ kind: xcuitest
 sauce:
   region: us-west-1
   concurrency: 2
+  retries: 3
 
 defaults:
   timeout: 20m
@@ -13,14 +14,25 @@ xcuitest:
 
 suites:
   - name: "High-end device"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPad Pro 12.9 2021"
         platformVersion: "15"
+
   - name: "Mid-range device"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone 8"
         platformVersion: "14"
+
   - name: "Low-end device"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone 6S"
         platformVersion: "15"

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -3,6 +3,7 @@ kind: xcuitest
 sauce:
   region: us-west-1
   concurrency: 2
+  retries: 3
 
 defaults:
   timeout: 20m
@@ -14,36 +15,57 @@ xcuitest:
 suites:
 
   - name: "iOS-16"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone.*"
         platformVersion: "16"
    
   - name: "iOS-15"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone.*"
         platformVersion: "15"
 
   - name: "iPhone-Pro"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone 13 Pro.*"
         platformVersion: "15"
         
   - name: "iOS-14"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone.*"
         platformVersion: "14"
 
   - name: "iOS-13"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone.*"
         platformVersion: "13"
 
   - name: "iOS-12"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone.*"
         platformVersion: "12"
 
   - name: "iOS-11"
+    passThreshold: 2
+    smartRetry:
+      failedOnly: true
     devices:
       - name: "iPhone.*"
         platformVersion: "11"


### PR DESCRIPTION
Instead of manually retrying SauceLabs tests with a loop in the CI job, we now use the retry mechanism of SauceLabs, which allows us only to rerun failing tests, which should speed up CI.

#skip-changelog