### PR TITLE
ref: Expose SDKInfo to Swift SDK Code

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		622C08DB29E554B9002571D4 /* SentrySpanContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */; };
 		62375FB92B47F9F000CC55F1 /* SentryDependencyContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62375FB82B47F9F000CC55F1 /* SentryDependencyContainerTests.swift */; };
 		623C45B02A651D8200D9E88B /* SentryCoreDataTracker+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 623C45AF2A651D8200D9E88B /* SentryCoreDataTracker+Test.m */; };
+		6271ADF32BA06D9B0098D2E9 /* SentryInternalSerializable.h in Headers */ = {isa = PBXBuildFile; fileRef = 6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */; };
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
 		62862B1C2B1DDBC8009B16E3 /* SentryDelayedFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 62862B1B2B1DDBC8009B16E3 /* SentryDelayedFrame.h */; };
 		62862B1E2B1DDC35009B16E3 /* SentryDelayedFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 62862B1D2B1DDC35009B16E3 /* SentryDelayedFrame.m */; };
@@ -973,6 +974,7 @@
 		62375FB82B47F9F000CC55F1 /* SentryDependencyContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDependencyContainerTests.swift; sourceTree = "<group>"; };
 		623C45AE2A651C4500D9E88B /* SentryCoreDataTracker+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryCoreDataTracker+Test.h"; sourceTree = "<group>"; };
 		623C45AF2A651D8200D9E88B /* SentryCoreDataTracker+Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentryCoreDataTracker+Test.m"; sourceTree = "<group>"; };
+		6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalSerializable.h; path = include/SentryInternalSerializable.h; sourceTree = "<group>"; };
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		62862B1B2B1DDBC8009B16E3 /* SentryDelayedFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDelayedFrame.h; path = include/SentryDelayedFrame.h; sourceTree = "<group>"; };
 		62862B1D2B1DDC35009B16E3 /* SentryDelayedFrame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDelayedFrame.m; sourceTree = "<group>"; };
@@ -1955,6 +1957,7 @@
 				D8CB7416294724CC00A5F964 /* SentryEnvelopeAttachmentHeader.m */,
 				7BC852382458830A005A70F0 /* SentryEnvelopeItemType.h */,
 				6304360F1EC0600A00C4D3FA /* SentrySerializable.h */,
+				6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */,
 				639FCF961EBC7B9700778193 /* SentryEvent.h */,
 				639FCF971EBC7B9700778193 /* SentryEvent.m */,
 				D880E3B02860A5A0008A90DB /* SentryEvent+Private.h */,
@@ -3742,6 +3745,7 @@
 				7BE1E32824F7AE08009D3AD0 /* SentrySession+Private.h in Headers */,
 				7B5CAF7127F5953400ED0DB6 /* SentryEnvelope+Private.h in Headers */,
 				63FE713320DA4C1100CDBAE8 /* SentryCrashCPU.h in Headers */,
+				6271ADF32BA06D9B0098D2E9 /* SentryInternalSerializable.h in Headers */,
 				D8853C842833EABC00700D64 /* SentryANRTracker.h in Headers */,
 				63FE715B20DA4C1100CDBAE8 /* SentryCrashSignalInfo.h in Headers */,
 				63FE70E520DA4C1000CDBAE8 /* SentryCrashMonitor_CPPException.h in Headers */,

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -21,6 +21,7 @@
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 #import "PrivateSentrySDKOnly.h"
+#import "SentryAppStartMeasurement.h"
 #import "SentryAppState.h"
 #import "SentryClient+Private.h"
 #import "SentryClient+TestInit.h"

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -1,4 +1,5 @@
 #import "PrivateSentrySDKOnly.h"
+#import "SentryAppStartMeasurement.h"
 #import "SentryBreadcrumb+Private.h"
 #import "SentryClient.h"
 #import "SentryDebugImageProvider.h"

--- a/Sources/Sentry/SentryBaggage.m
+++ b/Sources/Sentry/SentryBaggage.m
@@ -4,6 +4,7 @@
 #import "SentryOptions+Private.h"
 #import "SentryScope+Private.h"
 #import "SentrySerialization.h"
+#import "SentrySwift.h"
 #import "SentryTraceContext.h"
 #import "SentryTracer.h"
 #import "SentryUser.h"

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -1,11 +1,14 @@
 #import "PrivatesHeader.h"
-#import "SentryAppStartMeasurement.h"
-#import "SentryEnvelope.h"
-#import "SentryEnvelopeItemType.h"
 #import "SentryScreenFrames.h"
 
