### PR TITLE
ref: EnvelopeItemHeader: Init without filename

### DIFF
--- a/Sources/Sentry/Public/SentryEnvelopeItemHeader.h
+++ b/Sources/Sentry/Public/SentryEnvelopeItemHeader.h
@@ -9,6 +9,10 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithType:(NSString *)type
                       length:(NSUInteger)length
+                 contentType:(NSString *)contentType;
+
+- (instancetype)initWithType:(NSString *)type
+                      length:(NSUInteger)length
                    filenname:(NSString *)filename
                  contentType:(NSString *)contentType;
 

--- a/Sources/Sentry/SentryEnvelopeItemHeader.m
+++ b/Sources/Sentry/SentryEnvelopeItemHeader.m
@@ -26,9 +26,8 @@
                    filenname:(NSString *)filename
                  contentType:(NSString *)contentType
 {
-    if (self = [self initWithType:type length:length]) {
+    if (self = [self initWithType:type length:length contentType:contentType]) {
         _filename = filename;
-        _contentType = contentType;
     }
     return self;
 }

--- a/Sources/Sentry/SentryEnvelopeItemHeader.m
+++ b/Sources/Sentry/SentryEnvelopeItemHeader.m
@@ -13,6 +13,16 @@
 
 - (instancetype)initWithType:(NSString *)type
                       length:(NSUInteger)length
+                 contentType:(NSString *)contentType
+{
+    if (self = [self initWithType:type length:length]) {
+        _contentType = contentType;
+    }
+    return self;
+}
+
+- (instancetype)initWithType:(NSString *)type
+                      length:(NSUInteger)length
                    filenname:(NSString *)filename
                  contentType:(NSString *)contentType
 {

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -306,24 +307,38 @@ class SentryEnvelopeTests: XCTestCase {
         XCTAssertEqual(data2.count, 3)
     }
 
-    func test_SentryEnvelopeItemHeaderSerialization() {
-        let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10, filenname: "SomeFileName", contentType: "SomeContentType")
+    func test_SentryEnvelopeItemHeaderSerialization_DefaultInit() {
+        let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10)
 
         let data = header.serialize()
-        XCTAssertEqual(data["type"] as? String, "SomeType")
-        XCTAssertEqual(data["length"] as? Int, 10)
-        XCTAssertEqual(data["filename"] as? String, "SomeFileName")
-        XCTAssertEqual(data["content_type"] as? String, "SomeContentType")
-        XCTAssertEqual(data.count, 4)
+        expect(data.count) == 2
+        XCTAssertEqual(data.count, 2)
+        expect(data["type"] as? String) == "SomeType"
+        expect(data["length"] as? Int) == 10
+        expect(data["filename"]) == nil
+        expect(data["content_type"]) == nil
+    }
+    
+    func test_SentryEnvelopeItemHeaderSerialization_WithoutFileName() {
+        let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10, contentType: "text/html")
 
-        let header2 = SentryEnvelopeItemHeader(type: "SomeType", length: 10)
-
-        let data2 = header2.serialize()
-        XCTAssertEqual(data2.count, 2)
-        XCTAssertEqual(data2["type"] as? String, "SomeType")
-        XCTAssertEqual(data2["length"] as? Int, 10)
-        XCTAssertNil(data2["filename"])
-        XCTAssertNil(data2["content_type"])
+        let data = header.serialize()
+        expect(data["type"] as? String) == "SomeType"
+        expect(data["length"] as? Int) == 10
+        expect(data["filename"]) == nil
+        expect(data["content_type"] as? String) == "text/html"
+        expect(data.count) == 3
+    }
+    
+    func test_SentryEnvelopeItemHeaderSerialization_AllParameters() {
+        let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10, filenname: "SomeFileName", contentType: "text/html")
+        
+        let data = header.serialize()
+        expect(data["type"] as? String) == "SomeType"
+        expect(data["length"] as? Int) == 10
+        expect(data["filename"] as? String) == "SomeFileName"
+        expect(data["content_type"] as? String) == "text/html"
+        expect(data.count) == 4
     }
     
     func testInitWithDataAttachment_MaxAttachmentSize() {


### PR DESCRIPTION
Add an extra initializer without a filename, which is required for DDM.

#skip-changelog