### PR TITLE
fix: Sentry.framework does not support the minimum OS Version specified in the Info.plist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Sentry.framework does not support the minimum OS Version specified in the Info.plist ()
+- Sentry.framework does not support the minimum OS Version specified in the Info.plist (#3774)
 
 ## 8.22.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Sentry.framework does not support the minimum OS Version specified in the Info.plist ()
+
 ## 8.22.2
 
 - Fix runtime error when including Sentry as a static lib (#3764)

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -42,8 +42,7 @@ Pod::Spec.new do |s|
   
   s.subspec 'HybridSDK' do |sp|
       sp.source_files = "Sources/Sentry/**/*.{h,hpp,m,mm,c,cpp}",
-        "Sources/SentryCrash/**/*.{h,hpp,m,mm,c,cpp}", "Sources/Swift/**/*.{swift,h,hpp,m,mm,c,cpp}",
-        "Sources/Sentry/include/module.modulemap"
+        "Sources/SentryCrash/**/*.{h,hpp,m,mm,c,cpp}", "Sources/Swift/**/*.{swift,h,hpp,m,mm,c,cpp}"
         
       sp.public_header_files =
         "Sources/Sentry/Public/*.h", "Sources/Sentry/include/HybridPublic/*.h"

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-sdks=( iphoneos ) # iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
+sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
 
 rm -rf Carthage/
 mkdir Carthage

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-sdks=( iphoneos ) #iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
+sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
 
 rm -rf Carthage/
 mkdir Carthage
@@ -55,8 +55,8 @@ generate_xcframework() {
     $createxcframework
 }
 
-#generate_xcframework "Sentry" "-Dynamic"
+generate_xcframework "Sentry" "-Dynamic"
 
 generate_xcframework "Sentry" "" staticlib
 
-#generate_xcframework "SentrySwiftUI"
+generate_xcframework "SentrySwiftUI"

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -26,6 +26,10 @@ generate_xcframework() {
 
             if [ "$MACH_O_TYPE" = "staticlib" ]; then
                 local infoPlist="Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/Products/Library/Frameworks/${scheme}.framework/Info.plist"
+                
+                if [ ! -e "$infoPlist" ]; then
+                    infoPlist="Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/Products/Library/Frameworks/${scheme}.framework/Resources/Info.plist"
+                fi
                 plutil -replace "MinimumOSVersion" -string "9999" "$infoPlist"
             fi
             

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
+sdks=( iphoneos ) # iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
 
 rm -rf Carthage/
 mkdir Carthage
@@ -20,7 +20,7 @@ generate_xcframework() {
     
     for sdk in "${sdks[@]}"; do
         if [[ -n "$(grep "${sdk}" <<< "$ALL_SDKS")" ]]; then
-            xcodebuild archive -project Sentry.xcodeproj/ -scheme "$scheme" -configuration Release -sdk "$sdk" -archivePath ./Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive CODE_SIGNING_REQUIRED=NO SKIP_INSTALL=NO CODE_SIGN_IDENTITY= CARTHAGE=YES MACH_O_TYPE=$MACH_O_TYPE
+            xcodebuild archive -project Sentry.xcodeproj/ -scheme "$scheme" -configuration Release -sdk "$sdk" -archivePath ./Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive CODE_SIGNING_REQUIRED=NO SKIP_INSTALL=NO CODE_SIGN_IDENTITY= CARTHAGE=YES MACH_O_TYPE=$MACH_O_TYPE ENABLE_CODE_COVERAGE=NO
                  
             createxcframework+="-framework Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/Products/Library/Frameworks/${scheme}.framework "
 
@@ -43,7 +43,7 @@ generate_xcframework() {
     done
     
     #Create framework for mac catalyst
-    xcodebuild -project Sentry.xcodeproj/ -scheme "$scheme" -configuration Release -sdk macosx -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath ./Carthage/DerivedData CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES MACH_O_TYPE=$MACH_O_TYPE SUPPORTS_MACCATALYST=YES
+    xcodebuild -project Sentry.xcodeproj/ -scheme "$scheme" -configuration Release -sdk macosx -destination 'platform=macOS,variant=Mac Catalyst' -derivedDataPath ./Carthage/DerivedData CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= CARTHAGE=YES MACH_O_TYPE=$MACH_O_TYPE SUPPORTS_MACCATALYST=YES ENABLE_CODE_COVERAGE=NO
     
     if [ "$MACH_O_TYPE" = "staticlib" ]; then
         local infoPlist="Carthage/DerivedData/Build/Products/Release-maccatalyst/${scheme}.framework/Resources/Info.plist"

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -30,6 +30,8 @@ generate_xcframework() {
                 if [ ! -e "$infoPlist" ]; then
                     infoPlist="Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/Products/Library/Frameworks/${scheme}.framework/Resources/Info.plist"
                 fi
+                # This workaround is necessary to make Sentry Static framework to work
+                #More information in here: https://github.com/getsentry/sentry-cocoa/issues/3769
                 plutil -replace "MinimumOSVersion" -string "9999" "$infoPlist"
             fi
             


### PR DESCRIPTION
## :scroll: Description

Static framework was failing Xcode validation because of minimum os version.

## :bulb: Motivation and Context

close #3769 
