### PR TITLE
fix: InvalidArgException for sentryErrorWithDomain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ more about how to use the Metrics API.
 - Don't run onCrashedLastSession for nil Events (#3785)
 - Redistributable static libraries should never be built with module debugging enabled (#3800)
 - Fixed certain views getting loaded twice when adding a child view controller (#3753)
+- Fix NSInvalidArgumentException for `NSError sentryErrorWithDomain` (#3819)
+
 
 ## 8.22.4
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -233,7 +233,7 @@
 		63FE710920DA4C1000CDBAE8 /* SentryCrashFileUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE700B20DA4C1000CDBAE8 /* SentryCrashFileUtils.h */; };
 		63FE710B20DA4C1000CDBAE8 /* SentryCrashMach.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700C20DA4C1000CDBAE8 /* SentryCrashMach.c */; };
 		63FE710D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c */; };
-		63FE710F20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700E20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m */; };
+		63FE710F20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700E20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.m */; };
 		63FE711120DA4C1000CDBAE8 /* SentryCrashDebug.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE700F20DA4C1000CDBAE8 /* SentryCrashDebug.c */; };
 		63FE711520DA4C1000CDBAE8 /* SentryCrashJSONCodec.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE701120DA4C1000CDBAE8 /* SentryCrashJSONCodec.c */; };
 		63FE711720DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.c in Sources */ = {isa = PBXBuildFile; fileRef = 63FE701220DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.c */; };
@@ -263,7 +263,7 @@
 		63FE714920DA4C1100CDBAE8 /* SentryCrashStackCursor_Backtrace.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE702B20DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.h */; };
 		63FE714B20DA4C1100CDBAE8 /* SentryCrashString.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE702C20DA4C1000CDBAE8 /* SentryCrashString.h */; };
 		63FE714D20DA4C1100CDBAE8 /* SentryCrashJSONCodec.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE702D20DA4C1000CDBAE8 /* SentryCrashJSONCodec.h */; };
-		63FE714F20DA4C1100CDBAE8 /* NSError+SentrySimpleConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE702E20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.h */; };
+		63FE714F20DA4C1100CDBAE8 /* SentryCrashNSErrorUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE702E20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.h */; };
 		63FE715120DA4C1100CDBAE8 /* SentryCrashDebug.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE702F20DA4C1000CDBAE8 /* SentryCrashDebug.h */; };
 		63FE715320DA4C1100CDBAE8 /* SentryCrashObjCApple.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE703020DA4C1000CDBAE8 /* SentryCrashObjCApple.h */; };
 		63FE715520DA4C1100CDBAE8 /* SentryCrashStackCursor_MachineContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 63FE703120DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.h */; };
@@ -305,7 +305,7 @@
 		63FE720720DA66EC00CDBAE8 /* SentryCrashReportFilter_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71DB20DA66E700CDBAE8 /* SentryCrashReportFilter_Tests.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		63FE720920DA66EC00CDBAE8 /* XCTestCase+SentryCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71DE20DA66E800CDBAE8 /* XCTestCase+SentryCrash.m */; };
 		63FE720C20DA66EC00CDBAE8 /* SentryCrashMonitor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71E120DA66E800CDBAE8 /* SentryCrashMonitor_Tests.m */; };
-		63FE720D20DA66EC00CDBAE8 /* NSError+SimpleConstructor_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71E220DA66E800CDBAE8 /* NSError+SimpleConstructor_Tests.m */; };
+		63FE720D20DA66EC00CDBAE8 /* SentryCrashNSErrorUtilTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71E220DA66E800CDBAE8 /* SentryCrashNSErrorUtilTests.m */; };
 		63FE720E20DA66EC00CDBAE8 /* SentryCrashCString_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71E320DA66E800CDBAE8 /* SentryCrashCString_Tests.m */; };
 		63FE720F20DA66EC00CDBAE8 /* SentryCrashLogger_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71E420DA66E800CDBAE8 /* SentryCrashLogger_Tests.m */; };
 		63FE721020DA66EC00CDBAE8 /* SentryCrashCachedData_Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 63FE71E520DA66E800CDBAE8 /* SentryCrashCachedData_Tests.m */; };
