### PR TITLE
ci: Use replace sentry paths filter with dorny

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,4 +1,4 @@
-# This is used by the action https://github.com/dorny/paths-filter (which we have forked to https://github.com/getsentry/paths-filter)
+# This is used by the action https://github.com/dorny/paths-filter
 
 high_risk_code: &high_risk_code
   - 'Sources/Sentry/SentryNSURLSessionTaskSearch.m'

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Get changed files
         id: changes
-        uses: getsentry/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         with:
           token: ${{ github.token }}
           filters: .github/file-filters.yml


### PR DESCRIPTION
We archived our fork of dorny/paths-filter. The sentry repo also uses dorny/path-filter, see https://github.com/getsentry/sentry/pull/64233.

#skip-changelog