### PR TITLE
chore(profiling): place legacy compilation gates around profiling code that will need to be changed/removed

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -124,7 +124,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [SentryDependencyContainer.sharedInstance.extraContextProvider getExtraContext];
 }
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 + (uint64_t)startProfilerForTrace:(SentryId *)traceId;
 {
     [SentryProfiler startWithTracer:traceId];
@@ -157,7 +157,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     discardProfilerForTracer(traceId);
 }
 
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 + (BOOL)framesTrackingMeasurementHybridSDKMode
 {

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -1,18 +1,20 @@
 #import "SentryProfiledTracerConcurrency.h"
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_PROFILING_MODE_LEGACY
 
-#    import "SentryInternalDefines.h"
-#    import "SentryLog.h"
-#    import "SentryProfiler+Private.h"
-#    import "SentrySwift.h"
-#    include <mutex>
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    if SENTRY_HAS_UIKIT
-#        import "SentryDependencyContainer.h"
-#        import "SentryFramesTracker.h"
-#        import "SentryScreenFrames.h"
-#    endif // SENTRY_HAS_UIKIT
+#        import "SentryInternalDefines.h"
+#        import "SentryLog.h"
+#        import "SentryProfiler+Private.h"
+#        import "SentrySwift.h"
+#        include <mutex>
+
+#        if SENTRY_HAS_UIKIT
+#            import "SentryDependencyContainer.h"
+#            import "SentryFramesTracker.h"
+#            import "SentryScreenFrames.h"
+#        endif // SENTRY_HAS_UIKIT
 
 /**
  * a mapping of profilers to the number of tracers that started them that are still in-flight and
@@ -98,11 +100,11 @@ discardProfilerForTracer(SentryId *internalTraceId)
 
     _unsafe_cleanUpProfiler(profiler, tracerKey);
 
-#    if SENTRY_HAS_UIKIT
+#        if SENTRY_HAS_UIKIT
     if (_gProfilersToTracers.count == 0) {
         [SentryDependencyContainer.sharedInstance.framesTracker resetProfilingTimestamps];
     }
-#    endif // SENTRY_HAS_UIKIT
+#        endif // SENTRY_HAS_UIKIT
 }
 
 SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId)
@@ -122,18 +124,18 @@ SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId)
 
     _unsafe_cleanUpProfiler(profiler, tracerKey);
 
-#    if SENTRY_HAS_UIKIT
+#        if SENTRY_HAS_UIKIT
     profiler._screenFrameData =
         [SentryDependencyContainer.sharedInstance.framesTracker.currentFrames copy];
     if (_gProfilersToTracers.count == 0) {
         [SentryDependencyContainer.sharedInstance.framesTracker resetProfilingTimestamps];
     }
-#    endif // SENTRY_HAS_UIKIT
+#        endif // SENTRY_HAS_UIKIT
 
     return profiler;
 }
 
-#    if defined(TEST) || defined(TESTCI)
+#        if defined(TEST) || defined(TESTCI)
 void
 resetConcurrencyTracking()
 {
@@ -148,6 +150,8 @@ currentProfiledTracers()
     std::lock_guard<std::mutex> l(_gStateLock);
     return [_gTracersToProfilers count];
 }
-#    endif // defined(TEST) || defined(TESTCI)
+#        endif // defined(TEST) || defined(TESTCI)
 
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+#endif // SENTRY_PROFILING_MODE_LEGACY

--- a/Sources/Sentry/Public/SentryProfilingConditionals.h
+++ b/Sources/Sentry/Public/SentryProfilingConditionals.h
@@ -1,14 +1,19 @@
 #ifndef SentryProfilingConditionals_h
-#define SentryProfilingConditionals_h
+#    define SentryProfilingConditionals_h
 
-#include <TargetConditionals.h>
+#    include <TargetConditionals.h>
 
 // tvOS and watchOS do not support the kernel APIs required by our profiler
 // e.g. mach_msg, thread_suspend, thread_resume
-#if TARGET_OS_WATCH || TARGET_OS_TV
-#    define SENTRY_TARGET_PROFILING_SUPPORTED 0
-#else
-#    define SENTRY_TARGET_PROFILING_SUPPORTED 1
-#endif
+#    if TARGET_OS_WATCH || TARGET_OS_TV
+#        define SENTRY_TARGET_PROFILING_SUPPORTED 0
+#    else
+#        define SENTRY_TARGET_PROFILING_SUPPORTED 1
+#    endif
 
 #endif /* SentryProfilingConditionals_h */
+
+// feature flags we'll use to conditionally compile code as we migrate to continuous profiling:
+// https://github.com/getsentry/sentry-cocoa/issues/3555
+#define SENTRY_PROFILING_MODE_LEGACY 1
+#define SENTRY_PROFILING_MODE_CONTINUOUS 0

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -395,12 +395,12 @@ SentryHub () <SentryMetricsAPIDelegate>
                                       withSampled:tracesSamplerDecision.decision];
     transactionContext.sampleRate = tracesSamplerDecision.sampleRate;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     SentrySamplerDecision *profilesSamplerDecision
         = sampleProfile(samplingContext, tracesSamplerDecision, self.client.options);
 
     configuration.profilesSamplerDecision = profilesSamplerDecision;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED"
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY"
 
     SentryTracer *tracer = [[SentryTracer alloc] initWithTransactionContext:transactionContext
                                                                         hub:self

--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -1,12 +1,14 @@
 #import "SentryProfileTimeseries.h"
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_PROFILING_MODE_LEGACY
 
-#    import "SentryEvent+Private.h"
-#    import "SentryInternalDefines.h"
-#    import "SentryLog.h"
-#    import "SentrySample.h"
-#    import "SentryTransaction.h"
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#        import "SentryEvent+Private.h"
+#        import "SentryInternalDefines.h"
+#        import "SentryLog.h"
+#        import "SentrySample.h"
+#        import "SentryTransaction.h"
 
 /**
  * Print a debug log to help diagnose slicing errors.
@@ -81,4 +83,6 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
     return [samples objectsAtIndexes:indices];
 }
 
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+#endif // SENTRY_PROFILING_MODE_LEGACY

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -222,23 +222,23 @@ static NSDate *_Nullable startTimestamp = nil;
         [SentryDependencyContainer.sharedInstance.uiDeviceWrapper start];
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-        BOOL shouldstopAndTransmitLaunchProfile = YES;
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
+        BOOL shouldStopAndTransmitLaunchProfile = YES;
 #    if SENTRY_HAS_UIKIT
         if (SentryUIViewControllerPerformanceTracker.shared.enableWaitForFullDisplay) {
-            shouldstopAndTransmitLaunchProfile = NO;
+            shouldStopAndTransmitLaunchProfile = NO;
         }
 #    endif // SENTRY_HAS_UIKIT
 
         [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchAsyncWithBlock:^{
-            if (shouldstopAndTransmitLaunchProfile) {
+            if (shouldStopAndTransmitLaunchProfile) {
                 SENTRY_LOG_DEBUG(@"Stopping launch profile in SentrySDK.start because there will "
                                  @"be no automatic trace to attach it to.");
                 stopAndTransmitLaunchProfile(hub);
             }
             configureLaunchProfiling(options);
         }];
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     }];
 }
 

--- a/Sources/Sentry/SentrySampling.m
+++ b/Sources/Sentry/SentrySampling.m
@@ -80,7 +80,7 @@ sampleTrace(SentrySamplingContext *context, SentryOptions *options)
     return calcSampleFromNumericalRate(options.tracesSampleRate);
 }
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 SentrySamplerDecision *
 sampleProfile(SentrySamplingContext *context, SentrySamplerDecision *tracesSamplerDecision,
@@ -112,6 +112,6 @@ sampleProfile(SentrySamplingContext *context, SentrySamplerDecision *tracesSampl
     return calcSampleFromNumericalRate(options.profilesSampleRate);
 }
 
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -133,9 +133,9 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
         [self.initialDisplaySpan finish];
         if (!_waitForFullDisplay) {
             [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
-#    if SENTRY_TARGET_PROFILING_SUPPORTED
+#    if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
             stopAndDiscardLaunchProfileTracer();
-#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
         }
     }
     if (_waitForFullDisplay && _fullyDisplayedReported && self.fullDisplaySpan.isFinished == NO
@@ -143,9 +143,9 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
         SENTRY_LOG_DEBUG(@"Finishing full display span");
         self.fullDisplaySpan.timestamp = newFrameDate;
         [self.fullDisplaySpan finish];
-#    if SENTRY_TARGET_PROFILING_SUPPORTED
+#    if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
         stopAndDiscardLaunchProfileTracer();
-#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     }
 
     if (self.initialDisplaySpan.isFinished == YES && self.fullDisplaySpan.isFinished == YES) {

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -33,11 +33,11 @@
 #import <SentryMeasurementValue.h>
 #import <SentrySpanOperations.h>
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 #    import "SentryLaunchProfiling.h"
 #    import "SentryProfiledTracerConcurrency.h"
 #    import "SentryProfiler.h"
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryAppStartMeasurement.h"
@@ -81,9 +81,9 @@ SentryTracer ()
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 @property (nonatomic) BOOL isProfiling;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 @end
 
@@ -111,12 +111,12 @@ SentryTracer ()
 static NSObject *appStartMeasurementLock;
 static BOOL appStartMeasurementRead;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 + (void)load
 {
     startLaunchProfile();
 }
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 + (void)initialize
 {
@@ -187,7 +187,7 @@ static BOOL appStartMeasurementRead;
     }
 #endif // SENTRY_HAS_UIKIT
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     if (_configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes
         || isTracingAppLaunch) {
         _internalID = [[SentryId alloc] init];
@@ -197,7 +197,7 @@ static BOOL appStartMeasurementRead;
         }
         _startSystemTime = SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
     }
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
     SENTRY_LOG_DEBUG(@"Started tracer with id: %@", transactionContext.traceId.sentryIdString);
 
@@ -206,11 +206,11 @@ static BOOL appStartMeasurementRead;
 
 - (void)dealloc
 {
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     if (self.isProfiling) {
         discardProfilerForTracer(self.internalID);
     }
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 }
 
 - (nullable SentryTracer *)tracer
@@ -599,7 +599,7 @@ static BOOL appStartMeasurementRead;
 
     SentryTransaction *transaction = [self toTransaction];
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     if (self.isProfiling) {
         NSDate *startTimestamp;
 
@@ -621,12 +621,12 @@ static BOOL appStartMeasurementRead;
         [self captureTransactionWithProfile:transaction startTimestamp:startTimestamp];
         return;
     }
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
     [_hub captureTransaction:transaction withScope:_hub.scope];
 }
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 - (void)captureTransactionWithProfile:(SentryTransaction *)transaction
                        startTimestamp:(NSDate *)startTimestamp
 {
@@ -645,7 +645,7 @@ static BOOL appStartMeasurementRead;
                       withScope:_hub.scope
         additionalEnvelopeItems:@[ profileEnvelopeItem ]];
 }
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 - (void)trimEndTimestamp
 {
@@ -696,7 +696,7 @@ static BOOL appStartMeasurementRead;
     SentryTransaction *transaction = [[SentryTransaction alloc] initWithTrace:self children:spans];
     transaction.transaction = self.transactionContext.name;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
     if (self.isProfiling) {
         // if we have an app start span, use its app start timestamp. otherwise use the tracer's
         // start system time as we currently do
@@ -715,7 +715,7 @@ static BOOL appStartMeasurementRead;
         transaction.endSystemTime
             = SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
     }
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
     NSMutableArray *framesOfAllSpans = [NSMutableArray array];
     if ([(SentrySpan *)self frames]) {

--- a/Sources/Sentry/SentryTransactionContext.mm
+++ b/Sources/Sentry/SentryTransactionContext.mm
@@ -121,20 +121,22 @@ static const auto kSentryDefaultSamplingDecision = kSentrySampleDecisionUndecide
     return self;
 }
 
+#if SENTRY_PROFILING_MODE_LEGACY
 - (void)getThreadInfo
 {
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
     const auto threadID = sentry::profiling::ThreadHandle::current()->tid();
     self.threadInfo = [[SentryThread alloc] initWithThreadId:@(threadID)];
-#endif
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
 - (SentryThread *)sentry_threadInfo
 {
     return self.threadInfo;
 }
-#endif
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_PROFILING_MODE_LEGACY
 
 - (void)commonInitWithName:(NSString *)name
                     source:(SentryTransactionNameSource)source

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -83,7 +83,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (NSDictionary *)getExtraContext;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 /**
  * Start a profiler session associated with the given @c SentryId.
  * @return The system time when the profiler session started.
@@ -103,7 +103,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * This only needs to be called in case you haven't collected the profile (and don't intend to).
  */
 + (void)discardProfilerForTrace:(SentryId *)traceId;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 @property (class, nullable, nonatomic, copy)
     SentryOnAppStartMeasurementAvailable onAppStartMeasurementAvailable;

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -26,10 +26,10 @@ SentryEvent ()
  */
 @property (nonatomic, strong) NSArray *serializedBreadcrumbs;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 @property (nonatomic) uint64_t startSystemTime;
 @property (nonatomic) uint64_t endSystemTime;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 #if SENTRY_HAS_METRIC_KIT
 - (BOOL)isMetricKitEvent;

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -1,21 +1,29 @@
-#import "SentryDefines.h"
 #import "SentryProfilingConditionals.h"
-#import <Foundation/Foundation.h>
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryDefines.h"
+#    import <Foundation/Foundation.h>
 
 @class SentryHub;
 @class SentryId;
 @class SentryOptions;
+
+#    if SENTRY_PROFILING_MODE_LEGACY
+
 @class SentryTracerConfiguration;
 @class SentryTransactionContext;
 
-NS_ASSUME_NONNULL_BEGIN
-
 SENTRY_EXTERN BOOL isTracingAppLaunch;
+
+#    endif // SENTRY_PROFILING_MODE_LEGACY
+
+NS_ASSUME_NONNULL_BEGIN
 
 /** Try to start a profiled trace for this app launch, if the configuration allows. */
 SENTRY_EXTERN void startLaunchProfile(void);
+
+#    if SENTRY_PROFILING_MODE_LEGACY
 
 /**
  * Stop any profiled trace that may be in flight from the start of the app launch, and transmit the
@@ -29,6 +37,8 @@ void stopAndTransmitLaunchProfile(SentryHub *hub);
  * the profiler will be discarded in this case.
  */
 void stopAndDiscardLaunchProfileTracer(void);
+
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 
 /**
  * Write a file to disk containing sample rates for profiles and traces. The presence of this file

--- a/Sources/Sentry/include/SentryProfileTimeseries.h
+++ b/Sources/Sentry/include/SentryProfileTimeseries.h
@@ -1,9 +1,11 @@
 #import "SentryProfilingConditionals.h"
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_PROFILING_MODE_LEGACY
 
-#    import "SentryDefines.h"
-#    import <Foundation/Foundation.h>
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#        import "SentryDefines.h"
+#        import <Foundation/Foundation.h>
 
 @class SentrySample;
 @class SentryTransaction;
@@ -15,4 +17,6 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
 
 NS_ASSUME_NONNULL_END
 
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+#endif // SENTRY_PROFILING_MODE_LEGACY

--- a/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
@@ -1,10 +1,13 @@
-#import "SentryCompiler.h"
 #import "SentryProfilingConditionals.h"
-#import <Foundation/Foundation.h>
+
+#if SENTRY_PROFILING_MODE_LEGACY
+
+#    import "SentryCompiler.h"
+#    import <Foundation/Foundation.h>
 
 @class SentryProfiler, SentryId;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -30,13 +33,15 @@ void discardProfilerForTracer(SentryId *internalTraceId);
  */
 SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId);
 
