### PR TITLE
fix: reimplement crash logs written to file on disk

### DIFF
--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
@@ -41,7 +41,6 @@
 
 #include <memory.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
@@ -31,7 +31,6 @@
 #include "SentryCrashJSONCodec.h"
 #include "SentryCrashMonitorContext.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -30,7 +30,6 @@
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashThread.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <cxxabi.h>

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -34,7 +34,6 @@
 #include "SentryCrashThread.h"
 #include "SentryInternalCDefines.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #if SentryCrashCRASH_HAS_MACH

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -33,7 +33,6 @@
 #include "SentryCrashThread.h"
 #import "SentryDependencyContainer.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -33,7 +33,6 @@
 #include "SentryCrashStackCursor_MachineContext.h"
 #include "SentryCrashSystemCapabilities.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #if SentryCrashCRASH_HAS_SIGNAL

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -34,7 +34,6 @@
 #import "SentryCrashSysCtl.h"
 #import "SentryCrashSystemCapabilities.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 #import "SentryDefines.h"

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -42,7 +42,6 @@
 #import "SentryNSNotificationCenterWrapper.h"
 #import <SentryNSDataUtils.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -54,6 +54,10 @@
 /** True if SentryCrash has been installed. */
 static volatile bool g_installed = 0;
 
+#if SentryCrashLogger_CBufferSize > 0
+static char g_consoleLogPath[SentryCrashFU_MAX_PATH_LENGTH];
+#endif // SentryCrashLogger_CBufferSize > 0
+
 static SentryCrashMonitorType g_monitoring = SentryCrashMonitorTypeProductionSafeMinimal;
 static char g_lastCrashReportFilePath[SentryCrashFU_MAX_PATH_LENGTH];
 static void (*g_saveScreenShot)(const char *) = 0;
