### PR TITLE
chore: Add Xcode version to bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -55,6 +55,15 @@ body:
       required: true
 
   - type: input
+    id: xcode-version
+    attributes:
+      label: Xcode Version
+      description: Which version of Xcode do you use?
+      placeholder: 15.4 ← should look like this
+    validations:
+      required: true
+
+  - type: input
     id: previous-versions
     attributes:
       label: Did it work on previous versions?


### PR DESCRIPTION
I often ask this as a follow-up question. Now everybody has to put in the Xcode version when opening a bug.

#skip-changelog