### PR TITLE
ref: Swift NSLock return value

### DIFF
--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -12,4 +12,13 @@ extension NSLock {
         self.lock()
         return try closure()
     }
+    
+    /// Executes the closure while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    func synchronized(_ closure: () throws -> Void) rethrows {
+        defer { self.unlock() }
+        self.lock()
+        try closure()
+    }
 }

--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -12,13 +12,4 @@ extension NSLock {
         self.lock()
         return try closure()
     }
-    
-    /// Executes the closure while acquiring the lock.
-    ///
-    /// - Parameter closure: The closure to run.
-    func synchronized(_ closure: () throws -> Void) rethrows {
-        defer { self.unlock() }
-        self.lock()
-        try closure()
-    }
 }

--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -5,9 +5,11 @@ extension NSLock {
     /// Executes the closure while acquiring the lock.
     ///
     /// - Parameter closure: The closure to run.
-    func synchronized(_ closure: () throws -> Void) rethrows {
-        self.lock()
+    ///
+    /// - Returns:           The value the closure generated.
+    func synchronized<T>(_ closure: () throws -> T) rethrows -> T {
         defer { self.unlock() }
-        try closure()
+        self.lock()
+        return try closure()
     }
 }

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -10,7 +10,7 @@ final class NSLockTests: XCTestCase {
         var value = 0
         
         testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 9, writeWork: { _ in
-            let returnValue = lock.synchronized {
+            let returnValue: Int = lock.synchronized {
                 value += 1
                 return 10
             }

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -10,12 +10,18 @@ final class NSLockTests: XCTestCase {
         var value = 0
         
         testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 9, writeWork: { _ in
+            let returnValue = lock.synchronized {
+                value += 1
+                return 10
+            }
+            expect(returnValue) == 10
+            
             lock.synchronized {
                 value += 1
             }
         })
         
-        expect(value) == 100
+        expect(value) == 200
     }
     
     func testUnlockWhenThrowing() throws {


### PR DESCRIPTION
Use generics to allow a return value for NSLock synchronized.

#skip-changelog