### PR TITLE
fix(profiling): set continuous profile id in each serialized transaction at keypath contexts.trace.data.profile_id

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -689,6 +689,7 @@
 		84A305572BC9EF8C00D84283 /* SentryTraceProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A305552BC9EF8C00D84283 /* SentryTraceProfiler.h */; };
 		84A305582BC9EF8C00D84283 /* SentryTraceProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84A305562BC9EF8C00D84283 /* SentryTraceProfiler.mm */; };
 		84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */; };
+		84A7890A2C0E9F6400FF0803 /* SentrySpan+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A789092C0E9F5800FF0803 /* SentrySpan+Private.h */; };
 		84A8891C28DBD28900C51DFD /* SentryDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A8891A28DBD28900C51DFD /* SentryDevice.h */; };
 		84A8891D28DBD28900C51DFD /* SentryDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84A8891B28DBD28900C51DFD /* SentryDevice.mm */; };
 		84A8892128DBD8D600C51DFD /* SentryDeviceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84A8892028DBD8D600C51DFD /* SentryDeviceTests.mm */; };
@@ -1747,6 +1748,7 @@
 		84A305562BC9EF8C00D84283 /* SentryTraceProfiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryTraceProfiler.mm; sourceTree = "<group>"; };
 		84A305592BC9FD1600D84283 /* SentryTraceProfiler+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryTraceProfiler+Test.h"; sourceTree = "<group>"; };
 		84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Sentry.swift"; sourceTree = "<group>"; };
+		84A789092C0E9F5800FF0803 /* SentrySpan+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySpan+Private.h"; path = "include/SentrySpan+Private.h"; sourceTree = "<group>"; };
 		84A8891A28DBD28900C51DFD /* SentryDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDevice.h; path = include/SentryDevice.h; sourceTree = "<group>"; };
 		84A8891B28DBD28900C51DFD /* SentryDevice.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryDevice.mm; sourceTree = "<group>"; };
 		84A8892028DBD8D600C51DFD /* SentryDeviceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryDeviceTests.mm; sourceTree = "<group>"; };
@@ -3539,6 +3541,7 @@
 				7B3B83712833832B0001FDEB /* SentrySpanOperations.h */,
 				622C08D729E546F4002571D4 /* SentryTraceOrigins.h */,
 				8E4E7C6C25DAAAFE006AB9E2 /* SentrySpan.h */,
+				84A789092C0E9F5800FF0803 /* SentrySpan+Private.h */,
 				8EC3AE7925CA23B600E7591A /* SentrySpan.m */,
 				7BE912AA272162AF00E49E62 /* SentryNoOpSpan.h */,
 				7BE912AC272162D900E49E62 /* SentryNoOpSpan.m */,
@@ -4194,6 +4197,7 @@
 				7BC852392458830A005A70F0 /* SentryEnvelopeItemType.h in Headers */,
 				63AA769D1EB9C57A00D153DE /* SentryError.h in Headers */,
 				63FE714F20DA4C1100CDBAE8 /* SentryCrashNSErrorUtil.h in Headers */,
+				84A7890A2C0E9F6400FF0803 /* SentrySpan+Private.h in Headers */,
 				7BC5B6FA290BCDE500D99477 /* SentryHttpStatusCodeRange+Private.h in Headers */,
 				7B04A9AF24EAC02C00E710B1 /* SentryRetryAfterHeaderParser.h in Headers */,
 				9286059529A5096600F96038 /* SentryGeo.h in Headers */,

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -375,7 +375,7 @@ SentrySpan ()
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if (_profileSessionID != nil) {
-        mutableDictionary[@"profile_id"] = _profileSessionID;
+        mutableDictionary[@"profiler_id"] = _profileSessionID;
     }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -1,4 +1,3 @@
-#import "SentrySpan.h"
 #import "SentryCrashThread.h"
 #import "SentryDependencyContainer.h"
 #import "SentryFrame.h"
@@ -8,6 +7,7 @@
 #import "SentryNSDictionarySanitize.h"
 #import "SentryNoOpSpan.h"
 #import "SentrySampleDecision+Private.h"
+#import "SentrySpan+Private.h"
 #import "SentrySpanContext.h"
 #import "SentrySpanId.h"
 #import "SentrySwift.h"
