### PR TITLE
impr: Speed up adding breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ to receive SIGTERM events, set the option `enableSigtermReporting = true`.
 ### Improvements
 
 - Stop FramesTracker when app is in background (#3979)
+- Speed up adding breadcrumbs (#4029)
 
 ### Fixes
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -210,8 +210,6 @@ SentryScope ()
 
             if (index < _breadcrumbArray.count) {
                 [crumbs addObject:_breadcrumbArray[index]];
-            } else {
-                break;
             }
         }
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -215,7 +215,7 @@ SentryScope ()
             if (index < _breadcrumbArray.count) {
                 [crumbs addObject:_breadcrumbArray[index]];
             } else {
-            	break;
+                break;
             }
         }
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -214,6 +214,8 @@ SentryScope ()
 
             if (index < _breadcrumbArray.count) {
                 [crumbs addObject:_breadcrumbArray[index]];
+            } else {
+            	break;
             }
         }
 

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -292,7 +292,7 @@ SentrySessionReplay ()
     __block NSArray<SentryRRWebEvent *> *events;
 
     [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull scope) {
-        events = [self->_breadcrumbConverter convertWithBreadcrumbs:scope.breadcrumbArray
+        events = [self->_breadcrumbConverter convertWithBreadcrumbs:scope.breadcrumbs
                                                                from:videoInfo.start
                                                               until:videoInfo.end];
     }];

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -23,10 +23,7 @@ SentryScope ()
 
 @property (atomic, strong) SentryPropagationContext *propagationContext;
 
-/**
- * Contains the breadcrumbs which will be sent with the event
- */
-@property (atomic, strong) NSMutableArray<SentryBreadcrumb *> *breadcrumbArray;
+- (NSArray<SentryBreadcrumb *> *)breadcrumbs;
 
 /**
  * used to add values in event context.

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -579,6 +579,41 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(2, observer.clearInvocations)
     }
     
+    func testDefaultBreadcrumbCapacity() {
+        let scope = Scope()
+        for i in 0..<197 {
+            let crumb = Breadcrumb()
+            crumb.message = "\(i)"
+            scope.addBreadcrumb(crumb)
+        }
+
+        let scopeSerialized = scope.serialize()
+        let scopeCrumbs = scopeSerialized["breadcrumbs"] as? [[String: Any]]
+        XCTAssertEqual(100, scopeCrumbs?.count ?? 0)
+        
+        var j = 0
+        for i in 97..<197 {
+            let actualMessage = scopeCrumbs?[j]["message"] as? String
+            XCTAssertEqual("\(i)", actualMessage)
+            
+            j += 1
+        }
+    }
+    
+    func testClearBreadcrumb() {
+        let scope = Scope()
+        scope.clearBreadcrumbs()
+        for _ in 0..<101 {
+            scope.addBreadcrumb(fixture.breadcrumb)
+        }
+        scope.clearBreadcrumbs()
+        
+        let scopeSerialized = scope.serialize()
+        
+        let scopeCrumbs = scopeSerialized["breadcrumbs"] as? [[String: Any]]
+        XCTAssertEqual(0, scopeCrumbs?.count ?? 0)
+    }
+    
     class TestScopeObserver: NSObject, SentryScopeObserver {
         var tags: [String: String]?
         func setTags(_ tags: [String: String]?) {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -600,6 +600,24 @@ class SentryScopeSwiftTests: XCTestCase {
         }
     }
     
+    func testBreadcrumbsNotFull() {
+        let scope = Scope()
+        for i in 0..<97 {
+            let crumb = Breadcrumb()
+            crumb.message = "\(i)"
+            scope.addBreadcrumb(crumb)
+        }
+
+        let scopeSerialized = scope.serialize()
+        let scopeCrumbs = scopeSerialized["breadcrumbs"] as? [[String: Any]]
+        XCTAssertEqual(97, scopeCrumbs?.count ?? 0)
+        
+        for i in 0..<97 {
+            let actualMessage = scopeCrumbs?[i]["message"] as? String
+            XCTAssertEqual("\(i)", actualMessage)
+        }
+    }
+    
     func testClearBreadcrumb() {
         let scope = Scope()
         scope.clearBreadcrumbs()

--- a/Tests/SentryTests/SentryScopeTests.m
+++ b/Tests/SentryTests/SentryScopeTests.m
@@ -57,18 +57,6 @@
     XCTAssertEqual(expectedMaxBreadcrumb, [scope2Crumbs count]);
 }
 
-- (void)testDefaultMaxCapacity
-{
-    SentryScope *scope = [[SentryScope alloc] init];
-    for (int i = 0; i < 2000; ++i) {
-        [scope addBreadcrumb:[[SentryBreadcrumb alloc] init]];
-    }
-
-    NSDictionary<NSString *, id> *scopeSerialized = [scope serialize];
-    NSArray *scopeCrumbs = [scopeSerialized objectForKey:@"breadcrumbs"];
-    XCTAssertEqual(100, [scopeCrumbs count]);
-}
-
 - (void)testSetTagValueForKey
 {
     NSDictionary<NSString *, NSString *> *excpected = @{ @"A" : @"1", @"B" : @"2", @"C" : @"" };
@@ -161,15 +149,6 @@
     NSString *expectedReplayId = @"Some_replay_id";
     [scope setReplayId:expectedReplayId];
     XCTAssertEqualObjects([[scope serialize] objectForKey:@"replay_id"], expectedReplayId);
-}
-
-- (void)testClearBreadcrumb
-{
-    SentryScope *scope = [[SentryScope alloc] init];
-    [scope clearBreadcrumbs];
-    [scope addBreadcrumb:[self getBreadcrumb]];
-    [scope clearBreadcrumbs];
-    XCTAssertTrue([[[scope serialize] objectForKey:@"breadcrumbs"] count] == 0);
 }
 
 @end


### PR DESCRIPTION

## :scroll: Description

Adding breadcrumbs was O(n) because the SDK used removeObjectAtIndex:0 when reaching the max breadcrumb amount, which requires reshifting the whole array. Now, we use a ring buffer making adding breadcrumbs O(1).

## :bulb: Motivation and Context

Should fix GH-3341.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
