### PR TITLE
fix: Use proper application state before sending an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix retrieving GraphQL operation names crashing ([#3973](https://github.com/getsentry/sentry-cocoa/pull/3973))
 - Fix SentryCrashExceptionApplication subclass problem (#3993)
+- Fix wrong value for `In Foreground` flag on UIKit applications (#4005)
 
 ## 8.26.0
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -634,16 +634,16 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 #if SENTRY_HAS_UIKIT
         if (!isCrashEvent) {
             NSMutableDictionary *context =
-            [event.context mutableCopy] ?: [NSMutableDictionary dictionary];
+                [event.context mutableCopy] ?: [NSMutableDictionary dictionary];
             if (context[@"app"] == nil
                 || ([context[@"app"] isKindOfClass:NSDictionary.self]
                     && context[@"app"][@"in_foreground"] == nil)) {
-                NSMutableDictionary *app =
-                [(NSDictionary *)context[@"app"] mutableCopy] ?: [NSMutableDictionary dictionary];
+                NSMutableDictionary *app = [(NSDictionary *)context[@"app"] mutableCopy]
+                    ?: [NSMutableDictionary dictionary];
                 context[@"app"] = app;
-                
+
                 UIApplicationState appState =
-                [SentryDependencyContainer sharedInstance].application.applicationState;
+                    [SentryDependencyContainer sharedInstance].application.applicationState;
                 BOOL inForeground = appState == UIApplicationStateActive;
                 app[@"in_foreground"] = @(inForeground);
                 event.context = context;

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -1,7 +1,5 @@
 #import "SentryClient.h"
 #import "NSLocale+Sentry.h"
-#import "SentryAppState.h"
-#import "SentryAppStateManager.h"
 #import "SentryAttachment.h"
 #import "SentryClient+Private.h"
 #import "SentryCrashDefaultMachineContextWrapper.h"
@@ -634,20 +632,22 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         }
 
 #if SENTRY_HAS_UIKIT
-        NSMutableDictionary *context =
+        if (!isCrashEvent) {
+            NSMutableDictionary *context =
             [event.context mutableCopy] ?: [NSMutableDictionary dictionary];
-        if (context[@"app"] == nil
-            || ([context[@"app"] isKindOfClass:NSDictionary.self]
-                && context[@"app"][@"in_foreground"] == nil)) {
-            NSMutableDictionary *app =
+            if (context[@"app"] == nil
+                || ([context[@"app"] isKindOfClass:NSDictionary.self]
+                    && context[@"app"][@"in_foreground"] == nil)) {
+                NSMutableDictionary *app =
                 [(NSDictionary *)context[@"app"] mutableCopy] ?: [NSMutableDictionary dictionary];
-            context[@"app"] = app;
-
-            UIApplicationState appState =
+                context[@"app"] = app;
+                
+                UIApplicationState appState =
                 [SentryDependencyContainer sharedInstance].application.applicationState;
-            BOOL inForeground = appState == UIApplicationStateActive;
-            app[@"in_foreground"] = @(inForeground);
-            event.context = context;
+                BOOL inForeground = appState == UIApplicationStateActive;
+                app[@"in_foreground"] = @(inForeground);
+                event.context = context;
+            }
         }
 #endif
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -869,24 +869,13 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-#if SENTRY_HAS_UIKIT
-    func testCaptureExceptionWithAppStateInForegroudDoNotAddIfAppStateNil() {
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    func testCaptureExceptionWithAppStateInForegroudWhenAppIsInForeground() throws {
+        let app = TestSentryUIApplication()
+        app.applicationState = .active
+        SentryDependencyContainer.sharedInstance().application = app
+        
         let event = TestData.event
-        fixture.getSut().capture(event: event)
-        try assertLastSentEvent { actual in
-            let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-            XCTAssertEqual(inForeground, nil)
-        }
-    }
-
-    func testCaptureExceptionWithAppStateInForegroudCreateAppContext() {
-        let fileManager = try! TestFileManager(options: Options())
-        SentryDependencyContainer.sharedInstance().fileManager = fileManager
-        fileManager.appState = TestData.appState
-        fileManager.appState?.isActive = true
-
-        let event = TestData.event
-        event.context?.removeValue(forKey: "app")
         fixture.getSut().capture(event: event)
         try assertLastSentEvent { actual in
             let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
@@ -894,28 +883,37 @@ class SentryClientTest: XCTestCase {
         }
     }
 
-    func testCaptureExceptionWithAppStateInForegroud() {
-        let fileManager = try! TestFileManager(options: Options())
-        SentryDependencyContainer.sharedInstance().fileManager = fileManager
-        fileManager.appState = TestData.appState
-        fileManager.appState?.isActive = true
-
+    func testCaptureExceptionWithAppStateInForegroudWhenAppIsInBackground() throws {
+        let app = TestSentryUIApplication()
+        app.applicationState = .background
+        SentryDependencyContainer.sharedInstance().application = app
+        
         let event = TestData.event
-        event.context!["app"] = [ "test": "keep-value" ]
         fixture.getSut().capture(event: event)
         try assertLastSentEvent { actual in
             let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-            XCTAssertEqual(inForeground, true)
-            XCTAssertEqual(actual.context?["app"]?["test"] as? String, "keep-value")
+            XCTAssertEqual(inForeground, false)
         }
     }
-
-    func testCaptureExceptionWithAppStateInForegroudDoNotOverwriteExistingValue() {
-        let fileManager = try! TestFileManager(options: Options())
-        SentryDependencyContainer.sharedInstance().fileManager = fileManager
-        fileManager.appState = TestData.appState
-        fileManager.appState?.isActive = true
-
+    
+    func testCaptureExceptionWithAppStateInForegroudWhenAppIsInactive() throws {
+        let app = TestSentryUIApplication()
+        app.applicationState = .inactive
+        SentryDependencyContainer.sharedInstance().application = app
+        
+        let event = TestData.event
+        fixture.getSut().capture(event: event)
+        try assertLastSentEvent { actual in
+            let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
+            XCTAssertEqual(inForeground, false)
+        }
+    }
+    
+    func testCaptureExceptionWithAppStateInForegroundDoNotOverwriteExistingValue() throws {
+        let app = TestSentryUIApplication()
+        app.applicationState = .active
+        SentryDependencyContainer.sharedInstance().application = app
+        
         let event = TestData.event
         event.context!["app"] = [ "in_foreground": "keep-value" ]
         fixture.getSut().capture(event: event)
@@ -924,7 +922,7 @@ class SentryClientTest: XCTestCase {
             XCTAssertEqual(inForeground, "keep-value")
         }
     }
-#endif
+#endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
     func testCaptureExceptionWithoutAttachStacktrace() throws {
         let eventId = fixture.getSut(configureOptions: { options in
@@ -1846,6 +1844,12 @@ class SentryClientTest: XCTestCase {
     class TestSentryUIApplication: SentryUIApplication {
         override func relevantViewControllers() -> [UIViewController] {
             return [ClientTestViewController()]
+        }
+        
+        private var _underlyingAppState: UIApplication.State = .active
+        override var applicationState: UIApplication.State {
+            get { _underlyingAppState }
+            set { _underlyingAppState = newValue }
         }
     }
     


### PR DESCRIPTION
## :scroll: Description

Replaced source of truth for app state from `SentryAppStateManager` instance to `SentryUIApplication`.

## :bulb: Motivation and Context

This change is required since it's sending wrong value to for all events in an UIKit application.
This PR fixes #3991 

## :green_heart: How did you test it?

Existing unit tests pass

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
