### PR TITLE
fix: Clang error for Xcode 15.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Send Cocoa SDK features (#3948)
 
+### Fixes 
+
+- Clang error for Xcode 15.4 (#3958)
+
 ## 8.25.2
 
 ### Fixes

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -39,7 +39,7 @@ generate_xcframework() {
                 fi
                 # This workaround is necessary to make Sentry Static framework to work
                 #More information in here: https://github.com/getsentry/sentry-cocoa/issues/3769
-                plutil -replace "MinimumOSVersion" -string "9999" "$infoPlist"
+                plutil -replace "MinimumOSVersion" -string "17.3" "$infoPlist"
             fi
             
             if [ -d "Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/dSYMs/${scheme}.framework.dSYM" ]; then
@@ -56,7 +56,7 @@ generate_xcframework() {
 
     if [ "$MACH_O_TYPE" = "staticlib" ]; then
         local infoPlist="Carthage/DerivedData/Build/Products/"$configuration"-maccatalyst/${scheme}.framework/Resources/Info.plist"
-        plutil -replace "MinimumOSVersion" -string "9999" "$infoPlist"
+        plutil -replace "MinimumOSVersion" -string "17.3" "$infoPlist"
     fi
     
     createxcframework+="-framework Carthage/DerivedData/Build/Products/"$configuration"-maccatalyst/${scheme}.framework "

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -38,18 +38,9 @@ generate_xcframework() {
                     infoPlist="Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/Products/Library/Frameworks/${scheme}.framework/Resources/Info.plist"
                 fi
                 # This workaround is necessary to make Sentry Static framework to work
-                #More information in here: https://github.com/getsentry/sentry-cocoa/issues/3769
-                case "$sdk" in
-                iphoneos|iphonesimulator|appletvos|appletvsimulator) minimumOSVersion="17.4";;
-                macosx) minimumOSVersion="14.4" ;;
-                watchos|watchsimulator) minimumOSVersion="10.4";;
-                xros|xrsimulator) minimumOSVersion="1";;
-                *)
-                echo "Invalid platform specified."
-                exit 1
-                ;;
-                esac
-                plutil -replace "MinimumOSVersion" -string "$minimumOSVersion" "$infoPlist"
+                # More information in here: https://github.com/getsentry/sentry-cocoa/issues/3769
+                # The version 100 seems to work with all Xcode up to 15.4
+                plutil -replace "MinimumOSVersion" -string "100.0" "$infoPlist"
             fi
             
             if [ -d "Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/dSYMs/${scheme}.framework.dSYM" ]; then
@@ -66,7 +57,7 @@ generate_xcframework() {
 
     if [ "$MACH_O_TYPE" = "staticlib" ]; then
         local infoPlist="Carthage/DerivedData/Build/Products/"$configuration"-maccatalyst/${scheme}.framework/Resources/Info.plist"
-        plutil -replace "MinimumOSVersion" -string "17.4" "$infoPlist"
+        plutil -replace "MinimumOSVersion" -string "100.0" "$infoPlist"
     fi
     
     createxcframework+="-framework Carthage/DerivedData/Build/Products/"$configuration"-maccatalyst/${scheme}.framework "

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -39,7 +39,17 @@ generate_xcframework() {
                 fi
                 # This workaround is necessary to make Sentry Static framework to work
                 #More information in here: https://github.com/getsentry/sentry-cocoa/issues/3769
-                plutil -replace "MinimumOSVersion" -string "17.3" "$infoPlist"
+                case "$sdk" in
+                iphoneos|iphonesimulator|appletvos|appletvsimulator) minimumOSVersion="17.4";;
+                macosx) minimumOSVersion="14.4" ;;
+                watchos|watchsimulator) minimumOSVersion="10.4";;
+                xros|xrsimulator) minimumOSVersion="1";;
+                *)
+                echo "Invalid platform specified."
+                exit 1
+                ;;
+                esac
+                plutil -replace "MinimumOSVersion" -string "$minimumOSVersion" "$infoPlist"
             fi
             
             if [ -d "Carthage/archive/${scheme}${sufix}/${sdk}.xcarchive/dSYMs/${scheme}.framework.dSYM" ]; then
@@ -56,7 +66,7 @@ generate_xcframework() {
 
     if [ "$MACH_O_TYPE" = "staticlib" ]; then
         local infoPlist="Carthage/DerivedData/Build/Products/"$configuration"-maccatalyst/${scheme}.framework/Resources/Info.plist"
-        plutil -replace "MinimumOSVersion" -string "17.3" "$infoPlist"
+        plutil -replace "MinimumOSVersion" -string "17.4" "$infoPlist"
     fi
     
     createxcframework+="-framework Carthage/DerivedData/Build/Products/"$configuration"-maccatalyst/${scheme}.framework "


### PR DESCRIPTION
## :scroll: Description

The hacky solution introduced in the PR https://github.com/getsentry/sentry-cocoa/pull/3774 is breaking compilation for Xcode 15.4

This solution will keep both Xcode 15 (.3 and .4) working.

I believe we can remove the version replacement after a few months after Xcode 15.4 release.

## :bulb: Motivation and Context

closes #3947

## :green_heart: How did you test it?

Samples

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
