### PR TITLE
feat: Add enableMetricKitRawPayload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add enableMetricKitAttachments (#4044)
+
 ## 8.28.0
 
 ### Features
+
 - Add replay quality option (#4035)
 
 ## 8.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add enableMetricKitAttachments (#4044)
+- Add enableMetricKitRawPayload (#4044)
 
 ## 8.28.0
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -35,6 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             if #available(iOS 15.0, *) {
                 options.enableMetricKit = true
+                options.enableMetricKitAttachments = true
             }
             
             let args = ProcessInfo.processInfo.arguments

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -35,7 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             
             if #available(iOS 15.0, *) {
                 options.enableMetricKit = true
-                options.enableMetricKitAttachments = true
+                options.enableMetricKitRawPayload = true
             }
             
             let args = ProcessInfo.processInfo.arguments

--- a/Samples/iOS-Swift/iOS-Swift/Tools/MetricKitManager.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/MetricKitManager.swift
@@ -25,16 +25,5 @@ class MetricKitManager: NSObject, MXMetricManagerSubscriber {
             attachments.forEach { scope.addAttachment($0) }
         }
     }
-    
-    func didReceive(_ payloads: [MXDiagnosticPayload]) {
-        var attachments: [Attachment] = []
-        for payload in payloads {
-            let attachment = Attachment(data: payload.jsonRepresentation(), filename: "MXDiagnosticPayload.json")
-            attachments.append(attachment)
-        }
-        
-        SentrySDK.capture(message: "MetricKit received MXDiagnosticPayload.") { scope in
-            attachments.forEach { scope.addAttachment($0) }
-        }
-    }
+
 }

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -577,7 +577,7 @@ NS_SWIFT_NAME(Options)
  *
  * @note Default value is @c NO.
  */
