### PR TITLE
feat: Add beforeCaptureScreenshot Callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add start time to network request breadcrumbs (#4008)
 - Add C++ exception support for `__cxa_rethrow` (#3996)
+- Add beforeCaptureScreenshot callback (#4016)
 
 ### Improvements
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -22,6 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.beforeSend = { event in
                 return event
             }
+            options.beforeCaptureScreenshot = { _ in
+                return true
+            }
             options.debug = true
             
             if #available(iOS 16.0, *) {

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -82,6 +82,12 @@ typedef SentryBreadcrumb *_Nullable (^SentryBeforeBreadcrumbCallback)(
 typedef SentryEvent *_Nullable (^SentryBeforeSendEventCallback)(SentryEvent *_Nonnull event);
 
 /**
+ * Block can be used to decide if the SDK should capture a screenshot or not. Return @c true if the
+ * SDK should capture a screenshot, return @c false if not. This callback doesn't work for crashes.
+ */
+typedef BOOL (^SentryBeforeCaptureScreenshotCallback)(SentryEvent *_Nonnull event);
+
+/**
  * A callback to be notified when the last program execution terminated with a crash.
  */
 typedef void (^SentryOnCrashedLastRunCallback)(SentryEvent *_Nonnull event);

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -106,6 +106,13 @@ NS_SWIFT_NAME(Options)
 @property (nullable, nonatomic, copy) SentryBeforeBreadcrumbCallback beforeBreadcrumb;
 
 /**
+ * You can use this callback to decide if the SDK should capture a screenshot or not. Return @c true
+ * if the SDK should capture a screenshot, return @c false if not. This callback doesn't work for
+ * crashes.
+ */
+@property (nullable, nonatomic, copy) SentryBeforeCaptureScreenshotCallback beforeCaptureScreenshot;
+
+/**
  * A block called shortly after the initialization of the SDK when the last program execution
  * terminated with a crash.
  * @discussion This callback is only executed once during the entire run of the program to avoid

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -339,6 +339,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.beforeBreadcrumb = options[@"beforeBreadcrumb"];
     }
 
+    if ([self isBlock:options[@"beforeCaptureScreenshot"]]) {
+        self.beforeCaptureScreenshot = options[@"beforeCaptureScreenshot"];
+    }
+
     if ([self isBlock:options[@"onCrashedLastRun"]]) {
         self.onCrashedLastRun = options[@"onCrashedLastRun"];
     }

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -8,6 +8,7 @@
 #    import "SentryEvent+Private.h"
 #    import "SentryException.h"
 #    import "SentryHub+Private.h"
+#    import "SentryOptions.h"
 #    import "SentrySDK+Private.h"
 
 #    if SENTRY_HAS_METRIC_KIT
@@ -21,10 +22,19 @@ saveScreenShot(const char *path)
     [SentryDependencyContainer.sharedInstance.screenshot saveScreenShots:reportPath];
 }
 
+@interface
+SentryScreenshotIntegration ()
+
+@property (nonatomic, strong) SentryOptions *options;
+
+@end
+
 @implementation SentryScreenshotIntegration
 
 - (BOOL)installWithOptions:(nonnull SentryOptions *)options
 {
+    self.options = options;
+
     if (![super installWithOptions:options]) {
         return NO;
     }
@@ -67,6 +77,10 @@ saveScreenShot(const char *path)
     // If the event is an App hanging event, we cant take the
     // screenshot because the the main thread it's blocked.
     if (event.isAppHangEvent) {
+        return attachments;
+    }
+
+    if (self.options.beforeCaptureScreenshot && !self.options.beforeCaptureScreenshot(event)) {
         return attachments;
     }
 

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -137,6 +137,26 @@ class SentryScreenshotIntegrationTests: XCTestCase {
     }
 #endif // os(iOS) || targetEnvironment(macCatalyst)
     
+    func test_NoScreenShot_WhenDiscardedInCallback() {
+        let sut = fixture.getSut()
+        
+        let expectation = expectation(description: "BeforeCaptureScreenshot must be called.")
+        
+        let options = Options()
+        options.beforeCaptureScreenshot = { _ in
+            expectation.fulfill()
+            return false
+        }
+        
+        sut.install(with: options)
+        
+        let newAttachmentList = sut.processAttachments([], for: Event(error: NSError(domain: "", code: -1)))
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        XCTAssertEqual(newAttachmentList?.count, 0)
+    }
+    
     func test_noScreenshot_keepAttachment() {
         let sut = fixture.getSut()
         let event = Event()

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -310,6 +310,27 @@
     XCTAssertNil(options.beforeBreadcrumb);
 }
 
+- (void)testBeforeCaptureScreenshot
+{
+    SentryBeforeCaptureScreenshotCallback callback = ^(SentryEvent *event) {
+        if (event.level == kSentryLevelFatal) {
+            return NO;
+        }
+
+        return YES;
+    };
+    SentryOptions *options = [self getValidOptions:@{ @"beforeCaptureScreenshot" : callback }];
+
+    XCTAssertEqual(callback, options.beforeCaptureScreenshot);
+}
+
+- (void)testDefaultBeforeCaptureScreenshot
+{
+    SentryOptions *options = [self getValidOptions:@{}];
+
+    XCTAssertNil(options.beforeCaptureScreenshot);
+}
+
 - (void)testTracePropagationTargets
 {
     SentryOptions *options =


### PR DESCRIPTION



## :scroll: Description

Add a callback to the options to decide if the SDK should capture a screenshot or not.

PR for updating the docs: https://github.com/getsentry/sentry-docs/pull/10152.

## :bulb: Motivation and Context

Fixes GH-3137

## :green_heart: How did you test it?
Unit tests and sample app.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
