### PR TITLE
chore(metrics): Add BucketAggregator

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -85,6 +85,10 @@
 		622C08DB29E554B9002571D4 /* SentrySpanContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */; };
 		62375FB92B47F9F000CC55F1 /* SentryDependencyContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62375FB82B47F9F000CC55F1 /* SentryDependencyContainerTests.swift */; };
 		623C45B02A651D8200D9E88B /* SentryCoreDataTracker+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 623C45AF2A651D8200D9E88B /* SentryCoreDataTracker+Test.m */; };
+		626866722BA89641006995EA /* MetricsAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626866712BA89641006995EA /* MetricsAggregator.swift */; };
+		626866742BA89683006995EA /* BucketMetricsAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626866732BA89683006995EA /* BucketMetricsAggregatorTests.swift */; };
+		626866762BA896AD006995EA /* TestMetricsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626866752BA896AD006995EA /* TestMetricsClient.swift */; };
+		626866782BA89928006995EA /* BucketsMetricsAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626866772BA89928006995EA /* BucketsMetricsAggregator.swift */; };
 		6271ADF32BA06D9B0098D2E9 /* SentryInternalSerializable.h in Headers */ = {isa = PBXBuildFile; fileRef = 6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */; };
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
 		62862B1C2B1DDBC8009B16E3 /* SentryDelayedFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 62862B1B2B1DDBC8009B16E3 /* SentryDelayedFrame.h */; };