@@ -50,7 +50,6 @@ SentrySpan ()
 #endif // SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    NSString *_Nullable _profileSessionID;
     BOOL _isContinuousProfiling;
 #endif //  SENTRY_TARGET_PROFILING_SUPPORTED
 }

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -2,6 +2,8 @@
 #import "SentryEnvelopeItemType.h"
 #import "SentryMeasurementValue.h"
 #import "SentryNSDictionarySanitize.h"
+#import "SentryProfilingConditionals.h"
+#import "SentrySpan+Private.h"
 #import "SentrySwift.h"
 #import "SentryTransactionContext.h"
 
@@ -54,6 +56,11 @@ SentryTransaction ()
         serializedData[@"_metrics_summary"] = metricsSummary;
         [serializedTrace removeObjectForKey:@"_metrics_summary"];
     }
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+    NSMutableDictionary *traceProfileEntry = [NSMutableDictionary dictionary];
+    traceProfileEntry[@"profile_id"] = self.trace.profileSessionID;
+    serializedTrace[@"data"] = traceProfileEntry;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
     mutableContext[@"trace"] = serializedTrace;
 
     [serializedData setValue:mutableContext forKey:@"contexts"];

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -57,9 +57,10 @@ SentryTransaction ()
         [serializedTrace removeObjectForKey:@"_metrics_summary"];
     }
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    NSMutableDictionary *traceProfileEntry = [NSMutableDictionary dictionary];
-    traceProfileEntry[@"profile_id"] = self.trace.profileSessionID;
-    serializedTrace[@"data"] = traceProfileEntry;
+    NSMutableDictionary *traceDataEntry =
+        [serializedTrace[@"data"] mutableCopy] ?: [NSMutableDictionary dictionary];
+    traceDataEntry[@"profiler_id"] = self.trace.profileSessionID;
+    serializedTrace[@"data"] = traceDataEntry;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     mutableContext[@"trace"] = serializedTrace;
 