-@property (nonatomic, assign) BOOL enableMetricKitAttachments API_AVAILABLE(
+@property (nonatomic, assign) BOOL enableMetricKitRawPayload API_AVAILABLE(
     ios(15.0), macos(12.0), macCatalyst(15.0)) API_UNAVAILABLE(tvos, watchos);
 
 #endif // SENTRY_HAS_METRIC_KIT

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -571,6 +571,15 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableMetricKit API_AVAILABLE(
     ios(15.0), macos(12.0), macCatalyst(15.0)) API_UNAVAILABLE(tvos, watchos);
 
+/**
+ * When enabled, the SDK adds the raw MXDiagnosticPayloads as an attachment to the converted
+ * SentryEvent. You need to enable @c enableMetricKit for this flag to work.
+ *
+ * @note Default value is @c NO.
+ */
+@property (nonatomic, assign) BOOL enableMetricKitAttachments API_AVAILABLE(
+    ios(15.0), macos(12.0), macCatalyst(15.0)) API_UNAVAILABLE(tvos, watchos);
+
 #endif // SENTRY_HAS_METRIC_KIT
 
 /**

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -71,7 +71,7 @@ SentryMetricKitIntegration ()
     self.measurementFormatter.unitOptions = NSMeasurementFormatterUnitOptionsProvidedUnit;
     self.inAppLogic = [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
                                                         inAppExcludes:options.inAppExcludes];
-    self.attachDiagnosticAsAttachment = options.enableMetricKitAttachments;
+    self.attachDiagnosticAsAttachment = options.enableMetricKitRawPayload;
 
     return YES;
 }

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -6,6 +6,7 @@
 #    import "SentryOptions.h"
 #    import "SentryScope.h"
 #    import <Foundation/Foundation.h>
+#    import <SentryAttachment.h>
 #    import <SentryDebugMeta.h>
 #    import <SentryDependencyContainer.h>
 #    import <SentryEvent.h>
@@ -50,6 +51,7 @@ SentryMetricKitIntegration ()
 @property (nonatomic, strong, nullable) SentryMXManager *metricKitManager;
 @property (nonatomic, strong) NSMeasurementFormatter *measurementFormatter;
 @property (nonatomic, strong) SentryInAppLogic *inAppLogic;
+@property (nonatomic, assign) BOOL attachDiagnosticAsAttachment;
 
 @end
 
@@ -69,6 +71,7 @@ SentryMetricKitIntegration ()
     self.measurementFormatter.unitOptions = NSMeasurementFormatterUnitOptionsProvidedUnit;
     self.inAppLogic = [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
                                                         inAppExcludes:options.inAppExcludes];
+    self.attachDiagnosticAsAttachment = options.enableMetricKitAttachments;
 
     return YES;
 }
@@ -107,7 +110,9 @@ SentryMetricKitIntegration ()
     params.exceptionMechanism = @"MXCrashDiagnostic";
     params.timeStampBegin = timeStampBegin;
 
-    [self captureMXEvent:callStackTree params:params];
+    [self captureMXEvent:callStackTree
+                  params:params
+          diagnosticJSON:[diagnostic JSONRepresentation]];
 }
 
 - (void)didReceiveCpuExceptionDiagnostic:(MXCPUExceptionDiagnostic *)diagnostic
@@ -142,7 +147,9 @@ SentryMetricKitIntegration ()
     params.exceptionMechanism = SentryMetricKitCpuExceptionMechanism;
     params.timeStampBegin = timeStampBegin;
 
-    [self captureMXEvent:callStackTree params:params];
+    [self captureMXEvent:callStackTree
+                  params:params
+          diagnosticJSON:[diagnostic JSONRepresentation]];
 }
 
 - (void)didReceiveDiskWriteExceptionDiagnostic:(MXDiskWriteExceptionDiagnostic *)diagnostic
@@ -167,7 +174,9 @@ SentryMetricKitIntegration ()
     params.exceptionMechanism = SentryMetricKitDiskWriteExceptionMechanism;
     params.timeStampBegin = timeStampBegin;
 
-    [self captureMXEvent:callStackTree params:params];
+    [self captureMXEvent:callStackTree
+                  params:params
+          diagnosticJSON:[diagnostic JSONRepresentation]];
 }
 
 - (void)didReceiveHangDiagnostic:(MXHangDiagnostic *)diagnostic
@@ -189,11 +198,14 @@ SentryMetricKitIntegration ()
     params.exceptionMechanism = SentryMetricKitHangDiagnosticMechanism;
     params.timeStampBegin = timeStampBegin;
 
-    [self captureMXEvent:callStackTree params:params];
+    [self captureMXEvent:callStackTree
+                  params:params
+          diagnosticJSON:[diagnostic JSONRepresentation]];
 }
 
 - (void)captureMXEvent:(SentryMXCallStackTree *)callStackTree
                 params:(SentryMXExceptionParams *)params
+        diagnosticJSON:(NSData *)diagnosticJSON
 {
     // When receiving MXCrashDiagnostic the callStackPerThread was always true. In that case, the
     // MXCallStacks of the MXCallStackTree were individual threads, all belonging to the process
@@ -217,10 +229,12 @@ SentryMetricKitIntegration ()
 
         // The crash event can be way from the past. We don't want to impact the current session.
         // Therefore we don't call captureCrashEvent.
-        [SentrySDK captureEvent:event];
+        [self captureEvent:event withDiagnosticJSON:diagnosticJSON];
     } else {
         for (SentryMXCallStack *callStack in callStackTree.callStacks) {
-            [self buildAndCaptureMXEventFor:callStack.callStackRootFrames params:params];
+            [self buildAndCaptureMXEventFor:callStack.callStackRootFrames
+                                     params:params
+                             diagnosticJSON:diagnosticJSON];
         }
     }
 }
@@ -284,6 +298,7 @@ SentryMetricKitIntegration ()
  */
 - (void)buildAndCaptureMXEventFor:(NSArray<SentryMXFrame *> *)rootFrames
                            params:(SentryMXExceptionParams *)params
+                   diagnosticJSON:(NSData *)diagnosticJSON
 {
     for (SentryMXFrame *rootFrame in rootFrames) {
         NSMutableArray<SentryMXFrame *> *stackTraceFrames = [NSMutableArray array];
@@ -311,7 +326,9 @@ SentryMetricKitIntegration ()
             BOOL noChildren = currentFrame.subFrames.count == 0;
 
             if (noChildren && lastUnprocessedSibling) {
-                [self captureEventNotPerThread:stackTraceFrames params:params];
+                [self captureEventNotPerThread:stackTraceFrames
+                                        params:params
+                                diagnosticJSON:diagnosticJSON];
 
                 if (parentFrame == nil) {
                     // No parent frames
@@ -355,6 +372,7 @@ SentryMetricKitIntegration ()
 
 - (void)captureEventNotPerThread:(NSArray<SentryMXFrame *> *)frames
                           params:(SentryMXExceptionParams *)params
+                  diagnosticJSON:(NSData *)diagnosticJSON
 {
     SentryEvent *event = [self createEvent:params];
 
@@ -369,7 +387,7 @@ SentryMetricKitIntegration ()
     event.threads = @[ thread ];
     event.debugMeta = [self extractDebugMetaFromMXFrames:frames];
 
-    [SentrySDK captureEvent:event];
+    [self captureEvent:event withDiagnosticJSON:diagnosticJSON];
 }
 
 - (SentryEvent *)createEvent:(SentryMXExceptionParams *)params
@@ -386,6 +404,21 @@ SentryMetricKitIntegration ()
     event.exceptions = @[ exception ];
 
     return event;
+}
+
+- (void)captureEvent:(SentryEvent *)event withDiagnosticJSON:(NSData *)diagnosticJSON
+{
+    if (self.attachDiagnosticAsAttachment) {
+        [SentrySDK captureEvent:event
+                 withScopeBlock:^(SentryScope *_Nonnull scope) {
+                     SentryAttachment *attachment =
+                         [[SentryAttachment alloc] initWithData:diagnosticJSON
+                                                       filename:@"MXDiagnosticPayload.json"];
+                     [scope addAttachment:attachment];
+                 }];
+    } else {
+        [SentrySDK captureEvent:event];
+    }
 }
 
 - (NSArray<SentryThread *> *)convertToSentryThreads:(SentryMXCallStackTree *)callStackTree

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -197,7 +197,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 #if SENTRY_HAS_METRIC_KIT
         if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {
             self.enableMetricKit = NO;
-            self.enableMetricKitAttachments = NO;
+            self.enableMetricKitRawPayload = NO;
         }
 #endif // SENTRY_HAS_METRIC_KIT
     }
@@ -523,8 +523,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
     if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
         [self setBool:options[@"enableMetricKit"]
                 block:^(BOOL value) { self->_enableMetricKit = value; }];
-        [self setBool:options[@"enableMetricKitAttachments"]
-                block:^(BOOL value) { self->_enableMetricKitAttachments = value; }];
+        [self setBool:options[@"enableMetricKitRawPayload"]
+                block:^(BOOL value) { self->_enableMetricKitRawPayload = value; }];
     }
 #endif // SENTRY_HAS_METRIC_KIT
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -197,6 +197,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 #if SENTRY_HAS_METRIC_KIT
         if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {
             self.enableMetricKit = NO;
+            self.enableMetricKitAttachments = NO;
         }
 #endif // SENTRY_HAS_METRIC_KIT
     }
@@ -522,6 +523,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
     if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
         [self setBool:options[@"enableMetricKit"]
                 block:^(BOOL value) { self->_enableMetricKit = value; }];
+        [self setBool:options[@"enableMetricKitAttachments"]
+                block:^(BOOL value) { self->_enableMetricKitAttachments = value; }];
     }
 #endif // SENTRY_HAS_METRIC_KIT
 

