### PR TITLE
ref: Expose DispatchQueueWrapper to Swift

### DIFF
--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -28,7 +28,6 @@
 #import "SentryCrashWrapper.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchFactory.h"
-#import "SentryDispatchQueueWrapper.h"
 #import "SentryDispatchSourceWrapper.h"
 #import "SentryEnvelope.h"
 #import "SentryFileManager+Test.h"

--- a/SentryTestUtils/TestDispatchFactory.swift
+++ b/SentryTestUtils/TestDispatchFactory.swift
@@ -1,5 +1,5 @@
+import _SentryPrivate
 import Foundation
-import Sentry
 
 public class TestDispatchFactory: SentryDispatchFactory {
     public var vendedSourceHandler: ((TestDispatchSourceWrapper) -> Void)?

--- a/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
+++ b/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
@@ -1,3 +1,4 @@
+import _SentryPrivate
 import Foundation
 
 /// A wrapper around `SentryDispatchQueueWrapper` that memoized invocations to its methods and allows customization of async logic, specifically: dispatch-after calls can be made to run immediately, or not at all.

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -2,6 +2,7 @@
 
 #import "SentryBaggage.h"
 #import "SentryBaseIntegration.h"
+#import "SentryDispatchQueueWrapper.h"
 #import "SentryRandom.h"
 #import "SentrySdkInfo.h"
 #import "SentryTime.h"

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -1,3 +1,4 @@
+import _SentryPrivate
 @testable import Sentry
 import SentryTestUtils
 import XCTest

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -47,7 +47,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
                 notificationCenterWrapper: SentryNSNotificationCenterWrapper()
             )
             
-            framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: currentDate, dispatchQueueWrapper: SentryDispatchQueueWrapper(), keepDelayedFramesDuration: 0)
+            framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: currentDate, dispatchQueueWrapper: TestSentryDispatchQueueWrapper(), keepDelayedFramesDuration: 0)
             framesTracker.start()
             
             runtimeInitTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.2)

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -1,3 +1,4 @@
+import _SentryPrivate
 import Nimble
 import SentryTestUtils
 import XCTest

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -1,3 +1,4 @@
+import _SentryPrivate
 import Nimble
 import SentryTestUtils
 import XCTest

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -28,7 +28,7 @@ class SentrySubClassFinderTests: XCTestCase {
         }
         
         var sut: SentrySubClassFinder {
-            return SentrySubClassFinder(dispatchQueue: SentryDispatchQueueWrapper(), objcRuntimeWrapper: runtimeWrapper)
+            return SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: runtimeWrapper)
         }
     }
     

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -16,7 +16,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         var framesTracker: SentryFramesTracker
 
         init() {
-            framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: dateProvider, dispatchQueueWrapper: SentryDispatchQueueWrapper(), keepDelayedFramesDuration: 0)
+            framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: dateProvider, dispatchQueueWrapper: TestSentryDispatchQueueWrapper(), keepDelayedFramesDuration: 0)
             SentryDependencyContainer.sharedInstance().framesTracker = framesTracker
             framesTracker.start()
         }

--- a/Tests/SentryTests/Networking/SentryDispatchQueueWrapperTests.swift
+++ b/Tests/SentryTests/Networking/SentryDispatchQueueWrapperTests.swift
@@ -1,3 +1,4 @@
+import _SentryPrivate
 import XCTest
 
 class SentryDispatchQueueWrapperTests: XCTestCase {

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -541,7 +541,7 @@ class SentrySpanTests: XCTestCase {
     
     private func givenFramesTracker() -> (TestDisplayLinkWrapper, SentryFramesTracker) {
         let displayLinkWrapper = TestDisplayLinkWrapper(dateProvider: self.fixture.currentDateProvider)
-        let framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: self.fixture.currentDateProvider, dispatchQueueWrapper: SentryDispatchQueueWrapper(), keepDelayedFramesDuration: 10)
+        let framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: self.fixture.currentDateProvider, dispatchQueueWrapper: TestSentryDispatchQueueWrapper(), keepDelayedFramesDuration: 10)
         framesTracker.start()
         displayLinkWrapper.call()
         

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -1,3 +1,4 @@
+import _SentryPrivate
 import Nimble
 @testable import Sentry
 import SentryTestUtils


### PR DESCRIPTION
I also changed the usage of SentryDispatchQueueWrapper to TestSentryDispatchQueueWrapper in the test if possible.

This is required for DDM to send metrics on a background thread and for scheduling a repeating timer on the main thread.

#skip-changelog