### PR TITLE
New Memory Termination Handling (OOM)

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -889,6 +889,11 @@
 		D8F6A24E288553A800320515 /* SentryPredicateDescriptorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */; };
 		D8F8F5572B835BC600AC5465 /* SentryMsgPackSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D8F8F5562B835BC600AC5465 /* SentryMsgPackSerializerTests.m */; };
 		D8FFE50C2703DBB400607131 /* SwizzlingCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFE50B2703DAAE00607131 /* SwizzlingCallTests.swift */; };
+		FA334DF62BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.h in Headers */ = {isa = PBXBuildFile; fileRef = FA334DF42BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.h */; };
+		FA334DF72BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.m in Sources */ = {isa = PBXBuildFile; fileRef = FA334DF52BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.m */; };
+		FA334DFA2BD59E03004938C0 /* SentryAppMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = FA334DF82BD59E03004938C0 /* SentryAppMemory.h */; };
+		FA334DFB2BD59E03004938C0 /* SentryAppMemory.mm in Sources */ = {isa = PBXBuildFile; fileRef = FA334DF92BD59E03004938C0 /* SentryAppMemory.mm */; };
+		FA626A132BD6E150008A91F7 /* SentryAppMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA626A122BD6E150008A91F7 /* SentryAppMemoryTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1919,6 +1924,11 @@
 		D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryPredicateDescriptorTests.swift; sourceTree = "<group>"; };
 		D8F8F5562B835BC600AC5465 /* SentryMsgPackSerializerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMsgPackSerializerTests.m; sourceTree = "<group>"; };
 		D8FFE50B2703DAAE00607131 /* SwizzlingCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzlingCallTests.swift; sourceTree = "<group>"; };
+		FA334DF42BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryMemoryEventBreadcrumbs.h; sourceTree = "<group>"; };
+		FA334DF52BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMemoryEventBreadcrumbs.m; sourceTree = "<group>"; };
+		FA334DF82BD59E03004938C0 /* SentryAppMemory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryAppMemory.h; sourceTree = "<group>"; };
+		FA334DF92BD59E03004938C0 /* SentryAppMemory.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryAppMemory.mm; sourceTree = "<group>"; };
+		FA626A122BD6E150008A91F7 /* SentryAppMemoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SentryAppMemoryTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2351,6 +2361,8 @@
 				7BD729972463E93500EA3610 /* SentryDateUtil.m */,
 				7B98D7E325FB7A7200C5A389 /* SentryAppState.h */,
 				7B98D7E725FB7BCD00C5A389 /* SentryAppState.m */,
+				FA334DF82BD59E03004938C0 /* SentryAppMemory.h */,
+				FA334DF92BD59E03004938C0 /* SentryAppMemory.mm */,
 				7B8ECBF926498906005FE2EF /* SentryAppStateManager.h */,
 				7B8ECBFB26498958005FE2EF /* SentryAppStateManager.m */,
 				7BD86EC4264A63F6005439DB /* SentrySysctl.h */,
@@ -2981,6 +2993,7 @@
 				7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */,
 				7B85BD8D24C5C3A6000A4225 /* SentryFileManagerTestExtension.swift */,
 				7B4C817124D1BC2B0076ACE4 /* SentryFileManager+Test.h */,
+				FA626A122BD6E150008A91F7 /* SentryAppMemoryTests.swift */,
 				7B98D7EB25FB7C4900C5A389 /* SentryAppStateTests.swift */,
 				0A94158128F6C4C2006A5DD1 /* SentryAppStateManagerTests.swift */,
 				69BEE6F62620729E006DF9DF /* UrlSessionDelegateSpy.swift */,
@@ -3009,6 +3022,8 @@
 				7DC27EC423997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m */,
 				A839D89724864B80003B7AFD /* SentrySystemEventBreadcrumbs.h */,
 				A839D89924864BA8003B7AFD /* SentrySystemEventBreadcrumbs.m */,
+				FA334DF42BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.h */,
+				FA334DF52BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.m */,
 				639889B51EDECFA800EA7442 /* SentryBreadcrumbTracker.h */,
 				639889B61EDECFA800EA7442 /* SentryBreadcrumbTracker.m */,
 				62E081A829ED4260000F69FC /* SentryBreadcrumbDelegate.h */,
@@ -3798,6 +3813,7 @@
 				62262B862BA1C46D004DA3DD /* SentryStatsdClient.h in Headers */,
 				84354E1129BF944900CDBB8B /* SentryProfileTimeseries.h in Headers */,
 				D8ACE3CD2762187D00F5A213 /* SentryNSDataSwizzling.h in Headers */,
+				FA334DF62BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.h in Headers */,
 				7B08A3452924CF6C0059603A /* SentryMetricKitIntegration.h in Headers */,
 				0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */,
 				8EAE980C261E9F530073B6B3 /* SentryUIViewControllerPerformanceTracker.h in Headers */,
