### PR TITLE
test: disable all launch arguments by default

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -75,11 +75,11 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.wipe-data"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.slow-load-method"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-watchdog-tracking"
@@ -91,7 +91,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--profile-app-launches"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-crash-handler"


### PR DESCRIPTION
These were left over from testing app launch profiling, and shouldn't be enabled by default.