### PR TITLE
feat(profiling): include continuous profile IDs in spans

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -75,7 +75,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.enable-continuous-profiling"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.wipe-data"

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -17,6 +17,7 @@ class TestCleanup: NSObject {
         SentrySDK.crashedLastRunCalled = false
         SentrySDK.startInvocations = 0
         SentrySDK.setDetectedStartUpCrash(false)
+        SentrySDK.setStart(nil)
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false
         SentryNetworkTracker.sharedInstance.disable()
         

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -116,12 +116,6 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
         disableTimer();
     }
 
-    [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
-        postNotification:[[NSNotification alloc]
-                             initWithName:kSentryNotificationContinuousProfileStopped
-                                   object:nil
-                                 userInfo:nil]];
-
     {
         std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
         [_threadUnsafe_gContinuousCurrentProfiler

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -32,6 +32,9 @@ SentryProfiler *_Nullable _threadUnsafe_gContinuousCurrentProfiler;
 
 NSTimer *_Nullable _chunkTimer;
 
+/** @note: The session ID is reused for any profile sessions started in the same app session. */
+SentryId *_profileSessionID;
+
 void
 disableTimer()
 {
@@ -86,6 +89,10 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
             SENTRY_LOG_WARN(@"Continuous profiler was unable to be initialized.");
             return;
         }
+
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{ _profileSessionID = [[SentryId alloc] init]; });
+        _threadUnsafe_gContinuousCurrentProfiler.profilerId = _profileSessionID;
     }
 
     [SentryDependencyContainer.sharedInstance.notificationCenterWrapper

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -121,10 +121,7 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
 
         _sentry_threadUnsafe_transmitChunkEnvelope();
         disableTimer();
-    }
 
-    {
-        std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
         [_threadUnsafe_gContinuousCurrentProfiler
             stopForReason:SentryProfilerTruncationReasonNormal];
         _threadUnsafe_gContinuousCurrentProfiler = nil;

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -319,7 +319,9 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
         );
 
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
-    sentry_writeProfileFile(payload);
+    if (NSProcessInfo.processInfo.environment[@"io.sentry.ui-test.test-name"] != nil) {
+        sentry_writeProfileFile(payload);
+    }
 #    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
     if (payload == nil) {

--- a/Sources/Sentry/Profiling/SentryTraceProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryTraceProfiler.mm
@@ -47,6 +47,7 @@ SentryProfiler *_Nullable _threadUnsafe_gTraceProfiler;
             return NO;
         }
 
+        _threadUnsafe_gTraceProfiler.profilerId = [[SentryId alloc] init];
         sentry_trackProfilerForTracer(_threadUnsafe_gTraceProfiler, traceId);
     }
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -70,8 +70,6 @@ sentry_manageTraceProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
         return nil;
     }
 
-    _profilerId = [[SentryId alloc] init];
-
     SENTRY_LOG_DEBUG(@"Initialized new SentryProfiler %@", self);
 
 #    if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -131,12 +131,14 @@ SentrySpan ()
 
 - (void)stopObservingContinuousProfiling
 {
-    [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
-        removeObserver:self
-                  name:kSentryNotificationContinuousProfileStarted];
-    [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
-        removeObserver:self
-                  name:kSentryNotificationContinuousProfileStopped];
+    if (SentrySDK.options.enableContinuousProfiling) {
+        [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
+            removeObserver:self
+                      name:kSentryNotificationContinuousProfileStarted];
+        [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
+            removeObserver:self
+                      name:kSentryNotificationContinuousProfileStopped];
+    }
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -6,11 +6,7 @@
 #import "SentryLog.h"
 #import "SentryMeasurementValue.h"
 #import "SentryNSDictionarySanitize.h"
-#import "SentryNSNotificationCenterWrapper.h"
 #import "SentryNoOpSpan.h"
-#import "SentryOptions+Private.h"
-#import "SentryProfilingConditionals.h"
-#import "SentrySDK+Private.h"
 #import "SentrySampleDecision+Private.h"
 #import "SentrySpanContext.h"
 #import "SentrySpanId.h"
@@ -27,6 +23,10 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryContinuousProfiler.h"
+#    import "SentryNSNotificationCenterWrapper.h"
+#    import "SentryOptions+Private.h"
+#    import "SentryProfilingConditionals.h"
+#    import "SentrySDK+Private.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -103,15 +103,12 @@ SentrySpan ()
             if (SentryContinuousProfiler.isCurrentlyProfiling) {
                 [_profileSessionIDs
                     addObject:SentryContinuousProfiler.currentProfilerID.sentryIdString];
+            } else {
+                [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
+                    addObserver:self
+                       selector:@selector(linkProfiler)
+                           name:kSentryNotificationContinuousProfileStarted];
             }
-            [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
-                addObserver:self
-                   selector:@selector(linkProfiler)
-                       name:kSentryNotificationContinuousProfileStarted];
-            [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
-                addObserver:self
-                   selector:@selector(linkProfiler)
-                       name:kSentryNotificationContinuousProfileStopped];
         }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