@@ -1161,7 +1161,7 @@
 		63FE700B20DA4C1000CDBAE8 /* SentryCrashFileUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashFileUtils.h; sourceTree = "<group>"; };
 		63FE700C20DA4C1000CDBAE8 /* SentryCrashMach.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashMach.c; sourceTree = "<group>"; };
 		63FE700D20DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashStackCursor_MachineContext.c; sourceTree = "<group>"; };
-		63FE700E20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SentrySimpleConstructor.m"; sourceTree = "<group>"; };
+		63FE700E20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashNSErrorUtil.m; sourceTree = "<group>"; };
 		63FE700F20DA4C1000CDBAE8 /* SentryCrashDebug.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashDebug.c; sourceTree = "<group>"; };
 		63FE701120DA4C1000CDBAE8 /* SentryCrashJSONCodec.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashJSONCodec.c; sourceTree = "<group>"; };
 		63FE701220DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = SentryCrashStackCursor_Backtrace.c; sourceTree = "<group>"; };
@@ -1191,7 +1191,7 @@
 		63FE702B20DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashStackCursor_Backtrace.h; sourceTree = "<group>"; };
 		63FE702C20DA4C1000CDBAE8 /* SentryCrashString.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashString.h; sourceTree = "<group>"; };
 		63FE702D20DA4C1000CDBAE8 /* SentryCrashJSONCodec.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashJSONCodec.h; sourceTree = "<group>"; };
-		63FE702E20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSError+SentrySimpleConstructor.h"; sourceTree = "<group>"; };
+		63FE702E20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashNSErrorUtil.h; sourceTree = "<group>"; };
 		63FE702F20DA4C1000CDBAE8 /* SentryCrashDebug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashDebug.h; sourceTree = "<group>"; };
 		63FE703020DA4C1000CDBAE8 /* SentryCrashObjCApple.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashObjCApple.h; sourceTree = "<group>"; };
 		63FE703120DA4C1000CDBAE8 /* SentryCrashStackCursor_MachineContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SentryCrashStackCursor_MachineContext.h; sourceTree = "<group>"; };
@@ -1234,7 +1234,7 @@
 		63FE71DD20DA66E800CDBAE8 /* TestThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestThread.h; sourceTree = "<group>"; };
 		63FE71DE20DA66E800CDBAE8 /* XCTestCase+SentryCrash.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "XCTestCase+SentryCrash.m"; sourceTree = "<group>"; };
 		63FE71E120DA66E800CDBAE8 /* SentryCrashMonitor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashMonitor_Tests.m; sourceTree = "<group>"; };
-		63FE71E220DA66E800CDBAE8 /* NSError+SimpleConstructor_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+SimpleConstructor_Tests.m"; sourceTree = "<group>"; };
+		63FE71E220DA66E800CDBAE8 /* SentryCrashNSErrorUtilTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashNSErrorUtilTests.m; sourceTree = "<group>"; };
 		63FE71E320DA66E800CDBAE8 /* SentryCrashCString_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashCString_Tests.m; sourceTree = "<group>"; };
 		63FE71E420DA66E800CDBAE8 /* SentryCrashLogger_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashLogger_Tests.m; sourceTree = "<group>"; };
 		63FE71E520DA66E800CDBAE8 /* SentryCrashCachedData_Tests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryCrashCachedData_Tests.m; sourceTree = "<group>"; };
@@ -2590,8 +2590,8 @@
 		63FE700520DA4C1000CDBAE8 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				63FE702E20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.h */,
-				63FE700E20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m */,
+				63FE702E20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.h */,
+				63FE700E20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.m */,
 				63FE703E20DA4C1000CDBAE8 /* SentryCrashCPU_Apple.h */,
 				63FE701B20DA4C1000CDBAE8 /* SentryCrashCPU_arm.c */,
 				63FE701520DA4C1000CDBAE8 /* SentryCrashCPU_arm64.c */,
