### PR TITLE
chore: Format code with clang-format 18.1.5

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorType.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitorType.c
@@ -31,10 +31,7 @@ static const struct {
     const SentryCrashMonitorType type;
     const char *const name;
 } g_monitorTypes[] = {
-#define MONITORTYPE(NAME)                                                                          \
-    {                                                                                              \
-        NAME, #NAME                                                                                \
-    }
+#define MONITORTYPE(NAME) { NAME, #NAME }
     MONITORTYPE(SentryCrashMonitorTypeMachException),
     MONITORTYPE(SentryCrashMonitorTypeSignal),
     MONITORTYPE(SentryCrashMonitorTypeCPPException),

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.c
@@ -42,10 +42,7 @@ typedef struct {
     const int numCodes;
 } SentryCrashSignalInfo;
 
-#define ENUM_NAME_MAPPING(A)                                                                       \
-    {                                                                                              \
-        A, #A                                                                                      \
-    }
+#define ENUM_NAME_MAPPING(A) { A, #A }
 
 static const SentryCrashSignalCodeInfo g_sigIllCodes[] = {
 #ifdef ILL_NOOP
@@ -98,14 +95,8 @@ static const SentryCrashSignalCodeInfo g_sigSegVCodes[] = {
     ENUM_NAME_MAPPING(SEGV_ACCERR),
 };
 
-#define SIGNAL_INFO(SIGNAL, CODES)                                                                 \
-    {                                                                                              \
-        SIGNAL, #SIGNAL, CODES, sizeof(CODES) / sizeof(*CODES)                                     \
-    }
-#define SIGNAL_INFO_NOCODES(SIGNAL)                                                                \
-    {                                                                                              \
-        SIGNAL, #SIGNAL, 0, 0                                                                      \
-    }
+#define SIGNAL_INFO(SIGNAL, CODES) { SIGNAL, #SIGNAL, CODES, sizeof(CODES) / sizeof(*CODES) }
+#define SIGNAL_INFO_NOCODES(SIGNAL) { SIGNAL, #SIGNAL, 0, 0 }
 
 static const SentryCrashSignalInfo g_fatalSignalData[] = {
     SIGNAL_INFO_NOCODES(SIGABRT),


### PR DESCRIPTION
GH actions uses a new preinstalled clang-format version which now reformarts code on several PRs. Let's merge this so it doesn't need to do that on multiple PRs and they only need to update to main to fix this.

#skip-changelog