### PR TITLE
Fix swizzle loadView on UITableViewController

### DIFF
--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -355,8 +355,9 @@ SentryUIViewControllerSwizzling ()
     // loadView if the UIViewController doesn't implement it.
     SEL selector = NSSelectorFromString(@"loadView");
     IMP viewControllerImp = class_getMethodImplementation([UIViewController class], selector);
+    IMP tableViewControllerImp = class_getMethodImplementation([UITableViewController class], selector);
     IMP classLoadViewImp = class_getMethodImplementation(class, selector);
-    if (viewControllerImp == classLoadViewImp) {
+    if (viewControllerImp == classLoadViewImp || tableViewControllerImp == classLoadViewImp) {
         return;
     }
 


### PR DESCRIPTION
https://github.com/getsentry/sentry-cocoa/issues/4070

We've been getting a crash caused by Sentry in an IB file which is a subclass of `UITableViewController`. We've verified that this only happens when both `enableSwizzling` and `enableUIViewControllerTracing`, disabling either one fixes the issue.

We believe the crash is caused by sentry swizzling the `loadView` method, and the risk of this is acknowledged in a comment next to where this is done. This function has a check to test if the `loadView` method was overridden or not by comparing it to the default implementation from `UIViewController`. However, this does not include other subclasses of `UIViewController` from UIKit like `UITableViewController` that could have a different implementation internally than the one in UIViewController.

The proposed fix is to also check for `UITableViewController` in this function. If the theory mentioned above is correct, it means that just checking for these two might not be enough and it could be necessary to check for all possible view controllers provided by UIKit.

This fix has not been tested