### PR TITLE
test: disable flaky `SentryThreadWrapperTests.testOnMainThreadFromNonMainContext`

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -82,6 +82,9 @@
                <Test
                   Identifier = "SentryThreadInspectorTests/testStacktraceHasFrames_forEveryThread()">
                </Test>
+               <Test
+                  Identifier = "SentryThreadWrapperTests/testOnMainThreadFromNonMainContext()">
+               </Test>
             </SkippedTests>
          </TestableReference>
          <TestableReference


### PR DESCRIPTION
Failed most recently in https://github.com/getsentry/sentry-cocoa/pull/3738 (https://github.com/getsentry/sentry-cocoa/actions/runs/8274761217/job/22640682633?pr=3738#step:13:50) but I see it fail fairly regularly.

#skip-changelog