### PR TITLE
test: Remove @objc for TestTransport

### DIFF
--- a/SentryTestUtils/TestTransport.swift
+++ b/SentryTestUtils/TestTransport.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-@objc
 public class TestTransport: NSObject, Transport {
     
     public var sentEnvelopes = Invocations<SentryEnvelope>()


### PR DESCRIPTION
No ObjC code uses the TestTransport, and therefore the @objc can be removed.

#skip-changelog