--- a/Sources/Swift/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/MetricKit/SentryMXManager.swift
@@ -56,7 +56,9 @@ import MetricKit
         }
         
         payloads.forEach { payload in
+            
             payload.crashDiagnostics?.forEach { diagnostic in
+                
                 if disableCrashDiagnostics {
                     return
                 }

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -85,6 +85,25 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         }
     }
     
+    func testAttachDiagnosticAsAttachment() throws {
+        if #available(iOS 15, macOS 12, macCatalyst 15, *) {
+            givenSDKWithHubWithScope()
+            
+            let sut = SentryMetricKitIntegration()
+            givenInstalledWithEnabled(sut) { $0.enableMetricKitAttachments = true }
+            
+            let mxDelegate = sut as SentryMXManagerDelegate
+            let diagnostic = MXCrashDiagnostic()
+            mxDelegate.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
+            
+            assertEventWithScopeCaptured { _, scope, _ in
+                let diagnosticAttachment = scope?.attachments.first { $0.filename == "MXDiagnosticPayload.json" }
+                
+                XCTAssertEqual(diagnosticAttachment?.data, diagnostic.jsonRepresentation())
+            }
+        }
+    }
+    
     func testSetInAppIncludes_AppliesInAppToStackTrace() throws {
         if #available(iOS 15, macOS 12, macCatalyst 15, *) {
             givenSDKWithHubWithScope()

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -90,7 +90,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             givenSDKWithHubWithScope()
             
             let sut = SentryMetricKitIntegration()
-            givenInstalledWithEnabled(sut) { $0.enableMetricKitAttachments = true }
+            givenInstalledWithEnabled(sut) { $0.enableMetricKitRawPayload = true }
             
             let mxDelegate = sut as SentryMXManagerDelegate
             let diagnostic = MXCrashDiagnostic()

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -104,6 +104,24 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         }
     }
     
