### PR TITLE
Update SentryCrashMonitor_CPPException.cpp to include `exception`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Add enableMetricKitRawPayload (#4044)
 
+### Fixes
+- `SentryCrashMonitor_CPPException.cpp` compilation using Xcode 16b1 (#4051)
+
 ## 8.28.0
 
 ### Features

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <typeinfo>
+#include <exception>
 
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000


### PR DESCRIPTION
## :scroll: Description

Update SentryCrashMonitor_CPPException.cpp to include `exception`

## :bulb: Motivation and Context

Why is this change required? What problem does it solve?
To support compilation with Xcode 16b1.

If it fixes an open issue, please link to the issue here.
https://github.com/getsentry/sentry-cocoa/issues/4050

## :green_heart: How did you test it?
Building with Xcode 15.4 and Xcode 16b1
## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes. **(I don't know how to)**
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
People try the fix to make sure it doesn't break builds for existing Xcode versions.