### PR TITLE
ci: SauceLabs remove downloading junit artifacts

### DIFF
--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -5,7 +5,7 @@ sauce:
   concurrency: 4
 
 defaults:
-  timeout: 20m
+  timeout: 60m
 
 xcuitest:
   app: ./DerivedData/Build/Products/Debug-iphoneos/iOS-Swift.app

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -5,7 +5,7 @@ sauce:
   concurrency: 4
 
 defaults:
-  timeout: 20m
+  timeout: 60m
 
 xcuitest:
   app: ./DerivedData/Build/Products/Test-iphoneos/iOS-Swift.app

--- a/.sauce/config.yml
+++ b/.sauce/config.yml
@@ -34,10 +34,3 @@ suites:
     devices:
       - name: "iPhone.*"
         platformVersion: "12"
-      
-artifacts:
-  download:
-    when: always
-    match:
-      - "*.junit.xml"
-    directory: ./artifacts/

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -469,15 +469,19 @@ writeProfileFile(NSDictionary<NSString *, id> *payload)
     }
 
     if ([fm fileExistsAtPath:pathToWrite]) {
-        SENTRY_LOG_DEBUG(@"Already a%@ profile file present; make sure to remove them right after "
+        SENTRY_LOG_DEBUG(@"Already a %@ profile file present; make sure to remove them right after "
                          @"using them, and that tests clean state in between so there isn't "
                          @"leftover config producing one when it isn't expected.",
             isTracingAppLaunch ? @" launch" : @"");
+        return;
     }
 
     SENTRY_LOG_DEBUG(@"Writing%@ profile to file.", isTracingAppLaunch ? @" launch" : @"");
-    SENTRY_CASSERT(
-        [data writeToFile:pathToWrite atomically:YES], @"Failed to write profile to test file");
+
+    NSError *error;
+    if (![data writeToFile:pathToWrite options:NSDataWritingAtomic error:&error]) {
+        SENTRY_LOG_ERROR(@"Failed to write data to path %@: %@", pathToWrite, error);
+    }
 }
 #    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
 


### PR DESCRIPTION
Downloading the jUnit artifacts fails frequently, and we don't use them. Therefore, we can remove them.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/3663.

#skip-changelog