### PR TITLE
ref: Remove SentrySwift import for trace context

### DIFF
--- a/Sources/Sentry/SentryBaggage.m
+++ b/Sources/Sentry/SentryBaggage.m
@@ -4,6 +4,7 @@
 #import "SentryOptions+Private.h"
 #import "SentryScope+Private.h"
 #import "SentrySerialization.h"
+#import "SentrySwift.h"
 #import "SentryTraceContext.h"
 #import "SentryTracer.h"
 #import "SentryUser.h"

--- a/Sources/Sentry/include/SentryTraceContext.h
+++ b/Sources/Sentry/include/SentryTraceContext.h
@@ -4,15 +4,10 @@
 #    import "SentrySerializable.h"
 #endif
 
-#if __has_include(<Sentry/SentrySwift.h>)
-#    import <Sentry/SentrySwift.h>
-#else
-#    import "SentrySwift.h"
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryScope, SentryOptions, SentryTracer, SentryUser, SentryBaggage;
+@class SentryId;
 
 @interface SentryTraceContext : NSObject <SentrySerializable>
 


### PR DESCRIPTION
The SentryTraceContext doesn't need to SentrySwift import. It only needs a reference to SentryId.

#skip-changelog