### PR TITLE
feat(Session Replay): Maximum duration for a session replay

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -49,6 +49,11 @@ public class SentryReplayOptions: NSObject {
     let sessionSegmentDuration = TimeInterval(5)
     
     /**
+     * The maximum duration of a replay session.
+     */
+    let maximumDuration = TimeInterval(3_600)
+    
+    /**
      * Inittialize session replay options disabled
      */
     public override init() {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -194,6 +194,7 @@ class SentrySessionReplayTests: XCTestCase {
         Dynamic(sut).newFrame(nil)
         fixture.dateProvider.advance(by: 5)
         Dynamic(sut).newFrame(nil)
+        expect(Dynamic(sut).isRunning) == true
         fixture.dateProvider.advance(by: 3_600)
         Dynamic(sut).newFrame(nil)
         

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -184,6 +184,21 @@ class SentrySessionReplayTests: XCTestCase {
         
         assertFullSession(sut, expected: false)
     }
+    
+    @available(iOS 16.0, tvOS 16, *)
+    func testSessionReplayMaximumDuration() {
+        let fixture = startFixture()
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        sut.start(fixture.rootView, fullSession: true)
+        
+        Dynamic(sut).newFrame(nil)
+        fixture.dateProvider.advance(by: 5)
+        Dynamic(sut).newFrame(nil)
+        fixture.dateProvider.advance(by: 3_600)
+        Dynamic(sut).newFrame(nil)
+        
+        expect(Dynamic(sut).isRunning) == false
+    }
 
     @available(iOS 16.0, tvOS 16, *)
     func assertFullSession(_ sessionReplay: SentrySessionReplay, expected: Bool) {


### PR DESCRIPTION
A session can't be longer than 60 minutes.


_#skip-changelog_