### PR TITLE
feat: Add statsd item type

### DIFF
--- a/Sources/Sentry/SentryDataCategoryMapper.m
+++ b/Sources/Sentry/SentryDataCategoryMapper.m
@@ -11,6 +11,7 @@ NSString *const kSentryDataCategoryNameTransaction = @"transaction";
 NSString *const kSentryDataCategoryNameAttachment = @"attachment";
 NSString *const kSentryDataCategoryNameUserFeedback = @"user_report";
 NSString *const kSentryDataCategoryNameProfile = @"profile";
+NSString *const kSentryDataCategoryNameStatsd = @"statsd";
 NSString *const kSentryDataCategoryNameUnknown = @"unknown";
 
 NS_ASSUME_NONNULL_BEGIN
@@ -32,6 +33,9 @@ sentryDataCategoryForEnvelopItemType(NSString *itemType)
     }
     if ([itemType isEqualToString:SentryEnvelopeItemTypeProfile]) {
         return kSentryDataCategoryProfile;
+    }
+    if ([itemType isEqualToString:SentryEnvelopeItemTypeStatsd]) {
+        return kSentryDataCategoryStatsd;
     }
     return kSentryDataCategoryDefault;
 }
@@ -73,6 +77,9 @@ sentryDataCategoryForString(NSString *value)
     if ([value isEqualToString:kSentryDataCategoryNameProfile]) {
         return kSentryDataCategoryProfile;
     }
+    if ([value isEqualToString:kSentryDataCategoryNameStatsd]) {
+        return kSentryDataCategoryStatsd;
+    }
 
     return kSentryDataCategoryUnknown;
 }
@@ -101,6 +108,8 @@ nameForSentryDataCategory(SentryDataCategory category)
         return kSentryDataCategoryNameUserFeedback;
     case kSentryDataCategoryProfile:
         return kSentryDataCategoryNameProfile;
+    case kSentryDataCategoryStatsd:
+        return kSentryDataCategoryNameStatsd;
     case kSentryDataCategoryUnknown:
         return kSentryDataCategoryNameUnknown;
     }

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelopeItemType.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelopeItemType.h
@@ -5,3 +5,4 @@ static NSString *const SentryEnvelopeItemTypeTransaction = @"transaction";
 static NSString *const SentryEnvelopeItemTypeAttachment = @"attachment";
 static NSString *const SentryEnvelopeItemTypeClientReport = @"client_report";
 static NSString *const SentryEnvelopeItemTypeProfile = @"profile";
+static NSString *const SentryEnvelopeItemTypeStatsd = @"statsd";

