### PR TITLE
Chore: Explain in the changelog that session replay is for registered users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@
 ### Features
 
 - Add Session Replay, which is **still experimental**. (#3625)
-To get access, it requires adding your Sentry org to our feature flag. This way data can be ingested and displayed in Sentry.
-[Please let us know on the waitlist if you're interested](https://sentry.io/lp/mobile-replay-beta/)
+  - Access is limited to early access orgs on Sentry. If you're interested, [sign up for the waitlist](https://sentry.io/lp/mobile-replay-beta/)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Features
 
 - Add Session Replay, which is **still experimental**. (#3625)
+To get access, it requires adding your Sentry org to our feature flag. This way data can be ingested and displayed in Sentry.
+[Please let us know on the waitlist if you're interested](https://sentry.io/lp/mobile-replay-beta/)
 
 ### Fixes
 


### PR DESCRIPTION
Added the following comment in the changelog:

"To get access, it requires adding your Sentry org to our feature flag. This way data can be ingested and displayed in Sentry.
[Please let us know on the waitlist if you're interested](https://sentry.io/lp/mobile-replay-beta/)"

_#skip-changelog_