-#    if defined(TEST) || defined(TESTCI)
+#        if defined(TEST) || defined(TESTCI)
 void resetConcurrencyTracking(void);
 NSUInteger currentProfiledTracers(void);
-#    endif // defined(TEST) || defined(TESTCI)
+#        endif // defined(TEST) || defined(TESTCI)
 
 SENTRY_EXTERN_C_END
 
 NS_ASSUME_NONNULL_END
 
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+#endif // SENTRY_PROFILING_MODE_LEGACY

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -15,15 +15,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#    if SENTRY_PROFILING_MODE_LEGACY
+
 NSMutableDictionary<NSString *, id> *serializedProfileData(
     NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
     NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
     NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
-#    if SENTRY_HAS_UIKIT
+#        if SENTRY_HAS_UIKIT
     ,
     SentryScreenFrames *gpuData
-#    endif // SENTRY_HAS_UIKIT
+#        endif // SENTRY_HAS_UIKIT
 );
+
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 
 @interface
 SentryProfiler ()

--- a/Sources/Sentry/include/SentryProfiler.h
+++ b/Sources/Sentry/include/SentryProfiler.h
@@ -14,7 +14,9 @@
 
 typedef NS_ENUM(NSUInteger, SentryProfilerTruncationReason) {
     SentryProfilerTruncationReasonNormal,
+#    if SENTRY_PROFILING_MODE_LEGACY
     SentryProfilerTruncationReasonTimeout,
+#    endif // SENTRY_PROFILING_MODE_LEGACY
     SentryProfilerTruncationReasonAppMovedToBackground,
 };
 
