### PR TITLE
impr: Remove not needed log for logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Ignore SentryFramesTracker thread sanitizer data races (#3922)
 - Handle no releaseName in WatchDogTerminationLogic (#3919)
 
+### Improvements
+
+- Remove not needed lock for logging (#3934)
+
 ## 8.25.0
 
 ### Features

--- a/Sources/Sentry/SentryLog.m
+++ b/Sources/Sentry/SentryLog.m
@@ -1,4 +1,5 @@
 #import "SentryLog.h"
+#import "SentryInternalCDefines.h"
 #import "SentryLevelMapper.h"
 #import "SentryLogOutput.h"
 
@@ -37,10 +38,12 @@ static NSObject *logConfigureLock;
 }
 
 + (BOOL)willLogAtLevel:(SentryLevel)level
+    SENTRY_DISABLE_THREAD_SANITIZER(
+        "The SDK usually configures the log level and isDebug once when it starts. For tests, we "
+        "accept a data race causing some log messages of the wrong level over using a synchronized "
+        "block for this method, as it's called frequently in production.")
 {
-    @synchronized(logConfigureLock) {
-        return isDebug && level != kSentryLevelNone && level >= diagnosticLevel;
-    }
+    return isDebug && level != kSentryLevelNone && level >= diagnosticLevel;
 }
 
 // Internal and only needed for testing.


### PR DESCRIPTION


## :scroll: Description

Every log message needs to acquire a lock to evaluate whether the logger should log it. #3303 added this logic to fix a data race the thread sanitizer job found. As the SDK only calls the configure method when starting, we don't need to put a synchronized keyword around the code that evaluates the log level. This PR replaces the synchronized keyword by ignoring the thread sanitizer.

## :bulb: Motivation and Context

This came up while investigating failing unit tests for https://github.com/getsentry/sentry-cocoa/pull/3915/. The raw log messages show a 500ms delay in the SentryHttpTransport between two calls that only log a simple message: `SENTRY_LOG_DEBUG(@"No internet connection.");` and `SENTRY_LOG_DEBUG(@"Finished sending.");`

https://github.com/getsentry/sentry-cocoa/blob/8aec30ebd6b60262f8b935b5475741c92da38834/Sources/Sentry/SentryHttpTransport.m#L354-L363

```
2024-05-03 10:16:56.674070+0000 xctest[10854:44346] [Sentry] [debug] [SentryHttpTransport:359] No internet connection.
2024-05-03 10:16:57.214727+0000 xctest[10854:44346] [Sentry] [debug] [SentryHttpTransport:367] Finished sending.
```

I don't think the not needed lock is responsible for this, but removing it should improve overall performance of logging.

## :green_heart: How did you test it?
Logging still works.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
