### PR TITLE
fix(profiling): prefix some functions with "sentry_"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Crash due to a background call to -[UIApplication applicationState] (#3855)
 - Save framework without UIKit/AppKit as Github Asset for releases (#3858) 
-- Fix crash associated with runtime collision in global C function names (#3856)
+- Fix crash associated with runtime collision in global C function names (#3862)
 
 ## 8.24.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Crash due to a background call to -[UIApplication applicationState] (#3855)
 - Save framework without UIKit/AppKit as Github Asset for releases (#3858) 
+- Fix crash associated with runtime collision in global C function names (#3856)
 
 ## 8.24.0
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -634,7 +634,7 @@
 		84281C472A57905700EE88F2 /* SentrySample.m in Sources */ = {isa = PBXBuildFile; fileRef = 84281C452A57905700EE88F2 /* SentrySample.m */; };
 		84281C622A579D0700EE88F2 /* SentryProfilerMocksSwiftCompatible.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84281C4D2A579A0C00EE88F2 /* SentryProfilerMocksSwiftCompatible.mm */; };
 		84281C632A579D0700EE88F2 /* SentryProfilerMocks.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84281C492A57933600EE88F2 /* SentryProfilerMocks.mm */; };
-		84302A812B5767A50027A629 /* SentryLaunchProfiling.m in Sources */ = {isa = PBXBuildFile; fileRef = 84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */; };
+		84302A812B5767A50027A629 /* SentryLaunchProfiling.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84302A7F2B5767A50027A629 /* SentryLaunchProfiling.mm */; };
 		8431EE5B29ADB8EA00D8DC56 /* SentryTimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */; };
 		8431EFD129B27B1100D8DC56 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63AA759B1EB8AEF500D153DE /* Sentry.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		8431EFD329B27B1100D8DC56 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = 630C01951EC341D600C52CEF /* Resources */; };
@@ -1640,7 +1640,7 @@
 		84281C4D2A579A0C00EE88F2 /* SentryProfilerMocksSwiftCompatible.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfilerMocksSwiftCompatible.mm; sourceTree = "<group>"; };
 		84281C642A57D36100EE88F2 /* SentryProfilerState+ObjCpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryProfilerState+ObjCpp.h"; path = "../include/SentryProfilerState+ObjCpp.h"; sourceTree = "<group>"; };
 		84281C652A58A16500EE88F2 /* SentryProfiler+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryProfiler+Test.h"; sourceTree = "<group>"; };
-		84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLaunchProfiling.m; sourceTree = "<group>"; };
+		84302A7F2B5767A50027A629 /* SentryLaunchProfiling.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryLaunchProfiling.mm; sourceTree = "<group>"; };
 		8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTimeTests.m; sourceTree = "<group>"; };
 		8431EFD929B27B1100D8DC56 /* SentryProfilerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SentryProfilerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8431F00A29B284F200D8DC56 /* libSentryTestUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSentryTestUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1857,9 +1857,9 @@
 		D8751FA4274743710032F4DE /* SentryNSURLSessionTaskSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSURLSessionTaskSearchTests.swift; sourceTree = "<group>"; };
 		D8757D142A209F7300BFEFCC /* SentrySampleDecision+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySampleDecision+Private.h"; path = "include/SentrySampleDecision+Private.h"; sourceTree = "<group>"; };
 		D875ED0A276CC84700422FAC /* SentryNSDataTrackerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryNSDataTrackerTests.swift; sourceTree = "<group>"; };
+		D878C6C02BC8048A0039D6A3 /* SentryPrivate.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = SentryPrivate.podspec; sourceTree = "<group>"; };
 		D87C89022BC43C9C0086C7DF /* SentryRedactOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRedactOptions.swift; sourceTree = "<group>"; };
 		D87C892A2BC67BC20086C7DF /* SentryExperimentalOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExperimentalOptions.swift; sourceTree = "<group>"; };
-		D878C6C02BC8048A0039D6A3 /* SentryPrivate.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = SentryPrivate.podspec; sourceTree = "<group>"; };
 		D880E3A628573E87008A90DB /* SentryBaggageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBaggageTests.swift; sourceTree = "<group>"; };
 		D880E3B02860A5A0008A90DB /* SentryEvent+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryEvent+Private.h"; path = "include/SentryEvent+Private.h"; sourceTree = "<group>"; };
 		D884A20327C80F2700074664 /* SentryCoreDataTrackerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCoreDataTrackerTest.swift; sourceTree = "<group>"; };
@@ -3342,7 +3342,7 @@
 				03BCC38927E1BF49003232C7 /* SentryTime.h */,
 				03BCC38B27E1C01A003232C7 /* SentryTime.mm */,
 				84DEE8752B69AD6400A7BC17 /* SentryLaunchProfiling.h */,
-				84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */,
+				84302A7F2B5767A50027A629 /* SentryLaunchProfiling.mm */,
 			);
 			path = Profiling;
 			sourceTree = "<group>";
