### PR TITLE
feat: Add the option swizzleClassNameExcludes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 more about how to use the Metrics API.
 - Pre-main profiling data is now attached to the app start transaction (#3736)
 - Release framework without UIKit/AppKit (#3793)
+- Add the option swizzleClassNameExcludes (#3813)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -372,7 +372,7 @@ NS_SWIFT_NAME(Options)
  * An array of class names to ignore for swizzling.
  *
  * @discussion The SDK checks if a class name of a class to swizzle contains a class name of this
- * array. For example, if you add "MyUIViewController" to this list, the SDK excludes the following
+ * array. For example, if you add MyUIViewController to this list, the SDK excludes the following
  * classes from swizzling: YourApp.MyUIViewController, YourApp.MyUIViewControllerA,
  * MyApp.MyUIViewController.
  *

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -381,7 +381,7 @@ NS_SWIFT_NAME(Options)
  *
  * @note Default is an empty array.
  */
-@property (nonatomic, strong) NSArray<NSString *> *swizzleClassNameExcludes;
+@property (nonatomic, strong) NSSet<NSString *> *swizzleClassNameExcludes;
 
 /**
  * When enabled, the SDK tracks the performance of Core Data operations. It requires enabling

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -375,6 +375,9 @@ NS_SWIFT_NAME(Options)
  * array. For example, if you add MyUIViewController to this list, the SDK excludes the following
  * classes from swizzling: YourApp.MyUIViewController, YourApp.MyUIViewControllerA,
  * MyApp.MyUIViewController.
+ * We can't use an @c NSArray<Class>  here because we use this as a workaround for which users have
+ * to pass in class names that aren't available on specific iOS versions. By using @c
+ * NSArray<NSString *>, users can specify unavailable class names.
  *
  * @note Default is an empty array.
  */

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -369,6 +369,18 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableSwizzling;
 
 /**
+ * An array of class names to ignore for swizzling.
+ *
+ * @discussion The SDK checks if a class name of a class to swizzle contains a class name of this
+ * array. For example, if you add "MyUIViewController" to this list, the SDK excludes the following
+ * classes from swizzling: YourApp.MyUIViewController, YourApp.MyUIViewControllerA,
+ * MyApp.MyUIViewController.
+ *
+ * @note Default is an empty array.
+ */
+@property (nonatomic, strong) NSArray<NSString *> *swizzleClassNameExcludes;
+
+/**
  * When enabled, the SDK tracks the performance of Core Data operations. It requires enabling
  * performance monitoring. The default is @c YES.
  * @see <https://docs.sentry.io/platforms/apple/performance/>

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -128,6 +128,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;
+        self.swizzleClassNameExcludes = [NSArray new];
         self.sendClientReports = YES;
         self.swiftAsyncStacktraces = NO;
         self.enableSpotlight = NO;
@@ -448,6 +449,11 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[@"enableSwizzling"]
             block:^(BOOL value) { self->_enableSwizzling = value; }];
+
+    if ([options[@"swizzleClassNameExcludes"] isKindOfClass:[NSArray class]]) {
+        _swizzleClassNameExcludes =
+            [options[@"swizzleClassNameExcludes"] filteredArrayUsingPredicate:isNSString];
+    }
 
     [self setBool:options[@"enableCoreDataTracing"]
             block:^(BOOL value) { self->_enableCoreDataTracing = value; }];

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -128,7 +128,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;
-        self.swizzleClassNameExcludes = [NSArray new];
+        self.swizzleClassNameExcludes = [NSSet new];
         self.sendClientReports = YES;
         self.swiftAsyncStacktraces = NO;
         self.enableSpotlight = NO;
@@ -450,9 +450,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
     [self setBool:options[@"enableSwizzling"]
             block:^(BOOL value) { self->_enableSwizzling = value; }];
 
-    if ([options[@"swizzleClassNameExcludes"] isKindOfClass:[NSArray class]]) {
+    if ([options[@"swizzleClassNameExcludes"] isKindOfClass:[NSSet class]]) {
         _swizzleClassNameExcludes =
-            [options[@"swizzleClassNameExcludes"] filteredArrayUsingPredicate:isNSString];
+            [options[@"swizzleClassNameExcludes"] filteredSetUsingPredicate:isNSString];
     }
 
     [self setBool:options[@"enableCoreDataTracing"]

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -34,8 +34,9 @@ SentryPerformanceTrackingIntegration ()
                                               attributes:attributes];
 
     SentrySubClassFinder *subClassFinder = [[SentrySubClassFinder alloc]
-        initWithDispatchQueue:dispatchQueue
-           objcRuntimeWrapper:[SentryDefaultObjCRuntimeWrapper sharedInstance]];
+           initWithDispatchQueue:dispatchQueue
+              objcRuntimeWrapper:[SentryDefaultObjCRuntimeWrapper sharedInstance]
+        swizzleClassNameExcludes:options.swizzleClassNameExcludes];
 
     self.swizzling = [[SentryUIViewControllerSwizzling alloc]
            initWithOptions:options

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -14,7 +14,7 @@ SentrySubClassFinder ()
 
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
-@property (nonatomic, copy) NSArray<NSString *> *swizzleClassNameExcludes;
+@property (nonatomic, copy) NSSet<NSString *> *swizzleClassNameExcludes;
 
 @end
 
@@ -22,7 +22,7 @@ SentrySubClassFinder ()
 
 - (instancetype)initWithDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
                    objcRuntimeWrapper:(id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper
-             swizzleClassNameExcludes:(NSArray<NSString *> *)swizzleClassNameExcludes
+             swizzleClassNameExcludes:(NSSet<NSString *> *)swizzleClassNameExcludes
 {
     if (self = [super init]) {
         self.dispatchQueue = dispatchQueue;
@@ -64,8 +64,7 @@ SentrySubClassFinder ()
 
             BOOL shouldExcludeClassFromSwizzling = NO;
             for (NSString *swizzleClassNameExclude in self.swizzleClassNameExcludes) {
-                if ([className.lowercaseString
-                        containsString:swizzleClassNameExclude.lowercaseString]) {
+                if ([className containsString:swizzleClassNameExclude]) {
                     shouldExcludeClassFromSwizzling = YES;
                     break;
                 }

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -14,6 +14,7 @@ SentrySubClassFinder ()
 
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
+@property (nonatomic, copy) NSArray<NSString *> *swizzleClassNameExcludes;
 
 @end
 
@@ -21,10 +22,12 @@ SentrySubClassFinder ()
 
 - (instancetype)initWithDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
                    objcRuntimeWrapper:(id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper
+             swizzleClassNameExcludes:(NSArray<NSString *> *)swizzleClassNameExcludes
 {
     if (self = [super init]) {
         self.dispatchQueue = dispatchQueue;
         self.objcRuntimeWrapper = objcRuntimeWrapper;
+        self.swizzleClassNameExcludes = swizzleClassNameExcludes;
     }
     return self;
 }
@@ -58,6 +61,23 @@ SentrySubClassFinder ()
         NSMutableArray<NSString *> *classesToSwizzle = [NSMutableArray new];
         for (int i = 0; i < count; i++) {
             NSString *className = [NSString stringWithUTF8String:classes[i]];
+
+            BOOL shouldExcludeClassFromSwizzling = NO;
+            for (NSString *swizzleClassNameExclude in self.swizzleClassNameExcludes) {
+                if ([className.lowercaseString
+                        containsString:swizzleClassNameExclude.lowercaseString]) {
+                    shouldExcludeClassFromSwizzling = YES;
+                    break;
+                }
+            }
+
+            // It is vital to avoid calling NSClassFromString for the excluded classes because we
+            // had crashes for specific classes when calling NSClassFromString, such as
+            // https://github.com/getsentry/sentry-cocoa/issues/3798.
+            if (shouldExcludeClassFromSwizzling) {
+                continue;
+            }
+
             Class class = NSClassFromString(className);
             if ([self isClass:class subClassOf:viewControllerClass]) {
                 [classesToSwizzle addObject:className];

--- a/Sources/Sentry/include/SentrySubClassFinder.h
+++ b/Sources/Sentry/include/SentrySubClassFinder.h
@@ -11,7 +11,7 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
                    objcRuntimeWrapper:(id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper
-             swizzleClassNameExcludes:(NSArray<NSString *> *)swizzleClassNameExcludes;
+             swizzleClassNameExcludes:(NSSet<NSString *> *)swizzleClassNameExcludes;
 
 #if SENTRY_HAS_UIKIT
 /**

--- a/Sources/Sentry/include/SentrySubClassFinder.h
+++ b/Sources/Sentry/include/SentrySubClassFinder.h
@@ -10,7 +10,8 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_NO_INIT
 
 - (instancetype)initWithDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
-                   objcRuntimeWrapper:(id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper;
+                   objcRuntimeWrapper:(id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper
+             swizzleClassNameExcludes:(NSArray<NSString *> *)swizzleClassNameExcludes;
 
 #if SENTRY_HAS_UIKIT
 /**

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -27,7 +27,7 @@ class SentrySubClassFinderTests: XCTestCase {
             }
         }
         
-        func getSut(swizzleClassNameExcludes: [String] = []) -> SentrySubClassFinder {
+        func getSut(swizzleClassNameExcludes: Set<String> = []) -> SentrySubClassFinder {
             return SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: runtimeWrapper, swizzleClassNameExcludes: swizzleClassNameExcludes)
         }
     }
@@ -44,7 +44,7 @@ class SentrySubClassFinderTests: XCTestCase {
     }
     
     func testActOnSubclassesOfViewController_WithSwizzleClassNameExcludes() {
-        assertActOnSubclassesOfViewController(expected: [SecondViewController.self, ViewControllerNumberThree.self], swizzleClassNameExcludes: ["FirstViewController", "vcAnyNaming"])
+        assertActOnSubclassesOfViewController(expected: [SecondViewController.self, ViewControllerNumberThree.self], swizzleClassNameExcludes: ["FirstViewController", "VCAnyNaming"])
     }
     
     func testActOnSubclassesOfViewController_NoViewController() {
@@ -73,11 +73,11 @@ class SentrySubClassFinderTests: XCTestCase {
         XCTAssertFalse(SentryInitializeForGettingSubclassesCalled.wasCalled())
     }
     
-    private func assertActOnSubclassesOfViewController(expected: [AnyClass], swizzleClassNameExcludes: [String] = []) {
+    private func assertActOnSubclassesOfViewController(expected: [AnyClass], swizzleClassNameExcludes: Set<String> = []) {
         assertActOnSubclassesOfViewController(expected: expected, imageName: fixture.imageName, swizzleClassNameExcludes: swizzleClassNameExcludes)
     }
     
-    private func assertActOnSubclassesOfViewController(expected: [AnyClass], imageName: String, swizzleClassNameExcludes: [String] = []) {
+    private func assertActOnSubclassesOfViewController(expected: [AnyClass], imageName: String, swizzleClassNameExcludes: Set<String> = []) {
         let expect = expectation(description: "")
         
         if expected.isEmpty {

--- a/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentrySubClassFinderTests.swift
@@ -27,8 +27,8 @@ class SentrySubClassFinderTests: XCTestCase {
             }
         }
         
-        var sut: SentrySubClassFinder {
-            return SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: runtimeWrapper)
+        func getSut(swizzleClassNameExcludes: [String] = []) -> SentrySubClassFinder {
+            return SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: runtimeWrapper, swizzleClassNameExcludes: swizzleClassNameExcludes)
         }
     }
     
@@ -41,6 +41,10 @@ class SentrySubClassFinderTests: XCTestCase {
     
     func testActOnSubclassesOfViewController() {
         assertActOnSubclassesOfViewController(expected: [FirstViewController.self, SecondViewController.self, ViewControllerNumberThree.self, VCAnyNaming.self])
+    }
+    
+    func testActOnSubclassesOfViewController_WithSwizzleClassNameExcludes() {
+        assertActOnSubclassesOfViewController(expected: [SecondViewController.self, ViewControllerNumberThree.self], swizzleClassNameExcludes: ["FirstViewController", "vcAnyNaming"])
     }
     
     func testActOnSubclassesOfViewController_NoViewController() {
@@ -59,7 +63,7 @@ class SentrySubClassFinderTests: XCTestCase {
     }
   
     func testGettingSubclasses_DoesNotCallInitializer() {
-        let sut = SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: fixture.runtimeWrapper)
+        let sut = SentrySubClassFinder(dispatchQueue: TestSentryDispatchQueueWrapper(), objcRuntimeWrapper: fixture.runtimeWrapper, swizzleClassNameExcludes: [])
         
         var actual: [AnyClass] = []
         sut.actOnSubclassesOfViewController(inImage: fixture.imageName) { subClass in
@@ -69,11 +73,11 @@ class SentrySubClassFinderTests: XCTestCase {
         XCTAssertFalse(SentryInitializeForGettingSubclassesCalled.wasCalled())
     }
     
-    private func assertActOnSubclassesOfViewController(expected: [AnyClass]) {
-        assertActOnSubclassesOfViewController(expected: expected, imageName: fixture.imageName)
+    private func assertActOnSubclassesOfViewController(expected: [AnyClass], swizzleClassNameExcludes: [String] = []) {
+        assertActOnSubclassesOfViewController(expected: expected, imageName: fixture.imageName, swizzleClassNameExcludes: swizzleClassNameExcludes)
     }
     
-    private func assertActOnSubclassesOfViewController(expected: [AnyClass], imageName: String) {
+    private func assertActOnSubclassesOfViewController(expected: [AnyClass], imageName: String, swizzleClassNameExcludes: [String] = []) {
         let expect = expectation(description: "")
         
         if expected.isEmpty {
@@ -83,7 +87,8 @@ class SentrySubClassFinderTests: XCTestCase {
         }
         
         var actual: [AnyClass] = []
-        fixture.sut.actOnSubclassesOfViewController(inImage: imageName) { subClass in
+        let sut = fixture.getSut(swizzleClassNameExcludes: swizzleClassNameExcludes)
+        sut.actOnSubclassesOfViewController(inImage: imageName) { subClass in
             XCTAssertTrue(Thread.isMainThread, "Block must be executed on the main thread.")
             actual.append(subClass)
             expect.fulfill()

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -15,7 +15,7 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         let binaryImageCache: SentryBinaryImageCache
         
         init() {
-            subClassFinder = TestSubClassFinder(dispatchQueue: dispatchQueue, objcRuntimeWrapper: objcRuntimeWrapper)
+            subClassFinder = TestSubClassFinder(dispatchQueue: dispatchQueue, objcRuntimeWrapper: objcRuntimeWrapper, swizzleClassNameExcludes: [])
             binaryImageCache = SentryDependencyContainer.sharedInstance().binaryImageCache
         }
          

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -615,7 +615,7 @@
     XCTAssertEqual(@[], options.inAppExcludes);
     XCTAssertNil(options.urlSessionDelegate);
     XCTAssertEqual(YES, options.enableSwizzling);
-    XCTAssertEqual(@[], options.swizzleClassNameExcludes);
+    XCTAssertEqual([NSSet new], options.swizzleClassNameExcludes);
     XCTAssertEqual(YES, options.enableFileIOTracing);
     XCTAssertEqual(YES, options.enableAutoBreadcrumbTracking);
     XCTAssertFalse(options.swiftAsyncStacktraces);
@@ -815,8 +815,8 @@
 
 - (void)testSwizzleClassNameExcludes
 {
-    NSArray<NSString *> *expected = @[ @"Sentry" ];
-    NSArray *swizzleClassNameExcludes = @[ @"Sentry", @2 ];
+    NSSet<NSString *> *expected = [NSSet setWithObjects:@"Sentry", nil];
+    NSSet *swizzleClassNameExcludes = [NSSet setWithObjects:@"Sentry", @2, nil];
 
     SentryOptions *options =
         [self getValidOptions:@{ @"swizzleClassNameExcludes" : swizzleClassNameExcludes }];

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -555,6 +555,7 @@
         @"inAppExcludes" : [NSNull null],
         @"urlSessionDelegate" : [NSNull null],
         @"enableSwizzling" : [NSNull null],
+        @"swizzleClassNameExcludes" : [NSNull null],
         @"enableIOTracking" : [NSNull null],
         @"sdk" : [NSNull null],
         @"enableCaptureFailedRequests" : [NSNull null],
@@ -614,6 +615,7 @@
     XCTAssertEqual(@[], options.inAppExcludes);
     XCTAssertNil(options.urlSessionDelegate);
     XCTAssertEqual(YES, options.enableSwizzling);
+    XCTAssertEqual(@[], options.swizzleClassNameExcludes);
     XCTAssertEqual(YES, options.enableFileIOTracing);
     XCTAssertEqual(YES, options.enableAutoBreadcrumbTracking);
     XCTAssertFalse(options.swiftAsyncStacktraces);
@@ -809,6 +811,17 @@
 - (void)testEnableSwizzling
 {
     [self testBooleanField:@"enableSwizzling"];
+}
+
+- (void)testSwizzleClassNameExcludes
+{
+    NSArray<NSString *> *expected = @[ @"Sentry" ];
+    NSArray *swizzleClassNameExcludes = @[ @"Sentry", @2 ];
+
+    SentryOptions *options =
+        [self getValidOptions:@{ @"swizzleClassNameExcludes" : swizzleClassNameExcludes }];
+
+    XCTAssertEqualObjects(expected, options.swizzleClassNameExcludes);
 }
 
 - (void)testEnableTracing


### PR DESCRIPTION




## :scroll: Description

Add an option to exclude certain classes from swizzling.

Docs PR https://github.com/getsentry/sentry-docs/pull/9596.

## :bulb: Motivation and Context

Fixes GH-3798

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
