### PR TITLE
ci: Use accessibility id for crashTheApp button

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -696,6 +696,7 @@
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NNd-Ec-zXw">
                                                         <rect key="frame" x="0.0" y="56" width="160" height="28"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="crashTheApp"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Crash the app"/>
                                                         <connections>

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -7,8 +7,8 @@ class LaunchUITests: BaseUITest {
         //If we introduce a bug in the crash report process we will catch it with tests for iOS 13 or above.
         //For some reason is not possible to use @available(iOS 13, *) in the test function.
         if #available(iOS 13, *) {
-            app.buttons["Crash the app"].tap()
-            if app.buttons["Crash the app"].exists {
+            app.buttons["crashTheApp"].tap()
+            if app.buttons["crashTheApp"].exists {
                 XCTFail("App did not crashed")
             }
 


### PR DESCRIPTION
The `testCrashRecovery` failed here because it didn't find the crash the app button: https://github.com/getsentry/sentry-cocoa/actions/runs/7976509897/job/21777248607

#skip-changelog