@@ -2670,7 +2670,7 @@
 				7B7725D7292F5DC20015BBF9 /* SentryCrashInstallationTests.m */,
 				8FF94DF22B06A24C00BCD650 /* SentryCrash+Test.h */,
 				D855AD61286ED6A4002573E1 /* SentryCrashTests.m */,
-				63FE71E220DA66E800CDBAE8 /* NSError+SimpleConstructor_Tests.m */,
+				63FE71E220DA66E800CDBAE8 /* SentryCrashNSErrorUtilTests.m */,
 				63FE71D520DA66E600CDBAE8 /* RFC3339UTFString_Tests.m */,
 				63FE71E520DA66E800CDBAE8 /* SentryCrashCachedData_Tests.m */,
 				63FE71D720DA66E700CDBAE8 /* SentryCrashCPU_Tests.m */,
@@ -3899,7 +3899,7 @@
 				630435FE1EBCA9D900C4D3FA /* SentryNSURLRequest.h in Headers */,
 				7BC852392458830A005A70F0 /* SentryEnvelopeItemType.h in Headers */,
 				63AA769D1EB9C57A00D153DE /* SentryError.h in Headers */,
-				63FE714F20DA4C1100CDBAE8 /* NSError+SentrySimpleConstructor.h in Headers */,
+				63FE714F20DA4C1100CDBAE8 /* SentryCrashNSErrorUtil.h in Headers */,
 				7BC5B6FA290BCDE500D99477 /* SentryHttpStatusCodeRange+Private.h in Headers */,
 				7B04A9AF24EAC02C00E710B1 /* SentryRetryAfterHeaderParser.h in Headers */,
 				9286059529A5096600F96038 /* SentryGeo.h in Headers */,
@@ -4397,7 +4397,7 @@
 				63FE711720DA4C1000CDBAE8 /* SentryCrashStackCursor_Backtrace.c in Sources */,
 				63FE70CB20DA4C1000CDBAE8 /* SentryCrashReportFixer.c in Sources */,
 				D8CAC0412BA0984500E38F34 /* SentryIntegrationProtocol.swift in Sources */,
-				63FE710F20DA4C1000CDBAE8 /* NSError+SentrySimpleConstructor.m in Sources */,
+				63FE710F20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.m in Sources */,
 				8ECC674925C23A20000E2BF6 /* SentrySpanId.m in Sources */,
 				626866722BA89641006995EA /* MetricsAggregator.swift in Sources */,
 				626866782BA89928006995EA /* BucketsMetricsAggregator.swift in Sources */,
@@ -4487,7 +4487,7 @@
 				632331F62404FFA8008D91D6 /* SentryScopeTests.m in Sources */,
 				D808FB88281AB33C009A2A33 /* SentryUIEventTrackerTests.swift in Sources */,
 				0A283E79291A67E000EF4126 /* SentryUIDeviceWrapperTests.swift in Sources */,
-				63FE720D20DA66EC00CDBAE8 /* NSError+SimpleConstructor_Tests.m in Sources */,
+				63FE720D20DA66EC00CDBAE8 /* SentryCrashNSErrorUtilTests.m in Sources */,
 				69BEE6F72620729E006DF9DF /* UrlSessionDelegateSpy.swift in Sources */,
 				A8AFFCD42907E0CA00967CD7 /* SentryRequestTests.swift in Sources */,
 				7BD4BD4D27EB31820071F4FF /* SentryClientReportTests.swift in Sources */,

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -26,12 +26,12 @@
 //
 
 #import "SentryCrashInstallation.h"
-#import "NSError+SentrySimpleConstructor.h"
 #import "SentryCrash.h"
 #import "SentryCrashCString.h"
 #import "SentryCrashInstallation+Private.h"
 #import "SentryCrashJSONCodecObjC.h"
 #import "SentryCrashLogger.h"
+#import "SentryCrashNSErrorUtil.h"
 #import "SentryCrashReportFilterBasic.h"
 #import "SentryDependencyContainer.h"
 #import <objc/runtime.h>
@@ -216,10 +216,8 @@ SentryCrashInstallation ()
         }
     }
     if ([errors length] > 0) {
-        return [NSError
-            sentryErrorWithDomain:[[self class] description]
-                             code:0
-                      description:@"Installation properties failed validation: %@", errors];
+        return sentryErrorWithDomain([[self class] description], 0,
+            @"Installation properties failed validation: %@", errors);
     }
     return nil;
 }
