### PR TITLE
Changelog for 8.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,27 @@
 
 ## Unreleased
 
+### Features
+
+- Add support for Sentry [Spotlight](https://spotlightjs.com/) (#3642), which is basically Sentry
+for development. Read our [blog post](https://blog.sentry.io/sentry-for-development/) to find out more.
+- Add field `SentrySDK.detectedStartUpCrash` (#3644)
+- Automatically profile app launches (#3529)
+- Use CocoaPods resource_bundles for PrivacyInfo (#3651)
+- Make tags of SentryScope public (#3650)
+
+### Improvements
+
+- Cache installationID async to avoid file IO on the main thread when starting the SDK (#3601)
+- Add reason for NSPrivacyAccessedAPICategoryFileTimestamp (#3626)
+
 ### Fixes
 
+- Finish TTID span when transaction finishes (#3610)
+- Don't take screenshot and view hierarchy for app hanging (#3620)
+- Remove `free_storage` and `storage_size` from the device context (#3627), because Apple forbids sending
+information retrieved via `NSFileSystemFreeSize` and `NSFileSystemSize` off a device; see
+[Apple docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc).
 - Make SentryFramesTracker available for HybridSDKs ([#3683](https://github.com/getsentry/sentry-cocoa/pull/3683))
 - Make SentrySwizzle available for HybridSDKs ([#3684](https://github.com/getsentry/sentry-cocoa/pull/3684))
 - Move headers reference out of "extern C" (#3690)


### PR DESCRIPTION
Copy the changelog entries of 8.21.0-beta.0, so 8.21.0 contains the full summary of all changes.

#skip-changelog