### PR TITLE
ref(profiling): organize SentryProfiler implementation into separate code units

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -673,6 +673,8 @@
 		848A451A2BBF8D33006AAAEC /* SentryContinuousProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */; };
 		848A451D2BBF9504006AAAEC /* SentryProfilerTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */; };
 		848A451E2BBF9504006AAAEC /* SentryProfilerTestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */; };
+		848A45212BBF9D3F006AAAEC /* SentryProfilerSerialization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 848A45202BBF9D3F006AAAEC /* SentryProfilerSerialization.mm */; };
+		848A45222BBF9D3F006AAAEC /* SentryProfilerSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A451F2BBF9D3F006AAAEC /* SentryProfilerSerialization.h */; };
 		849AC40029E0C1FF00889C16 /* SentryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AC3FF29E0C1FF00889C16 /* SentryFormatterTests.swift */; };
 		84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */; };
 		84A8891C28DBD28900C51DFD /* SentryDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A8891A28DBD28900C51DFD /* SentryDevice.h */; };
@@ -1689,6 +1691,8 @@
 		848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryContinuousProfiler.m; sourceTree = "<group>"; };
 		848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilerTestHelpers.h; path = ../include/SentryProfilerTestHelpers.h; sourceTree = "<group>"; };
 		848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProfilerTestHelpers.m; sourceTree = "<group>"; };
+		848A451F2BBF9D3F006AAAEC /* SentryProfilerSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilerSerialization.h; path = ../include/SentryProfilerSerialization.h; sourceTree = "<group>"; };
+		848A45202BBF9D3F006AAAEC /* SentryProfilerSerialization.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfilerSerialization.mm; sourceTree = "<group>"; };
 		849472802971C107002603DE /* SentrySystemWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySystemWrapperTests.swift; sourceTree = "<group>"; };
 		849472822971C2CD002603DE /* SentryNSProcessInfoWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSProcessInfoWrapperTests.swift; sourceTree = "<group>"; };
 		849472842971C41A002603DE /* SentryNSTimerFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSTimerFactoryTest.swift; sourceTree = "<group>"; };
@@ -3322,6 +3326,8 @@
 				84AF45A529A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm */,
 				840B7EF22BBF83DF008B8120 /* SentryProfiler+Private.h */,
 				03F84D2B27DD4191008FE43F /* SentryProfiler.mm */,
+				848A451F2BBF9D3F006AAAEC /* SentryProfilerSerialization.h */,
+				848A45202BBF9D3F006AAAEC /* SentryProfilerSerialization.mm */,
 				848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */,
 				848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */,
 				848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */,
@@ -3791,6 +3797,7 @@
 				63FE71BA20DA4C1100CDBAE8 /* SentryCrashInstallation+Private.h in Headers */,
 				63FE71AE20DA4C1100CDBAE8 /* SentryCrashInstallation.h in Headers */,
 				63FE70F120DA4C1000CDBAE8 /* SentryCrashMonitorType.h in Headers */,
+				848A45222BBF9D3F006AAAEC /* SentryProfilerSerialization.h in Headers */,
 				7BA0C04628055F8E003E0326 /* SentryTransportAdapter.h in Headers */,
 				63FE717720DA4C1100CDBAE8 /* SentryCrashReportWriter.h in Headers */,
 				84DEE86B2B686BD400A7BC17 /* SentrySamplerDecision.h in Headers */,
@@ -4490,6 +4497,7 @@
 				63FE712720DA4C1000CDBAE8 /* SentryCrashThread.c in Sources */,
 				7B127B0F27CF6F4700A71ED2 /* SentryANRTrackingIntegration.m in Sources */,
 				62C316832B1F2EA1000D7031 /* SentryDelayedFramesTracker.m in Sources */,
+				848A45212BBF9D3F006AAAEC /* SentryProfilerSerialization.mm in Sources */,
 				D8BFE37329A3782F002E73F3 /* SentryTimeToDisplayTracker.m in Sources */,
 				D80694CE2B7E0A3E00B820E6 /* SentryReplayType.m in Sources */,
 				15360CCF2432777500112302 /* SentrySessionTracker.m in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -671,6 +671,8 @@
 		8489B8882A5F7905009A055A /* SentryThreadWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8489B8872A5F7905009A055A /* SentryThreadWrapperTests.swift */; };
 		848A45192BBF8D33006AAAEC /* SentryContinuousProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.m */; };
 		848A451A2BBF8D33006AAAEC /* SentryContinuousProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */; };
+		848A451D2BBF9504006AAAEC /* SentryProfilerTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */; };
+		848A451E2BBF9504006AAAEC /* SentryProfilerTestHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */; };
 		849AC40029E0C1FF00889C16 /* SentryFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849AC3FF29E0C1FF00889C16 /* SentryFormatterTests.swift */; };
 		84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */; };
 		84A8891C28DBD28900C51DFD /* SentryDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A8891A28DBD28900C51DFD /* SentryDevice.h */; };
@@ -1685,6 +1687,8 @@
 		8489B8872A5F7905009A055A /* SentryThreadWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SentryThreadWrapperTests.swift; path = Helper/SentryThreadWrapperTests.swift; sourceTree = "<group>"; };
 		848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryContinuousProfiler.h; path = ../include/SentryContinuousProfiler.h; sourceTree = "<group>"; };
 		848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryContinuousProfiler.m; sourceTree = "<group>"; };
+		848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilerTestHelpers.h; path = ../include/SentryProfilerTestHelpers.h; sourceTree = "<group>"; };
+		848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProfilerTestHelpers.m; sourceTree = "<group>"; };
 		849472802971C107002603DE /* SentrySystemWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySystemWrapperTests.swift; sourceTree = "<group>"; };
 		849472822971C2CD002603DE /* SentryNSProcessInfoWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSProcessInfoWrapperTests.swift; sourceTree = "<group>"; };
 		849472842971C41A002603DE /* SentryNSTimerFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSTimerFactoryTest.swift; sourceTree = "<group>"; };
@@ -3318,6 +3322,8 @@
 				84AF45A529A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm */,
 				840B7EF22BBF83DF008B8120 /* SentryProfiler+Private.h */,
 				03F84D2B27DD4191008FE43F /* SentryProfiler.mm */,
+				848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */,
+				848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */,
 				848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */,
 				848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.m */,
 				0354A22A2A134D9C003C3A04 /* SentryProfilerState.h */,
@@ -4057,6 +4063,7 @@
 				0A80E435291017D500095219 /* SentryWatchdogTerminationScopeObserver.h in Headers */,
 				7B610D642512399600B0B5D9 /* SentryHub+Private.h in Headers */,
 				D8F6A24B2885515C00320515 /* SentryPredicateDescriptor.h in Headers */,
+				848A451E2BBF9504006AAAEC /* SentryProfilerTestHelpers.h in Headers */,
 				639FCF9C1EBC7F9500778193 /* SentryThread.h in Headers */,
 				63FE716B20DA4C1100CDBAE8 /* SentryCrashJSONCodecObjC.h in Headers */,
 				63AA76A51EB9CBC200D153DE /* SentryDsn.h in Headers */,
@@ -4375,6 +4382,7 @@
 				62862B1E2B1DDC35009B16E3 /* SentryDelayedFrame.m in Sources */,
 				84AC61D729F75A98009EEF61 /* SentryDispatchFactory.m in Sources */,
 				15360CD62432832400112302 /* SentryAutoSessionTrackingIntegration.m in Sources */,
+				848A451D2BBF9504006AAAEC /* SentryProfilerTestHelpers.m in Sources */,
 				7B63459F280EBA7200CFA05A /* SentryUIEventTracker.m in Sources */,
 				7BF9EF782722B35D00B5BBEF /* SentrySubClassFinder.m in Sources */,
 				D80CD8D32B751447002F710B /* SentryMXCallStackTree.swift in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1643,7 +1643,7 @@
 		84281C4C2A579A0C00EE88F2 /* SentryProfilerMocksSwiftCompatible.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryProfilerMocksSwiftCompatible.h; sourceTree = "<group>"; };
 		84281C4D2A579A0C00EE88F2 /* SentryProfilerMocksSwiftCompatible.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfilerMocksSwiftCompatible.mm; sourceTree = "<group>"; };
 		84281C642A57D36100EE88F2 /* SentryProfilerState+ObjCpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryProfilerState+ObjCpp.h"; path = "../include/SentryProfilerState+ObjCpp.h"; sourceTree = "<group>"; };
-		84281C652A58A16500EE88F2 /* SentryProfiler+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryProfiler+Test.h"; sourceTree = "<group>"; };
+		84281C652A58A16500EE88F2 /* SentryProfiler+CppShims.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryProfiler+CppShims.h"; sourceTree = "<group>"; };
 		84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLaunchProfiling.m; sourceTree = "<group>"; };
 		8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTimeTests.m; sourceTree = "<group>"; };
 		8431EFD929B27B1100D8DC56 /* SentryProfilerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SentryProfilerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2422,8 +2422,7 @@
 				62872B602BA1B84400A4FA7D /* Swift */,
 				7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */,
 				D8BC83BA2AFCF08C00A662B7 /* SentryUIApplication+Private.h */,
-				84281C652A58A16500EE88F2 /* SentryProfiler+Test.h */,
-				84A3055A2BCA03B500D84283 /* SentryProfilerSerialization+Test.h */,
+				84281C652A58A16500EE88F2 /* SentryProfiler+CppShims.h */,
 				7B569DFE2590EEF600B653FC /* SentryScope+Equality.h */,
 				7B569E052590F04700B653FC /* SentryScope+Properties.h */,
 				7B9421C4260CA393001F9349 /* SentrySDK+Tests.h */,
@@ -3329,6 +3328,7 @@
 				840B7EF22BBF83DF008B8120 /* SentryProfiler+Private.h */,
 				03F84D2B27DD4191008FE43F /* SentryProfiler.mm */,
 				848A451F2BBF9D3F006AAAEC /* SentryProfilerSerialization.h */,
+				84A3055A2BCA03B500D84283 /* SentryProfilerSerialization+Test.h */,
 				848A45202BBF9D3F006AAAEC /* SentryProfilerSerialization.mm */,
 				848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */,
 				848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */,
@@ -5590,7 +5590,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.Sentry.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryProfiler.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -5652,7 +5652,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.Sentry.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryProfiler.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -5683,7 +5683,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.Sentry.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryProfiler.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -5714,7 +5714,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.Sentry.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryProfiler.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -5745,7 +5745,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.Sentry.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryProfiler.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
@@ -6075,7 +6075,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.Sentry.tests;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.SentryProfiler.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1697,6 +1697,7 @@
 		849472822971C2CD002603DE /* SentryNSProcessInfoWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSProcessInfoWrapperTests.swift; sourceTree = "<group>"; };
 		849472842971C41A002603DE /* SentryNSTimerFactoryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSTimerFactoryTest.swift; sourceTree = "<group>"; };
 		849AC3FF29E0C1FF00889C16 /* SentryFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryFormatterTests.swift; sourceTree = "<group>"; };
+		84A3055A2BCA03B500D84283 /* SentryProfilerSerialization+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryProfilerSerialization+Test.h"; sourceTree = "<group>"; };
 		84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Sentry.swift"; sourceTree = "<group>"; };
 		84A8891A28DBD28900C51DFD /* SentryDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDevice.h; path = include/SentryDevice.h; sourceTree = "<group>"; };
 		84A8891B28DBD28900C51DFD /* SentryDevice.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryDevice.mm; sourceTree = "<group>"; };
@@ -1865,9 +1866,9 @@
 		D8751FA4274743710032F4DE /* SentryNSURLSessionTaskSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSURLSessionTaskSearchTests.swift; sourceTree = "<group>"; };
 		D8757D142A209F7300BFEFCC /* SentrySampleDecision+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySampleDecision+Private.h"; path = "include/SentrySampleDecision+Private.h"; sourceTree = "<group>"; };
 		D875ED0A276CC84700422FAC /* SentryNSDataTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryNSDataTrackerTests.swift; sourceTree = "<group>"; };
+		D878C6C02BC8048A0039D6A3 /* SentryPrivate.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = SentryPrivate.podspec; sourceTree = "<group>"; };
 		D87C89022BC43C9C0086C7DF /* SentryRedactOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRedactOptions.swift; sourceTree = "<group>"; };
 		D87C892A2BC67BC20086C7DF /* SentryExperimentalOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExperimentalOptions.swift; sourceTree = "<group>"; };
-		D878C6C02BC8048A0039D6A3 /* SentryPrivate.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = SentryPrivate.podspec; sourceTree = "<group>"; };
 		D880E3A628573E87008A90DB /* SentryBaggageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBaggageTests.swift; sourceTree = "<group>"; };
 		D880E3B02860A5A0008A90DB /* SentryEvent+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryEvent+Private.h"; path = "include/SentryEvent+Private.h"; sourceTree = "<group>"; };
 		D884A20327C80F2700074664 /* SentryCoreDataTrackerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCoreDataTrackerTest.swift; sourceTree = "<group>"; };
@@ -2422,6 +2423,7 @@
 				7B3878E92490D90400EBDEA2 /* SentryClient+TestInit.h */,
 				D8BC83BA2AFCF08C00A662B7 /* SentryUIApplication+Private.h */,
 				84281C652A58A16500EE88F2 /* SentryProfiler+Test.h */,
