### PR TITLE
chore: Remove SentryPrivate from version bump

### DIFF
--- a/Utils/VersionBump/main.swift
+++ b/Utils/VersionBump/main.swift
@@ -11,7 +11,6 @@ let files = [
     "./SentrySwiftUI.podspec",
     "./Sources/Sentry/SentryMeta.m",
     "./Sources/Configuration/Sentry.xcconfig",
-    "./Sources/Configuration/SentryPrivate.xcconfig",
     "./Sources/Configuration/SentrySwiftUI.xcconfig",
     "./Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj",
     "./Tests/HybridSDKTest/HybridPod.podspec"


### PR DESCRIPTION
We removed SentryPrivate with GH-3623, so we also have to remove it from the version bump.

The release workflow failed here https://github.com/getsentry/sentry-cocoa/actions/runs/8328632979/job/22789361830.

I tested it locally by running `make bump-version TO=9.0.0-rc.0`

#skip-changelog