### PR TITLE
test: add more schema launch args and env vars to allow selectively enabling more sdk features

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -11,7 +11,7 @@ class BaseUITest: XCTestCase {
         super.setUp()
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
-        app.launchEnvironment["io.sentry.sdk-environment"] = "ui-tests"
+        app.launchEnvironment["--io.sentry.sdk-environment"] = "ui-tests"
         if automaticallyLaunchAndTerminateApp {
             launchApp()
         }
@@ -28,7 +28,7 @@ class BaseUITest: XCTestCase {
 extension BaseUITest {
     func newAppSession() -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchEnvironment["io.sentry.ui-test.test-name"] = name
+        app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
         return app
     }
     

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -74,6 +74,26 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--disable-spotlight"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--disable-automatic-session-tracking"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--disable-metrics"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--disable-metrickit-integration"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--disable-session-replay"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--io.sentry.enableContinuousProfiling"
             isEnabled = "YES">
          </CommandLineArgument>
@@ -156,6 +176,16 @@
          </EnvironmentVariable>
          <EnvironmentVariable
             key = "--io.sentry.profilesSamplerValue"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "--io.sentry.sdk-environment"
+            value = ""
+            isEnabled = "NO">
+         </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "--io.sentry.dsn"
             value = ""
             isEnabled = "NO">
          </EnvironmentVariable>

--- a/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
@@ -25,7 +25,7 @@ class ExtraViewController: UIViewController {
             }
         }
 
-        if let uiTestName = ProcessInfo.processInfo.environment["io.sentry.ui-test.test-name"] {
+        if let uiTestName = ProcessInfo.processInfo.environment["--io.sentry.ui-test.test-name"] {
             uiTestNameLabel.text = uiTestName
         }
         

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -330,7 +330,8 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
     }
 
 #    if defined(TEST) || defined(TESTCI)
-    if (NSProcessInfo.processInfo.environment[@"io.sentry.ui-test.test-name"] != nil) {
+    // only write profile payloads to disk for UI tests
+    if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] != nil) {
         sentry_writeProfileFile(JSONData);
     }
 #    endif // defined(TEST) || defined(TESTCI)

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -63,7 +63,7 @@ sentry_manageTraceProfilerOnStartSDK(SentryOptions *options, SentryHub *hub)
 {
 #    if defined(TEST) || defined(TESTCI)
     // we want to allow starting a launch profile from here for UI tests, but not unit tests
-    if (NSProcessInfo.processInfo.environment[@"io.sentry.ui-test.test-name"] == nil) {
+    if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] == nil) {
         return;
     }
 #    endif // defined(TEST) || defined(TESTCI)


### PR DESCRIPTION
I needed to be able to easily disable other SDK features while debugging profiling network requests, so I added more launch args and environment variables to help zero in on exactly what I needed.

Also cleaned up a few that were previously added.

#skip-changelog