### PR TITLE
ref: Uncouple DependencyContainer from SentryHub

### DIFF
--- a/Sentry.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Sentry.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:Sentry.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -43,6 +43,7 @@ static BOOL crashedLastRunCalled;
 static SentryAppStartMeasurement *sentrySDKappStartMeasurement;
 static NSObject *sentrySDKappStartMeasurementLock;
 static BOOL _detectedStartUpCrash;
+static SentryOptions *_Nullable startOption;
 
 /**
  * @brief We need to keep track of the number of times @c +[startWith...] is called, because our OOM
@@ -77,7 +78,7 @@ static NSDate *_Nullable startTimestamp = nil;
 + (nullable SentryOptions *)options
 {
     @synchronized(self) {
-        return [[currentHub getClient] options];
+        return startOption;
     }
 }
 
@@ -86,6 +87,7 @@ static NSDate *_Nullable startTimestamp = nil;
 {
     @synchronized(self) {
         currentHub = hub;
+        startOption = hub.client.options;
     }
 }
 
@@ -166,6 +168,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)startWithOptions:(SentryOptions *)options
 {
+    startOption = options;
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
     // We accept the tradeoff that the SDK might not be fully initialized directly after

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -19,6 +19,7 @@
 @class SentrySystemWrapper;
 @class SentryThreadWrapper;
 @class SentryThreadInspector;
+@class SentryOptions;
 @protocol SentryRandom;
 
 #if SENTRY_HAS_METRIC_KIT

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -27,6 +27,9 @@ SentrySDK ()
 
 + (SentryHub *)currentHub;
 
+/**
+ * The option used to start the SDK
+ */
 @property (nonatomic, nullable, readonly, class) SentryOptions *options;
 
 /**


### PR DESCRIPTION
Removed SentryHub dependency from SentryDependencyContainer to avoid cyclic reference that caused a problem in this PR.

_#skip-changelog_