@@ -295,10 +293,9 @@ SentryCrashInstallation ()
     id<SentryCrashReportFilter> sink = [self sink];
     if (sink == nil) {
         onCompletion(nil, NO,
-            [NSError sentryErrorWithDomain:[[self class] description]
-                                      code:0
-                               description:@"Sink was nil (subclasses must implement "
-                                           @"method \"sink\")"]);
+            sentryErrorWithDomain([[self class] description], 0,
+                @"Sink was nil (subclasses must implement "
+                @"method \"sink\")"));
         return;
     }
 

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -27,13 +27,13 @@
 
 #import "SentryCrash.h"
 
-#import "NSError+SentrySimpleConstructor.h"
 #import "SentryCrashC.h"
 #import "SentryCrashDoctor.h"
 #import "SentryCrashJSONCodecObjC.h"
 #import "SentryCrashMonitorContext.h"
 #import "SentryCrashMonitor_AppState.h"
 #import "SentryCrashMonitor_System.h"
+#import "SentryCrashNSErrorUtil.h"
 #import "SentryCrashReportFields.h"
 #import "SentryCrashReportStore.h"
 #import "SentryCrashSystemCapabilities.h"
@@ -367,9 +367,8 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
 
     if (self.sink == nil) {
         sentrycrash_callCompletion(onCompletion, reports, NO,
-            [NSError sentryErrorWithDomain:[[self class] description]
-                                      code:0
-                               description:@"No sink set. Crash reports not sent."]);
+            sentryErrorWithDomain(
+                [[self class] description], 0, @"No sink set. Crash reports not sent."));
         return;
     }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashNSErrorUtil.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashNSErrorUtil.h
@@ -27,43 +27,27 @@
 
 #import <Foundation/Foundation.h>
 
-/**
- * Simpler interface for constructing NSError objects.
- */
-@interface
-NSError (SentrySimpleConstructor)
+NS_ASSUME_NONNULL_BEGIN
 
 /** Convenience constructor to make an error with the specified localized
  * description.
  *
  * @param domain The domain
  * @param code The code
- * @param fmt Description of the error (gets placed into the user data with the
+ * @param format Description of the error (gets placed into the user data with the
  * key NSLocalizedDescriptionKey).
  */
-+ (NSError *)sentryErrorWithDomain:(NSString *)domain
-                              code:(NSInteger)code
-                       description:(NSString *)fmt, ...;
+NSError *sentryErrorWithDomain(NSString *domain, NSInteger code, NSString *format, ...);
 
 /** Fill an error pointer with an NSError object if it's not nil.
  *
  * @param error Error pointer to fill (ignored if nil).
  * @param domain The domain
  * @param code The code
- * @param fmt Description of the error (gets placed into the user data with the
+ * @param format Description of the error (gets placed into the user data with the
  * key NSLocalizedDescriptionKey).
  * @return NO (to keep the analyzer happy).
  */
-+ (BOOL)sentryFillError:(NSError **)error
-             withDomain:(NSString *)domain
-                   code:(NSInteger)code
-            description:(NSString *)fmt, ...;
+BOOL sentryFillError(NSError **error, NSString *domain, NSInteger code, NSString *format, ...);
 
-/** Clear a pointer-to-error to nil of its pointer is not nil.
- *
- * @param error Error pointer to fill (ignored if nil).
- * @return NO (to keep the analyzer happy).
- */
-+ (BOOL)sentryClearError:(NSError **)error;
-
-@end
+NS_ASSUME_NONNULL_END

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashNSErrorUtil.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashNSErrorUtil.m
@@ -25,19 +25,15 @@
 // THE SOFTWARE.
 //
 
-#import "NSError+SentrySimpleConstructor.h"
+#import "SentryCrashNSErrorUtil.h"
 
