### PR TITLE
fix: Redistributable static libraries should never be built with module debugging enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
       - Sentry.xcodeproj/**
       - Gemfile.lock
       - 'Package.swift'
+      - 'scripts/build-xcframework'
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Don't run onCrashedLastSession for nil Events (#3785)
+- Redistributable static libraries should never be built with module debugging enabled (#3800)
 
 ## 8.22.4
 

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -17,7 +17,7 @@ generate_xcframework() {
     local GCC_GENERATE_DEBUGGING_SYMBOLS="YES"
     
     if [ "$MACH_O_TYPE" = "staticlib" ]; then
-        #For static framework we disabled everything related to symbols
+        #For static framework we disabled symbols because they are not distributed in the framework causing warnings.
         GCC_GENERATE_DEBUGGING_SYMBOLS="NO"
     fi
     


### PR DESCRIPTION
## :scroll: Description

Removed symbol generation from Static framework.
Debug symbols will be generated by the project using our static framework.

## :bulb: Motivation and Context

close #3788