+				84A3055A2BCA03B500D84283 /* SentryProfilerSerialization+Test.h */,
 				7B569DFE2590EEF600B653FC /* SentryScope+Equality.h */,
 				7B569E052590F04700B653FC /* SentryScope+Properties.h */,
 				7B9421C4260CA393001F9349 /* SentrySDK+Tests.h */,

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentryProfilerTests.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentryProfilerTests.xcscheme
@@ -7,7 +7,7 @@
       buildImplicitDependencies = "YES">
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
@@ -25,7 +25,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTestUtils.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTestUtils.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8431F00929B284F200D8DC56"
+               BuildableName = "libSentryTestUtils.a"
+               BlueprintName = "SentryTestUtils"
+               ReferencedContainer = "container:Sentry.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Test"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8431F00929B284F200D8DC56"
+            BuildableName = "libSentryTestUtils.a"
+            BlueprintName = "SentryTestUtils"
+            ReferencedContainer = "container:Sentry.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTests.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTests.xcscheme
@@ -7,7 +7,7 @@
       buildImplicitDependencies = "YES">
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Test"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -17,7 +17,8 @@
 #import "SentryProfilingConditionals.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-#    import "SentryProfiler+Test.h"
+#    import "SentryProfiler+CppShims.h"
+#    import "SentryProfiler+Private.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 #import "PrivateSentrySDKOnly.h"

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -136,8 +136,8 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
                                                                     and:(uint64_t)endSystemTime
                                                                forTrace:(SentryId *)traceId;
 {
-    NSMutableDictionary<NSString *, id> *payload
-        = collectProfileData(startSystemTime, endSystemTime, traceId, [SentrySDK currentHub]);
+    NSMutableDictionary<NSString *, id> *payload = sentry_collectProfileData(
+        startSystemTime, endSystemTime, traceId, [SentrySDK currentHub]);
 
     if (payload != nil) {
         payload[@"platform"] = SentryPlatformName;
@@ -152,7 +152,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)discardProfilerForTrace:(SentryId *)traceId;
 {
-    discardProfilerForTracer(traceId);
+    sentry_discardProfilerForTracer(traceId);
 }
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -11,6 +11,7 @@
 #import "SentryOptions.h"
 #import "SentryProfiledTracerConcurrency.h"
 #import "SentryProfiler+Private.h"
+#import "SentryProfilerSerialization.h"
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import "SentrySwift.h"
@@ -135,11 +136,8 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
                                                                     and:(uint64_t)endSystemTime
                                                                forTrace:(SentryId *)traceId;
 {
-    NSMutableDictionary<NSString *, id> *payload =
-        [SentryProfiler collectProfileBetween:startSystemTime
-                                          and:endSystemTime
-                                     forTrace:traceId
-                                        onHub:[SentrySDK currentHub]];
+    NSMutableDictionary<NSString *, id> *payload
+        = collectProfileData(startSystemTime, endSystemTime, traceId, [SentrySDK currentHub]);
 
     if (payload != nil) {
         payload[@"platform"] = SentryPlatformName;

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -123,7 +123,7 @@ SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId)
     _unsafe_cleanUpProfiler(profiler, tracerKey);
 
 #    if SENTRY_HAS_UIKIT
-    profiler._screenFrameData =
+    profiler.screenFrameData =
         [SentryDependencyContainer.sharedInstance.framesTracker.currentFrames copy];
     if (_gProfilersToTracers.count == 0) {
         [SentryDependencyContainer.sharedInstance.framesTracker resetProfilingTimestamps];

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -54,7 +54,7 @@ _unsafe_cleanUpProfiler(SentryProfiler *profiler, NSString *tracerKey)
 std::mutex _gStateLock;
 
 void
-trackProfilerForTracer(SentryProfiler *profiler, SentryId *internalTraceId)
+sentry_trackProfilerForTracer(SentryProfiler *profiler, SentryId *internalTraceId)
 {
     std::lock_guard<std::mutex> l(_gStateLock);
 
@@ -82,7 +82,7 @@ trackProfilerForTracer(SentryProfiler *profiler, SentryId *internalTraceId)
 }
 
 void
-discardProfilerForTracer(SentryId *internalTraceId)
+sentry_discardProfilerForTracer(SentryId *internalTraceId)
 {
     std::lock_guard<std::mutex> l(_gStateLock);
 
@@ -105,7 +105,7 @@ discardProfilerForTracer(SentryId *internalTraceId)
 #    endif // SENTRY_HAS_UIKIT
 }
 
-SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId)
+SentryProfiler *_Nullable sentry_profilerForFinishedTracer(SentryId *internalTraceId)
 {
     std::lock_guard<std::mutex> l(_gStateLock);
 
@@ -135,7 +135,7 @@ SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId)
 
 #    if defined(TEST) || defined(TESTCI)
 void
-resetConcurrencyTracking()
+sentry_resetConcurrencyTracking()
 {
     std::lock_guard<std::mutex> l(_gStateLock);
     [_gTracersToProfilers removeAllObjects];
@@ -143,7 +143,7 @@ resetConcurrencyTracking()
 }
 
 NSUInteger
-currentProfiledTracers()
+sentry_currentProfiledTracers()
 {
     std::lock_guard<std::mutex> l(_gStateLock);
     return [_gTracersToProfilers count];

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization+Test.h
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization+Test.h
@@ -2,9 +2,11 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryDefines.h"
-#    import "SentryProfiler+Private.h"
-#    import <Foundation/Foundation.h>
+#    if defined(TEST) || defined(TESTCI)
+
+#        import "SentryDefines.h"
+#        import "SentryProfiler+Private.h"
+#        import <Foundation/Foundation.h>
 
 @class SentryDebugMeta;
 @class SentryHub;
@@ -26,12 +28,14 @@ SENTRY_EXTERN NSMutableDictionary<NSString *, id> *sentry_serializedProfileData(
     NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
     NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
     NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
-#    if SENTRY_HAS_UIKIT
+#        if SENTRY_HAS_UIKIT
     ,
     SentryScreenFrames *gpuData
-#    endif // SENTRY_HAS_UIKIT
+#        endif // SENTRY_HAS_UIKIT
 );
 
 NS_ASSUME_NONNULL_END
+
+#    endif // defined(TEST) || defined(TESTCI)
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -1,0 +1,260 @@
+#import "SentryProfilerSerialization.h"
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryClient+Private.h"
+#    import "SentryDateUtils.h"
+#    import "SentryDebugImageProvider.h"
+#    import "SentryDebugMeta.h"
+#    import "SentryDevice.h"
+#    import "SentryEnvelope.h"
+#    import "SentryEnvelopeItemHeader.h"
+#    import "SentryEnvelopeItemType.h"
+#    import "SentryEvent+Private.h"
+#    import "SentryFormatter.h"
+#    import "SentryHub.h"
+#    import "SentryMetricProfiler.h"
+#    import "SentryOptions.h"
+#    import "SentryProfileTimeseries.h"
+#    import "SentryProfiledTracerConcurrency.h"
+#    import "SentryProfiler+Test.h"
+#    import "SentryProfilerState.h"
+#    import "SentryProfilerTestHelpers.h"
+#    import "SentrySample.h"
+#    import "SentryScope+Private.h"
+#    import "SentrySerialization.h"
+#    import "SentrySwift.h"
+#    import "SentryThread.h"
+#    import "SentryTime.h"
+#    import "SentryTracer+Private.h"
+#    import "SentryTransaction.h"
+#    import "SentryTransactionContext+Private.h"
+
+NSString *const kSentryProfilerSerializationKeySlowFrameRenders = @"slow_frame_renders";
+NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders = @"frozen_frame_renders";
+NSString *const kSentryProfilerSerializationKeyFrameRates = @"screen_frame_rates";
+
+#    pragma mark - Private
+
+namespace {
+
+/** Given an array of samples with absolute timestamps, return the serialized JSON mapping with
+ * their data, with timestamps normalized relative to the provided transaction's start time. */
+NSArray<NSDictionary *> *
+serializedSamplesWithRelativeTimestamps(NSArray<SentrySample *> *samples, uint64_t startSystemTime)
+{
+    const auto result = [NSMutableArray<NSDictionary *> array];
+    [samples enumerateObjectsUsingBlock:^(
+        SentrySample *_Nonnull sample, NSUInteger idx, BOOL *_Nonnull stop) {
+        // This shouldn't happen as we would've filtered out any such samples, but we should still
+        // guard against it before calling getDurationNs as a defensive measure
+        if (!orderedChronologically(startSystemTime, sample.absoluteTimestamp)) {
+            SENTRY_LOG_WARN(@"Filtered sample not chronological with transaction.");
+            return;
+        }
+        const auto dict = [NSMutableDictionary dictionaryWithDictionary:@ {
+            @"elapsed_since_start_ns" :
+                sentry_stringForUInt64(getDurationNs(startSystemTime, sample.absoluteTimestamp)),
+            @"thread_id" : sentry_stringForUInt64(sample.threadID),
+            @"stack_id" : sample.stackIndex,
+        }];
+        if (sample.queueAddress) {
+            dict[@"queue_address"] = sample.queueAddress;
+        }
+
+        [result addObject:dict];
+    }];
+    return result;
+}
+
+} // namespace
+
+#    pragma mark - Public
+
+SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction)
+{
+    SENTRY_LOG_DEBUG(@"Creating profiling envelope item");
+    const auto profiler = profilerForFinishedTracer(transaction.trace.traceId);
+    if (!profiler) {
+        return nil;
+    }
+
+    const auto payload
+        = serializedProfileData([profiler._state copyProfilingData], transaction.startSystemTime,
+            transaction.endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
+            [profiler._metricProfiler serializeBetween:transaction.startSystemTime
+                                                   and:transaction.endSystemTime],
+            [profiler._debugImageProvider getDebugImagesCrashed:NO], transaction.trace.hub
+#    if SENTRY_HAS_UIKIT
+            ,
+            profiler._screenFrameData
+#    endif // SENTRY_HAS_UIKIT
+        );
+
+#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+    writeProfileFile(payload);
+#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
+    if (payload == nil) {
+        SENTRY_LOG_DEBUG(@"Payload was empty, will not create a profiling envelope item.");
+        return nil;
+    }
+
+    payload[@"platform"] = transaction.platform;
+    payload[@"transaction"] = @ {
+        @"id" : transaction.eventId.sentryIdString,
+        @"trace_id" : transaction.trace.traceId.sentryIdString,
+        @"name" : transaction.transaction,
+        @"active_thread_id" : [transaction.trace.transactionContext sentry_threadInfo].threadId
+    };
+    payload[@"timestamp"] = sentry_toIso8601String(transaction.trace.startTimestamp);
+
+    const auto JSONData = [SentrySerialization dataWithJSONObject:payload];
+    if (JSONData == nil) {
+        SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON.");
+        return nil;
+    }
+
+    const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
+                                                                length:JSONData.length];
+    return [[SentryEnvelopeItem alloc] initWithHeader:header data:JSONData];
+}
+
+NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
+    uint64_t startSystemTime, uint64_t endSystemTime, SentryId *traceId, SentryHub *hub)
+{
+    const auto profiler = profilerForFinishedTracer(traceId);
+    if (!profiler) {
+        return nil;
+    }
+
+    return serializedProfileData([profiler._state copyProfilingData], startSystemTime,
+        endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
+        [profiler._metricProfiler serializeBetween:startSystemTime and:endSystemTime],
+        [profiler._debugImageProvider getDebugImagesCrashed:NO], hub
+#    if SENTRY_HAS_UIKIT
+        ,
+        profiler._screenFrameData
+#    endif // SENTRY_HAS_UIKIT
+    );
+}
+
+#    pragma mark - Exported for tests
+
+NSString *
+profilerTruncationReasonName(SentryProfilerTruncationReason reason)
+{
+    switch (reason) {
+    case SentryProfilerTruncationReasonNormal:
+        return @"normal";
+    case SentryProfilerTruncationReasonAppMovedToBackground:
+        return @"backgrounded";
+    case SentryProfilerTruncationReasonTimeout:
+        return @"timeout";
+    }
+}
+
+NSMutableDictionary<NSString *, id> *
+serializedProfileData(
+    NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
+    NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
+    NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
+#    if SENTRY_HAS_UIKIT
+    ,
+    SentryScreenFrames *gpuData
+#    endif // SENTRY_HAS_UIKIT
+)
+{
+    NSMutableArray<SentrySample *> *const samples = profileData[@"profile"][@"samples"];
+    // We need at least two samples to be able to draw a stack frame for any given function: one
+    // sample for the start of the frame and another for the end. Otherwise we would only have a
+    // stack frame with 0 duration, which wouldn't make sense.
+    if ([samples count] < 2) {
+        SENTRY_LOG_DEBUG(@"Not enough samples in profile");
+        [hub.getClient recordLostEvent:kSentryDataCategoryProfile
+                                reason:kSentryDiscardReasonEventProcessor];
+        return nil;
+    }
+
+    // slice the profile data to only include the samples/metrics within the transaction
+    const auto slicedSamples = slicedProfileSamples(samples, startSystemTime, endSystemTime);
+    if (slicedSamples.count < 2) {
+        SENTRY_LOG_DEBUG(@"Not enough samples in profile during the transaction");
+        [hub.getClient recordLostEvent:kSentryDataCategoryProfile
+                                reason:kSentryDiscardReasonEventProcessor];
+        return nil;
+    }
+    const auto payload = [NSMutableDictionary<NSString *, id> dictionary];
+    NSMutableDictionary<NSString *, id> *const profile = [profileData[@"profile"] mutableCopy];
+    profile[@"samples"] = serializedSamplesWithRelativeTimestamps(slicedSamples, startSystemTime);
+    payload[@"profile"] = profile;
+
+    payload[@"version"] = @"1";
+    const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
+    for (SentryDebugMeta *debugImage in debugMeta) {
+        [debugImages addObject:[debugImage serialize]];
+    }
+    if (debugImages.count > 0) {
+        payload[@"debug_meta"] = @ { @"images" : debugImages };
+    }
+
+    payload[@"os"] = @ {
+        @"name" : sentry_getOSName(),
+        @"version" : sentry_getOSVersion(),
+        @"build_number" : sentry_getOSBuildNumber()
+    };
+
+    const auto isEmulated = sentry_isSimulatorBuild();
+    payload[@"device"] = @{
+        @"architecture" : sentry_getCPUArchitecture(),
+        @"is_emulator" : @(isEmulated),
+        @"locale" : NSLocale.currentLocale.localeIdentifier,
+        @"manufacturer" : @"Apple",
+        @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel()
+    };
+
+    payload[@"profile_id"] = [[[SentryId alloc] init] sentryIdString];
+    payload[@"truncation_reason"] = truncationReason;
+    payload[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment;
+    payload[@"release"] = hub.getClient.options.releaseName;
+
+    // add the gathered metrics
+    auto metrics = serializedMetrics;
+
+#    if SENTRY_HAS_UIKIT
+    const auto mutableMetrics =
+        [NSMutableDictionary<NSString *, id> dictionaryWithDictionary:metrics];
+    const auto slowFrames = sliceGPUData(gpuData.slowFrameTimestamps, startSystemTime,
+        endSystemTime, /*useMostRecentRecording */ NO);
+    if (slowFrames.count > 0) {
+        mutableMetrics[kSentryProfilerSerializationKeySlowFrameRenders] =
+            @ { @"unit" : @"nanosecond", @"values" : slowFrames };
+    }
+
+    const auto frozenFrames
+        = sliceGPUData(gpuData.frozenFrameTimestamps, startSystemTime, endSystemTime,
+            /*useMostRecentRecording */ NO);
+    if (frozenFrames.count > 0) {
+        mutableMetrics[kSentryProfilerSerializationKeyFrozenFrameRenders] =
+            @ { @"unit" : @"nanosecond", @"values" : frozenFrames };
+    }
+
+    if (slowFrames.count > 0 || frozenFrames.count > 0) {
+        const auto frameRates
+            = sliceGPUData(gpuData.frameRateTimestamps, startSystemTime, endSystemTime,
+                /*useMostRecentRecording */ YES);
+        if (frameRates.count > 0) {
+            mutableMetrics[kSentryProfilerSerializationKeyFrameRates] =
+                @ { @"unit" : @"hz", @"values" : frameRates };
+        }
+    }
+    metrics = mutableMetrics;
+#    endif // SENTRY_HAS_UIKIT
+
+    if (metrics.count > 0) {
+        payload[@"measurements"] = metrics;
+    }
+
+    return payload;
+}
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -82,7 +82,7 @@ SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction
 
     const auto payload
         = serializedProfileData([profiler.state copyProfilingData], transaction.startSystemTime,
-            transaction.endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
+            transaction.endSystemTime, profilerTruncationReasonName(profiler.truncationReason),
             [profiler._metricProfiler serializeBetween:transaction.startSystemTime
                                                    and:transaction.endSystemTime],
             [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO],
@@ -130,7 +130,7 @@ NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
     }
 
     return serializedProfileData([profiler.state copyProfilingData], startSystemTime, endSystemTime,
-        profilerTruncationReasonName(profiler._truncationReason),
+        profilerTruncationReasonName(profiler.truncationReason),
         [profiler._metricProfiler serializeBetween:startSystemTime and:endSystemTime],
         [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO], hub
 #    if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -83,13 +83,13 @@ SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction
     const auto payload
         = serializedProfileData([profiler.state copyProfilingData], transaction.startSystemTime,
             transaction.endSystemTime, profilerTruncationReasonName(profiler.truncationReason),
-            [profiler._metricProfiler serializeBetween:transaction.startSystemTime
-                                                   and:transaction.endSystemTime],
+            [profiler.metricProfiler serializeBetween:transaction.startSystemTime
+                                                  and:transaction.endSystemTime],
             [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO],
             transaction.trace.hub
 #    if SENTRY_HAS_UIKIT
             ,
-            profiler._screenFrameData
+            profiler.screenFrameData
 #    endif // SENTRY_HAS_UIKIT
         );
 
@@ -131,11 +131,11 @@ NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
 
     return serializedProfileData([profiler.state copyProfilingData], startSystemTime, endSystemTime,
         profilerTruncationReasonName(profiler.truncationReason),
-        [profiler._metricProfiler serializeBetween:startSystemTime and:endSystemTime],
+        [profiler.metricProfiler serializeBetween:startSystemTime and:endSystemTime],
         [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO], hub
 #    if SENTRY_HAS_UIKIT
         ,
-        profiler._screenFrameData
+        profiler.screenFrameData
 #    endif // SENTRY_HAS_UIKIT
     );
 }

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -6,6 +6,7 @@
 #    import "SentryDateUtils.h"
 #    import "SentryDebugImageProvider.h"
 #    import "SentryDebugMeta.h"
+#    import "SentryDependencyContainer.h"
 #    import "SentryDevice.h"
 #    import "SentryEnvelope.h"
 #    import "SentryEnvelopeItemHeader.h"
@@ -80,11 +81,12 @@ SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction
     }
 
     const auto payload
