### PR TITLE
ci: fix job names for iOS-Swift UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -107,7 +107,7 @@ jobs:
 
     
   ios-swift-ui-tests:
-    name: iOS SwiftUI Tests ${{matrix.device}}
+    name: iOS-Swift UI Tests ${{matrix.device}}
     runs-on: ${{matrix.runs-on}}
     strategy:
       fail-fast: false


### PR DESCRIPTION
I've been trying to figure out why `ProfilingUITests` have been running in our SwiftUI sample app. Well, they weren't 😛 

#skip-changelog