### PR TITLE
fix: CFBundleShortVersionString in the Info.plist file is invalid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - name: 'Generate XCFramework'
         run: |
           ./scripts/ci-select-xcode.sh 15.2
+          make bump-version TO=${{ github.event.inputs.version }}
           # We need to build the framework during release to get it's SHA value
           # the framework will be saved as an artefact and we will use the same
           # binary for the entire release process to avoid the SHA to change

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- CFBundleShortVersionString in the Info.plist file is invalid (#3787)
+
 ## 8.22.3
 
 ### Fixes


### PR DESCRIPTION
## :scroll: Description

We need to update SDK version before creating the framework and saving it as artefact.

## :bulb: Motivation and Context

closes #3786