### PR TITLE
fix: remove unused DSN property in SentryNSURLRequest

### DIFF
--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -17,13 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 NSString *const SentryServerVersionString = @"7";
 NSTimeInterval const SentryRequestTimeout = 15;
 
-@interface
-SentryNSURLRequest ()
-
-@property (nonatomic, strong) SentryDsn *dsn;
-
-@end
-
 @implementation SentryNSURLRequest
 
 - (_Nullable instancetype)initStoreRequestWithDsn:(SentryDsn *)dsn


### PR DESCRIPTION
Noticed this while debugging some network requests: I saw this _dsn ivar that was always nil. Turns out this prop is never used, the DSN is only a method parameter used in those method impls.

#skip-changelog