### PR TITLE
impr: Skip evaluating log messages when not logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to receive SIGTERM events, set the option `enableSigtermReporting = true`.
 ### Improvements
 
 - Stop FramesTracker when app is in background (#3979)
+- Skip evaluating log messages when not logged (#4028)
 
 ### Fixes
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		62E081AB29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */; };
 		62E146D02BAAE47600ED34FD /* LocalMetricsAggregator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E146CF2BAAE47600ED34FD /* LocalMetricsAggregator.swift */; };
 		62E146D22BAAF55B00ED34FD /* LocalMetricsAggregatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E146D12BAAF55B00ED34FD /* LocalMetricsAggregatorTests.swift */; };
+		62F05D2B2C0DB1F100916E3F /* SentryLogTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */; };
 		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
 		62F4DDA12C04CB9700588890 /* SentryBaggageSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62F4DDA02C04CB9700588890 /* SentryBaggageSerializationTests.swift */; };
 		62FC69362BEDFF18002D3EF2 /* SentryLogExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62FC69352BEDFF18002D3EF2 /* SentryLogExtensions.swift */; };
@@ -1111,6 +1112,8 @@
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
 		62E146CF2BAAE47600ED34FD /* LocalMetricsAggregator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMetricsAggregator.swift; sourceTree = "<group>"; };
 		62E146D12BAAF55B00ED34FD /* LocalMetricsAggregatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalMetricsAggregatorTests.swift; sourceTree = "<group>"; };
+		62F05D292C0DB1C800916E3F /* SentryLogTestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryLogTestHelper.h; sourceTree = "<group>"; };
+		62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLogTestHelper.m; sourceTree = "<group>"; };
 		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
 		62F226B829A37C270038080D /* SentryBooleanSerialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryBooleanSerialization.h; sourceTree = "<group>"; };
 		62F4DDA02C04CB9700588890 /* SentryBaggageSerializationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBaggageSerializationTests.swift; sourceTree = "<group>"; };
@@ -3047,6 +3050,8 @@
 				15E0A8EF240F638200F044E3 /* SentrySerializationNilTests.m */,
 				7BA61EA525F21E660008CAA2 /* SentryLogTests.swift */,
 				7BA61EAB25F2206E0008CAA2 /* SentryLog+TestInit.h */,
+				62F05D292C0DB1C800916E3F /* SentryLogTestHelper.h */,
+				62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */,
 				7BBD18BA24530D2600427C76 /* SentryFileManagerTests.swift */,
 				7BD4E8E727FD95900086C410 /* SentryMigrateSessionInitTests.m */,
 				7BD4E8E527FD84480086C410 /* TestFileManagerDelegate.swift */,
@@ -4791,6 +4796,7 @@
 				7BF9EF742722A85B00B5BBEF /* SentryClassRegistrator.m in Sources */,
 				D8F67AF42BE10F9600C9197B /* UIRedactBuilderTests.swift in Sources */,
 				63B819141EC352A7002FDF4C /* SentryInterfacesTests.m in Sources */,
+				62F05D2B2C0DB1F100916E3F /* SentryLogTestHelper.m in Sources */,
 				7B68345128F7EB3D00FB7064 /* SentryMeasurementUnitTests.swift in Sources */,
 				7B14089A248791660035403D /* SentryCrashStackEntryMapperTests.swift in Sources */,
 				D85790292976A69F00C6AC1F /* TestDebugImageProvider.swift in Sources */,

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -22,11 +22,13 @@ SENTRY_NO_INIT
 
 NS_ASSUME_NONNULL_END
 #define SENTRY_LOG(_SENTRY_LOG_LEVEL, ...)                                                         \
-    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                            \
-                                        [[[NSString stringWithUTF8String:__FILE__]                 \
-                                            lastPathComponent] stringByDeletingPathExtension],     \
-                                        __LINE__, [NSString stringWithFormat:__VA_ARGS__]]         \
-                     andLevel:_SENTRY_LOG_LEVEL]
+    if ([SentryLog willLogAtLevel:_SENTRY_LOG_LEVEL]) {                                            \
+        [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                        \
+                                            [[[NSString stringWithUTF8String:__FILE__]             \
+                                                lastPathComponent] stringByDeletingPathExtension], \
+                                            __LINE__, [NSString stringWithFormat:__VA_ARGS__]]     \
+                         andLevel:_SENTRY_LOG_LEVEL];                                              \
+    }
 #define SENTRY_LOG_DEBUG(...) SENTRY_LOG(kSentryLevelDebug, __VA_ARGS__)
 #define SENTRY_LOG_INFO(...) SENTRY_LOG(kSentryLevelInfo, __VA_ARGS__)
 #define SENTRY_LOG_WARN(...) SENTRY_LOG(kSentryLevelWarning, __VA_ARGS__)

