### PR TITLE
Fixed deadlock during offline start.

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -18,6 +18,7 @@
 #import "SentryNSURLRequest.h"
 #import "SentryNSURLRequestBuilder.h"
 #import "SentryOptions.h"
+#import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import "SentrySwift.h"
 
@@ -268,6 +269,11 @@ SentryHttpTransport ()
     SENTRY_LOG_DEBUG(@"sendAllCachedEnvelopes start.");
 
     @synchronized(self) {
+        if (nil == SentrySDK.currentHub) {
+            SENTRY_LOG_DEBUG(@"Not started yet.");
+            return;
+        }
+        
         if (self.isSending || ![self.requestManager isReady]) {
             SENTRY_LOG_DEBUG(@"Already sending.");
             return;

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -73,9 +73,6 @@ static NSDate *_Nullable startTimestamp = nil;
 + (SentryHub *)currentHub
 {
     @synchronized(self) {
-        if (nil == currentHub) {
-            currentHub = [[SentryHub alloc] initWithClient:nil andScope:nil];
-        }
         return currentHub;
     }
 }


### PR DESCRIPTION
## :scroll: Description

See details in #3956 

## :bulb: Motivation and Context

Sentry deadlocked during offline startup.

## :green_heart: How did you test it?

I've added sleep into the crash wrapper. And when background thread tried to send envelope it locked SentrySdk @synchronized(self).

```
- (NSDictionary *)systemInfo
{
    static NSDictionary *sharedInfo = nil;
    static dispatch_once_t onceToken;
    dispatch_once(&onceToken,
                  ^{
        sleep(5);
        sharedInfo = SentryDependencyContainer.sharedInstance.crashReporter.systemInfo;
    });
    return sharedInfo;
}
```

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
