### PR TITLE
ci: Remove SauceLabs retries

### DIFF
--- a/.github/workflows/saucelabs-UI-tests.yml
+++ b/.github/workflows/saucelabs-UI-tests.yml
@@ -124,9 +124,8 @@ jobs:
 
       - run: npm install -g saucectl@0.173.2
 
-      # As Sauce Labs is a bit flaky we retry 5 times
       - name: Run Tests in SauceLab
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-        run: for i in {1..5}; do saucectl run --select-suite ${{ matrix.suite }} && break ; done
+        run: saucectl run --select-suite ${{ matrix.suite }}


### PR DESCRIPTION
SauceLabs retries aren't necessary anymore because SauceLabs isn't failing that often anymore. The retries queue many jobs in SauceLabs. Instead, we should take failing SauceLabs tests seriously and try to fix them or disable a flaky test if necessary.

#skip-changelog