### PR TITLE
ref: CurrentDate as dependency for rate limits

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -96,8 +96,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                     fileManager:(SentryFileManager *)fileManager
          deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
 {
-    NSArray<id<SentryTransport>> *transports = [SentryTransportFactory initTransports:options
-                                                                    sentryFileManager:fileManager];
+    NSArray<id<SentryTransport>> *transports = [SentryTransportFactory
+             initTransports:options
+          sentryFileManager:fileManager
+        currentDateProvider:SentryDependencyContainer.sharedInstance.dateProvider];
 
     SentryTransportAdapter *transportAdapter =
         [[SentryTransportAdapter alloc] initWithTransports:transports options:options];

--- a/Sources/Sentry/SentryDateUtil.m
+++ b/Sources/Sentry/SentryDateUtil.m
@@ -1,5 +1,4 @@
 #import "SentryDateUtil.h"
-#import "SentryDependencyContainer.h"
 #import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -7,17 +6,26 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryDateUtil ()
 
+@property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;
+
 @end
 
 @implementation SentryDateUtil
 
-+ (BOOL)isInFuture:(NSDate *_Nullable)date
+- (instancetype)initWithCurrentDateProvider:(SentryCurrentDateProvider *)currentDateProvider
+{
+    if (self = [super init]) {
+        self.currentDateProvider = currentDateProvider;
+    }
+    return self;
+}
+
+- (BOOL)isInFuture:(NSDate *_Nullable)date
 {
     if (date == nil)
         return NO;
 
-    NSComparisonResult result =
-        [[SentryDependencyContainer.sharedInstance.dateProvider date] compare:date];
+    NSComparisonResult result = [[self.currentDateProvider date] compare:date];
     return result == NSOrderedAscending;
 }
 

--- a/Sources/Sentry/SentryDefaultRateLimits.m
+++ b/Sources/Sentry/SentryDefaultRateLimits.m
@@ -2,7 +2,6 @@
 #import "SentryConcurrentRateLimitsDictionary.h"
 #import "SentryDataCategoryMapper.h"
 #import "SentryDateUtil.h"
-#import "SentryDependencyContainer.h"
 #import "SentryLog.h"
 #import "SentryRateLimitParser.h"
 #import "SentryRetryAfterHeaderParser.h"
@@ -17,6 +16,8 @@ SentryDefaultRateLimits ()
 @property (nonatomic, strong) SentryConcurrentRateLimitsDictionary *rateLimits;
 @property (nonatomic, strong) SentryRetryAfterHeaderParser *retryAfterHeaderParser;
 @property (nonatomic, strong) SentryRateLimitParser *rateLimitParser;
+@property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;
+@property (nonatomic, strong) SentryDateUtil *dateUtil;
 
 @end
 
@@ -25,11 +26,14 @@ SentryDefaultRateLimits ()
 - (instancetype)initWithRetryAfterHeaderParser:
                     (SentryRetryAfterHeaderParser *)retryAfterHeaderParser
                             andRateLimitParser:(SentryRateLimitParser *)rateLimitParser
+                           currentDateProvider:(SentryCurrentDateProvider *)currentDateProvider
 {
     if (self = [super init]) {
         self.rateLimits = [[SentryConcurrentRateLimitsDictionary alloc] init];
         self.retryAfterHeaderParser = retryAfterHeaderParser;
         self.rateLimitParser = rateLimitParser;
+        self.currentDateProvider = currentDateProvider;
+        self.dateUtil = [[SentryDateUtil alloc] initWithCurrentDateProvider:currentDateProvider];
     }
     return self;
 }
@@ -39,8 +43,8 @@ SentryDefaultRateLimits ()
     NSDate *categoryDate = [self.rateLimits getRateLimitForCategory:category];
     NSDate *allCategoriesDate = [self.rateLimits getRateLimitForCategory:kSentryDataCategoryAll];
 
-    BOOL isActiveForCategory = [SentryDateUtil isInFuture:categoryDate];
-    BOOL isActiveForCategories = [SentryDateUtil isInFuture:allCategoriesDate];
+    BOOL isActiveForCategory = [self.dateUtil isInFuture:categoryDate];
+    BOOL isActiveForCategories = [self.dateUtil isInFuture:allCategoriesDate];
 
     if (isActiveForCategory || isActiveForCategories) {
         return YES;
@@ -67,8 +71,7 @@ SentryDefaultRateLimits ()
 
         if (nil == retryAfterHeaderDate) {
             // parsing failed use default value
-            retryAfterHeaderDate = [[SentryDependencyContainer.sharedInstance.dateProvider date]
-                dateByAddingTimeInterval:60];
+            retryAfterHeaderDate = [self.currentDateProvider.date dateByAddingTimeInterval:60];
         }
 
         [self updateRateLimit:kSentryDataCategoryAll withDate:retryAfterHeaderDate];

--- a/Sources/Sentry/SentryRateLimitParser.m
+++ b/Sources/Sentry/SentryRateLimitParser.m
@@ -1,7 +1,6 @@
 #import "SentryRateLimitParser.h"
 #import "SentryDataCategoryMapper.h"
 #import "SentryDateUtil.h"
-#import "SentryDependencyContainer.h"
 #import "SentrySwift.h"
 #import <Foundation/Foundation.h>
 
@@ -10,9 +9,19 @@ NS_ASSUME_NONNULL_BEGIN
 @interface
 SentryRateLimitParser ()
 
+@property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;
+
 @end
 
 @implementation SentryRateLimitParser
+
+- (instancetype)initWithCurrentDateProvider:(SentryCurrentDateProvider *)currentDateProvider
+{
+    if (self = [super init]) {
+        self.currentDateProvider = currentDateProvider;
+    }
+    return self;
+}
 
 - (NSDictionary<NSNumber *, NSDate *> *)parse:(NSString *)header
 {
@@ -80,7 +89,7 @@ SentryRateLimitParser ()
 - (NSDate *)getLongerRateLimit:(NSDate *)existingRateLimit
          andRateLimitInSeconds:(NSNumber *)newRateLimitInSeconds
 {
-    NSDate *newDate = [SentryDependencyContainer.sharedInstance.dateProvider.date
+    NSDate *newDate = [self.currentDateProvider.date
         dateByAddingTimeInterval:[newRateLimitInSeconds doubleValue]];
     return [SentryDateUtil getMaximumDate:newDate andOther:existingRateLimit];
 }

--- a/Sources/Sentry/SentryRetryAfterHeaderParser.m
+++ b/Sources/Sentry/SentryRetryAfterHeaderParser.m
@@ -1,5 +1,4 @@
 #import "SentryRetryAfterHeaderParser.h"
-#import "SentryDependencyContainer.h"
 #import "SentryHttpDateParser.h"
 #import "SentrySwift.h"
 #import <Foundation/Foundation.h>
@@ -10,15 +9,18 @@ NS_ASSUME_NONNULL_BEGIN
 SentryRetryAfterHeaderParser ()
 
 @property (nonatomic, strong) SentryHttpDateParser *httpDateParser;
+@property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;
 
 @end
 
 @implementation SentryRetryAfterHeaderParser
 
 - (instancetype)initWithHttpDateParser:(SentryHttpDateParser *)httpDateParser
+                   currentDateProvider:(SentryCurrentDateProvider *)currentDateProvider
 {
     if (self = [super init]) {
         self.httpDateParser = httpDateParser;
+        self.currentDateProvider = currentDateProvider;
     }
     return self;
 }
@@ -31,8 +33,7 @@ SentryRetryAfterHeaderParser ()
 
     NSInteger retryAfterSeconds = [retryAfterHeader integerValue];
     if (0 != retryAfterSeconds) {
-        return [[SentryDependencyContainer.sharedInstance.dateProvider date]
-            dateByAddingTimeInterval:retryAfterSeconds];
+        return [self.currentDateProvider.date dateByAddingTimeInterval:retryAfterSeconds];
     }
 
     // parsing as double/seconds failed, try to parse as date

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -26,6 +26,7 @@ SentryTransportFactory ()
 
 + (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
                                sentryFileManager:(SentryFileManager *)sentryFileManager
+                             currentDateProvider:(SentryCurrentDateProvider *)currentDateProvider
 {
     NSURLSessionConfiguration *configuration =
         [NSURLSessionConfiguration ephemeralSessionConfiguration];
@@ -37,11 +38,14 @@ SentryTransportFactory ()
 
     SentryHttpDateParser *httpDateParser = [[SentryHttpDateParser alloc] init];
     SentryRetryAfterHeaderParser *retryAfterHeaderParser =
-        [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser];
-    SentryRateLimitParser *rateLimitParser = [[SentryRateLimitParser alloc] init];
+        [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser
+                                                 currentDateProvider:currentDateProvider];
+    SentryRateLimitParser *rateLimitParser =
+        [[SentryRateLimitParser alloc] initWithCurrentDateProvider:currentDateProvider];
     id<SentryRateLimits> rateLimits =
         [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser
-                                                     andRateLimitParser:rateLimitParser];
+                                                     andRateLimitParser:rateLimitParser
+                                                    currentDateProvider:currentDateProvider];
 
     SentryEnvelopeRateLimit *envelopeRateLimit =
         [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];

--- a/Sources/Sentry/include/SentryDateUtil.h
+++ b/Sources/Sentry/include/SentryDateUtil.h
@@ -1,11 +1,15 @@
-#import <Foundation/Foundation.h>
+#import "SentryDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-NS_SWIFT_NAME(DateUtil)
-@interface SentryDateUtil : NSObject
+@class SentryCurrentDateProvider;
 
-+ (BOOL)isInFuture:(NSDate *_Nullable)date;
+@interface SentryDateUtil : NSObject
+SENTRY_NO_INIT
+
+- (instancetype)initWithCurrentDateProvider:(SentryCurrentDateProvider *)currentDateProvider;
+
+- (BOOL)isInFuture:(NSDate *_Nullable)date;
 
 + (NSDate *_Nullable)getMaximumDate:(NSDate *_Nullable)first andOther:(NSDate *_Nullable)second;
 

--- a/Sources/Sentry/include/SentryDefaultRateLimits.h
+++ b/Sources/Sentry/include/SentryDefaultRateLimits.h
@@ -3,6 +3,7 @@
 
 @class SentryRetryAfterHeaderParser;
 @class SentryRateLimitParser;
+@class SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,7 +18,8 @@ NS_SWIFT_NAME(DefaultRateLimits)
 
 - (instancetype)initWithRetryAfterHeaderParser:
                     (SentryRetryAfterHeaderParser *)retryAfterHeaderParser
-                            andRateLimitParser:(SentryRateLimitParser *)rateLimitParser;
+                            andRateLimitParser:(SentryRateLimitParser *)rateLimitParser
+                           currentDateProvider:(SentryCurrentDateProvider *)currentDateProvider;
 
 @end
 

--- a/Sources/Sentry/include/SentryRateLimitParser.h
+++ b/Sources/Sentry/include/SentryRateLimitParser.h
@@ -1,4 +1,6 @@
-#import <Foundation/Foundation.h>
+#import "SentryDefines.h"
+
+@class SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -12,6 +14,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 NS_SWIFT_NAME(RateLimitParser)
 @interface SentryRateLimitParser : NSObject
+SENTRY_NO_INIT
+
+- (instancetype)initWithCurrentDateProvider:(SentryCurrentDateProvider *)currentDateProvider;
 
 - (NSDictionary<NSNumber *, NSDate *> *)parse:(NSString *)header;
 

--- a/Sources/Sentry/include/SentryRetryAfterHeaderParser.h
+++ b/Sources/Sentry/include/SentryRetryAfterHeaderParser.h
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 
 @class SentryHttpDateParser;
+@class SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,7 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 NS_SWIFT_NAME(RetryAfterHeaderParser)
 @interface SentryRetryAfterHeaderParser : NSObject
 
-- (instancetype)initWithHttpDateParser:(SentryHttpDateParser *)httpDateParser;
+- (instancetype)initWithHttpDateParser:(SentryHttpDateParser *)httpDateParser
+                   currentDateProvider:(SentryCurrentDateProvider *)currentDateProvider;
 
 /** Parses the HTTP header into a NSDate.
 

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -3,6 +3,7 @@
 #import "SentryTransport.h"
 
 @class SentryOptions, SentryFileManager;
+@class SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,7 +11,8 @@ NS_SWIFT_NAME(TransportInitializer)
 @interface SentryTransportFactory : NSObject
 
 + (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
-                               sentryFileManager:(SentryFileManager *)sentryFileManager;
+                               sentryFileManager:(SentryFileManager *)sentryFileManager
+                             currentDateProvider:(SentryCurrentDateProvider *)currentDateProvider;
 
 @end
 

--- a/Tests/SentryTests/Helper/SentryDateUtilTests.swift
+++ b/Tests/SentryTests/Helper/SentryDateUtilTests.swift
@@ -8,40 +8,41 @@ class SentryDateUtilTests: XCTestCase {
     override func setUp() {
         super.setUp()
         currentDateProvider = TestCurrentDateProvider()
-        SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-        clearTestState()
     }
     
     func testIsInFutureWithFutureDte() {
-        XCTAssertTrue(DateUtil.is(inFuture: currentDateProvider.date().addingTimeInterval(1)))
+        let sut = SentryDateUtil(currentDateProvider: currentDateProvider)
+        XCTAssertTrue(sut.is(inFuture: currentDateProvider.date().addingTimeInterval(1)))
     }
     
     func testIsInFutureWithPresentDate() {
-        XCTAssertFalse(DateUtil.is(inFuture: currentDateProvider.date()))
+        let sut = SentryDateUtil(currentDateProvider: currentDateProvider)
+        
+        XCTAssertFalse(sut.is(inFuture: currentDateProvider.date()))
     }
     
     func testIsInFutureWithPastDate() {
-           XCTAssertFalse(DateUtil.is(inFuture: currentDateProvider.date().addingTimeInterval(-1)))
-       }
+        let sut = SentryDateUtil(currentDateProvider: currentDateProvider)
+        
+        XCTAssertFalse(sut.is(inFuture: currentDateProvider.date().addingTimeInterval(-1)))
+   }
     
     func testIsInFutureWithNil() {
-        XCTAssertFalse(DateUtil.is(inFuture: nil))
+        let sut = SentryDateUtil(currentDateProvider: currentDateProvider)
+        
+        XCTAssertFalse(sut.is(inFuture: nil))
     }
 
     func testGetMaximumFirstMaximum() {
         let maximum = currentDateProvider.date().addingTimeInterval(1)
-        let actual = DateUtil.getMaximumDate(maximum, andOther: currentDateProvider.date())
+        let actual = SentryDateUtil.getMaximumDate(maximum, andOther: currentDateProvider.date())
 
         XCTAssertEqual(maximum, actual)
     }
 
     func testGetMaximumSecondMaximum() {
         let maximum = currentDateProvider.date().addingTimeInterval(1)
-        let actual = DateUtil.getMaximumDate(currentDateProvider.date(), andOther: maximum)
+        let actual = SentryDateUtil.getMaximumDate(currentDateProvider.date(), andOther: maximum)
 
         XCTAssertEqual(maximum, actual)
     }
@@ -49,9 +50,9 @@ class SentryDateUtilTests: XCTestCase {
     func testGetMaximumWithNil() {
         let date = currentDateProvider.date()
     
-        XCTAssertEqual(date, DateUtil.getMaximumDate(nil, andOther: date))
-        XCTAssertEqual(date, DateUtil.getMaximumDate(date, andOther: nil))
-        XCTAssertNil(DateUtil.getMaximumDate(nil, andOther: nil))
+        XCTAssertEqual(date, SentryDateUtil.getMaximumDate(nil, andOther: date))
+        XCTAssertEqual(date, SentryDateUtil.getMaximumDate(date, andOther: nil))
+        XCTAssertNil(SentryDateUtil.getMaximumDate(nil, andOther: nil))
     }
 
 }

--- a/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
@@ -12,14 +12,8 @@ class SentryDefaultRateLimitsTests: XCTestCase {
     override func setUp() {
         super.setUp()
         currentDateProvider = TestCurrentDateProvider()
-        SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
     
-        sut = DefaultRateLimits(retryAfterHeaderParser: RetryAfterHeaderParser(httpDateParser: HttpDateParser()), andRateLimitParser: RateLimitParser())
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-        clearTestState()
+        sut = DefaultRateLimits(retryAfterHeaderParser: RetryAfterHeaderParser(httpDateParser: HttpDateParser(), currentDateProvider: currentDateProvider), andRateLimitParser: RateLimitParser(currentDateProvider: currentDateProvider), currentDateProvider: currentDateProvider)
     }
     
     func testNoUpdateCalled() {
@@ -98,7 +92,7 @@ class SentryDefaultRateLimitsTests: XCTestCase {
     }
     
     func testRetryAfterHeaderHttpDate() {
-        let headerValue = HttpDateFormatter.string(from: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(1))
+        let headerValue = HttpDateFormatter.string(from: currentDateProvider.date().addingTimeInterval(1))
         assertRetryHeaderWith1Second(value: headerValue)
     }
     

--- a/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRateLimitsParserTests.swift
@@ -5,11 +5,12 @@ import XCTest
 class SentryRateLimitsParserTests: XCTestCase {
     
     private var sut: RateLimitParser!
+    private var currentDate: TestCurrentDateProvider!
     
     override func setUp() {
         super.setUp()
-        SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
-        sut = RateLimitParser()
+        currentDate = TestCurrentDateProvider()
+        sut = RateLimitParser(currentDateProvider: currentDate)
     }
     
     override func tearDown() {
@@ -19,7 +20,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     
     func testOneQuotaOneCategory() {
         let expected = [
-            SentryDataCategory.transaction.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(50)
+            SentryDataCategory.transaction.asNSNumber: currentDate.date().addingTimeInterval(50)
         ]
         
         let actual = sut.parse("50:transaction:key")
@@ -34,7 +35,7 @@ class SentryRateLimitsParserTests: XCTestCase {
      */
     func testIgnoreReasonCode() {
         let expected = [
-            SentryDataCategory.transaction.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(50)
+            SentryDataCategory.transaction.asNSNumber: currentDate.date().addingTimeInterval(50)
         ]
         
         let actual = sut.parse("50:transaction:key:reason")
@@ -43,7 +44,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
     
     func testOneQuotaTwoCategories() {
-        let retryAfter = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(50)
+        let retryAfter = currentDate.date().addingTimeInterval(50)
         let expected = [
             SentryDataCategory.transaction.asNSNumber: retryAfter,
             SentryDataCategory.error.asNSNumber: retryAfter
@@ -55,9 +56,9 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
 
     func testTwoQuotasMultipleCategories() {
-        let retryAfter2700 = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(2_700)
+        let retryAfter2700 = currentDate.date().addingTimeInterval(2_700)
         let expected = [
-            SentryDataCategory.transaction.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(50),
+            SentryDataCategory.transaction.asNSNumber: currentDate.date().addingTimeInterval(50),
             SentryDataCategory.error.asNSNumber: retryAfter2700,
             SentryDataCategory.default.asNSNumber: retryAfter2700,
             SentryDataCategory.attachment.asNSNumber: retryAfter2700
@@ -70,7 +71,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     
     func testKeepMaximumRateLimit() {
         let expected = [
-            SentryDataCategory.transaction.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(50)
+            SentryDataCategory.transaction.asNSNumber: currentDate.date().addingTimeInterval(50)
         ]
         
         let actual = sut.parse("3:transaction:key,50:transaction:key,5:transaction:key")
@@ -79,7 +80,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
     
     func testInvalidRetryAfter() {
-        let expected = [SentryDataCategory.default.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(1)]
+        let expected = [SentryDataCategory.default.asNSNumber: currentDate.date().addingTimeInterval(1)]
         
         let actual = sut.parse("A1:transaction:key, 1:default:organization, -20:B:org, 0:event:key")
         
@@ -87,7 +88,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
     
     func testAllCategories() {
-        let expected = [SentryDataCategory.all.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(1_000)]
+        let expected = [SentryDataCategory.all.asNSNumber: currentDate.date().addingTimeInterval(1_000)]
         
         let actual = sut.parse("1000::organization ")
         
@@ -95,7 +96,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
     
     func testOneUnknownAndOneKnownCategory() {
-        let expected = [SentryDataCategory.error.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(2)]
+        let expected = [SentryDataCategory.error.asNSNumber: currentDate.date().addingTimeInterval(2)]
         
         let actual = sut.parse("2:foobar;error:organization")
         
@@ -108,7 +109,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
     
     func testAllKnownCategories() {
-        let date = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(1)
+        let date = currentDate.date().addingTimeInterval(1)
         let expected = [
             SentryDataCategory.default.asNSNumber: date,
             SentryDataCategory.error.asNSNumber: date,
@@ -125,8 +126,8 @@ class SentryRateLimitsParserTests: XCTestCase {
     }
     
     func testWhitespacesSpacesAreRemoved() {
-        let retryAfter10 = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(10)
-        let expected = [SentryDataCategory.all.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(67),
+        let retryAfter10 = currentDate.date().addingTimeInterval(10)
+        let expected = [SentryDataCategory.all.asNSNumber: currentDate.date().addingTimeInterval(67),
                         SentryDataCategory.transaction.asNSNumber: retryAfter10,
                         SentryDataCategory.error.asNSNumber: retryAfter10
         ]
@@ -149,7 +150,7 @@ class SentryRateLimitsParserTests: XCTestCase {
     
     func testValidHeaderAndGarbage() {
         let expected = [
-            SentryDataCategory.transaction.asNSNumber: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(50)
+            SentryDataCategory.transaction.asNSNumber: currentDate.date().addingTimeInterval(50)
         ]
         
         let actual = sut.parse("A9813Hell,50:transaction:key,123Garbage")

--- a/Tests/SentryTests/Networking/RateLimits/SentryRetryAfterHeaderParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRetryAfterHeaderParserTests.swift
@@ -15,13 +15,7 @@ class SentryRetryAfterHeaderParserTests: XCTestCase {
     override func setUp() {
         super.setUp()
         currentDateProvider = TestCurrentDateProvider()
-        SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
-        sut = RetryAfterHeaderParser(httpDateParser: HttpDateParser())
-    }
-    
-    override func tearDown() {
-        super.tearDown()
-        clearTestState()
+        sut = RetryAfterHeaderParser(httpDateParser: HttpDateParser(), currentDateProvider: currentDateProvider)
     }
 
     func testNil() {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -77,7 +77,9 @@ class SentryHttpTransportTests: XCTestCase {
             fileManager = try! TestFileManager(options: options)
 
             requestManager = TestRequestManager(session: URLSession(configuration: URLSessionConfiguration.ephemeral))
-            rateLimits = DefaultRateLimits(retryAfterHeaderParser: RetryAfterHeaderParser(httpDateParser: HttpDateParser()), andRateLimitParser: RateLimitParser())
+            
+            let currentDate = TestCurrentDateProvider()
+            rateLimits = DefaultRateLimits(retryAfterHeaderParser: RetryAfterHeaderParser(httpDateParser: HttpDateParser(), currentDateProvider: currentDate), andRateLimitParser: RateLimitParser(currentDateProvider: currentDate), currentDateProvider: currentDate)
 
             userFeedback = TestData.userFeedback
             let userFeedbackEnvelope = SentryEnvelope(userFeedback: userFeedback)

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -20,7 +20,7 @@ class SentryTransportFactoryTests: XCTestCase {
         options.urlSessionDelegate = urlSessionDelegateSpy
         
         let fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
-        let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager)
+        let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager, currentDateProvider: TestCurrentDateProvider())
         let httpTransport = transports.first
         let requestManager = Dynamic(httpTransport).requestManager.asObject as! SentryQueueableRequestManager
         
@@ -34,7 +34,7 @@ class SentryTransportFactoryTests: XCTestCase {
     func testShouldReturnTwoTransports_WhenSpotlightEnabled() throws {
         let options = Options()
         options.enableSpotlight = true
-        let transports = TransportInitializer.initTransports(options, sentryFileManager: try SentryFileManager(options: options))
+        let transports = TransportInitializer.initTransports(options, sentryFileManager: try SentryFileManager(options: options), currentDateProvider: TestCurrentDateProvider())
         
         expect(transports.contains {
             $0.isKind(of: SentrySpotlightTransport.self)

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -19,7 +19,7 @@ class SentryTransportInitializerTests: XCTestCase {
     func testDefault() throws {
         let options = try Options(dict: ["dsn": SentryTransportInitializerTests.dsnAsString])
     
-        let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager)
+        let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager, currentDateProvider: TestCurrentDateProvider())
         expect(result.count) == 1
         
         let firstTransport = result.first


### PR DESCRIPTION
Replace access to the DependencyContainer in the RateLimits code by passing the current date as a dependency to reduce global state and the need to call clearTestState.

This came up when tackling https://github.com/getsentry/sentry-cocoa/issues/3805.

#skip-changelog