### PR TITLE
feat: Disable SIGTERM reporting by default

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,24 +4,24 @@ on:
     branches:
       - main
     paths:
-      - 'Sources/**'
-      - 'Tests/**'
-      - 'test-server/**'
-      - 'Samples/**'
-      - '.github/workflows/lint.yml'
-      - 'scripts/ci-select-xcode.sh'
+      - "Sources/**"
+      - "Tests/**"
+      - "test-server/**"
+      - "Samples/**"
+      - ".github/workflows/lint.yml"
+      - "scripts/ci-select-xcode.sh"
 
   pull_request:
     paths:
-      - 'Sources/**'
-      - 'Tests/**'
-      - 'test-server/**'
-      - 'Samples/**'
-      - '.github/workflows/lint.yml'
-      - 'scripts/ci-select-xcode.sh'
-      - 'Sentry.xcodeproj/**'
-      - '*.podspec'
-      - 'Gemfile.lock'
+      - "Sources/**"
+      - "Tests/**"
+      - "test-server/**"
+      - "Samples/**"
+      - ".github/workflows/lint.yml"
+      - "scripts/ci-select-xcode.sh"
+      - "Sentry.xcodeproj/**"
+      - "*.podspec"
+      - "Gemfile.lock"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -50,10 +50,11 @@ jobs:
     name: pod lint ${{ matrix.podspec}} ${{ matrix.library_type }} ${{ matrix.platform}}
     runs-on: macos-13
     strategy:
+      fail-fast: false
       matrix:
