### PR TITLE
chore: Add Target for release worflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       force:
         description: Force a release even when there are release-blockers (optional)
         required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
 
 jobs:
   job_release:


### PR DESCRIPTION
This allows us to choose which branch the release will be merged back.

_#skip-changelog_