### PR TITLE
Swizzling of view controllers `loadView` that don`t implement `loadView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix potential deadlock in app hang detection (#4063)
+- Swizzling of view controllers `loadView` that don`t implement `loadView` () 
 
 ## 8.29.0
 

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -354,7 +354,7 @@ SentryUIViewControllerSwizzling ()
     // workaround, we skip swizzling the loadView and accept that the SKD doesn't create a span for
     // loadView if the UIViewController doesn't implement it.
     SEL selector = NSSelectorFromString(@"loadView");
-    IMP viewControllerImp = class_getMethodImplementation([UIViewController class], selector);
+    IMP viewControllerImp = class_getMethodImplementation([class superclass], selector);
     IMP classLoadViewImp = class_getMethodImplementation(class, selector);
     if (viewControllerImp == classLoadViewImp) {
         return;


### PR DESCRIPTION
## :scroll: Description

Stop swizzling `loadView` function of UIViewControllers that doesn't implement it.

## :bulb: Motivation and Context

close #4070

## :green_heart: How did you test it?

In the sample.
Current ui tests already tackles this. 

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