@@ -76,6 +80,10 @@ onCrash(struct SentryCrash_MonitorContext *monitorContext)
 {
     SentryCrashLOG_DEBUG("Updating application state to note crash.");
     sentrycrashstate_notifyAppCrash();
+
+#if SentryCrashLogger_CBufferSize > 0
+    monitorContext->consoleLogPath = g_consoleLogPath;
+#endif // SentryCrashLogger_CBufferSize > 0
 
     if (monitorContext->crashedDuringCrashHandling) {
         sentrycrashreport_writeRecrashReport(monitorContext, g_lastCrashReportFilePath);
@@ -133,6 +141,11 @@ sentrycrash_install(const char *appName, const char *const installPath)
     sentrycrashfu_makePath(path);
     snprintf(path, sizeof(path), "%s/Data/CrashState.json", installPath);
     sentrycrashstate_initialize(path);
+
+#if SentryCrashLogger_CBufferSize > 0
+    snprintf(g_consoleLogPath, sizeof(g_consoleLogPath), "%s/Data/ConsoleLog.txt", installPath);
+    sentrycrashlog_setLogFilename(g_consoleLogPath, true);
+#endif // SentryCrashLogger_CBufferSize > 0
 
     sentrycrashccd_init(60);
 

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -39,7 +39,6 @@
 #include "SentryCrashString.h"
 #include "SentryCrashSystemCapabilities.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <inttypes.h>

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.c
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.c
@@ -26,7 +26,6 @@
 #include "SentryCrashCachedData.h"
 #include "SentryInternalCDefines.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -48,7 +48,6 @@
 #include "SentryCrashUUIDConversion.h"
 #include "SentryScopeSyncC.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU.c
@@ -32,7 +32,6 @@
 #include <mach-o/arch.h>
 #include <mach/mach.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 const char *

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm.c
@@ -33,7 +33,6 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = { "r0", "r1", "r2", "r3", "r4", "r5", "r6", "r7", "r8", "r9",

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_arm64.c
@@ -33,7 +33,6 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 #    define KSPACStrippingMask_ARM64e 0x0000000fffffffff

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_32.c
@@ -33,7 +33,6 @@
 #    include "SentryCrashMachineContext_Apple.h"
 #    include <stdlib.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCPU_x86_64.c
@@ -34,7 +34,6 @@
 
 #    include <stdlib.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #    include "SentryCrashLogger.h"
 
 static const char *g_registerNames[] = { "rax", "rbx", "rcx", "rdx", "rdi", "rsi", "rbp", "rsp",

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDebug.c
@@ -27,7 +27,6 @@
 
 #include "SentryCrashDebug.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -27,7 +27,6 @@
 
 #include "SentryCrashFileUtils.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <dirent.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
@@ -43,19 +43,6 @@
 #define likely_if(x) if (__builtin_expect(x, 1))
 #define unlikely_if(x) if (__builtin_expect(x, 0))
 
-/** The buffer size to use when writing log entries.
- *
- * If this value is > 0, any log entries that expand beyond this length will
- * be truncated.
- * If this value = 0, the logging system will dynamically allocate memory
- * and never truncate. However, the log functions won't be async-safe.
- *
- * Unless you're logging from within signal handlers, it's safe to set it to 0.
- */
-#ifndef SentryCrashLOGGER_CBufferSize
-#    define SentryCrashLOGGER_CBufferSize 1024
-#endif
-
 /** Where console logs will be written */
 static char g_logFilename[1024];
 
@@ -93,7 +80,7 @@ writeFmtToLog(const char *fmt, ...)
     va_end(args);
 }
 
-#if SentryCrashLOGGER_CBufferSize > 0
+#if SentryCrashLogger_CBufferSize > 0
 
 /** The file descriptor where log entries get written. */
 static int g_fd = -1;
@@ -120,7 +107,7 @@ writeFmtArgsToLog(const char *fmt, va_list args)
     unlikely_if(fmt == NULL) { writeToLog("(null)"); }
     else
     {
-        char buffer[SentryCrashLOGGER_CBufferSize];
+        char buffer[SentryCrashLogger_CBufferSize];
         vsnprintf(buffer, sizeof(buffer), fmt, args);
         writeToLog(buffer);
     }
@@ -205,7 +192,7 @@ flushLog(void)
     fflush(g_file);
 }
 
-#endif
+#endif // if SentryCrashLogger_CBufferSize <= 0
 
 // ===========================================================================
 #pragma mark - C -

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.h
@@ -129,114 +129,138 @@
  * ===============
  *
  * The C logger changes its behavior depending on the value of the preprocessor
- * define SentryCrashLogger_CBufferSize.
+ * define @c SentryCrashLogger_CBufferSize.
  *
- * If SentryCrashLogger_CBufferSize is > 0, the C logger will behave in an
+ * If @c SentryCrashLogger_CBufferSize is > 0, the C logger will behave in an
  * async-safe manner, calling write() instead of printf(). Any log messages that
  * exceed the length specified by SentryCrashLogger_CBufferSize will be
  * truncated.
  *
- * If SentryCrashLogger_CBufferSize == 0, the C logger will use printf(), and
+ * If @c SentryCrashLogger_CBufferSize == 0, the C logger will use printf(), and
  * there will be no limit on the log message length.
  *
- * SentryCrashLogger_CBufferSize can only be set as a preprocessor define, and
+ * @c SentryCrashLogger_CBufferSize can only be set as a preprocessor define, and
  * will default to 1024 if not specified during compilation.
  */
+
+/** The buffer size to use when writing log entries.
+ *
+ * If this value is > 0, any log entries that expand beyond this length will
+ * be truncated.
+ * If this value = 0, the logging system will dynamically allocate memory
+ * and never truncate. However, the log functions won't be async-safe.
+ *
+ * Unless you're logging from within signal handlers, it's safe to set it to 0.
+ */
+#ifndef SentryCrashLogger_CBufferSize
+#define SentryCrashLogger_CBufferSize 1024
+#endif
 
 // ============================================================================
 #pragma mark - (internal) -
 // ============================================================================
 
 #ifndef HDR_SentryCrashLogger_h
-#    define HDR_SentryCrashLogger_h
+#define HDR_SentryCrashLogger_h
 
-#    ifdef __cplusplus
+#ifdef __cplusplus
 extern "C" {
-#    endif
+#endif
 
-#    include <stdbool.h>
+#include <stdbool.h>
 
-#    ifdef __OBJC__
+#ifdef __OBJC__
 
-#        import <CoreFoundation/CoreFoundation.h>
+#    import <CoreFoundation/CoreFoundation.h>
 
 void i_sentrycrashlog_logObjC(
     const char *level, const char *file, int line, const char *function, CFStringRef fmt, ...);
 
 void i_sentrycrashlog_logObjCBasic(CFStringRef fmt, ...);
 
-#        define i_SentryCrashLOG_FULL(LEVEL, FILE, LINE, FUNCTION, FMT, ...)                       \
-            i_sentrycrashlog_logObjC(                                                              \
-                LEVEL, FILE, LINE, FUNCTION, (__bridge CFStringRef)FMT, ##__VA_ARGS__)
-#        define i_SentryCrashLOG_BASIC(FMT, ...)                                                   \
-            i_sentrycrashlog_logObjCBasic((__bridge CFStringRef)FMT, ##__VA_ARGS__)
+#    define i_SentryCrashLOG_FULL(LEVEL, FILE, LINE, FUNCTION, FMT, ...)                           \
+        i_sentrycrashlog_logObjC(                                                                  \
+            LEVEL, FILE, LINE, FUNCTION, (__bridge CFStringRef)FMT, ##__VA_ARGS__)
+#    define i_SentryCrashLOG_BASIC(FMT, ...)                                                       \
+        i_sentrycrashlog_logObjCBasic((__bridge CFStringRef)FMT, ##__VA_ARGS__)
 
-#    else // __OBJC__
+#else // __OBJC__
 
 void i_sentrycrashlog_logC(
     const char *level, const char *file, int line, const char *function, const char *fmt, ...);
 
 void i_sentrycrashlog_logCBasic(const char *fmt, ...);
 
-#        define i_SentryCrashLOG_FULL i_sentrycrashlog_logC
-#        define i_SentryCrashLOG_BASIC i_sentrycrashlog_logCBasic
+#    define i_SentryCrashLOG_FULL i_sentrycrashlog_logC
+#    define i_SentryCrashLOG_BASIC i_sentrycrashlog_logCBasic
 
-#    endif // __OBJC__
+#endif // __OBJC__
 
 /* Back up any existing defines by the same name */
-#    ifdef SentryCrash_NONE
-#        define SentryCrashLOG_BAK_NONE SentryCrash_NONE
-#        undef SentryCrash_NONE
-#    endif
-#    ifdef ERROR
-#        define SentryCrashLOG_BAK_ERROR ERROR
-#        undef ERROR
-#    endif
-#    ifdef WARN
-#        define SentryCrashLOG_BAK_WARN WARN
-#        undef WARN
-#    endif
-#    ifdef INFO
-#        define SentryCrashLOG_BAK_INFO INFO
-#        undef INFO
-#    endif
-#    ifdef DEBUG
-#        define SentryCrashLOG_BAK_DEBUG DEBUG
-#        undef DEBUG
-#    endif
-#    ifdef TRACE
-#        define SentryCrashLOG_BAK_TRACE TRACE
-#        undef TRACE
-#    endif
+#ifdef SentryCrash_NONE
+#    define SentryCrashLOG_BAK_NONE SentryCrash_NONE
+#    undef SentryCrash_NONE
+#endif
+#ifdef ERROR
+#    define SentryCrashLOG_BAK_ERROR ERROR
+#    undef ERROR
+#endif
+#ifdef WARN
+#    define SentryCrashLOG_BAK_WARN WARN
+#    undef WARN
+#endif
+#ifdef INFO
+#    define SentryCrashLOG_BAK_INFO INFO
+#    undef INFO
+#endif
+#ifdef DEBUG
+#    define SentryCrashLOG_BAK_DEBUG DEBUG
+#    undef DEBUG
+#endif
+#ifdef TRACE
+#    define SentryCrashLOG_BAK_TRACE TRACE
+#    undef TRACE
+#endif
 
-#    define SentryCrashLogger_Level_None 0
-#    define SentryCrashLogger_Level_Error 10
-#    define SentryCrashLogger_Level_Warn 20
-#    define SentryCrashLogger_Level_Info 30
-#    define SentryCrashLogger_Level_Debug 40
-#    define SentryCrashLogger_Level_Trace 50
+#define SentryCrashLogger_Level_None 0
+#define SentryCrashLogger_Level_Error 10
+#define SentryCrashLogger_Level_Warn 20
+#define SentryCrashLogger_Level_Info 30
+#define SentryCrashLogger_Level_Debug 40
+#define SentryCrashLogger_Level_Trace 50
 
-#    define SentryCrash_NONE SentryCrashLogger_Level_None
-#    define ERROR SentryCrashLogger_Level_Error
-#    define WARN SentryCrashLogger_Level_Warn
-#    define INFO SentryCrashLogger_Level_Info
-#    define DEBUG SentryCrashLogger_Level_Debug
-#    define TRACE SentryCrashLogger_Level_Trace
+#define SentryCrash_NONE SentryCrashLogger_Level_None
+#define ERROR SentryCrashLogger_Level_Error
+#define WARN SentryCrashLogger_Level_Warn
+#define INFO SentryCrashLogger_Level_Info
+#define DEBUG SentryCrashLogger_Level_Debug
+#define TRACE SentryCrashLogger_Level_Trace
 
-#    ifndef SentryCrashLogger_Level
-#        define SentryCrashLogger_Level SentryCrashLogger_Level_Error
-#    endif
+#ifndef SentryCrashLogger_Level
+#    define SentryCrashLogger_Level SentryCrashLogger_Level_Error
+#endif
 
-#    ifndef SentryCrashLogger_LocalLevel
-#        define SentryCrashLogger_LocalLevel SentryCrashLogger_Level_None
-#    endif
+#ifndef SentryCrashLogger_LocalLevel
+#    define SentryCrashLogger_LocalLevel SentryCrashLogger_Level_Trace
+#endif
 
-#    define a_SentryCrashLOG_FULL(LEVEL, FMT, ...)                                                 \
-        i_SentryCrashLOG_FULL(LEVEL, __FILE__, __LINE__, __PRETTY_FUNCTION__, FMT, ##__VA_ARGS__)
+#define a_SentryCrashLOG_FULL(LEVEL, FMT, ...)                                                     \
+    i_SentryCrashLOG_FULL(LEVEL, __FILE__, __LINE__, __PRETTY_FUNCTION__, FMT, ##__VA_ARGS__)
 
 // ============================================================================
-#    pragma mark - API -
+#pragma mark - API -
 // ============================================================================
+
+/** Set the filename to log to.
+ *
+ * @param filename The file to write to (NULL = write to stdout).
+ *
+ * @param overwrite If true, overwrite the log file.
+ */
+bool sentrycrashlog_setLogFilename(const char *filename, bool overwrite);
+
+/** Clear the log file. */
+bool sentrycrashlog_clearLogFile(void);
 
 /** Tests if the logger would print at the specified level.
  *
@@ -249,115 +273,115 @@ void i_sentrycrashlog_logCBasic(const char *fmt, ...);
  *
  * @return TRUE if the logger would print at the specified level.
  */
-#    define SentryCrashLOG_PRINTS_AT_LEVEL(LEVEL)                                                  \
-        (SentryCrashLogger_Level >= LEVEL || SentryCrashLogger_LocalLevel >= LEVEL)
+#define SentryCrashLOG_PRINTS_AT_LEVEL(LEVEL)                                                      \
+    (SentryCrashLogger_Level >= LEVEL || SentryCrashLogger_LocalLevel >= LEVEL)
 
 /** Log a message regardless of the log settings.
  * Normal version prints out full context. Basic version prints directly.
  *
  * @param FMT The format specifier, followed by its arguments.
  */
-#    define SentryCrashLOG_ALWAYS(FMT, ...) a_SentryCrashLOG_FULL("FORCE", FMT, ##__VA_ARGS__)
-#    define SentryCrashLOGBASIC_ALWAYS(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
+#define SentryCrashLOG_ALWAYS(FMT, ...) a_SentryCrashLOG_FULL("FORCE", FMT, ##__VA_ARGS__)
+#define SentryCrashLOGBASIC_ALWAYS(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
 
 /** Log an error.
  * Normal version prints out full context. Basic version prints directly.
  *
  * @param FMT The format specifier, followed by its arguments.
  */
-#    if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Error)
-#        define SentryCrashLOG_ERROR(FMT, ...) a_SentryCrashLOG_FULL("ERROR", FMT, ##__VA_ARGS__)
-#        define SentryCrashLOGBASIC_ERROR(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
-#    else
-#        define SentryCrashLOG_ERROR(FMT, ...)
-#        define SentryCrashLOGBASIC_ERROR(FMT, ...)
-#    endif
+#if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Error)
+#    define SentryCrashLOG_ERROR(FMT, ...) a_SentryCrashLOG_FULL("ERROR", FMT, ##__VA_ARGS__)
+#    define SentryCrashLOGBASIC_ERROR(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
+#else
+#    define SentryCrashLOG_ERROR(FMT, ...)
+#    define SentryCrashLOGBASIC_ERROR(FMT, ...)
+#endif
 
 /** Log a warning.
  * Normal version prints out full context. Basic version prints directly.
  *
  * @param FMT The format specifier, followed by its arguments.
  */
-#    if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Warn)
-#        define SentryCrashLOG_WARN(FMT, ...) a_SentryCrashLOG_FULL("WARN ", FMT, ##__VA_ARGS__)
-#        define SentryCrashLOGBASIC_WARN(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
-#    else
-#        define SentryCrashLOG_WARN(FMT, ...)
-#        define SentryCrashLOGBASIC_WARN(FMT, ...)
-#    endif
+#if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Warn)
+#    define SentryCrashLOG_WARN(FMT, ...) a_SentryCrashLOG_FULL("WARN ", FMT, ##__VA_ARGS__)
+#    define SentryCrashLOGBASIC_WARN(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
+#else
+#    define SentryCrashLOG_WARN(FMT, ...)
+#    define SentryCrashLOGBASIC_WARN(FMT, ...)
+#endif
 
 /** Log an info message.
  * Normal version prints out full context. Basic version prints directly.
  *
  * @param FMT The format specifier, followed by its arguments.
  */
-#    if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Info)
-#        define SentryCrashLOG_INFO(FMT, ...) a_SentryCrashLOG_FULL("INFO ", FMT, ##__VA_ARGS__)
-#        define SentryCrashLOGBASIC_INFO(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
-#    else
-#        define SentryCrashLOG_INFO(FMT, ...)
-#        define SentryCrashLOGBASIC_INFO(FMT, ...)
-#    endif
+#if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Info)
+#    define SentryCrashLOG_INFO(FMT, ...) a_SentryCrashLOG_FULL("INFO ", FMT, ##__VA_ARGS__)
+#    define SentryCrashLOGBASIC_INFO(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
+#else
+#    define SentryCrashLOG_INFO(FMT, ...)
+#    define SentryCrashLOGBASIC_INFO(FMT, ...)
+#endif
 
 /** Log a debug message.
  * Normal version prints out full context. Basic version prints directly.
  *
  * @param FMT The format specifier, followed by its arguments.
  */
-#    if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Debug)
-#        define SentryCrashLOG_DEBUG(FMT, ...) a_SentryCrashLOG_FULL("DEBUG", FMT, ##__VA_ARGS__)
-#        define SentryCrashLOGBASIC_DEBUG(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
-#    else
-#        define SentryCrashLOG_DEBUG(FMT, ...)
-#        define SentryCrashLOGBASIC_DEBUG(FMT, ...)
-#    endif
+#if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Debug)
+#    define SentryCrashLOG_DEBUG(FMT, ...) a_SentryCrashLOG_FULL("DEBUG", FMT, ##__VA_ARGS__)
+#    define SentryCrashLOGBASIC_DEBUG(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
+#else
+#    define SentryCrashLOG_DEBUG(FMT, ...)
+#    define SentryCrashLOGBASIC_DEBUG(FMT, ...)
+#endif
 
 /** Log a trace message.
  * Normal version prints out full context. Basic version prints directly.
  *
  * @param FMT The format specifier, followed by its arguments.
  */
-#    if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Trace)
-#        define SentryCrashLOG_TRACE(FMT, ...) a_SentryCrashLOG_FULL("TRACE", FMT, ##__VA_ARGS__)
-#        define SentryCrashLOGBASIC_TRACE(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
-#    else
-#        define SentryCrashLOG_TRACE(FMT, ...)
-#        define SentryCrashLOGBASIC_TRACE(FMT, ...)
-#    endif
+#if SentryCrashLOG_PRINTS_AT_LEVEL(SentryCrashLogger_Level_Trace)
+#    define SentryCrashLOG_TRACE(FMT, ...) a_SentryCrashLOG_FULL("TRACE", FMT, ##__VA_ARGS__)
+#    define SentryCrashLOGBASIC_TRACE(FMT, ...) i_SentryCrashLOG_BASIC(FMT, ##__VA_ARGS__)
+#else
+#    define SentryCrashLOG_TRACE(FMT, ...)
+#    define SentryCrashLOGBASIC_TRACE(FMT, ...)
+#endif
 
 // ============================================================================
-#    pragma mark - (internal) -
+#pragma mark - (internal) -
 // ============================================================================
 
 /* Put everything back to the way we found it. */
-#    undef ERROR
-#    ifdef SentryCrashLOG_BAK_ERROR
-#        define ERROR SentryCrashLOG_BAK_ERROR
-#        undef SentryCrashLOG_BAK_ERROR
-#    endif
-#    undef WARNING
-#    ifdef SentryCrashLOG_BAK_WARN
-#        define WARNING SentryCrashLOG_BAK_WARN
-#        undef SentryCrashLOG_BAK_WARN
-#    endif
-#    undef INFO
-#    ifdef SentryCrashLOG_BAK_INFO
-#        define INFO SentryCrashLOG_BAK_INFO
-#        undef SentryCrashLOG_BAK_INFO
-#    endif
-#    undef DEBUG
-#    ifdef SentryCrashLOG_BAK_DEBUG
-#        define DEBUG SentryCrashLOG_BAK_DEBUG
-#        undef SentryCrashLOG_BAK_DEBUG
-#    endif
-#    undef TRACE
-#    ifdef SentryCrashLOG_BAK_TRACE
-#        define TRACE SentryCrashLOG_BAK_TRACE
-#        undef SentryCrashLOG_BAK_TRACE
-#    endif
+#undef ERROR
+#ifdef SentryCrashLOG_BAK_ERROR
+#    define ERROR SentryCrashLOG_BAK_ERROR
+#    undef SentryCrashLOG_BAK_ERROR
+#endif
+#undef WARNING
+#ifdef SentryCrashLOG_BAK_WARN
+#    define WARNING SentryCrashLOG_BAK_WARN
+#    undef SentryCrashLOG_BAK_WARN
+#endif
+#undef INFO
+#ifdef SentryCrashLOG_BAK_INFO
+#    define INFO SentryCrashLOG_BAK_INFO
+#    undef SentryCrashLOG_BAK_INFO
+#endif
+#undef DEBUG
+#ifdef SentryCrashLOG_BAK_DEBUG
+#    define DEBUG SentryCrashLOG_BAK_DEBUG
+#    undef SentryCrashLOG_BAK_DEBUG
+#endif
+#undef TRACE
+#ifdef SentryCrashLOG_BAK_TRACE
+#    define TRACE SentryCrashLOG_BAK_TRACE
+#    undef SentryCrashLOG_BAK_TRACE
+#endif
 
-#    ifdef __cplusplus
+#ifdef __cplusplus
 }
-#    endif
+#endif
 
 #endif // HDR_SentryCrashLogger_h

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -35,7 +35,6 @@
 
 #include <mach/mach.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #ifdef __arm64__

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMemory.c
@@ -27,7 +27,6 @@
 
 #include "SentryCrashMemory.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <_types/_uint8_t.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor.c
@@ -28,7 +28,6 @@
 #include "SentryCrashSymbolicator.h"
 #include <stdlib.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 static bool

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_Backtrace.c
@@ -26,7 +26,6 @@
 #include "SentryCrashStackCursor_Backtrace.h"
 #include "SentryCrashCPU.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 static bool

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.c
@@ -30,7 +30,6 @@
 
 #include <stdlib.h>
 
-#define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 /** Represents an entry in a frame list.

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -28,7 +28,6 @@
 #import "SentryLog.h"
 #include <execinfo.h>
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #define MAX_BACKTRACE_LENGTH                                                                       \

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
@@ -27,7 +27,6 @@
 
 #include "SentryCrashSysCtl.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <errno.h>

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
@@ -30,7 +30,6 @@
 #include "SentryCrashMemory.h"
 #include "SentryCrashSystemCapabilities.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #include "SentryCrashLogger.h"
 
 #include <dispatch/dispatch.h>

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -30,7 +30,6 @@
 #import "SentryCrashVarArgs.h"
 #import "SentryDictionaryDeepSearch.h"
 
-// #define SentryCrashLogger_LocalLevel TRACE
 #import "SentryCrashLogger.h"
 
 @implementation SentryCrashReportFilterPassthrough


### PR DESCRIPTION
This is helpful to debug crash handling, which can't be done with the debugger attached. Reading log files is easier than getting the same info out of the system console.

I removed the file-based local level definitions, so that it's completely centralized. 

Also moved the macro def that effectively switches between console and file logging to the header so that it can be used to conditionally compile the other parts that set up file-based logging. Those pieces of code have been brought back after being removed in #2440 

#skip-changelog