-@class SentryDebugMeta, SentryAppStartMeasurement, SentryScreenFrames, SentryOptions,
-    SentryBreadcrumb, SentryUser;
+@class SentryDebugMeta;
+@class SentryScreenFrames;
+@class SentryAppStartMeasurement;
+@class SentryOptions;
+@class SentryBreadcrumb;
+@class SentryUser;
+@class SentryEnvelope;
+@class SentryId;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryInternalSerializable.h
+++ b/Sources/Sentry/include/SentryInternalSerializable.h
@@ -1,0 +1,18 @@
+#import "SentryDefines.h"
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Use this protocol for internal ObjC classes that are exposed to Swift code by adding them to
+ * SentryPrivate.h instead of SentrySerializable because CocoaPods throws duplicate header warnings
+ * when running pod lib lint when using a public protocol on such classes.
+ */
+@protocol SentryInternalSerializable <NSObject>
+SENTRY_NO_INIT
+
+- (NSDictionary<NSString *, id> *)serialize;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -2,4 +2,5 @@
 
 #import "SentryBaseIntegration.h"
 #import "SentryRandom.h"
+#import "SentrySdkInfo.h"
 #import "SentryTime.h"

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -1,5 +1,10 @@
-#import "SentrySerializable.h"
 #import <Foundation/Foundation.h>
+
+#if __has_include(<Sentry/SentrySerializable.h>)
+#    import <Sentry/SentrySerializable.h>
+#else
+#    import "SentrySerializable.h"
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -1,10 +1,5 @@
+#import "SentryDefines.h"
 #import <Foundation/Foundation.h>
-
-#if __has_include(<Sentry/SentrySerializable.h>)
-#    import <Sentry/SentrySerializable.h>
-#else
-#    import "SentrySerializable.h"
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Both name and version are required.
  * @see https://develop.sentry.dev/sdk/event-payloads/sdk/
  */
-@interface SentrySdkInfo : NSObject <SentrySerializable>
+@interface SentrySdkInfo : NSObject
 SENTRY_NO_INIT
 
 /**
@@ -34,6 +29,8 @@ SENTRY_NO_INIT
 - (instancetype)initWithDict:(NSDictionary *)dict;
 
 - (instancetype)initWithDict:(NSDictionary *)dict orDefaults:(SentrySdkInfo *)info;
+
+- (NSDictionary<NSString *, id> *)serialize;
 
 @end
 

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -1,10 +1,5 @@
+#import "SentrySerializable.h"
 #import <Foundation/Foundation.h>
-
-#if __has_include(<Sentry/SentrySerializable.h>)
-#    import <Sentry/SentrySerializable.h>
-#else
-#    import "SentrySerializable.h"
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentryInternalSerializable.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -8,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @note Both name and version are required.
  * @see https://develop.sentry.dev/sdk/event-payloads/sdk/
  */
-@interface SentrySdkInfo : NSObject
+@interface SentrySdkInfo : NSObject <SentryInternalSerializable>
 SENTRY_NO_INIT
 
 /**
@@ -29,8 +30,6 @@ SENTRY_NO_INIT
 - (instancetype)initWithDict:(NSDictionary *)dict;
 
 - (instancetype)initWithDict:(NSDictionary *)dict orDefaults:(SentrySdkInfo *)info;
-
-- (NSDictionary<NSString *, id> *)serialize;
 
 @end
 

--- a/Sources/Sentry/include/SentrySpan.h
+++ b/Sources/Sentry/include/SentrySpan.h
@@ -4,7 +4,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryTracer, SentryId, SentrySpanId, SentryFrame, SentrySpanContext;
-@protocol SentrySerializable;
 
 #if SENTRY_HAS_UIKIT
 @class SentryFramesTracker;

--- a/Sources/Sentry/include/SentryTraceContext.h
+++ b/Sources/Sentry/include/SentryTraceContext.h
@@ -4,15 +4,10 @@
 #    import "SentrySerializable.h"
 #endif
 
-#if __has_include(<Sentry/SentrySwift.h>)
-#    import <Sentry/SentrySwift.h>
-#else
-#    import "SentrySwift.h"
-#endif
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryScope, SentryOptions, SentryTracer, SentryUser, SentryBaggage;
+@class SentryId;
 
 @interface SentryTraceContext : NSObject <SentrySerializable>
 

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -162,7 +162,6 @@
 #import "SentryScreenFrames.h"
 #import "SentryScreenshot.h"
 #import "SentryScreenshotIntegration.h"
-#import "SentrySdkInfo.h"
 #import "SentrySwift.h"
 #import "SentrySwiftAsyncIntegration.h"
 

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -137,6 +137,13 @@ When making an Objective-C class public for Swift SDK code, do the following:
 * Add the import `@_implementationOnly import _SentryPrivate` to your Swift class that wants to use
 the Objective-C class.
 
+## Public Protocols
+
+pod lib lint fails with the warning duplicate protocol definition when including a public header for
+a protocol in a private ObjC class header, when adding that header to `SentryPrivate.h` to expose it
+to internal SDK Swift code, as `SentrySDKInfo.h`. To solve this problem we have to use the
+`SentryInternalSerializable` for internal classes implementing serializable.
+
 ### Detailed explanation of the Swift and Objective-C Interoperability setup
 
 The SentrySDK uses Swift and Objective-C code. Public Objective-C classes, made public


### PR DESCRIPTION
This is the first step of exposing the Client to Swift SDK code. I'm doing this in multiple steps because CI keeps failing for https://github.com/getsentry/sentry-cocoa/pull/3724, and I'm unable to track down the problem.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/3726.
 
#skip-changelog