### PR TITLE
fix: Ignore FramesTracker thread data races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Ignore SentryFramesTracker thread sanitizer data races (#3922)
+
 ## 8.25.0
 
 ### Features

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -7,6 +7,7 @@
 #    import "SentryDelayedFramesTracker.h"
 #    import "SentryDispatchQueueWrapper.h"
 #    import "SentryDisplayLinkWrapper.h"
+#    import "SentryInternalDefines.h"
 #    import "SentryLog.h"
 #    import "SentryProfiler+Private.h"
 #    import "SentryProfilingConditionals.h"
@@ -85,6 +86,25 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 - (void)setDisplayLinkWrapper:(SentryDisplayLinkWrapper *)displayLinkWrapper
 {
     _displayLinkWrapper = displayLinkWrapper;
+}
+
+/**
+ * As you can only disable the thread sanitizer for methods, we must manually create the setter
+ * here.
+ */
+- (void)setPreviousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp
+    SENTRY_DISABLE_THREAD_SANITIZER
+{
+    _previousFrameSystemTimestamp = previousFrameSystemTimestamp;
+}
+
+/**
+ * As you can only disable the thread sanitizer for methods, we must manually create the getter
+ * here.
+ */
+- (uint64_t)getPreviousFrameSystemTimestamp SENTRY_DISABLE_THREAD_SANITIZER
+{
+    return _previousFrameSystemTimestamp;
 }
 
 - (void)resetFrames
@@ -231,7 +251,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-- (SentryScreenFrames *)currentFrames
+- (SentryScreenFrames *)currentFrames SENTRY_DISABLE_THREAD_SANITIZER
 {
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
     return [[SentryScreenFrames alloc] initWithTotal:_totalFrames
@@ -247,19 +267,8 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
-/**
- * The ThreadSanitizer ignores this method; see ThreadSanitizer.sup.
- *
- * We accept the data race of the two properties _currentFrameRate and previousFrameSystemTimestamp,
- * that are updated on the main thread in the displayLinkCallback. This method only reads these
- * properties. In most scenarios, this method will be called on the main thread, for which no
- * synchronization is needed. When calling this function from a background thread, the frames delay
- * statistics don't need to be that accurate because background spans contribute less to delayed
- * frames. We prefer having not 100% correct frames delay numbers for background spans instead of
- * adding the overhead of synchronization.
- */
 - (CFTimeInterval)getFramesDelay:(uint64_t)startSystemTimestamp
-              endSystemTimestamp:(uint64_t)endSystemTimestamp
+              endSystemTimestamp:(uint64_t)endSystemTimestamp SENTRY_DISABLE_THREAD_SANITIZER
 {
     return [self.delayedFramesTracker getFramesDelay:startSystemTimestamp
                                   endSystemTimestamp:endSystemTimestamp

--- a/Sources/Sentry/include/HybridPublic/SentryFramesTracker.h
+++ b/Sources/Sentry/include/HybridPublic/SentryFramesTracker.h
@@ -20,6 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Tracks total, frozen and slow frames for iOS, tvOS, and Mac Catalyst.
+ *
+ * @discussion This class ignores a couple of methods for the thread sanitizer. We intentionally
+ * accept several data races in this class, a decision that is driven by the fact that the code
+ * always writes on the main thread. This approach, while it may not provide 100% correct frame
+ * statistic for background spans, significantly reduces the overhead of synchronization, thereby
+ * enhancing performance.
  */
 @interface SentryFramesTracker : NSObject
 

--- a/Sources/Sentry/include/SentryInternalDefines.h
+++ b/Sources/Sentry/include/SentryInternalDefines.h
@@ -66,3 +66,16 @@ static NSString *const SentryPlatformName = @"cocoa";
 #define SPAN_DATA_BLOCKED_MAIN_THREAD @"blocked_main_thread"
 #define SPAN_DATA_THREAD_ID @"thread.id"
 #define SPAN_DATA_THREAD_NAME @"thread.name"
+
+/**
+ * For disabling the thread sanitizer for a method
+ */
+#if defined(__has_feature)
+#    if __has_feature(thread_sanitizer)
+#        define SENTRY_DISABLE_THREAD_SANITIZER __attribute__((no_sanitize("thread")))
+#    else
+#        define SENTRY_DISABLE_THREAD_SANITIZER
+#    endif
+#else
+#    define SENTRY_DISABLE_THREAD_SANITIZER
+#endif

--- a/Tests/ThreadSanitizer.sup
+++ b/Tests/ThreadSanitizer.sup
@@ -31,6 +31,3 @@ race:disable
 race:URLSessionDataTaskMock
 race:getOriginalImplementation
 race:SentrySpanContext
-
-# Ignore SentryFramesTracer:getFramesDelay. Visit the method for the explanation.
-race:getFramesDelay


### PR DESCRIPTION




## :scroll: Description

The ThreadSanitizer reports data races for the SentryFramesTracker, which we can ignore.

I defined a macro for ignoring thread sanitizer warnings directly in the code. I will open another PR to replace the ThreadSanitizer.sup by ignoring the warnings directly in the code.

## :bulb: Motivation and Context

Fixes GH-3702

## :green_heart: How did you test it?
Running the iOS-Swift project with the thread sanitizer enabled.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