@@ -4325,7 +4325,6 @@
 				7BCFBD6F2681D0EE00BC27D8 /* SentryCrashScopeObserver.m in Sources */,
 				7BD86ED1264A7CF6005439DB /* SentryAppStartMeasurement.m in Sources */,
 				7DC27EC723997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m in Sources */,
-				D820CE142BB2F13C00BA339D /* SentryCoreGraphicsHelper.m in Sources */,
 				63FE717B20DA4C1100CDBAE8 /* SentryCrashReport.c in Sources */,
 				7B7A599726B692F00060A676 /* SentryScreenFrames.m in Sources */,
 				7B3398652459C15200BD9C96 /* SentryEnvelopeRateLimit.m in Sources */,
@@ -4339,7 +4338,7 @@
 				7B6C5EDE264E8DF00010D138 /* SentryFramesTracker.m in Sources */,
 				D84F833E2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m in Sources */,
 				7B6438AB26A70F24000D0F65 /* UIViewController+Sentry.m in Sources */,
-				84302A812B5767A50027A629 /* SentryLaunchProfiling.m in Sources */,
+				84302A812B5767A50027A629 /* SentryLaunchProfiling.mm in Sources */,
 				63AA76A31EB9CBAA00D153DE /* SentryDsn.m in Sources */,
 				63B818FA1EC34639002FDF4C /* SentryDebugMeta.m in Sources */,
 				7B98D7D325FB65AE00C5A389 /* SentryWatchdogTerminationTracker.m in Sources */,

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -634,7 +634,7 @@
 		84281C472A57905700EE88F2 /* SentrySample.m in Sources */ = {isa = PBXBuildFile; fileRef = 84281C452A57905700EE88F2 /* SentrySample.m */; };
 		84281C622A579D0700EE88F2 /* SentryProfilerMocksSwiftCompatible.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84281C4D2A579A0C00EE88F2 /* SentryProfilerMocksSwiftCompatible.mm */; };
 		84281C632A579D0700EE88F2 /* SentryProfilerMocks.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84281C492A57933600EE88F2 /* SentryProfilerMocks.mm */; };
-		84302A812B5767A50027A629 /* SentryLaunchProfiling.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84302A7F2B5767A50027A629 /* SentryLaunchProfiling.mm */; };
+		84302A812B5767A50027A629 /* SentryLaunchProfiling.m in Sources */ = {isa = PBXBuildFile; fileRef = 84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */; };
 		8431EE5B29ADB8EA00D8DC56 /* SentryTimeTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */; };
 		8431EFD129B27B1100D8DC56 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63AA759B1EB8AEF500D153DE /* Sentry.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		8431EFD329B27B1100D8DC56 /* Resources in Resources */ = {isa = PBXBuildFile; fileRef = 630C01951EC341D600C52CEF /* Resources */; };
