### PR TITLE
ci: Remove macos-11 runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,20 +77,6 @@ jobs:
       matrix:
         # Can't run tests on watchOS because XCTest is not available
         include:
-          # iOS 13.7
-          - runs-on: macos-11
-            platform: "iOS"
-            xcode: "13.2.1"
-            test-destination-os: "13.7"
-            device: "iPhone 8"
-
-          # iOS 14
-          - runs-on: macos-11
-            platform: "iOS"
-            xcode: "13.2.1"
-            test-destination-os: "14.5"
-            device: "iPhone 8"
-
           # iOS 15
           - runs-on: macos-12
             platform: "iOS"
@@ -111,12 +97,6 @@ jobs:
             xcode: "15.2"
             test-destination-os: "17.2"
             device: "iPhone 15"
-
-          # macOS 11
-          - runs-on: macos-11
-            platform: "macOS"
-            xcode: "13.2.1"
-            test-destination-os: "latest"
 
           # macOS 12
           - runs-on: macos-12
@@ -179,14 +159,6 @@ jobs:
         run: curl http://localhost:8080/echo-baggage-header
 
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
-
-      - name: Prepare iOS 13.7 simulator
-        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '13.7'}}
-        run: ./scripts/create-simulator.sh 11.7 13.7 13-7
-
-      - name: Prepare iOS 14.5 simulator
-        if: ${{ matrix.platform == 'iOS' && matrix.test-destination-os == '14.5'}}
-        run: ./scripts/create-simulator.sh 12.5.1 14.5 14-5
 
       - name: Install Slather
         run: gem install slather

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -113,10 +113,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-11
-            xcode: "13.2.1"
-            device: "iPhone 8 (13.7)"
-          
           - runs-on: macos-12
             xcode: "13.4.1"
             device: "iPhone 8 (15.5)"
@@ -132,10 +128,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
-
-      - name: Create iOS 13.7 simulator
-        if: ${{ matrix.device == 'iPhone 8 (13.7)' }}
-        run: ./scripts/create-simulator.sh 11.7 13.7 13-7
 
       - name: Create iOS 16.4 simulator
         if: ${{ matrix.device == 'iPhone 14 (16.4)' }}

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # For available Xcode versions see:
-# - https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md#xcode
 # - https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
 # - https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
 # - https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md


### PR DESCRIPTION
[GH will deprecate the macos-11](https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal) runners by the end of June 2043. We have to remove them.



#skip-changelog