@@ -47,6 +49,15 @@ SENTRY_EXTERN_C_END
 
 @property (strong, nonatomic) SentryId *profilerId;
 
+#    if SENTRY_PROFILING_MODE_CONTINUOUS
+
++ (void)start;
++ (void)stop;
+
+#    endif // SENTRY_PROFILING_MODE_CONTINUOUS
+
+#    if SENTRY_PROFILING_MODE_LEGACY
+
 /**
  * Start a profiler, if one isn't already running.
  */
@@ -56,6 +67,8 @@ SENTRY_EXTERN_C_END
  * Stop the profiler if it is running.
  */
 - (void)stopForReason:(SentryProfilerTruncationReason)reason;
+
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 
 /**
  * Whether the profiler instance is currently running. If not, then it probably timed out or aborted
@@ -76,6 +89,8 @@ SENTRY_EXTERN_C_END
  */
 + (void)recordMetrics;
 
+#    if SENTRY_PROFILING_MODE_LEGACY
+
 /**
  * Given a transaction, return an envelope item containing any corresponding profile data to be
  * attached to the transaction envelope.
@@ -91,6 +106,9 @@ SENTRY_EXTERN_C_END
                                                                     and:(uint64_t)endSystemTime
                                                                forTrace:(SentryId *)traceId
                                                                   onHub:(SentryHub *)hub;
+
+#    endif // SENTRY_PROFILING_MODE_LEGACY
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySampling.h
+++ b/Sources/Sentry/include/SentrySampling.h
@@ -12,13 +12,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 SentrySamplerDecision *sampleTrace(SentrySamplingContext *context, SentryOptions *options);
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 /**
  * Determines whether a profile should be sampled based on the context, options, and
  * whether the trace corresponding to the profile was sampled.
  */
 SentrySamplerDecision *sampleProfile(SentrySamplingContext *context,
     SentrySamplerDecision *tracesSamplerDecision, SentryOptions *options);
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryTracerConfiguration.h
+++ b/Sources/Sentry/include/SentryTracerConfiguration.h
@@ -28,12 +28,12 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic) BOOL waitForChildren;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 /**
  * Whether to sample a profile corresponding to this transaction
  */
 @property (nonatomic, strong, nullable) SentrySamplerDecision *profilesSamplerDecision;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED"
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY"
 
 /**
  * The idle time to wait until to finish the transaction

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -36,13 +36,14 @@ SentryTransactionContext ()
                      sampled:(SentrySampleDecision)sampled
                parentSampled:(SentrySampleDecision)parentSampled;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 // This is currently only exposed for testing purposes, see -[SentryProfilerTests
 // testProfilerMutationDuringSerialization]
+// !!!: the above comment is no longer true. remove this declaration
 @property (nonatomic, strong) SentryThread *threadInfo;
 
 - (SentryThread *)sentry_threadInfo;
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 @end
 

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
@@ -14,6 +14,7 @@
 
 @implementation SentryAppLaunchProfilingTests
 
+#    if SENTRY_PROFILING_MODE_LEGACY
 - (void)testLaunchProfileTransactionContext
 {
     SentryTransactionContext *actualContext = context(@1);
@@ -22,9 +23,9 @@
     XCTAssert(actualContext.sampled);
 }
 
-#    define SENTRY_OPTION(name, value)                                                             \
-        NSStringFromSelector(@selector(name))                                                      \
-            : value
+#        define SENTRY_OPTION(name, value)                                                         \
+            NSStringFromSelector(@selector(name))                                                  \
+                : value
 
 - (void)testDefaultOptionsDoNotEnableLaunchProfiling
 {
@@ -116,6 +117,7 @@
         @"Default options with app launch profiling and tracing enabled, traces sample rate of 1, "
         @"but profiles sample rate of 0 should not enable launch profiling");
 }
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 
 #    pragma mark - Private
 
@@ -124,8 +126,10 @@
 {
     NSMutableDictionary<NSString *, id> *options = [NSMutableDictionary<NSString *, id>
         dictionaryWithDictionary:@{ SENTRY_OPTION(enableAppLaunchProfiling, @YES),
+#    if SENTRY_PROFILING_MODE_LEGACY
                                      SENTRY_OPTION(enableTracing, @YES),
                                      SENTRY_OPTION(tracesSampleRate, @1),
+#    endif // SENTRY_PROFILING_MODE_LEGACY
                                      SENTRY_OPTION(profilesSampleRate, @1) }];
     [options addEntriesFromDictionary:overrides];
     return [self defaultOptionsWithOverrides:options];

--- a/Tests/SentryProfilerTests/SentryBacktraceTests.mm
+++ b/Tests/SentryProfilerTests/SentryBacktraceTests.mm
@@ -249,4 +249,4 @@ countof(Array &)
 
 @end
 
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
@@ -75,4 +75,4 @@ idleThreadEntry(__unused void *ptr)
 
 @end
 
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryProfilerTests/SentryThreadHandleTests.mm
+++ b/Tests/SentryProfilerTests/SentryThreadHandleTests.mm
@@ -171,4 +171,4 @@ threadGetName(void *namePtr)
 
 @end
 
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
+++ b/Tests/SentryProfilerTests/SentryThreadMetadataCacheTests.mm
@@ -112,4 +112,4 @@ threadSpin(void *name)
 
 @end
 
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -10,17 +10,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef struct {
     BOOL shouldProfile;
+#    if SENTRY_PROFILING_MODE_LEGACY
     SentrySamplerDecision *_Nullable tracesDecision;
+#    endif // SENTRY_PROFILING_MODE_LEGACY
     SentrySamplerDecision *_Nullable profilesDecision;
 } SentryLaunchProfileConfig;
 
 SENTRY_EXTERN SentryLaunchProfileConfig shouldProfileNextLaunch(SentryOptions *options);
 
+#    if SENTRY_PROFILING_MODE_LEGACY
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 
+#    if SENTRY_PROFILING_MODE_LEGACY
 SENTRY_EXTERN SentryTransactionContext *context(NSNumber *tracesRate);
 SENTRY_EXTERN SentryTracerConfiguration *config(NSNumber *profilesRate);
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 
 NS_ASSUME_NONNULL_END
 

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -645,7 +645,7 @@
 #    pragma clang diagnostic pop
     XCTAssertNil(options.profilesSampleRate);
     XCTAssertNil(options.profilesSampler);
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
     XCTAssertTrue([options.spotlightUrl isEqualToString:@"http://localhost:8969/stream"]);
 }
@@ -1116,7 +1116,7 @@
     XCTAssertNil(options.profilesSampler);
 }
 
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 - (void)testInAppIncludes
 {

--- a/Tests/SentryTests/SentryProfiler+Test.h
+++ b/Tests/SentryTests/SentryProfiler+Test.h
@@ -10,9 +10,10 @@ SentryProfiler ()
 
 + (SentryProfiler *)getCurrentProfiler;
 
+#    if SENTRY_PROFILING_MODE_LEGACY
 + (void)resetConcurrencyTracking;
-
 + (NSUInteger)currentProfiledTracers;
+#    endif // SENTRY_PROFILING_MODE_LEGACY
 
 @end
 

--- a/Tests/SentryTests/Transaction/SentryTracerObjCTests.m
+++ b/Tests/SentryTests/Transaction/SentryTracerObjCTests.m
@@ -8,9 +8,9 @@
 #import "SentryTransactionContext.h"
 #import <XCTest/XCTest.h>
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
+#if SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 #    import "SentryProfiler.h"
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED && SENTRY_PROFILING_MODE_LEGACY
 
 @interface SentryTracerObjCTests : XCTestCase
 


### PR DESCRIPTION
To kick off work for #3555, introduce two new preprocessor definitions to help transition the profiling implementation from the current form (henceforth known as "legacy") to continuous mode.

Gate declarations and implementation that will change or be removed with the legacy flag. This is not necessarily exhaustive, but serves as a guidepost for further work.

#skip-changelog