### PR TITLE
fix: Crash in hasUnfinishedChildSpansToWaitFor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ more about how to use the Metrics API.
 - Fixed certain views getting loaded twice when adding a child view controller (#3753)
 - Fix NSInvalidArgumentException for `NSError sentryErrorWithDomain` (#3819)
 - Again fix runtime error when including Sentry as a static lib (#3820)
+- Fix crash in hasUnfinishedChildSpansToWaitFor (#3821)
 
 ## 8.22.4
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -547,10 +547,6 @@ static BOOL appStartMeasurementRead;
         self.finishCallback = nil;
     }
 
-    if (self.shouldIgnoreWaitForChildrenCallback) {
-        self.shouldIgnoreWaitForChildrenCallback = nil;
-    }
-
     // Prewarming can execute code up to viewDidLoad of a UIViewController, and keep the app in the
     // background. This can lead to auto-generated transactions lasting for minutes or even hours.
     // Therefore, we drop transactions lasting longer than SENTRY_AUTO_TRANSACTION_MAX_DURATION.


### PR DESCRIPTION




## :scroll: Description

Fix a crash in SentryTracer hasUnfinishedChildSpansToWaitFor by not setting the shouldIgnoreWaitForChildrenCallback to nil when finishing the tracer.

## :bulb: Motivation and Context

Fixes GH-3781

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
