### PR TITLE
fix: Move headers out of Extern C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Make SentryFramesTracker available for HybridSDKs ([#3683](https://github.com/getsentry/sentry-cocoa/pull/3683))
 - Make SentrySwizzle available for HybridSDKs ([#3684](https://github.com/getsentry/sentry-cocoa/pull/3684))
+- Move headers reference out of "extern C" (#)
 
 ## 8.21.0-beta.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Make SentryFramesTracker available for HybridSDKs ([#3683](https://github.com/getsentry/sentry-cocoa/pull/3683))
 - Make SentrySwizzle available for HybridSDKs ([#3684](https://github.com/getsentry/sentry-cocoa/pull/3684))
-- Move headers reference out of "extern C" (#)
+- Move headers reference out of "extern C" (#3690)
 
 ## 8.21.0-beta.0
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.h
@@ -31,14 +31,14 @@
 #ifndef HDR_SentryCrashMonitor_h
 #define HDR_SentryCrashMonitor_h
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "SentryCrashMonitorType.h"
 #include "SentryCrashThread.h"
 
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct SentryCrash_MonitorContext;
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.h
@@ -26,11 +26,11 @@
 #ifndef HDR_SentryCrashMonitor_CPPException_h
 #define HDR_SentryCrashMonitor_CPPException_h
 
+#include "SentryCrashMonitor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SentryCrashMonitor.h"
 
 /** Access the Monitor API.
  */

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.h
@@ -26,11 +26,11 @@
 #ifndef SentryCrashStackCursor_Backtrace_h
 #define SentryCrashStackCursor_Backtrace_h
 
+#import "SentryCrashStackCursor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SentryCrashStackCursor.h"
 
 /** Exposed for other internal systems to use.
  */

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.h
@@ -26,11 +26,11 @@
 #ifndef SentryCrashStackCursor_MachineContext_h
 #define SentryCrashStackCursor_MachineContext_h
 
+#import "SentryCrashStackCursor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SentryCrashStackCursor.h"
 
 #define MAX_STACKTRACE_LENGTH 100
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.h
@@ -26,11 +26,11 @@
 #ifndef SentryCrashStackCursor_SelfThread_h
 #define SentryCrashStackCursor_SelfThread_h
 
+#import "SentryCrashStackCursor.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SentryCrashStackCursor.h"
 
 /** Initialize a stack cursor for the current thread.
  *  You may want to skip some entries to account for the trace immediately

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSymbolicator.h
@@ -26,12 +26,12 @@
 #ifndef SentryCrashSymbolicator_h
 #define SentryCrashSymbolicator_h
 
+#import "SentryCrashStackCursor.h"
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "SentryCrashStackCursor.h"
-#include <stdbool.h>
 
 /** Symbolicate a stack cursor.
  *


### PR DESCRIPTION
## :scroll: Description

If a project uses a C++ compiler, it will not compile because of some headers inside a "extern C" block referencing C++ code.

This appears to be an inheritance from KSCrash that I don't fully understand the reasoning behind. Moving these headers out of the extern block hasn't caused any crashes in our default pipeline, so I believe we're fine with it.

## :bulb: Motivation and Context

close #3689 

## :green_heart: How did you test it?

CI

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