@@ -990,6 +994,10 @@
 		62375FB82B47F9F000CC55F1 /* SentryDependencyContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDependencyContainerTests.swift; sourceTree = "<group>"; };
 		623C45AE2A651C4500D9E88B /* SentryCoreDataTracker+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryCoreDataTracker+Test.h"; sourceTree = "<group>"; };
 		623C45AF2A651D8200D9E88B /* SentryCoreDataTracker+Test.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentryCoreDataTracker+Test.m"; sourceTree = "<group>"; };
+		626866712BA89641006995EA /* MetricsAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsAggregator.swift; sourceTree = "<group>"; };
+		626866732BA89683006995EA /* BucketMetricsAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketMetricsAggregatorTests.swift; sourceTree = "<group>"; };
+		626866752BA896AD006995EA /* TestMetricsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestMetricsClient.swift; sourceTree = "<group>"; };
+		626866772BA89928006995EA /* BucketsMetricsAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketsMetricsAggregator.swift; sourceTree = "<group>"; };
 		6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalSerializable.h; path = include/SentryInternalSerializable.h; sourceTree = "<group>"; };
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		62862B1B2B1DDBC8009B16E3 /* SentryDelayedFrame.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDelayedFrame.h; path = include/SentryDelayedFrame.h; sourceTree = "<group>"; };
@@ -1931,10 +1939,12 @@
 		62262B892BA1C4B0004DA3DD /* Metrics */ = {
 			isa = PBXGroup;
 			children = (
-				62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */,
-				62BAD7552BA202C300EBAAFC /* SentryMetricsClient.swift */,
 				62262B8C2BA1C4DB004DA3DD /* Metric.swift */,
 				62262B902BA1C520004DA3DD /* CounterMetric.swift */,
+				626866712BA89641006995EA /* MetricsAggregator.swift */,
+				626866772BA89928006995EA /* BucketsMetricsAggregator.swift */,
+				62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */,
+				62BAD7552BA202C300EBAAFC /* SentryMetricsClient.swift */,
 			);
 			path = Metrics;
 			sourceTree = "<group>";
@@ -1944,6 +1954,8 @@
 			children = (
 				62262B952BA1C564004DA3DD /* EncodeMetricTests.swift */,
 				62BAD74F2BA1C5AF00EBAAFC /* SentryMetricsClientTests.swift */,
+				626866732BA89683006995EA /* BucketMetricsAggregatorTests.swift */,
+				626866752BA896AD006995EA /* TestMetricsClient.swift */,
 			);
 			path = Metrics;
 			sourceTree = "<group>";
@@ -4356,6 +4368,8 @@
 				D8CAC0412BA0984500E38F34 /* SentryIntegrationProtocol.swift in Sources */,
 				63FE710F20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m in Sources */,
 				8ECC674925C23A20000E2BF6 /* SentrySpanId.m in Sources */,
+				626866722BA89641006995EA /* MetricsAggregator.swift in Sources */,
+				626866782BA89928006995EA /* BucketsMetricsAggregator.swift in Sources */,
 				6344DDB51EC309E000D9160D /* SentryCrashReportSink.m in Sources */,
 				8EAE9806261E87120073B6B3 /* SentryUIViewControllerPerformanceTracker.m in Sources */,
 				D88817D826D7149100BF2251 /* SentryTraceContext.m in Sources */,
@@ -4447,6 +4461,7 @@
 				8EE017A126704CD500470616 /* SentryUIViewControllerPerformanceTrackerTests.swift in Sources */,
 				7B18DE4428D9F8F6004845C6 /* TestNSNotificationCenterWrapper.swift in Sources */,
 				7B5B94352657AD21002E474B /* SentryFramesTrackingIntegrationTests.swift in Sources */,
+				626866762BA896AD006995EA /* TestMetricsClient.swift in Sources */,
 				8431EE5B29ADB8EA00D8DC56 /* SentryTimeTests.m in Sources */,
 				7B0A54562523178700A71716 /* SentryScopeSwiftTests.swift in Sources */,
 				7B5B94332657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift in Sources */,
@@ -4614,6 +4629,7 @@
 				7BA61CAF247BBF3C00C130A8 /* SentryDebugImageProviderTests.swift in Sources */,
 				7BB7E7C729267A28004BF96B /* EmptyIntegration.swift in Sources */,
 				7B965728268321CD00C66E25 /* SentryCrashScopeObserverTests.swift in Sources */,
+				626866742BA89683006995EA /* BucketMetricsAggregatorTests.swift in Sources */,
 				7BD86ECB264A6DB5005439DB /* TestSysctl.swift in Sources */,
 				7B0DC73428869BF40039995F /* NSMutableDictionarySentryTests.swift in Sources */,
 				7B6ADFCF26A02CAE0076C206 /* SentryCrashReportTests.swift in Sources */,

--- a/Sources/Swift/Metrics/BucketsMetricsAggregator.swift
+++ b/Sources/Swift/Metrics/BucketsMetricsAggregator.swift
@@ -1,0 +1,176 @@
+@_implementationOnly import _SentryPrivate
+
+/// The bucket timestamp is calculated:
+///     ( timeIntervalSince1970 / ROLLUP_IN_SECONDS ) * ROLLUP_IN_SECONDS
+typealias BucketTimestamp = UInt64
+let ROLLUP_IN_SECONDS: TimeInterval = 10
+
+extension SentryCurrentDateProvider {
+    var bucketTimestamp: BucketTimestamp {
+        let now = self.date()
+        let seconds = now.timeIntervalSince1970
+
+        return (UInt64(seconds) / UInt64(ROLLUP_IN_SECONDS)) * UInt64(ROLLUP_IN_SECONDS)
+    }
+}
+
+class BucketMetricsAggregator: MetricsAggregator {
+
+    private let client: SentryMetricsClient
+    private let currentDate: SentryCurrentDateProvider
+    private let dispatchQueue: SentryDispatchQueueWrapper
+    private let random: SentryRandomProtocol
+    private let totalMaxWeight: UInt
+    private let flushShift: TimeInterval
+    private let flushInterval: TimeInterval
+    private let flushTolerance: TimeInterval
+
+    private var timer: DispatchSourceTimer?
+    private var totalBucketsWeight: UInt = 0
+    private var buckets: [BucketTimestamp: [String: Metric]] = [:]
+    private let lock = NSLock()
+
+    convenience init(client: SentryMetricsClient, currentDate: SentryCurrentDateProvider, dispatchQueue: SentryDispatchQueueWrapper, random: SentryRandomProtocol) {
+
+        self.init(
+            client: client,
+            currentDate: currentDate,
+            dispatchQueue: dispatchQueue,
+            random: random,
+            totalMaxWeight: METRICS_AGGREGATOR_TOTAL_MAX_WEIGHT,
+            flushInterval: METRICS_AGGREGATOR_FLUSH_INTERVAL,
+            flushTolerance: METRICS_AGGREGATOR_FLUSH_TOLERANCE
+        )
+    }
+
+    init(
+        client: SentryMetricsClient,
+        currentDate: SentryCurrentDateProvider,
+        dispatchQueue: SentryDispatchQueueWrapper,
+        random: SentryRandomProtocol,
+        totalMaxWeight: UInt,
+        flushInterval: TimeInterval,
+        flushTolerance: TimeInterval
+    ) {
+        self.client = client
+        self.currentDate = currentDate
+        self.dispatchQueue = dispatchQueue
+        self.random = random
+
+        // The aggregator shifts its flushing by up to an entire rollup window to
+        // avoid multiple clients trampling on end of a 10 second window as all the
+        // buckets are anchored to multiples of ROLLUP seconds. We randomize this
+        // number once per aggregator boot to achieve some level of offsetting
+        // across a fleet of deployed SDKs.
+        let flushShift = random.nextNumber() * ROLLUP_IN_SECONDS
+        self.totalMaxWeight = totalMaxWeight
+        self.flushInterval = flushInterval
+        self.flushShift = flushShift
+        self.flushTolerance = flushTolerance
+
+        startTimer()
+    }
+
+    private func startTimer() {
+        let timer = DispatchSource.makeTimerSource(flags: [], queue: dispatchQueue.queue)
+
+        // Set leeway to reduce energy impact
+        let leewayInMilliseconds: Int = Int(flushTolerance * 1_000)
+        timer.schedule(deadline: .now() + flushInterval, repeating: self.flushInterval, leeway: .milliseconds(leewayInMilliseconds))
+        timer.setEventHandler { [weak self] in
+            self?.flush(force: false)
+        }
+        timer.activate()
+        self.timer = timer
+    }
+
+    func add(type: MetricType, key: String, value: Double, unit: MeasurementUnit, tags: [String: String]) {
+
+        // It's important to sort the tags in order to
+        // obtain the same bucket key.
+        let tagsKey = tags.sorted(by: { $0.key < $1.key }).description
+        let bucketKey = "\(type)_\(key)_\(unit.unit)_\(tagsKey)"
+
+        let bucketTimestamp = currentDate.bucketTimestamp
+
+        var isOverWeight = false
+
+        lock.synchronized {
+            var bucket = buckets[bucketTimestamp] ?? [:]
+
+            let metric = bucket[bucketKey] ?? CounterMetric(key: key, unit: unit, tags: tags)
+            let oldWeight = bucket[bucketKey]?.weight ?? 0
+
+            metric.add(value: value)
+            let addedWeight = metric.weight - oldWeight
+
+            bucket[bucketKey] = metric
+            totalBucketsWeight += addedWeight
+
+            buckets[bucketTimestamp] = bucket
+
+            let totalWeight = UInt(buckets.count) + totalBucketsWeight
+            isOverWeight = totalWeight >= totalMaxWeight
+        }
+
+        if isOverWeight {
+            dispatchQueue.dispatchAsync({ [weak self] in
+                self?.flush(force: true)
+            })
+        }
+    }
+
+    func flush(force: Bool) {
+        var flushableBuckets: [BucketTimestamp: [Metric]] = [:]
+
+        if force {
+            lock.synchronized {
+                for (timestamp, metrics) in buckets {
+                    flushableBuckets[timestamp] = Array(metrics.values)
+                }
+
+                buckets.removeAll()
+                totalBucketsWeight = 0
+            }
+        } else {
+            let cutoff = BucketTimestamp(currentDate.date().timeIntervalSince1970 - ROLLUP_IN_SECONDS - flushShift)
+
+            lock.synchronized {
+                for (bucketTimestamp, bucket) in buckets {
+                    if bucketTimestamp <= cutoff {
+                        flushableBuckets[bucketTimestamp] = Array(bucket.values)
+                    }
+                }
+
+                var weightToRemove: UInt = 0
+                for (bucketTimestamp, metrics) in flushableBuckets {
+                    for metric in metrics {
+                        weightToRemove += metric.weight
+                    }
+                    buckets.removeValue(forKey: bucketTimestamp)
+                }
+
+                totalBucketsWeight -= weightToRemove
+            }
+        }
+
+        if !flushableBuckets.isEmpty {
+            client.capture(flushableBuckets: flushableBuckets)
+        }
+    }
+
+    func close() {
+        self.flush(force: true)
+
+        cancelTimer()
+    }
+
+    deinit {
+        cancelTimer()
+    }
+
+    private func cancelTimer() {
+        self.timer?.cancel()
+        self.timer = nil
+    }
+}

--- a/Sources/Swift/Metrics/Metric.swift
+++ b/Sources/Swift/Metrics/Metric.swift
@@ -1,10 +1,5 @@
 import Foundation
 
-/// The bucket timestamp is calculated:
-///     ( timeIntervalSince1970 / ROLLUP_IN_SECONDS ) * ROLLUP_IN_SECONDS
-typealias BucketTimestamp = UInt64
-private let ROLLUP_IN_SECONDS: TimeInterval = 10
-
 typealias Metric = MetricBase & MetricProtocol
 
 protocol MetricProtocol {

--- a/Sources/Swift/Metrics/MetricsAggregator.swift
+++ b/Sources/Swift/Metrics/MetricsAggregator.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+let METRICS_AGGREGATOR_TOTAL_MAX_WEIGHT: UInt = 1_000
+let METRICS_AGGREGATOR_FLUSH_INTERVAL: TimeInterval = 10.0
+let METRICS_AGGREGATOR_FLUSH_TOLERANCE: TimeInterval = 0.5
+
+protocol MetricsAggregator {
+    func add(type: MetricType, key: String, value: Double, unit: MeasurementUnit, tags: [String: String])
+
+    func flush(force: Bool)
+    func close()
+}
+
+class NoOpMetricsAggregator: MetricsAggregator {
+
+    func add(type: MetricType, key: String, value: Double, unit: MeasurementUnit, tags: [String: String]) {
+        // empty on purpose
+    }
+
+    func flush(force: Bool) {
+        // empty on purpose
+    }
+
+    func close() {
+        // empty on purpose
+    }
+}

--- a/Tests/SentryTests/Swift/Metrics/BucketMetricsAggregatorTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/BucketMetricsAggregatorTests.swift
@@ -1,0 +1,340 @@
+@testable import _SentryPrivate
+import Nimble
+@testable import Sentry
+import SentryTestUtils
+import XCTest
+
+final class BucketMetricsAggregatorTests: XCTestCase {
+
+    private func getSut(totalMaxWeight: UInt = 4, flushShift: Double = 0.0, dispatchQueue: SentryDispatchQueueWrapper = TestSentryDispatchQueueWrapper()) throws -> (BucketMetricsAggregator, TestCurrentDateProvider, TestMetricsClient) {
+        let currentDate = TestCurrentDateProvider()
+        let metricsClient = try TestMetricsClient()
+        let random = TestRandom(value: flushShift)
+
+        return (BucketMetricsAggregator(client: metricsClient, currentDate: currentDate, dispatchQueue: dispatchQueue, random: random, totalMaxWeight: totalMaxWeight, flushInterval: 10.0, flushTolerance: 1.0), currentDate, metricsClient)
+    }
+
+    func testSameMetricAggregated_WhenInSameBucket() throws {
+        let (sut, currentDate, metricsClient) = try getSut()
+
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        currentDate.setDate(date: currentDate.date().advanced(by: 9.99))
+        sut.add(type: .counter, key: "key", value: 1.1, unit: MeasurementUnitDuration.day, tags: [:])
+
+        sut.flush(force: true)
+
+        expect(metricsClient.captureInvocations.count) == 1
+        let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
+
+        let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
+        expect(bucket.count) == 1
+        let counterMetric = try XCTUnwrap(bucket.first as? CounterMetric)
+
+        expect(counterMetric.key) == "key"
+        expect(counterMetric.serialize()) == ["2.1"]
+        expect(counterMetric.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric.tags) == [:]
+    }
+
+    func testFlushShift_MetricsUsuallyInSameBucket_AreInDifferent() throws {
+        let (sut, currentDate, metricsClient) = try getSut(flushShift: 0.1)
+
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        currentDate.setDate(date: currentDate.date().advanced(by: 9.99))
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        // Not flushing yet
+        currentDate.setDate(date: currentDate.date().advanced(by: 1.0))
+        sut.flush(force: false)
+        expect(metricsClient.captureInvocations.count) == 0
+
+        // This ends up in a different bucket
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        // Now we pass the flush shift threshold
+        currentDate.setDate(date: currentDate.date().advanced(by: 0.01))
+        sut.flush(force: false)
+
+        expect(metricsClient.captureInvocations.count) == 1
+        let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
+
+        let previousBucketTimestamp = currentDate.bucketTimestamp - 10
+        let bucket = try XCTUnwrap(buckets[previousBucketTimestamp])
+        expect(bucket.count) == 1
+        let counterMetric = try XCTUnwrap(bucket.first as? CounterMetric)
+
+        expect(counterMetric.key) == "key"
+        expect(counterMetric.serialize()) == ["2.0"]
+        expect(counterMetric.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric.tags) == [:]
+    }
+
+    func testDifferentMetrics_NotInSameBucket() throws {
+        let (sut, currentDate, metricsClient) = try getSut()
+
+        sut.add(type: .counter, key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: ["some": "tag", "and": "another-one"])
+        sut.add(type: .counter, key: "key2", value: 2.0, unit: MeasurementUnitDuration.day, tags: ["and": "another-one", "some": "tag"])
+
+        sut.flush(force: true)
+
+        expect(metricsClient.captureInvocations.count) == 1
+        let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
+
+        let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
+        expect(bucket.count) == 2
+
+        let counterMetric1 = try XCTUnwrap(bucket.first { $0.key == "key1" } as? CounterMetric)
+        expect(counterMetric1.key) == "key1"
+        expect(counterMetric1.serialize()) == ["1.0"]
+        expect(counterMetric1.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric1.tags) == ["some": "tag", "and": "another-one"]
+
+        let counterMetric2 = try XCTUnwrap(bucket.first { $0.key == "key2" } as? CounterMetric)
+        expect(counterMetric2.key) == "key2"
+        expect(counterMetric2.serialize()) == ["2.0"]
+        expect(counterMetric2.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric2.tags) == ["some": "tag", "and": "another-one"]
+    }
+
+    func testSameMetricDifferentTag_NotInSameBucket() throws {
+        let (sut, currentDate, metricsClient) = try getSut()
+
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: ["some": "tag"])
+        sut.add(type: .counter, key: "key", value: 2.0, unit: MeasurementUnitDuration.day, tags: ["some": "other-tag"])
+
+        sut.flush(force: true)
+
+        expect(metricsClient.captureInvocations.count) == 1
+        let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
+
+        let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
+        expect(bucket.count) == 2
+
+        let counterMetric1 = try XCTUnwrap(bucket.first { $0.tags == ["some": "tag"] } as? CounterMetric)
+        expect(counterMetric1.key) == "key"
+        expect(counterMetric1.serialize()) == ["1.0"]
+        expect(counterMetric1.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric1.tags) == ["some": "tag"]
+
+        let counterMetric2 = try XCTUnwrap(bucket.first { $0.tags == ["some": "other-tag"] } as? CounterMetric)
+        expect(counterMetric2.key) == "key"
+        expect(counterMetric2.serialize()) == ["2.0"]
+        expect(counterMetric2.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric2.tags) == ["some": "other-tag"]
+    }
+
+    func testSameMetricNotAggregated_WhenNotInSameBucket() throws {
+        let (sut, currentDate, metricsClient) = try getSut(totalMaxWeight: 5)
+
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        currentDate.setDate(date: currentDate.date().advanced(by: 10.0))
+        sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        sut.flush(force: true)
+
+        expect(metricsClient.captureInvocations.count) == 1
+        let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
+
+        expect(buckets.count) == 2
+
+        let bucket1 = try XCTUnwrap(buckets.values.first)
+        expect(bucket1.count) == 1
+        let counterMetric1 = try XCTUnwrap(bucket1.first as? CounterMetric)
+
+        expect(counterMetric1.key) == "key"
+        expect(counterMetric1.serialize()) == ["1.0"]
+        expect(counterMetric1.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric1.tags) == [:]
+
+        let bucket2 = try XCTUnwrap(Array(buckets.values).last)
+        let counterMetric2 = try XCTUnwrap(bucket2.first as? CounterMetric)
+
+        expect(counterMetric2.key) == "key"
+        expect(counterMetric2.serialize()) == ["1.0"]
+        expect(counterMetric2.unit.unit) == MeasurementUnitDuration.day.unit
+        expect(counterMetric2.tags) == [:]
+    }
+
+    func testCallFlushWhenOverweight() throws {
+        let (sut, _, metricsClient) = try getSut(totalMaxWeight: 3, dispatchQueue: SentryDispatchQueueWrapper())
+
+        let expectation = expectation(description: "Before capture block called")
+        metricsClient.beforeCaptureBlock = {
+            expect(Thread.isMainThread).to(equal(false), description: "Flush must be called on a background thread, but was called on the main thread.")
+            expectation.fulfill()
+        }
+
+        sut.add(type: .counter, key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        sut.add(type: .counter, key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        wait(for: [expectation], timeout: 1.0)
+        expect(metricsClient.captureInvocations.count) == 1
+    }
+    
+    func testConvenienceInit_SetsCorrectMaxWeight() throws {
+        let metricsClient = try TestMetricsClient()
+        let sut = BucketMetricsAggregator(client: metricsClient, currentDate: TestCurrentDateProvider(), dispatchQueue: TestSentryDispatchQueueWrapper(), random: SentryRandom())
+
+        for i in 0..<998 {
+            sut.add(type: .counter, key: "key\(i)", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        }
+        
+        // Total weight is now 999 because the bucket counts for one
+        // So nothing should be sent
+        expect(metricsClient.captureInvocations.count) == 0
+        
+        // Now we pass the 1000 threshold
+        sut.add(type: .counter, key: "another key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        expect(metricsClient.captureInvocations.count) == 1
+    }
+
+    func testFlushOnlyWhenNeeded() throws {
+        let (sut, currentDate, metricsClient) = try getSut(totalMaxWeight: 5)
+
+        sut.add(type: .counter, key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        sut.flush(force: false)
+        expect(metricsClient.captureInvocations.invocations.count) == 0
+
+        currentDate.setDate(date: currentDate.date().advanced(by: 9.99))
+        sut.flush(force: false)
+        expect(metricsClient.captureInvocations.invocations.count) == 0
+
+        currentDate.setDate(date: currentDate.date().advanced(by: 0.01))
+        sut.add(type: .counter, key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        sut.flush(force: false)
+        let buckets1 = try XCTUnwrap(metricsClient.captureInvocations.first)
+        expect(buckets1.count) == 1
+        expect(buckets1.values.count) == 1
+
+        // Key2 wasn't flushed. We increment it to 2.0
+        sut.add(type: .counter, key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        // The weight should be 2 now, so we need to add 3 more to trigger a flush
+        sut.add(type: .counter, key: "key3", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        sut.add(type: .counter, key: "key4", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        sut.add(type: .counter, key: "key5", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        expect(metricsClient.captureInvocations.count) == 2
+        let buckets2 = try XCTUnwrap(metricsClient.captureInvocations.invocations[1])
+
+        expect(buckets2.count) == 1
+        let bucket = try XCTUnwrap(buckets2.first)
+
+        // All 4 metrics should be in the bucket
+        expect(bucket.value.count) == 4
+
+        // Check that key2 was incremented
+        let counterMetric = try XCTUnwrap(bucket.value.first { $0.key == "key2" } as? CounterMetric)
+        expect(counterMetric.serialize()) == ["2.0"]
+    }
+
+    func testInitStartsRepeatingTimer() throws {
+        let currentDate = TestCurrentDateProvider()
+        let metricsClient = try TestMetricsClient()
+
+        // Start the flush timer with very high interval
+        let sut = BucketMetricsAggregator(client: metricsClient, currentDate: currentDate, dispatchQueue: SentryDispatchQueueWrapper(), random: SentryRandom(), totalMaxWeight: 1_000, flushInterval: 0.000001, flushTolerance: 0.0)
+
+        let expectation = expectation(description: "Adding metrics")
+        expectation.expectedFulfillmentCount = 100
+
+        // Keep adding metrics async so the flush timer has a few chances to
+        // send metrics
+        for i in 0..<100 {
+            DispatchQueue.global().async {
+                sut.add(type: .counter, key: "key\(i)", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+                currentDate.setDate(date: currentDate.date().advanced(by: 10.0))
+
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+
+        expect(metricsClient.captureInvocations.count).to(beGreaterThan(0), description: "Repeating flush timer should send some metrics.")
+    }
+
+    func testClose_InvalidatesTimer() throws {
+        let currentDate = TestCurrentDateProvider()
+        let metricsClient = try TestMetricsClient()
+
+        // Start the flush timer with very high interval
+        let sut = BucketMetricsAggregator(client: metricsClient, currentDate: currentDate, dispatchQueue: SentryDispatchQueueWrapper(), random: SentryRandom(), totalMaxWeight: 1_000, flushInterval: 0.000001, flushTolerance: 0.0)
+
+        sut.close()
+
+        let expectation = expectation(description: "Adding metrics")
+        expectation.expectedFulfillmentCount = 100
+
+        // Keep adding metrics async so the flush timer has a few chances to
+        // send metrics
+        for i in 0..<100 {
+            DispatchQueue.global().async {
+                sut.add(type: .counter, key: "key\(i)", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+                currentDate.setDate(date: currentDate.date().advanced(by: 10.0))
+
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+
+        expect(metricsClient.captureInvocations.count).to(equal(0), description: "No metrics should be sent cause the flush timer should be cancelled.")
+    }
+
+    func testFlashCalledOnCallingThread() throws {
+        let (sut, _, metricsClient) = try getSut(dispatchQueue: SentryDispatchQueueWrapper())
+
+        let expectation = expectation(description: "Before capture block called")
+        metricsClient.beforeCaptureBlock = {
+            expect(Thread.isMainThread).to(equal(true), description: "Flush must be called on the calling thread, but was called on a background thread.")
+            expectation.fulfill()
+        }
+
+        sut.add(type: .counter, key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        sut.add(type: .counter, key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        sut.flush(force: true)
+
+        wait(for: [expectation], timeout: 1.0)
+        expect(metricsClient.captureInvocations.count) == 1
+    }
+
+    func testCloseCallsFlush() throws {
+        let (sut, _, metricsClient) = try getSut()
+
+        sut.add(type: .counter, key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+        sut.add(type: .counter, key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
+
+        sut.close()
+
+        expect(metricsClient.captureInvocations.count) == 1
+    }
+    
+    func testWriteMultipleMetricsInParallel_NonForceFlush_DoesNotCrash() throws {
+        let currentDate = TestCurrentDateProvider()
+        let metricsClient = try TestMetricsClient()
+
+        // Start the flush timer with very high interval
+        let sut = BucketMetricsAggregator(client: metricsClient, currentDate: currentDate, dispatchQueue: SentryDispatchQueueWrapper(), random: SentryRandom(), totalMaxWeight: 1_000, flushInterval: 0.001, flushTolerance: 0.0)
+        
+        testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 1_000, writeWork: { i in
+            sut.add(type: .counter, key: "key\(i)", value: 1.1, unit: .none, tags: ["some": "tag"])
+            currentDate.setDate(date: currentDate.date().advanced(by: 0.01))
+        })
+        
+        sut.close()
+    }
+    
+    func testWriteMultipleMetricsInParallel_ForceFlush_DoesNotCrash() throws {
+        let (sut, _, _) = try getSut(totalMaxWeight: 5)
+        
+        testConcurrentModifications(asyncWorkItems: 10, writeLoopCount: 1_000, writeWork: { i in
+            sut.add(type: .counter, key: "key\(i)", value: 1.1, unit: .none, tags: ["some": "tag"])
+        })
+    }
+}

--- a/Tests/SentryTests/Swift/Metrics/TestMetricsClient.swift
+++ b/Tests/SentryTests/Swift/Metrics/TestMetricsClient.swift
@@ -1,0 +1,22 @@
+import _SentryPrivate
+import Foundation
+@testable import Sentry
+import SentryTestUtils
+import XCTest
+
+class TestMetricsClient: SentryMetricsClient {
+
+    init() throws {
+        let testClient = try XCTUnwrap(TestClient(options: Options()))
+        let statsdClient = SentryStatsdClient(client: testClient)
+
+        super.init(client: statsdClient)
+    }
+
+    var beforeCaptureBlock: (() -> Void)?
+    var captureInvocations = Invocations<[BucketTimestamp: [Metric]]>()
+    override func capture(flushableBuckets: [BucketTimestamp: [Metric]]) {
+        beforeCaptureBlock?()
+        captureInvocations.record(flushableBuckets)
+    }
+}


### PR DESCRIPTION
Add BucketMetricsAggregator to aggregate metrics in timestamp buckets to avoid sending multiple HTTP requests for every added metric.

This is part of adding DDM to the SDK https://github.com/getsentry/sentry-cocoa/issues/3631.

#skip-changelog