### PR TITLE
ref: Remove unused imports

### DIFF
--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -8,7 +8,6 @@
 #    import "SentryOptions.h"
 #    import "SentryPerformanceTracker.h"
 #    import "SentrySDK+Private.h"
-#    import "SentryScope.h"
 #    import "SentrySpanId.h"
 #    import "SentrySwift.h"
 #    import "SentryTimeToDisplayTracker.h"

--- a/Sources/Sentry/include/SentryDelayedFramesTracker.h
+++ b/Sources/Sentry/include/SentryDelayedFramesTracker.h
@@ -2,7 +2,6 @@
 
 #if SENTRY_HAS_UIKIT
 
-@class SentryDisplayLinkWrapper;
 @class SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
Remove two unused imports in
SentryUIViewControllerPerformanceTracker
and SentryDelayedFramesTracker.

#skip-changelog