### PR TITLE
fix: Remove boot_time from crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Don't transmit device boot time in envelopes enriched with crash data (#3912)
+- Don't transmit device boot time in envelopes enriched with crash data (#3912, #3916)
 
 ### Improvements
 

--- a/Sources/Sentry/include/SentryAppState.h
+++ b/Sources/Sentry/include/SentryAppState.h
@@ -31,6 +31,11 @@ SENTRY_NO_INIT
  * The boot time of the system rounded down to seconds. As the precision of the serialization is
  * only milliseconds and a precision of seconds is enough we round down to seconds. With this we
  * avoid getting different dates before and after serialization.
+ *
+ * @warning We must not send this information off device because Apple forbids that.
+ * We are allowed send the amount of time that has elapsed between events that occurred within the
+ * app though. For more information see
+ * https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.
  */
 @property (readonly, nonatomic, copy) NSDate *systemBootTimestamp;
 

--- a/Sources/Sentry/include/SentrySysctl.h
+++ b/Sources/Sentry/include/SentrySysctl.h
@@ -9,6 +9,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Returns the time the system was booted with a precision of microseconds.
+ *
+ * @warning We must not send this information off device because Apple forbids that.
+ * We are allowed send the amount of time that has elapsed between events that occurred within the
+ * app though. For more information see
+ * https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.
  */
 @property (readonly) NSDate *systemBootTimestamp;
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorContext.h
@@ -179,6 +179,12 @@ typedef struct SentryCrash_MonitorContext {
         const char *kernelVersion;
         const char *osVersion;
         bool isJailbroken;
+        /**
+         * @warning We must not send this information off device because Apple forbids that.
+         * We are allowed send the amount of time that has elapsed between events that occurred
+         * within the app though. For more information see
+         * https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.
+         */
         const char *bootTime;
         const char *appStartTime;
         const char *executablePath;

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1551,8 +1551,6 @@ writeSystemInfo(const SentryCrashReportWriter *const writer, const char *const k
         writer->addBooleanElement(
             writer, SentryCrashField_Jailbroken, monitorContext->System.isJailbroken);
         writer->addStringElement(
-            writer, SentryCrashField_BootTime, monitorContext->System.bootTime);
-        writer->addStringElement(
             writer, SentryCrashField_AppStartTime, monitorContext->System.appStartTime);
         writer->addStringElement(
             writer, SentryCrashField_ExecutablePath, monitorContext->System.executablePath);

--- a/Sources/SentryCrash/Recording/SentryCrashReportFields.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFields.h
@@ -183,7 +183,6 @@
 #pragma mark System
 #define SentryCrashField_AppStartTime "app_start_time"
 #define SentryCrashField_AppUUID "app_uuid"
-#define SentryCrashField_BootTime "boot_time"
 #define SentryCrashField_BundleID "CFBundleIdentifier"
 #define SentryCrashField_BundleName "CFBundleName"
 #define SentryCrashField_BundleShortVersion "CFBundleShortVersionString"

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -108,6 +108,16 @@ class SentryCrashReportTests: XCTestCase {
         }
     }
     
+    func testCrashReportDoesNotContainBootTime() throws {
+        writeCrashReport()
+        
+        let crashReportContents = FileManager.default.contents(atPath: fixture.reportPath) ?? Data()
+        
+        let crashReportContentsAsString = String(data: crashReportContents, encoding: .ascii)
+        
+        expect(crashReportContentsAsString).toNot(contain("boot_time"), description: "The crash report must not contain boot_time because Apple forbids sending this information off device see: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.")
+    }
+    
     private func writeCrashReport() {
         var monitorContext = SentryCrash_MonitorContext()
         


### PR DESCRIPTION


## :scroll: Description

Remove the boot_time from crash reports.

## :bulb: Motivation and Context

This is a follow up on #3912.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
