### PR TITLE
ci: update codeql actions to unpinned v3

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # pin@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
 
@@ -42,4 +42,4 @@ jobs:
           -destination platform="iOS Simulator,OS=latest,name=iPhone 14 Pro" | xcpretty && exit ${PIPESTATUS[0]}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a # pin@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
I keep seeing this warning on CodeQL workflows: 
<img width="889" alt="image" src="https://github.com/getsentry/sentry-cocoa/assets/3241469/49a42abb-a398-4a38-bed6-2bfc32bffd8e">

#skip-changelog