### PR TITLE
chore: Pinning tvOS tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,19 +128,19 @@ jobs:
           - runs-on: macos-12
             platform: "tvOS"
             xcode: "13.4.1"
-            test-destination-os: "latest"
+            test-destination-os: "16.1"
 
           # tvOS 16
           - runs-on: macos-13
             platform: "tvOS"
             xcode: "14.3"
-            test-destination-os: "latest"
+            test-destination-os: "17.2"
 
           # tvOS 17
           - runs-on: macos-14
             platform: "tvOS"
             xcode: "15.2"
-            test-destination-os: "latest"
+            test-destination-os: "17.5"
 
     steps:
       - uses: actions/checkout@v4

--- a/Tests/SentryTests/Helper/SentryDeviceTests.mm
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.mm
@@ -89,10 +89,10 @@
     const auto osVersion = sentry_getOSVersion();
     XCTAssertNotEqual(osVersion.length, 0U);
 #if TARGET_OS_OSX
-    SENTRY_ASSERT_PREFIX(osVersion, @"10.", @"11.", @"12.", @"13.", @"14.");
+    SENTRY_ASSERT_PREFIX(osVersion, @"10.", @"11.", @"12.", @"13.", @"14.", @"15.");
 #elif TARGET_OS_IOS || TARGET_OS_MACCATALYST || TARGET_OS_TV
     SENTRY_ASSERT_PREFIX(
-        osVersion, @"9.", @"10.", @"11.", @"12.", @"13.", @"14.", @"15.", @"16.", @"17.");
+        osVersion, @"9.", @"10.", @"11.", @"12.", @"13.", @"14.", @"15.", @"16.", @"17.", @"18.");
 #elif TARGET_OS_WATCH
     // TODO: create a watch UI test target to test this branch
     SENTRY_ASSERT_PREFIX(osVersion, @"2.", @"3.", @"4.", @"5.", @"6.", @"7.", @"8.", @"9.");


### PR DESCRIPTION
Pinning tvOS tests to latest stable versions.
Github added beta simulators and those were being used as `latest`.


_#skip-changelog_