### PR TITLE
ci: Stop using xlarge runners

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   build-benchmark-test-target:
     name: Build app and test runner
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh
@@ -102,7 +102,7 @@ jobs:
 
   app-metrics:
     name: Collect app metrics
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     name: Build XCFramework
     # The macos-13 uses an Intel processor and doesn't compile the XCFramework for visionOS. 
     # The large image compiles on arm64 and successfully creates the XCFramework for visionOS.
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 15.2
@@ -118,7 +118,7 @@ jobs:
 
   validate-xcframework:
     name: Validate XCFramework
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     needs: build-xcframework
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
     name: Build XCFramework
     # The macos-13 uses an Intel processor and doesn't compile the XCFramework for visionOS. 
     # The large image compiles on arm64 and successfully creates the XCFramework for visionOS.
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 15.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
 
   xcode-analyze:
     name: Xcode Analyze
-    runs-on: macos-13-xlarge
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,14 +107,14 @@ jobs:
             device: "iPhone 8"
 
           # iOS 16
-          - runs-on: macos-13-xlarge
+          - runs-on: macos-13
             platform: "iOS"
             xcode: "14.3"
             test-destination-os: "16.4"
             device: "iPhone 14"
 
           # iOS 17
-          - runs-on: macos-14-xlarge
+          - runs-on: macos-14
             platform: "iOS"
             xcode: "15.2"
             test-destination-os: "17.2"
@@ -133,13 +133,13 @@ jobs:
             test-destination-os: "latest"
 
           # macOS 13
-          - runs-on: macos-13-xlarge
+          - runs-on: macos-13
             platform: "macOS"
             xcode: "14.3"
             test-destination-os: "latest"
 
           # macOS 14
-          - runs-on: macos-14-xlarge
+          - runs-on: macos-14
             platform: "macOS"
             xcode: "15.2"
             test-destination-os: "latest"
@@ -147,7 +147,7 @@ jobs:
           # Catalyst. We only test the latest version, as
           # the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
-          - runs-on: macos-14-xlarge
+          - runs-on: macos-14
             platform: "Catalyst"
             xcode: "15.2"
             test-destination-os: "latest"
@@ -159,13 +159,13 @@ jobs:
             test-destination-os: "latest"
 
           # tvOS 16
-          - runs-on: macos-13-xlarge
+          - runs-on: macos-13
             platform: "tvOS"
             xcode: "14.3"
             test-destination-os: "latest"
 
           # tvOS 17
-          - runs-on: macos-14-xlarge
+          - runs-on: macos-14
             platform: "tvOS"
             xcode: "15.2"
             test-destination-os: "latest"


### PR DESCRIPTION
Stop using xlarge runners cause they eat up 20% of our GH actions quota.

