### PR TITLE
chore: Remove BaseIntegrationProtocol from Replay integration

### DIFF
--- a/Sources/Sentry/include/SentrySessionReplayIntegration.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration.h
@@ -1,11 +1,10 @@
 #import "SentryBaseIntegration.h"
 #import "SentryDefines.h"
-#import "SentrySwift.h"
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
-@interface SentrySessionReplayIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
+@interface SentrySessionReplayIntegration : SentryBaseIntegration
 
 @end
 #endif // SENTRY_HAS_UIKIT && !TARGET_OS_VISION


### PR DESCRIPTION
Removing a swift protocol from SentrySessionReplayIntegration for hybrid SDK usage.

We really dont need the protocol, maybe we should reconsider its use.

_#skip-changelog_