-@implementation
-NSError (SentrySimpleConstructor)
-
-+ (NSError *)sentryErrorWithDomain:(NSString *)domain
-                              code:(NSInteger)code
-                       description:(NSString *)fmt, ...
+NSError *
+sentryErrorWithDomain(NSString *domain, NSInteger code, NSString *format, ...)
 {
     va_list args;
-    va_start(args, fmt);
+    va_start(args, format);
 
-    NSString *desc = [[NSString alloc] initWithFormat:fmt arguments:args];
+    NSString *desc = [[NSString alloc] initWithFormat:format arguments:args];
     va_end(args);
 
     return [NSError errorWithDomain:domain
@@ -45,39 +41,3 @@ NSError (SentrySimpleConstructor)
                            userInfo:[NSDictionary dictionaryWithObject:desc
                                                                 forKey:NSLocalizedDescriptionKey]];
 }
-
-+ (BOOL)sentryFillError:(NSError *__autoreleasing *)error
-             withDomain:(NSString *)domain
-                   code:(NSInteger)code
-            description:(NSString *)fmt, ...
-{
-    if (error != nil) {
-        va_list args;
-        va_start(args, fmt);
-
-        NSString *desc = [[NSString alloc] initWithFormat:fmt arguments:args];
-        va_end(args);
-
-        *error =
-            [NSError errorWithDomain:domain
-                                code:code
-                            userInfo:[NSDictionary dictionaryWithObject:desc
-                                                                 forKey:NSLocalizedDescriptionKey]];
-    }
-    return NO;
-}
-
-+ (BOOL)sentryClearError:(NSError *__autoreleasing *)error
-{
-    if (error != nil) {
-        *error = nil;
-    }
-    return NO;
-}
-
-@end
-
-@interface sentrycrashobjc_NSError_SimpleConstructor_AOG8G : NSObject
-@end
-@implementation sentrycrashobjc_NSError_SimpleConstructor_AOG8G
-@end

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -27,7 +27,7 @@
 
 #import "SentryCrashReportFilterBasic.h"
 #import "Container+SentryDeepSearch.h"
-#import "NSError+SentrySimpleConstructor.h"
+#import "SentryCrashNSErrorUtil.h"
 #import "SentryCrashVarArgs.h"
 
 // #define SentryCrashLogger_LocalLevel TRACE
@@ -130,10 +130,8 @@ SentryCrashReportFilterCombine ()
 
     if (filterCount != [keys count]) {
         sentrycrash_callCompletion(onCompletion, reports, NO,
-            [NSError sentryErrorWithDomain:[[self class] description]
-                                      code:0
-                               description:@"Key/filter mismatch (%d keys, %d filters",
-                               [keys count], filterCount]);
+            sentryErrorWithDomain([[self class] description], 0,
+                @"Key/filter mismatch (%d keys, %d filters", [keys count], filterCount));
         return;
     }
 
@@ -152,9 +150,8 @@ SentryCrashReportFilterCombine ()
                 sentrycrash_callCompletion(onCompletion, filteredReports, completed, filterError);
             } else if (filteredReports == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError sentryErrorWithDomain:[[self class] description]
-                                              code:0
-                                       description:@"filteredReports was nil"]);
+                    sentryErrorWithDomain(
+                        [[self class] description], 0, @"filteredReports was nil"));
             }
             disposeOfCompletion();
             return;
@@ -265,9 +262,8 @@ SentryCrashReportFilterPipeline ()
                 sentrycrash_callCompletion(onCompletion, filteredReports, completed, filterError);
             } else if (filteredReports == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError sentryErrorWithDomain:[[self class] description]
-                                              code:0
-                                       description:@"filteredReports was nil"]);
+                    sentryErrorWithDomain(
+                        [[self class] description], 0, @"filteredReports was nil"));
             }
             disposeOfCompletion();
             return;
@@ -335,9 +331,8 @@ SentryCrashReportFilterObjectForKey ()
         if (object == nil) {
             if (!self.allowNotFound) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError sentryErrorWithDomain:[[self class] description]
-                                              code:0
-                                       description:@"Key not found: %@", self.key]);
+                    sentryErrorWithDomain(
+                        [[self class] description], 0, @"Key not found: %@", self.key));
                 return;
             }
             [filteredReports addObject:[NSDictionary dictionary]];
