### PR TITLE
ci: retry UI tests up to 3 times

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -141,8 +141,9 @@ jobs:
         if: ${{ matrix.device == 'iPhone 14 (16.4)' }}
         run: ./scripts/create-simulator.sh 14.3.1 16.4 16-4
 
+        # UI tests have been flaking lately due to: Testing failed: iOS-SwiftUITests-Runner (13303) encountered an error (The test runner failed to initialize for UI testing. (Underlying Error: Timed out while loading Accessibility.))
       - name: Run Fastlane
-        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}" 
+        run: for i in {1..3}; do fastlane ui_tests_ios_swift device:"${{matrix.device}}" && break ; done
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
I've been seeing a lot of this lately, the iOS-SwiftUITests-Runner not reporting an app launch, so the tests run times out. One retry usually fixes it, but that's annoying to do manually.
> Testing failed: iOS-SwiftUITests-Runner (13303) encountered an error (The test runner failed to initialize for UI testing. (Underlying Error: Timed out while loading Accessibility.))

https://github.com/getsentry/sentry-cocoa/actions/runs/8806093882/job/24170123920?pr=3875#step:6:1014

#skip-changelog