### PR TITLE
fix: Avoid duplicating loadView / viewDidLoad events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Write NSException reason for crash report (#3705)
 - Add context to event with CrashIntegration disabled (#3699)
+- Fixed certain views getting loaded twice when adding a child view controller (#3753)
 
 ## 8.21.0
 

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		84FB812A284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
 		84FB812B284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
 		8E8C57AF25EF16E6001CEEFA /* TraceTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */; };
+		B70038852BB33E7700065A38 /* ReplaceContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70038842BB33E7700065A38 /* ReplaceContentViewController.swift */; };
 		D80D021329EE93630084393D /* ErrorsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D021229EE93630084393D /* ErrorsViewController.swift */; };
 		D80D021A29EE936F0084393D /* ExtraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D021929EE936F0084393D /* ExtraViewController.swift */; };
 		D80D021B29EE9E3D0084393D /* ErrorsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D021229EE93630084393D /* ErrorsViewController.swift */; };
@@ -311,6 +312,7 @@
 		84FB8129284001B800F3A94A /* SentryBenchmarking.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryBenchmarking.mm; sourceTree = "<group>"; };
 		84FB812C2840021B00F3A94A /* iOS-Swift-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOS-Swift-Bridging-Header.h"; sourceTree = "<group>"; };
 		8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTestViewController.swift; sourceTree = "<group>"; };
+		B70038842BB33E7700065A38 /* ReplaceContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceContentViewController.swift; sourceTree = "<group>"; };
 		D80D021229EE93630084393D /* ErrorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorsViewController.swift; sourceTree = "<group>"; };
 		D80D021929EE936F0084393D /* ExtraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraViewController.swift; sourceTree = "<group>"; };
 		D8269A39274C095E00BD5BD5 /* iOS13-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS13-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -573,6 +575,7 @@
 				D8C33E1E29FBB1F70071B75A /* UIEventBreadcrumbsController.swift */,
 				D8F01DE92A1376B5008F4996 /* InfoForBreadcrumbController.swift */,
 				D8832B1D2AF52D0500C522B0 /* PageViewController.swift */,
+				B70038842BB33E7700065A38 /* ReplaceContentViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -942,6 +945,7 @@
 				D8DBDA78274D5FC400007380 /* SplitViewController.swift in Sources */,
 				84ACC43C2A73CB5900932A18 /* ProfilingNetworkScanner.swift in Sources */,
 				D80D021A29EE936F0084393D /* ExtraViewController.swift in Sources */,