-        = serializedProfileData([profiler._state copyProfilingData], transaction.startSystemTime,
+        = serializedProfileData([profiler.state copyProfilingData], transaction.startSystemTime,
             transaction.endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
             [profiler._metricProfiler serializeBetween:transaction.startSystemTime
                                                    and:transaction.endSystemTime],
-            [profiler._debugImageProvider getDebugImagesCrashed:NO], transaction.trace.hub
+            [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO], 
+                transaction.trace.hub
 #    if SENTRY_HAS_UIKIT
             ,
             profiler._screenFrameData
@@ -130,7 +132,7 @@ NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
     return serializedProfileData([profiler._state copyProfilingData], startSystemTime,
         endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
         [profiler._metricProfiler serializeBetween:startSystemTime and:endSystemTime],
-        [profiler._debugImageProvider getDebugImagesCrashed:NO], hub
+        [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO], hub
 #    if SENTRY_HAS_UIKIT
         ,
         profiler._screenFrameData

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -196,7 +196,7 @@ serializedProfileData(
 SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction)
 {
     SENTRY_LOG_DEBUG(@"Creating profiling envelope item");
-    const auto profiler = profilerForFinishedTracer(transaction.trace.traceId);
+    const auto profiler = profilerForFinishedTracer(transaction.trace.internalID);
     if (!profiler) {
         return nil;
     }

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -21,6 +21,7 @@
 #    import "SentryProfiledTracerConcurrency.h"
 #    import "SentryProfiler+Private.h"
 #    import "SentryProfilerSerialization+Test.h"
+#    import "SentryProfilerSerialization.h"
 #    import "SentryProfilerState.h"
 #    import "SentryProfilerTestHelpers.h"
 #    import "SentrySample.h"
@@ -201,7 +202,7 @@ SentryEnvelopeItem *_Nullable sentry_profileEnvelopeItem(
     SentryTransaction *transaction, NSDate *startTimestamp)
 {
     SENTRY_LOG_DEBUG(@"Creating profiling envelope item");
-    const auto profiler = profilerForFinishedTracer(transaction.trace.internalID);
+    const auto profiler = sentry_profilerForFinishedTracer(transaction.trace.internalID);
     if (!profiler) {
         return nil;
     }
@@ -251,7 +252,7 @@ SentryEnvelopeItem *_Nullable sentry_profileEnvelopeItem(
 NSMutableDictionary<NSString *, id> *_Nullable sentry_collectProfileData(
     uint64_t startSystemTime, uint64_t endSystemTime, SentryId *traceId, SentryHub *hub)
 {
-    const auto profiler = profilerForFinishedTracer(traceId);
+    const auto profiler = sentry_profilerForFinishedTracer(traceId);
     if (!profiler) {
         return nil;
     }

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -85,8 +85,8 @@ SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction
             transaction.endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
             [profiler._metricProfiler serializeBetween:transaction.startSystemTime
                                                    and:transaction.endSystemTime],
-            [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO], 
-                transaction.trace.hub
+            [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO],
+            transaction.trace.hub
 #    if SENTRY_HAS_UIKIT
             ,
             profiler._screenFrameData
@@ -129,8 +129,8 @@ NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
         return nil;
     }
 
-    return serializedProfileData([profiler._state copyProfilingData], startSystemTime,
-        endSystemTime, profilerTruncationReasonName(profiler._truncationReason),
+    return serializedProfileData([profiler.state copyProfilingData], startSystemTime, endSystemTime,
+        profilerTruncationReasonName(profiler._truncationReason),
         [profiler._metricProfiler serializeBetween:startSystemTime and:endSystemTime],
         [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesCrashed:NO], hub
 #    if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -193,7 +193,8 @@ serializedProfileData(
 
 #    pragma mark - Public
 
-SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction)
+SentryEnvelopeItem *_Nullable profileEnvelopeItem(
+    SentryTransaction *transaction, NSDate *startTimestamp)
 {
     SENTRY_LOG_DEBUG(@"Creating profiling envelope item");
     const auto profiler = profilerForFinishedTracer(transaction.trace.internalID);
@@ -230,7 +231,7 @@ SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction
         @"name" : transaction.transaction,
         @"active_thread_id" : [transaction.trace.transactionContext sentry_threadInfo].threadId
     };
-    payload[@"timestamp"] = sentry_toIso8601String(transaction.trace.startTimestamp);
+    payload[@"timestamp"] = sentry_toIso8601String(startTimestamp);
 
     const auto JSONData = [SentrySerialization dataWithJSONObject:payload];
     if (JSONData == nil) {

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -96,6 +96,7 @@ SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
     writeProfileFile(payload);
 #    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
+
     if (payload == nil) {
         SENTRY_LOG_DEBUG(@"Payload was empty, will not create a profiling envelope item.");
         return nil;

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -1,0 +1,74 @@
+#import "SentryProfilerTestHelpers.h"
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryFileManager.h"
+#    import "SentryInternalDefines.h"
+#    import "SentryLaunchProfiling.h"
+#    import "SentrySerialization.h"
+
+BOOL
+threadSanitizerIsPresent(void)
+{
+#    if defined(__has_feature)
+#        if __has_feature(thread_sanitizer)
+    return YES;
+#            pragma clang diagnostic push
+#            pragma clang diagnostic ignored "-Wunreachable-code"
+#        endif // __has_feature(thread_sanitizer)
+#    endif // defined(__has_feature)
+
+    return NO;
+}
+
+#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+
+void
+writeProfileFile(NSDictionary<NSString *, id> *payload)
+{
+    NSData *data = [SentrySerialization dataWithJSONObject:payload];
+    NSFileManager *fm = [NSFileManager defaultManager];
+    NSString *appSupportDirPath = sentryApplicationSupportPath();
+
+    if (![fm fileExistsAtPath:appSupportDirPath]) {
+        SENTRY_LOG_DEBUG(@"Creating app support directory.");
+        NSError *error;
+        if (!SENTRY_CASSERT_RETURN([fm createDirectoryAtPath:appSupportDirPath
+                                       withIntermediateDirectories:NO
+                                                        attributes:nil
+                                                             error:&error],
+                @"Failed to create sentry app support directory")) {
+            return;
+        }
+    } else {
+        SENTRY_LOG_DEBUG(@"App support directory already exists.");
+    }
+
+    NSString *pathToWrite;
+    if (isTracingAppLaunch) {
+        SENTRY_LOG_DEBUG(@"Writing app launch profile.");
+        pathToWrite = [appSupportDirPath stringByAppendingPathComponent:@"launchProfile"];
+    } else {
+        SENTRY_LOG_DEBUG(@"Overwriting last non-launch profile.");
+        pathToWrite = [appSupportDirPath stringByAppendingPathComponent:@"profile"];
+    }
+
+    if ([fm fileExistsAtPath:pathToWrite]) {
+        SENTRY_LOG_DEBUG(@"Already a %@ profile file present; make sure to remove them right after "
+                         @"using them, and that tests clean state in between so there isn't "
+                         @"leftover config producing one when it isn't expected.",
+            isTracingAppLaunch ? @" launch" : @"");
+        return;
+    }
+
+    SENTRY_LOG_DEBUG(@"Writing%@ profile to file.", isTracingAppLaunch ? @" launch" : @"");
+
+    NSError *error;
+    if (![data writeToFile:pathToWrite options:NSDataWritingAtomic error:&error]) {
+        SENTRY_LOG_ERROR(@"Failed to write data to path %@: %@", pathToWrite, error);
+    }
+}
+
+#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -8,7 +8,7 @@
 #    import "SentrySerialization.h"
 
 BOOL
-threadSanitizerIsPresent(void)
+sentry_threadSanitizerIsPresent(void)
 {
 #    if defined(__has_feature)
 #        if __has_feature(thread_sanitizer)
@@ -24,7 +24,7 @@ threadSanitizerIsPresent(void)
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
 void
-writeProfileFile(NSDictionary<NSString *, id> *payload)
+sentry_writeProfileFile(NSDictionary<NSString *, id> *payload)
 {
     NSData *data = [SentrySerialization dataWithJSONObject:payload];
     NSFileManager *fm = [NSFileManager defaultManager];

--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -14,6 +14,8 @@
 #        import "SentryScreenFrames.h"
 #    endif // SENTRY_HAS_UIKIT
 
+namespace {
+
 /**
  * Print a debug log to help diagnose slicing errors.
  * @param start @c YES if this is an attempt to find the start of the sliced data based on the
@@ -21,7 +23,7 @@
  * transaction's end, to accurately describe what's happening in the log statement.
  */
 void
-logSlicingFailureWithArray(
+_sentry_logSlicingFailureWithArray(
     NSArray<SentrySample *> *array, uint64_t startSystemTime, uint64_t endSystemTime, BOOL start)
 {
     if (!SENTRY_CASSERT_RETURN(
@@ -45,7 +47,9 @@ logSlicingFailureWithArray(
         firstSampleRelativeToTransactionStart, lastSampleRelativeToTransactionStart);
 }
 
-NSArray<SentrySample *> *_Nullable slicedProfileSamples(
+} // namespace
+
+NSArray<SentrySample *> *_Nullable sentry_slicedProfileSamples(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime, uint64_t endSystemTime)
 {
     if (samples.count == 0) {
@@ -61,7 +65,7 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
     }];
 
     if (firstIndex == NSNotFound) {
-        logSlicingFailureWithArray(samples, startSystemTime, endSystemTime, /*start*/ YES);
+        _sentry_logSlicingFailureWithArray(samples, startSystemTime, endSystemTime, /*start*/ YES);
         return nil;
     } else {
         SENTRY_LOG_DEBUG(@"Found first slice sample at index %lu", firstIndex);
@@ -76,7 +80,7 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
                               }];
 
     if (lastIndex == NSNotFound) {
-        logSlicingFailureWithArray(samples, startSystemTime, endSystemTime, /*start*/ NO);
+        _sentry_logSlicingFailureWithArray(samples, startSystemTime, endSystemTime, /*start*/ NO);
         return nil;
     } else {
         SENTRY_LOG_DEBUG(@"Found last slice sample at index %lu", lastIndex);
@@ -100,8 +104,8 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
  * for it.
  */
 NSArray<SentrySerializedMetricEntry *> *
-sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, uint64_t startSystemTime, uint64_t endSystemTime,
-    BOOL useMostRecentRecording)
+sentry_sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, uint64_t startSystemTime,
+    uint64_t endSystemTime, BOOL useMostRecentRecording)
 {
     auto slicedGPUEntries = [NSMutableArray<SentrySerializedMetricEntry *> array];
     __block NSNumber *nearestPredecessorValue;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -130,7 +130,7 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
         SENTRY_LOG_DEBUG(@"A profiler is already running.");
         trackProfilerForTracer(_gCurrentProfiler, traceId);
         // record a new metric sample for every concurrent span start
-        [_gCurrentProfiler._metricProfiler recordMetrics];
+        [_gCurrentProfiler.metricProfiler recordMetrics];
         return YES;
     }
 
@@ -156,7 +156,7 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
     if (_gCurrentProfiler == nil) {
         return;
     }
-    [_gCurrentProfiler._metricProfiler recordMetrics];
+    [_gCurrentProfiler.metricProfiler recordMetrics];
 }
 
 - (void)timeoutAbort
@@ -184,7 +184,7 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
 - (void)stopForReason:(SentryProfilerTruncationReason)reason
 {
     [_timeoutTimer invalidate];
-    [self._metricProfiler stop];
+    [self.metricProfiler stop];
     self.truncationReason = reason;
 
     if (![self isRunning]) {
@@ -206,8 +206,8 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
 
 - (void)startMetricProfiler
 {
-    self._metricProfiler = [[SentryMetricProfiler alloc] init];
-    [self._metricProfiler start];
+    self.metricProfiler = [[SentryMetricProfiler alloc] init];
+    [self.metricProfiler start];
 }
 
 - (void)start

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -128,7 +128,7 @@ sentry_manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
 
     if (_sentry_gCurrentProfiler && [_sentry_gCurrentProfiler isRunning]) {
         SENTRY_LOG_DEBUG(@"A profiler is already running.");
-        trackProfilerForTracer(_sentry_gCurrentProfiler, traceId);
+        sentry_trackProfilerForTracer(_sentry_gCurrentProfiler, traceId);
         // record a new metric sample for every concurrent span start
         [_sentry_gCurrentProfiler.metricProfiler recordMetrics];
         return YES;
@@ -140,7 +140,7 @@ sentry_manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
         return NO;
     }
 
-    trackProfilerForTracer(_sentry_gCurrentProfiler, traceId);
+    sentry_trackProfilerForTracer(_sentry_gCurrentProfiler, traceId);
     return YES;
 }
 
@@ -273,17 +273,17 @@ sentry_manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
 #    if defined(TEST) || defined(TESTCI)
 + (SentryProfiler *)getCurrentProfiler
 {
-    return _gCurrentProfiler;
+    return _sentry_gCurrentProfiler;
 }
 
 + (void)resetConcurrencyTracking
 {
-    resetConcurrencyTracking();
+    sentry_resetConcurrencyTracking();
 }
 
 + (NSUInteger)currentProfiledTracers
 {
-    return currentProfiledTracers();
+    return sentry_currentProfiledTracers();
 }
 #    endif // defined(TEST) || defined(TESTCI)
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -6,10 +6,8 @@
 #    import "SentryContinuousProfiler.h"
 #    import "SentryDateUtils.h"
 #    import "SentryDebugImageProvider.h"
-#    import "SentryDebugMeta.h"
 #    import "SentryDefines.h"
 #    import "SentryDependencyContainer.h"
-#    import "SentryDevice.h"
 #    import "SentryDispatchFactory.h"
 #    import "SentryDispatchSourceWrapper.h"
 #    import "SentryEnvelope.h"
@@ -19,20 +17,19 @@
 #    import "SentryFormatter.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryHub+Private.h"
-#    import "SentryInternalDefines.h"
 #    import "SentryLog.h"
+#    import "SentryMetricProfiler.h"
 #    import "SentryNSNotificationCenterWrapper.h"
 #    import "SentryNSProcessInfoWrapper.h"
 #    import "SentryNSTimerFactory.h"
 #    import "SentryOptions.h"
-#    import "SentryProfileTimeseries.h"
 #    import "SentryProfiledTracerConcurrency.h"
+#    import "SentryProfilerSerialization.h"
 #    import "SentryProfilerState+ObjCpp.h"
 #    import "SentryProfilerTestHelpers.h"
 #    import "SentrySDK+Private.h"
 #    import "SentrySample.h"
 #    import "SentrySamplingProfiler.hpp"
-#    import "SentryScope+Private.h"
 #    import "SentrySerialization.h"
 #    import "SentrySpanId.h"
 #    import "SentrySwift.h"
@@ -54,166 +51,14 @@
 const int kSentryProfilerFrequencyHz = 101;
 NSTimeInterval kSentryProfilerTimeoutInterval = 30;
 
-NSString *const kSentryProfilerSerializationKeySlowFrameRenders = @"slow_frame_renders";
-NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders = @"frozen_frame_renders";
-NSString *const kSentryProfilerSerializationKeyFrameRates = @"screen_frame_rates";
-
 using namespace sentry::profiling;
 
 std::mutex _gProfilerLock;
 SentryProfiler *_Nullable _gCurrentProfiler;
 
-NSString *
-profilerTruncationReasonName(SentryProfilerTruncationReason reason)
-{
-    switch (reason) {
-    case SentryProfilerTruncationReasonNormal:
-        return @"normal";
-    case SentryProfilerTruncationReasonAppMovedToBackground:
-        return @"backgrounded";
-    case SentryProfilerTruncationReasonTimeout:
-        return @"timeout";
-    }
-}
-
-/** Given an array of samples with absolute timestamps, return the serialized JSON mapping with
- * their data, with timestamps normalized relative to the provided transaction's start time. */
-NSArray<NSDictionary *> *
-serializedSamplesWithRelativeTimestamps(NSArray<SentrySample *> *samples, uint64_t startSystemTime)
-{
-    const auto result = [NSMutableArray<NSDictionary *> array];
-    [samples enumerateObjectsUsingBlock:^(
-        SentrySample *_Nonnull sample, NSUInteger idx, BOOL *_Nonnull stop) {
-        // This shouldn't happen as we would've filtered out any such samples, but we should still
-        // guard against it before calling getDurationNs as a defensive measure
-        if (!orderedChronologically(startSystemTime, sample.absoluteTimestamp)) {
-            SENTRY_LOG_WARN(@"Filtered sample not chronological with transaction.");
-            return;
-        }
-        const auto dict = [NSMutableDictionary dictionaryWithDictionary:@ {
-            @"elapsed_since_start_ns" :
-                sentry_stringForUInt64(getDurationNs(startSystemTime, sample.absoluteTimestamp)),
-            @"thread_id" : sentry_stringForUInt64(sample.threadID),
-            @"stack_id" : sample.stackIndex,
-        }];
-        if (sample.queueAddress) {
-            dict[@"queue_address"] = sample.queueAddress;
-        }
-
-        [result addObject:dict];
-    }];
-    return result;
-}
-
-NSMutableDictionary<NSString *, id> *
-serializedProfileData(
-    NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
-    NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
-    NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
-#    if SENTRY_HAS_UIKIT
-    ,
-    SentryScreenFrames *gpuData
-#    endif // SENTRY_HAS_UIKIT
-)
-{
-    NSMutableArray<SentrySample *> *const samples = profileData[@"profile"][@"samples"];
-    // We need at least two samples to be able to draw a stack frame for any given function: one
-    // sample for the start of the frame and another for the end. Otherwise we would only have a
-    // stack frame with 0 duration, which wouldn't make sense.
-    if ([samples count] < 2) {
-        SENTRY_LOG_DEBUG(@"Not enough samples in profile");
-        [hub.getClient recordLostEvent:kSentryDataCategoryProfile
-                                reason:kSentryDiscardReasonEventProcessor];
-        return nil;
-    }
-
-    // slice the profile data to only include the samples/metrics within the transaction
-    const auto slicedSamples = slicedProfileSamples(samples, startSystemTime, endSystemTime);
-    if (slicedSamples.count < 2) {
-        SENTRY_LOG_DEBUG(@"Not enough samples in profile during the transaction");
-        [hub.getClient recordLostEvent:kSentryDataCategoryProfile
-                                reason:kSentryDiscardReasonEventProcessor];
-        return nil;
-    }
-    const auto payload = [NSMutableDictionary<NSString *, id> dictionary];
-    NSMutableDictionary<NSString *, id> *const profile = [profileData[@"profile"] mutableCopy];
-    profile[@"samples"] = serializedSamplesWithRelativeTimestamps(slicedSamples, startSystemTime);
-    payload[@"profile"] = profile;
-
-    payload[@"version"] = @"1";
-    const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
-    for (SentryDebugMeta *debugImage in debugMeta) {
-        [debugImages addObject:[debugImage serialize]];
-    }
-    if (debugImages.count > 0) {
-        payload[@"debug_meta"] = @ { @"images" : debugImages };
-    }
-
-    payload[@"os"] = @ {
-        @"name" : sentry_getOSName(),
-        @"version" : sentry_getOSVersion(),
-        @"build_number" : sentry_getOSBuildNumber()
-    };
-
-    const auto isEmulated = sentry_isSimulatorBuild();
-    payload[@"device"] = @{
-        @"architecture" : sentry_getCPUArchitecture(),
-        @"is_emulator" : @(isEmulated),
-        @"locale" : NSLocale.currentLocale.localeIdentifier,
-        @"manufacturer" : @"Apple",
-        @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel()
-    };
-
-    payload[@"profile_id"] = [[[SentryId alloc] init] sentryIdString];
-    payload[@"truncation_reason"] = truncationReason;
-    payload[@"environment"] = hub.scope.environmentString ?: hub.getClient.options.environment;
-    payload[@"release"] = hub.getClient.options.releaseName;
-
-    // add the gathered metrics
-    auto metrics = serializedMetrics;
-
-#    if SENTRY_HAS_UIKIT
-    const auto mutableMetrics =
-        [NSMutableDictionary<NSString *, id> dictionaryWithDictionary:metrics];
-    const auto slowFrames = sliceGPUData(gpuData.slowFrameTimestamps, startSystemTime,
-        endSystemTime, /*useMostRecentRecording */ NO);
-    if (slowFrames.count > 0) {
-        mutableMetrics[@"slow_frame_renders"] =
-            @ { @"unit" : @"nanosecond", @"values" : slowFrames };
-    }
-
-    const auto frozenFrames
-        = sliceGPUData(gpuData.frozenFrameTimestamps, startSystemTime, endSystemTime,
-            /*useMostRecentRecording */ NO);
-    if (frozenFrames.count > 0) {
-        mutableMetrics[@"frozen_frame_renders"] =
-            @ { @"unit" : @"nanosecond", @"values" : frozenFrames };
-    }
-
-    if (slowFrames.count > 0 || frozenFrames.count > 0) {
-        const auto frameRates
-            = sliceGPUData(gpuData.frameRateTimestamps, startSystemTime, endSystemTime,
-                /*useMostRecentRecording */ YES);
-        if (frameRates.count > 0) {
-            mutableMetrics[@"screen_frame_rates"] = @ { @"unit" : @"hz", @"values" : frameRates };
-        }
-    }
-    metrics = mutableMetrics;
-#    endif // SENTRY_HAS_UIKIT
-
-    if (metrics.count > 0) {
-        payload[@"measurements"] = metrics;
-    }
-
-    return payload;
-}
-
 @implementation SentryProfiler {
     std::shared_ptr<SamplingProfiler> _profiler;
-    SentryMetricProfiler *_metricProfiler;
-    SentryDebugImageProvider *_debugImageProvider;
 
-    SentryProfilerTruncationReason _truncationReason;
     NSTimer *_timeoutTimer;
 }
 
@@ -228,7 +73,7 @@ serializedProfileData(
     _profilerId = [[SentryId alloc] init];
 
     SENTRY_LOG_DEBUG(@"Initialized new SentryProfiler %@", self);
-    _debugImageProvider = [SentryDependencyContainer sharedInstance].debugImageProvider;
+    self._debugImageProvider = [SentryDependencyContainer sharedInstance].debugImageProvider;
 
 #    if SENTRY_HAS_UIKIT
     // the frame tracker may not be running if SentryOptions.enableAutoPerformanceTracing is NO
@@ -280,7 +125,7 @@ serializedProfileData(
         SENTRY_LOG_DEBUG(@"A profiler is already running.");
         trackProfilerForTracer(_gCurrentProfiler, traceId);
         // record a new metric sample for every concurrent span start
-        [_gCurrentProfiler->_metricProfiler recordMetrics];
+        [_gCurrentProfiler._metricProfiler recordMetrics];
         return YES;
     }
 
@@ -306,87 +151,7 @@ serializedProfileData(
     if (_gCurrentProfiler == nil) {
         return;
     }
-    [_gCurrentProfiler->_metricProfiler recordMetrics];
-}
-
-+ (nullable SentryEnvelopeItem *)createProfilingEnvelopeItemForTransaction:
-                                     (SentryTransaction *)transaction
-                                                            startTimestamp:(NSDate *)startTimestamp
-{
-    SENTRY_LOG_DEBUG(@"Creating profiling envelope item");
-    const auto payload = [self collectProfileBetween:transaction.startSystemTime
-                                                 and:transaction.endSystemTime
-                                            forTrace:transaction.trace.internalID
-                                               onHub:transaction.trace.hub];
-    if (payload == nil) {
-        SENTRY_LOG_DEBUG(@"Payload was empty, will not create a profiling envelope item.");
-        return nil;
-    }
-
-    [self updateProfilePayload:payload forTransaction:transaction startTimestamp:startTimestamp];
-    return [self createEnvelopeItemForProfilePayload:payload];
-}
-
-+ (nullable SentryEnvelopeItem *)createEnvelopeItemForProfilePayload:
-    (NSDictionary<NSString *, id> *)payload;
-{
-    const auto JSONData = [SentrySerialization dataWithJSONObject:payload];
-    if (JSONData == nil) {
-        SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON.");
-        return nil;
-    }
-
-    const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
-                                                                length:JSONData.length];
-    return [[SentryEnvelopeItem alloc] initWithHeader:header data:JSONData];
-}
-
-+ (nullable NSMutableDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
-                                                                    and:(uint64_t)endSystemTime
-                                                               forTrace:(SentryId *)traceId
-                                                                  onHub:(SentryHub *)hub;
-{
-    const auto profiler = profilerForFinishedTracer(traceId);
-    if (!profiler) {
-        return nil;
-    }
-
-    const auto payload = [profiler serializeBetween:startSystemTime and:endSystemTime onHub:hub];
-
-#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
-    writeProfileFile(payload);
-#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
-
-    return payload;
-}
-
-+ (void)updateProfilePayload:(NSMutableDictionary<NSString *, id> *)payload
-              forTransaction:(SentryTransaction *)transaction
-              startTimestamp:(NSDate *)startTimestamp
-{
-    payload[@"platform"] = transaction.platform;
-    payload[@"transaction"] = @{
-        @"id" : transaction.eventId.sentryIdString,
-        @"trace_id" : transaction.trace.traceId.sentryIdString,
-        @"name" : transaction.transaction,
-        @"active_thread_id" : [transaction.trace.transactionContext sentry_threadInfo].threadId
-    };
-    payload[@"timestamp"] = sentry_toIso8601String(startTimestamp);
-}
-
-- (NSMutableDictionary<NSString *, id> *)serializeBetween:(uint64_t)startSystemTime
-                                                      and:(uint64_t)endSystemTime
-                                                    onHub:(SentryHub *)hub;
-{
-    return serializedProfileData([self._state copyProfilingData], startSystemTime, endSystemTime,
-        profilerTruncationReasonName(_truncationReason),
-        [_metricProfiler serializeBetween:startSystemTime and:endSystemTime],
-        [_debugImageProvider getDebugImagesCrashed:NO], hub
-#    if SENTRY_HAS_UIKIT
-        ,
-        self._screenFrameData
-#    endif // SENTRY_HAS_UIKIT
-    );
+    [_gCurrentProfiler._metricProfiler recordMetrics];
 }
 
 - (void)timeoutAbort
@@ -414,8 +179,8 @@ serializedProfileData(
 - (void)stopForReason:(SentryProfilerTruncationReason)reason
 {
     [_timeoutTimer invalidate];
-    [_metricProfiler stop];
-    _truncationReason = reason;
+    [self._metricProfiler stop];
+    self._truncationReason = reason;
 
     if (![self isRunning]) {
         SENTRY_LOG_WARN(@"Profiler is not currently running.");
@@ -436,8 +201,8 @@ serializedProfileData(
 
 - (void)startMetricProfiler
 {
-    _metricProfiler = [[SentryMetricProfiler alloc] init];
-    [_metricProfiler start];
+    self._metricProfiler = [[SentryMetricProfiler alloc] init];
+    [self._metricProfiler start];
 }
 
 - (void)start

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -21,7 +21,6 @@
 #    import "SentryHub+Private.h"
 #    import "SentryInternalDefines.h"
 #    import "SentryLog.h"
-#    import "SentryMetricProfiler.h"
 #    import "SentryNSNotificationCenterWrapper.h"
 #    import "SentryNSProcessInfoWrapper.h"
 #    import "SentryNSTimerFactory.h"
@@ -49,7 +48,6 @@
 #    import <memory>
 
 #    if SENTRY_HAS_UIKIT
-#        import "SentryScreenFrames.h"
 #        import <UIKit/UIKit.h>
 #    endif // SENTRY_HAS_UIKIT
 
@@ -77,57 +75,6 @@ profilerTruncationReasonName(SentryProfilerTruncationReason reason)
         return @"timeout";
     }
 }
-
-#    if SENTRY_HAS_UIKIT
-/**
- * Convert the data structure that records timestamps for GPU frame render info from
- * SentryFramesTracker to the structure expected for profiling metrics, and throw out any that
- * didn't occur within the profile time.
- * @param useMostRecentRecording @c SentryFramesTracker doesn't stop running once it starts.
- * Although we reset the profiling timestamps each time the profiler stops and starts, concurrent
- * transactions that start after the first one won't have a screen frame rate recorded within their
- * timeframe, because it will have already been recorded for the first transaction and isn't
- * recorded again unless the system changes it. In these cases, use the most recently recorded data
- * for it.
- */
-NSArray<SentrySerializedMetricReading *> *
-sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, uint64_t startSystemTime, uint64_t endSystemTime,
-    BOOL useMostRecentRecording)
-{
-    auto slicedGPUEntries = [NSMutableArray<SentrySerializedMetricEntry *> array];
-    __block NSNumber *nearestPredecessorValue;
-    [frameInfo enumerateObjectsUsingBlock:^(
-        NSDictionary<NSString *, NSNumber *> *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-        const auto timestamp = obj[@"timestamp"].unsignedLongLongValue;
-
-        if (!orderedChronologically(startSystemTime, timestamp)) {
-            SENTRY_LOG_DEBUG(@"GPU info recorded (%llu) before transaction start (%llu), "
-                             @"will not report it.",
-                timestamp, startSystemTime);
-            nearestPredecessorValue = obj[@"value"];
-            return;
-        }
-
-        if (!orderedChronologically(timestamp, endSystemTime)) {
-            SENTRY_LOG_DEBUG(@"GPU info recorded after transaction finished, won't record.");
-            return;
-        }
-        const auto relativeTimestamp = getDurationNs(startSystemTime, timestamp);
-
-        [slicedGPUEntries addObject:@ {
-            @"elapsed_since_start_ns" : sentry_stringForUInt64(relativeTimestamp),
-            @"value" : obj[@"value"],
-        }];
-    }];
-    if (useMostRecentRecording && slicedGPUEntries.count == 0 && nearestPredecessorValue != nil) {
-        [slicedGPUEntries addObject:@ {
-            @"elapsed_since_start_ns" : @"0",
-            @"value" : nearestPredecessorValue,
-        }];
-    }
-    return slicedGPUEntries;
-}
-#    endif // SENTRY_HAS_UIKIT
 
 /** Given an array of samples with absolute timestamps, return the serialized JSON mapping with
  * their data, with timestamps normalized relative to the provided transaction's start time. */

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -1,48 +1,23 @@
 #import "SentryProfiler+Private.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-#    import "SentryAppStartMeasurement.h"
 #    import "SentryClient+Private.h"
 #    import "SentryContinuousProfiler.h"
-#    import "SentryDateUtils.h"
-#    import "SentryDebugImageProvider.h"
 #    import "SentryDefines.h"
 #    import "SentryDependencyContainer.h"
-#    import "SentryDispatchFactory.h"
-#    import "SentryDispatchSourceWrapper.h"
-#    import "SentryEnvelope.h"
-#    import "SentryEnvelopeItemHeader.h"
-#    import "SentryEnvelopeItemType.h"
-#    import "SentryEvent+Private.h"
-#    import "SentryFormatter.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryHub+Private.h"
 #    import "SentryLog.h"
 #    import "SentryMetricProfiler.h"
 #    import "SentryNSNotificationCenterWrapper.h"
-#    import "SentryNSProcessInfoWrapper.h"
 #    import "SentryNSTimerFactory.h"
 #    import "SentryOptions.h"
 #    import "SentryProfiledTracerConcurrency.h"
-#    import "SentryProfilerSerialization.h"
 #    import "SentryProfilerState+ObjCpp.h"
-#    import "SentryProfilerTestHelpers.h"
 #    import "SentrySDK+Private.h"
-#    import "SentrySample.h"
 #    import "SentrySamplingProfiler.hpp"
-#    import "SentrySerialization.h"
-#    import "SentrySpanId.h"
 #    import "SentrySwift.h"
-#    import "SentrySystemWrapper.h"
-#    import "SentryThread.h"
 #    import "SentryThreadWrapper.h"
-#    import "SentryTime.h"
-#    import "SentryTracer+Private.h"
-#    import "SentryTransaction.h"
-#    import "SentryTransactionContext+Private.h"
-
-#    import <cstdint>
-#    import <memory>
 
 #    if SENTRY_HAS_UIKIT
 #        import <UIKit/UIKit.h>

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -185,7 +185,7 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
 {
     [_timeoutTimer invalidate];
     [self._metricProfiler stop];
-    self._truncationReason = reason;
+    self.truncationReason = reason;
 
     if (![self isRunning]) {
         SENTRY_LOG_WARN(@"Profiler is not currently running.");

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -238,7 +238,7 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
     SENTRY_LOG_DEBUG(@"Starting profiler.");
 
     SentryProfilerState *const state = [[SentryProfilerState alloc] init];
-    self._state = state;
+    self.state = state;
     _profiler = std::make_shared<SamplingProfiler>(
         [state](auto &backtrace) {
     // in test, we'll overwrite the sample's timestamp to one mocked by SentryCurrentDate

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -271,9 +271,6 @@ SentryProfiler *_Nullable _gCurrentProfiler;
     return _gCurrentProfiler;
 }
 
-// this just calls through to SentryProfiledTracerConcurrency.resetConcurrencyTracking(). we have to
-// do this through SentryTracer because SentryProfiledTracerConcurrency cannot be included in test
-// targets via ObjC bridging headers because it contains C++.
 + (void)resetConcurrencyTracking
 {
     resetConcurrencyTracking();

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -79,7 +79,6 @@ manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
     _profilerId = [[SentryId alloc] init];
 
     SENTRY_LOG_DEBUG(@"Initialized new SentryProfiler %@", self);
-    self._debugImageProvider = [SentryDependencyContainer sharedInstance].debugImageProvider;
 
 #    if SENTRY_HAS_UIKIT
     // the frame tracker may not be running if SentryOptions.enableAutoPerformanceTracing is NO

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -224,7 +224,7 @@ static NSDate *_Nullable startTimestamp = nil;
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-        manageProfilerOnStartSDK(options, hub);
+        sentry_manageProfilerOnStartSDK(options, hub);
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }];
 }

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -30,7 +30,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryContinuousProfiler.h"
-#    import "SentryLaunchProfiling.h"
+#    import "SentryProfiler+Private.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @interface
@@ -224,21 +224,7 @@ static NSDate *_Nullable startTimestamp = nil;
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-        BOOL shouldstopAndTransmitLaunchProfile = YES;
-#    if SENTRY_HAS_UIKIT
-        if (SentryUIViewControllerPerformanceTracker.shared.enableWaitForFullDisplay) {
-            shouldstopAndTransmitLaunchProfile = NO;
-        }
-#    endif // SENTRY_HAS_UIKIT
-
-        [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchAsyncWithBlock:^{
-            if (shouldstopAndTransmitLaunchProfile) {
-                SENTRY_LOG_DEBUG(@"Stopping launch profile in SentrySDK.start because there will "
-                                 @"be no automatic trace to attach it to.");
-                stopAndTransmitLaunchProfile(hub);
-            }
-            configureLaunchProfiling(options);
-        }];
+        manageProfilerOnStartSDK(options, hub);
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }];
 }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -210,7 +210,7 @@ static BOOL appStartMeasurementRead;
 {
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if (self.isProfiling) {
-        discardProfilerForTracer(self.internalID);
+        sentry_discardProfilerForTracer(self.internalID);
     }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -628,7 +628,7 @@ static BOOL appStartMeasurementRead;
 - (void)captureTransactionWithProfile:(SentryTransaction *)transaction
                        startTimestamp:(NSDate *)startTimestamp
 {
-    SentryEnvelopeItem *envelopeItem = profileEnvelopeItem(transaction, startTimestamp);
+    SentryEnvelopeItem *envelopeItem = sentry_profileEnvelopeItem(transaction, startTimestamp);
 
     if (!envelopeItem) {
         [_hub captureTransaction:transaction withScope:_hub.scope];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -11,6 +11,7 @@
 #import "SentryNSTimerFactory.h"
 #import "SentryNoOpSpan.h"
 #import "SentryOptions+Private.h"
+#import "SentryProfilerSerialization.h"
 #import "SentryProfilingConditionals.h"
 #import "SentryRandom.h"
 #import "SentrySDK+Private.h"
@@ -627,11 +628,9 @@ static BOOL appStartMeasurementRead;
 - (void)captureTransactionWithProfile:(SentryTransaction *)transaction
                        startTimestamp:(NSDate *)startTimestamp
 {
-    SentryEnvelopeItem *profileEnvelopeItem =
-        [SentryProfiler createProfilingEnvelopeItemForTransaction:transaction
-                                                   startTimestamp:startTimestamp];
+    SentryEnvelopeItem *envelopeItem = profileEnvelopeItem(transaction);
 
-    if (!profileEnvelopeItem) {
+    if (!envelopeItem) {
         [_hub captureTransaction:transaction withScope:_hub.scope];
         return;
     }
@@ -640,7 +639,7 @@ static BOOL appStartMeasurementRead;
         transaction.eventId.sentryIdString, self.internalID.sentryIdString);
     [_hub captureTransaction:transaction
                       withScope:_hub.scope
-        additionalEnvelopeItems:@[ profileEnvelopeItem ]];
+        additionalEnvelopeItems:@[ envelopeItem ]];
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -628,7 +628,7 @@ static BOOL appStartMeasurementRead;
 - (void)captureTransactionWithProfile:(SentryTransaction *)transaction
                        startTimestamp:(NSDate *)startTimestamp
 {
-    SentryEnvelopeItem *envelopeItem = profileEnvelopeItem(transaction);
+    SentryEnvelopeItem *envelopeItem = profileEnvelopeItem(transaction, startTimestamp);
 
     if (!envelopeItem) {
         [_hub captureTransaction:transaction withScope:_hub.scope];

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -21,7 +21,7 @@ SENTRY_EXTERN void startLaunchProfile(void);
  * Stop any profiled trace that may be in flight from the start of the app launch, and transmit the
  * dedicated transaction with the profiling data attached.
  */
-void stopAndTransmitLaunchProfile(SentryHub *hub);
+SENTRY_EXTERN void stopAndTransmitLaunchProfile(SentryHub *hub);
 
 /**
  * Stop the tracer that started the launch profiler. Use when the profiler will be attached to an
@@ -36,7 +36,7 @@ void stopAndDiscardLaunchProfileTracer(void);
  * thread sampling decisions through to SentryHub later when it needs to start a transaction for the
  * profile to be attached to.
  */
-void configureLaunchProfiling(SentryOptions *options);
+SENTRY_EXTERN void configureLaunchProfiling(SentryOptions *options);
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/Sentry/include/SentryProfileTimeseries.h
+++ b/Sources/Sentry/include/SentryProfileTimeseries.h
@@ -15,12 +15,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSArray<SentrySample *> *_Nullable slicedProfileSamples(
+NSArray<SentrySample *> *_Nullable sentry_slicedProfileSamples(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime, uint64_t endSystemTime);
 
 #    if SENTRY_HAS_UIKIT
 
-NSArray<SentrySerializedMetricEntry *> *sliceGPUData(SentryFrameInfoTimeSeries *frameInfo,
+NSArray<SentrySerializedMetricEntry *> *sentry_sliceGPUData(SentryFrameInfoTimeSeries *frameInfo,
     uint64_t startSystemTime, uint64_t endSystemTime, BOOL useMostRecentRecording);
 
 #    endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryProfileTimeseries.h
+++ b/Sources/Sentry/include/SentryProfileTimeseries.h
@@ -8,10 +8,22 @@
 @class SentrySample;
 @class SentryTransaction;
 
+#    if SENTRY_HAS_UIKIT
+#        import "SentryMetricProfiler.h"
+#        import "SentryScreenFrames.h"
+#    endif // SENTRY_HAS_UIKIT
+
 NS_ASSUME_NONNULL_BEGIN
 
 NSArray<SentrySample *> *_Nullable slicedProfileSamples(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime, uint64_t endSystemTime);
+
+#    if SENTRY_HAS_UIKIT
+
+NSArray<SentrySerializedMetricEntry *> *sliceGPUData(SentryFrameInfoTimeSeries *frameInfo,
+    uint64_t startSystemTime, uint64_t endSystemTime, BOOL useMostRecentRecording);
+
+#    endif // SENTRY_HAS_UIKIT
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
@@ -1,10 +1,11 @@
-#import "SentryCompiler.h"
 #import "SentryProfilingConditionals.h"
-#import <Foundation/Foundation.h>
-
-@class SentryProfiler, SentryId;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryCompiler.h"
+#    import <Foundation/Foundation.h>
+
+@class SentryProfiler, SentryId;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -14,13 +15,13 @@ SENTRY_EXTERN_C_BEGIN
  * Associate the provided profiler and tracer so that profiling data may be retrieved by the tracer
  * when it is ready to transmit its envelope.
  */
-void trackProfilerForTracer(SentryProfiler *profiler, SentryId *internalTraceId);
+void sentry_trackProfilerForTracer(SentryProfiler *profiler, SentryId *internalTraceId);
 
 /**
  * For transactions that will be discarded, clean up the bookkeeping state associated with them to
  * reclaim the memory they're using.
  */
-void discardProfilerForTracer(SentryId *internalTraceId);
+void sentry_discardProfilerForTracer(SentryId *internalTraceId);
 
 /**
  * Return the profiler instance associated with the tracer. If it was the last tracer for the
@@ -28,11 +29,11 @@ void discardProfilerForTracer(SentryId *internalTraceId);
  * profiler instance, and if this is the last profiler being tracked, reset the
  * @c SentryFramesTracker data.
  */
-SentryProfiler *_Nullable profilerForFinishedTracer(SentryId *internalTraceId);
+SentryProfiler *_Nullable sentry_profilerForFinishedTracer(SentryId *internalTraceId);
 
 #    if defined(TEST) || defined(TESTCI)
-void resetConcurrencyTracking(void);
-NSUInteger currentProfiledTracers(void);
+void sentry_resetConcurrencyTracking(void);
+NSUInteger sentry_currentProfiledTracers(void);
 #    endif // defined(TEST) || defined(TESTCI)
 
 SENTRY_EXTERN_C_END

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -43,8 +43,7 @@ SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *h
 
 @property (strong, nonatomic) SentryId *profilerId;
 
-@property (strong, nonatomic) SentryProfilerState *_state;
-
+@property (strong, nonatomic) SentryProfilerState *state;
 
 @property (assign, nonatomic) SentryProfilerTruncationReason _truncationReason;
 

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  * launch's profiling, stop legacy profiling if no automatic performance transaction is running,
  * start the continuous profiler if enabled and not profiling from launch.
  */
-SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub);
+SENTRY_EXTERN void sentry_manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub);
 
 /**
  * A wrapper around the low-level components used to gather sampled backtrace profiles.

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -45,7 +45,7 @@ SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *h
 
 @property (strong, nonatomic) SentryProfilerState *state;
 
-@property (assign, nonatomic) SentryProfilerTruncationReason _truncationReason;
+@property (assign, nonatomic) SentryProfilerTruncationReason truncationReason;
 
 @property (strong, nonatomic) SentryMetricProfiler *_metricProfiler;
 

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -45,7 +45,6 @@ SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *h
 
 @property (strong, nonatomic) SentryProfilerState *_state;
 
-@property (strong, nonatomic) SentryDebugImageProvider *_debugImageProvider;
 
 @property (assign, nonatomic) SentryProfilerTruncationReason _truncationReason;
 

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -47,10 +47,10 @@ SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *h
 
 @property (assign, nonatomic) SentryProfilerTruncationReason truncationReason;
 
-@property (strong, nonatomic) SentryMetricProfiler *_metricProfiler;
+@property (strong, nonatomic) SentryMetricProfiler *metricProfiler;
 
 #    if SENTRY_HAS_UIKIT
-@property (strong, nonatomic) SentryScreenFrames *_screenFrameData;
+@property (strong, nonatomic) SentryScreenFrames *screenFrameData;
 #    endif // SENTRY_HAS_UIKIT
 
 /**

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -42,11 +42,8 @@ SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *h
 @interface SentryProfiler : NSObject
 
 @property (strong, nonatomic) SentryId *profilerId;
-
 @property (strong, nonatomic) SentryProfilerState *state;
-
 @property (assign, nonatomic) SentryProfilerTruncationReason truncationReason;
-
 @property (strong, nonatomic) SentryMetricProfiler *metricProfiler;
 
 #    if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -6,8 +6,10 @@
 #    import "SentrySpan.h"
 #    import <Foundation/Foundation.h>
 
+@class SentryDebugImageProvider;
 @class SentryEnvelopeItem;
 @class SentryHub;
+@class SentryMetricProfiler;
 @class SentryProfilerState;
 @class SentryTransaction;
 
@@ -26,10 +28,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN const int kSentryProfilerFrequencyHz;
 
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
-
 SENTRY_EXTERN_C_BEGIN
 
 /**
@@ -37,8 +35,6 @@ SENTRY_EXTERN_C_BEGIN
  * the situation described here: https://github.com/envoyproxy/envoy/issues/2561
  */
 BOOL threadSanitizerIsPresent(void);
-
-NSString *profilerTruncationReasonName(SentryProfilerTruncationReason reason);
 
 SENTRY_EXTERN_C_END
 
@@ -52,6 +48,12 @@ SENTRY_EXTERN_C_END
 @property (strong, nonatomic) SentryId *profilerId;
 
 @property (strong, nonatomic) SentryProfilerState *_state;
+
+@property (strong, nonatomic) SentryDebugImageProvider *_debugImageProvider;
+
+@property (assign, nonatomic) SentryProfilerTruncationReason _truncationReason;
+
+@property (strong, nonatomic) SentryMetricProfiler *_metricProfiler;
 
 #    if SENTRY_HAS_UIKIT
 @property (strong, nonatomic) SentryScreenFrames *_screenFrameData;
@@ -86,21 +88,6 @@ SENTRY_EXTERN_C_END
  */
 + (void)recordMetrics;
 
-/**
- * Given a transaction, return an envelope item containing any corresponding profile data to be
- * attached to the transaction envelope.
- * */
-+ (nullable SentryEnvelopeItem *)createProfilingEnvelopeItemForTransaction:
-                                     (SentryTransaction *)transaction
-                                                            startTimestamp:startTimestamp;
-
-/**
- * Collect profile data corresponding with the given traceId and time period.
- * */
-+ (nullable NSMutableDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
-                                                                    and:(uint64_t)endSystemTime
-                                                               forTrace:(SentryId *)traceId
-                                                                  onHub:(SentryHub *)hub;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -2,7 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryCompiler.h"
+#    import "SentryDefines.h"
 #    import "SentrySpan.h"
 #    import <Foundation/Foundation.h>
 
@@ -10,6 +10,7 @@
 @class SentryEnvelopeItem;
 @class SentryHub;
 @class SentryMetricProfiler;
+@class SentryOptions;
 @class SentryProfilerState;
 @class SentryTransaction;
 
@@ -26,17 +27,12 @@ typedef NS_ENUM(NSUInteger, SentryProfilerTruncationReason) {
 
 NS_ASSUME_NONNULL_BEGIN
 
-SENTRY_EXTERN const int kSentryProfilerFrequencyHz;
-
-SENTRY_EXTERN_C_BEGIN
-
 /**
- * Disable profiling when running with TSAN because it produces a TSAN false positive, similar to
- * the situation described here: https://github.com/envoyproxy/envoy/issues/2561
+ * Perform necessary profiler tasks that should take place when the SDK starts: configure the next
+ * launch's profiling, stop legacy profiling if no automatic performance transaction is running,
+ * start the continuous profiler if enabled and not profiling from launch.
  */
-BOOL threadSanitizerIsPresent(void);
-
-SENTRY_EXTERN_C_END
+SENTRY_EXTERN void manageProfilerOnStartSDK(SentryOptions *options, SentryHub *hub);
 
 /**
  * A wrapper around the low-level components used to gather sampled backtrace profiles.

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -1,0 +1,27 @@
+#import "SentryProfilingConditionals.h"
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryInternalDefines.h"
+#    import <Foundation/Foundation.h>
+
+@class SentryEnvelopeItem;
+@class SentryHub;
+@class SentryId;
+@class SentryTransaction;
+
+NS_ASSUME_NONNULL_BEGIN
+
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
+
+SENTRY_EXTERN SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction);
+
+/** Alternative affordance for use by PrivateSentrySDKOnly for hybrid SDKs. */
+NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
+    uint64_t startSystemTime, uint64_t endSystemTime, SentryId *traceId, SentryHub *hub);
+
+NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -12,7 +12,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SENTRY_EXTERN SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction);
+SENTRY_EXTERN SentryEnvelopeItem *_Nullable profileEnvelopeItem(
+    SentryTransaction *transaction, NSDate *startTimestamp);
 
 /** Alternative affordance for use by PrivateSentrySDKOnly for hybrid SDKs. */
 NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -12,10 +12,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
-
 SENTRY_EXTERN SentryEnvelopeItem *_Nullable profileEnvelopeItem(SentryTransaction *transaction);
 
 /** Alternative affordance for use by PrivateSentrySDKOnly for hybrid SDKs. */

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -2,7 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryInternalDefines.h"
+#    import "SentryDefines.h"
 #    import <Foundation/Foundation.h>
 
 @class SentryEnvelopeItem;

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -12,11 +12,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SENTRY_EXTERN SentryEnvelopeItem *_Nullable profileEnvelopeItem(
+SENTRY_EXTERN SentryEnvelopeItem *_Nullable sentry_profileEnvelopeItem(
     SentryTransaction *transaction, NSDate *startTimestamp);
 
 /** Alternative affordance for use by PrivateSentrySDKOnly for hybrid SDKs. */
-NSMutableDictionary<NSString *, id> *_Nullable collectProfileData(
+NSMutableDictionary<NSString *, id> *_Nullable sentry_collectProfileData(
     uint64_t startSystemTime, uint64_t endSystemTime, SentryId *traceId, SentryHub *hub);
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -1,3 +1,7 @@
+/**
+ * These declarations are needed in both SDK and test code, for use with various testing scenarios.
+ */
+
 #import "SentryProfilingConditionals.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -15,6 +15,10 @@ SENTRY_EXTERN BOOL threadSanitizerIsPresent(void);
 
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
+/**
+ * Write a file to application support containing the profile data. This is an affordance for UI
+ * tests to be able to validate the contents of a profile.
+ */
 SENTRY_EXTERN void writeProfileFile(NSDictionary<NSString *, id> *payload);
 
 #    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -7,6 +7,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * Disable profiling when running with TSAN because it produces a TSAN false positive, similar to
+ * the situation described here: https://github.com/envoyproxy/envoy/issues/2561
+ */
 SENTRY_EXTERN BOOL threadSanitizerIsPresent(void);
 
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -1,0 +1,20 @@
+#import "SentryProfilingConditionals.h"
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryDefines.h"
+#    import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+SENTRY_EXTERN BOOL threadSanitizerIsPresent(void);
+
+#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+
+SENTRY_EXTERN void writeProfileFile(NSDictionary<NSString *, id> *payload);
+
+#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
+
+NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Disable profiling when running with TSAN because it produces a TSAN false positive, similar to
  * the situation described here: https://github.com/envoyproxy/envoy/issues/2561
  */
-SENTRY_EXTERN BOOL threadSanitizerIsPresent(void);
+SENTRY_EXTERN BOOL sentry_threadSanitizerIsPresent(void);
 
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
@@ -23,7 +23,7 @@ SENTRY_EXTERN BOOL threadSanitizerIsPresent(void);
  * Write a file to application support containing the profile data. This is an affordance for UI
  * tests to be able to validate the contents of a profile.
  */
-SENTRY_EXTERN void writeProfileFile(NSDictionary<NSString *, id> *payload);
+SENTRY_EXTERN void sentry_writeProfileFile(NSDictionary<NSString *, id> *payload);
 
 #    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
 

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -836,7 +836,7 @@ private extension SentryProfilerSwiftTests {
         }
 
         if shouldTimeout {
-            XCTAssertEqual(try XCTUnwrap(profile["truncation_reason"] as? String), profilerTruncationReasonName(.timeout))
+            XCTAssertEqual(try XCTUnwrap(profile["truncation_reason"] as? String), sentry_profilerTruncationReasonName(.timeout))
         }
     }
 

--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -571,7 +571,7 @@ private extension SentryProfilerSwiftTests {
     }
 
     func addMockSamples(threadMetadata: ThreadMetadata = ThreadMetadata(id: 1, priority: 2, name: "test-thread"), addresses: [NSNumber] = [0x3, 0x4, 0x5]) {
-        let state = SentryProfiler.getCurrent()._state
+        let state = SentryProfiler.getCurrent().state
         fixture.currentDateProvider.advanceBy(nanoseconds: 1)
         SentryProfilerMocksSwiftCompatible.appendMockBacktrace(to: state, threadID: threadMetadata.id, threadPriority: threadMetadata.priority, threadName: threadMetadata.name, addresses: addresses)
         fixture.currentDateProvider.advanceBy(nanoseconds: 1)

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -1,24 +1,23 @@
-#import "SentryEvent+Private.h"
-#import "SentryHub+Test.h"
-#import "SentryProfileTimeseries.h"
-#import "SentryProfiler+Private.h"
-#import "SentryProfiler+Test.h"
-#import "SentryProfilerMocks.h"
-#import "SentryProfilerSerialization+Test.h"
-#import "SentryProfilerState+ObjCpp.h"
 #import "SentryProfilingConditionals.h"
-#import "SentryScreenFrames.h"
-#import "SentryThread.h"
-#import "SentryTransaction.h"
-#import "SentryTransactionContext+Private.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-using namespace sentry::profiling;
-
+#    import "SentryEvent+Private.h"
+#    import "SentryHub+Test.h"
+#    import "SentryProfileTimeseries.h"
+#    import "SentryProfiler+CppShims.h"
 #    import "SentryProfiler+Private.h"
+#    import "SentryProfilerMocks.h"
+#    import "SentryProfilerSerialization+Test.h"
+#    import "SentryProfilerState+ObjCpp.h"
+#    import "SentryScreenFrames.h"
+#    import "SentryThread.h"
+#    import "SentryTransaction.h"
+#    import "SentryTransactionContext+Private.h"
 #    import <XCTest/XCTest.h>
 #    import <execinfo.h>
+
+using namespace sentry::profiling;
 
 @interface SentryProfilerTests : XCTestCase
 @end

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -110,7 +110,7 @@ using namespace sentry::profiling;
     void (^sliceBlock)(void) = ^(void) {
         [state mutate:^(SentryProfilerMutableState *mutableState) {
             __unused const auto slice
-                = slicedProfileSamples(mutableState.samples, startSystemTime, endSystemTime);
+                = sentry_slicedProfileSamples(mutableState.samples, startSystemTime, endSystemTime);
             [sliceExpectation fulfill];
         }];
     };
@@ -170,9 +170,9 @@ using namespace sentry::profiling;
     // serialize the data as if it were captured in a transaction envelope
     const auto profileData = [state copyProfilingData];
 
-    const auto serialization = serializedProfileData(
-        profileData, 1, 2, profilerTruncationReasonName(SentryProfilerTruncationReasonNormal), @{},
-        @[], [[SentryHub alloc] initWithClient:nil andScope:nil]
+    const auto serialization = sentry_serializedProfileData(profileData, 1, 2,
+        sentry_profilerTruncationReasonName(SentryProfilerTruncationReasonNormal), @{}, @[],
+        [[SentryHub alloc] initWithClient:nil andScope:nil]
 #    if SENTRY_HAS_UIKIT
         ,
         [[SentryScreenFrames alloc] initWithTotal:5

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -4,6 +4,7 @@
 #import "SentryProfiler+Private.h"
 #import "SentryProfiler+Test.h"
 #import "SentryProfilerMocks.h"
+#import "SentryProfilerSerialization.h"
 #import "SentryProfilerState+ObjCpp.h"
 #import "SentryProfilingConditionals.h"
 #import "SentryScreenFrames.h"

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -4,7 +4,7 @@
 #import "SentryProfiler+Private.h"
 #import "SentryProfiler+Test.h"
 #import "SentryProfilerMocks.h"
-#import "SentryProfilerSerialization.h"
+#import "SentryProfilerSerialization+Test.h"
 #import "SentryProfilerState+ObjCpp.h"
 #import "SentryProfilingConditionals.h"
 #import "SentryScreenFrames.h"

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -684,7 +684,7 @@ private extension SentryFramesTrackerTests {
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     func assertProfilingData(slow: UInt? = nil, frozen: UInt? = nil, frameRates: UInt? = nil) throws {
-        if threadSanitizerIsPresent() {
+        if sentry_threadSanitizerIsPresent() {
             // profiling data will not have been gathered with TSAN running
             return
         }

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -125,7 +125,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
       * Smoke Tests profiling via PrivateSentrySDKOnly. Actual profiling unit tests are done elsewhere.
      */
     func testProfilingStartAndCollect() throws {
-        if threadSanitizerIsPresent() {
+        if sentry_threadSanitizerIsPresent() {
             throw XCTSkip("Profiler does not run if thread sanitizer is attached.")
         }
         let options = Options()

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -98,7 +98,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         var timeout: TimeInterval = 1
         #if !os(watchOS) && !os(tvOS)
         // observed the async task taking a long time to finish if TSAN is attached
-        if threadSanitizerIsPresent() {
+        if sentry_threadSanitizerIsPresent() {
             timeout = 10
         }
         #endif // !os(watchOS) || !os(tvOS)
@@ -128,7 +128,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
         var timeout: TimeInterval = 1
         #if !os(watchOS) && !os(tvOS)
         // observed the async task taking a long time to finish if TSAN is attached
-        if threadSanitizerIsPresent() {
+        if sentry_threadSanitizerIsPresent() {
             timeout = 10
         }
         #endif // !os(watchOS) || !os(tvOS)

--- a/Tests/SentryTests/SentryProfiler+CppShims.h
+++ b/Tests/SentryTests/SentryProfiler+CppShims.h
@@ -13,8 +13,12 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryProfiler ()
 
-#    if defined(TEST) || defined(TESTCI)
-
+// #    if defined(TEST) || defined(TESTCI)
+/**
+ * Provided as a pass-through to the SentryProfiledTracerConcurrency function of the same name,
+ * because that file contains C++ which cannot be included in test targets via ObjC bridging headers
+ * for usage in Swift.
+ */
 + (SentryProfiler *)getCurrentProfiler;
 
 /**
@@ -31,7 +35,7 @@ SentryProfiler ()
  */
 + (NSUInteger)currentProfiledTracers;
 
-#    endif // defined(TEST) || defined(TESTCI)
+// #    endif // defined(TEST) || defined(TESTCI)
 
 @end
 

--- a/Tests/SentryTests/SentryProfiler+Test.h
+++ b/Tests/SentryTests/SentryProfiler+Test.h
@@ -4,6 +4,7 @@
 
 #    import "SentryInternalDefines.h"
 #    import "SentryProfiler+Private.h"
+#    import <Foundation/Foundation.h>
 
 @class SentryDebugMeta;
 
@@ -12,11 +13,25 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryProfiler ()
 
+#    if defined(TEST) || defined(TESTCI)
+
 + (SentryProfiler *)getCurrentProfiler;
 
+/**
+ * Provided as a pass-through to the SentryProfiledTracerConcurrency function of the same name,
+ * because that file contains C++ which cannot be included in test targets via ObjC bridging headers
+ * for usage in Swift.
+ */
 + (void)resetConcurrencyTracking;
 
+/**
+ * Provided as a pass-through to the SentryProfiledTracerConcurrency function of the same name,
+ * because that file contains C++ which cannot be included in test targets via ObjC bridging headers
+ * for usage in Swift.
+ */
 + (NSUInteger)currentProfiledTracers;
+
+#    endif // defined(TEST) || defined(TESTCI)
 
 SENTRY_EXTERN NSString *profilerTruncationReasonName(SentryProfilerTruncationReason reason);
 

--- a/Tests/SentryTests/SentryProfiler+Test.h
+++ b/Tests/SentryTests/SentryProfiler+Test.h
@@ -10,6 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
+
 @interface
 SentryProfiler ()
 

--- a/Tests/SentryTests/SentryProfiler+Test.h
+++ b/Tests/SentryTests/SentryProfiler+Test.h
@@ -2,6 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
+#    import "SentryInternalDefines.h"
 #    import "SentryProfiler+Private.h"
 
 @class SentryDebugMeta;
@@ -11,7 +12,20 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryProfiler ()
 
-NSMutableDictionary<NSString *, id> *serializedProfileData(
++ (SentryProfiler *)getCurrentProfiler;
+
++ (void)resetConcurrencyTracking;
+
++ (NSUInteger)currentProfiledTracers;
+
+SENTRY_EXTERN NSString *profilerTruncationReasonName(SentryProfilerTruncationReason reason);
+
+/**
+ * An intermediate function that can serve requests from either the native SDK or hybrid SDKs; they
+ * will have different structures/objects available, these parameters are the common elements
+ * needed to construct the payload dictionary.
+ */
+SENTRY_EXTERN NSMutableDictionary<NSString *, id> *serializedProfileData(
     NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
     NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
     NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
@@ -20,12 +34,6 @@ NSMutableDictionary<NSString *, id> *serializedProfileData(
     SentryScreenFrames *gpuData
 #    endif // SENTRY_HAS_UIKIT
 );
-
-+ (SentryProfiler *)getCurrentProfiler;
-
-+ (void)resetConcurrencyTracking;
-
-+ (NSUInteger)currentProfiledTracers;
 
 @end
 

--- a/Tests/SentryTests/SentryProfiler+Test.h
+++ b/Tests/SentryTests/SentryProfiler+Test.h
@@ -2,17 +2,13 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryInternalDefines.h"
+#    import "SentryDefines.h"
 #    import "SentryProfiler+Private.h"
 #    import <Foundation/Foundation.h>
 
 @class SentryDebugMeta;
 
 NS_ASSUME_NONNULL_BEGIN
-
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
-SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
 
 @interface
 SentryProfiler ()
@@ -36,23 +32,6 @@ SentryProfiler ()
 + (NSUInteger)currentProfiledTracers;
 
 #    endif // defined(TEST) || defined(TESTCI)
-
-SENTRY_EXTERN NSString *profilerTruncationReasonName(SentryProfilerTruncationReason reason);
-
-/**
- * An intermediate function that can serve requests from either the native SDK or hybrid SDKs; they
- * will have different structures/objects available, these parameters are the common elements
- * needed to construct the payload dictionary.
- */
-SENTRY_EXTERN NSMutableDictionary<NSString *, id> *serializedProfileData(
-    NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
-    NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
-    NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
-#    if SENTRY_HAS_UIKIT
-    ,
-    SentryScreenFrames *gpuData
-#    endif // SENTRY_HAS_UIKIT
-);
 
 @end
 

--- a/Tests/SentryTests/SentryProfilerSerialization+Test.h
+++ b/Tests/SentryTests/SentryProfilerSerialization+Test.h
@@ -1,0 +1,37 @@
+#import "SentryProfilingConditionals.h"
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import "SentryDefines.h"
+#    import "SentryProfiler+Private.h"
+#    import <Foundation/Foundation.h>
+
+@class SentryDebugMeta;
+@class SentryHub;
+
+NS_ASSUME_NONNULL_BEGIN
+
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
+SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
+
+SENTRY_EXTERN NSString *profilerTruncationReasonName(SentryProfilerTruncationReason reason);
+
+/**
+ * An intermediate function that can serve requests from either the native SDK or hybrid SDKs; they
+ * will have different structures/objects available, these parameters are the common elements
+ * needed to construct the payload dictionary.
+ */
+SENTRY_EXTERN NSMutableDictionary<NSString *, id> *serializedProfileData(
+    NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
+    NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
+    NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub
+#    if SENTRY_HAS_UIKIT
+    ,
+    SentryScreenFrames *gpuData
+#    endif // SENTRY_HAS_UIKIT
+);
+
+NS_ASSUME_NONNULL_END
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryTests/SentryProfilerSerialization+Test.h
+++ b/Tests/SentryTests/SentryProfilerSerialization+Test.h
@@ -15,14 +15,14 @@ SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeySlowFrameRenders;
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrozenFrameRenders;
 SENTRY_EXTERN NSString *const kSentryProfilerSerializationKeyFrameRates;
 
-SENTRY_EXTERN NSString *profilerTruncationReasonName(SentryProfilerTruncationReason reason);
+SENTRY_EXTERN NSString *sentry_profilerTruncationReasonName(SentryProfilerTruncationReason reason);
 
 /**
  * An intermediate function that can serve requests from either the native SDK or hybrid SDKs; they
  * will have different structures/objects available, these parameters are the common elements
  * needed to construct the payload dictionary.
  */
-SENTRY_EXTERN NSMutableDictionary<NSString *, id> *serializedProfileData(
+SENTRY_EXTERN NSMutableDictionary<NSString *, id> *sentry_serializedProfileData(
     NSDictionary<NSString *, id> *profileData, uint64_t startSystemTime, uint64_t endSystemTime,
     NSString *truncationReason, NSDictionary<NSString *, id> *serializedMetrics,
     NSArray<SentryDebugMeta *> *debugMeta, SentryHub *hub

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -33,6 +33,7 @@
 #    import "SentryProfilerMocksSwiftCompatible.h"
 #    import "SentryProfilerSerialization.h"
 #    import "SentryProfilerState.h"
+#    import "SentryProfilerTestHelpers.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 #import "NSLocale+Sentry.h"

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -32,7 +32,7 @@
 #    import "SentryProfiler+Private.h"
 #    import "SentryProfiler+Test.h"
 #    import "SentryProfilerMocksSwiftCompatible.h"
-#    import "SentryProfilerSerialization.h"
+#    import "SentryProfilerSerialization+Test.h"
 #    import "SentryProfilerState.h"
 #    import "SentryProfilerTestHelpers.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -31,6 +31,7 @@
 #    import "SentryProfiler+Private.h"
 #    import "SentryProfiler+Test.h"
 #    import "SentryProfilerMocksSwiftCompatible.h"
+#    import "SentryProfilerSerialization.h"
 #    import "SentryProfilerState.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -27,6 +27,7 @@
 #endif // SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
+#    import "SentryLaunchProfiling+Tests.h"
 #    import "SentryMetricProfiler.h"
 #    import "SentryProfiler+Private.h"
 #    import "SentryProfiler+Test.h"
@@ -130,7 +131,6 @@
 #import "SentryInstallation+Test.h"
 #import "SentryInstallation.h"
 #import "SentryInternalNotificationNames.h"
-#import "SentryLaunchProfiling+Tests.h"
 #import "SentryLevelMapper.h"
 #import "SentryLog+TestInit.h"
 #import "SentryLog.h"

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -29,8 +29,8 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryLaunchProfiling+Tests.h"
 #    import "SentryMetricProfiler.h"
+#    import "SentryProfiler+CppShims.h"
 #    import "SentryProfiler+Private.h"
-#    import "SentryProfiler+Test.h"
 #    import "SentryProfilerMocksSwiftCompatible.h"
 #    import "SentryProfilerSerialization+Test.h"
 #    import "SentryProfilerState.h"

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -256,7 +256,7 @@ class SentryTracerTests: XCTestCase {
     
     func testCancelDeadlineTimer_TracerDeallocated() throws {
 #if !os(tvOS) && !os(watchOS)
-        if threadSanitizerIsPresent() {
+        if sentry_threadSanitizerIsPresent() {
             throw XCTSkip("doesn't currently work with TSAN enabled. the tracer instance remains retained by something in the TSAN dylib, and we cannot debug the memory graph with TSAN attached to see what is retaining it. it's likely out of our control.")
         }
 #endif // !os(tvOS) && !os(watchOS)
@@ -624,7 +624,7 @@ class SentryTracerTests: XCTestCase {
     
     func testIdleTimeout_TracerDeallocated() throws {
 #if !os(tvOS) && !os(watchOS)
-        if threadSanitizerIsPresent() {
+        if sentry_threadSanitizerIsPresent() {
             throw XCTSkip("doesn't currently work with TSAN enabled. the tracer instance remains retained by something in the TSAN dylib, and we cannot debug the memory graph with TSAN attached to see what is retaining it. it's likely out of our control.")
         }
 #endif // !os(tvOS) && !os(watchOS)


### PR DESCRIPTION
This is a good opportunity to clean up SentryProfiler.mm and organize the functions in there ahead of adding new parallel logic for continuous profiling mode. This PR does not alter any logic, only moves around and renames functions/code. 

- Moved some declarations of SDK functions that need to be exposed for use in tests into `SentryProfilerTestHelpers`.
- `SentryProfiler+Test.h` in the test target has been renamed to `SentryProfiler+CppShims.h` as that's all that they are.
- Convert more things from static ObjC class methods to C functions, like `+ [ SentryProfiler createProfilingEnvelopeItemForTransaction:startTimestamp:]` and `+ [SentryProfiler collectProfileBetween:and:forTrace:onHub:]`
	- These included with several other small functions involved with building a profiling envelope that were all called in a linear fashion, that I streamlined into one function in the new file `SentryProfilerSerialization`.
- Renamed C functions to include the prefix `sentry_` as in #3862 
- Extracted some profiling logic from other places into functions in profiling code units, like the part in `SentrySDK.startWithOptions` moving to `sentry_manageProfilerOnStartSDK` in SentryProfiler.mm.

#skip-changelog

for #3555