### PR TITLE
ref: pass options object into SentryTimeToDisplayTracker

### DIFF
--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -7,6 +7,7 @@
 #    import "SentryFramesTracker.h"
 #    import "SentryLog.h"
 #    import "SentryMeasurementValue.h"
+#    import "SentryOptions.h"
 #    import "SentryProfilingConditionals.h"
 #    import "SentrySpan.h"
 #    import "SentrySpanContext.h"
@@ -35,7 +36,6 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     BOOL _waitForFullDisplay;
     BOOL _initialDisplayReported;
     BOOL _fullyDisplayedReported;
-    BOOL _stopLaunchProfiles;
     NSString *_controllerName;
 }
 
@@ -46,7 +46,6 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     if (self = [super init]) {
         _controllerName = [SwiftDescriptor getObjectClassName:controller];
         _waitForFullDisplay = options.enableTimeToFullDisplayTracing;
-        _stopLaunchProfiles = !options.enableContinuousProfiling;
         _dispatchQueueWrapper = dispatchQueueWrapper;
         _initialDisplayReported = NO;
         _fullyDisplayedReported = NO;

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -35,16 +35,18 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     BOOL _waitForFullDisplay;
     BOOL _initialDisplayReported;
     BOOL _fullyDisplayedReported;
+    BOOL _stopLaunchProfiles;
     NSString *_controllerName;
 }
 
 - (instancetype)initForController:(UIViewController *)controller
-               waitForFullDisplay:(BOOL)waitForFullDisplay
+                          options:(nonnull SentryOptions *)options
              dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
 {
     if (self = [super init]) {
         _controllerName = [SwiftDescriptor getObjectClassName:controller];
-        _waitForFullDisplay = waitForFullDisplay;
+        _waitForFullDisplay = options.enableTimeToFullDisplayTracing;
+        _stopLaunchProfiles = !options.enableContinuousProfiling;
         _dispatchQueueWrapper = dispatchQueueWrapper;
         _initialDisplayReported = NO;
         _fullyDisplayedReported = NO;

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -7,7 +7,6 @@
 #    import "SentryLog.h"
 #    import "SentryOptions.h"
 #    import "SentryPerformanceTracker.h"
-#    import "SentrySDK+Private.h"
 #    import "SentryScope.h"
 #    import "SentrySpanId.h"
 #    import "SentrySwift.h"
@@ -28,7 +27,9 @@ SentryUIViewControllerPerformanceTracker ()
 
 @end
 
-@implementation SentryUIViewControllerPerformanceTracker
+@implementation SentryUIViewControllerPerformanceTracker {
+    SentryOptions *_options;
+}
 
 + (instancetype)shared
 {
@@ -38,12 +39,11 @@ SentryUIViewControllerPerformanceTracker ()
     return instance;
 }
 
-- (instancetype)init
+- (instancetype)initWithOptions:(SentryOptions *)options
 {
     if (self = [super init]) {
+        _options = options;
         self.tracker = SentryPerformanceTracker.shared;
-
-        SentryOptions *options = [SentrySDK options];
         self.inAppLogic = [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
                                                             inAppExcludes:options.inAppExcludes];
 
@@ -145,7 +145,7 @@ SentryUIViewControllerPerformanceTracker ()
 
     SentryTimeToDisplayTracker *ttdTracker =
         [[SentryTimeToDisplayTracker alloc] initForController:controller
-                                           waitForFullDisplay:self.enableWaitForFullDisplay
+                                                      options:_options
                                          dispatchQueueWrapper:_dispatchQueueWrapper];
 
     objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER, ttdTracker,

--- a/Sources/Sentry/include/SentryTimeToDisplayTracker.h
+++ b/Sources/Sentry/include/SentryTimeToDisplayTracker.h
@@ -2,6 +2,7 @@
 
 #if SENTRY_HAS_UIKIT
 
+@class SentryOptions;
 @class SentrySpan;
 @class SentryTracer;
 @class SentryDispatchQueueWrapper;
@@ -26,7 +27,7 @@ SENTRY_NO_INIT
 @property (nonatomic, readonly) BOOL waitForFullDisplay;
 
 - (instancetype)initForController:(UIViewController *)controller
-               waitForFullDisplay:(BOOL)waitForFullDisplay
+                          options:(SentryOptions *)options
              dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 
 - (void)startForTracer:(SentryTracer *)tracer;

--- a/Sources/Sentry/include/SentryUIViewControllerPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryUIViewControllerPerformanceTracker.h
@@ -2,6 +2,7 @@
 
 #if SENTRY_HAS_UIKIT
 
+@class SentryOptions;
 @class SentrySpan;
 @class SentryInAppLogic;
 @class UIViewController;
@@ -25,6 +26,10 @@ static NSString *const SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER
  * This class is intended to be used in a swizzled context.
  */
 @interface SentryUIViewControllerPerformanceTracker : NSObject
+
+SENTRY_NO_INIT
+
+- (instancetype)initWithOptions:(SentryOptions *)options;
 
 @property (nonatomic, readonly, class) SentryUIViewControllerPerformanceTracker *shared;
 

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -833,7 +833,7 @@ class SentryHubTests: XCTestCase {
         fixture.options.enableTimeToFullDisplayTracing = true
         let sut = fixture.getSut(fixture.options)
         
-        let testTTDTracker = TestTimeToDisplayTracker()
+        let testTTDTracker = TestTimeToDisplayTracker(options: fixture.options)
         
         Dynamic(SentryUIViewControllerPerformanceTracker.shared).currentTTDTracker = testTTDTracker
         
@@ -847,7 +847,7 @@ class SentryHubTests: XCTestCase {
         fixture.options.enableTimeToFullDisplayTracing = false
         let sut = fixture.getSut(fixture.options)
         
-        let testTTDTracker = TestTimeToDisplayTracker()
+        let testTTDTracker = TestTimeToDisplayTracker(options: fixture.options)
         
         Dynamic(SentryUIViewControllerPerformanceTracker.shared).currentTTDTracker = testTTDTracker
         
@@ -1232,8 +1232,8 @@ class SentryHubTests: XCTestCase {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class TestTimeToDisplayTracker: SentryTimeToDisplayTracker {
     
-    init() {
-        super.init(for: UIViewController(), waitForFullDisplay: false, dispatchQueueWrapper: SentryDispatchQueueWrapper())
+    init(options: Options) {
+        super.init(for: UIViewController(), options: options, dispatchQueueWrapper: SentryDispatchQueueWrapper())
     }
     
     var registerFullDisplayCalled = false

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -622,7 +622,7 @@ class SentrySDKTests: XCTestCase {
 
         SentrySDK.start(options: fixture.options)
 
-        let testTTDTracker = TestTimeToDisplayTracker()
+        let testTTDTracker = TestTimeToDisplayTracker(options: fixture.options)
 
         Dynamic(SentryUIViewControllerPerformanceTracker.shared).currentTTDTracker = testTTDTracker
 


### PR DESCRIPTION
This will help us use the enableContinuousProfiling option in the implementation without adding too many new parameters to the initializer.

#skip-changelog; for #3555