@@ -467,9 +462,8 @@ SentryCrashReportFilterSubset ()
             id object = [report sentry_objectForKeyPath:keyPath];
             if (object == nil) {
                 sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                    [NSError sentryErrorWithDomain:[[self class] description]
-                                              code:0
-                                       description:@"Report did not have key path %@", keyPath]);
+                    sentryErrorWithDomain([[self class] description], 0,
+                        @"Report did not have key path %@", keyPath));
                 return;
             }
             [subset setObject:object forKey:[keyPath lastPathComponent]];
@@ -517,9 +511,8 @@ SentryCrashReportFilterSubset ()
         NSData *converted = [report dataUsingEncoding:NSUTF8StringEncoding];
         if (converted == nil) {
             sentrycrash_callCompletion(onCompletion, filteredReports, NO,
-                [NSError sentryErrorWithDomain:[[self class] description]
-                                          code:0
-                                   description:@"Could not convert report to UTF-8"]);
+                sentryErrorWithDomain(
+                    [[self class] description], 0, @"Could not convert report to UTF-8"));
             return;
         } else {
             [filteredReports addObject:converted];

--- a/Tests/SentryTests/SentryCrash/SentryCrashNSErrorUtilTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashNSErrorUtilTests.m
@@ -27,7 +27,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "NSError+SentrySimpleConstructor.h"
+#import "SentryCrashNSErrorUtil.h"
 
 @interface NSError_SimpleConstructor_Tests : XCTestCase
 @end
@@ -36,48 +36,13 @@
 
 - (void)testSentryErrorWithDomain
 {
-    NSError *error = [NSError sentryErrorWithDomain:@"Domain"
-                                               code:10
-                                        description:@"A description %d", 1];
+    NSError *error = sentryErrorWithDomain(@"Domain", 10, @"A description %d", 1);
     NSString *expectedDomain = @"Domain";
     NSInteger expectedCode = 10;
     NSString *expectedDescription = @"A description 1";
     XCTAssertEqualObjects(error.domain, expectedDomain, @"");
     XCTAssertEqual(error.code, expectedCode, @"");
     XCTAssertEqualObjects(error.localizedDescription, expectedDescription, @"");
-}
-
-- (void)testSentryFillError
-{
-    NSError *error = nil;
-    [NSError sentryFillError:&error
-                  withDomain:@"Domain"
-                        code:10
-                 description:@"A description %d", 1];
-    NSString *expectedDomain = @"Domain";
-    NSInteger expectedCode = 10;
-    NSString *expectedDescription = @"A description 1";
-    XCTAssertEqualObjects(error.domain, expectedDomain, @"");
-    XCTAssertEqual(error.code, expectedCode, @"");
-    XCTAssertEqualObjects(error.localizedDescription, expectedDescription, @"");
-}
-
-- (void)testSentryFillErrorNil
-{
-    [NSError sentryFillError:nil withDomain:@"Domain" code:10 description:@"A description %d", 1];
-}
-
-- (void)testSentryClearError
-{
-    NSError *error = [NSError sentryErrorWithDomain:@"" code:1 description:@""];
-    XCTAssertNotNil(error, @"");
-    [NSError sentryClearError:&error];
-    XCTAssertNil(error, @"");
-}
-
-- (void)testSentryClearErrorNil
-{
-    [NSError sentryClearError:nil];
 }
 
 @end

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportFilter_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportFilter_Tests.m
@@ -27,7 +27,7 @@
 
 #import <XCTest/XCTest.h>
 
-#import "NSError+SentrySimpleConstructor.h"
+#import "SentryCrashNSErrorUtil.h"
 #import "SentryCrashReportFilter.h"
 #import "SentryCrashReportFilterBasic.h"
 


### PR DESCRIPTION




## :scroll: Description

Fix NSInvalidArgumentException for NSError sentryErrorWithDomain by removing the category functions because they get stripped for static libraries. This is related to GH-3764.

## :bulb: Motivation and Context

Fixes GH-3818

## :green_heart: How did you test it?

Same problem as https://github.com/getsentry/sentry-cocoa/issues/3763, for which removing the category function worked. So no need for an extra test.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ x No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
