### PR TITLE
fix(profiling): put back the missing insertion of initial frame rate

### DIFF
--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -138,6 +138,7 @@ sentry_sliceGPUData(SentryFrameInfoTimeSeries *frameInfo, uint64_t startSystemTi
             break;
         }
         entry[@"value"] = mostRecentFrameRate;
+        [slicedGPUEntries addObject:entry];
     }
     return slicedGPUEntries;
 }


### PR DESCRIPTION
In #3932, this line of code got accidentally removed. I'm not sure if this codepath is ever actually taken. It's not currently covered in tests; to be honest the mocking around GPU timestamps is a mess, and I haven't been able to untangle it to get this particular codepath covered. I hope to make more progress on that in #3985.

But I would like to get this merged before any release goes out, in case something would actually break.

#skip-changelog, for #3555