### PR TITLE
chore: Add synchronized extension for NSLock

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -84,6 +84,8 @@
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
 		62862B1C2B1DDBC8009B16E3 /* SentryDelayedFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 62862B1B2B1DDBC8009B16E3 /* SentryDelayedFrame.h */; };
 		62862B1E2B1DDC35009B16E3 /* SentryDelayedFrame.m in Sources */ = {isa = PBXBuildFile; fileRef = 62862B1D2B1DDC35009B16E3 /* SentryDelayedFrame.m */; };
+		62872B5F2BA1B7F300A4FA7D /* NSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B5E2BA1B7F300A4FA7D /* NSLock.swift */; };
+		62872B632BA1B86100A4FA7D /* NSLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B622BA1B86100A4FA7D /* NSLockTests.swift */; };
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
@@ -978,6 +980,8 @@
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		62862B1B2B1DDBC8009B16E3 /* SentryDelayedFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDelayedFrame.h; path = include/SentryDelayedFrame.h; sourceTree = "<group>"; };
 		62862B1D2B1DDC35009B16E3 /* SentryDelayedFrame.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDelayedFrame.m; sourceTree = "<group>"; };
+		62872B5E2BA1B7F300A4FA7D /* NSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLock.swift; sourceTree = "<group>"; };
+		62872B622BA1B86100A4FA7D /* NSLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLockTests.swift; sourceTree = "<group>"; };
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
 		62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionContextTests.swift; sourceTree = "<group>"; };
 		629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReachabilitySwiftTests.swift; sourceTree = "<group>"; };
@@ -1899,6 +1903,22 @@
 			path = Helper;
 			sourceTree = "<group>";
 		};
+		62872B602BA1B84400A4FA7D /* Swift */ = {
+			isa = PBXGroup;
+			children = (
+				62872B612BA1B84C00A4FA7D /* Extensions */,
+			);
+			path = Swift;
+			sourceTree = "<group>";
+		};
+		62872B612BA1B84C00A4FA7D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				62872B622BA1B86100A4FA7D /* NSLockTests.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		630436001EBCB87500C4D3FA /* Networking */ = {
 			isa = PBXGroup;
 			children = (
@@ -2269,6 +2289,7 @@
 		63AA75931EB8AEDB00D153DE /* SentryTests */ = {
 			isa = PBXGroup;
 			children = (
+				62872B602BA1B84400A4FA7D /* Swift */,
 				7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */,
 				D8BC83BA2AFCF08C00A662B7 /* SentryUIApplication+Private.h */,
 				84281C652A58A16500EE88F2 /* SentryProfiler+Test.h */,
@@ -3506,6 +3527,7 @@
 			isa = PBXGroup;
 			children = (
 				D8F016B52B962548007B9AFB /* StringExtensions.swift */,
+				62872B5E2BA1B7F300A4FA7D /* NSLock.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4233,6 +4255,7 @@
 				6304360B1EC0595B00C4D3FA /* NSData+SentryCompression.m in Sources */,
 				639889B81EDECFA800EA7442 /* SentryBreadcrumbTracker.m in Sources */,
 				84AF45A729A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm in Sources */,
+				62872B5F2BA1B7F300A4FA7D /* NSLock.swift in Sources */,
 				7DC8310C2398283C0043DD9A /* SentryCrashIntegration.m in Sources */,
 				03F84D3227DD4191008FE43F /* SentryProfiler.mm in Sources */,
 				635B3F391EBC6E2500A6176D /* SentryAsynchronousOperation.m in Sources */,
@@ -4525,6 +4548,7 @@
 				7BC6EC04255C235F0059822A /* SentryFrameTests.swift in Sources */,
 				0AE455AD28F584D2006680E5 /* SentryReachabilityTests.m in Sources */,
 				63FE720420DA66EC00CDBAE8 /* SentryCrashString_Tests.m in Sources */,
+				62872B632BA1B86100A4FA7D /* NSLockTests.swift in Sources */,
 				849AC40029E0C1FF00889C16 /* SentryFormatterTests.swift in Sources */,
 				7BDDE3CC2966BD4700EB9177 /* SentryMXManagerTests.swift in Sources */,
 				7BC6EC0C255C3DF80059822A /* SentryThreadTests.swift in Sources */,

--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension NSLock {
+    
+    /// Executes the closure while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    func synchronized(_ closure: () throws -> Void) rethrows {
+        self.lock()
+        defer { self.unlock() }
+        try closure()
+    }
+}

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -1,0 +1,47 @@
+import Nimble
+@testable import Sentry
+import XCTest
+
+final class NSLockTests: XCTestCase {
+
+    func testLockForIncrement() throws {
+        let lock = NSLock()
+        
+        var value = 0
+        
+        testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 9, writeWork: { _ in
+            lock.synchronized {
+                value += 1
+            }
+        })
+        
+        expect(value) == 100
+    }
+    
+    func testUnlockWhenThrowing() throws {
+        let lock = NSLock()
+        
+        let errorMessage = "It's broken"
+        do {
+            try lock.synchronized {
+                throw NSLockError.runtimeError(errorMessage)
+            }
+        } catch NSLockError.runtimeError(let actualErrorMessage) {
+            expect(actualErrorMessage) == errorMessage
+        }
+        
+        let expectation = expectation(description: "Lock should be non blocking")
+        
+        DispatchQueue.global().async {
+            lock.synchronized {
+                expectation.fulfill()
+            }
+        }
+        
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    enum NSLockError: Error {
+        case runtimeError(String)
+    }
+}


### PR DESCRIPTION
Add a synchronized extension for NSLock for a convenient way to synchronize a closure call in Swift.

This is required to synchronize access to the buckets for DDM.

#skip-changelog