### PR TITLE
test: Enable App Launch Profiling UI tests

### DIFF
--- a/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
+++ b/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
@@ -27,7 +27,7 @@
         [app launch];
         [app.tabBars[@"Tab Bar"].buttons[@"Transactions"] tap];
 
-        [app.buttons[@"Start transaction (main thread)"] tap];
+        [app.buttons[@"startTransactionMainThread"] tap];
 
         [app.tabBars[@"Tab Bar"].buttons[@"Profiling"] tap];
 

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -39,12 +39,6 @@
             </BuildableReference>
             <SkippedTests>
                <Test
-                  Identifier = "ProfilingUITests/testProfiledAppLaunches()">
-               </Test>
-               <Test
-                  Identifier = "ProfilingUITests/testProfilingGPUInfo()">
-               </Test>
-               <Test
                   Identifier = "SentryFileIOTrackingIntegrationTests/test_DataConsistency_readPath_disabled()">
                </Test>
                <Test

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -135,7 +135,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("[iOS-Swift] [debug] launch arguments: \(ProcessInfo.processInfo.arguments)")
         print("[iOS-Swift] [debug] environment: \(ProcessInfo.processInfo.environment)")
         
-        maybeWipeData()
+        if ProcessInfo.processInfo.arguments.contains("--io.sentry.wipe-data") {
+            removeAppData()
+        }
         AppDelegate.startSentry()
         
         if #available(iOS 15.0, *) {
@@ -164,19 +166,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return _metricKit as! MetricKitManager
         // swiftlint:enable force_cast
     }
