### PR TITLE
feat(profiling): add private option to feature flag continuous profiling mode

### DIFF
--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -125,6 +125,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         _enableProfiling = NO;
         self.profilesSampleRate = nil;
+        _enableContinuousProfiling = NO;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;
@@ -472,6 +473,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[NSStringFromSelector(@selector(enableAppLaunchProfiling))]
             block:^(BOOL value) { self->_enableAppLaunchProfiling = value; }];
+
+    [self setBool:options[@"enableContinuousProfiling"]
+            block:^(BOOL value) { self->_enableContinuousProfiling = value; }];
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
     [self setBool:options[@"sendClientReports"]

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -8,6 +8,7 @@ FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
 SentryOptions ()
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 @property (nonatomic, assign) BOOL enableProfiling_DEPRECATED_TEST_ONLY;
+@property (nonatomic, assign) BOOL enableContinuousProfiling;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 SENTRY_EXTERN BOOL isValidSampleRate(NSNumber *sampleRate);

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -647,6 +647,7 @@
 #    pragma clang diagnostic pop
     XCTAssertNil(options.profilesSampleRate);
     XCTAssertNil(options.profilesSampler);
+    XCTAssertFalse(options.enableContinuousProfiling);
 #endif
 
     XCTAssertTrue([options.spotlightUrl isEqualToString:@"http://localhost:8969/stream"]);
@@ -1005,17 +1006,20 @@
     [self testBooleanField:@"enableProfiling" defaultValue:NO];
 }
 
+- (void)testEnableContinuousProfiling
+{
+    [self testBooleanField:@"enableContinuousProfiling" defaultValue:NO];
+}
+
 - (void)testProfilesSampleRate
 {
     SentryOptions *options = [self getValidOptions:@{ @"profilesSampleRate" : @0.1 }];
-
     XCTAssertEqual(options.profilesSampleRate.doubleValue, 0.1);
 }
 
 - (void)testDefaultProfilesSampleRate
 {
     SentryOptions *options = [self getValidOptions:@{}];
-
     XCTAssertEqual(options.profilesSampleRate.doubleValue, 0);
 }
 
@@ -1063,6 +1067,7 @@
 {
     SentryOptions *options = [[SentryOptions alloc] init];
     XCTAssertFalse(options.isProfilingEnabled);
+    XCTAssertFalse(options.enableContinuousProfiling);
 }
 
 - (void)testIsProfilingEnabled_ProfilesSampleRateSetToZero_IsDisabled
@@ -1070,6 +1075,7 @@
     SentryOptions *options = [[SentryOptions alloc] init];
     options.profilesSampleRate = @0.00;
     XCTAssertFalse(options.isProfilingEnabled);
+    XCTAssertFalse(options.enableContinuousProfiling);
 }
 
 - (void)testIsProfilingEnabled_ProfilesSampleRateSet_IsEnabled
@@ -1077,6 +1083,7 @@
     SentryOptions *options = [[SentryOptions alloc] init];
     options.profilesSampleRate = @0.01;
     XCTAssertTrue(options.isProfilingEnabled);
+    XCTAssertFalse(options.enableContinuousProfiling);
 }
 
 - (void)testIsProfilingEnabled_ProfilesSamplerSet_IsEnabled
@@ -1087,6 +1094,7 @@
         return @0.0;
     };
     XCTAssertTrue(options.isProfilingEnabled);
+    XCTAssertFalse(options.enableContinuousProfiling);
 }
 
 - (void)testIsProfilingEnabled_EnableProfilingSet_IsEnabled
@@ -1097,11 +1105,7 @@
     options.enableProfiling = YES;
 #    pragma clang diagnostic pop
     XCTAssertTrue(options.isProfilingEnabled);
-}
-
-- (double)profilesSamplerCallback:(NSDictionary *)context
-{
-    return 0.1;
+    XCTAssertFalse(options.enableContinuousProfiling);
 }
 
 - (void)testProfilesSampler
@@ -1115,6 +1119,7 @@
 
     SentrySamplingContext *context = [[SentrySamplingContext alloc] init];
     XCTAssertEqual(options.profilesSampler(context), @1.0);
+    XCTAssertFalse(options.enableContinuousProfiling);
 }
 
 - (void)testDefaultProfilesSampler
@@ -1129,7 +1134,7 @@
     XCTAssertNil(options.profilesSampler);
 }
 
-#endif
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 - (void)testInAppIncludes
 {


### PR DESCRIPTION
A private (for now) feature flag that will be used to switch between implementations of legacy and continuous profiling.

For #3555 

#skip-changelog