### PR TITLE
fix: Handle no releaseName in WatchdogLogic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Handle no releaseName in WatchDogTerminationLogic (#3918)
+
 ## 8.25.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Handle no releaseName in WatchDogTerminationLogic (#3918)
+- Handle no releaseName in WatchDogTerminationLogic (#3919)
 
 ## 8.25.0
 

--- a/Sources/Sentry/SentryAppState.m
+++ b/Sources/Sentry/SentryAppState.m
@@ -5,7 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryAppState
 
-- (instancetype)initWithReleaseName:(NSString *)releaseName
+- (instancetype)initWithReleaseName:(nullable NSString *)releaseName
                           osVersion:(NSString *)osVersion
                            vendorId:(NSString *)vendorId
                         isDebugging:(BOOL)isDebugging
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
         id releaseName = [jsonObject valueForKey:@"release_name"];
-        if (releaseName == nil || ![releaseName isKindOfClass:[NSString class]]) {
+        if (releaseName != nil && ![releaseName isKindOfClass:[NSString class]]) {
             return nil;
         } else {
             _releaseName = releaseName;
@@ -107,7 +107,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSMutableDictionary *data = [[NSMutableDictionary alloc] init];
 
-    [data setValue:self.releaseName forKey:@"release_name"];
+    if (self.releaseName != nil) {
+        [data setValue:self.releaseName forKey:@"release_name"];
+    }
     [data setValue:self.osVersion forKey:@"os_version"];
     [data setValue:self.vendorId forKey:@"vendor_id"];
     [data setValue:@(self.isDebugging) forKey:@"is_debugging"];

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -51,7 +51,8 @@ SentryWatchdogTerminationLogic ()
     }
 
     // If the release name is different we assume it's an upgrade
-    if (![currentAppState.releaseName isEqualToString:previousAppState.releaseName]) {
+    if (currentAppState.releaseName != nil && previousAppState.releaseName != nil
+        && ![currentAppState.releaseName isEqualToString:previousAppState.releaseName]) {
         return NO;
     }
 

--- a/Sources/Sentry/include/SentryAppState.h
+++ b/Sources/Sentry/include/SentryAppState.h
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryAppState : NSObject <SentrySerializable>
 SENTRY_NO_INIT
 
-- (instancetype)initWithReleaseName:(NSString *)releaseName
+- (instancetype)initWithReleaseName:(nullable NSString *)releaseName
                           osVersion:(NSString *)osVersion
                            vendorId:(NSString *)vendorId
                         isDebugging:(BOOL)isDebugging
@@ -19,7 +19,7 @@ SENTRY_NO_INIT
  */
 - (nullable instancetype)initWithJSONObject:(NSDictionary *)jsonObject;
 
-@property (readonly, nonatomic, copy) NSString *releaseName;
+@property (nullable, readonly, nonatomic, copy) NSString *releaseName;
 
 @property (readonly, nonatomic, copy) NSString *osVersion;
 

--- a/Tests/SentryTests/Helper/SentryAppStateTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 import XCTest
 
 class SentryAppStateTests: XCTestCase {
@@ -17,10 +18,28 @@ class SentryAppStateTests: XCTestCase {
         XCTAssertEqual(appState.isSDKRunning, actual["is_sdk_running"] as? Bool)
     }
     
-    func testInitWithJSON_AllFields() {
+    func testSerialize_ReleaseNameIsNil_DoesNotAddReleaseName() {
+        let appState = SentryAppState(releaseName: nil, osVersion: "14.4.1", vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: TestData.timestamp)
+        
+        let actual = appState.serialize()
+        
+        expect(actual["release_name"]) == nil
+    }
+    
+    func testInitWithJSON_ReleaseNameIsNil_DoesNotAddReleaseName() {
+        let appState = SentryAppState(releaseName: nil, osVersion: "14.4.1", vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: TestData.timestamp)
+        
+        let actual = SentryAppState(jsonObject: appState.serialize())
+        
+        expect(actual?.releaseName) == nil
+    }
+    
+    func testInitWithJSON_AllFields() throws {
         let appState = TestData.appState
+        
+        let releaseName = try XCTUnwrap(appState.releaseName)
         let dict = [
-            "release_name": appState.releaseName,
+            "release_name": releaseName,
             "os_version": appState.osVersion,
             "vendor_id": appState.vendorId,
             "is_debugging": appState.isDebugging,
@@ -37,7 +56,6 @@ class SentryAppStateTests: XCTestCase {
     }
     
     func testInitWithJSON_IfJsonMissesField_AppStateIsNil() {
-        withValue { $0["release_name"] = nil }
         withValue { $0["os_version"] = nil }
         withValue { $0["vendor_id"] = nil }
         withValue { $0["is_debugging"] = nil }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
@@ -67,9 +67,10 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         XCTAssertEqual(path, ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"])
     }
     
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func testANRDetected_UpdatesAppStateToTrue() throws {
-        givenInitializedTracker()
+        fixture.crashWrapper.internalIsBeingTraced = false
+        let sut = givenIntegration()
+        sut.install(with: Options())
         
         Dynamic(sut).anrDetected()
 
@@ -77,10 +78,11 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         
         XCTAssertTrue(appState.isANROngoing)
     }
-#endif
   
     func testANRStopped_UpdatesAppStateToFalse() {
-        givenInitializedTracker()
+        fixture.crashWrapper.internalIsBeingTraced = false
+        let sut = givenIntegration()
+        sut.install(with: Options())
         
         Dynamic(sut).anrStopped()
         
@@ -115,13 +117,6 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         let sut = SentryWatchdogTerminationTrackingIntegration()
         Dynamic(sut).setTestConfigurationFilePath(nil)
         return sut
-    }
-    
-    private func givenInitializedTracker(isBeingTraced: Bool = false) {
-        fixture.crashWrapper.internalIsBeingTraced = isBeingTraced
-        sut = givenIntegration()
-        let options = Options()
-        sut.install(with: options)
     }
     
 }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -12,8 +13,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         let options: Options
         let client: TestClient!
         let crashWrapper: TestSentryCrashWrapper
-        lazy var mockFileManager = try! TestFileManager(options: options)
-        lazy var realFileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: dispatchQueue)
+        let fileManager: SentryFileManager
         let currentDate = TestCurrentDateProvider()
         let sysctl = TestSysctl()
         let dispatchQueue = TestSentryDispatchQueueWrapper()
@@ -25,6 +25,8 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
             options.dsn = SentryWatchdogTerminationTrackerTests.dsnAsString
             options.releaseName = TestData.appState.releaseName
             
+            fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: dispatchQueue)
+            
             client = TestClient(options: options)
             
             crashWrapper = TestSentryCrashWrapper.sharedInstance()
@@ -33,8 +35,8 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
             SentrySDK.setCurrentHub(hub)
         }
         
-        func getSut(usingRealFileManager: Bool) -> SentryWatchdogTerminationTracker {
-            return getSut(fileManager: usingRealFileManager ? realFileManager : mockFileManager)
+        func getSut() -> SentryWatchdogTerminationTracker {
+            return getSut(fileManager: fileManager )
         }
         
         func getSut(fileManager: SentryFileManager) -> SentryWatchdogTerminationTracker {
@@ -67,7 +69,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         super.setUp()
         
         fixture = Fixture()
-        sut = fixture.getSut(usingRealFileManager: false)
+        sut = fixture.getSut()
         SentrySDK.startInvocations = 1
     }
     
@@ -80,13 +82,13 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
     }
 
     func testStart_StoresAppState() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
 
-        XCTAssertNil(fixture.realFileManager.readAppState())
+        XCTAssertNil(fixture.fileManager.readAppState())
 
         sut.start()
         
-        let actual = fixture.realFileManager.readAppState()
+        let actual = fixture.fileManager.readAppState()
         
         let appState = SentryAppState(releaseName: fixture.options.releaseName ?? "", osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: fixture.sysctl.systemBootTimestamp)
         
@@ -95,30 +97,38 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
     }
     
     func testGoToForeground_SetsIsActive() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
 
         sut.start()
         
         goToForeground()
         
-        XCTAssertTrue(fixture.realFileManager.readAppState()?.isActive ?? false)
+        XCTAssertTrue(fixture.fileManager.readAppState()?.isActive ?? false)
         
         goToBackground()
         
-        XCTAssertFalse(fixture.realFileManager.readAppState()?.isActive ?? true)
+        XCTAssertFalse(fixture.fileManager.readAppState()?.isActive ?? true)
         XCTAssertEqual(3, fixture.dispatchQueue.dispatchAsyncCalled)
     }
     
     func testGoToForeground_WhenAppStateNil_NothingIsStored() {
         sut.start()
-        fixture.mockFileManager.deleteAppState()
+        fixture.fileManager.deleteAppState()
         goToForeground()
         
-        XCTAssertNil(fixture.mockFileManager.readAppState())
+        XCTAssertNil(fixture.fileManager.readAppState())
     }
 
     func testDifferentAppVersions_NoOOM() {
         givenPreviousAppState(appState: SentryAppState(releaseName: "0.9.0", osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: SentryDependencyContainer.sharedInstance().dateProvider.date()))
+        
+        sut.start()
+        
+        assertNoOOMSent()
+    }
+    
+    func testDifferentReleaseNameNil_NoOOM() {
+        givenPreviousAppState(appState: SentryAppState(releaseName: nil, osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: SentryDependencyContainer.sharedInstance().dateProvider.date()))
         
         sut.start()
         
@@ -219,23 +229,23 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
     }
 
     func testDifferentBootTime_NoOOM() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
         sut.start()
         let appState = SentryAppState(releaseName: fixture.options.releaseName ?? "", osVersion: UIDevice.current.systemVersion, vendorId: TestData.someUUID, isDebugging: false, systemBootTimestamp: fixture.sysctl.systemBootTimestamp.addingTimeInterval(1))
 
         givenPreviousAppState(appState: appState)
-        fixture.mockFileManager.moveAppStateToPreviousAppState()
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertNoOOMSent()
     }
 
     func testAppWasInForeground_OOM() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
 
         sut.start()
         goToForeground()
 
-        fixture.mockFileManager.moveAppStateToPreviousAppState()
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
@@ -253,11 +263,11 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
     }
 
     func testAppOOM_WithBreadcrumbs() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
 
         let breadcrumb = TestData.crumb
 
-        let sentryWatchdogTerminationScopeObserver = SentryWatchdogTerminationScopeObserver(maxBreadcrumbs: Int(fixture.options.maxBreadcrumbs), fileManager: fixture.mockFileManager)
+        let sentryWatchdogTerminationScopeObserver = SentryWatchdogTerminationScopeObserver(maxBreadcrumbs: Int(fixture.options.maxBreadcrumbs), fileManager: fixture.fileManager)
 
         for _ in 0..<3 {
             sentryWatchdogTerminationScopeObserver.addSerializedBreadcrumb(breadcrumb.serialize())
@@ -266,8 +276,8 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         sut.start()
         goToForeground()
 
-        fixture.mockFileManager.moveAppStateToPreviousAppState()
-        fixture.mockFileManager.moveBreadcrumbsToPreviousBreadcrumbs()
+        fixture.fileManager.moveAppStateToPreviousAppState()
+        fixture.fileManager.moveBreadcrumbsToPreviousBreadcrumbs()
         sut.start()
         assertOOMEventSent(expectedBreadcrumbs: 2)
 
@@ -276,36 +286,36 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
     }
 
     func testAppOOM_WithOnlyHybridSdkDidBecomeActive() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
 
         sut.start()
         hybridSdkDidBecomeActive()
 
-        fixture.mockFileManager.moveAppStateToPreviousAppState()
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
     
     func testAppOOM_Foreground_And_HybridSdkDidBecomeActive() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
 
         sut.start()
         goToForeground()
         hybridSdkDidBecomeActive()
 
-        fixture.mockFileManager.moveAppStateToPreviousAppState()
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
     
     func testAppOOM_HybridSdkDidBecomeActive_and_Foreground() {
-        sut = fixture.getSut(usingRealFileManager: true)
+        sut = fixture.getSut()
         
         sut.start()
         hybridSdkDidBecomeActive()
         goToForeground()
 
-        fixture.mockFileManager.moveAppStateToPreviousAppState()
+        fixture.fileManager.moveAppStateToPreviousAppState()
         sut.start()
         assertOOMEventSent()
     }
@@ -344,13 +354,14 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
     }
     
     private func givenPreviousAppState(appState: SentryAppState) {
-        fixture.mockFileManager.store(appState)
+        fixture.fileManager.store(appState)
+        fixture.fileManager.moveAppStateToPreviousAppState()
     }
     
     private func update(appState: (SentryAppState) -> Void) {
-        if let currentAppState = fixture.mockFileManager.readAppState() {
+        if let currentAppState = fixture.fileManager.readAppState() {
             appState(currentAppState)
-            fixture.mockFileManager.store(currentAppState)
+            fixture.fileManager.store(currentAppState)
         }
     }
     


### PR DESCRIPTION

## :scroll: Description

The release name passed to the app state from the options is nullable. The SentryAppState including the SentryWatchdogTerminationLogic couldn't handle this edge case correctly, which is fixed now.

## :bulb: Motivation and Context

Unit tests started to fail suddenly on the main branch https://github.com/getsentry/sentry-cocoa/actions/runs/8879401702/job/24377229574.

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