@@ -3923,6 +3939,7 @@
 				7B31C291277B04A000337126 /* SentryCrashPlatformSpecificDefines.h in Headers */,
 				7B77BE3527EC8445003C9020 /* SentryDiscardReasonMapper.h in Headers */,
 				7B610D602512390E00B0B5D9 /* SentrySDK+Private.h in Headers */,
+				FA334DFA2BD59E03004938C0 /* SentryAppMemory.h in Headers */,
 				62A456E12B03704A003F19A1 /* SentryUIEventTrackerMode.h in Headers */,
 				03F84D2327DD414C008FE43F /* SentryThreadHandle.hpp in Headers */,
 				7B6C5EE0264E8E050010D138 /* SentryFramesTracker.h in Headers */,
@@ -4218,7 +4235,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1410;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1530;
 				ORGANIZATIONNAME = Sentry;
 				TargetAttributes = {
 					63AA759A1EB8AEF500D153DE = {
@@ -4368,6 +4385,7 @@
 				7BA61CCA247D128B00C130A8 /* SentryThreadInspector.m in Sources */,
 				63FE718D20DA4C1100CDBAE8 /* SentryCrashReportStore.c in Sources */,
 				62A2F43E2BA9AC10000C9FDD /* DistributionMetric.swift in Sources */,
+				FA334DFB2BD59E03004938C0 /* SentryAppMemory.mm in Sources */,
 				7BA0C0482805600A003E0326 /* SentryTransportAdapter.m in Sources */,
 				63FE712920DA4C1000CDBAE8 /* SentryCrashCPU_arm.c in Sources */,
 				03F84D3427DD4191008FE43F /* SentryThreadMetadataCache.cpp in Sources */,
@@ -4501,6 +4519,7 @@
 				03F84D3227DD4191008FE43F /* SentryProfiler.mm in Sources */,
 				635B3F391EBC6E2500A6176D /* SentryAsynchronousOperation.m in Sources */,
 				63FE717520DA4C1100CDBAE8 /* SentryCrash.m in Sources */,
+				FA334DF72BD58C21004938C0 /* SentryMemoryEventBreadcrumbs.m in Sources */,
 				6344DDB11EC308E400D9160D /* SentryCrashInstallationReporter.m in Sources */,
 				D85596F3280580F10041FF8B /* SentryScreenshotIntegration.m in Sources */,
 				7BAF3DCE243DCBFE008A5414 /* SentryTransportFactory.m in Sources */,
@@ -4615,6 +4634,7 @@
 				63B819141EC352A7002FDF4C /* SentryInterfacesTests.m in Sources */,
 				7B68345128F7EB3D00FB7064 /* SentryMeasurementUnitTests.swift in Sources */,
 				7B14089A248791660035403D /* SentryCrashStackEntryMapperTests.swift in Sources */,
+				FA626A132BD6E150008A91F7 /* SentryAppMemoryTests.swift in Sources */,
 				D85790292976A69F00C6AC1F /* TestDebugImageProvider.swift in Sources */,
 				62E146D22BAAF55B00ED34FD /* LocalMetricsAggregatorTests.swift in Sources */,
 				7B869EBC249B91D8004F4FDB /* SentryDebugMetaEquality.swift in Sources */,

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1400"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentryProfilerTests.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentryProfilerTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentrySwiftUI.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1420"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTests.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/SentryTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sources/Sentry/SentryAppMemory.h
+++ b/Sources/Sentry/SentryAppMemory.h
@@ -1,0 +1,49 @@
+#import "SentryDefines.h"
+#import "SentrySerializable.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+FOUNDATION_EXPORT NSNotificationName const SentryAppMemoryLevelChangedNotification;
+FOUNDATION_EXPORT NSNotificationName const SentryAppMemoryPressureChangedNotification;
+FOUNDATION_EXPORT NSString *const SentryAppMemoryNewValueKey;
+FOUNDATION_EXPORT NSString *const SentryAppMemoryOldValueKey;
+
+typedef NS_ENUM(NSUInteger, SentryAppMemoryLevel) {
+    SentryAppMemoryLevelNormal = 0,
+    SentryAppMemoryLevelWarn,
+    SentryAppMemoryLevelUrgent,
+    SentryAppMemoryLevelCritical,
+    SentryAppMemoryLevelTerminal
+};
+FOUNDATION_EXPORT NSString *SentryAppMemoryLevelToString(SentryAppMemoryLevel level);
+FOUNDATION_EXPORT SentryAppMemoryLevel SentryAppMemoryLevelFromString(NSString *const level);
+
+typedef NS_ENUM(NSUInteger, SentryAppMemoryPressure) {
+    SentryAppMemoryPressureNormal = 0,
+    SentryAppMemoryPressureWarn,
+    SentryAppMemoryPressureCritical,
+};
+FOUNDATION_EXPORT NSString *SentryAppMemoryPressureToString(SentryAppMemoryPressure pressure);
+FOUNDATION_EXPORT SentryAppMemoryPressure SentryAppMemoryPressureFromString(NSString *const pressure);
+
+@interface SentryAppMemory : NSObject <SentrySerializable>
+
++ (nullable instancetype)current;
+- (nullable instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
+
+@property (readonly, nonatomic, assign) uint64_t footprint;
+@property (readonly, nonatomic, assign) uint64_t remaining;
+@property (readonly, nonatomic, assign) uint64_t limit;
+@property (readonly, nonatomic, assign) SentryAppMemoryLevel level;
+@property (readonly, nonatomic, assign) SentryAppMemoryPressure pressure;
+
+- (BOOL)isLikelyOutOfMemory;
+
+@end
+
+// Internal and for tests.
+@interface SentryAppMemory ()
+- (instancetype)initWithFootprint:(uint64_t)footprint remaining:(uint64_t)remaining pressure:(SentryAppMemoryPressure)pressure;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryAppMemory.mm
+++ b/Sources/Sentry/SentryAppMemory.mm
@@ -1,0 +1,360 @@
+#import <SentryAppMemory.h>
+#import <SentryDateUtils.h>
+
+#import <mach/mach.h>
+#import <mach/task.h>
+#import <atomic>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ The memory tracker takes care of centralizing the knowledge around memory.
+ It does the following:
+ 
+ 1- Wraps memory pressure. This is more useful than `didReceiveMemoryWarning`
+ as it vends different levels of pressure caused by the app as well as the rest of the OS.
+ 
+ 2- Vends a memory level. This is pretty novel. It vends levels of where the app is wihtin
+ the memory limit.
+ 
+ Some useful info. 
+ 
+ Memory Pressure is mostly useful when the app is in the background.
+ It helps understand how much `pressure` is on the app due to external concerns. Using
+ this data, we can make informed decisions around the reasons the app might have been
+ terminated.
+ 
+ Memory Level is useful in the foreground as well as background. It indicates where the app is
+ within its memory limit. That limit being calculated by the addition of `remaining` and `footprint`.
+ Using this data, we can also make informaed decisions around foreground and background memory
+ terminations, aka. OOMs.
+ 
+ See: https://github.com/naftaly/Footprint
+ */
+@interface SentryAppMemoryTracker : NSObject {
+    dispatch_queue_t _heartbeatQueue;
+    dispatch_source_t _pressureSource;
+    dispatch_source_t _limitSource;
+    std::atomic<SentryAppMemoryPressure> _pressure;
+    std::atomic<SentryAppMemoryLevel> _level;
+}
+
++ (instancetype)shared;
+
+@property (atomic, readonly) SentryAppMemoryPressure pressure;
+
+@end
+
+@implementation SentryAppMemoryTracker
+
+// For memory tracking to be useful it needs to start early.
+// This adds a dash of startup time.
+// For simplicity sake, I've strted it here for now.
++ (void)load
+{
+    (void)SentryAppMemoryTracker.shared;
+}
+
++ (instancetype)shared
+{
+    static SentryAppMemoryTracker *sTracker;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sTracker = [SentryAppMemoryTracker new];
+        [sTracker start];
+    });
+    return sTracker;
+}
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        _heartbeatQueue = dispatch_queue_create_with_target("io.sentry.memory.heartbeat", DISPATCH_QUEUE_SERIAL, dispatch_get_global_queue(QOS_CLASS_UTILITY, 0));
+        _level = SentryAppMemoryLevelNormal;
+        _pressure = SentryAppMemoryPressureNormal;
+    }
+    return self;
+}
+
+- (void)dealloc
+{
+    [self stop];
+}
+
+- (void)start
+{
+    // kill the old ones
+    if (_pressureSource || _limitSource) {
+        [self stop];
+    }
+
+    // memory pressure
+    uintptr_t mask = DISPATCH_MEMORYPRESSURE_NORMAL | DISPATCH_MEMORYPRESSURE_WARN | DISPATCH_MEMORYPRESSURE_CRITICAL;
+    _pressureSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_MEMORYPRESSURE, 0, mask, dispatch_get_main_queue());
+    
+    __weak __typeof(self)weakMe = self;
+    
+    dispatch_source_set_event_handler(_pressureSource, ^{
+        [weakMe _memoryPressureChanged:YES];
+    });
+    dispatch_activate(_pressureSource);
+
+    // memory limit (level)
+    _limitSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, _heartbeatQueue);
+    dispatch_source_set_event_handler(_limitSource, ^{
+        [weakMe _heartbeat:YES];
+    });
+    dispatch_source_set_timer(_limitSource, dispatch_time(DISPATCH_TIME_NOW, 0), NSEC_PER_SEC, NSEC_PER_SEC/10);
+    dispatch_activate(_limitSource);
+}
+
+- (void)stop
+{
+    if (_pressureSource) {
+        dispatch_source_cancel(_pressureSource);
+        _pressureSource = nil;
+    }
+    
+    if (_limitSource) {
+        dispatch_source_cancel(_limitSource);
+        _limitSource = nil;
+    }
+}
+
+- (void)_heartbeat:(BOOL)sendObservers
+{
+    // This handles the memory limit.
+    SentryAppMemoryLevel newLevel = [SentryAppMemory current].level;
+    SentryAppMemoryLevel oldLevel = _level.exchange(newLevel);
+    if (newLevel != oldLevel && sendObservers) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[NSNotificationCenter defaultCenter] postNotificationName:SentryAppMemoryLevelChangedNotification object:self userInfo:@{
+                SentryAppMemoryNewValueKey: @(newLevel),
+                SentryAppMemoryOldValueKey: @(oldLevel)
+            }];
+        });
+#if TARGET_OS_SIMULATOR
+      
+        // On the simulator, if we're at a terminal level
+        // let's fake an OOM by sending a SIGKILL signal
+        //
+        // NOTE: Some teams might want to do this in prod.
+        // For example, we could send a SIGTERM so the system
+        // catches a stack trace.
+        if (newLevel == SentryAppMemoryLevelTerminal) {
+            kill(getpid(), SIGKILL);
+            _exit(0);
+        }
+#endif
+    }
+}
+
+- (void)_memoryPressureChanged:(BOOL)sendObservers
+{
+    // This handles system based memory pressure.
+    SentryAppMemoryPressure pressure = SentryAppMemoryPressureNormal;
+    dispatch_source_memorypressure_flags_t flags = dispatch_source_get_data(_pressureSource);
+    if (flags == DISPATCH_MEMORYPRESSURE_NORMAL) {
+        pressure = SentryAppMemoryPressureNormal;
+    } else if (flags == DISPATCH_MEMORYPRESSURE_WARN) {
+        pressure = SentryAppMemoryPressureWarn;
+    } else if (flags == DISPATCH_MEMORYPRESSURE_CRITICAL) {
+        pressure = SentryAppMemoryPressureCritical;
+    }
+    SentryAppMemoryPressure oldPressure = _pressure.exchange(pressure);
+    if (oldPressure != pressure && sendObservers) {
+        [[NSNotificationCenter defaultCenter] postNotificationName:SentryAppMemoryPressureChangedNotification object:self userInfo:@{
+            SentryAppMemoryNewValueKey: @(pressure),
+            SentryAppMemoryOldValueKey: @(oldPressure)
+        }];
+    }
+}
+
+- (SentryAppMemoryPressure)pressure
+{
+    return _pressure.load();
+}
+
+- (SentryAppMemoryLevel)level
+{
+    return _level.load();
+}
+
+@end
+
+@implementation SentryAppMemory
+
++ (nullable instancetype)current
+{
+    task_vm_info_data_t         info = {};
+    mach_msg_type_number_t      count = TASK_VM_INFO_COUNT;
+    kern_return_t               err = task_info(mach_task_self(), TASK_VM_INFO, (task_info_t)&info, &count);
+    if (err != KERN_SUCCESS) {
+        return nil;
+    }
+    
+    uint64_t remaining = info.limit_bytes_remaining;
+#if TARGET_OS_SIMULATOR
+    // in simulator, remaining is always 0. So let's fake it. 
+    // How about a limit of 3GB.
+    uint64_t limit = 3000000000;
+    remaining = limit < info.phys_footprint ? 0 : limit - info.phys_footprint;
+#endif
+    
+    return [[self alloc] initWithFootprint:info.phys_footprint
+                                 remaining:remaining
+                                  pressure:SentryAppMemoryTracker.shared.pressure];
+}
+
+- (instancetype)initWithFootprint:(uint64_t)footprint remaining:(uint64_t)remaining pressure:(SentryAppMemoryPressure)pressure
+{
+    if (self = [super init]) {
+        _footprint = footprint;
+        _remaining = remaining;
+        _pressure = pressure;
+    }
+    return self;
+}
+
+- (nullable instancetype)initWithJSONObject:(NSDictionary *)jsonObject
+{
+    NSNumber *const footprintRef = jsonObject[@"footprint"];
+    NSNumber *const remainingRef = jsonObject[@"remaining"];
+    NSString *const pressureRef = jsonObject[@"pressure"];
+    
+    uint64_t footprint = 0;
+    if ([footprintRef isKindOfClass:NSNumber.class]) {
+        footprint = footprintRef.unsignedLongLongValue;
+    } else {
+        return nil;
+    }
+    
+    uint64_t remaining = 0;
+    if ([remainingRef isKindOfClass:NSNumber.class]) {
+        remaining = remainingRef.unsignedLongLongValue;
+    } else {
+        return nil;
+    }
+    
+    SentryAppMemoryPressure pressure = SentryAppMemoryPressureNormal;
+    if ([pressureRef isKindOfClass:NSString.class]) {
+        pressure = SentryAppMemoryPressureFromString(pressureRef);
+    }
+    
+    return [self initWithFootprint:footprint
+                         remaining:remaining
+                          pressure:pressure];
+}
+
+- (BOOL)isEqual:(id)object
+{
+    if (![object isKindOfClass:self.class]) {
+        return NO;
+    }
+    SentryAppMemory *comp = (SentryAppMemory *)object;
+    return comp.footprint == self.footprint &&
+    comp.remaining == self.remaining &&
+    comp.pressure == self.pressure;
+}
+
+- (nonnull NSDictionary<NSString *,id> *)serialize
+{
+    return @{
+        @"footprint": @(self.footprint),
+        @"remaining": @(self.remaining),
+        @"limit": @(self.limit),
+        @"level": SentryAppMemoryLevelToString(self.level),
+        @"pressure": SentryAppMemoryPressureToString(self.pressure)
+    };
+}
+
+- (uint64_t)limit 
+{
+    return _footprint + _remaining;
+}
+
+- (SentryAppMemoryLevel)level
+{
+    double usedRatio = (double)self.footprint/(double)self.limit;
+    
+    return usedRatio < 0.25 ? SentryAppMemoryLevelNormal :
+    usedRatio < 0.50 ? SentryAppMemoryLevelWarn :
+    usedRatio < 0.75 ? SentryAppMemoryLevelUrgent :
+    usedRatio < 0.95 ? SentryAppMemoryLevelCritical : SentryAppMemoryLevelTerminal;
+}
+
+- (BOOL)isLikelyOutOfMemory
+{
+    return self.level >= SentryAppMemoryLevelCritical || self.pressure >= SentryAppMemoryPressureCritical;
+}
+
+@end
+
+NSString *SentryAppMemoryLevelToString(SentryAppMemoryLevel level)
+{
+    switch (level) {
+        case SentryAppMemoryLevelNormal: return @"normal";
+        case SentryAppMemoryLevelWarn: return @"warn";
+        case SentryAppMemoryLevelUrgent: return @"urgent";
+        case SentryAppMemoryLevelCritical: return @"critical";
+        case SentryAppMemoryLevelTerminal: return @"terminal";
+    }
+}
+
+SentryAppMemoryLevel SentryAppMemoryLevelFromString(NSString *const level)
+{
+    if ([level isEqualToString:@"normal"]) {
+        return SentryAppMemoryLevelNormal;
+    }
+    
+    if ([level isEqualToString:@"warn"]) {
+        return SentryAppMemoryLevelWarn;
+    }
+    
+    if ([level isEqualToString:@"urgent"]) {
+        return SentryAppMemoryLevelUrgent;
+    }
+    
+    if ([level isEqualToString:@"critical"]) {
+        return SentryAppMemoryLevelCritical;
+    }
+    
+    if ([level isEqualToString:@"terminal"]) {
+        return SentryAppMemoryLevelTerminal;
+    }
+    
+    return SentryAppMemoryLevelNormal;
+}
+
+NSString *SentryAppMemoryPressureToString(SentryAppMemoryPressure pressure)
+{
+    switch (pressure) {
+        case SentryAppMemoryPressureNormal: return @"normal";
+        case SentryAppMemoryPressureWarn: return @"warn";
+        case SentryAppMemoryPressureCritical: return @"critical";
+    }
+}
+
+SentryAppMemoryPressure SentryAppMemoryPressureFromString(NSString *const pressure)
+{
+    if ([pressure isEqualToString:@"normal"]) {
+        return SentryAppMemoryPressureNormal;
+    }
+    
+    if ([pressure isEqualToString:@"warn"]) {
+        return SentryAppMemoryPressureWarn;
+    }
+    
+    if ([pressure isEqualToString:@"critical"]) {
+        return SentryAppMemoryPressureCritical;
+    }
+    
+    return SentryAppMemoryPressureNormal;
+}
+
+NSNotificationName const SentryAppMemoryLevelChangedNotification = @"SentryAppMemoryLevelChangedNotification";
+NSNotificationName const SentryAppMemoryPressureChangedNotification = @"SentryAppMemoryPressureChangedNotification";
+NSString *const SentryAppMemoryNewValueKey = @"SentryAppMemoryNewValueKey";
+NSString *const SentryAppMemoryOldValueKey = @"SentryAppMemoryOldValueKey";
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryAppState.m
+++ b/Sources/Sentry/SentryAppState.m
@@ -26,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
         _wasTerminated = NO;
         _isANROngoing = NO;
         _isSDKRunning = YES;
