### PR TITLE
fix: Scope addCrumb threading issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ to receive SIGTERM events, set the option `enableSigtermReporting = true`.
 ### Improvements
 
 - Stop FramesTracker when app is in background (#3979)
-- Speed up adding breadcrumbs (#4029)
+- Speed up adding breadcrumbs (#4029, #4034)
 - Skip evaluating log messages when not logged (#4028)
 
 ### Fixes

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -415,7 +415,55 @@ class SentryScopeSwiftTests: XCTestCase {
         // The number is kept small for the CI to not take too long.
         // If you really want to test this increase to 100_000 or so.
         testConcurrentModifications(asyncWorkItems: 2, writeLoopCount: 10, writeWork: { _ in
-            self.modifyScope(scope: scope)
+            
+            let key = "key"
+            
+            _ = Scope(scope: scope)
+            
+            for _ in 0...100 {
+                scope.addBreadcrumb(self.fixture.breadcrumb)
+            }
+            
+            scope.serialize()
+            scope.clearBreadcrumbs()
+            scope.addBreadcrumb(self.fixture.breadcrumb)
+            
+            scope.applyTo(session: SentrySession(releaseName: "1.0.0", distinctId: "some-id"))
+            
+            scope.setFingerprint(nil)
+            scope.setFingerprint(["finger", "print"])
+            
+            scope.setContext(value: ["some": "value"], key: key)
+            scope.removeContext(key: key)
+            
+            scope.setExtra(value: 1, key: key)
+            scope.removeExtra(key: key)
+            scope.setExtras(["value": "1", "value2": "2"])
+            
+            scope.applyTo(event: TestData.event, maxBreadcrumbs: 5)
+            
+            scope.setTag(value: "value", key: key)
+            scope.removeTag(key: key)
+            scope.setTags(["tag1": "hello", "tag2": "hello"])
+            
+            scope.addAttachment(TestData.fileAttachment)
+            scope.clearAttachments()
+            scope.addAttachment(TestData.fileAttachment)
+            
+            for _ in 0...10 {
+                scope.addBreadcrumb(self.fixture.breadcrumb)
+            }
+            scope.serialize()
+            
+            scope.setUser(self.fixture.user)
+            scope.setDist("dist")
+            scope.setEnvironment("env")
+            scope.setLevel(SentryLevel.debug)
+            
+            scope.applyTo(session: SentrySession(releaseName: "1.0.0", distinctId: "some-id"))
+            scope.applyTo(event: TestData.event, maxBreadcrumbs: 5)
+            
+            scope.serialize()
         })
     }
     
@@ -687,56 +735,5 @@ class SentryScopeSwiftTests: XCTestCase {
         func setUser(_ user: User?) {
             self.user = user
         }
-    }
-
-    private func modifyScope(scope: Scope) {
-        let key = "key"
-        
-        _ = Scope(scope: scope)
-        
-        for _ in 0...100 {
-            scope.addBreadcrumb(self.fixture.breadcrumb)
-        }
-        
-        scope.serialize()
-        scope.clearBreadcrumbs()
-        scope.addBreadcrumb(self.fixture.breadcrumb)
-        
-        scope.applyTo(session: SentrySession(releaseName: "1.0.0", distinctId: "some-id"))
-        
-        scope.setFingerprint(nil)
-        scope.setFingerprint(["finger", "print"])
-        
-        scope.setContext(value: ["some": "value"], key: key)
-        scope.removeContext(key: key)
-        
-        scope.setExtra(value: 1, key: key)
-        scope.removeExtra(key: key)
-        scope.setExtras(["value": "1", "value2": "2"])
-        
-        scope.applyTo(event: TestData.event, maxBreadcrumbs: 5)
-        
-        scope.setTag(value: "value", key: key)
-        scope.removeTag(key: key)
-        scope.setTags(["tag1": "hello", "tag2": "hello"])
-        
-        scope.addAttachment(TestData.fileAttachment)
-        scope.clearAttachments()
-        scope.addAttachment(TestData.fileAttachment)
-        
-        for _ in 0...10 {
-            scope.addBreadcrumb(self.fixture.breadcrumb)
-        }
-        scope.serialize()
-        
-        scope.setUser(self.fixture.user)
-        scope.setDist("dist")
-        scope.setEnvironment("env")
-        scope.setLevel(SentryLevel.debug)
-        
-        scope.applyTo(session: SentrySession(releaseName: "1.0.0", distinctId: "some-id"))
-        scope.applyTo(event: TestData.event, maxBreadcrumbs: 5)
-        
-        scope.serialize()
     }
 }


### PR DESCRIPTION


## :scroll: Description

The SentryScopeTest.testModifyingFromMultipleThreads was failing frequently in CI, because of some threading issues introduced with #4029. This is fixed now by not swapping the array reference and other minor improvements.

## :bulb: Motivation and Context

`SentryScopeTest.testModifyingFromMultipleThreads` was failing frequently in CI.

## :green_heart: How did you test it?
Running the `SentryScopeTest.testModifyingFromMultipleThreads` locally.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