-}
-
-private extension AppDelegate {
-    // previously tried putting this in an AppDelegate.load override in ObjC, but it wouldn't run until after a launch profiler would have an opportunity to run, since SentryProfiler.load would always run first due to being dynamically linked in a framework module. it is sufficient to do it before calling SentrySDK.startWithOptions to clear state for testProfiledAppLaunches because we don't make any assertions on a launch profile the first launch of the app in that test 
-    func maybeWipeData() {
-        if ProcessInfo.processInfo.arguments.contains("--io.sentry.wipe-data") {
-            print("[iOS-Swift] [debug] removing app data")
-            let appSupport = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
-            let cache = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
-            for path in [appSupport, cache] {
-                for item in FileManager.default.enumerator(atPath: path)! {
-                    try! FileManager.default.removeItem(atPath: (path as NSString).appendingPathComponent((item as! String)))
-                }
+    
+    /**
+     * previously tried putting this in an AppDelegate.load override in ObjC, but it wouldn't run until
+     * after a launch profiler would have an opportunity to run, since SentryProfiler.load would always run
+     * first due to being dynamically linked in a framework module. it is sufficient to do it before
+     * calling SentrySDK.startWithOptions to clear state for testProfiledAppLaunches because we don't make
+     * any assertions on a launch profile the first launch of the app in that test
+     */
+    private func removeAppData() {
+        print("[iOS-Swift] [debug] removing app data")
+        let appSupport = NSSearchPathForDirectoriesInDomains(.applicationSupportDirectory, .userDomainMask, true).first!
+        let cache = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
+        for path in [appSupport, cache] {
+            for item in FileManager.default.enumerator(atPath: path)! {
+                try! FileManager.default.removeItem(atPath: (path as NSString).appendingPathComponent((item as! String)))
             }
         }
     }

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -34,6 +34,7 @@
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="60A-0I-s24">
                                                 <rect key="frame" x="0.0" y="0.0" width="187" height="28"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="startTransactionMainThread"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                 <state key="normal" title="Start transaction (main thread)"/>
@@ -54,6 +55,7 @@
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M4W-xc-mEo">
                                         <rect key="frame" x="0.0" y="56" width="259" height="28"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="stopTransaction"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="Stop transaction"/>
@@ -225,6 +227,7 @@
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vwa-d9-1BM">
                                         <rect key="frame" x="111.5" y="56" width="97" height="28"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="viewLastProfile"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="View last profile"/>
@@ -243,6 +246,7 @@
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F1h-qu-BzX">
                                         <rect key="frame" x="102.5" y="112" width="115" height="28"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="viewLaunchProfile"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" title="View launch profile"/>
@@ -880,6 +884,7 @@
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2e4-48-rLl">
                                                         <rect key="frame" x="0.0" y="98" width="152" height="28"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="anrFillingRunLoopExtra"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="ANR filling run loop"/>
                                                         <connections>

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -46,7 +46,7 @@ class ProfilingUITests: BaseUITest {
         goToTransactions()
         startTransaction()
         
-        app.buttons["ANR filling run loop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
+        app.buttons["anrFillingRunLoop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
         stopTransaction()
     
         goToProfiling()
@@ -97,11 +97,11 @@ extension ProfilingUITests {
     }
     
     func startTransaction() {
-        app.buttons["Start transaction (main thread)"].afterWaitingForExistence("Couldn't find button to start transaction").tap()
+        app.buttons["startTransactionMainThread"].afterWaitingForExistence("Couldn't find button to start transaction").tap()
     }
     
     func stopTransaction() {
-        app.buttons["Stop transaction"].afterWaitingForExistence("Couldn't find button to end transaction").tap()
+        app.buttons["stopTransaction"].afterWaitingForExistence("Couldn't find button to end transaction").tap()
     }
     
     func goToProfiling() {
@@ -109,11 +109,11 @@ extension ProfilingUITests {
     }
     
     func retrieveLastProfileData() {
-        app.buttons["View last profile"].afterWaitingForExistence("Couldn't find button to view last profile").tap()
+        app.buttons["viewLastProfile"].afterWaitingForExistence("Couldn't find button to view last profile").tap()
     }
     
     func retrieveLaunchProfileData() {
-        app.buttons["View launch profile"].afterWaitingForExistence("Couldn't find button to view launch profile").tap()
+        app.buttons["viewLaunchProfile"].afterWaitingForExistence("Couldn't find button to view launch profile").tap()
     }
 
     func assertLaunchProfile() throws {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -2,7 +2,6 @@ import XCTest
 
 //swiftlint:disable function_body_length todo
 
-@available(iOS 16, *)
 class ProfilingUITests: BaseUITest {
     override var automaticallyLaunchAndTerminateApp: Bool { false }
     
@@ -66,7 +65,6 @@ class ProfilingUITests: BaseUITest {
     }
 }
 
-@available(iOS 16, *)
 extension ProfilingUITests {
     
     enum Error: Swift.Error {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -2,71 +2,73 @@ import XCTest
 
 //swiftlint:disable function_body_length todo
 
-@available(iOS 16, *)
 class ProfilingUITests: BaseUITest {
     override var automaticallyLaunchAndTerminateApp: Bool { false }
     
     func testProfiledAppLaunches() throws {
-        app.launchArguments.append("--io.sentry.wipe-data")
-        launchApp()
-        
-        // First launch enables in-app profiling by setting traces/profiles sample rates to 1 (which is the default configuration in the sample app), but not launch profiling; assert that we did not write a config to allow the next launch to be profiled.
-        try performAssertions(shouldProfileThisLaunch: false, shouldProfileNextLaunch: false)
-        
-        // no profiling should be done on this launch; set the option to allow launch profiling for the next launch, keeping the default numerical sampling rates of 1 for traces and profiles
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: true)
-        
-        // this launch should run the profiler, then set the option to allow launch profiling to true, but set the numerical sample rates to 0 so that the next launch should not profile
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: true, shouldEnableLaunchProfilingOptionForNextLaunch: true, profilesSampleRate: 0, tracesSampleRate: 0)
-        
-        // this launch should not run the profiler; configure sampler functions returning 1 and numerical rates set to 0, which should result in a profile being taken as samplers override numerical rates
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: true, profilesSampleRate: 0, tracesSampleRate: 0, profilesSamplerValue: 1, tracesSamplerValue: 1)
-        
-        // this launch should run the profiler; configure sampler functions returning 0 and numerical rates set to 0, which should result in no profile being taken next launch
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: true, shouldEnableLaunchProfilingOptionForNextLaunch: true, profilesSamplerValue: 0, tracesSamplerValue: 0)
-        
-        // this launch should not run the profiler, but configure it to run the next launch
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: true)
-        
-        // this launch should run the profiler, and configure it not to run the next launch due to disabling tracing, which would override the option to enable launch profiling
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: true, shouldEnableLaunchProfilingOptionForNextLaunch: true, shouldDisableTracing: true)
-        
-        // make sure the profiler respects the last configuration not to run; don't let another config file get written
-        try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: false)
+        if #available(iOS 16, *) {
+            app.launchArguments.append("--io.sentry.wipe-data")
+            launchApp()
+            
+            // First launch enables in-app profiling by setting traces/profiles sample rates to 1 (which is the default configuration in the sample app), but not launch profiling; assert that we did not write a config to allow the next launch to be profiled.
+            try performAssertions(shouldProfileThisLaunch: false, shouldProfileNextLaunch: false)
+            
+            // no profiling should be done on this launch; set the option to allow launch profiling for the next launch, keeping the default numerical sampling rates of 1 for traces and profiles
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: true)
+            
+            // this launch should run the profiler, then set the option to allow launch profiling to true, but set the numerical sample rates to 0 so that the next launch should not profile
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: true, shouldEnableLaunchProfilingOptionForNextLaunch: true, profilesSampleRate: 0, tracesSampleRate: 0)
+            
+            // this launch should not run the profiler; configure sampler functions returning 1 and numerical rates set to 0, which should result in a profile being taken as samplers override numerical rates
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: true, profilesSampleRate: 0, tracesSampleRate: 0, profilesSamplerValue: 1, tracesSamplerValue: 1)
+            
+            // this launch should run the profiler; configure sampler functions returning 0 and numerical rates set to 0, which should result in no profile being taken next launch
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: true, shouldEnableLaunchProfilingOptionForNextLaunch: true, profilesSamplerValue: 0, tracesSamplerValue: 0)
+            
+            // this launch should not run the profiler, but configure it to run the next launch
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: true)
+            
+            // this launch should run the profiler, and configure it not to run the next launch due to disabling tracing, which would override the option to enable launch profiling
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: true, shouldEnableLaunchProfilingOptionForNextLaunch: true, shouldDisableTracing: true)
+            
+            // make sure the profiler respects the last configuration not to run; don't let another config file get written
+            try relaunchAndConfigureSubsequentLaunches(shouldProfileThisLaunch: false, shouldEnableLaunchProfilingOptionForNextLaunch: false)
+        }
     }
     
     /**
      * We had a bug where we forgot to install the frames tracker into the profiler, so weren't sending any GPU frame information with profiles. Since it's not possible to enforce such installation via the compiler, we test for the results we expect here, by starting a transaction, triggering an ANR which will cause degraded frame rendering, stop the transaction, and inspect the profile payload.
      */
     func testProfilingGPUInfo() throws {
-        app.launchArguments.append("--disable-swizzling") // we're only interested in the manual transaction, the automatic stuff messes up how we try to retrieve the target profile info
-        app.launchArguments.append("--io.sentry.wipe-data")
-        launchApp()
-        
-        goToTransactions()
-        startTransaction()
-        
-        app.buttons["anrFillingRunLoop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
-        stopTransaction()
-    
-        goToProfiling()
-        retrieveLastProfileData()
-        let profileDict = try marshalJSONDictionaryFromApp()
-        
-        let metrics = try XCTUnwrap(profileDict["measurements"] as? [String: Any])
-        // We can only be sure about frozen frames when triggering an ANR.
-        // It could be that there is no slow frame for the captured transaction.
-        let frozenFrames = try XCTUnwrap(metrics["frozen_frame_renders"] as? [String: Any])
-        let frozenFrameValues = try XCTUnwrap(frozenFrames["values"] as? [[String: Any]])
-        XCTAssertFalse(frozenFrameValues.isEmpty, "The test triggered an ANR while the transaction is running. There must be at least one frozen frame, but there was none.")
-        
-        let frameRates = try XCTUnwrap(metrics["screen_frame_rates"] as? [String: Any])
-        let frameRateValues = try XCTUnwrap(frameRates["values"] as? [[String: Any]])
-        XCTAssertFalse(frameRateValues.isEmpty)
+        if #available(iOS 16, *) {
+            app.launchArguments.append("--disable-swizzling") // we're only interested in the manual transaction, the automatic stuff messes up how we try to retrieve the target profile info
+            app.launchArguments.append("--io.sentry.wipe-data")
+            launchApp()
+            
+            goToTransactions()
+            startTransaction()
+            
+            app.buttons["anrFillingRunLoop"].afterWaitingForExistence("Couldn't find button to ANR").tap()
+            stopTransaction()
+            
+            goToProfiling()
+            retrieveLastProfileData()
+            let profileDict = try marshalJSONDictionaryFromApp()
+            
+            let metrics = try XCTUnwrap(profileDict["measurements"] as? [String: Any])
+            // We can only be sure about frozen frames when triggering an ANR.
+            // It could be that there is no slow frame for the captured transaction.
+            let frozenFrames = try XCTUnwrap(metrics["frozen_frame_renders"] as? [String: Any])
+            let frozenFrameValues = try XCTUnwrap(frozenFrames["values"] as? [[String: Any]])
+            XCTAssertFalse(frozenFrameValues.isEmpty, "The test triggered an ANR while the transaction is running. There must be at least one frozen frame, but there was none.")
+            
+            let frameRates = try XCTUnwrap(metrics["screen_frame_rates"] as? [String: Any])
+            let frameRateValues = try XCTUnwrap(frameRates["values"] as? [[String: Any]])
+            XCTAssertFalse(frameRateValues.isEmpty)
+        }
     }
 }
 
-@available(iOS 16, *)
 extension ProfilingUITests {
     
     enum Error: Swift.Error {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/ProfilingUITests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 //swiftlint:disable function_body_length todo
 
+@available(iOS 16, *)
 class ProfilingUITests: BaseUITest {
     override var automaticallyLaunchAndTerminateApp: Bool { false }
     
@@ -65,6 +66,7 @@ class ProfilingUITests: BaseUITest {
     }
 }
 
+@available(iOS 16, *)
 extension ProfilingUITests {
     
     enum Error: Swift.Error {


### PR DESCRIPTION
GH-3665 didn't enable the app launch profiling tests because they were still disabled in Xcode. This PR fixes that and also uses more accessibility identifiers in the profiling tests.

#skip-changelog