### PR TITLE
feat(metrics): Add rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add timing API for Metrics (#3812):
+- Add [rate limiting](https://develop.sentry.dev/sdk/rate-limiting/) for Metrics (#3838)
 
 ## 8.23.0
 

--- a/Sources/Sentry/SentryDataCategoryMapper.m
+++ b/Sources/Sentry/SentryDataCategoryMapper.m
@@ -11,7 +11,7 @@ NSString *const kSentryDataCategoryNameTransaction = @"transaction";
 NSString *const kSentryDataCategoryNameAttachment = @"attachment";
 NSString *const kSentryDataCategoryNameUserFeedback = @"user_report";
 NSString *const kSentryDataCategoryNameProfile = @"profile";
-NSString *const kSentryDataCategoryNameStatsd = @"statsd";
+NSString *const kSentryDataCategoryNameMetricBucket = @"metric_bucket";
 NSString *const kSentryDataCategoryNameUnknown = @"unknown";
 
 NS_ASSUME_NONNULL_BEGIN
@@ -34,8 +34,10 @@ sentryDataCategoryForEnvelopItemType(NSString *itemType)
     if ([itemType isEqualToString:SentryEnvelopeItemTypeProfile]) {
         return kSentryDataCategoryProfile;
     }
+    // The envelope item type used for metrics is statsd whereas the client report category for
+    // discarded events is metric_bucket.
     if ([itemType isEqualToString:SentryEnvelopeItemTypeStatsd]) {
-        return kSentryDataCategoryStatsd;
+        return kSentryDataCategoryMetricBucket;
     }
     return kSentryDataCategoryDefault;
 }
@@ -77,8 +79,8 @@ sentryDataCategoryForString(NSString *value)
     if ([value isEqualToString:kSentryDataCategoryNameProfile]) {
         return kSentryDataCategoryProfile;
     }
-    if ([value isEqualToString:kSentryDataCategoryNameStatsd]) {
-        return kSentryDataCategoryStatsd;
+    if ([value isEqualToString:kSentryDataCategoryNameMetricBucket]) {
+        return kSentryDataCategoryMetricBucket;
     }
 
     return kSentryDataCategoryUnknown;
@@ -108,8 +110,8 @@ nameForSentryDataCategory(SentryDataCategory category)
         return kSentryDataCategoryNameUserFeedback;
     case kSentryDataCategoryProfile:
         return kSentryDataCategoryNameProfile;
-    case kSentryDataCategoryStatsd:
-        return kSentryDataCategoryNameStatsd;
+    case kSentryDataCategoryMetricBucket:
+        return kSentryDataCategoryNameMetricBucket;
     case kSentryDataCategoryUnknown:
         return kSentryDataCategoryNameUnknown;
     }

--- a/Sources/Sentry/SentryRateLimitParser.m
+++ b/Sources/Sentry/SentryRateLimitParser.m
@@ -45,8 +45,24 @@ SentryRateLimitParser ()
         }
 
         for (NSNumber *category in [self parseCategories:parameters[1]]) {
-            rateLimits[category] = [self getLongerRateLimit:rateLimits[category]
-                                      andRateLimitInSeconds:rateLimitInSeconds];
+            SentryDataCategory dataCategory
+                = sentryDataCategoryForNSUInteger(category.integerValue);
+
+            // Namespaces should only be available for MetricBucket
+            if (dataCategory == kSentryDataCategoryMetricBucket && parameters.count > 4) {
+                NSString *namespacesAsString = parameters[4];
+
+                NSArray<NSString *> *namespaces =
+                    [namespacesAsString componentsSeparatedByString:@";"];
+                if (namespacesAsString.length == 0 || [namespaces containsObject:@"custom"]) {
+                    rateLimits[category] = [self getLongerRateLimit:rateLimits[category]
+                                              andRateLimitInSeconds:rateLimitInSeconds];
+                }
+
+            } else {
+                rateLimits[category] = [self getLongerRateLimit:rateLimits[category]
+                                          andRateLimitInSeconds:rateLimitInSeconds];
+            }
         }
     }
 

--- a/Sources/Sentry/include/SentryDataCategory.h
+++ b/Sources/Sentry/include/SentryDataCategory.h
@@ -14,22 +14,6 @@ typedef NS_ENUM(NSUInteger, SentryDataCategory) {
     kSentryDataCategoryAttachment = 5,
     kSentryDataCategoryUserFeedback = 6,
     kSentryDataCategoryProfile = 7,
-    kSentryDataCategoryStatsd = 8,
+    kSentryDataCategoryMetricBucket = 8,
     kSentryDataCategoryUnknown = 9
 };
