### PR TITLE
feat(internal): Add serialized app start measurements getter with spans for Hybrid SDKs

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -91,20 +91,20 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
     NSDictionary *uiKitInitSpan = @{
         @"description" : @"UIKit init",
-        @"startTimestampMs" : moduleInitializationTimestampMs,
-        @"endTimestampMs" : sdkStartTimestampMs,
+        @"start_timestamp_ms" : moduleInitializationTimestampMs,
+        @"end_timestamp_ms" : sdkStartTimestampMs,
     };
 
     NSArray *spans = measurement.isPreWarmed ? @[
         @{
             @"description": @"Pre Runtime Init",
-            @"startTimestampMs": appStartTimestampMs,
-            @"endTimestampMs": runtimeInitTimestampMs,
+            @"start_timestamp_ms": appStartTimestampMs,
+            @"end_timestamp_ms": runtimeInitTimestampMs,
         },
         @{
             @"description": @"Runtime init to Pre Main initializers",
-            @"startTimestampMs": runtimeInitTimestampMs,
-            @"endTimestampMs": moduleInitializationTimestampMs,
+            @"start_timestamp_ms": runtimeInitTimestampMs,
+            @"end_timestamp_ms": moduleInitializationTimestampMs,
         },
         uiKitInitSpan,
     ] : @[

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -72,6 +72,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans
 {
+#if SENTRY_HAS_UIKIT
     SentryAppStartMeasurement *measurement = [SentrySDK getAppStartMeasurement];
     if (measurement == nil) {
         return nil;
@@ -119,6 +120,9 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
         @"sdk_start_timestamp_ms" : sdkStartTimestampMs,
         @"spans" : spans,
     };
+#else
+    return nil;
+#endif // SENTRY_HAS_UIKIT
 }
 
 + (NSString *)installationID

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -88,32 +88,36 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     NSNumber *sdkStartTimestampMs =
         [NSNumber numberWithDouble:measurement.sdkStartTimestamp.timeIntervalSince1970 * 1000];
 
+    NSDictionary *uiKitInitSpan = @{
+        @"description" : @"UIKit init",
+        @"startTimestampMs" : moduleInitializationTimestampMs,
+        @"endTimestampMs" : sdkStartTimestampMs,
+    };
+
+    NSArray *spans = isPreWarmed ? @[
+        @{
+            @"description": @"Pre Runtime Init",
+            @"startTimestampMs": appStartTimestampMs,
+            @"endTimestampMs": runtimeInitTimestampMs,
+        },
+        @{
+            @"description": @"Runtime init to Pre Main initializers",
+            @"startTimestampMs": runtimeInitTimestampMs,
+            @"endTimestampMs": moduleInitializationTimestampMs,
+        },
+        uiKitInitSpan,
+    ] : @[
+      uiKitInitSpan,
+    ];
+
     return @{
-        @"type": type != nil ? type : @"unknown",
-        @"is_pre_warmed": isPreWarmed,
-        @"app_start_timestamp_ms": appStartTimestampMs,
-        @"runtime_init_timestamp_ms": runtimeInitTimestampMs,
-        @"module_initialization_timestamp_ms": moduleInitializationTimestampMs,
-        @"sdk_start_timestamp_ms": sdkStartTimestampMs,
-        @"prewarmed_spans": isPreWarmed ? @[
-            @{
-                @"description": @"Pre Runtime Init",
-                @"startTimestampMs": appStartTimestampMs,
-                @"endTimestampMs": runtimeInitTimestampMs,
-            },
-            @{
-                @"description": @"Runtime init to Pre Main initializers",
-                @"startTimestampMs": runtimeInitTimestampMs,
-                @"endTimestampMs": moduleInitializationTimestampMs,
-            },
-        ] : @[],
-        @"generic_start_spans": @[
-            @{
-                @"description": @"UIKit init",
-                @"startTimestampMs": moduleInitializationTimestampMs,
-                @"endTimestampMs": sdkStartTimestampMs,
-            },
-        ],
+        @"type" : type != nil ? type : @"unknown",
+        @"is_pre_warmed" : isPreWarmed,
+        @"app_start_timestamp_ms" : appStartTimestampMs,
+        @"runtime_init_timestamp_ms" : runtimeInitTimestampMs,
+        @"module_initialization_timestamp_ms" : moduleInitializationTimestampMs,
+        @"sdk_start_timestamp_ms" : sdkStartTimestampMs,
+        @"spans" : spans,
     };
 }
 

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -111,6 +111,11 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
       uiKitInitSpan,
     ];
 
