### PR TITLE
feat: Pause and resume AppHangTracking API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add pause and resume AppHangTracking API (#4077). You can now pause and resume app hang tracking with `SentrySDK.pauseAppHangTracking()` and `SentrySDK.resumeAppHangTracking()`.
+
 ### Fixes
 
 - Fix potential deadlock in app hang detection (#4063)

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -943,7 +943,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ckT-1E-GWZ">
-                                                        <rect key="frame" x="0.0" y="32.5" width="152" height="28"/>
+                                                        <rect key="frame" x="0.0" y="28" width="152" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Close SDK"/>
                                                         <connections>
@@ -951,7 +951,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rpD-Rf-xbz">
-                                                        <rect key="frame" x="0.0" y="65.5" width="152" height="28"/>
+                                                        <rect key="frame" x="0.0" y="56" width="152" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="ANR fully blocking"/>
                                                         <connections>
@@ -959,7 +959,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2e4-48-rLl">
-                                                        <rect key="frame" x="0.0" y="98" width="152" height="28"/>
+                                                        <rect key="frame" x="0.0" y="84" width="152" height="28"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="anrFillingRunLoopExtra"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="ANR filling run loop"/>
@@ -967,8 +967,17 @@
                                                             <action selector="anrFillingRunLoop:" destination="VqS-l1-kwe" eventType="touchUpInside" id="ON6-DV-3Tz"/>
                                                         </connections>
                                                     </button>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Jr-19-VhC">
+                                                        <rect key="frame" x="0.0" y="112" width="152" height="28"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="anrFillingRunLoopExtra"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                        <state key="normal" title="Pasteboard Contents"/>
+                                                        <connections>
+                                                            <action selector="getPasteBoardString:" destination="VqS-l1-kwe" eventType="touchUpInside" id="RXr-u0-uBD"/>
+                                                        </connections>
+                                                    </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F0l-xf-cQd">
-                                                        <rect key="frame" x="0.0" y="130.5" width="152" height="28"/>
+                                                        <rect key="frame" x="0.0" y="140" width="152" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                         <state key="normal" title="Start 100 threads"/>
@@ -977,7 +986,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Evt-B9-zEC">
-                                                        <rect key="frame" x="0.0" y="163.5" width="152" height="28"/>
+                                                        <rect key="frame" x="0.0" y="168" width="152" height="28"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="breadcrumbInfoButton"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>

--- a/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
@@ -105,6 +105,21 @@ class ExtraViewController: UIViewController {
         triggerANRFillingRunLoop(button: self.anrFillingRunLoopButton)
     }
 
+    @IBAction func getPasteBoardString(_ sender: Any) {
+        SentrySDK.pauseAppHangTracking()
+        
+        // Getting the pasteboard string asks for permission
+        // and the SDK would detect an ANR if we don't pause it.
+        // Make sure to copy something into the pasteboard, cause
+        // iOS only opens the system permission dialog if you do.
+        
+        if let clipboard = UIPasteboard.general.string {
+            SentrySDK.capture(message: clipboard)
+        }
+        
+        SentrySDK.resumeAppHangTracking()
+    }
+    
     @IBAction func start100Threads(_ sender: UIButton) {
         highlightButton(sender)
         for _ in 0..<100 {

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -307,6 +307,19 @@ SENTRY_NO_INIT
 + (void)reportFullyDisplayed;
 
 /**
+ * Pauses sending detected app hangs to Sentry.
+ *
+ * @discussion This method doesn't close the detection of app hangs. Instead, the app hang detection
+ * will ignore detected app hangs until you call @c resumeAppHangTracking.
+ */
++ (void)pauseAppHangTracking;
+
+/**
+ * Resumes sending detected app hangs to Sentry.
+ */
++ (void)resumeAppHangTracking;
+
+/**
  * Waits synchronously for the SDK to flush out all queued and cached items for up to the specified
  * timeout in seconds. If there is no internet connection, the function returns immediately. The SDK
  * doesn't dispose the client or the hub.

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -29,6 +29,7 @@ SentryANRTrackingIntegration ()
 
 @property (nonatomic, strong) SentryANRTracker *tracker;
 @property (nonatomic, strong) SentryOptions *options;
+@property (atomic, assign) BOOL reportAppHangs;
 
 @end
 
@@ -45,6 +46,7 @@ SentryANRTrackingIntegration ()
 
     [self.tracker addListener:self];
     self.options = options;
+    self.reportAppHangs = YES;
 
     return YES;
 }
@@ -52,6 +54,16 @@ SentryANRTrackingIntegration ()
 - (SentryIntegrationOption)integrationOptions
 {
     return kIntegrationOptionEnableAppHangTracking | kIntegrationOptionDebuggerNotAttached;
+}
+
+- (void)pauseAppHangTracking
+{
+    self.reportAppHangs = NO;
+}
+
+- (void)resumeAppHangTracking
+{
+    self.reportAppHangs = YES;
 }
 
 - (void)uninstall
@@ -66,6 +78,11 @@ SentryANRTrackingIntegration ()
 
 - (void)anrDetected
 {
+    if (self.reportAppHangs == NO) {
+        SENTRY_LOG_DEBUG(@"AppHangTracking paused. Ignoring reported app hang.")
+        return;
+    }
+
 #if SENTRY_HAS_UIKIT
     // If the app is not active, the main thread may be blocked or too busy.
     // Since there is no UI for the user to interact, there is no need to report app hang.

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -566,6 +566,18 @@ SentryHub () <SentryMetricsAPIDelegate>
     }
 }
 
+- (nullable id<SentryIntegrationProtocol>)getInstalledIntegration:(Class)integrationClass
+{
+    @synchronized(_integrationsLock) {
+        for (id<SentryIntegrationProtocol> item in _installedIntegrations) {
+            if ([item isKindOfClass:integrationClass]) {
+                return item;
+            }
+        }
+        return nil;
+    }
+}
+
 - (BOOL)hasIntegration:(NSString *)integrationName
 {
     // installedIntegrations and installedIntegrationNames share the same lock.

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -1,5 +1,6 @@
 #import "SentrySDK.h"
 #import "PrivateSentrySDKOnly.h"
+#import "SentryANRTrackingIntegration.h"
 #import "SentryAppStartMeasurement.h"
 #import "SentryAppStateManager.h"
 #import "SentryBinaryImageCache.h"
@@ -469,6 +470,39 @@ static NSDate *_Nullable startTimestamp = nil;
 + (void)reportFullyDisplayed
 {
     [SentrySDK.currentHub reportFullyDisplayed];
+}
+
++ (void)pauseAppHangTracking
+{
+    SentryANRTrackingIntegration *anrTrackingIntegration = [SentrySDK getANRTrackingIntegration];
+
+    if (anrTrackingIntegration == nil) {
+        return;
+    }
+
+    [anrTrackingIntegration pauseAppHangTracking];
+}
+
++ (void)resumeAppHangTracking
+{
+    SentryANRTrackingIntegration *anrTrackingIntegration = [SentrySDK getANRTrackingIntegration];
+
+    if (anrTrackingIntegration == nil) {
+        return;
+    }
+
+    [anrTrackingIntegration resumeAppHangTracking];
+}
+
++ (nullable SentryANRTrackingIntegration *)getANRTrackingIntegration
+{
+    id<SentryIntegrationProtocol> integration =
+        [SentrySDK.currentHub getInstalledIntegration:[SentryANRTrackingIntegration class]];
+    if (integration == nil) {
+        return nil;
+    }
+
+    return (SentryANRTrackingIntegration *)integration;
 }
 
 + (void)flush:(NSTimeInterval)timeout

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -474,35 +474,20 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)pauseAppHangTracking
 {
-    SentryANRTrackingIntegration *anrTrackingIntegration = [SentrySDK getANRTrackingIntegration];
-
-    if (anrTrackingIntegration == nil) {
-        return;
-    }
+    SentryANRTrackingIntegration *anrTrackingIntegration
+        = (SentryANRTrackingIntegration *)[SentrySDK.currentHub
+            getInstalledIntegration:[SentryANRTrackingIntegration class]];
 
     [anrTrackingIntegration pauseAppHangTracking];
 }
 
 + (void)resumeAppHangTracking
 {
-    SentryANRTrackingIntegration *anrTrackingIntegration = [SentrySDK getANRTrackingIntegration];
-
-    if (anrTrackingIntegration == nil) {
-        return;
-    }
+    SentryANRTrackingIntegration *anrTrackingIntegration
+        = (SentryANRTrackingIntegration *)[SentrySDK.currentHub
+            getInstalledIntegration:[SentryANRTrackingIntegration class]];
 
     [anrTrackingIntegration resumeAppHangTracking];
-}
-
-+ (nullable SentryANRTrackingIntegration *)getANRTrackingIntegration
-{
-    id<SentryIntegrationProtocol> integration =
-        [SentrySDK.currentHub getInstalledIntegration:[SentryANRTrackingIntegration class]];
-    if (integration == nil) {
-        return nil;
-    }
-
-    return (SentryANRTrackingIntegration *)integration;
 }
 
 + (void)flush:(NSTimeInterval)timeout

--- a/Sources/Sentry/include/SentryANRTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryANRTrackingIntegration.h
@@ -10,6 +10,9 @@ static NSString *const SentryANRExceptionType = @"App Hanging";
 @interface SentryANRTrackingIntegration
     : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerDelegate>
 
+- (void)pauseAppHangTracking;
+- (void)resumeAppHangTracking;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -62,6 +62,8 @@ SentryHub ()
 
 - (void)captureEnvelope:(SentryEnvelope *)envelope;
 
+- (nullable id<SentryIntegrationProtocol>)getInstalledIntegration:(Class)integrationClass;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -911,6 +911,7 @@ class SentryHubTests: XCTestCase {
                     let integrationName = "Integration\(i)\(j)"
                     sut.addInstalledIntegration(EmptyIntegration(), name: integrationName)
                     XCTAssertTrue(sut.hasIntegration(integrationName))
+                    XCTAssertNotNil(sut.getInstalledIntegration(EmptyIntegration.self))
                 }
                 group.leave()
             }
@@ -940,6 +941,7 @@ class SentryHubTests: XCTestCase {
                     sut.addInstalledIntegration(EmptyIntegration(), name: integrationName)
                     sut.hasIntegration(integrationName)
                     sut.isIntegrationInstalled(EmptyIntegration.self)
+                    sut.getInstalledIntegration(EmptyIntegration.self)
                 }
                 XCTAssertLessThanOrEqual(0, sut.installedIntegrations().count)
                 sut.installedIntegrations().forEach { XCTAssertNotNil($0) }
@@ -953,6 +955,22 @@ class SentryHubTests: XCTestCase {
         }
         
         group.wait()
+    }
+    
+    func testGetInstalledIntegration() {
+        let integration = EmptyIntegration()
+        sut.addInstalledIntegration(integration, name: "EmptyIntegration")
+        
+        let installedIntegration = sut.getInstalledIntegration(EmptyIntegration.self)
+        
+        XCTAssert(integration === installedIntegration)
+    }
+    
+    func testGetInstalledIntegration_ReturnsNilIfNotFound() {
+        let integration = EmptyIntegration()
+        sut.addInstalledIntegration(integration, name: "EmptyIntegration")
+        
+        XCTAssertNil(sut.getInstalledIntegration(SentryANRTrackingIntegration.self))
     }
     
     func testEventContainsOnlyHandledErrors() {


### PR DESCRIPTION




## :scroll: Description

Add two methods pauseAppHangTracking and
resumeAppHangTracking to ignore reported AppHangs.

Docs PR https://github.com/getsentry/sentry-docs/pull/10409.

## :bulb: Motivation and Context

Fixes GH-3472

## :green_heart: How did you test it?
Unit tests and sample app.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
