### PR TITLE
test: Remove Nimble from iOS-Swift sample app

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -786,7 +786,6 @@
 			);
 			mainGroup = 637AFD9D243B02760034958B;
 			packageReferences = (
-				6268F2C02B0DF9920019DA38 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 637AFDA7243B02760034958B /* Products */;
 			projectDirPath = "";
@@ -2096,17 +2095,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		6268F2C02B0DF9920019DA38 /* XCRemoteSwiftPackageReference "Nimble" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Quick/Nimble";
-			requirement = {
-				kind = exactVersion;
-				version = 10.0.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCVersionGroup section */
 		D845F35927BAD4CC00A4D7A2 /* SentryData.xcdatamodeld */ = {


### PR DESCRIPTION
We don't use Nimble for the iOS-Swift UI tests, so we can remove the package reference.

#skip-changelog