### PR TITLE
test(profiling): mock the correct expected thread name for unit tests

### DIFF
--- a/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift
@@ -570,7 +570,7 @@ private extension SentryProfilerSwiftTests {
         return try XCTUnwrap(envelope.event as? Transaction)
     }
 
-    func addMockSamples(threadMetadata: ThreadMetadata = ThreadMetadata(id: 1, priority: 2, name: "test-thread"), addresses: [NSNumber] = [0x3, 0x4, 0x5]) {
+    func addMockSamples(threadMetadata: ThreadMetadata = ThreadMetadata(id: 1, priority: 2, name: "main"), addresses: [NSNumber] = [0x3, 0x4, 0x5]) {
         let state = SentryProfiler.getCurrent()._state
         fixture.currentDateProvider.advanceBy(nanoseconds: 1)
         SentryProfilerMocksSwiftCompatible.appendMockBacktrace(to: state, threadID: threadMetadata.id, threadPriority: threadMetadata.priority, threadName: threadMetadata.name, addresses: addresses)


### PR DESCRIPTION
I was investigating a seeming test flake in `-[SentryProfilerTests.SentryProfilerSwiftTests testProfileTimeoutTimer]`, which failed [here](https://github.com/getsentry/sentry-cocoa/blob/42f4107997def601a9f8782c44a51d150f2dbcbf/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift#L776) in [this run](https://github.com/getsentry/sentry-cocoa/blob/42f4107997def601a9f8782c44a51d150f2dbcbf/Tests/SentryProfilerTests/SentryProfilerSwiftTests.swift#L776) for #3876 due to there being no samples on the `main` thread. This test would've added some mock samples for a thread named `test-thread`, and, since it should've almost instantaneously simulated a timeout, wouldn't even be expected to have any actual samples from the real `main` thread. I'm guessing that due to execution speed, there usually are a couple such real samples, so this test usually doesn't fail, but in this example, it finally did run fast enough to not get any real main thread samples.

Then I looked again at how `addMockSamples` is used, and nothing specifically needs samples from that `test-thread` that is its default parameter thread metadata value. There is one call that overrides the metadata to the same as the default. So, this should be fine to change to mocking `main` thread samples. I don't remember any more the reasoning behind mocking samples on `test-thread` but then asserting samples on `main`, I'm guessing the assertion was written long before the mocking was put in place, and then not changed accordingly when mocking was added.

#skip-changelog