### PR TITLE
test: Set orientation portrait for UI tests

### DIFF
--- a/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
+++ b/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
@@ -8,6 +8,13 @@
 
 @implementation SentrySDKPerformanceBenchmarkTests
 
+- (void)setUp
+{
+    [super setUp];
+
+    [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationPortrait];
+}
+
 - (void)testCPUBenchmark
 {
     XCTSkipIf(isSimulator() && !isDebugging());

--- a/Tests/SentryTests/Helper/SentryDeviceTests.mm
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.mm
@@ -30,17 +30,6 @@
 
 @implementation SentryDeviceTests
 
-- (void)setUp
-{
-    [super setUp];
-
-    // We run these UI tests on multiple platforms, but we only need to set the orientation to
-    // portrait for iOS, because we only run UI tests on real devices for iOS.
-#if TARGET_OS_IOS
-    [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationPortrait];
-#endif
-}
-
 - (void)testCPUArchitecture
 {
     const auto arch = sentry_getCPUArchitecture();

--- a/Tests/SentryTests/Helper/SentryDeviceTests.mm
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.mm
@@ -30,6 +30,13 @@
 
 @implementation SentryDeviceTests
 
+- (void)setUp
+{
+    [super setUp];
+
+    [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationPortrait];
+}
+
 - (void)testCPUArchitecture
 {
     const auto arch = sentry_getCPUArchitecture();

--- a/Tests/SentryTests/Helper/SentryDeviceTests.mm
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.mm
@@ -34,6 +34,8 @@
 {
     [super setUp];
 
+    // We run these UI tests on multiple platforms, but we only need to set the orientation to
+    // portrait for iOS, because we only run UI tests on real devices for iOS.
 #if TARGET_OS_IOS
     [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationPortrait];
 #endif

--- a/Tests/SentryTests/Helper/SentryDeviceTests.mm
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.mm
@@ -34,7 +34,9 @@
 {
     [super setUp];
 
+#if TARGET_OS_IOS
     [[XCUIDevice sharedDevice] setOrientation:UIDeviceOrientationPortrait];
+#endif
 }
 
 - (void)testCPUArchitecture


### PR DESCRIPTION
Some [failing benchmark tests](https://app.saucelabs.com/tests/0ed189cd1b26481eaf1d9a87581746fe#1) in SauceLabs show the devices in landscape mode. The`SentrySDKPerformanceBenchmarkTests` now use portrait mode. 

#skip-changelog