### PR TITLE
Save framework without UIKit/AppKit as Github Asset for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
             Carthage/Sentry.xcframework.zip
             Carthage/Sentry-Dynamic.xcframework.zip
             Carthage/SentrySwiftUI.xcframework.zip
+            Carthage/Sentry-WihoutUIKitOrAppKit.zip
           overwrite: true
 
   job_release:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Save framework without UIKit/AppKit as Github Asset for releases (#) 
+- Save framework without UIKit/AppKit as Github Asset for releases (#3858) 
 
 ## 8.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add Session Replay, which is **still experimental**. (#3625)
 
+### Fixes
+
+- Save framework without UIKit/AppKit as Github Asset for releases (#) 
+
 ## 8.24.0
 
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ build-xcframework:
 	ditto -c -k -X --rsrc --keepParent Carthage/Sentry.xcframework Carthage/Sentry.xcframework.zip
 	ditto -c -k -X --rsrc --keepParent Carthage/Sentry-Dynamic.xcframework Carthage/Sentry-Dynamic.xcframework.zip
 	ditto -c -k -X --rsrc --keepParent Carthage/SentrySwiftUI.xcframework Carthage/SentrySwiftUI.xcframework.zip
+	ditto -c -k -X --rsrc --keepParent Carthage/Sentry-WihoutUIKitOrAppKit.xcframework Carthage/Sentry-WihoutUIKitOrAppKit.zip
 
 build-xcframework-sample:
 	./scripts/create-carthage-json.sh


### PR DESCRIPTION
The compiled framework that is not linked with UI APIs wast not being saved as asset.