### PR TITLE
test: disable flaky tests

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -56,6 +56,18 @@
             </BuildableReference>
             <SkippedTests>
                <Test
+                  Identifier = "SentryANRTrackerTests/testANRButAppInBackground_NoANR()">
+               </Test>
+               <Test
+                  Identifier = "SentryANRTrackerTests/testMultipleListeners()">
+               </Test>
+               <Test
+                  Identifier = "SentryCoreDataTrackerTests/testFetchRequestBackgroundThread()">
+               </Test>
+               <Test
+                  Identifier = "SentryCoreDataTrackerTests/testSaveBackgroundThread()">
+               </Test>
+               <Test
                   Identifier = "SentryCrashIntegrationTests/testStartUpCrash_CallsFlush()">
                </Test>
                <Test
@@ -65,7 +77,22 @@
                   Identifier = "SentryCrashReportStore_Tests/testDeleteAllReports">
                </Test>
                <Test
+                  Identifier = "SentryCrashReportStore_Tests/testStoresLoadsMultipleReports">
+               </Test>
+               <Test
+                  Identifier = "SentryHttpTransportTests/testFlush_BlocksCallingThread_FinishesFlushingWhenSent()">
+               </Test>
+               <Test
+                  Identifier = "SentryHttpTransportTests/testFlush_CalledSequentially_BlocksTwice()">
+               </Test>
+               <Test
+                  Identifier = "SentryHttpTransportTests/testFlush_WhenNoInternet_BlocksAndFinishes()">
+               </Test>
+               <Test
                   Identifier = "SentryNetworkTrackerIntegrationTests/testGetCaptureFailedRequestsEnabled()">
+               </Test>
+               <Test
+                  Identifier = "SentryNetworkTrackerIntegrationTests/testGetRequest_CompareSentryTraceHeader()">
                </Test>
                <Test
                   Identifier = "SentryProfilerSwiftTests/testConcurrentSpansWithTimeout()">


### PR DESCRIPTION
Disables the following flaky tests, with examples from recent test runs:

SentryHttpTransportTests.testFlush_CalledSequentially_BlocksTwice: https://github.com/getsentry/sentry-cocoa/actions/runs/8806093889/job/24170251358#step:13:58
SentryHttpTransportTests.testFlush_WhenNoInternet_BlocksAndFinishes: https://github.com/getsentry/sentry-cocoa/actions/runs/8806093889/job/24170251358#step:13:58
SentryHttpTransportTests.testFlush_BlocksCallingThread_FinishesFlushingWhenSent(): https://github.com/getsentry/sentry-cocoa/actions/runs/8805283627/job/24167641611#step:13:40
SentryNetworkTrackerIntegrationTests.testGetRequest_CompareSentryTraceHeader: https://github.com/getsentry/sentry-cocoa/actions/runs/8807764479/job/24175590193#step:13:58
SentryANRTrackerTests.testMultipleListeners: https://github.com/getsentry/sentry-cocoa/actions/runs/8806093889/job/24170251022#step:13:50
SentryCrashReportStore_Tests testStoresLoadsMultipleReports: https://github.com/getsentry/sentry-cocoa/actions/runs/8806113963/job/24170594779#step:13:51
SentryCoreDataTrackerTests.testFetchRequestBackgroundThread: https://github.com/getsentry/sentry-cocoa/actions/runs/8807764479/job/24177045536#step:13:58
SentryCoreDataTrackerTests.testSaveBackgroundThread: https://github.com/getsentry/sentry-cocoa/actions/runs/8807764479/job/24177045536#step:13:59
SentryANRTrackerTests.testANRButAppInBackground_NoANR: https://github.com/getsentry/sentry-cocoa/actions/runs/8805283627/job/24167641611#step:13:40

#skip-changelog