### PR TITLE
ref(profiling): move sliceGPUData to timeseries code unit; prefix C functions

### DIFF
--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -7,6 +7,10 @@
 #    import "SentryLog.h"
 #    import "SentrySample.h"
 #    import "SentryTransaction.h"
+#    if SENTRY_HAS_UIKIT
+#        import "SentryFormatter.h"
+#        import "SentryTime.h"
+#    endif // SENTRY_HAS_UIKIT
 
 /**
  * Print a debug log to help diagnose slicing errors.
@@ -39,7 +43,7 @@ logSlicingFailureWithArray(
         firstSampleRelativeToTransactionStart, lastSampleRelativeToTransactionStart);
 }
 
-NSArray<SentrySample *> *_Nullable slicedProfileSamples(
+NSArray<SentrySample *> *_Nullable sentry_slicedProfileSamples(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime, uint64_t endSystemTime)
 {
     if (samples.count == 0) {
@@ -80,5 +84,56 @@ NSArray<SentrySample *> *_Nullable slicedProfileSamples(
     const auto indices = [NSIndexSet indexSetWithIndexesInRange:range];
     return [samples objectsAtIndexes:indices];
 }
+
+#    if SENTRY_HAS_UIKIT
+/**
+ * Convert the data structure that records timestamps for GPU frame render info from
+ * SentryFramesTracker to the structure expected for profiling metrics, and throw out any that
+ * didn't occur within the profile time.
+ * @param useMostRecentRecording @c SentryFramesTracker doesn't stop running once it starts.
+ * Although we reset the profiling timestamps each time the profiler stops and starts, concurrent
+ * transactions that start after the first one won't have a screen frame rate recorded within their
+ * timeframe, because it will have already been recorded for the first transaction and isn't
+ * recorded again unless the system changes it. In these cases, use the most recently recorded data
+ * for it.
+ */
+NSArray<SentrySerializedMetricEntry *> *
+sentry_sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, uint64_t startSystemTime,
+    uint64_t endSystemTime, BOOL useMostRecentRecording)
+{
+    auto slicedGPUEntries = [NSMutableArray<SentrySerializedMetricEntry *> array];
+    __block NSNumber *nearestPredecessorValue;
+    [frameInfo enumerateObjectsUsingBlock:^(
+        NSDictionary<NSString *, NSNumber *> *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
+        const auto timestamp = obj[@"timestamp"].unsignedLongLongValue;
+
+        if (!orderedChronologically(startSystemTime, timestamp)) {
+            SENTRY_LOG_DEBUG(@"GPU info recorded (%llu) before transaction start (%llu), "
+                             @"will not report it.",
+                timestamp, startSystemTime);
+            nearestPredecessorValue = obj[@"value"];
+            return;
+        }
+
+        if (!orderedChronologically(timestamp, endSystemTime)) {
+            SENTRY_LOG_DEBUG(@"GPU info recorded after transaction finished, won't record.");
+            return;
+        }
+        const auto relativeTimestamp = getDurationNs(startSystemTime, timestamp);
+
+        [slicedGPUEntries addObject:@ {
+            @"elapsed_since_start_ns" : sentry_stringForUInt64(relativeTimestamp),
+            @"value" : obj[@"value"],
+        }];
+    }];
+    if (useMostRecentRecording && slicedGPUEntries.count == 0 && nearestPredecessorValue != nil) {
+        [slicedGPUEntries addObject:@ {
+            @"elapsed_since_start_ns" : @"0",
+            @"value" : nearestPredecessorValue,
+        }];
+    }
+    return slicedGPUEntries;
+}
+#    endif // SENTRY_HAS_UIKIT
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/include/SentryProfileTimeseries.h
+++ b/Sources/Sentry/include/SentryProfileTimeseries.h
@@ -5,13 +5,23 @@
 #    import "SentryDefines.h"
 #    import <Foundation/Foundation.h>
 
+#    if SENTRY_HAS_UIKIT
+#        import "SentryMetricProfiler.h"
+#        import "SentryScreenFrames.h"
+#    endif // SENTRY_HAS_UIKIT
+
 @class SentrySample;
 @class SentryTransaction;
 
 NS_ASSUME_NONNULL_BEGIN
 
-NSArray<SentrySample *> *_Nullable slicedProfileSamples(
+NSArray<SentrySample *> *_Nullable sentry_slicedProfileSamples(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime, uint64_t endSystemTime);
+
+#    if SENTRY_HAS_UIKIT
+NSArray<SentrySerializedMetricEntry *> *sentry_sliceGPUData(SentryFrameInfoTimeSeries *frameInfo,
+    uint64_t startSystemTime, uint64_t endSystemTime, BOOL useMostRecentRecording);
+#    endif // SENTRY_HAS_UIKIT
 
 NS_ASSUME_NONNULL_END
 

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -109,7 +109,7 @@ using namespace sentry::profiling;
     void (^sliceBlock)(void) = ^(void) {
         [state mutate:^(SentryProfilerMutableState *mutableState) {
             __unused const auto slice
-                = slicedProfileSamples(mutableState.samples, startSystemTime, endSystemTime);
+                = sentry_slicedProfileSamples(mutableState.samples, startSystemTime, endSystemTime);
             [sliceExpectation fulfill];
         }];
     };


### PR DESCRIPTION
Taking some time to clean up the implementation of SentryProfiler and organize it a little better before moving forward with adding the continuous profiling implementation.

This moves the `sliceGPU` function out of SentryProfiler.mm and into SentryProfilerTimeseries.mm. Also prefix the C function names with `_sentry` as in #3862 

for #3555 #skip-changelog