### PR TITLE
ref: Remove forward declarations for Envelope

### DIFF
--- a/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelope.h
@@ -8,8 +8,12 @@
 
 #endif
 
-@class SentryEvent, SentrySession, SentryId, SentryUserFeedback, SentryAttachment,
-    SentryTransaction, SentryClientReport, SentryEnvelopeItemHeader;
+@class SentryEvent;
+@class SentrySession;
+@class SentryId;
+@class SentryUserFeedback;
+@class SentryAttachment;
+@class SentryEnvelopeItemHeader;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryEnvelope+Private.h
+++ b/Sources/Sentry/include/SentryEnvelope+Private.h
@@ -2,6 +2,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SentryClientReport;
+
 @interface
 SentryEnvelopeItem ()
 


### PR DESCRIPTION
Having unused forward declarations in the SentryEnvelope.h doesn't make sense and makes it harder to expose that specific class to Swift. Therefore, we can remove them.

#skip-changelog