### PR TITLE
feat(replay): add `captureReplay` without Event param for Hybrid SDKs

### DIFF
--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -143,6 +143,10 @@ SentrySessionReplay ()
         return NO;
     }
 
+    if (_isFullSession) {
+        return YES;
+    }
+
     if ([_sentryRandom nextNumber] > _replayOptions.errorSampleRate) {
         return NO;
     }

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -129,12 +129,25 @@ SentrySessionReplay ()
         return;
     }
 
-    if ([_sentryRandom nextNumber] > _replayOptions.errorSampleRate) {
+    BOOL didCaptureReplay = [self captureReplay];
+    if (!didCaptureReplay) {
         return;
     }
 
-    [self startFullReplay];
     [self setEventContext:event];
+}
+
+- (BOOL)captureReplay
+{
+    if (!_isRunning) {
+        return NO;
+    }
+
+    if ([_sentryRandom nextNumber] > _replayOptions.errorSampleRate) {
+        return NO;
+    }
+
+    [self startFullReplay];
 
     NSURL *finalPath = [_urlToCache URLByAppendingPathComponent:@"replay.mp4"];
     NSDate *replayStart =
@@ -143,6 +156,8 @@ SentrySessionReplay ()
     [self createAndCapture:finalPath
                   duration:_replayOptions.errorReplayDuration
                  startedAt:replayStart];
+
+    return YES;
 }
 
 - (void)setEventContext:(SentryEvent *)event

--- a/Sources/Sentry/include/SentrySessionReplay.h
+++ b/Sources/Sentry/include/SentrySessionReplay.h
@@ -62,6 +62,11 @@ API_AVAILABLE(ios(16.0), tvos(16.0))
  */
 - (void)captureReplayForEvent:(SentryEvent *)event;
 
+/**
+ * Captures a replay. This method is used by the Hybrid SDKs.
+ */
+- (BOOL)captureReplay;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -192,6 +192,18 @@ class SentrySessionReplayTests: XCTestCase {
     }
     
     @available(iOS 16.0, tvOS 16, *)
+    func testChangeReplayMode_forHybridSDKEvent() {
+        let fixture = startFixture()
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        sut.start(fixture.rootView, fullSession: false)
+
+        sut.capture()
+
+        expect(fixture.hub.scope.replayId) == sut.sessionReplayId.sentryIdString
+        assertFullSession(sut, expected: true)
+    }
+
+    @available(iOS 16.0, tvOS 16, *)
     func testSessionReplayMaximumDuration() {
         let fixture = startFixture()
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))


### PR DESCRIPTION
This PR splits `captureReplayForEvent` into `captureReplay` and `captureReplayForEvent`, as Hybrid SDKs need to capture replay without passing their event to native.

This PR is need for the `alpha.0` of RN replay.

- https://github.com/getsentry/sentry-react-native/pull/3714

_#skip-changelog_