@@ -135,9 +132,6 @@ SentrySpan ()
         [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
             removeObserver:self
                       name:kSentryNotificationContinuousProfileStarted];
-        [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
-            removeObserver:self
-                      name:kSentryNotificationContinuousProfileStopped];
     }
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -51,6 +51,7 @@ SentrySpan ()
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     NSString *_Nullable _profileSessionID;
+    BOOL _isContinuousProfiling;
 #endif //  SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
@@ -98,7 +99,8 @@ SentrySpan ()
         _origin = context.origin;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-        if (SentrySDK.options.enableContinuousProfiling) {
+        _isContinuousProfiling = SentrySDK.options.enableContinuousProfiling;
+        if (_isContinuousProfiling) {
             _profileSessionID = SentryContinuousProfiler.currentProfilerID.sentryIdString;
             if (_profileSessionID == nil) {
                 [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
@@ -126,7 +128,7 @@ SentrySpan ()
 
 - (void)stopObservingContinuousProfiling
 {
-    if (SentrySDK.options.enableContinuousProfiling) {
+    if (_isContinuousProfiling) {
         [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
             removeObserver:self
                       name:kSentryNotificationContinuousProfileStarted];

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -50,7 +50,7 @@ SentrySpan ()
 #endif // SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    NSMutableSet<NSString *> *_profileSessionIDs;
+    NSString *_Nullable _profileSessionID;
 #endif //  SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
@@ -99,11 +99,8 @@ SentrySpan ()
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         if (SentrySDK.options.enableContinuousProfiling) {
-            _profileSessionIDs = [NSMutableSet<NSString *> set];
-            if (SentryContinuousProfiler.isCurrentlyProfiling) {
-                [_profileSessionIDs
-                    addObject:SentryContinuousProfiler.currentProfilerID.sentryIdString];
-            } else {
+            _profileSessionID = SentryContinuousProfiler.currentProfilerID.sentryIdString;
+            if (_profileSessionID == nil) {
                 [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
                     addObserver:self
                        selector:@selector(linkProfiler)
@@ -123,7 +120,8 @@ SentrySpan ()
 
 - (void)linkProfiler
 {
-    [_profileSessionIDs addObject:SentryContinuousProfiler.currentProfilerID.sentryIdString];
+    _profileSessionID = SentryContinuousProfiler.currentProfilerID.sentryIdString;
+    [self stopObservingContinuousProfiling];
 }
 
 - (void)stopObservingContinuousProfiling
@@ -375,8 +373,8 @@ SentrySpan ()
     }
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    if (_profileSessionIDs.count > 0) {
-        mutableDictionary[@"profile_ids"] = [_profileSessionIDs allObjects];
+    if (_profileSessionID != nil) {
+        mutableDictionary[@"profile_id"] = _profileSessionID;
     }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -1,6 +1,6 @@
-#import "SentrySpanContext.h"
 #import "SentryLog.h"
 #import "SentrySampleDecision+Private.h"
+#import "SentrySpanContext+Private.h"
 #import "SentrySpanId.h"
 #import "SentrySwift.h"
 #import "SentryTraceOrigins.h"

--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -1,6 +1,6 @@
+#import "SentrySpanContext.h"
 #import "SentryLog.h"
 #import "SentrySampleDecision+Private.h"
-#import "SentrySpanContext+Private.h"
 #import "SentrySpanId.h"
 #import "SentrySwift.h"
 #import "SentryTraceOrigins.h"

--- a/Sources/Sentry/include/SentryContinuousProfiler.h
+++ b/Sources/Sentry/include/SentryContinuousProfiler.h
@@ -4,7 +4,14 @@
 
 #    import <Foundation/Foundation.h>
 
+@class SentryId;
+
 NS_ASSUME_NONNULL_BEGIN
+
+static NSString *const kSentryNotificationContinuousProfileStarted
+    = @"io.sentry.notification.continuous-profile-started";
+static NSString *const kSentryNotificationContinuousProfileStopped
+    = @"io.sentry.notification.continuous-profile-stopped";
 
 /**
  * An interface to the new continuous profiling implementation.
@@ -18,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /** Stop a continuous profiling session if there is one ongoing. */
 + (void)stop;
+
++ (nullable SentryId *)currentProfilerID;
 
 @end
 

--- a/Sources/Sentry/include/SentryContinuousProfiler.h
+++ b/Sources/Sentry/include/SentryContinuousProfiler.h
@@ -10,8 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const kSentryNotificationContinuousProfileStarted
     = @"io.sentry.notification.continuous-profile-started";
-static NSString *const kSentryNotificationContinuousProfileStopped
-    = @"io.sentry.notification.continuous-profile-stopped";
 
 /**
  * An interface to the new continuous profiling implementation.

--- a/Tests/SentryTests/SentryCrash/CrashReport.swift
+++ b/Tests/SentryTests/SentryCrash/CrashReport.swift
@@ -9,7 +9,7 @@ extension XCTestCase {
     
     func givenStoredSentryCrashReport(resource: String) throws {
         let jsonData = try jsonDataOfResource(resource: resource)
-        jsonData.withUnsafeBytes { ( bytes: UnsafeRawBufferPointer) -> Void in
+        jsonData.withUnsafeBytes { ( bytes: UnsafeRawBufferPointer) in
             let pointer = bytes.bindMemory(to: Int8.self)
             sentrycrashcrs_addUserReport(pointer.baseAddress, Int32(jsonData.count))
         }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -90,7 +90,7 @@ class SentrySpanTests: XCTestCase {
         let continuousProfileObservations = fixture.notificationCenter.addObserverInvocations.invocations.filter {
             $0.name.rawValue == kSentryNotificationContinuousProfileStarted
         }
-        XCTAssertEqual(continuousProfileObservations.count, 1)
+        XCTAssertEqual(continuousProfileObservations.count, 0)
     }
     
     func testSpanDoesNotSubscribeToNotificationsIfContinuousProfilingDisabled() {
@@ -133,7 +133,7 @@ class SentrySpanTests: XCTestCase {
 
         let serialized = span.serialize()
 
-        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_id"] as? String)
         XCTAssert(includedProfileIDs.contains(profileId))
     }
 
@@ -154,7 +154,7 @@ class SentrySpanTests: XCTestCase {
 
         let serialized = span.serialize()
 
-        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_id"] as? String)
         XCTAssert(includedProfileIDs.contains(profileId))
     }
 
@@ -175,7 +175,7 @@ class SentrySpanTests: XCTestCase {
 
         let serialized = span.serialize()
 
-        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_id"] as? String)
         XCTAssert(includedProfileIDs.contains(profileId))
     }
 
@@ -195,7 +195,7 @@ class SentrySpanTests: XCTestCase {
 
         let serialized = span.serialize()
 
-        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_id"] as? String)
         XCTAssert(includedProfileIDs.contains(profileId))
     }
 
@@ -218,7 +218,7 @@ class SentrySpanTests: XCTestCase {
         span.finish()
 
         let serialized = span.serialize()
-        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_id"] as? String)
         XCTAssert(includedProfileIDs.contains(profileId1))
         XCTAssert(includedProfileIDs.contains(profileId2))
     }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -65,52 +65,93 @@ class SentrySpanTests: XCTestCase {
 
     // test that a span that starts before a continuous profile and ends before
     // the profile ends includes that profile id in the span
-    func testSpanWithProfileId() {
+    func testSpanWithProfileId() throws {
         let span = fixture.getSut()
         SentryContinuousProfiler.start()
-        let profileId = SentryContinuousProfiler.profiler()?.profilerId.sentryIdString
+        let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         span.finish()
         
         let serialized = span.serialize()
-        XCTAssertEqual(profileId, try XCTUnwrap(serialized["profile_id"] as? String))
+        
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        XCTAssert(includedProfileIDs.contains(profileId))
     }
 
     // test that a span that starts before a continuous profile and ends after
     // the profile ends includes that profile id in the span
-    func testSpanWithProfileId1() {
+    func testSpanWithProfileId1() throws {
         let span = fixture.getSut()
         SentryContinuousProfiler.start()
-        let profileId = SentryContinuousProfiler.profiler()?.profilerId.sentryIdString
+        let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         SentryContinuousProfiler.stop()
         span.finish()
         
         let serialized = span.serialize()
-        XCTAssertEqual(profileId, try XCTUnwrap(serialized["profile_id"] as? String))
+        
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        XCTAssert(includedProfileIDs.contains(profileId))
     }
    
     // test that a span that starts after a continuous profile and ends after
     // the profile ends includes that profile id in the span
-    func testSpanWithProfileId2() {
+    func testSpanWithProfileId2() throws {
         SentryContinuousProfiler.start()
-        let profileId = SentryContinuousProfiler.profiler()?.profilerId.sentryIdString
+        let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
         SentryContinuousProfiler.stop()
         span.finish()
         
         let serialized = span.serialize()
-        XCTAssertEqual(profileId, try XCTUnwrap(serialized["profile_id"] as? String))
+        
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        XCTAssert(includedProfileIDs.contains(profileId))
     }
 
     // test that a span that starts after a continuous profile and ends before the
     // profile ends includes that profile id in the span
-    func testSpanWithProfileId3() {
+    func testSpanWithProfileId3() throws {
         SentryContinuousProfiler.start()
-        let profileId = SentryContinuousProfiler.profiler()?.profilerId.sentryIdString
+        let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
         span.finish()
         
         let serialized = span.serialize()
-        XCTAssertEqual(profileId, try XCTUnwrap(serialized["profile_id"] as? String))
+        
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        XCTAssert(includedProfileIDs.contains(profileId))
+    }
+
+    // test that a span that starts before a continuous profile and ends after
+    // the profile ends includes that profile id in the span
+    func testSpanWithProfileId4() throws {
+        let span = fixture.getSut()
+        SentryContinuousProfiler.start()
+        let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
+        SentryContinuousProfiler.stop()
+        span.finish()
+        
+        let serialized = span.serialize()
+        
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        XCTAssert(includedProfileIDs.contains(profileId))
+    }
+
+    // test that a span that starts and stops while two continuous profiles
+    // stop and start contain both profile ids in the span
+    func testSpanWithProfileId5() throws {
+        let span = fixture.getSut()
+        SentryContinuousProfiler.start()
+        let profileId1 = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
+        SentryContinuousProfiler.stop()
+        SentryContinuousProfiler.start()
+        let profileId2 = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
+        SentryContinuousProfiler.stop()
+        span.finish()
+        
+        let serialized = span.serialize()
+        let includedProfileIDs = try XCTUnwrap(serialized["profile_ids"] as? [String])
+        XCTAssert(includedProfileIDs.contains(profileId1))
+        XCTAssert(includedProfileIDs.contains(profileId2))
     }
 
     // test that a span that starts and ends before a continuous profile starts

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -62,7 +62,17 @@ class SentrySpanTests: XCTestCase {
         super.tearDown()
         clearTestState()
     }
-
+    
+    func testSpanDoesNotIncludeTraceProfilerID() throws {
+        fixture.options.profilesSampleRate = 1
+        let span = fixture.getSut()
+        XCTAssert(SentryTraceProfiler.isCurrentlyProfiling())
+        span.finish()
+        
+        let serialized = span.serialize()
+        XCTAssertNil(serialized["profile_ids"])
+    }
+    
     // test that a span that starts before a continuous profile and ends before
     // the profile ends includes that profile id in the span
     func testSpanWithProfileId() throws {


### PR DESCRIPTION
The last piece of the puzzle is to include any continuous profiling session IDs in span serialized payloads so they can be linked in the backend.

for #3555; #skip-changelog