### PR TITLE
chore(ddm): Add MetricsClient with statsd encoding

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -76,6 +76,11 @@
 		620379DB2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h in Headers */ = {isa = PBXBuildFile; fileRef = 620379DA2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h */; };
 		620379DD2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m in Sources */ = {isa = PBXBuildFile; fileRef = 620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */; };
 		621D9F2F2B9B0320003D94DE /* SentryCurrentDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621D9F2E2B9B0320003D94DE /* SentryCurrentDateProvider.swift */; };
+		62262B862BA1C46D004DA3DD /* SentryStatsdClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 62262B852BA1C46D004DA3DD /* SentryStatsdClient.h */; };
+		62262B882BA1C490004DA3DD /* SentryStatsdClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 62262B872BA1C490004DA3DD /* SentryStatsdClient.m */; };
+		62262B8B2BA1C4C1004DA3DD /* EncodeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */; };
+		62262B8D2BA1C4DB004DA3DD /* Metric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B8C2BA1C4DB004DA3DD /* Metric.swift */; };
+		62262B912BA1C520004DA3DD /* CounterMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B902BA1C520004DA3DD /* CounterMetric.swift */; };
 		622C08D829E546F4002571D4 /* SentryTraceOrigins.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D729E546F4002571D4 /* SentryTraceOrigins.h */; };
 		622C08DB29E554B9002571D4 /* SentrySpanContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */; };
 		62375FB92B47F9F000CC55F1 /* SentryDependencyContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62375FB82B47F9F000CC55F1 /* SentryDependencyContainerTests.swift */; };
@@ -95,6 +100,9 @@
 		62A456E32B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */; };
 		62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */; };
 		62B86CFC29F052BB008F3947 /* SentryTestLogConfig.m in Sources */ = {isa = PBXBuildFile; fileRef = 62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */; };
+		62BAD74E2BA1C58D00EBAAFC /* EncodeMetricTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B952BA1C564004DA3DD /* EncodeMetricTests.swift */; };
+		62BAD7502BA1C5AF00EBAAFC /* SentryMetricsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BAD74F2BA1C5AF00EBAAFC /* SentryMetricsClientTests.swift */; };
+		62BAD7572BA2033F00EBAAFC /* SentryMetricsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BAD7552BA202C300EBAAFC /* SentryMetricsClient.swift */; };
 		62C1AFAB2B7E10EA0038C5F7 /* SentrySpotlightTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = 62C1AFAA2B7E10EA0038C5F7 /* SentrySpotlightTransport.m */; };
 		62C25C862B075F4900C68CBD /* TestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C25C852B075F4900C68CBD /* TestOptions.swift */; };
 		62C316812B1F2E93000D7031 /* SentryDelayedFramesTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 62C316802B1F2E93000D7031 /* SentryDelayedFramesTracker.h */; };