--- a/Sources/Sentry/include/SentryDataCategory.h
+++ b/Sources/Sentry/include/SentryDataCategory.h
@@ -14,7 +14,8 @@ typedef NS_ENUM(NSUInteger, SentryDataCategory) {
     kSentryDataCategoryAttachment = 5,
     kSentryDataCategoryUserFeedback = 6,
     kSentryDataCategoryProfile = 7,
-    kSentryDataCategoryUnknown = 8
+    kSentryDataCategoryStatsd = 8,
+    kSentryDataCategoryUnknown = 9
 };
 
 static DEPRECATED_MSG_ATTRIBUTE(
@@ -29,5 +30,6 @@ static DEPRECATED_MSG_ATTRIBUTE(
           @"attachment",
           @"user_report",
           @"profile",
+          @"statsd",
           @"unkown",
       };

--- a/Sources/Sentry/include/SentryDataCategoryMapper.h
+++ b/Sources/Sentry/include/SentryDataCategoryMapper.h
@@ -11,6 +11,7 @@ FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameTransaction;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameAttachment;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameUserFeedback;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameProfile;
+FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameStatsd;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameUnknown;
 
 SentryDataCategory sentryDataCategoryForNSUInteger(NSUInteger value);

--- a/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
@@ -1,53 +1,58 @@
+import Nimble
 @testable import Sentry
 import XCTest
 
 class SentryDataCategoryMapperTests: XCTestCase {
     func testEnvelopeItemType() {
-        XCTAssertEqual(.error, sentryDataCategoryForEnvelopItemType("event"))
-        XCTAssertEqual(.session, sentryDataCategoryForEnvelopItemType("session"))
-        XCTAssertEqual(.transaction, sentryDataCategoryForEnvelopItemType("transaction"))
-        XCTAssertEqual(.attachment, sentryDataCategoryForEnvelopItemType("attachment"))
-        XCTAssertEqual(.profile, sentryDataCategoryForEnvelopItemType("profile"))
-        XCTAssertEqual(.default, sentryDataCategoryForEnvelopItemType("unknown item type"))
+        expect(sentryDataCategoryForEnvelopItemType("event")) == .error
+        expect(sentryDataCategoryForEnvelopItemType("session")) == .session
+        expect(sentryDataCategoryForEnvelopItemType("transaction")) == .transaction
+        expect(sentryDataCategoryForEnvelopItemType("attachment")) == .attachment
+        expect(sentryDataCategoryForEnvelopItemType("profile")) == .profile
+        expect(sentryDataCategoryForEnvelopItemType("statsd")) == .statsd
+        expect(sentryDataCategoryForEnvelopItemType("unknown item type")) == .default
     }
 
     func testMapIntegerToCategory() {
-        XCTAssertEqual(.all, sentryDataCategoryForNSUInteger(0))
-        XCTAssertEqual(.default, sentryDataCategoryForNSUInteger(1))
-        XCTAssertEqual(.error, sentryDataCategoryForNSUInteger(2))
-        XCTAssertEqual(.session, sentryDataCategoryForNSUInteger(3))
-        XCTAssertEqual(.transaction, sentryDataCategoryForNSUInteger(4))
-        XCTAssertEqual(.attachment, sentryDataCategoryForNSUInteger(5))
-        XCTAssertEqual(.userFeedback, sentryDataCategoryForNSUInteger(6))
-        XCTAssertEqual(.profile, sentryDataCategoryForNSUInteger(7))
-        XCTAssertEqual(.unknown, sentryDataCategoryForNSUInteger(8))
+        expect(sentryDataCategoryForNSUInteger(0)) == .all
+        expect(sentryDataCategoryForNSUInteger(1)) == .default
+        expect(sentryDataCategoryForNSUInteger(2)) == .error
+        expect(sentryDataCategoryForNSUInteger(3)) == .session
+        expect(sentryDataCategoryForNSUInteger(4)) == .transaction
+        expect(sentryDataCategoryForNSUInteger(5)) == .attachment
+        expect(sentryDataCategoryForNSUInteger(6)) == .userFeedback
+        expect(sentryDataCategoryForNSUInteger(7)) == .profile
+        expect(sentryDataCategoryForNSUInteger(8)) == .statsd
+        expect(sentryDataCategoryForNSUInteger(9)) == .unknown
 
-        XCTAssertEqual(.unknown, sentryDataCategoryForNSUInteger(9), "Failed to map unknown category number to case .unknown")
+        XCTAssertEqual(.unknown, sentryDataCategoryForNSUInteger(10), "Failed to map unknown category number to case .unknown")
     }
     
     func testMapStringToCategory() {
-        XCTAssertEqual(.all, sentryDataCategoryForString(kSentryDataCategoryNameAll))
-        XCTAssertEqual(.default, sentryDataCategoryForString(kSentryDataCategoryNameDefault))
-        XCTAssertEqual(.error, sentryDataCategoryForString(kSentryDataCategoryNameError))
-        XCTAssertEqual(.session, sentryDataCategoryForString(kSentryDataCategoryNameSession))
-        XCTAssertEqual(.transaction, sentryDataCategoryForString(kSentryDataCategoryNameTransaction))
-        XCTAssertEqual(.attachment, sentryDataCategoryForString(kSentryDataCategoryNameAttachment))
-        XCTAssertEqual(.userFeedback, sentryDataCategoryForString(kSentryDataCategoryNameUserFeedback))
-        XCTAssertEqual(.profile, sentryDataCategoryForString(kSentryDataCategoryNameProfile))
-        XCTAssertEqual(.unknown, sentryDataCategoryForString(kSentryDataCategoryNameUnknown))
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameAll)) == .all
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameDefault)) == .default
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameError)) == .error
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameSession)) == .session
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameTransaction)) == .transaction
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameAttachment)) == .attachment
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameUserFeedback)) == .userFeedback
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameProfile)) == .profile
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameStatsd)) == .statsd
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameUnknown)) == .unknown
 
         XCTAssertEqual(.unknown, sentryDataCategoryForString("gdfagdfsa"), "Failed to map unknown category name to case .unknown")
     }
 
     func testMapCategoryToString() {
-        XCTAssertEqual(kSentryDataCategoryNameAll, nameForSentryDataCategory(.all))
-        XCTAssertEqual(kSentryDataCategoryNameDefault, nameForSentryDataCategory(.default))
-        XCTAssertEqual(kSentryDataCategoryNameError, nameForSentryDataCategory(.error))
-        XCTAssertEqual(kSentryDataCategoryNameSession, nameForSentryDataCategory(.session))
-        XCTAssertEqual(kSentryDataCategoryNameTransaction, nameForSentryDataCategory(.transaction))
-        XCTAssertEqual(kSentryDataCategoryNameAttachment, nameForSentryDataCategory(.attachment))
-        XCTAssertEqual(kSentryDataCategoryNameUserFeedback, nameForSentryDataCategory(.userFeedback))
-        XCTAssertEqual(kSentryDataCategoryNameProfile, nameForSentryDataCategory(.profile))
-        XCTAssertEqual(kSentryDataCategoryNameUnknown, nameForSentryDataCategory(.unknown))
+        expect(nameForSentryDataCategory(.all)) == kSentryDataCategoryNameAll
+        expect(nameForSentryDataCategory(.default)) == kSentryDataCategoryNameDefault
+        expect(nameForSentryDataCategory(.error)) == kSentryDataCategoryNameError
+        expect(nameForSentryDataCategory(.session)) == kSentryDataCategoryNameSession
+        expect(nameForSentryDataCategory(.transaction)) == kSentryDataCategoryNameTransaction
+        expect(nameForSentryDataCategory(.attachment)) == kSentryDataCategoryNameAttachment
+        expect(nameForSentryDataCategory(.userFeedback)) == kSentryDataCategoryNameUserFeedback
+        expect(nameForSentryDataCategory(.profile)) == kSentryDataCategoryNameProfile
+        expect(nameForSentryDataCategory(.statsd)) == kSentryDataCategoryNameStatsd
+        expect(nameForSentryDataCategory(.unknown)) == kSentryDataCategoryNameUnknown
     }
 }


### PR DESCRIPTION
Add envelope item type and data category for statsd, which is required for the metrics API.

Fist step for https://github.com/getsentry/sentry-cocoa/issues/3631.

#skip-changelog