### PR TITLE
ci: Increase benchmark binary size max

### DIFF
--- a/Tests/Perf/metrics-test.yml
+++ b/Tests/Perf/metrics-test.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 200 KiB
-  diffMax: 600 KiB
+  diffMax: 700 KiB


### PR DESCRIPTION
Our SDK got bigger because we added plenty of new features. 700 KiB is still acceptable.

#skip-changelog