-        podspec: ['Sentry', 'SentrySwiftUI']
-        platform: ['ios', 'macos', 'tvos', 'watchos']
-        library_type: ['dynamic', 'static']
+        podspec: ["Sentry", "SentrySwiftUI"]
+        platform: ["ios", "macos", "tvos", "watchos"]
+        library_type: ["dynamic", "static"]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add start time to network request breadcrumbs (#4008)
 - Add C++ exception support for `__cxa_rethrow` (#3996)
 - Add beforeCaptureScreenshot callback (#4016)
-- Add option to enable SIGTERM reporting (#4025). We added support
+- Disable SIGTERM reporting by default (#4025). We added support
 for SIGTERM reporting in the last release and enabled it by default.
 For some users, SIGTERM events were verbose and not actionable.
 Therefore, we disable it per default in this release. If you'd like

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 - Add start time to network request breadcrumbs (#4008)
 - Add C++ exception support for `__cxa_rethrow` (#3996)
 - Add beforeCaptureScreenshot callback (#4016)
+- Add option to enable SIGTERM reporting (#4025). We added support
+for SIGTERM reporting in the last release and enabled it by default.
+For some users, SIGTERM events were verbose and not actionable.
+Therefore, we disable it per default in this release. If you'd like
+to receive SIGTERM events, set the option `enableSigtermReporting = true`.
 
 ### Improvements
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.beforeSend = { event in
                 return event
             }
+            options.enableSigtermReporting = true
             options.beforeCaptureScreenshot = { _ in
                 return true
             }

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -85,7 +85,7 @@ NS_SWIFT_NAME(Options)
  *
  * @note The default value is @c NO.
  */
-@property (nonatomic, assign) BOOL enableSigtermReporting;
+@property (nonatomic, assign) BOOL enableSigtermReporting API_UNAVAILABLE(watchos);
 
 /**
  * How many breadcrumbs do you want to keep in memory?

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -75,6 +75,19 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableCrashHandler;
 
 /**
+ * When enabled, the SDK reports SIGTERM signals to Sentry.
+ *
+ * It's crucial for developers to understand that the OS sends a SIGTERM to their app as a prelude
+ * to a graceful shutdown, before resorting to a SIGKILL. This SIGKILL, which your app can't catch
+ * or ignore, is a direct order to terminate your app's process immediately. Developers should be
+ * aware that their app can receive a SIGTERM in various scenarios, such as  CPU or disk overuse,
+ * watchdog terminations, or when the OS updates your app.
+ *
+ * @note The default value is @c NO.
+ */
+@property (nonatomic, assign) BOOL enableSigtermReporting;
+
+/**
  * How many breadcrumbs do you want to keep in memory?
  * @note Default is @c 100 .
  */

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -74,6 +74,8 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) BOOL enableCrashHandler;
 
+#if !TARGET_OS_WATCH
+
 /**
  * When enabled, the SDK reports SIGTERM signals to Sentry.
  *
@@ -85,7 +87,9 @@ NS_SWIFT_NAME(Options)
  *
  * @note The default value is @c NO.
  */
-@property (nonatomic, assign) BOOL enableSigtermReporting API_UNAVAILABLE(watchos);
+@property (nonatomic, assign) BOOL enableSigtermReporting;
+
+#endif // !TARGET_OS_WATCH
 
 /**
  * How many breadcrumbs do you want to keep in memory?

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -129,11 +129,7 @@ SentryCrashIntegration ()
         }
 
 #if !TARGET_OS_WATCH
-        if (enableSigtermReporting) {
-            setEnableSigtermReporting(true);
-        } else {
-            setEnableSigtermReporting(false);
-        }
+        sentrycrashcm_setEnableSigtermReporting(enableSigtermReporting);
 #endif // !TARGET_OS_WATCH
 
         [installation install:cacheDirectory];

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -129,7 +129,11 @@ SentryCrashIntegration ()
         }
 
 #if !TARGET_OS_WATCH
-        setEnableSigtermReporting(enableSigtermReporting);
+        if (enableSigtermReporting) {
+            setEnableSigtermReporting(true);
+        } else {
+            setEnableSigtermReporting(false);
+        }
 #endif // !TARGET_OS_WATCH
 
         [installation install:cacheDirectory];

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -1,5 +1,6 @@
 #import "SentryCrashIntegration.h"
 #import "SentryCrashInstallationReporter.h"
+#import "SentryCrashMonitor_Signal.h"
 #import "SentryCrashWrapper.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryEvent.h"
@@ -87,7 +88,8 @@ SentryCrashIntegration ()
     self.scopeObserver =
         [[SentryCrashScopeObserver alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs];
 
-    [self startCrashHandler:options.cacheDirectoryPath];
+    [self startCrashHandler:options.cacheDirectoryPath
+        enableSigtermReporting:options.enableSigtermReporting];
 
     [self configureScope];
 
@@ -100,6 +102,7 @@ SentryCrashIntegration ()
 }
 
 - (void)startCrashHandler:(NSString *)cacheDirectory
+    enableSigtermReporting:(BOOL)enableSigtermReporting
 {
     void (^block)(void) = ^{
         BOOL canSendReports = NO;
@@ -116,6 +119,7 @@ SentryCrashIntegration ()
             canSendReports = YES;
         }
 
+        setEnableSigtermReporting(enableSigtermReporting);
         [installation install:cacheDirectory];
 
         // We need to send the crashed event together with the crashed session in the same envelope

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -1,6 +1,7 @@
 #import "SentryCrashIntegration.h"
 #import "SentryCrashInstallationReporter.h"
 
+#include "SentryCrashMonitor_Signal.h"
 #import "SentryCrashWrapper.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryEvent.h"
@@ -17,10 +18,6 @@
 #import <SentryDependencyContainer.h>
 #import <SentrySDK+Private.h>
 #import <SentrySysctl.h>
-
-#if !TARGET_OS_WATCH
-#    include "SentryCrashMonitor_Signal.h"
-#endif // !TARGET_OS_WATCH
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryUIApplication.h"

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -1,6 +1,6 @@
 #import "SentryCrashIntegration.h"
 #import "SentryCrashInstallationReporter.h"
-#import "SentryCrashMonitor_Signal.h"
+
 #import "SentryCrashWrapper.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryEvent.h"
@@ -17,6 +17,10 @@
 #import <SentryDependencyContainer.h>
 #import <SentrySDK+Private.h>
 #import <SentrySysctl.h>
+
+#if !TARGET_OS_WATCH
+#    import "SentryCrashMonitor_Signal.h"
+#endif // !TARGET_OS_WATCH
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryUIApplication.h"
@@ -119,7 +123,10 @@ SentryCrashIntegration ()
             canSendReports = YES;
         }
 
+#if !TARGET_OS_WATCH
         setEnableSigtermReporting(enableSigtermReporting);
+#endif // !TARGET_OS_WATCH
+
         [installation install:cacheDirectory];
 
         // We need to send the crashed event together with the crashed session in the same envelope

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -89,11 +89,13 @@ SentryCrashIntegration ()
     self.scopeObserver =
         [[SentryCrashScopeObserver alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs];
 
-    [self startCrashHandler:options.cacheDirectoryPath
+    BOOL enableSigtermReporting = NO;
 #if !TARGET_OS_WATCH
-        enableSigtermReporting:options.enableSigtermReporting
+    enableSigtermReporting = options.enableSigtermReporting;
 #endif // !TARGET_OS_WATCH
-    ];
+
+    [self startCrashHandler:options.cacheDirectoryPath
+        enableSigtermReporting:enableSigtermReporting];
 
     [self configureScope];
 
@@ -106,9 +108,7 @@ SentryCrashIntegration ()
 }
 
 - (void)startCrashHandler:(NSString *)cacheDirectory
-#if !TARGET_OS_WATCH
     enableSigtermReporting:(BOOL)enableSigtermReporting
-#endif // !TARGET_OS_WATCH
 {
     void (^block)(void) = ^{
         BOOL canSendReports = NO;
@@ -125,9 +125,7 @@ SentryCrashIntegration ()
             canSendReports = YES;
         }
 
-#if !TARGET_OS_WATCH
         sentrycrashcm_setEnableSigtermReporting(enableSigtermReporting);
-#endif // !TARGET_OS_WATCH
 
         [installation install:cacheDirectory];
 

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -19,7 +19,7 @@
 #import <SentrySysctl.h>
 
 #if !TARGET_OS_WATCH
-#    import "SentryCrashMonitor_Signal.h"
+#    include "SentryCrashMonitor_Signal.h"
 #endif // !TARGET_OS_WATCH
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -93,7 +93,10 @@ SentryCrashIntegration ()
         [[SentryCrashScopeObserver alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs];
 
     [self startCrashHandler:options.cacheDirectoryPath
-        enableSigtermReporting:options.enableSigtermReporting];
+#if !TARGET_OS_WATCH
+        enableSigtermReporting:options.enableSigtermReporting
+#endif // !TARGET_OS_WATCH
+    ];
 
     [self configureScope];
 
@@ -106,7 +109,9 @@ SentryCrashIntegration ()
 }
 
 - (void)startCrashHandler:(NSString *)cacheDirectory
+#if !TARGET_OS_WATCH
     enableSigtermReporting:(BOOL)enableSigtermReporting
+#endif // !TARGET_OS_WATCH
 {
     void (^block)(void) = ^{
         BOOL canSendReports = NO;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -87,6 +87,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enabled = YES;
         self.shutdownTimeInterval = 2.0;
         self.enableCrashHandler = YES;
+        self.enableSigtermReporting = NO;
         self.diagnosticLevel = kSentryLevelDebug;
         self.debug = NO;
         self.maxBreadcrumbs = defaultMaxBreadcrumbs;
@@ -315,6 +316,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[@"enableCrashHandler"]
             block:^(BOOL value) { self->_enableCrashHandler = value; }];
+
+    [self setBool:options[@"enableSigtermReporting"]
+            block:^(BOOL value) { self->_enableSigtermReporting = value; }];
 
     if ([options[@"maxBreadcrumbs"] isKindOfClass:[NSNumber class]]) {
         self.maxBreadcrumbs = [options[@"maxBreadcrumbs"] unsignedIntValue];

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -87,7 +87,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enabled = YES;
         self.shutdownTimeInterval = 2.0;
         self.enableCrashHandler = YES;
+#if !TARGET_OS_WATCH
         self.enableSigtermReporting = NO;
+#endif // !TARGET_OS_WATCH
         self.diagnosticLevel = kSentryLevelDebug;
         self.debug = NO;
         self.maxBreadcrumbs = defaultMaxBreadcrumbs;
@@ -317,8 +319,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
     [self setBool:options[@"enableCrashHandler"]
             block:^(BOOL value) { self->_enableCrashHandler = value; }];
 
+#if !TARGET_OS_WATCH
     [self setBool:options[@"enableSigtermReporting"]
             block:^(BOOL value) { self->_enableSigtermReporting = value; }];
+#endif // !TARGET_OS_WATCH
 
     if ([options[@"maxBreadcrumbs"] isKindOfClass:[NSNumber class]]) {
         self.maxBreadcrumbs = [options[@"maxBreadcrumbs"] unsignedIntValue];

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -52,7 +52,7 @@ static volatile bool g_isEnabled = false;
 static bool g_isSigtermReportingEnabled = false;
 
 void
-setEnableSigtermReporting(bool enabled)
+sentrycrashcm_setEnableSigtermReporting(bool enabled)
 {
     g_isSigtermReportingEnabled = enabled;
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -215,6 +215,11 @@ uninstallSignalHandler(void)
     int fatalSignalsCount = sentrycrashsignal_numFatalSignals();
 
     for (int i = 0; i < fatalSignalsCount; i++) {
+        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
+            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping restoring handler.");
+            continue;
+        }
+
         SentryCrashLOG_DEBUG("Restoring original handler for signal %d", fatalSignals[i]);
         sigaction(fatalSignals[i], &g_previousSignalHandlers[i], NULL);
     }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -170,10 +170,10 @@ installSignalHandler(void)
     action.sa_sigaction = &handleSignal;
 
     for (int i = 0; i < fatalSignalsCount; i++) {
-        //        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
-        //            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping assigning
-        //            handler."); continue;
-        //        }
+        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
+            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping assigning handler.");
+            continue;
+        }
 
         SentryCrashLOG_DEBUG("Assigning handler for signal %d", fatalSignals[i]);
         if (sigaction(fatalSignals[i], &action, &g_previousSignalHandlers[i]) != 0) {
@@ -215,10 +215,10 @@ uninstallSignalHandler(void)
     int fatalSignalsCount = sentrycrashsignal_numFatalSignals();
 
     for (int i = 0; i < fatalSignalsCount; i++) {
-        //        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
-        //            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping restoring
-        //            handler."); continue;
-        //        }
+        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
+            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping restoring handler.");
+            continue;
+        }
 
         SentryCrashLOG_DEBUG("Restoring original handler for signal %d", fatalSignals[i]);
         sigaction(fatalSignals[i], &g_previousSignalHandlers[i], NULL);

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -51,12 +51,6 @@
 static volatile bool g_isEnabled = false;
 static bool g_isSigtermReportingEnabled = false;
 
-void
-sentrycrashcm_setEnableSigtermReporting(bool enabled)
-{
-    g_isSigtermReportingEnabled = enabled;
-}
-
 static SentryCrash_MonitorContext g_monitorContext;
 static SentryCrashStackCursor g_stackCursor;
 
@@ -262,6 +256,14 @@ addContextualInfoToEvent(struct SentryCrash_MonitorContext *eventContext)
 }
 
 #endif
+
+void
+sentrycrashcm_setEnableSigtermReporting(bool enabled)
+{
+#if SentryCrashCRASH_HAS_SIGNAL
+    g_isSigtermReportingEnabled = enabled;
+#endif
+}
 
 SentryCrashMonitorAPI *
 sentrycrashcm_signal_getAPI(void)

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -49,7 +49,7 @@
 // ============================================================================
 
 static volatile bool g_isEnabled = false;
-static volatile bool g_isSigtermReportingEnabled = false;
+static bool g_isSigtermReportingEnabled = false;
 
 void
 setEnableSigtermReporting(bool enabled)

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -170,10 +170,10 @@ installSignalHandler(void)
     action.sa_sigaction = &handleSignal;
 
     for (int i = 0; i < fatalSignalsCount; i++) {
-        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
-            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping assigning handler.");
-            continue;
-        }
+        //        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
+        //            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping assigning
+        //            handler."); continue;
+        //        }
 
         SentryCrashLOG_DEBUG("Assigning handler for signal %d", fatalSignals[i]);
         if (sigaction(fatalSignals[i], &action, &g_previousSignalHandlers[i]) != 0) {
@@ -215,10 +215,10 @@ uninstallSignalHandler(void)
     int fatalSignalsCount = sentrycrashsignal_numFatalSignals();
 
     for (int i = 0; i < fatalSignalsCount; i++) {
-        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
-            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping restoring handler.");
-            continue;
-        }
+        //        if (fatalSignals[i] == SIGTERM && !g_isSigtermReportingEnabled) {
+        //            SentryCrashLOG_DEBUG("SIGTERM handling disabled. Skipping restoring
+        //            handler."); continue;
+        //        }
 
         SentryCrashLOG_DEBUG("Restoring original handler for signal %d", fatalSignals[i]);
         sigaction(fatalSignals[i], &g_previousSignalHandlers[i], NULL);

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.h
@@ -37,6 +37,10 @@ extern "C" {
 
 #include "SentryCrashMonitor.h"
 
+/** Wether to assign the signal handler for SIGTERM or not.
+ */
+void setEnableSigtermReporting(bool enabled);
+
 /** Access the Monitor API.
  */
 SentryCrashMonitorAPI *sentrycrashcm_signal_getAPI(void);

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.h
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.h
@@ -39,7 +39,7 @@ extern "C" {
 
 /** Wether to assign the signal handler for SIGTERM or not.
  */
-void setEnableSigtermReporting(bool enabled);
+void sentrycrashcm_setEnableSigtermReporting(bool enabled);
 
 /** Access the Monitor API.
  */

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSignalInfo.c
@@ -126,7 +126,7 @@ static const int g_fatalSignals[] = {
     // SIGTERM can be caught and is usually sent by iOS and variants
     // when Apple wants to try and gracefully shutdown the app
     // before sending a SIGKILL (which can't be caught).
-    // Some areas I've seen this happen are:
+    // Some areas this might happen are:
     // - When the OS updates an app.
     // - In some circumstances for Watchdog Events.
     // - Resource overuse (CPU, Disk, ...).

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -155,6 +155,11 @@
     XCTAssertEqual(expected, options.diagnosticLevel);
 }
 
+- (void)testEnableSigtermReporting
+{
+    [self testBooleanField:@"enableSigtermReporting" defaultValue:NO];
+}
+
 - (void)testValidEnabled
 {
     [self testEnabledWith:@YES expected:YES];


### PR DESCRIPTION




## :scroll: Description

We added support for SIGTERM reporting in the last release and enabled it by default. For some users, SIGTERM events were verbose and not actionable. Therefore, we disable it per default.

## :bulb: Motivation and Context

Fixes GH-4013

## :green_heart: How did you test it?
Options via unit test. The signal handling installation manually with log messages cause this code isn't testable at all at the moment, and I don't think we should change that by adding a simple boolean check.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
