### PR TITLE
chore: Set HEADER_SEARCH_PATHS to expose _SentryPrivate to Objc

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -4770,6 +4770,7 @@
 					"$(inherited)",
 				);
 				GCC_WARN_SHADOW = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Sources/Sentry/include/**";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -4806,6 +4807,7 @@
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_WARN_SHADOW = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Sources/Sentry/include/**";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -4981,6 +4983,7 @@
 					"TESTCI=1",
 				);
 				GCC_WARN_SHADOW = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Sources/Sentry/include/**";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5120,6 +5123,7 @@
 					"$(inherited)",
 				);
 				GCC_WARN_SHADOW = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Sources/Sentry/include/**";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5607,6 +5611,7 @@
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_WARN_SHADOW = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Sources/Sentry/include/**";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -5845,6 +5850,7 @@
 				GCC_C_LANGUAGE_STANDARD = "compiler-default";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_WARN_SHADOW = YES;
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Sources/Sentry/include/**";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_DYLIB_INSTALL_NAME = "$(DYLIB_INSTALL_NAME_BASE:standardizepath)/$(EXECUTABLE_PATH)";
 				LD_RUNPATH_SEARCH_PATHS = (


### PR DESCRIPTION
Setting HEADER_SEARCH_PATHS to `$(SRCROOT)/Sources/Sentry/include` recursive, so Objc compiler can use module.modulemap

_#skip-changelog_