@@ -1640,7 +1640,7 @@
 		84281C4D2A579A0C00EE88F2 /* SentryProfilerMocksSwiftCompatible.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfilerMocksSwiftCompatible.mm; sourceTree = "<group>"; };
 		84281C642A57D36100EE88F2 /* SentryProfilerState+ObjCpp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryProfilerState+ObjCpp.h"; path = "../include/SentryProfilerState+ObjCpp.h"; sourceTree = "<group>"; };
 		84281C652A58A16500EE88F2 /* SentryProfiler+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryProfiler+Test.h"; sourceTree = "<group>"; };
-		84302A7F2B5767A50027A629 /* SentryLaunchProfiling.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryLaunchProfiling.mm; sourceTree = "<group>"; };
+		84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLaunchProfiling.m; sourceTree = "<group>"; };
 		8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTimeTests.m; sourceTree = "<group>"; };
 		8431EFD929B27B1100D8DC56 /* SentryProfilerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SentryProfilerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8431F00A29B284F200D8DC56 /* libSentryTestUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSentryTestUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -3342,7 +3342,7 @@
 				03BCC38927E1BF49003232C7 /* SentryTime.h */,
 				03BCC38B27E1C01A003232C7 /* SentryTime.mm */,
 				84DEE8752B69AD6400A7BC17 /* SentryLaunchProfiling.h */,
-				84302A7F2B5767A50027A629 /* SentryLaunchProfiling.mm */,
+				84302A7F2B5767A50027A629 /* SentryLaunchProfiling.m */,
 			);
 			path = Profiling;
 			sourceTree = "<group>";
@@ -4338,7 +4338,7 @@
 				7B6C5EDE264E8DF00010D138 /* SentryFramesTracker.m in Sources */,
 				D84F833E2A1CC401005828E0 /* SentrySwiftAsyncIntegration.m in Sources */,
 				7B6438AB26A70F24000D0F65 /* UIViewController+Sentry.m in Sources */,
-				84302A812B5767A50027A629 /* SentryLaunchProfiling.mm in Sources */,
+				84302A812B5767A50027A629 /* SentryLaunchProfiling.m in Sources */,
 				63AA76A31EB9CBAA00D153DE /* SentryDsn.m in Sources */,
 				63B818FA1EC34639002FDF4C /* SentryDebugMeta.m in Sources */,
 				7B98D7D325FB65AE00C5A389 /* SentryWatchdogTerminationTracker.m in Sources */,

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -6,6 +6,7 @@
 #    import "SentryDispatchQueueWrapper.h"
 #    import "SentryFileManager.h"
 #    import "SentryInternalDefines.h"
+#    import "SentryLaunchProfiling+Tests.h"
 #    import "SentryLog.h"
 #    import "SentryOptions.h"
 #    import "SentryProfiler+Private.h"
@@ -22,20 +23,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BOOL sentry_isTracingAppLaunch;
 NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate = @"traces";
 NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate = @"profiles";
 
 #    pragma mark - Private
 
-namespace {
 static SentryTracer *_Nullable sentry_launchTracer;
-
-typedef struct {
-    BOOL shouldProfile;
-    SentrySamplerDecision *_Nullable tracesDecision;
-    SentrySamplerDecision *_Nullable profilesDecision;
-} SentryLaunchProfileConfig;
 
 SentryTracerConfiguration *
 sentry_config(NSNumber *profilesRate)
@@ -46,8 +39,6 @@ sentry_config(NSNumber *profilesRate)
                                           forSampleRate:profilesRate];
     return config;
 }
-
-} // namespace
 
 SentryLaunchProfileConfig
 sentry_shouldProfileNextLaunch(SentryOptions *options)

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -28,6 +28,7 @@ NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate = @"profiles";
 
 #    pragma mark - Private
 
