### PR TITLE
ci: Increase SauceLabs Timeout

### DIFF
--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -5,7 +5,7 @@ sauce:
   concurrency: 4
 
 defaults:
-  timeout: 20m
+  timeout: 60m
 
 xcuitest:
   app: ./DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -5,7 +5,7 @@ sauce:
   concurrency: 4
 
 defaults:
-  timeout: 20m
+  timeout: 60m
 
 xcuitest:
   app: ./DerivedData/Build/Products/Test-iphoneos/iOS-Swift.app


### PR DESCRIPTION
The UI tests in SauceLabs frequently time out. Let's increase the value to 60m, as it's better to have delayed UI test results than failing CI.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/3662.

#skip-changelog