### PR TITLE
fix: 'SentryFileManager+Test.h' file not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- 'SentryFileManager+Test.h' file not found (#3950)
+
 ## 8.25.1
 
 ### Features

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -50,11 +50,6 @@
 #    import <SentryScreenFrames.h>
 #endif // SENTRY_HAS_UIKIT
 
-#if defined(TEST) || defined(TESTCI) || defined(DEBUG)
-#    import "SentryFileManager+Test.h"
-#    import "SentryInternalDefines.h"
-#endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
-
 NS_ASSUME_NONNULL_BEGIN
 
 static const void *spanTimestampObserver = &spanTimestampObserver;


### PR DESCRIPTION
## :scroll: Description

The pr https://github.com/getsentry/sentry-cocoa/pull/3929 introduced a bug that happens when Sentry is added with cocoapod, by exposing a Test file during debug, but this file is not available for cocoapod.

![image](https://github.com/getsentry/sentry-cocoa/assets/28265868/5574263e-eca0-4727-9a5a-64dfabdd655f)

## :green_heart: How did you test it?

Sample

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
