### PR TITLE
fix: Write NSException reason for crash report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Remove SentryPrivate library (#3623)
 
+### Fixes
+
+-  Write NSException reason for crash report (#3705)
+
+
 ## 8.21.0
 
 ### Features

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1316,8 +1316,9 @@ writeError(const SentryCrashReportWriter *const writer, const char *const key,
                 writer->addStringElement(writer, SentryCrashField_Name, crash->NSException.name);
                 writer->addStringElement(
                     writer, SentryCrashField_UserInfo, crash->NSException.userInfo);
-                writeAddressReferencedByString(
-                    writer, SentryCrashField_ReferencedObject, crash->crashReason);
+                if (crash->crashReason != NULL) {
+                    writer->addStringElement(writer, SentryCrashField_Reason, crash->crashReason);
+                }
             }
             writer->endContainer(writer);
             break;

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -80,15 +80,12 @@ class SentryCrashReportTests: XCTestCase {
         }
         
         let crashReportContents = FileManager.default.contents(atPath: fixture.reportPath) ?? Data()
-        do {
-            let crashReport: CrashReport = try JSONDecoder().decode(CrashReport.self, from: crashReportContents)
+
+        let crashReport: CrashReport = try? JSONDecoder().decode(CrashReport.self, from: crashReportContents)
             
-            expect(crashReport.crash.error.type) == "nsexception"
-            expect(crashReport.crash.error.reason) == reason
-            expect(crashReport.crash.error.nsexception?.reason) == reason
-        } catch {
-            XCTFail("Couldn't decode crash report: \(error)")
-        }
+        expect(crashReport?.crash.error.type) == "nsexception"
+        expect(crashReport?.crash.error.reason) == reason
+        expect(crashReport?.crash.error.nsexception?.reason) == reason
     }
     
     func testShouldNotWriteReason_WhenWritingNSException() {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -66,7 +66,7 @@ class SentryCrashReportTests: XCTestCase {
         }
     }
     
-    func testShouldWriteReason_WhenWritingNSException() {
+    func testShouldWriteReason_WhenWritingNSException() throws {
         var monitorContext = SentryCrash_MonitorContext()
         
         let reason = "Something bad happened"
@@ -81,11 +81,11 @@ class SentryCrashReportTests: XCTestCase {
         
         let crashReportContents = FileManager.default.contents(atPath: fixture.reportPath) ?? Data()
 
-        let crashReport: CrashReport = try? JSONDecoder().decode(CrashReport.self, from: crashReportContents)
+        let crashReport: CrashReport = try XCTUnwrap( JSONDecoder().decode(CrashReport.self, from: crashReportContents))
             
-        expect(crashReport?.crash.error.type) == "nsexception"
-        expect(crashReport?.crash.error.reason) == reason
-        expect(crashReport?.crash.error.nsexception?.reason) == reason
+        expect(crashReport.crash.error.type) == "nsexception"
+        expect(crashReport.crash.error.reason) == reason
+        expect(crashReport.crash.error.nsexception?.reason) == reason
     }
     
     func testShouldNotWriteReason_WhenWritingNSException() {


### PR DESCRIPTION
## :scroll: Description

Correctly write the NSException reason when writing a crash report. When writing a crash report for NSException the crash report writer wrote the crash reason to ReferencedObject, which didn't make any sense. This is fixed now by using the reason field.

## :bulb: Motivation and Context

Fixes GH-3265

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
