### PR TITLE
chore: Add SDK version to User-Agent header

### DIFF
--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -58,7 +58,9 @@ SentryNSURLRequest ()
         self.HTTPMethod = @"POST";
         [self setValue:authHeader forHTTPHeaderField:@"X-Sentry-Auth"];
         [self setValue:@"application/json" forHTTPHeaderField:@"Content-Type"];
-        [self setValue:SentryMeta.sdkName forHTTPHeaderField:@"User-Agent"];
+        [self setValue:[NSString
+                           stringWithFormat:@"%@/%@", SentryMeta.sdkName, SentryMeta.versionString]
+            forHTTPHeaderField:@"User-Agent"];
         [self setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
         self.HTTPBody = [data sentry_gzippedWithCompressionLevel:-1 error:error];
     }
@@ -93,7 +95,9 @@ SentryNSURLRequest ()
             [self setValue:authHeader forHTTPHeaderField:@"X-Sentry-Auth"];
         }
         [self setValue:@"application/x-sentry-envelope" forHTTPHeaderField:@"Content-Type"];
-        [self setValue:SentryMeta.sdkName forHTTPHeaderField:@"User-Agent"];
+        [self setValue:[NSString
+                           stringWithFormat:@"%@/%@", SentryMeta.sdkName, SentryMeta.versionString]
+            forHTTPHeaderField:@"User-Agent"];
         [self setValue:@"gzip" forHTTPHeaderField:@"Content-Encoding"];
         self.HTTPBody = [data sentry_gzippedWithCompressionLevel:-1 error:error];
     }

--- a/Tests/SentryTests/SentryNSURLRequestTests.swift
+++ b/Tests/SentryTests/SentryNSURLRequestTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -11,10 +12,21 @@ class SentryNSURLRequestTests: XCTestCase {
     
     func testRequestWithEnvelopeEndpoint() {
         let request = try! SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        XCTAssertTrue(request.url!.absoluteString.hasSuffix("/envelope/"))
+        expect(request.url!.absoluteString).to(endWith("/envelope/"))
     }
+    
     func testRequestWithStoreEndpoint() {
         let request = try! SentryNSURLRequest(storeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        XCTAssertTrue(request.url!.absoluteString.hasSuffix("/store/"))
+        expect(request.url!.absoluteString).to(endWith("/store/"))
+    }
+    
+    func testRequestWithEnvelopeEndpoint_hasUserAgentWithSdkNameAndVersion() {
+        let request = try! SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
+        expect(request.allHTTPHeaderFields?["User-Agent"]).to(beginWith(String(format: "%@/%@", SentryMeta.sdkName, SentryMeta.versionString)))
+    }
+    
+    func testRequestWithStoreEndpoint_hasUserAgentWithSdkNameAndVersion() {
+        let request = try! SentryNSURLRequest(storeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
+        expect(request.allHTTPHeaderFields?["User-Agent"]).to(beginWith(String(format: "%@/%@", SentryMeta.sdkName, SentryMeta.versionString)))
     }
 }

--- a/Tests/SentryTests/SentryNSURLRequestTests.swift
+++ b/Tests/SentryTests/SentryNSURLRequestTests.swift
@@ -22,11 +22,11 @@ class SentryNSURLRequestTests: XCTestCase {
     
     func testRequestWithEnvelopeEndpoint_hasUserAgentWithSdkNameAndVersion() {
         let request = try! SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        expect(request.allHTTPHeaderFields?["User-Agent"]).to(beginWith(String(format: "%@/%@", SentryMeta.sdkName, SentryMeta.versionString)))
+        expect(request.allHTTPHeaderFields?["User-Agent"]) == "\(SentryMeta.sdkName)/\(SentryMeta.versionString)"
     }
     
     func testRequestWithStoreEndpoint_hasUserAgentWithSdkNameAndVersion() {
         let request = try! SentryNSURLRequest(storeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        expect(request.allHTTPHeaderFields?["User-Agent"]).to(beginWith(String(format: "%@/%@", SentryMeta.sdkName, SentryMeta.versionString)))
+        expect(request.allHTTPHeaderFields?["User-Agent"]) == "\(SentryMeta.sdkName)/\(SentryMeta.versionString)"
     }
 }


### PR DESCRIPTION
## :scroll: Description

adds SDK version to the User-Agent reported when using SentryNSURLRequest for /envelope and /store endpoints

#skip-changelog

## :bulb: Motivation and Context

fixes https://github.com/getsentry/sentry-cocoa/issues/3713

## :green_heart: How did you test it?

manual, unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] ~I updated the docs if needed.~
- [ ] ~Review from the native team if needed.~
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
