### PR TITLE
test: disable flaky `SentrySDKTests.testStartOnTheMainThread`

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -74,6 +74,9 @@
                   Identifier = "SentrySDKIntegrationTestsBase">
                </Test>
                <Test
+                  Identifier = "SentrySDKTests/testStartOnTheMainThread()">
+               </Test>
+               <Test
                   Identifier = "SentrySessionGeneratorTests/testSendSessions()">
                </Test>
                <Test


### PR DESCRIPTION
Failed most recently in https://github.com/getsentry/sentry-cocoa/pull/3738 (https://github.com/getsentry/sentry-cocoa/actions/runs/8274761217/job/22640682547?pr=3738#step:13:56) but I see it fail fairly regularly.

#skip-changelog