-
-static DEPRECATED_MSG_ATTRIBUTE(
-    "Use one of the functions to convert between literals and enum cases in "
-    "SentryDataCategoryMapper instead.") NSString *_Nonnull const SentryDataCategoryNames[]
-    = {
-          @"", // empty on purpose
-          @"default",
-          @"error",
-          @"session",
-          @"transaction",
-          @"attachment",
-          @"user_report",
-          @"profile",
-          @"statsd",
-          @"unkown",
-      };

--- a/Sources/Sentry/include/SentryDataCategoryMapper.h
+++ b/Sources/Sentry/include/SentryDataCategoryMapper.h
@@ -11,7 +11,7 @@ FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameTransaction;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameAttachment;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameUserFeedback;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameProfile;
-FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameStatsd;
+FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameMetricBucket;
 FOUNDATION_EXPORT NSString *const kSentryDataCategoryNameUnknown;
 
 SentryDataCategory sentryDataCategoryForNSUInteger(NSUInteger value);

--- a/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
@@ -3,13 +3,14 @@ import Nimble
 import XCTest
 
 class SentryDataCategoryMapperTests: XCTestCase {
+    
     func testEnvelopeItemType() {
         expect(sentryDataCategoryForEnvelopItemType("event")) == .error
         expect(sentryDataCategoryForEnvelopItemType("session")) == .session
         expect(sentryDataCategoryForEnvelopItemType("transaction")) == .transaction
         expect(sentryDataCategoryForEnvelopItemType("attachment")) == .attachment
         expect(sentryDataCategoryForEnvelopItemType("profile")) == .profile
-        expect(sentryDataCategoryForEnvelopItemType("statsd")) == .statsd
+        expect(sentryDataCategoryForEnvelopItemType("statsd")) == .metricBucket
         expect(sentryDataCategoryForEnvelopItemType("unknown item type")) == .default
     }
 
@@ -22,7 +23,7 @@ class SentryDataCategoryMapperTests: XCTestCase {
         expect(sentryDataCategoryForNSUInteger(5)) == .attachment
         expect(sentryDataCategoryForNSUInteger(6)) == .userFeedback
         expect(sentryDataCategoryForNSUInteger(7)) == .profile
-        expect(sentryDataCategoryForNSUInteger(8)) == .statsd
+        expect(sentryDataCategoryForNSUInteger(8)) == .metricBucket
         expect(sentryDataCategoryForNSUInteger(9)) == .unknown
 
         XCTAssertEqual(.unknown, sentryDataCategoryForNSUInteger(10), "Failed to map unknown category number to case .unknown")
@@ -37,7 +38,7 @@ class SentryDataCategoryMapperTests: XCTestCase {
         expect(sentryDataCategoryForString(kSentryDataCategoryNameAttachment)) == .attachment
         expect(sentryDataCategoryForString(kSentryDataCategoryNameUserFeedback)) == .userFeedback
         expect(sentryDataCategoryForString(kSentryDataCategoryNameProfile)) == .profile
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameStatsd)) == .statsd
+        expect(sentryDataCategoryForString(kSentryDataCategoryNameMetricBucket)) == .metricBucket
         expect(sentryDataCategoryForString(kSentryDataCategoryNameUnknown)) == .unknown
 
         XCTAssertEqual(.unknown, sentryDataCategoryForString("gdfagdfsa"), "Failed to map unknown category name to case .unknown")
@@ -52,7 +53,7 @@ class SentryDataCategoryMapperTests: XCTestCase {
         expect(nameForSentryDataCategory(.attachment)) == kSentryDataCategoryNameAttachment
         expect(nameForSentryDataCategory(.userFeedback)) == kSentryDataCategoryNameUserFeedback
         expect(nameForSentryDataCategory(.profile)) == kSentryDataCategoryNameProfile
-        expect(nameForSentryDataCategory(.statsd)) == kSentryDataCategoryNameStatsd
+        expect(nameForSentryDataCategory(.metricBucket)) == kSentryDataCategoryNameMetricBucket
         expect(nameForSentryDataCategory(.unknown)) == kSentryDataCategoryNameUnknown
     }
 }

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -344,6 +344,17 @@ class SentryHttpTransportTests: XCTestCase {
         assertRateLimitUpdated(response: response)
         assertClientReportStoredInMemory()
     }
+    
+    func testSendEventWithMetricBucketRateLimitResponse() {
+        fixture.requestManager.nextError = NSError(domain: "something", code: 12)
+
+        let response = givenRateLimitResponse(forCategory: SentryEnvelopeItemTypeSession)
+
+        sendEvent()
+
+        assertRateLimitUpdated(response: response)
+        assertClientReportStoredInMemory()
+    }
 
     func testSendEnvelopeWithRetryAfterResponse() {
         let response = givenRetryAfterResponse()


### PR DESCRIPTION




## :scroll: Description

This adds the handling of rate limits for the new metric_bucket category, including handling the metric namespace.

## :bulb: Motivation and Context

Fixes GH-3805

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
