### PR TITLE
tests: Write test profile only when data exists

### DIFF
--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -329,11 +329,11 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
         return nil;
     }
 
-#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#    if defined(TEST) || defined(TESTCI)
     if (NSProcessInfo.processInfo.environment[@"io.sentry.ui-test.test-name"] != nil) {
         sentry_writeProfileFile(JSONData);
     }
-#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#    endif // defined(TEST) || defined(TESTCI)
 
     const auto header =
         [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfileChunk
@@ -385,9 +385,9 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(
         return nil;
     }
 
-#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#    if defined(TEST) || defined(TESTCI)
     sentry_writeProfileFile(JSONData);
-#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#    endif // defined(TEST) || defined(TESTCI)
 
     const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
                                                                 length:JSONData.length];

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -318,12 +318,6 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
 #    endif // SENTRY_HAS_UIKIT
         );
 
-#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
-    if (NSProcessInfo.processInfo.environment[@"io.sentry.ui-test.test-name"] != nil) {
-        sentry_writeProfileFile(payload);
-    }
-#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
-
     if (payload == nil) {
         SENTRY_LOG_DEBUG(@"Payload was empty, will not create a profiling envelope item.");
         return nil;
@@ -334,6 +328,12 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
         SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON.");
         return nil;
     }
+
+#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+    if (NSProcessInfo.processInfo.environment[@"io.sentry.ui-test.test-name"] != nil) {
+        sentry_writeProfileFile(JSONData);
+    }
+#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
     const auto header =
         [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfileChunk
@@ -365,10 +365,6 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(
 #    endif // SENTRY_HAS_UIKIT
     );
 
-#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
-    sentry_writeProfileFile(payload);
-#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
-
     if (payload == nil) {
         SENTRY_LOG_DEBUG(@"Payload was empty, will not create a profiling envelope item.");
         return nil;
@@ -388,6 +384,10 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(
         SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON.");
         return nil;
     }
+
+#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+    sentry_writeProfileFile(JSONData);
+#    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
     const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
                                                                 length:JSONData.length];

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -24,9 +24,8 @@ sentry_threadSanitizerIsPresent(void)
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
 
 void
-sentry_writeProfileFile(NSDictionary<NSString *, id> *payload)
+sentry_writeProfileFile(NSData *JSONData)
 {
-    NSData *data = [SentrySerialization dataWithJSONObject:payload];
     NSFileManager *fm = [NSFileManager defaultManager];
     NSString *testProfileDirPath =
         [sentryApplicationSupportPath() stringByAppendingPathComponent:@"profiles"];
@@ -64,7 +63,8 @@ sentry_writeProfileFile(NSDictionary<NSString *, id> *payload)
     }
 
     SENTRY_LOG_DEBUG(@"Writing profile to file: %@.", pathToWrite);
-    SENTRY_CASSERT([data writeToFile:pathToWrite options:NSDataWritingAtomic error:&error],
+
+    SENTRY_CASSERT([JSONData writeToFile:pathToWrite options:NSDataWritingAtomic error:&error],
         @"Failed to write data to path %@: %@", pathToWrite, error);
 }
 

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -23,7 +23,7 @@ SENTRY_EXTERN BOOL sentry_threadSanitizerIsPresent(void);
  * Write a file to application support containing the profile data. This is an affordance for UI
  * tests to be able to validate the contents of a profile.
  */
-SENTRY_EXTERN void sentry_writeProfileFile(NSDictionary<NSString *, id> *payload);
+SENTRY_EXTERN void sentry_writeProfileFile(NSData *JSONData);
 
 #    endif // defined(TEST) || defined(TESTCI) || defined(DEBUG)
 


### PR DESCRIPTION
Only write the test profile when the serialization succeeds. We had crashes in UI tests when trying to write empty serialized profile data, because the SENTRY_CASSERT failed. This PR avoids creating the profile paths and file when there is nothing to write.

I could reproduce the problem by running `TopViewControllerTests` locally. Now, the tests run smoothly.

The UI tests here failed because of other problems fixed with https://github.com/getsentry/sentry-cocoa/pull/4033.

#skip-changelog