+BOOL sentry_isTracingAppLaunch;
 static SentryTracer *_Nullable sentry_launchTracer;
 
 SentryTracerConfiguration *

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.mm
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.mm
@@ -29,23 +29,23 @@ NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate = @"profiles";
 #    pragma mark - Private
 
 namespace {
-    static SentryTracer *_Nullable sentry_launchTracer;
+static SentryTracer *_Nullable sentry_launchTracer;
 
-    typedef struct {
-        BOOL shouldProfile;
-        SentrySamplerDecision *_Nullable tracesDecision;
-        SentrySamplerDecision *_Nullable profilesDecision;
-    } SentryLaunchProfileConfig;
+typedef struct {
+    BOOL shouldProfile;
+    SentrySamplerDecision *_Nullable tracesDecision;
+    SentrySamplerDecision *_Nullable profilesDecision;
+} SentryLaunchProfileConfig;
 
-    SentryTracerConfiguration *
-    sentry_config(NSNumber *profilesRate)
-    {
-        SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
-        config.profilesSamplerDecision =
-            [[SentrySamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
-                                              forSampleRate:profilesRate];
-        return config;
-    }
+SentryTracerConfiguration *
+sentry_config(NSNumber *profilesRate)
+{
+    SentryTracerConfiguration *config = [SentryTracerConfiguration defaultConfiguration];
+    config.profilesSamplerDecision =
+        [[SentrySamplerDecision alloc] initWithDecision:kSentrySampleDecisionYes
+                                          forSampleRate:profilesRate];
+    return config;
+}
 
 } // namespace
 
@@ -149,9 +149,10 @@ sentry_startLaunchProfile(void)
         }
 
         SENTRY_LOG_INFO(@"Starting app launch profile at %llu.", getAbsoluteTime());
-        sentry_launchTracer = [[SentryTracer alloc] initWithTransactionContext:sentry_context(tracesRate)
-                                                                    hub:nil
-                                                          configuration:sentry_config(profilesRate)];
+        sentry_launchTracer =
+            [[SentryTracer alloc] initWithTransactionContext:sentry_context(tracesRate)
+                                                         hub:nil
+                                               configuration:sentry_config(profilesRate)];
     });
 }
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -400,14 +400,14 @@ SentryHub () <SentryMetricsAPIDelegate>
                                             customSamplingContext:customSamplingContext];
 
     SentrySamplerDecision *tracesSamplerDecision
-        = sampleTrace(samplingContext, self.client.options);
+        = sentry_sampleTrace(samplingContext, self.client.options);
     transactionContext = [self transactionContext:transactionContext
                                       withSampled:tracesSamplerDecision.decision];
     transactionContext.sampleRate = tracesSamplerDecision.sampleRate;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     SentrySamplerDecision *profilesSamplerDecision
-        = sampleProfile(samplingContext, tracesSamplerDecision, self.client.options);
+        = sentry_sampleProfile(samplingContext, tracesSamplerDecision, self.client.options);
 
     configuration.profilesSamplerDecision = profilesSamplerDecision;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED"

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -436,7 +436,7 @@ writeProfileFile(NSDictionary<NSString *, id> *payload)
     }
 
     NSString *pathToWrite;
-    if (isTracingAppLaunch) {
+    if (sentry_isTracingAppLaunch) {
         SENTRY_LOG_DEBUG(@"Writing app launch profile.");
         pathToWrite = [appSupportDirPath stringByAppendingPathComponent:@"launchProfile"];
     } else {
@@ -448,11 +448,11 @@ writeProfileFile(NSDictionary<NSString *, id> *payload)
         SENTRY_LOG_DEBUG(@"Already a %@ profile file present; make sure to remove them right after "
                          @"using them, and that tests clean state in between so there isn't "
                          @"leftover config producing one when it isn't expected.",
-            isTracingAppLaunch ? @" launch" : @"");
+            sentry_isTracingAppLaunch ? @" launch" : @"");
         return;
     }
 