+        _appMemory = [SentryAppMemory current];
     }
     return self;
 }
@@ -99,6 +100,8 @@ NS_ASSUME_NONNULL_BEGIN
         } else {
             _isSDKRunning = [isSDKRunning boolValue];
         }
+        
+        _appMemory = [[SentryAppMemory alloc] initWithJSONObject:jsonObject[@"app_memory"]];
     }
     return self;
 }
@@ -117,7 +120,8 @@ NS_ASSUME_NONNULL_BEGIN
     [data setValue:@(self.wasTerminated) forKey:@"was_terminated"];
     [data setValue:@(self.isANROngoing) forKey:@"is_anr_ongoing"];
     [data setValue:@(self.isSDKRunning) forKey:@"is_sdk_running"];
-
+    [data setValue:[_appMemory serialize] ?: @{} forKey:@"app_memory"];
+    
     return data;
 }
 

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -6,6 +6,7 @@
 #import "SentryOptions.h"
 #import "SentrySDK.h"
 #import "SentrySystemEventBreadcrumbs.h"
+#import "SentryMemoryEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,6 +17,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 @property (nonatomic, strong) SentrySystemEventBreadcrumbs *systemEventBreadcrumbs;
+@property (nonatomic, strong) SentryMemoryEventBreadcrumbs *memoryEventBreadcrumbs;
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 @end
@@ -36,6 +38,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
                          initWithFileManager:[SentryDependencyContainer sharedInstance].fileManager
                 andNotificationCenterWrapper:[SentryDependencyContainer sharedInstance]
                                                  .notificationCenterWrapper]