--- a/Sources/Sentry/include/SentrySpan+Private.h
+++ b/Sources/Sentry/include/SentrySpan+Private.h
@@ -1,0 +1,12 @@
+#import "SentrySpan.h"
+
+#import "SentryProfilingConditionals.h"
+
+@interface
+SentrySpan ()
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+@property (copy, nonatomic) NSString *_Nullable profileSessionID;
+#endif //  SENTRY_TARGET_PROFILING_SUPPORTED
+
+@end

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class SentrySpanTests: XCTestCase {
     private var logOutput: TestLogOutput!
     private var fixture: Fixture!
-
+    
     private class Fixture {
         let someTransaction = "Some Transaction"
         let someOperation = "Some Operation"
@@ -21,7 +21,7 @@ class SentrySpanTests: XCTestCase {
 #else
         let tracer = SentryTracer(context: SpanContext(operation: "TEST"))
 #endif
-
+        
         init() {
             options = Options()
             options.tracesSampleRate = 1
@@ -52,11 +52,11 @@ class SentrySpanTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-
+        
         logOutput = TestLogOutput()
         SentryLog.configure(true, diagnosticLevel: SentryLevel.debug)
         SentryLog.setLogOutput(logOutput)
-
+        
         fixture = Fixture()
         SentryDependencyContainer.sharedInstance().dateProvider = fixture.currentDateProvider
     }
@@ -112,7 +112,7 @@ class SentrySpanTests: XCTestCase {
         }
         XCTAssertEqual(continuousProfileObservations.count, 1)
     }
-
+    
     /// Test a span that starts before and ends before a continuous profile, includes profile id
     ///
     /// ```
@@ -129,12 +129,12 @@ class SentrySpanTests: XCTestCase {
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         span.finish()
-
+        
         let serialized = span.serialize()
-
+        
         XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
     }
-
+    
     /// Test a span that starts before and ends after a continuous profile, includes profile id
     ///
     /// ```
@@ -149,12 +149,12 @@ class SentrySpanTests: XCTestCase {
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         SentryContinuousProfiler.stop()
         span.finish()
-
+        
         let serialized = span.serialize()
-
+        
         XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
     }
-
+    
     /// Test a span that starts after and ends after a continuous profile, includes profile id
     ///
     /// ```
@@ -169,12 +169,12 @@ class SentrySpanTests: XCTestCase {
         let span = fixture.getSut()
         SentryContinuousProfiler.stop()
         span.finish()
-
+        
         let serialized = span.serialize()
-
+        
         XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
     }
-
+    
     /// Test a span that starts after and ends before a continuous profile, includes profile id
     ///
     /// ```
@@ -188,11 +188,11 @@ class SentrySpanTests: XCTestCase {
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
         span.finish()
-
+        
         let serialized = span.serialize()
         XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
     }
-
+    
     /// Test a span that spans multiple profiles, which both should have the same profile ID, and that
     /// the span also contains that profile ID.
     ///
@@ -212,11 +212,11 @@ class SentrySpanTests: XCTestCase {
         SentryContinuousProfiler.stop()
         XCTAssertEqual(profileId1, profileId2)
         span.finish()
-
+        
         let serialized = span.serialize()
         XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId1)
     }
-
+    
     /// Test a span that starts and ends before a profile starts, does not include profile id
     ///
     /// ```
@@ -230,12 +230,12 @@ class SentrySpanTests: XCTestCase {
         SentryContinuousProfiler.stop()
         let span = fixture.getSut()
         span.finish()
-
+        
         let serialized = span.serialize()
         XCTAssertNil(serialized["profile_id"])
     }
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-
+    
     func testInitAndCheckForTimestamps() {
         let span = fixture.getSut()
         XCTAssertNotNil(span.startTimestamp)
@@ -325,22 +325,22 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(lastEvent.startTimestamp, TestData.timestamp)
         XCTAssertEqual(lastEvent.type, SentryEnvelopeItemTypeTransaction)
     }
-
+    
     func testFinishSpanWithDefaultTimestamp() {
         let span = fixture.getSutWithTracer()
         span.finish()
-
+        
         XCTAssertEqual(span.startTimestamp, TestData.timestamp)
         XCTAssertEqual(span.timestamp, TestData.timestamp)
         XCTAssertTrue(span.isFinished)
         XCTAssertEqual(span.status, .ok)
     }
-
+    
     func testFinishSpanWithCustomTimestamp() {
         let span = fixture.getSutWithTracer()
         span.timestamp = Date(timeIntervalSince1970: 123)
         span.finish()
-
+        
         XCTAssertEqual(span.startTimestamp, TestData.timestamp)
         XCTAssertEqual(span.timestamp, Date(timeIntervalSince1970: 123))
         XCTAssertTrue(span.isFinished)
@@ -393,25 +393,25 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual(childSpan.operation, fixture.someOperation)
         XCTAssertEqual(childSpan.spanDescription, fixture.someDescription)
     }
-
+    
     func testStartChildOnFinishedSpan() {
         let span = fixture.getSut()
         span.finish()
-
+        
         let childSpan = span.startChild(operation: fixture.someOperation, description: fixture.someDescription)
-
+        
         XCTAssertNil(childSpan.parentSpanId)
         XCTAssertEqual(childSpan.operation, "")
         XCTAssertNil(childSpan.spanDescription)
         XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(" Starting a child on a finished span is not supported; it won\'t be sent to Sentry.") }).isEmpty)
     }
