### PR TITLE
test: use correct a11y property and skip if not correct OS version

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -518,7 +518,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gz6-bT-PrL">
-                                <rect key="frame" x="65" y="85" width="190" height="38.5"/>
+                                <rect key="frame" x="65" y="85" width="190" height="34.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="extractInfoButton"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Extract Info from view"/>
@@ -565,7 +565,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="O3d-DK-XDH">
-                                <rect key="frame" x="86" y="101" width="148" height="39"/>
+                                <rect key="frame" x="86" y="101" width="148" height="34.5"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Replace content"/>
                                 <connections>
@@ -573,7 +573,7 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wtH-El-bo1">
-                                <rect key="frame" x="40" y="148" width="240" height="378"/>
+                                <rect key="frame" x="40" y="143.5" width="240" height="382.5"/>
                                 <color key="backgroundColor" systemColor="systemGray5Color"/>
                             </view>
                         </subviews>
@@ -686,13 +686,13 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="40A-vG-dFA">
-                                <rect key="frame" x="0.0" y="64" width="320" height="250.5"/>
+                                <rect key="frame" x="0.0" y="64" width="320" height="246.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="fn9-mQ-2PY">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="122.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="118.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Q2k-6Y-RnD">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="122.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="118.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NFC-V3-lgW">
                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
@@ -703,7 +703,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Llv-Yz-cwF">
-                                                        <rect key="frame" x="0.0" y="31.5" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="30" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Capture NSException"/>
                                                         <connections>
@@ -711,7 +711,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJ4-gS-64G" userLabel="fatalError">
-                                                        <rect key="frame" x="0.0" y="63" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="60.5" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Throw FatalError"/>
                                                         <connections>
@@ -719,7 +719,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NYx-6R-0bb">
-                                                        <rect key="frame" x="0.0" y="94.5" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="90.5" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="OOM crash"/>
                                                         <connections>
@@ -729,7 +729,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="2CV-VI-MDY">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="122.5"/>
+                                                <rect key="frame" x="160" y="0.0" width="160" height="118.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zbo-2T-1Zm">
                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
@@ -750,7 +750,7 @@
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NNd-Ec-zXw">
                                                         <rect key="frame" x="0.0" y="56" width="160" height="28"/>
-                                                        <accessibility key="accessibilityConfiguration" identifier="crashTheApp"/>
+                                                        <accessibility key="accessibilityConfiguration" label="crashTheApp"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Crash the app"/>
                                                         <connections>
@@ -758,7 +758,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJs-Av-cg2">
-                                                        <rect key="frame" x="0.0" y="84" width="160" height="38.5"/>
+                                                        <rect key="frame" x="0.0" y="84" width="160" height="34.5"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Use-after-free"/>
                                                         <connections>
@@ -770,7 +770,7 @@
                                         </subviews>
                                     </stackView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1zm-ho-TCr">
-                                        <rect key="frame" x="0.0" y="122.5" width="320" height="128"/>
+                                        <rect key="frame" x="0.0" y="118.5" width="320" height="128"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="128" id="lc6-97-p3W"/>
                                         </constraints>
@@ -1071,7 +1071,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YQi-VW-lsa">
-                                <rect key="frame" x="44.5" y="509.5" width="231" height="38.5"/>
+                                <rect key="frame" x="44.5" y="513.5" width="231" height="34.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="editingChangedButton"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Perform &quot;Editing Changed&quot;"/>
@@ -1080,7 +1080,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sL7-7x-NzY">
-                                <rect key="frame" x="49.5" y="454" width="221.5" height="38.5"/>
+                                <rect key="frame" x="49.5" y="462" width="221.5" height="34.5"/>
                                 <accessibility key="accessibilityConfiguration" identifier="editingDidEndButton"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="Perform &quot;Editing Did End&quot;"/>

--- a/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-SwiftUITests/LaunchUITests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 class LaunchUITests: BaseUITest {
 
-    func testCrashRecovery() {
+    func testCrashRecovery() throws {
         //We will be removing this test from iOS 12 because it fails during CI, which looks like a bug that we cannot reproduce.
         //If we introduce a bug in the crash report process we will catch it with tests for iOS 13 or above.
         //For some reason is not possible to use @available(iOS 13, *) in the test function.
@@ -14,6 +14,8 @@ class LaunchUITests: BaseUITest {
 
             app.launch()
             waitForExistenceOfMainScreen()
+        } else {
+            throw XCTSkip("Only run on iOS 13 or later.")
         }
     }
 


### PR DESCRIPTION
I noticed this fail locally due to a XCUIElement query timeout, but it worked when I changed `crashTheApp` from being the accessibilityIdentifier to the accessibilityLabel for the button.

I also set it up to report the test case as skipped if the OS version req is not met.

I've noticed this test flake in the past but not sure this will fix that.

#skip-changelog