### PR TITLE
ref: Remove duplicate code in NSDataTracker

### DIFF
--- a/Sources/Sentry/SentryNSDataTracker.m
+++ b/Sources/Sentry/SentryNSDataTracker.m
@@ -158,10 +158,6 @@ SentryNSDataTracker ()
         return nil;
     }
 
-    if ([self ignoreFile:path]) {
-        return nil;
-    }
-
     __block id<SentrySpan> ioSpan;
     [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
         ioSpan = [span startChildWithOperation:operation


### PR DESCRIPTION
#skip-changelog

This code is a duplicate. I remove one occurence.

https://github.com/getsentry/sentry-cocoa/blob/c83ffd949311d9b6594a041d1ad32e1e61dd74f5/Sources/Sentry/SentryNSDataTracker.m#L157-L163