+    // We don't have access to didFinishLaunchingTimestamp on HybridSDKs,
+    // the Cocoa SDK misses the didFinishLaunchNotification and
+    // the didBecomeVisibleNotification. Therefore, we can't set the
+    // didFinishLaunchingTimestamp. This would only work for munualy initialized native SDKs.
+
     return @{
         @"type" : type,
         @"is_pre_warmed" : isPreWarmed,

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -77,7 +77,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
         return nil;
     }
 
-    NSString *type = SentryAppStartType_toString[measurement.type];
+    NSString *type = [SentryAppStartTypeToString convert:measurement.type];
     NSNumber *isPreWarmed = [NSNumber numberWithBool:measurement.isPreWarmed];
     NSNumber *appStartTimestampMs =
         [NSNumber numberWithDouble:measurement.appStartTimestamp.timeIntervalSince1970 * 1000];
@@ -94,7 +94,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
         @"endTimestampMs" : sdkStartTimestampMs,
     };
 
-    NSArray *spans = isPreWarmed ? @[
+    NSArray *spans = measurement.isPreWarmed ? @[
         @{
             @"description": @"Pre Runtime Init",
             @"startTimestampMs": appStartTimestampMs,
@@ -111,7 +111,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     ];
 
     return @{
-        @"type" : type != nil ? type : @"unknown",
+        @"type" : type,
         @"is_pre_warmed" : isPreWarmed,
         @"app_start_timestamp_ms" : appStartTimestampMs,
         @"runtime_init_timestamp_ms" : runtimeInitTimestampMs,

--- a/Sources/Sentry/SentryAppStartMeasurement.m
+++ b/Sources/Sentry/SentryAppStartMeasurement.m
@@ -6,6 +6,20 @@
 #    import "SentryLog.h"
 #    import <Foundation/Foundation.h>
 
+@implementation SentryAppStartTypeToString
++ (NSString *)convert:(SentryAppStartType)type
+{
+    switch (type) {
+    case SentryAppStartTypeWarm:
+        return @"warm";
+    case SentryAppStartTypeCold:
+        return @"cold";
+    case SentryAppStartTypeUnknown:
+        return @"unknown";
+    }
+}
+@end
+
 @implementation SentryAppStartMeasurement
 #    if SENTRY_HAS_UIKIT
 {

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -158,6 +158,8 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 + (NSData *)captureViewHierarchy;
 #endif // SENTRY_UIKIT_AVAILABLE
 
++ (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans;
+
 + (SentryUser *)userWithDictionary:(NSDictionary *)dictionary;
 
 + (SentryBreadcrumb *)breadcrumbWithDictionary:(NSDictionary *)dictionary;

--- a/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
+++ b/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
@@ -10,6 +10,13 @@ typedef NS_ENUM(NSUInteger, SentryAppStartType) {
     SentryAppStartTypeUnknown,
 };
 
+// This is need for serialization in HybridSDKs
+NSString *_Nonnull const SentryAppStartType_toString[] = {
+    [SentryAppStartTypeWarm] = @"warm",
+    [SentryAppStartTypeCold] = @"cold",
+    [SentryAppStartTypeUnknown] = @"unknown",
+};
+
 /**
  * @warning This feature is not available in @c Debug_without_UIKit and @c Release_without_UIKit
  * configurations even when targeting iOS or tvOS platforms.

--- a/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
+++ b/Sources/Sentry/include/HybridPublic/SentryAppStartMeasurement.h
@@ -11,11 +11,10 @@ typedef NS_ENUM(NSUInteger, SentryAppStartType) {
 };
 
 // This is need for serialization in HybridSDKs
-NSString *_Nonnull const SentryAppStartType_toString[] = {
-    [SentryAppStartTypeWarm] = @"warm",
-    [SentryAppStartTypeCold] = @"cold",
-    [SentryAppStartTypeUnknown] = @"unknown",
-};
+@interface SentryAppStartTypeToString : NSObject
+SENTRY_NO_INIT
++ (NSString *_Nonnull)convert:(SentryAppStartType)type;
+@end
 
 /**
  * @warning This feature is not available in @c Debug_without_UIKit and @c Release_without_UIKit

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -92,6 +92,72 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         SentrySDK.setAppStartMeasurement(nil)
         XCTAssertNil(PrivateSentrySDKOnly.appStartMeasurement)
     }
+
+    func testGetAppStartMeasurementWithSpansCold() {
+        SentrySDK.setAppStartMeasurement(
+            TestData.getAppStartMeasurement(type: .cold, runtimeInitSystemTimestamp: 1)
+        )
+
+        let actualAppStartMeasurement = PrivateSentrySDKOnly.appStartMeasurementWithSpans()
+
+        XCTAssertNotNil(actualAppStartMeasurement)
+        XCTAssertEqual(actualAppStartMeasurement!["type"] as! String, "cold")
+        XCTAssertEqual(actualAppStartMeasurement!["is_pre_warmed"] as! Int, 0)
+        XCTAssertEqual((actualAppStartMeasurement!["spans"] as! NSArray).count, 1)
+        XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["description"] as! String, "UIKit init")
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["startTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["endTimestampMs"] is NSNumber)
+    }
+
+    func testGetAppStartMeasurementWithSpansPreWarmed() {
+        SentrySDK.setAppStartMeasurement(
+            TestData.getAppStartMeasurement(
+                type: .warm,
+                runtimeInitSystemTimestamp: 1,
+                preWarmed: true)
+        )
+
+        let actualAppStartMeasurement = PrivateSentrySDKOnly.appStartMeasurementWithSpans()
+
+        XCTAssertNotNil(actualAppStartMeasurement)
+        XCTAssertEqual(actualAppStartMeasurement!["type"] as! String, "warm")
+        XCTAssertEqual(actualAppStartMeasurement!["is_pre_warmed"] as! Int, 1)
+        XCTAssertEqual((actualAppStartMeasurement!["spans"] as! NSArray).count, 3)
+        XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["description"] as! String, "Pre Runtime Init")
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["startTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["endTimestampMs"] is NSNumber)
+        XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["description"] as! String, "Runtime init to Pre Main initializers")
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["startTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["endTimestampMs"] is NSNumber)
+        XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["description"] as! String, "UIKit init")
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["startTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["endTimestampMs"] is NSNumber)
+    }
+
+    func testGetAppStartMeasurementWithSpansReturnsTimestampsInMs() {
+        SentrySDK.setAppStartMeasurement(
+            TestData.getAppStartMeasurement(
+                type: .cold,
+                appStartTimestamp: Date(timeIntervalSince1970: 5),
+                runtimeInitSystemTimestamp: 1,
+                preWarmed: true,
+                moduleInitializationTimestamp: Date(timeIntervalSince1970: 20),
+                runtimeInitTimestamp: Date(timeIntervalSince1970: 15),
+                sdkStartTimestamp: Date(timeIntervalSince1970: 10))
+        )
+
+        let actualAppStartMeasurement = PrivateSentrySDKOnly.appStartMeasurementWithSpans()
+
+        XCTAssertNotNil(actualAppStartMeasurement)
+        XCTAssert(actualAppStartMeasurement!["app_start_timestamp_ms"] is NSNumber)
+        XCTAssert(actualAppStartMeasurement!["runtime_init_timestamp_ms"] is NSNumber)
+        XCTAssert(actualAppStartMeasurement!["module_initialization_timestamp_ms"] is NSNumber)
+        XCTAssert(actualAppStartMeasurement!["sdk_start_timestamp_ms"] is NSNumber)
+        XCTAssertEqual(actualAppStartMeasurement!["app_start_timestamp_ms"] as! NSNumber, 5_000)
+        XCTAssertEqual(actualAppStartMeasurement!["runtime_init_timestamp_ms"] as! NSNumber, 15_000)
+        XCTAssertEqual(actualAppStartMeasurement!["module_initialization_timestamp_ms"] as! NSNumber, 20_000)
+        XCTAssertEqual(actualAppStartMeasurement!["sdk_start_timestamp_ms"] as! NSNumber, 10_000)
+    }
     #endif
 
     func testGetInstallationId() {

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -105,8 +105,8 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(actualAppStartMeasurement!["is_pre_warmed"] as! Int, 0)
         XCTAssertEqual((actualAppStartMeasurement!["spans"] as! NSArray).count, 1)
         XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["description"] as! String, "UIKit init")
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["startTimestampMs"] is NSNumber)
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["endTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["start_timestamp_ms"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["end_timestamp_ms"] is NSNumber)
     }
 
     func testGetAppStartMeasurementWithSpansPreWarmed() {
@@ -124,14 +124,14 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(actualAppStartMeasurement!["is_pre_warmed"] as! Int, 1)
         XCTAssertEqual((actualAppStartMeasurement!["spans"] as! NSArray).count, 3)
         XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["description"] as! String, "Pre Runtime Init")
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["startTimestampMs"] is NSNumber)
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["endTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["start_timestamp_ms"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[0] as! NSDictionary)["end_timestamp_ms"] is NSNumber)
         XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["description"] as! String, "Runtime init to Pre Main initializers")
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["startTimestampMs"] is NSNumber)
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["endTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["start_timestamp_ms"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[1] as! NSDictionary)["end_timestamp_ms"] is NSNumber)
         XCTAssertEqual(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["description"] as! String, "UIKit init")
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["startTimestampMs"] is NSNumber)
-        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["endTimestampMs"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["start_timestamp_ms"] is NSNumber)
+        XCTAssert(((actualAppStartMeasurement!["spans"] as! NSArray)[2] as! NSDictionary)["end_timestamp_ms"] is NSNumber)
     }
 
     func testGetAppStartMeasurementWithSpansReturnsTimestampsInMs() {

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -326,15 +326,32 @@ class TestData {
     }
 
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-
-    static func getAppStartMeasurement(type: SentryAppStartType, appStartTimestamp: Date = TestData.timestamp, runtimeInitSystemTimestamp: UInt64) -> SentryAppStartMeasurement {
+    
+    static func getAppStartMeasurement(
+        type: SentryAppStartType,
+        appStartTimestamp: Date = TestData.timestamp,
+        runtimeInitSystemTimestamp: UInt64,
+        preWarmed: Bool = false,
+        moduleInitializationTimestamp: Date? = nil,
+        runtimeInitTimestamp: Date? = nil,
+        sdkStartTimestamp: Date? = nil
+    ) -> SentryAppStartMeasurement {
         let appStartDuration = 0.5
-        let main = appStartTimestamp.addingTimeInterval(0.15)
-        let runtimeInit = appStartTimestamp.addingTimeInterval(0.05)
-        let sdkStart = appStartTimestamp.addingTimeInterval(0.1)
+        let main = moduleInitializationTimestamp ?? appStartTimestamp.addingTimeInterval(0.15)
+        let runtimeInit = runtimeInitTimestamp ?? appStartTimestamp.addingTimeInterval(0.05)
+        let sdkStart = sdkStartTimestamp ?? appStartTimestamp.addingTimeInterval(0.1)
         let didFinishLaunching = appStartTimestamp.addingTimeInterval(0.2)
         
-        return SentryAppStartMeasurement(type: type, isPreWarmed: false, appStartTimestamp: appStartTimestamp, runtimeInitSystemTimestamp: runtimeInitSystemTimestamp, duration: appStartDuration, runtimeInitTimestamp: runtimeInit, moduleInitializationTimestamp: main, sdkStartTimestamp: sdkStart, didFinishLaunchingTimestamp: didFinishLaunching)
+        return SentryAppStartMeasurement(
+            type: type,
+            isPreWarmed: preWarmed,
+            appStartTimestamp: appStartTimestamp,
+            runtimeInitSystemTimestamp: runtimeInitSystemTimestamp,
+            duration: appStartDuration,
+            runtimeInitTimestamp: runtimeInit,
+            moduleInitializationTimestamp: main,
+            sdkStartTimestamp: sdkStart,
+            didFinishLaunchingTimestamp: didFinishLaunching)
     }
 
     #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/SentryCrash/CrashReport.swift
+++ b/Tests/SentryTests/SentryCrash/CrashReport.swift
@@ -9,7 +9,7 @@ extension XCTestCase {
     
     func givenStoredSentryCrashReport(resource: String) throws {
         let jsonData = try jsonDataOfResource(resource: resource)
-        jsonData.withUnsafeBytes { ( bytes: UnsafeRawBufferPointer) -> Void in
+        jsonData.withUnsafeBytes { ( bytes: UnsafeRawBufferPointer) in
             let pointer = bytes.bindMemory(to: Int8.self)
             sentrycrashcrs_addUserReport(pointer.baseAddress, Int32(jsonData.count))
         }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

This PR adds a new method to the HybridSDKs interface which returns serializable app start data including span structures.

This can be used in Flutter (replacing current custom impl), React Native and other hybrid SDKs like Unity, Capacitor and others.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

- https://github.com/getsentry/sentry-react-native/issues/3445

## :green_heart: How did you test it?

unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
#skip-changelog 