### PR TITLE
ref: FramesTrackingIntegration remove stop

### DIFF
--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -4,8 +4,6 @@
 
 #    import "PrivateSentrySDKOnly.h"
 #    import "SentryDependencyContainer.h"
-#    import "SentryLog.h"
-
 #    import "SentryFramesTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -38,11 +36,6 @@ SentryFramesTrackingIntegration ()
 }
 
 - (void)uninstall
-{
-    [self stop];
-}
-
-- (void)stop
 {
     if (nil != self.tracker) {
         [self.tracker stop];

--- a/Sources/Sentry/include/SentryFramesTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryFramesTrackingIntegration.h
@@ -10,8 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryFramesTrackingIntegration : SentryBaseIntegration <SentryIntegrationProtocol>
 
-- (void)stop;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Remove not needed stop method.

Came up while investigating https://github.com/getsentry/sentry-cocoa/issues/3700.

#skip-changelog