### PR TITLE
fix: Stop SessionReplay when closing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Ignore SentryFramesTracker thread sanitizer data races (#3922)
 - Handle no releaseName in WatchDogTerminationLogic (#3919)
+- Stop SessionReplay when closing SDK (#3941)
 
 ### Improvements
 

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -114,6 +114,11 @@ SentrySessionReplay ()
     }
 }
 
+- (void)dealloc
+{
+    [self stop];
+}
+
 - (void)captureReplayForEvent:(SentryEvent *)event;
 {
     if (!_isRunning) {

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -150,6 +150,7 @@ SentryOnDemandReplay (SentryReplayMaker) <SentryReplayMaker>
 
 - (void)uninstall
 {
+    [self stop];
 }
 
 - (BOOL)shouldReplayFullSession:(CGFloat)rate

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -218,6 +218,17 @@ class SentrySessionReplayTests: XCTestCase {
         
         expect(Dynamic(sut).isRunning) == false
     }
+    
+    @available(iOS 16.0, tvOS 16, *)
+    func testDealloc_CallsStop() {
+        let fixture = startFixture()
+        func sutIsDeallocatedAfterCallingMe() {
+            _ = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        }
+        sutIsDeallocatedAfterCallingMe()
+        
+        expect(fixture.displayLink.invalidateInvocations.count) == 1
+    }
 
     @available(iOS 16.0, tvOS 16, *)
     func assertFullSession(_ sessionReplay: SentrySessionReplay, expected: Bool) {


### PR DESCRIPTION


## :scroll: Description

Call SessionReplay.stop when uninstalling the SDK and invalidate the DisplayLinkWrapper when SessionReplay gets deallocated.

## :bulb: Motivation and Context

This came up when investigating a failing test on the main branch: https://github.com/getsentry/sentry-cocoa/actions/runs/8969460754/job/24630955316?pr=3940. The logs show SessionReplay running, although it shouldn't. We also have a problem with accessing UIWindow, but we'll fix this in another PR. 

```
Test Case '-[SentryTests.SentryViewHierarchyTests test_appViewHierarchy_usesMainThread]' started.
2024-05-06 13:01:44.899951+0000 xctest[4660:15933] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
[SentryOnDemandReplay] Could not save replay frame. Error: Error Domain=NSCocoaErrorDomain Code=4 "The file “0.png” doesn’t exist." UserInfo={NSFilePath=/Users/runner/Library/Developer/CoreSimulator/Devices/9854D8B3-535A-430C-9E2C-91A75EB44494/data/Library/Caches/io.sentry/replay/B560D7AF-3250-41B7-A86B-321C1DE4BB2F/0.png, NSUnderlyingError=0x600004da9260 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
=================================================================
Main Thread Checker: UI API called on a background thread: -[UIWindow screen]
PID: 4660, TID: 20723, Thread name: (none), Queue name: com.apple.root.default-qos, QoS: 0
Backtrace:
4   Sentry                              0x000000010bf0da76 -[SentryCrashWrapper enrichScope:] + 2006
5   Sentry                              0x000000010bf4148a -[SentryHub initWithClient:andScope:] + 1210
6   Sentry                              0x000000010bf97227 +[SentrySDK currentHub] + 135
7   Sentry                              0x000000010bf8c18b -[SentrySessionReplay captureSegment:video:replayId:replayType:] + 683
8   Sentry                              0x000000010bf8be52 __59-[SentrySessionReplay createAndCapture:duration:startedAt:]_block_invoke + 466
9   Sentry                              0x000000010c0129d4 $s6Sentry0A9VideoInfoCSgSo7NSErrorCSgIeyByy_ADs5Error_pSgIeggg_TR + 116
10  Sentry                              0x000000010c012593 $s6Sentry0A14OnDemandReplayC15createVideoWith8duration9beginning13outputFileURL10completionySd_10Foundation4DateVAI0L0VyAA0aF4InfoCSg_s5Error_pSgtctKFyycfU_yycfU_ + 2419
11  Sentry                              0x000000010c0153bc $s6Sentry0A14OnDemandReplayC15createVideoWith8duration9beginning13outputFileURL10completionySd_10Foundation4DateVAI0L0VyAA0aF4InfoCSg_s5Error_pSgtctKFyycfU_yycfU_TA + 204
12  Sentry                              0x000000010c004928 $sIeg_IeyB_TR + 40
13  Foundation                          0x00007ff8016432c1 __111+[__NSOperationInternalObserver _observeValueForKeyPath:ofObject:changeKind:oldValue:newValue:indexes:context:]_block_invoke_2 + 17
14  libdispatch.dylib                   0x00007ff8001896a1 _dispatch_call_block_and_release + 12
15  libdispatch.dylib                   0x00007ff80018a8d9 _dispatch_client_callout + 8
16  libdispatch.dylib                   0x00007ff80019d709 _dispatch_root_queue_drain + 920
17  libdispatch.dylib                   0x00007ff80019dfde _dispatch_worker_thread2 + 236
18  libsystem_pthread.dylib             0x000000010993bf8a _pthread_wqthread + 256
19  libsystem_pthread.dylib             0x000000010993af57 start_wqthread + 15
2024-05-06 13:01:44.951396+0000 xctest[4660:20723] [reports] Main Thread Checker: UI API called on a background thread: -[UIWindow screen]
PID: 4660, TID: 20723, Thread name: (none), Queue name: com.apple.root.default-qos, QoS: 0
Backtrace:
4   Sentry                              0x000000010bf0da76 -[SentryCrashWrapper enrichScope:] + 2006
5   Sentry                              0x000000010bf4148a -[SentryHub initWithClient:andScope:] + 1210
6   Sentry                              0x000000010bf97227 +[SentrySDK currentHub] + 135
7   Sentry                              0x000000010bf8c18b -[SentrySessionReplay captureSegment:video:replayId:replayType:] + 683
8   Sentry                              0x000000010bf8be52 __59-[SentrySessionReplay createAndCapture:duration:startedAt:]_block_invoke + 466
9   Sentry                              0x000000010c0129d4 $s6Sentry0A9VideoInfoCSgSo7NSErrorCSgIeyByy_ADs5Error_pSgIeggg_TR + 116
10  Sentry                              0x000000010c012593 $s6Sentry0A14OnDemandReplayC15createVideoWith8duration9beginning13outputFileURL10completionySd_10Foundation4DateVAI0L0VyAA0aF4InfoCSg_s5Error_pSgtctKFyycfU_yycfU_ + 2419
11  Sentry                              0x000000010c0153bc $s6Sentry0A14OnDemandReplayC15createVideoWith8duration9beginning13outputFileURL10completionySd_10Foundation4DateVAI0L0VyAA0aF4InfoCSg_s5Error_pSgtctKFyycfU_yycfU_TA + 204
12  Sentry                              0x000000010c004928 $sIeg_IeyB_TR + 40
13  Foundation                          0x00007ff8016432c1 __111+[__NSOperationInternalObserver _observeValueForKeyPath:ofObject:changeKind:oldValue:newValue:indexes:context:]_block_invoke_2 + 17
14  libdispatch.dylib                   0x00007ff8001896a1 _dispatch_call_block_and_release + 12
15  libdispatch.dylib                   0x00007ff80018a8d9 _dispatch_client_callout + 8
16  libdispatch.dylib                   0x00007ff80019d709 _dispatch_root_queue_drain + 920
17  libdispatch.dylib                   0x00007ff80019dfde _dispatch_worker_thread2 + 236
18  libsystem_pthread.dylib             0x000000010993bf8a _pthread_wqthread + 256
19  libsystem_pthread.dylib             0x000000010993af57 start_wqthread + 15
2024-05-06 13:01:59.832174+0000 xctest[7166:21925] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2024-05-06 13:01:59.832937+0000 xctest[7166:21925] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2024-05-06 13:01:59.833530+0000 xctest[7166:21925] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2024-05-06 13:01:59.834178+0000 xctest[7166:21925] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2024-05-06 13:01:59.834749+0000 xctest[7166:21925] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.
2024-05-06 13:01:59.835339+0000 xctest[7166:21925] [Sentry] [debug] [SentryThreadWrapper:26] Already on main thread.

Restarting after unexpected exit, crash, or test timeout in SentryViewHierarchyTests.test_appViewHierarchy_usesMainThread(); summary will include totals from previous launches.
```

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