@@ -971,6 +979,12 @@
 		620379DA2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBuildAppStartSpans.h; path = include/SentryBuildAppStartSpans.h; sourceTree = "<group>"; };
 		620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBuildAppStartSpans.m; sourceTree = "<group>"; };
 		621D9F2E2B9B0320003D94DE /* SentryCurrentDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCurrentDateProvider.swift; sourceTree = "<group>"; };
+		62262B852BA1C46D004DA3DD /* SentryStatsdClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryStatsdClient.h; path = include/SentryStatsdClient.h; sourceTree = "<group>"; };
+		62262B872BA1C490004DA3DD /* SentryStatsdClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryStatsdClient.m; sourceTree = "<group>"; };
+		62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeMetrics.swift; sourceTree = "<group>"; };
+		62262B8C2BA1C4DB004DA3DD /* Metric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metric.swift; sourceTree = "<group>"; };
+		62262B902BA1C520004DA3DD /* CounterMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterMetric.swift; sourceTree = "<group>"; };
+		62262B952BA1C564004DA3DD /* EncodeMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeMetricTests.swift; sourceTree = "<group>"; };
 		622C08D729E546F4002571D4 /* SentryTraceOrigins.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTraceOrigins.h; path = include/SentryTraceOrigins.h; sourceTree = "<group>"; };
 		622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySpanContext+Private.h"; path = "include/SentrySpanContext+Private.h"; sourceTree = "<group>"; };
 		62375FB82B47F9F000CC55F1 /* SentryDependencyContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDependencyContainerTests.swift; sourceTree = "<group>"; };
@@ -990,6 +1004,8 @@
 		62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUIEventTrackerTransactionMode.h; path = include/SentryUIEventTrackerTransactionMode.h; sourceTree = "<group>"; };
 		62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryUIEventTrackerTransactionMode.m; sourceTree = "<group>"; };
 		62B86CFB29F052BB008F3947 /* SentryTestLogConfig.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTestLogConfig.m; sourceTree = "<group>"; };
+		62BAD74F2BA1C5AF00EBAAFC /* SentryMetricsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsClientTests.swift; sourceTree = "<group>"; };
+		62BAD7552BA202C300EBAAFC /* SentryMetricsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsClient.swift; sourceTree = "<group>"; };
 		62C1AFA92B7E10D30038C5F7 /* SentrySpotlightTransport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpotlightTransport.h; path = include/SentrySpotlightTransport.h; sourceTree = "<group>"; };
 		62C1AFAA2B7E10EA0038C5F7 /* SentrySpotlightTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpotlightTransport.m; sourceTree = "<group>"; };
 		62C25C852B075F4900C68CBD /* TestOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestOptions.swift; sourceTree = "<group>"; };
@@ -1903,9 +1919,39 @@
 			path = Helper;
 			sourceTree = "<group>";
 		};
+		62262B842BA1C453004DA3DD /* Metrics */ = {
+			isa = PBXGroup;
+			children = (
+				62262B852BA1C46D004DA3DD /* SentryStatsdClient.h */,
+				62262B872BA1C490004DA3DD /* SentryStatsdClient.m */,
+			);
+			name = Metrics;
+			sourceTree = "<group>";
+		};
+		62262B892BA1C4B0004DA3DD /* Metrics */ = {
+			isa = PBXGroup;
+			children = (
+				62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */,
+				62BAD7552BA202C300EBAAFC /* SentryMetricsClient.swift */,
+				62262B8C2BA1C4DB004DA3DD /* Metric.swift */,
+				62262B902BA1C520004DA3DD /* CounterMetric.swift */,
+			);
+			path = Metrics;
+			sourceTree = "<group>";
+		};
+		62262B942BA1C550004DA3DD /* Metrics */ = {
+			isa = PBXGroup;
+			children = (
+				62262B952BA1C564004DA3DD /* EncodeMetricTests.swift */,
+				62BAD74F2BA1C5AF00EBAAFC /* SentryMetricsClientTests.swift */,
+			);
+			path = Metrics;
+			sourceTree = "<group>";
+		};
 		62872B602BA1B84400A4FA7D /* Swift */ = {
 			isa = PBXGroup;
 			children = (
+				62262B942BA1C550004DA3DD /* Metrics */,
 				62872B612BA1B84C00A4FA7D /* Extensions */,
 			);
 			path = Swift;
@@ -2348,6 +2394,7 @@
 		63AA75C61EB8B06100D153DE /* Sentry */ = {
 			isa = PBXGroup;
 			children = (
+				62262B842BA1C453004DA3DD /* Metrics */,
 				630436031EC058FA00C4D3FA /* Categories */,
 				639889D51EDF10BE00EA7442 /* Helper */,
 				630436001EBCB87500C4D3FA /* Networking */,
@@ -3355,6 +3402,7 @@
 		D800942328F82E8D005D3943 /* Swift */ = {
 			isa = PBXGroup;
 			children = (
+				62262B892BA1C4B0004DA3DD /* Metrics */,
 				621D9F2D2B9B030E003D94DE /* Helper */,
 				D8F016B42B962533007B9AFB /* Extensions */,
 				7BF65060292B8EFE00BBA5A8 /* MetricKit */,
@@ -3575,6 +3623,7 @@
 				D88817DA26D72AB800BF2251 /* SentryTraceContext.h in Headers */,
 				7B6C5F8126034354007F7DFF /* SentryWatchdogTerminationLogic.h in Headers */,
 				63FE708520DA4C1000CDBAE8 /* SentryCrashReportFilter.h in Headers */,
+				62262B862BA1C46D004DA3DD /* SentryStatsdClient.h in Headers */,
 				84354E1129BF944900CDBB8B /* SentryProfileTimeseries.h in Headers */,
 				D8ACE3CD2762187D00F5A213 /* SentryNSDataSwizzling.h in Headers */,
 				7B08A3452924CF6C0059603A /* SentryMetricKitIntegration.h in Headers */,
@@ -4130,6 +4179,7 @@
 				8453421628BE8A9500C22EEC /* SentrySpanStatus.m in Sources */,
 				7B9657262683104C00C66E25 /* NSData+Sentry.m in Sources */,
 				7B08A3472924CF9C0059603A /* SentryMetricKitIntegration.m in Sources */,
+				62262B8B2BA1C4C1004DA3DD /* EncodeMetrics.swift in Sources */,
 				7B63459B280EB9E200CFA05A /* SentryUIEventTrackingIntegration.m in Sources */,
 				15E0A8ED240F2CB000F044E3 /* SentrySerialization.m in Sources */,
 				7BC85235245880AE005A70F0 /* SentryDataCategoryMapper.m in Sources */,
@@ -4225,6 +4275,7 @@
 				7B6C5EDC264E8DA80010D138 /* SentryFramesTrackingIntegration.m in Sources */,
 				63295AF71EF3C7DB002D4490 /* NSDictionary+SentrySanitize.m in Sources */,
 				7B8ECBFC26498958005FE2EF /* SentryAppStateManager.m in Sources */,
+				62262B8D2BA1C4DB004DA3DD /* Metric.swift in Sources */,
 				7B2A70DD27D6083D008B0D15 /* SentryThreadWrapper.m in Sources */,
 				D8ACE3C72762187200F5A213 /* SentryNSDataSwizzling.m in Sources */,
 				638DC9A11EBC6B6400A66E41 /* SentryRequestOperation.m in Sources */,
@@ -4239,6 +4290,7 @@
 				63BE85711ECEC6DE00DC44F5 /* NSDate+SentryExtras.m in Sources */,
 				7BD4BD4927EB2A5D0071F4FF /* SentryDiscardedEvent.m in Sources */,
 				03F84D3827DD4191008FE43F /* SentryBacktrace.cpp in Sources */,
+				62BAD7572BA2033F00EBAAFC /* SentryMetricsClient.swift in Sources */,
 				63FE712720DA4C1000CDBAE8 /* SentryCrashThread.c in Sources */,
 				7B127B0F27CF6F4700A71ED2 /* SentryANRTrackingIntegration.m in Sources */,
 				62C316832B1F2EA1000D7031 /* SentryDelayedFramesTracker.m in Sources */,
@@ -4272,6 +4324,7 @@
 				63FE712D20DA4C1100CDBAE8 /* SentryCrashJSONCodecObjC.m in Sources */,
 				7BBD18932449BEDD00427C76 /* SentryDefaultRateLimits.m in Sources */,
 				7BD729982463E93500EA3610 /* SentryDateUtil.m in Sources */,
+				62262B882BA1C490004DA3DD /* SentryStatsdClient.m in Sources */,
 				639FCF9D1EBC7F9500778193 /* SentryThread.m in Sources */,
 				8E8C57A225EEFC07001CEEFA /* SentrySampling.m in Sources */,
 				8454CF8D293EAF9A006AC140 /* SentryMetricProfiler.mm in Sources */,
@@ -4334,6 +4387,7 @@
 				63FE714520DA4C1100CDBAE8 /* SentryCrashObjC.c in Sources */,
 				63FE710520DA4C1000CDBAE8 /* SentryCrashLogger.c in Sources */,
 				0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */,
+				62262B912BA1C520004DA3DD /* CounterMetric.swift in Sources */,
 				639FCF991EBC7B9700778193 /* SentryEvent.m in Sources */,
 				632F43521F581D5400A18A36 /* SentryCrashExceptionApplication.m in Sources */,
 				620379DD2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m in Sources */,
@@ -4476,6 +4530,7 @@
 				7B87C916295ECFD700510C52 /* SentryMetricKitEventTests.swift in Sources */,
 				7B6D98ED24C703F8005502FA /* Async.swift in Sources */,
 				7BA0C04C28056556003E0326 /* SentryTransportAdapterTests.swift in Sources */,
+				62BAD74E2BA1C58D00EBAAFC /* EncodeMetricTests.swift in Sources */,
 				7BE0DC29272A9E1C004FA8B7 /* SentryBreadcrumbTrackerTests.swift in Sources */,
 				63FE722520DA66EC00CDBAE8 /* SentryCrashFileUtils_Tests.m in Sources */,
 				7BFC16BA2524D4AF00FF6266 /* SentryMessage+Equality.m in Sources */,
@@ -4571,6 +4626,7 @@
 				7B4F22DC294089530067EA17 /* FormatHexAddress.swift in Sources */,
 				8EAC7FF8265C8910005B44E5 /* SentryTracerTests.swift in Sources */,
 				0A1B497328E597DD00D7BFA3 /* TestLogOutput.swift in Sources */,
+				62BAD7502BA1C5AF00EBAAFC /* SentryMetricsClientTests.swift in Sources */,
 				D8CB742E294B294B00A5F964 /* MockUIScene.m in Sources */,
 				7BA61CBD247BC6B900C130A8 /* TestSentryCrashBinaryImageProvider.swift in Sources */,
 				7BFA69F627E0840400233199 /* SentryANRTrackingIntegrationTests.swift in Sources */,

--- a/Sources/Sentry/SentryStatsdClient.m
+++ b/Sources/Sentry/SentryStatsdClient.m
@@ -1,0 +1,52 @@
+#import "SentryStatsdClient.h"
+#import "SentryClient+Private.h"
+#import "SentryEnvelope.h"
+#import "SentryEnvelopeItemHeader.h"
+#import "SentryEnvelopeItemType.h"
+#import "SentrySwift.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface
+SentryStatsdClient ()
+
+@property (nonatomic, strong) SentryClient *client;
+
+@end
+
+@implementation SentryStatsdClient
+
+- (instancetype)initWithClient:(SentryClient *)client
+{
+    if (self = [super init]) {
+        self.client = client;
+    }
+
+    return self;
+}
+
+- (void)captureStatsdEncodedData:(NSData *)statsdEncodedData
+{
+    if (statsdEncodedData.length == 0) {
+        return;
+    }
+
+    SentryEnvelopeItemHeader *header =
+        [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeStatsd
+                                                length:statsdEncodedData.length
+                                           contentType:@"application/octet-stream"];
+
+    SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithHeader:header
+                                                                     data:statsdEncodedData];
+
+    SentryEnvelopeHeader *envelopeHeader =
+        [[SentryEnvelopeHeader alloc] initWithId:[[SentryId alloc] init]];
+    NSArray *items = @[ item ];
+    SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader items:items];
+
+    [self.client captureEnvelope:envelope];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -4,4 +4,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentryRandom.h"
 #import "SentrySdkInfo.h"
+#import "SentryStatsdClient.h"
 #import "SentryTime.h"

--- a/Sources/Sentry/include/SentryStatsdClient.h
+++ b/Sources/Sentry/include/SentryStatsdClient.h
@@ -1,0 +1,16 @@
+#import "SentryDefines.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SentryClient;
+
+@interface SentryStatsdClient : NSObject
+SENTRY_NO_INIT
+
+- (instancetype)initWithClient:(SentryClient *)client;
+
+- (void)captureStatsdEncodedData:(NSData *)statsdEncodedData;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Metrics/CounterMetric.swift
+++ b/Sources/Swift/Metrics/CounterMetric.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+class CounterMetric: Metric {
+
+    private var value: Double = 0.0
+    var weight: UInt = 1
+
+    init(key: String, unit: MeasurementUnit, tags: [String: String]) {
+        super.init(type: .counter, key: key, unit: unit, tags: tags)
+    }
+
+    func add(value: Double) {
+        self.value += value
+    }
+
+    func serialize() -> [String] {
+        return ["\(value)"]
+    }
+
+}

--- a/Sources/Swift/Metrics/EncodeMetrics.swift
+++ b/Sources/Swift/Metrics/EncodeMetrics.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Encodes the metrics into a Statsd compatible format.
+/// See https://github.com/statsd/statsd#usage and https://getsentry.github.io/relay/relay_metrics/index.html for more details about the format.
+func encodeToStatsd(flushableBuckets: [BucketTimestamp: [Metric]]) -> Data {
+    var statsdString = ""
+
+    for bucket in flushableBuckets {
+        let timestamp = bucket.key
+        let buckets = bucket.value
+        for metric in buckets {
+
+            statsdString.append(sanitize(key: metric.key))
+            statsdString.append("@")
+
+            statsdString.append(metric.unit.unit)
+
+            for serializedValue in metric.serialize() {
+                statsdString.append(":\(serializedValue)")
+            }
+
+            statsdString.append("|")
+            statsdString.append(metric.type.rawValue)
+
+            var firstTag = true
+            for (tagKey, tagValue) in metric.tags {
+                let sanitizedTagKey = sanitize(key: tagKey)
+
+                if firstTag {
+                    statsdString.append("|#")
+                    firstTag = false
+                } else {
+                    statsdString.append(",")
+                }
+
+                statsdString.append("\(sanitizedTagKey):")
+                statsdString.append(sanitize(value: tagValue))
+            }
+
+            statsdString.append("|T")
+            statsdString.append("\(timestamp)")
+            statsdString.append("\n")
+        }
+    }
+
+    return statsdString.data(using: .utf8) ?? Data()
+}
+
+private func sanitize(key: String) -> String {
+    return key.replacingOccurrences(of: "[^a-zA-Z0-9_/.-]+", with: "_", options: .regularExpression)
+}
+
+private func sanitize(value: String) -> String {
+    return value.replacingOccurrences(of: "[^\\w\\d\\s_:/@\\.\\{\\}\\[\\]$-]+", with: "", options: .regularExpression)
+}

--- a/Sources/Swift/Metrics/Metric.swift
+++ b/Sources/Swift/Metrics/Metric.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+/// The bucket timestamp is calculated:
+///     ( timeIntervalSince1970 / ROLLUP_IN_SECONDS ) * ROLLUP_IN_SECONDS
+typealias BucketTimestamp = UInt64
+private let ROLLUP_IN_SECONDS: TimeInterval = 10
+
+typealias Metric = MetricBase & MetricProtocol
+
+protocol MetricProtocol {
+
+    var weight: UInt { get }
+    func add(value: Double)
+    func serialize() -> [String]
+}
+
+class MetricBase {
+
+    let type: MetricType
+    let key: String
+    let unit: MeasurementUnit
+    let tags: [String: String]
+
+    init(type: MetricType, key: String, unit: MeasurementUnit, tags: [String: String]) {
+        self.type = type
+        self.key = key
+        self.unit = unit
+        self.tags = tags
+    }
+}
+
+enum MetricType: Character {
+    case counter = "c"
+    case gauge = "g"
+    case distribution = "d"
+    case set = "s"
+}

--- a/Sources/Swift/Metrics/SentryMetricsClient.swift
+++ b/Sources/Swift/Metrics/SentryMetricsClient.swift
@@ -1,0 +1,19 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+@objc class SentryMetricsClient: NSObject {
+    
+    /// Exposing envelopes to Swift code is challenging because the
+    /// SentryEnvelope.h is part of the podspec SentryHybridPublic, which causes
+    /// problems. As the envelope logic is simple, we keep it in ObjC and do the
+    /// rest in Swift.
+    private let client: SentryStatsdClient
+    
+    @objc init(client: SentryStatsdClient) {
+        self.client = client
+    }
+    
+    func capture(flushableBuckets: [BucketTimestamp: [Metric]]) {        
+        client.captureStatsdEncodedData(encodeToStatsd(flushableBuckets: flushableBuckets))
+    }
+}

--- a/Tests/SentryTests/Swift/Metrics/EncodeMetricTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/EncodeMetricTests.swift
@@ -1,0 +1,80 @@
+import Nimble
+@testable import Sentry
+import SentryTestUtils
+import XCTest
+
+final class EncodeMetricTests: XCTestCase {
+
+    func testEncodeCounterMetricWithoutTags() {
+        let counterMetric = CounterMetric(key: "app.start", unit: .none, tags: [:])
+        counterMetric.add(value: 1.0)
+
+        let data = encodeToStatsd(flushableBuckets: [12_345: [counterMetric]])
+
+        expect(data.decodeStatsd()) == "app.start@:1.0|c|T12345\n"
+    }
+
+    func testEncodeCounterMetricWithFractionalPart() {
+        let counterMetric = CounterMetric(key: "app.start", unit: MeasurementUnitDuration.second, tags: [:])
+        counterMetric.add(value: 1.123456)
+
+        let data = encodeToStatsd(flushableBuckets: [10_234: [counterMetric]])
+
+        expect(data.decodeStatsd()) == "app.start@second:1.123456|c|T10234\n"
+    }
+
+    func testEncodeCounterMetricWithOneTag() {
+        let counterMetric = CounterMetric(key: "app.start", unit: MeasurementUnitDuration.second, tags: ["key": "value"])
+        counterMetric.add(value: 10.1)
+
+        let data = encodeToStatsd(flushableBuckets: [10_234: [counterMetric]])
+
+        expect(data.decodeStatsd()) == "app.start@second:10.1|c|#key:value|T10234\n"
+    }
+
+    func testEncodeCounterMetricWithTwoTags() {
+        let counterMetric = CounterMetric(key: "app.start", unit: MeasurementUnitDuration.second, tags: ["key1": "value1", "key2": "value2"])
+        counterMetric.add(value: 10.1)
+
+        let data = encodeToStatsd(flushableBuckets: [10_234: [counterMetric]])
+
+        expect(data.decodeStatsd()).to(beginWith("app.start@second:10.1|c|"))
+        expect(data.decodeStatsd()).to(endWith("|T10234\n"))
+        expect(data.decodeStatsd()).to(contain("key1:value1"))
+        expect(data.decodeStatsd()).to(contain("key2:value2"))
+    }
+
+    func testEncodeCounterMetricWithKeyToSanitize() {
+        let counterMetric = CounterMetric(key: "abyzABYZ09_/.-!@a#$Äa", unit: MeasurementUnitDuration.second, tags: [:])
+        counterMetric.add(value: 10.1)
+
+        let data = encodeToStatsd(flushableBuckets: [10_234: [counterMetric]])
+
+        expect(data.decodeStatsd()) == "abyzABYZ09_/.-_a_a@second:10.1|c|T10234\n"
+    }
+
+    func testEncodeCounterMetricWithTagKeyToSanitize() {
+        let counterMetric = CounterMetric(key: "app.start", unit: MeasurementUnitDuration.second, tags: ["abyzABYZ09_/.-!@a#$Äa": "value"])
+        counterMetric.add(value: 10.1)
+
+        let data = encodeToStatsd(flushableBuckets: [10_234: [counterMetric]])
+
+        expect(data.decodeStatsd()) == "app.start@second:10.1|c|#abyzABYZ09_/.-_a_a:value|T10234\n"
+    }
+
+    func testEncodeCounterMetricWithTagValueToSanitize() {
+        let counterMetric = CounterMetric(key: "app.start", unit: MeasurementUnitDuration.second, tags: ["key": #"azAZ1 _:/@.{}[]$\%^&a*"#])
+
+        counterMetric.add(value: 10.1)
+
+        let data = encodeToStatsd(flushableBuckets: [10_234: [counterMetric]])
+
+        expect(data.decodeStatsd()) == "app.start@second:10.1|c|#key:azAZ1 _:/@.{}[]$a|T10234\n"
+    }
+}
+
+private extension Data {
+    func decodeStatsd() -> String {
+        return String(data: self, encoding: .utf8) ?? ""
+    }
+}

--- a/Tests/SentryTests/Swift/Metrics/SentryMetricsClientTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/SentryMetricsClientTests.swift
@@ -1,0 +1,45 @@
+import _SentryPrivate
+import Nimble
+@testable import Sentry
+import SentryTestUtils
+import XCTest
+
+final class SentryMetricsClientTests: XCTestCase {
+
+    func testCaptureMetricsWithCounterMetric() throws {
+        let testClient = try XCTUnwrap(TestClient(options: Options()))
+
+        let sut = SentryMetricsClient(client: SentryStatsdClient(client: testClient))
+
+        let metric = CounterMetric(key: "app.start", unit: MeasurementUnitDuration.second, tags: ["sentry": "awesome"])
+        let flushableBuckets: [BucketTimestamp: [Metric]] = [0: [metric]]
+        
+        let encodedMetricsData = encodeToStatsd(flushableBuckets: flushableBuckets)
+        
+        sut.capture(flushableBuckets: flushableBuckets)
+
+        expect(testClient.captureEnvelopeInvocations.count) == 1
+
+        let envelope = try XCTUnwrap(testClient.captureEnvelopeInvocations.first)
+        expect(envelope.header.eventId) != nil
+
+        expect(envelope.items.count) == 1
+        let envelopeItem = try XCTUnwrap(envelope.items.first)
+        expect(envelopeItem.header.type) == SentryEnvelopeItemTypeStatsd
+        expect(envelopeItem.header.contentType) == "application/octet-stream"
+        expect(envelopeItem.header.length) == UInt(encodedMetricsData.count)
+        expect(envelopeItem.data) == encodedMetricsData
+    }
+
+    func testCaptureMetricsWithNoMetrics() throws {
+        let testClient = try XCTUnwrap(TestClient(options: Options()))
+
+        let sut = SentryMetricsClient(client: SentryStatsdClient(client: testClient))
+
+        let flushableBuckets: [BucketTimestamp: [CounterMetric]] = [:]
+        sut.capture(flushableBuckets: flushableBuckets)
+
+        expect(testClient.captureEnvelopeInvocations.count) == 0
+    }
+
+}


### PR DESCRIPTION


## :scroll: Description

Add the MetricsClient, which uses statsd encoding to send metrics to Sentry.

#skip-changelog

## :bulb: Motivation and Context

This is another PR for adding DDM to the SDK.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
