### PR TITLE
Add privacy manifest to SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,7 @@ let package = Package(
                   dependencies: ["Sentry", "SentryInternal"],
                   path: "Sources/SentrySwiftUI",
                   exclude: ["SentryInternal/", "module.modulemap"],
+                  resources: [.process("../Resources/PrivacyInfo.xcprivacy")],
                   linkerSettings: [
                      .linkedFramework("Sentry")
                   ]
@@ -33,6 +34,7 @@ let package = Package(
                  sources: [
                     "SentryInternal/"
                  ],
+                 resources: [.process("../Resources/PrivacyInfo.xcprivacy")],
                  publicHeadersPath: "SentryInternal/"
                )
     ],


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Add privacy manifest to targets on SPM

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The app store just sent me a warning about using NSPrivacyAccessedAPICategorySystemBootTime and NSPrivacyAccessedAPICategoryFileTimestamp and doesn't specified that on the manifest

## :green_heart: How did you test it?
Running Sentry Package

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