-
+    
     func testStartGrandChildOnFinishedSpan() {
         let span = fixture.getSut()
         let childSpan = span.startChild(operation: fixture.someOperation)
         childSpan.finish()
         span.finish()
-
+        
         let grandChild = childSpan.startChild(operation: fixture.someOperation, description: fixture.someDescription)
         XCTAssertNil(grandChild.parentSpanId)
         XCTAssertEqual(grandChild.operation, "")
@@ -421,7 +421,7 @@ class SentrySpanTests: XCTestCase {
     
     func testAddAndRemoveData() {
         let span = fixture.getSut()
-
+        
         span.setData(value: fixture.extraValue, key: fixture.extraKey)
         
         XCTAssertEqual(span.data.count, 3)
@@ -455,7 +455,7 @@ class SentrySpanTests: XCTestCase {
         //Faking extra info to test serialization
         span.parentSpanId = SpanId()
         span.spanDescription = "Span Description"
-
+        
         let serialization = span.serialize()
         XCTAssertEqual(serialization["span_id"] as? String, span.spanId.sentrySpanIdString)
         XCTAssertEqual(serialization["parent_span_id"] as? String, span.parentSpanId?.sentrySpanIdString)
@@ -476,44 +476,44 @@ class SentrySpanTests: XCTestCase {
         XCTAssertEqual((serialization["tags"] as! Dictionary)[fixture.extraKey], fixture.extraValue)
         XCTAssertEqual("manual", serialization["origin"] as? String)
     }
-
+    
     func testSerialization_NoStacktraceFrames() {
         let span = fixture.getSutWithTracer()
         let serialization = span.serialize()
-
+        
         XCTAssertEqual(2, (serialization["data"] as? [String: Any])?.count, "Only expected thread.name and thread.id in data.")
     }
-
+    
     func testSerialization_withStacktraceFrames() {
         let span = fixture.getSutWithTracer()
         span.frames = [TestData.mainFrame, TestData.testFrame]
-
+        
         let serialization = span.serialize()
-
+        
         XCTAssertNotNil(serialization["data"])
         let callStack = (serialization["data"] as? [String: Any])?["call_stack"] as? [[String: Any]]
         XCTAssertNotNil(callStack)
         XCTAssertEqual(callStack?.first?["function"] as? String, TestData.mainFrame.function)
         XCTAssertEqual(callStack?.last?["function"] as? String, TestData.testFrame.function)
     }
-
+    
     func testSanitizeData() {
         let span = fixture.getSut()
-
+        
         span.setData(value: Date(timeIntervalSince1970: 10), key: "date")
         span.finish()
-
+        
         let serialization = span.serialize()
         let data = serialization["data"] as? [String: Any]
         XCTAssertEqual(data?["date"] as? String, "1970-01-01T00:00:10.000Z")
     }
-
+    
     func testSanitizeDataSpan() {
         let span = fixture.getSutWithTracer()
-
+        
         span.setData(value: Date(timeIntervalSince1970: 10), key: "date")
         span.finish()
-
+        
         let serialization = span.serialize()
         let data = serialization["data"] as? [String: Any]
         XCTAssertEqual(data?["date"] as? String, "1970-01-01T00:00:10.000Z")
@@ -527,7 +527,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(serialization["tag"])
     }
     
-    func testInit_DoesNotIntializeLocalMetricAggregator() {
+    func testInit_DoesNotInitializeLocalMetricAggregator() {
         let sut = fixture.getSut()
         
         let serialized = sut.serialize()
@@ -594,7 +594,7 @@ class SentrySpanTests: XCTestCase {
         let data = sut.data as [String: Any]
         XCTAssertEqual(0, data["key"] as? Int)
     }
-         
+    
     func testSpanWithoutTracer_StartChild_ReturnsNoOpSpan() {
         // Span has a weak reference to tracer. If we don't keep a reference
         // to the tracer ARC will deallocate the tracer.
@@ -609,7 +609,7 @@ class SentrySpanTests: XCTestCase {
         }
         
         let sut = sutGenerator()
-
+        
         let actual = sut.startChild(operation: fixture.someOperation)
         XCTAssertTrue(SentryNoOpSpan.shared() === actual)
         
@@ -620,7 +620,7 @@ class SentrySpanTests: XCTestCase {
     func testModifyingExtraFromMultipleThreads() {
         let queue = DispatchQueue(label: "SentrySpanTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
-                
+        
         let span = fixture.getSut()
         
         // The number is kept small for the CI to not take to long.
@@ -647,7 +647,7 @@ class SentrySpanTests: XCTestCase {
         let threadDataItemCount = 2
         XCTAssertEqual(span.data.count, outerLoop * innerLoop + threadDataItemCount)
     }
-
+    
     func testSpanStatusNames() {
         XCTAssertEqual(nameForSentrySpanStatus(.undefined), kSentrySpanStatusNameUndefined)
         XCTAssertEqual(nameForSentrySpanStatus(.ok), kSentrySpanStatusNameOk)
@@ -739,7 +739,7 @@ class SentrySpanTests: XCTestCase {
         expect(sut.data["frames.delay"]) == nil
     }
     
-    private func givenFramesTracker() -> (TestDisplayLinkWrapper, SentryFramesTracker) {
+    func givenFramesTracker() -> (TestDisplayLinkWrapper, SentryFramesTracker) {
         let displayLinkWrapper = TestDisplayLinkWrapper(dateProvider: self.fixture.currentDateProvider)
         let framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: self.fixture.currentDateProvider, dispatchQueueWrapper: TestSentryDispatchQueueWrapper(), notificationCenter: TestNSNotificationCenterWrapper(), keepDelayedFramesDuration: 10)
         framesTracker.start()
@@ -747,5 +747,5 @@ class SentrySpanTests: XCTestCase {
         
         return (displayLinkWrapper, framesTracker)
     }
-#endif
+#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 }

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -132,7 +132,7 @@ class SentrySpanTests: XCTestCase {
         
         let serialized = span.serialize()
         
-        XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
+        XCTAssertEqual(try XCTUnwrap(serialized["profiler_id"] as? String), profileId)
     }
     
     /// Test a span that starts before and ends after a continuous profile, includes profile id
@@ -152,7 +152,7 @@ class SentrySpanTests: XCTestCase {
         
         let serialized = span.serialize()
         
-        XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
+        XCTAssertEqual(try XCTUnwrap(serialized["profiler_id"] as? String), profileId)
     }
     
     /// Test a span that starts after and ends after a continuous profile, includes profile id
@@ -172,7 +172,7 @@ class SentrySpanTests: XCTestCase {
         
         let serialized = span.serialize()
         
-        XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
+        XCTAssertEqual(try XCTUnwrap(serialized["profiler_id"] as? String), profileId)
     }
     
     /// Test a span that starts after and ends before a continuous profile, includes profile id
@@ -190,7 +190,7 @@ class SentrySpanTests: XCTestCase {
         span.finish()
         
         let serialized = span.serialize()
-        XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId)
+        XCTAssertEqual(try XCTUnwrap(serialized["profiler_id"] as? String), profileId)
     }
     
     /// Test a span that spans multiple profiles, which both should have the same profile ID, and that
@@ -214,7 +214,7 @@ class SentrySpanTests: XCTestCase {
         span.finish()
         
         let serialized = span.serialize()
-        XCTAssertEqual(try XCTUnwrap(serialized["profile_id"] as? String), profileId1)
+        XCTAssertEqual(try XCTUnwrap(serialized["profiler_id"] as? String), profileId1)
     }
     
     /// Test a span that starts and ends before a profile starts, does not include profile id

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -211,4 +211,22 @@ class SentryTransactionTests: XCTestCase {
         expect(metric["count"] as? Int) == 1
         expect(metric["sum"] as? Double) == 1.0
     }
+    
+#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+    // test that when a trace runs concurrently with the continuous profiler
+    // and is serialized to a transaction, that it contains the profile id at
+    // the keypath contexts.trace.data.profile_id
+    func testTransactionWithContinuousProfile() throws {
+        SentrySDK.setStart(Options())
+        let transaction = fixture.getTransaction()
+        SentryContinuousProfiler.start()
+        let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
+        let serialized = transaction.serialize()
+        let contexts = try XCTUnwrap(serialized["contexts"] as? [String: Any])
+        let trace = try XCTUnwrap(contexts["trace"] as? [String: Any])
+        let data = try XCTUnwrap(trace["data"] as? [String: String])
+        let profileIdFromContexts = try XCTUnwrap(data["profile_id"])
+        XCTAssertEqual(profileId, profileIdFromContexts)
+    }
+#endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
 }

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -234,8 +234,8 @@ class SentryTransactionTests: XCTestCase {
         let serialized = transaction.serialize()
         let contexts = try XCTUnwrap(serialized["contexts"] as? [String: Any])
         let trace = try XCTUnwrap(contexts["trace"] as? [String: Any])
-        let data = try XCTUnwrap(trace["data"] as? [String: String])
-        let profileIdFromContexts = try XCTUnwrap(data["profile_id"])
+        let data = try XCTUnwrap(trace["data"] as? [String: Any])
+        let profileIdFromContexts = try XCTUnwrap(data["profiler_id"] as? String)
         XCTAssertEqual(profileId, profileIdFromContexts)
     }
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -212,6 +212,16 @@ class SentryTransactionTests: XCTestCase {
         expect(metric["sum"] as? Double) == 1.0
     }
     
+    func testSerializedSpanData() throws {
+        let sut = fixture.getTransaction()
+        let serialized = sut.serialize()
+        let contexts = try XCTUnwrap(serialized["contexts"] as? [String: Any])
+        let trace = try XCTUnwrap(contexts["trace"] as? [String: Any])
+        let data = try XCTUnwrap(trace["data"] as? [String: Any])
+        XCTAssertNotNil(try XCTUnwrap(data["thread.id"]))
+        XCTAssertNotNil(try XCTUnwrap(data["thread.name"]))
+    }
+    
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     // test that when a trace runs concurrently with the continuous profiler
     // and is serialized to a transaction, that it contains the profile id at


### PR DESCRIPTION
Following along with #4009 , we also need the profile ID in each transaction (which just takes the id already recorded by the SentrySpan additions in that last PR when creating the transaction from the trace, which uses the span's logic as it's the superclass).

for #3555; #skip-changelog