+    func testDontAttachDiagnosticAsAttachment() throws {
+        if #available(iOS 15, macOS 12, macCatalyst 15, *) {
+            givenSDKWithHubWithScope()
+            
+            let sut = SentryMetricKitIntegration()
+            
+            let mxDelegate = sut as SentryMXManagerDelegate
+            let diagnostic = MXCrashDiagnostic()
+            mxDelegate.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
+            
+            assertEventWithScopeCaptured { _, scope, _ in
+                let diagnosticAttachment = scope?.attachments.first { $0.filename == "MXDiagnosticPayload.json" }
+                
+                XCTAssertNil(diagnosticAttachment)
+            }
+        }
+    }
+    
     func testSetInAppIncludes_AppliesInAppToStackTrace() throws {
         if #available(iOS 15, macOS 12, macCatalyst 15, *) {
             givenSDKWithHubWithScope()

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -659,7 +659,7 @@
 #if SENTRY_HAS_METRIC_KIT
     if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {
         XCTAssertEqual(NO, options.enableMetricKit);
-        XCTAssertEqual(NO, options.enableMetricKitAttachments);
+        XCTAssertEqual(NO, options.enableMetricKitRawPayload);
     }
 #endif
 
@@ -850,10 +850,10 @@
     }
 }
 
-- (void)testEnableMetricKitAttachments
+- (void)testenableMetricKitRawPayload
 {
     if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
-        [self testBooleanField:@"enableMetricKitAttachments" defaultValue:NO];
+        [self testBooleanField:@"enableMetricKitRawPayload" defaultValue:NO];
     }
 }
 #endif

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -659,6 +659,7 @@
 #if SENTRY_HAS_METRIC_KIT
     if (@available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)) {
         XCTAssertEqual(NO, options.enableMetricKit);
+        XCTAssertEqual(NO, options.enableMetricKitAttachments);
     }
 #endif
 
@@ -846,6 +847,13 @@
 {
     if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
         [self testBooleanField:@"enableMetricKit" defaultValue:NO];
+    }
+}
+
+- (void)testEnableMetricKitAttachments
+{
+    if (@available(iOS 14.0, macOS 12.0, macCatalyst 14.0, *)) {
+        [self testBooleanField:@"enableMetricKitAttachments" defaultValue:NO];
     }
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

When enableMetricKitRawPayload is enabled, the SDK adds the raw MXDiagnosticPayloads as an attachment to the converted SentryEvent.

Docs PR https://github.com/getsentry/sentry-docs/pull/10334.

## :bulb: Motivation and Context

It's extremely hard to debug https://github.com/getsentry/sentry-cocoa/issues/4040 without the raw payload. Furthermore, for some users, the raw MetricKit payload could be valuable.

## :green_heart: How did you test it?
Unit tests and sample app.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
