### PR TITLE
fix(profiling): various fixes needed for chunk envelopes to validate

### DIFF
--- a/Sources/Sentry/Profiling/SentryProfilerState.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerState.mm
@@ -149,8 +149,8 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
 
         const auto sample = [[SentrySample alloc] init];
         sample.absoluteTimestamp = backtrace.absoluteTimestamp;
-        sample.absoluteNSDateInterval = SentryDependencyContainer.sharedInstance.dateProvider.date
-                                            .timeIntervalSinceReferenceDate;
+        sample.absoluteNSDateInterval
+            = SentryDependencyContainer.sharedInstance.dateProvider.date.timeIntervalSince1970;
         sample.threadID = backtrace.threadMetadata.threadID;
 
         const auto stackKey = [stack componentsJoinedByString:@"|"];

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -202,9 +202,8 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
     NSDate *thisFrameNSDate = self.dateProvider.date;
     BOOL isContinuousProfiling = [SentryContinuousProfiler isCurrentlyProfiling];
-    NSNumber *profilingTimestamp = isContinuousProfiling
-        ? @(thisFrameNSDate.timeIntervalSinceReferenceDate)
-        : @(thisFrameSystemTimestamp);
+    NSNumber *profilingTimestamp = isContinuousProfiling ? @(thisFrameNSDate.timeIntervalSince1970)
+                                                         : @(thisFrameSystemTimestamp);
     if ([SentryTraceProfiler isCurrentlyProfiling] || isContinuousProfiling) {
         BOOL hasNoFrameRatesYet = self.frameRateTimestamps.count == 0;
         uint64_t previousFrameRate

--- a/Sources/Sentry/SentryMetricProfiler.mm
+++ b/Sources/Sentry/SentryMetricProfiler.mm
@@ -297,7 +297,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
     reading.value = value;
     const auto dateProvider = SentryDependencyContainer.sharedInstance.dateProvider;
     reading.absoluteSystemTimestamp = dateProvider.systemTime;
-    reading.absoluteNSDateInterval = dateProvider.date.timeIntervalSinceReferenceDate;
+    reading.absoluteNSDateInterval = dateProvider.date.timeIntervalSince1970;
     return reading;
 }
 


### PR DESCRIPTION
After pairing up with @phacops and @Zylphrex , we identified a few changes needed to get continuous profiling chunk envelopes accepted by the backend.

- we need to use standard unix epoch instead of apple's newer reference date
- need GPU value units to be correctly stated as nanoseconds (mistakenly changed it to "milliseconds" when changing the _timestamps_ to a non-nanosecond-integer value)
- need the envelope header ID (which is also injected as the event ID) to be the same as the chunk ID 

for #3555; #skip-changelog