### PR TITLE
Fix: Session replay video size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fix retrieving GraphQL operation names crashing ([#3973](https://github.com/getsentry/sentry-cocoa/pull/3973))
 - Fix SentryCrashExceptionApplication subclass problem (#3993)
 - Fix wrong value for `In Foreground` flag on UIKit applications (#4005)
+- Session replay wrong video size (#)
 
 ## 8.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fix retrieving GraphQL operation names crashing ([#3973](https://github.com/getsentry/sentry-cocoa/pull/3973))
 - Fix SentryCrashExceptionApplication subclass problem (#3993)
 - Fix wrong value for `In Foreground` flag on UIKit applications (#4005)
-- Session replay wrong video size (#)
+- Session replay wrong video size (#4018)
 
 ## 8.26.0
 

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -90,6 +90,8 @@ SentrySessionReplay ()
     _videoSegmentStart = nil;
     _currentSegmentId = 0;
     _sessionReplayId = [[SentryId alloc] init];
+    _replayMaker.videoWidth = (NSInteger)(rootView.frame.size.width * _replayOptions.sizeScale);
+    _replayMaker.videoHeight = (NSInteger)(rootView.frame.size.height * _replayOptions.sizeScale);
 
     imageCollection = [NSMutableArray array];
     if (full) {

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
@@ -4,6 +4,9 @@ import UIKit
 
 @objc
 protocol SentryReplayVideoMaker: NSObjectProtocol {
+    var videoWidth: Int { get set }
+    var videoHeight: Int { get set }
+    
     func addFrameAsync(image: UIImage)
     func releaseFramesUntil(_ date: Date)
     func createVideoWith(duration: TimeInterval, beginning: Date, outputFileURL: URL, completion: @escaping (SentryVideoInfo?, Error?) -> Void) throws

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -15,6 +15,9 @@ class SentrySessionReplayTests: XCTestCase {
      
     private class TestReplayMaker: NSObject, SentryReplayVideoMaker {
         
+        var videoWidth: Int = 0
+        var videoHeight: Int = 0
+        
         struct CreateVideoCall {
             var duration: TimeInterval
             var beginning: Date
@@ -106,6 +109,18 @@ class SentrySessionReplayTests: XCTestCase {
         Dynamic(sut).newFrame(nil)
         
         expect(fixture.hub.lastEvent) == nil
+    }
+    
+    func testVideoSize() {
+        let fixture = startFixture()
+        let options = SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1)
+        let sut = fixture.getSut(options: options)
+        let view = fixture.rootView
+        view.frame = CGRect(x: 0, y: 0, width: 320, height: 900)
+        sut.start(fixture.rootView, fullSession: true)
+        
+        XCTAssertEqual(Int(320 * options.sizeScale), fixture.replayMaker.videoWidth)
+        XCTAssertEqual(Int(900 * options.sizeScale), fixture.replayMaker.videoHeight)
     }
     
     func testSentReplay_FullSession() {


### PR DESCRIPTION
## :scroll: Description

Session replay used to have a hardcoded video size. Now it gets from the window size

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
