### PR TITLE
fix: remove dead property/accessor/setter that seem to be duplicates of that in SentryCrash

### DIFF
--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.h
@@ -39,14 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SentryCrashInstallation : NSObject
 
-/** C Function to call during a crash report to give the callee an opportunity
- * to add to the report. NULL = ignore.
- *
- * WARNING: Only call async-safe functions from this function! DO NOT call
- * Objective-C methods!!!
- */
-@property (atomic, readwrite, assign) SentryCrashReportWriteCallback onCrash;
-
 /** Install this installation. Call this instead of -[SentryCrash install] to
  * install with everything needed for your particular backend.
  */

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -165,20 +165,6 @@ SentryCrashInstallation ()
     return result;
 }
 
-- (SentryCrashReportWriteCallback)onCrash
-{
-    @synchronized(self) {
-        return self.crashHandlerData->userCrashCallback;
-    }
-}
-
-- (void)setOnCrash:(SentryCrashReportWriteCallback)onCrash
-{
-    @synchronized(self) {
-        self.crashHandlerData->userCrashCallback = onCrash;
-    }
-}
-
 - (void)install:(NSString *)customCacheDirectory
 {
     SentryCrash *handler = SentryDependencyContainer.sharedInstance.crashReporter;


### PR DESCRIPTION
Noticed while investigating something in the crash reporter. None of these appear in the static call graph or via textual search.

There is a parallel version at https://github.com/getsentry/sentry-cocoa/blob/d9280eec4f311096709ba84fc6a5d04423503c6c/Sources/SentryCrash/Recording/SentryCrash.h#L141 that is actually used.

Validated that crash reports are still sent using the iOS-Swift button to test a crash and checking the dashboard.

#skip-changelog