-    SENTRY_LOG_DEBUG(@"Writing%@ profile to file.", isTracingAppLaunch ? @" launch" : @"");
+    SENTRY_LOG_DEBUG(@"Writing%@ profile to file.", sentry_isTracingAppLaunch ? @" launch" : @"");
 
     NSError *error;
     if (![data writeToFile:pathToWrite options:NSDataWritingAtomic error:&error]) {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -235,9 +235,9 @@ static NSDate *_Nullable startTimestamp = nil;
             if (shouldstopAndTransmitLaunchProfile) {
                 SENTRY_LOG_DEBUG(@"Stopping launch profile in SentrySDK.start because there will "
                                  @"be no automatic trace to attach it to.");
-                stopAndTransmitLaunchProfile(hub);
+                sentry_stopAndTransmitLaunchProfile(hub);
             }
-            configureLaunchProfiling(options);
+            sentry_configureLaunchProfiling(options);
         }];
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }];

--- a/Sources/Sentry/SentrySampling.m
+++ b/Sources/Sentry/SentrySampling.m
@@ -55,7 +55,7 @@ calcSampleFromNumericalRate(NSNumber *rate)
 #pragma mark - Public
 
 SentrySamplerDecision *
-sampleTrace(SentrySamplingContext *context, SentryOptions *options)
+sentry_sampleTrace(SentrySamplingContext *context, SentryOptions *options)
 {
     // check this transaction's sampling decision, if already decided
     if (context.transactionContext.sampled != kSentrySampleDecisionUndecided) {
@@ -83,7 +83,7 @@ sampleTrace(SentrySamplingContext *context, SentryOptions *options)
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 SentrySamplerDecision *
-sampleProfile(SentrySamplingContext *context, SentrySamplerDecision *tracesSamplerDecision,
+sentry_sampleProfile(SentrySamplingContext *context, SentrySamplerDecision *tracesSamplerDecision,
     SentryOptions *options)
 {
     // Profiles are always undersampled with respect to traces. If the trace is not sampled,

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -134,7 +134,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
         if (!_waitForFullDisplay) {
             [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-            stopAndDiscardLaunchProfileTracer();
+            sentry_stopAndDiscardLaunchProfileTracer();
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
         }
     }
@@ -144,7 +144,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
         self.fullDisplaySpan.timestamp = newFrameDate;
         [self.fullDisplaySpan finish];
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
-        stopAndDiscardLaunchProfileTracer();
+        sentry_stopAndDiscardLaunchProfileTracer();
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -115,7 +115,7 @@ static BOOL appStartMeasurementRead;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 + (void)load
 {
-    startLaunchProfile();
+    sentry_startLaunchProfile();
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -190,7 +190,7 @@ static BOOL appStartMeasurementRead;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if (_configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes
-        || isTracingAppLaunch) {
+        || sentry_isTracingAppLaunch) {
         _internalID = [[SentryId alloc] init];
         if ((_isProfiling = [SentryProfiler startWithTracer:_internalID])) {
             SENTRY_LOG_DEBUG(@"Started profiler for trace %@ with internal id %@",

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -2,6 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
+#    import "SentryDefines.h"
 #    import <Foundation/Foundation.h>
 
 @class SentryHub;
@@ -12,7 +13,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-BOOL sentry_isTracingAppLaunch;
+SENTRY_EXTERN BOOL sentry_isTracingAppLaunch;
 
 /** Try to start a profiled trace for this app launch, if the configuration allows. */
 void sentry_startLaunchProfile(void);

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -12,23 +12,23 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SENTRY_EXTERN BOOL isTracingAppLaunch;
+SENTRY_EXTERN BOOL sentry_isTracingAppLaunch;
 
 /** Try to start a profiled trace for this app launch, if the configuration allows. */
-SENTRY_EXTERN void startLaunchProfile(void);
+SENTRY_EXTERN void sentry_startLaunchProfile(void);
 
 /**
  * Stop any profiled trace that may be in flight from the start of the app launch, and transmit the
  * dedicated transaction with the profiling data attached.
  */
-void stopAndTransmitLaunchProfile(SentryHub *hub);
+SENTRY_EXTERN void sentry_stopAndTransmitLaunchProfile(SentryHub *hub);
 
 /**
  * Stop the tracer that started the launch profiler. Use when the profiler will be attached to an
  * app start transaction and doesn't need to be attached to a dedicated tracer. The tracer managing
  * the profiler will be discarded in this case.
  */
-void stopAndDiscardLaunchProfileTracer(void);
+void sentry_stopAndDiscardLaunchProfileTracer(void);
 
 /**
  * Write a file to disk containing sample rates for profiles and traces. The presence of this file
@@ -36,7 +36,7 @@ void stopAndDiscardLaunchProfileTracer(void);
  * thread sampling decisions through to SentryHub later when it needs to start a transaction for the
  * profile to be attached to.
  */
-void configureLaunchProfiling(SentryOptions *options);
+SENTRY_EXTERN void sentry_configureLaunchProfiling(SentryOptions *options);
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -1,8 +1,8 @@
-#import "SentryDefines.h"
 #import "SentryProfilingConditionals.h"
-#import <Foundation/Foundation.h>
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
+
+#    import <Foundation/Foundation.h>
 
 @class SentryHub;
 @class SentryId;
@@ -12,16 +12,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-SENTRY_EXTERN BOOL sentry_isTracingAppLaunch;
+BOOL sentry_isTracingAppLaunch;
 
 /** Try to start a profiled trace for this app launch, if the configuration allows. */
-SENTRY_EXTERN void sentry_startLaunchProfile(void);
+void sentry_startLaunchProfile(void);
 
 /**
  * Stop any profiled trace that may be in flight from the start of the app launch, and transmit the
  * dedicated transaction with the profiling data attached.
  */
-SENTRY_EXTERN void sentry_stopAndTransmitLaunchProfile(SentryHub *hub);
+void sentry_stopAndTransmitLaunchProfile(SentryHub *hub);
 
 /**
  * Stop the tracer that started the launch profiler. Use when the profiler will be attached to an
@@ -36,7 +36,7 @@ void sentry_stopAndDiscardLaunchProfileTracer(void);
  * thread sampling decisions through to SentryHub later when it needs to start a transaction for the
  * profile to be attached to.
  */
-SENTRY_EXTERN void sentry_configureLaunchProfiling(SentryOptions *options);
+void sentry_configureLaunchProfiling(SentryOptions *options);
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/Sentry/include/SentrySampling.h
+++ b/Sources/Sentry/include/SentrySampling.h
@@ -1,5 +1,6 @@
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>
+#import "SentryDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -10,14 +11,14 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Determines whether a trace should be sampled based on the context and options.
  */
-SentrySamplerDecision *sampleTrace(SentrySamplingContext *context, SentryOptions *options);
+SENTRY_EXTERN SentrySamplerDecision *sentry_sampleTrace(SentrySamplingContext *context, SentryOptions *options);
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 /**
  * Determines whether a profile should be sampled based on the context, options, and
  * whether the trace corresponding to the profile was sampled.
  */
-SentrySamplerDecision *sampleProfile(SentrySamplingContext *context,
+SENTRY_EXTERN SentrySamplerDecision *sentry_sampleProfile(SentrySamplingContext *context,
     SentrySamplerDecision *tracesSamplerDecision, SentryOptions *options);
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/include/SentrySampling.h
+++ b/Sources/Sentry/include/SentrySampling.h
@@ -1,6 +1,6 @@
+#import "SentryDefines.h"
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>
-#import "SentryDefines.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,7 +11,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Determines whether a trace should be sampled based on the context and options.
  */
-SENTRY_EXTERN SentrySamplerDecision *sentry_sampleTrace(SentrySamplingContext *context, SentryOptions *options);
+SENTRY_EXTERN SentrySamplerDecision *sentry_sampleTrace(
+    SentrySamplingContext *context, SentryOptions *options);
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 /**

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
@@ -16,7 +16,7 @@
 
 - (void)testLaunchProfileTransactionContext
 {
-    SentryTransactionContext *actualContext = context(@1);
+    SentryTransactionContext *actualContext = sentry_context(@1);
     XCTAssertEqual(actualContext.nameSource, kSentryTransactionNameSourceCustom);
     XCTAssert([actualContext.origin isEqualToString:SentryTraceOriginAutoAppStartProfile]);
     XCTAssert(actualContext.sampled);
@@ -28,14 +28,14 @@
 
 - (void)testDefaultOptionsDoNotEnableLaunchProfiling
 {
-    XCTAssertFalse(shouldProfileNextLaunch([self defaultOptionsWithOverrides:nil]).shouldProfile,
+    XCTAssertFalse(sentry_shouldProfileNextLaunch([self defaultOptionsWithOverrides:nil]).shouldProfile,
         @"Default options should not enable launch profiling");
 }
 
 - (void)testAppLaunchProfilingNotSufficientToEnableLaunchProfiling
 {
     XCTAssertFalse(
-        shouldProfileNextLaunch(
+        sentry_shouldProfileNextLaunch(
             [self defaultOptionsWithOverrides:@{ SENTRY_OPTION(enableAppLaunchProfiling, @YES) }])
             .shouldProfile,
         @"Default options with only launch profiling option set is not sufficient to enable launch "
@@ -45,7 +45,7 @@
 - (void)testAppLaunchProfilingAndTracingOptionsNotSufficientToEnableAppLaunchProfiling
 {
     XCTAssertFalse(
-        shouldProfileNextLaunch(
+        sentry_shouldProfileNextLaunch(
             [self defaultOptionsWithOverrides:@{ SENTRY_OPTION(enableAppLaunchProfiling, @YES),
                                                   SENTRY_OPTION(enableTracing, @YES) }])
             .shouldProfile,
@@ -57,7 +57,7 @@
     testAppLaunchProfilingAndTracingAndTracesSampleRateOptionsNotSufficientToEnableAppLaunchProfiling
 {
     XCTAssertFalse(
-        shouldProfileNextLaunch(
+        sentry_shouldProfileNextLaunch(
             [self defaultOptionsWithOverrides:@{ SENTRY_OPTION(enableAppLaunchProfiling, @YES),
                                                   SENTRY_OPTION(enableTracing, @YES),
                                                   SENTRY_OPTION(tracesSampleRate, @1) }])
@@ -68,7 +68,7 @@
 
 - (void)testMinimumOptionsRequiredToEnableAppLaunchProfiling
 {
-    XCTAssert(shouldProfileNextLaunch([self defaultLaunchProfilingOptionsWithOverrides:nil])
+    XCTAssert(sentry_shouldProfileNextLaunch([self defaultLaunchProfilingOptionsWithOverrides:nil])
                   .shouldProfile,
         @"Default options with app launch profiling and tracing enabled and traces and profiles "
         @"sample rates of 1 should enable launch profiling");
@@ -77,7 +77,7 @@
 - (void)testDisablingLaunchProfilingOptionDisablesAppLaunchProfiling
 {
     XCTAssertFalse(
-        shouldProfileNextLaunch(
+        sentry_shouldProfileNextLaunch(
             [self defaultLaunchProfilingOptionsWithOverrides:@{ SENTRY_OPTION(
                                                                  enableAppLaunchProfiling, @NO) }])
             .shouldProfile,
@@ -87,7 +87,7 @@
 
 - (void)testDisablingTracingOptionDisablesAppLaunchProfiling
 {
-    XCTAssertFalse(shouldProfileNextLaunch(
+    XCTAssertFalse(sentry_shouldProfileNextLaunch(
                        [self defaultLaunchProfilingOptionsWithOverrides:@{ SENTRY_OPTION(
                                                                             enableTracing, @NO) }])
                        .shouldProfile,
@@ -98,7 +98,7 @@
 - (void)testSettingTracesSampleRateTo0DisablesAppLaunchProfiling
 {
     XCTAssertFalse(
-        shouldProfileNextLaunch(
+        sentry_shouldProfileNextLaunch(
             [self defaultLaunchProfilingOptionsWithOverrides:@{ SENTRY_OPTION(
                                                                  tracesSampleRate, @0) }])
             .shouldProfile,
@@ -109,7 +109,7 @@
 - (void)testSettingProfilesSampleRateTo0DisablesAppLaunchProfiling
 {
     XCTAssertFalse(
-        shouldProfileNextLaunch(
+        sentry_shouldProfileNextLaunch(
             [self defaultLaunchProfilingOptionsWithOverrides:@{ SENTRY_OPTION(
                                                                  profilesSampleRate, @0) }])
             .shouldProfile,

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.m
@@ -28,7 +28,8 @@
 
 - (void)testDefaultOptionsDoNotEnableLaunchProfiling
 {
-    XCTAssertFalse(sentry_shouldProfileNextLaunch([self defaultOptionsWithOverrides:nil]).shouldProfile,
+    XCTAssertFalse(
+        sentry_shouldProfileNextLaunch([self defaultOptionsWithOverrides:nil]).shouldProfile,
         @"Default options should not enable launch profiling");
 }
 

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -1,4 +1,3 @@
-#import "SentryDefines.h"
 #import "SentryLaunchProfiling.h"
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -14,12 +13,12 @@ typedef struct {
     SentrySamplerDecision *_Nullable profilesDecision;
 } SentryLaunchProfileConfig;
 
-SENTRY_EXTERN SentryLaunchProfileConfig sentry_shouldProfileNextLaunch(SentryOptions *options);
+SentryLaunchProfileConfig sentry_shouldProfileNextLaunch(SentryOptions *options);
 
-SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
-SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
+NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
+NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 
-SENTRY_EXTERN SentryTransactionContext *sentry_context(NSNumber *tracesRate);
+SentryTransactionContext *sentry_context(NSNumber *tracesRate);
 
 NS_ASSUME_NONNULL_END
 

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -14,13 +14,12 @@ typedef struct {
     SentrySamplerDecision *_Nullable profilesDecision;
 } SentryLaunchProfileConfig;
 
-SENTRY_EXTERN SentryLaunchProfileConfig shouldProfileNextLaunch(SentryOptions *options);
+SENTRY_EXTERN SentryLaunchProfileConfig sentry_shouldProfileNextLaunch(SentryOptions *options);
 
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 
-SENTRY_EXTERN SentryTransactionContext *context(NSNumber *tracesRate);
-SENTRY_EXTERN SentryTracerConfiguration *config(NSNumber *profilesRate);
+SENTRY_EXTERN SentryTransactionContext *sentry_context(NSNumber *tracesRate);
 
 NS_ASSUME_NONNULL_END
 

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -15,10 +15,10 @@ typedef struct {
     SentrySamplerDecision *_Nullable profilesDecision;
 } SentryLaunchProfileConfig;
 
-SentryLaunchProfileConfig sentry_shouldProfileNextLaunch(SentryOptions *options);
-
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
+
+SentryLaunchProfileConfig sentry_shouldProfileNextLaunch(SentryOptions *options);
 
 SentryTransactionContext *sentry_context(NSNumber *tracesRate);
 

--- a/Tests/SentryTests/SentryLaunchProfiling+Tests.h
+++ b/Tests/SentryTests/SentryLaunchProfiling+Tests.h
@@ -2,6 +2,8 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
+#    import "SentryDefines.h"
+
 @class SentrySamplerDecision;
 @class SentryOptions;
 
@@ -15,8 +17,8 @@ typedef struct {
 
 SentryLaunchProfileConfig sentry_shouldProfileNextLaunch(SentryOptions *options);
 
-NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
-NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
+SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
+SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 
 SentryTransactionContext *sentry_context(NSNumber *tracesRate);
 


### PR DESCRIPTION
We should've been prefixing any functions in the global namespace to avoid potential collisions with other apps' functions. Fixes the immediate problem reported in https://github.com/getsentry/sentry-cocoa/issues/3856, but we may need to do more here with all other functions. These generic functions names present the most likely possibility for collisions, though, so this should practically fix most of the issue.

Closes https://github.com/getsentry/sentry-cocoa/issues/3856