+				B70038852BB33E7700065A38 /* ReplaceContentViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -19,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Cod-iq-tSj">
-                                <rect key="frame" x="30.5" y="123.5" width="259" height="336"/>
+                                <rect key="frame" x="30.5" y="109.5" width="259" height="364"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cdR-H3-8fr">
                                         <rect key="frame" x="0.0" y="0.0" width="259" height="28"/>
@@ -143,6 +143,15 @@
                                         <connections>
                                             <action selector="showPageController:" destination="BYZ-38-t0r" eventType="touchUpInside" id="593-oc-O0p"/>
                                             <action selector="uiClickTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UJy-CY-NIQ"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="csA-q7-7fD" userLabel="Page Controller">
+                                        <rect key="frame" x="0.0" y="336" width="259" height="28"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="pageControllerBtn"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <state key="normal" title="Container Controller"/>
+                                        <connections>
+                                            <segue destination="Ws2-CW-vfL" kind="show" id="Eh6-66-G6K"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -509,7 +518,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gz6-bT-PrL">
-                                <rect key="frame" x="65" y="85" width="190" height="35"/>
+                                <rect key="frame" x="65" y="85" width="190" height="38.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="extractInfoButton"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Extract Info from view"/>
@@ -546,6 +555,47 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="CJw-J7-n7w" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="995.625" y="-1275"/>
+        </scene>
+        <!--Replace Content View Controller-->
+        <scene sceneID="5K4-Io-L6g">
+            <objects>
+                <viewController id="Ws2-CW-vfL" customClass="ReplaceContentViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="teN-d0-AzK">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O3d-DK-XDH">
+                                <rect key="frame" x="86" y="101" width="148" height="39"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Replace content"/>
+                                <connections>
+                                    <action selector="tappedReplaceContent:" destination="Ws2-CW-vfL" eventType="touchUpInside" id="tw8-9q-NYb"/>
+                                </connections>
+                            </button>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wtH-El-bo1">
+                                <rect key="frame" x="40" y="148" width="240" height="378"/>
+                                <color key="backgroundColor" systemColor="systemGray5Color"/>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="ta7-jO-tqX"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="O3d-DK-XDH" firstAttribute="centerX" secondItem="teN-d0-AzK" secondAttribute="centerX" id="63x-VO-Ik9"/>
+                            <constraint firstItem="ta7-jO-tqX" firstAttribute="bottom" secondItem="wtH-El-bo1" secondAttribute="bottom" constant="42" id="Q7d-Rz-ECE"/>
+                            <constraint firstItem="wtH-El-bo1" firstAttribute="top" secondItem="O3d-DK-XDH" secondAttribute="bottom" constant="8" id="ZsK-bm-Xqe"/>
+                            <constraint firstItem="wtH-El-bo1" firstAttribute="centerX" secondItem="O3d-DK-XDH" secondAttribute="centerX" id="fH1-kc-J8s"/>
+                            <constraint firstItem="wtH-El-bo1" firstAttribute="leading" secondItem="ta7-jO-tqX" secondAttribute="leading" constant="40" id="yE9-X9-kgV"/>
+                            <constraint firstItem="O3d-DK-XDH" firstAttribute="top" secondItem="ta7-jO-tqX" secondAttribute="top" constant="37" id="yeg-iO-oAt"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="qcM-tE-U3i"/>
+                    <connections>
+                        <outlet property="containerView" destination="wtH-El-bo1" id="201-8T-zVY"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="9rb-4j-CaG" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1708" y="-1095"/>
         </scene>
         <!--Split View Controller-->
         <scene sceneID="6Nq-cD-DlA">
@@ -636,13 +686,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="40A-vG-dFA">
-                                <rect key="frame" x="0.0" y="64" width="320" height="246.5"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="250.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="fn9-mQ-2PY">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="118.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="122.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Q2k-6Y-RnD">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="118.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="122.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NFC-V3-lgW">
                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
@@ -653,7 +703,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Llv-Yz-cwF">
-                                                        <rect key="frame" x="0.0" y="30" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="31.5" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Capture NSException"/>
                                                         <connections>
@@ -661,7 +711,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJ4-gS-64G" userLabel="fatalError">
-                                                        <rect key="frame" x="0.0" y="60.5" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="63" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Throw FatalError"/>
                                                         <connections>
@@ -669,7 +719,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NYx-6R-0bb">
-                                                        <rect key="frame" x="0.0" y="90.5" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="94.5" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="OOM crash"/>
                                                         <connections>
@@ -679,7 +729,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="2CV-VI-MDY">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="118.5"/>
+                                                <rect key="frame" x="160" y="0.0" width="160" height="122.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zbo-2T-1Zm">
                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
@@ -708,7 +758,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJs-Av-cg2">
-                                                        <rect key="frame" x="0.0" y="84" width="160" height="34.5"/>
+                                                        <rect key="frame" x="0.0" y="84" width="160" height="38.5"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Use-after-free"/>
                                                         <connections>
@@ -720,7 +770,7 @@
                                         </subviews>
                                     </stackView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1zm-ho-TCr">
-                                        <rect key="frame" x="0.0" y="118.5" width="320" height="128"/>
+                                        <rect key="frame" x="0.0" y="122.5" width="320" height="128"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="128" id="lc6-97-p3W"/>
                                         </constraints>
@@ -1021,7 +1071,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YQi-VW-lsa">
-                                <rect key="frame" x="44.5" y="513" width="231" height="35"/>
+                                <rect key="frame" x="44.5" y="509.5" width="231" height="38.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="editingChangedButton"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Perform &quot;Editing Changed&quot;"/>
@@ -1030,7 +1080,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sL7-7x-NzY">
-                                <rect key="frame" x="49.5" y="461" width="221.5" height="35"/>
+                                <rect key="frame" x="49.5" y="454" width="221.5" height="38.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="editingDidEndButton"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Perform &quot;Editing Did End&quot;"/>
@@ -1075,6 +1125,9 @@
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/ReplaceContentViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/ReplaceContentViewController.swift
@@ -1,0 +1,99 @@
+//
+//  ReplaceContentViewController.swift
+//  iOS-Swift
+//
+//  Created by BJ Homer on 3/26/24.
+//  Copyright © 2024 Sentry. All rights reserved.
+//
+
+import UIKit
+
+class ReplaceContentViewController: UIViewController {
+
+    @IBOutlet var containerView: UIView!
+    private var currentChild: UIViewController!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Add the initial child controller
+        let childVC = LoadCountReportingViewController(color: UIColor.systemBlue)
+        self.addChild(childVC)
+        childVC.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        childVC.view.frame = containerView.bounds
+        containerView.addSubview(childVC.view)
+        childVC.didMove(toParent: self)
+
+        currentChild = childVC
+    }
+    
+    @IBAction func tappedReplaceContent(_ sender: Any) {
+        swapChild()
+    }
+
+    private func swapChild() {
+        let oldChild = currentChild!
+        let newChild = LoadCountReportingViewController(color: .systemPurple)
+
+        self.addChild(newChild)
+        oldChild.willMove(toParent: nil)
+
+        self.transition(from: oldChild,
+                        to: newChild,
+                        duration: 0.15,
+                        options: .transitionCrossDissolve,
+                        animations: {
+            newChild.view.frame = self.containerView.bounds
+        },
+                        completion: { (_) in
+            self.currentChild = newChild
+            newChild.didMove(toParent: self)
+            oldChild.removeFromParent()
+        })
+    }
+
+}
+
+// We're using this to test some code related to child view controllers.
+// The code has different behavior depending on whether the child
+// controller is a container view controller, so this needs to be a
+// container controller.
+private class LoadCountReportingViewController: UISplitViewController {
+    init(color: UIColor) {
+        self.color = color
+        super.init(nibName: nil, bundle: nil)
+    }
+    required init?(coder: NSCoder) {
+        fatalError("This controller does not support XIB or Storyboard initialization")
+    }
+
+    let color: UIColor
+    var loadCountLabel: UILabel?
+    private var loadCount: Int = 0
+
+    override func loadView() {
+
+        // swiftlint:disable prohibited_super_call
+        super.loadView()
+        // swiftlint:enable prohibited_super_call
+        loadCount += 1
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        if loadCountLabel == nil {
+            loadCountLabel = UILabel()
+            loadCountLabel!.accessibilityIdentifier = "LBL_LOAD_COUNT"
+            loadCountLabel!.translatesAutoresizingMaskIntoConstraints = false
+            self.view.addSubview(loadCountLabel!)
+            loadCountLabel!.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+            loadCountLabel!.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        }
+
+        loadCountLabel!.text = "loadView() called \(loadCount) times"
+
+        self.view.backgroundColor = self.color
+    }
+
+}

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/ReplaceContentViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/ReplaceContentViewController.swift
@@ -1,11 +1,3 @@
-//
-//  ReplaceContentViewController.swift
-//  iOS-Swift
-//
-//  Created by BJ Homer on 3/26/24.
-//  Copyright © 2024 Sentry. All rights reserved.
-//
-
 import UIKit
 
 class ReplaceContentViewController: UIViewController {

--- a/Samples/iOS-Swift/iOS-SwiftUITests/TopViewControllerTests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/TopViewControllerTests.swift
@@ -60,7 +60,18 @@ class TopViewControllerTests: BaseUITest {
         getTopBT.tap()
         XCTAssertEqual(lbTopVC.label, "RedViewController")
     }
-    
+
+    func testChildControllerLoadCount() {
+        app.buttons["Transactions"].tap()
+        app.buttons["Container Controller"].tap()
+
+        XCTAssertEqual(app.staticTexts["LBL_LOAD_COUNT"].label, "loadView() called 1 times")
+
+        app.buttons["Replace content"].tap()
+
+        XCTAssertEqual(app.staticTexts["LBL_LOAD_COUNT"].label, "loadView() called 1 times")
+    }
+
     func openInspector() {
         app.buttons["Extra"].tap()
         app.buttons["TOPVCBTN"].tap()

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -175,6 +175,7 @@
             // If the navigation is occupying the whole view controller we will consider this the
             // case.
             if ([self isContainerViewController:childVC]
+                && childVC.isViewLoaded
                 && CGRectEqualToRect(childVC.view.frame, topVC.view.bounds)) {
                 relevantChild = childVC;
                 break;


### PR DESCRIPTION
## :scroll: Description
When performance tracking is enabled, `loadView`'s swizzled implementation may result in a duplicate chain of events, that result in multiple `viewDidLoad` invocations, in our main app's VC/

Thanks in advance!!

## :bulb: Motivation and Context
Fixes #3753

## :green_heart: How did you test it?
I'm afraid I did not test this change. Sentry's `Package.swift` points towards a binary distribution, and because of time constraints, I've been unable to pull together a Package Description for local testing.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