+     memoryEventBreadcrumbs:[SentryMemoryEventBreadcrumbs new]
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
     ];
 
@@ -54,6 +57,7 @@ SentryAutoBreadcrumbTrackingIntegration ()
          breadcrumbTracker:(SentryBreadcrumbTracker *)breadcrumbTracker
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     systemEventBreadcrumbs:(SentrySystemEventBreadcrumbs *)systemEventBreadcrumbs
+    memoryEventBreadcrumbs:(SentryMemoryEventBreadcrumbs *)memoryEventBreadcrumbs
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 {
     self.breadcrumbTracker = breadcrumbTracker;
@@ -68,6 +72,9 @@ SentryAutoBreadcrumbTrackingIntegration ()
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     self.systemEventBreadcrumbs = systemEventBreadcrumbs;
     [self.systemEventBreadcrumbs startWithDelegate:self];
+    
+    self.memoryEventBreadcrumbs = memoryEventBreadcrumbs;
+    [self.memoryEventBreadcrumbs startWithDelegate:self];
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 }
 
@@ -79,6 +86,10 @@ SentryAutoBreadcrumbTrackingIntegration ()
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     if (nil != self.systemEventBreadcrumbs) {
         [self.systemEventBreadcrumbs stop];
+    }
+    
+    if (nil != self.memoryEventBreadcrumbs) {
+        [self.memoryEventBreadcrumbs stop];
     }
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 }

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -813,7 +813,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     SentryException *exception = event.exceptions[0];
     return exception.mechanism != nil &&
