### PR TITLE
ci: XLarge runner for Address Sanitizer UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -85,7 +85,7 @@ jobs:
 
   ui-tests-address-sanitizer:
     name: UI Tests with Address Sanitizer
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
 
     steps:
       - uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swift device:"iPhone 14 (17.2)" address_sanitizer:true && break ; done
+        run: fastlane ui_tests_ios_swift device:"iPhone 14 (17.2)" address_sanitizer:true
         shell: sh
 
       - name: Archiving Raw Test Logs

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -85,13 +85,14 @@ jobs:
 
   ui-tests-address-sanitizer:
     name: UI Tests with Address Sanitizer
+    # Enabling the address sanitizer is a bit more resource intensive. Therefore, we run it on a larger machine
+    # to reduce some flakiness.
     runs-on: macos-13-xlarge
 
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 15.2
 
-      # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
         run: fastlane ui_tests_ios_swift device:"iPhone 14 (17.2)" address_sanitizer:true
         shell: sh


### PR DESCRIPTION
The address sanitizer is a bit more resource-intensive, so the tests for UI frames sometimes fail.
We can avoid this problem by using a more powerful GH actions runner.

It turns out that there are still problems in the UI tests, which will be fixed by https://github.com/getsentry/sentry-cocoa/pull/4032. After merging https://github.com/getsentry/sentry-cocoa/pull/4032, we can merge those changes in here and validate if this PR still makes sense.

#skip-changelog