### PR TITLE
chore: Make init uses bundle install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ init: setup-git
 	brew bundle
 	rbenv install --skip-existing
 	rbenv exec gem update bundler
-	rbenv exec bundle update
+	rbenv exec bundle install
 
 .PHONY: setup-git
 setup-git:


### PR DESCRIPTION
Make init now uses bundle install, which installs the gems specified in the gemfile, instead of bundle update, which updates the gems to the latest version specified in the gemfile.

#skip-changelog