### PR TITLE
fix: Hybrid SDKs without SentryPrivate

### DIFF
--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -1,5 +1,6 @@
 #import "PrivatesHeader.h"
 #import "SentryScreenFrames.h"
+#import "SentrySwift.h"
 
 @class SentryDebugMeta;
 @class SentryScreenFrames;


### PR DESCRIPTION
## :scroll: Description

We need to update some references in order for HybridSDKs to work properly