### PR TITLE
fix: Point out missing reason for NSExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Fix retrieving GraphQL operation names crashing ([#3973](https://github.com/getsentry/sentry-cocoa/pull/3973))
 - Fix SentryCrashExceptionApplication subclass problem (#3993)
+- Point out missing reason for fatal NSExceptions (#4011)
+
 
 ## 8.26.0
 

--- a/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
+++ b/Samples/macOS-Swift/macOS-Swift/AppDelegate.swift
@@ -5,7 +5,6 @@ import Sentry
 class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        UserDefaults.standard.register(defaults: ["NSApplicationCrashOnExceptions": true])
         
         // Insert code here to initialize your application
         SentrySDK.start { options in

--- a/Samples/macOS-Swift/macOS-Swift/Info.plist
+++ b/Samples/macOS-Swift/macOS-Swift/Info.plist
@@ -27,7 +27,7 @@
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+	<string>SentryCrashExceptionApplication</string>
 	<key>NSSupportsAutomaticTermination</key>
 	<true/>
 	<key>NSSupportsSuddenTermination</key>

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -409,8 +409,10 @@ SentryCrashReportConverter ()
     exception.threadId = crashedThread.threadId;
     exception.stacktrace = crashedThread.stacktrace;
 
-    if (nil != self.diagnosis && self.diagnosis.length > 0
-        && ![self.diagnosis containsString:exception.value]) {
+    BOOL hasDiagnosis = self.diagnosis != nil && self.diagnosis.length > 0;
+    BOOL hasExceptionValue = exception.value != nil && exception.value.length > 0;
+
+    if (hasDiagnosis && hasExceptionValue && ![self.diagnosis containsString:exception.value]) {
         exception.value = [exception.value
             stringByAppendingString:[NSString stringWithFormat:@" >\n%@", self.diagnosis]];
     }
@@ -419,14 +421,14 @@ SentryCrashReportConverter ()
 
 - (SentryException *)parseNSException
 {
-    NSString *reason = @"";
+    NSString *reason = nil;
     if (nil != self.exceptionContext[@"nsexception"][@"reason"]) {
         reason = self.exceptionContext[@"nsexception"][@"reason"];
     } else if (nil != self.exceptionContext[@"reason"]) {
         reason = self.exceptionContext[@"reason"];
     }
 
-    return [[SentryException alloc] initWithValue:[NSString stringWithFormat:@"%@", reason]
+    return [[SentryException alloc] initWithValue:reason
                                              type:self.exceptionContext[@"nsexception"][@"name"]];
 }
 

--- a/Tests/Resources/NSExceptionWithoutReason.json
+++ b/Tests/Resources/NSExceptionWithoutReason.json
@@ -1,0 +1,113 @@
+{
+    "report": {
+        "version": "3.2.0",
+        "id": "BEBB7B2D-E4F8-4ED2-BB7F-FCF04F6282AE",
+        "process_name": null,
+        "timestamp": 1716459692,
+        "type": "standard"
+    },
+    "process": {},
+    "system": {
+        "system_name": null,
+        "system_version": null,
+        "machine": null,
+        "model": null,
+        "kernel_version": null,
+        "os_version": null,
+        "jailbroken": false,
+        "app_start_time": null,
+        "CFBundleExecutablePath": null,
+        "CFBundleExecutable": null,
+        "CFBundleIdentifier": null,
+        "CFBundleName": null,
+        "CFBundleVersion": null,
+        "CFBundleShortVersionString": null,
+        "app_uuid": null,
+        "cpu_arch": null,
+        "cpu_type": 0,
+        "cpu_subtype": 0,
+        "binary_cpu_type": 0,
+        "binary_cpu_subtype": 0,
+        "process_name": null,
+        "process_id": 0,
+        "parent_process_id": 0,
+        "device_app_hash": null,
+        "build_type": null,
+        "memory": {
+            "size": 0,
+            "usable": 0,
+            "free": 0
+        },
+        "application_stats": {
+            "application_active": false,
+            "application_in_foreground": true,
+            "launches_since_last_crash": 1,
+            "sessions_since_last_crash": 1,
+            "active_time_since_last_crash": 0,
+            "background_time_since_last_crash": 0,
+            "sessions_since_launch": 1,
+            "active_time_since_launch": 0,
+            "background_time_since_launch": 0
+        }
+    },
+    "crash": {
+        "error": {
+            "mach": {
+                "exception": 10,
+                "exception_name": "EXC_CRASH",
+                "code": 0,
+                "subcode": 0
+            },
+            "signal": {
+                "signal": 6,
+                "name": "SIGABRT",
+                "code": 0
+            },
+            "address": 0,
+            "type": "nsexception",
+            "nsexception": {
+                "name": "MyCustomException",
+                "userInfo": "{\n    detail = \"Additional information\";\n}"
+            }
+        }
+    },
+    "sentry_sdk_scope": {
+        "breadcrumbs": []
+    },
+    "user": {
+        "context": {
+            "app": {
+                "app_build": "1",
+                "app_id": "0B84C76D-16DE-3EE2-85B1-E93FA7080DFA",
+                "app_identifier": "io.sentry.macOS-Swift",
+                "app_name": "macOS-Swift",
+                "app_start_time": "2024-05-23T10:21:30Z",
+                "app_version": "1.0",
+                "build_type": "unknown",
+                "device_app_hash": "2a5fab9e6e92e8fb0bccda61214e76d9a1eeb751"
+            },
+            "device": {
+                "arch": "arm64",
+                "family": "macOS",
+                "free_memory": 2408169472,
+                "locale": "en_AT",
+                "memory_size": 68719476736,
+                "model": "Mac14,5",
+                "simulator": false,
+                "usable_memory": 61236002816
+            },
+            "os": {
+                "build": "23E224",
+                "kernel_version": "Darwin Kernel Version 23.4.0: Fri Mar 15 00:12:49 PDT 2024; root:xnu-10063.101.17~1/RELEASE_ARM64_T6020",
+                "name": "macOS",
+                "rooted": false,
+                "version": "14.4.1"
+            }
+        },
+        "release": "io.sentry.macOS-Swift@1.0+1",
+        "user": {
+            "email": "philipp-hofmann@example.com"
+        }
+    },
+    "debug": {}
+}

--- a/Tests/SentryTests/SentryCrash/SentryCrashDoctorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashDoctorTests.swift
@@ -26,4 +26,12 @@ final class SentryCrashDoctorTests: XCTestCase {
         
         XCTAssertEqual("Graceful OS termination requested.", diagnose)
     }
+    
+    func testNSExceptionWithoutReason() throws {
+        let report = try getCrashReport(resource: "Resources/NSExceptionWithoutReason")
+        
+        let diagnose = SentryCrashDoctor().diagnoseCrash(report)
+        
+        XCTAssertEqual("Application threw exception MyCustomException: (null)", diagnose)
+    }
 }

--- a/Tests/SentryTests/SentryKSCrashReportConverterTests.m
+++ b/Tests/SentryTests/SentryKSCrashReportConverterTests.m
@@ -289,6 +289,17 @@
     XCTAssertEqualObjects(exception.value, @"this is the reason");
 }
 
+- (void)testNSExceptionWithoutReason
+{
+    [self isValidReport:@"Resources/NSExceptionWithoutReason"];
+    NSDictionary *rawCrash = [self getCrashReport:@"Resources/NSExceptionWithoutReason"];
+    SentryCrashReportConverter *reportConverter =
+        [[SentryCrashReportConverter alloc] initWithReport:rawCrash inAppLogic:self.inAppLogic];
+    SentryEvent *event = [reportConverter convertReportToEvent];
+    SentryException *exception = event.exceptions.firstObject;
+    XCTAssertNil(exception.value);
+}
+
 - (void)testFatalError
 {
     [self isValidReport:@"Resources/fatal-error-notable-addresses"];


### PR DESCRIPTION




## :scroll: Description

Stop sending an empty reason for fatal NSExceptions, which is confusing to users. When the SentryException doesn't contain a value, Sentry displays (no error message).

## :bulb: Motivation and Context

Fixes GH-3706

## :green_heart: How did you test it?
Unit tests and with the macOS sample app. Fatal NSExceptions now look like this in Sentry.
![CleanShot 2024-05-23 at 13 48 55@2x](https://github.com/getsentry/sentry-cocoa/assets/2443292/586afcb5-291e-48f1-bbfd-0d95b3c4d75a)

I will create an issue on Sentry to replace the placeholder (no error message) with (no reason) for NSExceptions.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
