### PR TITLE
chore: bump sentry-fastlane from 1.15.0 to 1.22.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -168,7 +168,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-sentry (1.15.0)
+    fastlane-plugin-sentry (1.22.1)
       os (~> 1.1, >= 1.1.4)
     ffi (1.16.3)
     fourflusher (2.3.1)


### PR DESCRIPTION
#skip-changelog