### PR TITLE
fix: Remove wrong error log in CoreDataTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Crash due to a background call to -[UIApplication applicationState] (#3855)
 - Save framework without UIKit/AppKit as Github Asset for releases (#3858) 
 - Fix crash associated with runtime collision in global C function names (#3862)
+- Remove wrong error log in SentryCoreDataTracker (#3894)
 
 ## 8.24.0
 

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -48,9 +48,6 @@
         SENTRY_LOG_DEBUG(@"SentryCoreDataTracker automatically started a new span with "
                          @"description: %@, operation: %@",
             fetchSpan.description, fetchSpan.operation);
-    } else {
-        SENTRY_LOG_ERROR(
-            @"managedObjectContext:executeFetchRequest:error:originalImp: fetchSpan is nil.");
     }
 
     NSArray *result = original(request, error);


### PR DESCRIPTION




## :scroll: Description

The SentryCoreDataTracker logged an error for fetch requests when no span was bound to the scope, which happens when no auto-generated transaction is running. This is fixed now by removing that log.

## :bulb: Motivation and Context

Fixes GH-3586

## :green_heart: How did you test it?
Code review.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
