### PR TITLE
test: Remove clearTestState for ViewHierarchyTests

### DIFF
--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -37,7 +37,7 @@ class SentryViewHierarchyTests: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        clearTestState()
+        SentryDependencyContainer.reset()
     }
 
     func test_Multiple_Window() {


### PR DESCRIPTION
The SentryViewHierarchyTests only need to reset the SentryDependencyContainer and not reset the whole global test state.

#skip-changelog