### PR TITLE
ci: Replace iOS 11 with 17 for SauceLabs

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -13,6 +13,11 @@ xcuitest:
 
 suites:
 
+  - name: "iOS-17"
+    devices:
+      - name: "iPhone.*"
+        platformVersion: "17"
+
   - name: "iOS-16"
     devices:
       - name: "iPhone.*"
@@ -42,11 +47,6 @@ suites:
     devices:
       - name: "iPhone.*"
         platformVersion: "12"
-
-  - name: "iOS-11"
-    devices:
-      - name: "iPhone.*"
-        platformVersion: "11"
       
 artifacts:
   download:


### PR DESCRIPTION
Xcode 15 only supports debugging on iOS 12. We can remove running UI tests in SauceLabs on iOS 11 and instead run them on iOS 17.

#skip-changelog