### PR TITLE
Add ability to set attachments on a sentry event

### DIFF
--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -6,7 +6,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryThread, SentryException, SentryStacktrace, SentryUser, SentryDebugMeta, SentryContext,
-    SentryBreadcrumb, SentryId, SentryMessage, SentryRequest;
+    SentryBreadcrumb, SentryId, SentryMessage, SentryRequest, SentryAttachment;
 
 NS_SWIFT_NAME(Event)
 @interface SentryEvent : NSObject <SentrySerializable>
@@ -163,6 +163,11 @@ NS_SWIFT_NAME(Event)
  * Set the HTTP request information.
  */
 @property (nonatomic, strong, nullable) SentryRequest *request;
+
+/**
+ * Add attachments to event.
+ */
+@property(nonatomic, strong) NSArray<SentryAttachment *> *_Nullable attachments;
 
 /**
  * Init an @c SentryEvent will set all needed fields by default.

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -417,6 +417,13 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     SentryTraceContext *traceContext = [self getTraceStateWithEvent:event withScope:scope];
 
     NSArray *attachments = scope.attachments;
+    NSArray *eventAttachments = event.attachments;
+    if (eventAttachments != nil) {
+        NSMutableArray *result = [NSMutableArray arrayWithCapacity:attachments.count + eventAttachments.count];
+        [result addObjectsFromArray:attachments];
+        [result addObjectsFromArray:eventAttachments];
+        attachments = result;
+    }
     if (self.attachmentProcessors.count) {
         for (id<SentryClientAttachmentProcessor> attachmentProcessor in self.attachmentProcessors) {
             attachments = [attachmentProcessor processAttachments:attachments
@@ -438,6 +445,13 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 {
     if (nil != event) {
         NSArray *attachments = scope.attachments;
+        NSArray *eventAttachments = event.attachments;
+        if (eventAttachments != nil) {
+            NSMutableArray *result = [NSMutableArray arrayWithCapacity:attachments.count + eventAttachments.count];
+            [result addObjectsFromArray:attachments];
+            [result addObjectsFromArray:eventAttachments];
+            attachments = result;
+        }
         if (self.attachmentProcessors.count) {
             for (id<SentryClientAttachmentProcessor> attachmentProcessor in self
                      .attachmentProcessors) {


### PR DESCRIPTION
## :scroll: Description

This just exposes a property on the event which will allow the user to add attachments to be sent.

## :bulb: Motivation and Context

This is so I can add log data along with crashes. Its incredibly necessary in resolving not so obvious bugs.

## :green_heart: How did you test it?

It's currently live in our app and seems to work.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
