### PR TITLE
chore: Rename SentryDispatchQueueWrapper function name for Swift

### DIFF
--- a/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
+++ b/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
@@ -27,21 +27,21 @@ public class TestSentryDispatchQueueWrapper: SentryDispatchQueueWrapper {
     public var blockOnMainInvocations = Invocations<() -> Void>()
     public var blockBeforeMainBlock: () -> Bool = { true }
 
-    public override func dispatch(onMainQueue block: @escaping () -> Void) {
+    public override func dispatchOnMainQueue(block: @escaping () -> Void) {
         blockOnMainInvocations.record(block)
         if blockBeforeMainBlock() {
             block()
         }
     }
 
-    public override func dispatchAsync(onMainQueue block: @escaping () -> Void) {
+    public override func dispatchAsyncOnMainQueue(block: @escaping () -> Void) {
         blockOnMainInvocations.record(block)
         if blockBeforeMainBlock() {
             block()
         }
     }
 
-    public override func dispatchSync(onMainQueue block: @escaping () -> Void) {
+    public override func dispatchSyncOnMainQueue(block: @escaping () -> Void) {
         blockOnMainInvocations.record(block)
         if blockBeforeMainBlock() {
             block()

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -56,43 +56,23 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (nullable id)dispatchSyncOnMainQueueWithResult:(id (^)(void))block
-{
-    return [self dispatchSyncOnMainQueueWithResult:block timeout:DISPATCH_TIME_FOREVER];
-}
-
 - (BOOL)dispatchSyncOnMainQueue:(void (^)(void))block timeout:(NSTimeInterval)timeout
 {
-    NSNumber *result = [self
-        dispatchSyncOnMainQueueWithResult:^id _Nonnull {
-            block();
-            return @YES;
-        }
-                                  timeout:timeout];
-    return result.boolValue;
-}
-
-- (nullable id)dispatchSyncOnMainQueueWithResult:(id (^)(void))block timeout:(NSTimeInterval)timeout
-{
     if ([NSThread isMainThread]) {
-        return block();
+        block();
     } else {
         dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-        __block id result;
 
         dispatch_async(dispatch_get_main_queue(), ^{
-            result = block();
+            block();
             dispatch_semaphore_signal(semaphore);
         });
 
         dispatch_time_t timeout_t
             = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
-        if (dispatch_semaphore_wait(semaphore, timeout_t) == 0) {
-            return result;
-        } else {
-            return nil;
-        }
+        return dispatch_semaphore_wait(semaphore, timeout_t) == 0;
     }
+    return YES;
 }
 
 - (void)dispatchAfter:(NSTimeInterval)interval block:(dispatch_block_t)block

--- a/Sources/Sentry/SentryUIApplication.m
+++ b/Sources/Sentry/SentryUIApplication.m
@@ -64,8 +64,9 @@
 
 - (NSArray<UIWindow *> *)windows
 {
-    return [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper
-        dispatchSyncOnMainQueueWithResult:^id _Nonnull {
+    __block NSArray<UIWindow *> *windows = nil;
+    [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper
+        dispatchSyncOnMainQueue:^{
             UIApplication *app = [self sharedApplication];
             NSMutableArray *result = [NSMutableArray array];
 
@@ -89,9 +90,10 @@
                 [result addObject:appDelegate.window];
             }
 
-            return result;
+            windows = result;
         }
-                                  timeout:0.01];
+                        timeout:0.01];
+    return windows ?: @[];
 }
 
 - (NSArray<UIViewController *> *)relevantViewControllers
@@ -115,8 +117,10 @@
 
 - (nullable NSArray<NSString *> *)relevantViewControllersNames
 {
-    return [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper
-        dispatchSyncOnMainQueueWithResult:^id _Nonnull {
+    __block NSArray<NSString *> *result = nil;
+
+    [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper
+        dispatchSyncOnMainQueue:^{
             NSArray *viewControllers
                 = SentryDependencyContainer.sharedInstance.application.relevantViewControllers;
             NSMutableArray *vcsNames =
@@ -124,9 +128,11 @@
             for (id vc in viewControllers) {
                 [vcsNames addObject:[SwiftDescriptor getObjectClassName:vc]];
             }
-            return [NSArray arrayWithArray:vcsNames];
+            result = [NSArray arrayWithArray:vcsNames];
         }
-                                  timeout:0.01];
+                        timeout:0.01];
+
+    return result;
 }
 
 - (NSArray<UIViewController *> *)relevantViewControllerFromWindow:(UIWindow *)window

--- a/Sources/Sentry/include/SentryDispatchQueueWrapper.h
+++ b/Sources/Sentry/include/SentryDispatchQueueWrapper.h
@@ -13,18 +13,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)dispatchAsyncWithBlock:(void (^)(void))block;
 
-- (void)dispatchAsyncOnMainQueue:(void (^)(void))block;
+- (void)dispatchAsyncOnMainQueue:(void (^)(void))block
+    NS_SWIFT_NAME(dispatchAsyncOnMainQueue(block:));
 
-- (void)dispatchOnMainQueue:(void (^)(void))block;
+- (void)dispatchOnMainQueue:(void (^)(void))block NS_SWIFT_NAME(dispatchOnMainQueue(block:));
 
-- (void)dispatchSyncOnMainQueue:(void (^)(void))block;
-
-- (nullable id)dispatchSyncOnMainQueueWithResult:(id (^)(void))block;
+- (void)dispatchSyncOnMainQueue:(void (^)(void))block
+    NS_SWIFT_NAME(dispatchSyncOnMainQueue(block:));
 
 - (BOOL)dispatchSyncOnMainQueue:(void (^)(void))block timeout:(NSTimeInterval)timeout;
-
-- (nullable id)dispatchSyncOnMainQueueWithResult:(id (^)(void))block
-                                         timeout:(NSTimeInterval)timeout;
 
 - (void)dispatchAfter:(NSTimeInterval)interval block:(dispatch_block_t)block;
 


### PR DESCRIPTION
`SentryDispatchQueueWrapper` is confusing to use with Swift. It behaves as if it were a DispatchQueue but also includes functions that interact with the main queue. When converting to Swift, the functions that manipulate its own queue overlap with those that interact with the main queue, distinguished only by the argument name, which can be omitted because it's a block.

Renaming those functions in Swift would better reflect their respective actions.

_#skip-changelog_