### PR TITLE
fix: XCFramework Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixes 
+
+- Package.json xcframework path ()
+
 ## 8.22.0
+**Warning:** this version is not working with SPM
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes 
 
-- Package.json xcframework path ()
+- Package.json xcframework path (#3760)
 
 ## 8.22.0
 **Warning:** this version is not working with SPM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes 
 
-- Package.json xcframework path (#3760)
+- Checksum error when resolving the SDK via SPM (#3760)
 
 ## 8.22.0
 **Warning:** this version is not working with SPM

--- a/Package.swift
+++ b/Package.swift
@@ -12,12 +12,12 @@ let package = Package(
     targets: [
         .binaryTarget(
                     name: "Sentry",
-                    url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.22.0-alpha.0/Sentry.xcframework.zip",
+                    url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.22.0/Sentry.xcframework.zip",
                     checksum: "a6b8d72656318314baf3756c8a9cf4c923fa94abaaca4df0838ba04adcd3d246" //Sentry-Static
                 ),
         .binaryTarget(
                     name: "Sentry-Dynamic",
-                    url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.22.0-alpha.0/Sentry-Dynamic.xcframework.zip",
+                    url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.22.0/Sentry-Dynamic.xcframework.zip",
                     checksum: "410ffbb6eb325d579086b6434d720831b2984825f98496ff3f770dc1c532e32c" //Sentry-Dynamic
                 ),
         .target ( name: "SentrySwiftUI",


### PR DESCRIPTION
The path to the XCFramework in the package.json was incorrect before releasing the new version, so the bump tool did not properly update it.

Closes #3759 


