### PR TITLE
test: Remove unit test performance tests

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -156,20 +156,6 @@ class SentryFramesTrackerTests: XCTestCase {
 
         try assert(slow: 1, frozen: 1, total: 2, frameRates: 2)
     }
-
-    func testPerformanceOfTrackingFrames() throws {
-        let sut = fixture.sut
-        sut.start()
-
-        let frames: UInt = 1_000
-        self.measure {
-            for _ in 0 ..< frames {
-                fixture.displayLinkWrapper.normalFrame()
-            }
-        }
-
-        try assert(slow: 0, frozen: 0)
-    }
     
     /**
      * The following test validates one slow and one frozen frame in the time interval. The slow frame starts at

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -1,3 +1,4 @@
+import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -557,42 +558,27 @@ class SentryHttpTransportTests: XCTestCase {
         XCTAssertEqual(1, attachment?.quantity)
     }
 
-    func testPerformanceOfSending() {
-        self.measure {
-            givenNoInternetConnection()
-            for _ in 0...5 {
-                sendEventAsync()
-            }
-            givenOkResponse()
-            for _ in 0...5 {
-                sendEventAsync()
-            }
-        }
-    }
-
     func testSendEnvelopesConcurrent() {
-        self.measure {
-            fixture.requestManager.responseDelay = 0.0001
+        fixture.requestManager.responseDelay = 0.0001
 
-            let queue = fixture.queue
+        let queue = fixture.queue
 
-            let group = DispatchGroup()
-            for _ in 0...20 {
-                group.enter()
-                queue.async {
-                    self.givenRecordedLostEvents()
-                    self.sendEventAsync()
-                    group.leave()
-                }
+        let group = DispatchGroup()
+        for _ in 0...20 {
+            group.enter()
+            queue.async {
+                self.givenRecordedLostEvents()
+                self.sendEventAsync()
+                group.leave()
             }
-
-            queue.activate()
-            group.waitWithTimeout()
-
-            waitForAllRequests()
         }
 
-        XCTAssertEqual(210, fixture.requestManager.requests.count)
+        queue.activate()
+        group.waitWithTimeout()
+
+        waitForAllRequests()
+
+        expect(self.fixture.requestManager.requests.count) == 21
     }
     
     func testBuildingRequestFails_DeletesEnvelopeAndSendsNext() {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -408,31 +408,6 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(0, scope.attachments.count)
     }
     
-    func testPeformanceOfSyncToSentryCrash() {
-        // To avoid spamming the test logs
-        SentryLog.configure(true, diagnosticLevel: .error)
-        
-        let scope = fixture.scope
-        scope.add(SentryCrashScopeObserver(maxBreadcrumbs: 100))
-        
-        self.measure {
-            modifyScope(scope: scope)
-        }
-        
-        setTestDefaultLogLevel()
-    }
-    
-    func testPeformanceOfSyncToSentryCrash_OneCrumb() {
-        let scope = fixture.scope
-        scope.add(SentryCrashScopeObserver(maxBreadcrumbs: 100))
-        
-        modifyScope(scope: scope)
-        
-        self.measure {
-            scope.addBreadcrumb(self.fixture.breadcrumb)
-        }
-    }
-    
     // With this test we test if modifications from multiple threads don't lead to a crash.
     func testModifyingFromMultipleThreads() {
         let scope = fixture.scope


### PR DESCRIPTION
Performance unit tests require baseline profiles bound to an exact machine configuration, which we can't generate for CI. Thus, the performance tests run without any benefit in CI. We can remove them with this PR.

#skip-changelog