### PR TITLE
ci: Run SauceLabs UI tests only on 3 devices

### DIFF
--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -12,41 +12,28 @@ xcuitest:
   testApp: ./DerivedData/Build/Products/Test-iphoneos/iOS-SwiftUITests-Runner.app
 
 suites:
-
+  # CI speed and reliability are essential for developer productivity. Running UI tests on SauceLabs
+  # takes time, and when running multiple CI jobs in parallel for various PRs, SauceLabs becomes the
+  # bottleneck. Ideally, we would run our UI tests on a wide range of devices with different OS
+  # versions, but that's expensive and doesn't increase the likelihood of catching SDK bugs
+  # significantly. Instead, we choose a minimum set of devices. Furthermore, our unit tests surface most
+  # SDK bugs.
+ 
+  # We need to run the tests on an iPhone Pro because it has 120Hz refresh rate.
+  - name: "iPhone-Pro"
+    devices:
+      - name: "iPhone 13 Pro.*"
+        platformVersion: "17"
+   
   - name: "iOS-16"
     devices:
       - name: "iPhone.*"
         platformVersion: "16"
-   
-  - name: "iOS-15"
-    devices:
-      - name: "iPhone.*"
-        platformVersion: "15"
-
-  - name: "iPhone-Pro"
-    devices:
-      - name: "iPhone 13 Pro.*"
-        platformVersion: "15"
-        
-  - name: "iOS-14"
-    devices:
-      - name: "iPhone.*"
-        platformVersion: "14"
-
-  - name: "iOS-13"
-    devices:
-      - name: "iPhone.*"
-        platformVersion: "13"
 
   - name: "iOS-12"
     devices:
       - name: "iPhone.*"
         platformVersion: "12"
-
-  - name: "iOS-11"
-    devices:
-      - name: "iPhone.*"
-        platformVersion: "11"
       
 artifacts:
   download:


### PR DESCRIPTION
CI speed and reliability are essential for developer productivity. Running UI tests on SauceLabs takes time, and when running multiple CI jobs in parallel for various PRs, SauceLabs becomes the bottleneck. Ideally, we would run our UI tests on a wide range of devices with different OS versions, but that's expensive and doesn't increase the likelihood of catching SDK bugs significantly. Instead, we choose a minimum set of devices. Furthermore, our unit tests surface most SDK bugs.

#skip-changelog