### PR TITLE
Fix: Missing argument for Craft step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}


### PR DESCRIPTION
It was missing an argument for Craft step in order for the target merge to work.

_#skip-changelog_