-        [exception.mechanism.type isEqualToString:SentryWatchdogTerminationMechanismType];
+        ([exception.mechanism.type isEqualToString:SentryWatchdogTerminationMechanismType] ||
+    [exception.mechanism.type isEqualToString:SentryOOMTerminationExceptionType]);
 }
 
 - (void)applyCultureContextToEvent:(SentryEvent *)event

--- a/Sources/Sentry/SentryMemoryEventBreadcrumbs.h
+++ b/Sources/Sentry/SentryMemoryEventBreadcrumbs.h
@@ -1,0 +1,21 @@
+#import "SentryFileManager.h"
+#import <Foundation/Foundation.h>
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+#    import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol SentryBreadcrumbDelegate;
+
+@interface SentryMemoryEventBreadcrumbs : NSObject
+
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate;
+- (void)stop;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryMemoryEventBreadcrumbs.m
+++ b/Sources/Sentry/SentryMemoryEventBreadcrumbs.m
@@ -1,0 +1,59 @@
+#import "SentryMemoryEventBreadcrumbs.h"
+#import "SentryBreadcrumb.h"
+#import "SentryBreadcrumbDelegate.h"
+#import "SentryDefines.h"
+#import "SentryDependencyContainer.h"
+#import "SentryLog.h"
+#import "SentryAppMemory.h"
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+@interface
+SentryMemoryEventBreadcrumbs ()
+@property (nonatomic, weak) id<SentryBreadcrumbDelegate> delegate;
+@end
+
+@implementation SentryMemoryEventBreadcrumbs
+
+- (void)stop
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:SentryAppMemoryPressureChangedNotification
+                                                  object:nil];
+}
+
+- (void)dealloc
+{
+    [self stop];
+}
+
+- (void)startWithDelegate:(id<SentryBreadcrumbDelegate>)delegate
+{
+    [self stop];
+    
+    _delegate = delegate;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_memoryChanged) 
+                                                 name:SentryAppMemoryPressureChangedNotification
+                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(_memoryChanged) 
+                                                 name:SentryAppMemoryLevelChangedNotification
+                                               object:nil];
+    
+    [self _memoryChanged];
+}
+
+- (void)_memoryChanged
+{
+    SentryBreadcrumb *crumb = [[SentryBreadcrumb alloc] initWithLevel:kSentryLevelInfo
+                                                             category:@"memory.event"];
+    crumb.type = @"memory";
+    crumb.data = [SentryAppMemory current].serialize;
+    [_delegate addBreadcrumb:crumb];
+}
+
+@end
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentrySessionCrashedHandler.m
+++ b/Sources/Sentry/SentrySessionCrashedHandler.m
@@ -41,7 +41,7 @@ SentrySessionCrashedHandler ()
 {
     if (self.crashWrapper.crashedLastLaunch
 #if SENTRY_HAS_UIKIT
-        || [self.watchdogTerminationLogic isWatchdogTermination]
+        || [self.watchdogTerminationLogic isWatchdogTermination:NULL]
 #endif // SENTRY_HAS_UIKIT
     ) {
         SentryFileManager *fileManager = [[[SentrySDK currentHub] getClient] fileManager];

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -32,7 +32,7 @@ SentryWatchdogTerminationLogic ()
     return self;
 }
 
-- (BOOL)isWatchdogTermination
+- (BOOL)isWatchdogTermination:(BOOL *)oom
 {
     if (!self.options.enableWatchdogTerminationTracking) {
         return NO;
@@ -107,6 +107,11 @@ SentryWatchdogTerminationLogic ()
     // only report a Watchdog Termination when the SDK is started the first time.
     if (SentrySDK.startInvocations != 1) {
         return NO;
+    }
+    
+    // If we have a likely OOM it's a special watchdog event.
+    if (oom) {
+        *oom = previousAppState.appMemory.isLikelyOutOfMemory;
     }
 
     return YES;

--- a/Sources/Sentry/include/SentryAppState.h
+++ b/Sources/Sentry/include/SentryAppState.h
@@ -1,5 +1,6 @@
 #import "SentryDefines.h"
 #import "SentrySerializable.h"
+#import "SentryAppMemory.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -41,6 +42,8 @@ SENTRY_NO_INIT
 @property (nonatomic, assign) BOOL isANROngoing;
 
 @property (nonatomic, assign) BOOL isSDKRunning;
+
+@property (nonatomic, strong) SentryAppMemory *appMemory;
 
 @end
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationLogic.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationLogic.h
@@ -13,7 +13,7 @@ SENTRY_NO_INIT
                    crashAdapter:(SentryCrashWrapper *)crashAdapter
                 appStateManager:(SentryAppStateManager *)appStateManager;
 
-- (BOOL)isWatchdogTermination;
+- (BOOL)isWatchdogTermination:(nullable BOOL *)oom;
 
 @end
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
@@ -7,8 +7,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const SentryWatchdogTerminationExceptionType = @"WatchdogTermination";
 static NSString *const SentryWatchdogTerminationExceptionValue
-    = @"The OS watchdog terminated your app, possibly because it overused RAM.";
+    = @"The OS watchdog terminated your app.";
 static NSString *const SentryWatchdogTerminationMechanismType = @"watchdog_termination";
+
+static NSString *const SentryOOMTerminationExceptionType = @"OutOfMemoryTermination";
+static NSString *const SentryOOMTerminationExceptionValue
+= @"The OS watchdog terminated your app because it overused RAM.";
+static NSString *const SentryOOMTerminationMechanismType = @"oom_termination";
 
 /**
  * Detect OOMs based on heuristics described in a blog post:

--- a/Sources/SentryCrash/Recording/SentryCrashDoctor.m
+++ b/Sources/SentryCrash/Recording/SentryCrashDoctor.m
@@ -471,7 +471,6 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
                               (void *)address];
             }
         }
-
         return nil;
     } @catch (NSException *e) {
         NSArray *symbols = [e callStackSymbols];

--- a/Tests/SentryTests/Helper/SentryAppMemoryTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppMemoryTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+class SentryAppMemoryTests: XCTestCase {
+
+    func testSerialize() {
+        let appMemory = TestData.appMemory
+        
+        let actual = appMemory.serialize()
+        
+        XCTAssertEqual(appMemory.footprint, actual["footprint"] as? UInt64)
+        XCTAssertEqual(appMemory.remaining, actual["remaining"] as? UInt64)
+        XCTAssertEqual(appMemory.limit, actual["limit"] as? UInt64)
+        XCTAssertEqual(appMemory.level, SentryAppMemoryLevelFromString(actual["level"] as! String))
+        XCTAssertEqual(appMemory.pressure, SentryAppMemoryPressureFromString(actual["pressure"] as! String))
+    }
+    
+    func testInitWithJSON_AllFields() {
+        let appMemory = TestData.appMemory
+        let dict = [
+            "footprint": appMemory.footprint,
+            "remaining": appMemory.remaining,
+            "pressure": appMemory.pressure,
+            
+            // unsued. calculated.
+            "level": appMemory.level,
+            "limit": appMemory.limit,
+        ] as [String: Any]
+        
+        let actual = SentryAppMemory(jsonObject: dict)
+        
+        XCTAssertEqual(appMemory, actual)
+    }
+    
+    func testLevel() {
+        XCTAssertEqual(appMemoryLevel(0, 100), SentryAppMemoryLevel.normal)
+        XCTAssertEqual(appMemoryLevel(25, 100), SentryAppMemoryLevel.warn)
+        XCTAssertEqual(appMemoryLevel(50, 100), SentryAppMemoryLevel.urgent)
+        XCTAssertEqual(appMemoryLevel(75, 100), SentryAppMemoryLevel.critical)
+        XCTAssertEqual(appMemoryLevel(95, 100), SentryAppMemoryLevel.terminal)
+    }
+    
+    func appMemoryLevel(_ footprint: UInt64, _ limit: UInt64) -> SentryAppMemoryLevel {
+        SentryAppMemory(footprint: footprint, remaining: limit-footprint, pressure: .normal).level
+    }
+}

--- a/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
@@ -103,7 +103,7 @@ class SentryAppStateManagerTests: XCTestCase {
         sut.stop(withForce: true)
         XCTAssertEqual(sut.startCount, 0)
 
-        XCTAssertEqual(fixture.notificationCenterWrapper.removeObserverWithNameInvocations.count, 4)
+        XCTAssertEqual(fixture.notificationCenterWrapper.removeObserverWithNameInvocations.count, 6)
     }
 
     func testUpdateAppState() {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegration+Test.h
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegration+Test.h
@@ -2,7 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class SentryOptions, SentryBreadcrumbTracker, SentrySystemEventBreadcrumbs;
+@class SentryOptions, SentryBreadcrumbTracker, SentrySystemEventBreadcrumbs, SentryMemoryEventBreadcrumbs;
 
 @interface
 SentryAutoBreadcrumbTrackingIntegration (Test)
@@ -11,6 +11,7 @@ SentryAutoBreadcrumbTrackingIntegration (Test)
          breadcrumbTracker:(SentryBreadcrumbTracker *)breadcrumbTracker
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
     systemEventBreadcrumbs:(SentrySystemEventBreadcrumbs *)systemEventBreadcrumbs
+    memoryEventBreadcrumbs:(SentryMemoryEventBreadcrumbs *)memoryEventBreadcrumbs
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
     ;
 

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
@@ -365,7 +365,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         XCTAssertEqual(1, crashEvent?.exceptions?.count)
         
         let exception = crashEvent?.exceptions?.first
-        XCTAssertEqual("The OS watchdog terminated your app, possibly because it overused RAM.", exception?.value)
+        XCTAssertEqual("The OS watchdog terminated your app.", exception?.value)
         XCTAssertEqual("WatchdogTermination", exception?.type)
         
         XCTAssertNotNil(exception?.mechanism)

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -253,6 +253,10 @@ class TestData {
         return SentryAppState(releaseName: "1.0.0", osVersion: "14.4.1", vendorId: someUUID, isDebugging: false, systemBootTimestamp: timestamp)
     }
     
+    static var appMemory: SentryAppMemory {
+        return SentryAppMemory(footprint: 500, remaining: 500, pressure: .normal)
+    }
+    
     static var oomEvent: Event {
         let event = Event(level: SentryLevel.fatal)
         let exception = Exception(value: SentryWatchdogTerminationExceptionValue, type: SentryWatchdogTerminationExceptionType)

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -185,6 +185,7 @@
 #import "SentryEnvelopeAttachmentHeader.h"
 #import "SentryExtraContextProvider.h"
 #import "SentryMeasurementValue.h"
+#import "SentryMemoryEventBreadcrumbs.h"
 #import "SentryNSProcessInfoWrapper.h"
 #import "SentryPerformanceTracker+Testing.h"
 #import "SentryPropagationContext.h"


### PR DESCRIPTION
## :scroll: Description

This PR introduces `memory pressure` and `memory level` systems in order to effectively track memory terminations and correctly report them.

[Example Report](https://bedroomcode.sentry.io/issues/5235790069/events/latest/?query=is%3Aunresolved&referrer=latest-event&statsPeriod=24h&stream_index=0)

<img width="918" alt="Screenshot 2024-04-22 at 3 34 56 PM" src="https://github.com/getsentry/sentry-cocoa/assets/221626/8e4b8f2c-d187-4638-8d28-100037daf736">
<img width="876" alt="Screenshot 2024-04-22 at 3 35 08 PM" src="https://github.com/getsentry/sentry-cocoa/assets/221626/9e40e6e1-8a98-4f72-b5d5-464485647d2a">


## :bulb: Motivation and Context

A lot has changed since [this article](https://engineering.fb.com/2015/08/24/ios/reducing-fooms-in-the-facebook-ios-app/) about handling memory terminations. In order to bring Sentry OOM handling up to date, some additional heuristics are needed. 

At this point, this is more of a proposal than a full PR since a few things would need to be updated to land this. For example, SentryAppMemoryTracker should be move to the dependency container.

## :green_heart: How did you test it?

Some new tests were added for new memory classes. More in depth testing is required as well as some changes to DI in order to allow for these tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