--- a/Tests/SentryTests/Helper/SentryLogTestHelper.h
+++ b/Tests/SentryTests/Helper/SentryLogTestHelper.h
@@ -1,0 +1,8 @@
+#import "SentryLog.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+void sentryLogDebugWithMacroArgsNotEvaluated(void);
+void sentryLogErrorWithMacro(NSString *message);
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Helper/SentryLogTestHelper.m
+++ b/Tests/SentryTests/Helper/SentryLogTestHelper.m
@@ -1,0 +1,22 @@
+#import "SentryLogTestHelper.h"
+#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+
+NSString *
+doNotCallMe(void)
+{
+    XCTFail("The args for the log macro must not be evaluated.");
+    return @"Don't call me";
+}
+
+void
+sentryLogDebugWithMacroArgsNotEvaluated(void)
+{
+    SENTRY_LOG_DEBUG(@"%@", doNotCallMe());
+}
+
+void
+sentryLogErrorWithMacro(NSString *message)
+{
+    SENTRY_LOG_ERROR(@"%@", message);
+}

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -69,4 +69,24 @@ class SentryLogTests: XCTestCase {
                         "[Sentry] [info] 3",
                         "[Sentry] [debug] 4"], logOutput.loggedMessages)
     }
+    
+    func testMacroLogsErrorMessage() {
+        let logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+        SentryLog.configure(true, diagnosticLevel: SentryLevel.error)
+        
+        sentryLogErrorWithMacro("error")
+        
+        XCTAssertEqual(["[Sentry] [error] [SentryLogTestHelper:16] error"], logOutput.loggedMessages)
+    }
+    
+    func testMacroDoesNotEvaluateArgs_WhenNotMessageNotLogged() {
+        let logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+        SentryLog.configure(true, diagnosticLevel: SentryLevel.info)
+        
+        sentryLogDebugWithMacroArgsNotEvaluated()
+        
+        XCTAssertTrue(logOutput.loggedMessages.isEmpty)
+    }
 }

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -77,7 +77,7 @@ class SentryLogTests: XCTestCase {
         
         sentryLogErrorWithMacro("error")
         
-        XCTAssertEqual(["[Sentry] [error] [SentryLogTestHelper:16] error"], logOutput.loggedMessages)
+        XCTAssertEqual(["[Sentry] [error] [SentryLogTestHelper:21] error"], logOutput.loggedMessages)
     }
     
     func testMacroDoesNotEvaluateArgs_WhenNotMessageNotLogged() {

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -139,6 +139,7 @@
 #import "SentryLog+TestInit.h"
 #import "SentryLog.h"
 #import "SentryLogOutput.h"
+#import "SentryLogTestHelper.h"
 #import "SentryMeasurementValue.h"
 #import "SentryMechanism.h"
 #import "SentryMechanismMeta.h"


### PR DESCRIPTION


## :scroll: Description

Skip evaluating log messages the SDK doesn't log. The SDK now only evaluates log messages when it's actually logging the log message. Previously, the SDK evaluated all log messages regardless of the log level. This improves the overall SDK performance slightly.

## :bulb: Motivation and Context

This came up when investigating https://github.com/getsentry/sentry-cocoa/issues/3341. Some [SDK crashes](https://sentry.sentry.io/issues/4734720113/?project=4505469596663808&query=is%3Aunresolved+addbreadcrumb&referrer=issue-stream&sort=user&statsPeriod=30d&stream_index=1) are caused by allocating memory for the string for a log message when adding a breadcrumb. This specific SDK crash happens mostly on lower-end devices / older iPhones.

```
NSMallocException
Exception Type: EXC_CRASH (SIGABRT)

Thread 0 Crashed:
0   CoreFoundation                  0x193baab28         __exceptionPreprocess
1   libobjc.A.dylib                 0x18ba26f74         objc_exception_throw
2   CoreFoundation                  0x193c76b5c         _CFRaiseMemoryException
3   CoreFoundation                  0x193c755f0         __CFStringHandleOutOfMemory
4   CoreFoundation                  0x193ae12d0         __CFStringChangeSizeMultiple
5   CoreFoundation                  0x193ade18c         CFStringAppend
6   CoreFoundation                  0x193add558         __CFStringAppendFormatCore
7   CoreFoundation                  0x193ada9fc         _CFStringCreateWithFormatAndArgumentsReturningMetadata
8   CoreFoundation                  0x193ada938         _CFStringCreateWithFormatAndArgumentsAux2
9   Foundation                      0x192967bf8         +[NSString stringWithFormat:]
```

This also fixes point 3 of https://github.com/getsentry/sentry-cocoa/issues/4020.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
