### PR TITLE
feat: reuse the vendorIdentifier if already fetched.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Remove SentryPrivate library (#3623)
+- Cache "vendorIdentifier" (#3734)
 
 ### Fixes
 

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -181,17 +181,15 @@ SentryAppStateManager ()
     bool isDebugging = self.crashWrapper.isBeingTraced;
 
     UIDevice *device = [UIDevice currentDevice];
-    
-    // Prevent multiple calls to UIDevice.currentDevice.identifierForVendor in a short period of time, thereby violating privacy compliance requirements in China Mainland.
-    NSString *vendorId = self.vendorIdentifier;
-    if (self.vendorIdentifier.length == 0) {
-        vendorId = [device.identifierForVendor UUIDString];
-        self.vendorIdentifier = vendorId;
+
+    // Prevent multiple calls to UIDevice.currentDevice.identifierForVendor by caching it
+    if (self.vendorIdentifier == nil) {
+        self.vendorIdentifier = [device.identifierForVendor UUIDString];
     }
 
     return [[SentryAppState alloc] initWithReleaseName:self.options.releaseName
                                              osVersion:device.systemVersion
-                                              vendorId:vendorId
+                                              vendorId:self.vendorIdentifier
                                            isDebugging:isDebugging
                                    systemBootTimestamp:SentryDependencyContainer.sharedInstance
                                                            .sysctlWrapper.systemBootTimestamp];

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -26,6 +26,7 @@ SentryAppStateManager ()
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) SentryNSNotificationCenterWrapper *notificationCenterWrapper;
 @property (nonatomic) NSInteger startCount;
+@property (nonatomic, copy) NSString *vendorIdentifier;
 
 @end
 
@@ -180,7 +181,13 @@ SentryAppStateManager ()
     bool isDebugging = self.crashWrapper.isBeingTraced;
 
     UIDevice *device = [UIDevice currentDevice];
-    NSString *vendorId = [device.identifierForVendor UUIDString];
+    
+    // Prevent multiple calls to UIDevice.currentDevice.identifierForVendor in a short period of time, thereby violating privacy compliance requirements in China Mainland.
+    NSString *vendorId = self.vendorIdentifier;
+    if (self.vendorIdentifier.length == 0) {
+        vendorId = [device.identifierForVendor UUIDString];
+        self.vendorIdentifier = vendorId;
+    }
 
     return [[SentryAppState alloc] initWithReleaseName:self.options.releaseName
                                              osVersion:device.systemVersion


### PR DESCRIPTION
## :scroll: Description

Reuse the `vendorIdentifier` if already fetched beforehand.Due to the China mainland privacy policy, apps cannot call the UIDevice.currentDevice.identifierForVendor multiple times in a short period of time.So to simultaneously use Sentry SDK and  meet the privacy policy.It's maybe the simplest solution that I could figure out right now😂

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
