### PR TITLE
chore: cleanup replay exports for hybrid SDKs

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -3,7 +3,6 @@
 #import "SentryBreadcrumb+Private.h"
 #import "SentryClient.h"
 #import "SentryDebugImageProvider.h"
-#import "SentryDefines.h"
 #import "SentryExtraContextProvider.h"
 #import "SentryHub+Private.h"
 #import "SentryInstallation.h"

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -3,6 +3,7 @@
 #import "SentryBreadcrumb+Private.h"
 #import "SentryClient.h"
 #import "SentryDebugImageProvider.h"
+#import "SentryDefines.h"
 #import "SentryExtraContextProvider.h"
 #import "SentryHub+Private.h"
 #import "SentryInstallation.h"
@@ -305,7 +306,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [[SentryBreadcrumb alloc] initWithDictionary:dictionary];
 }
 
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 + (nullable SentrySessionReplayIntegration *)getReplayIntegration
 {
 
@@ -320,31 +321,19 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
     return replayIntegration;
 }
-#endif
 
 + (void)captureReplay
 {
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
     [[PrivateSentrySDKOnly getReplayIntegration] captureReplay];
-#else
-    SENTRY_LOG_DEBUG(
-        @"SentrySessionReplayIntegration only works with UIKit enabled and target is "
-        @"not visionOS. Ensure you're using the right configuration of Sentry that links UIKit.");
-#endif
 }
 
 + (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
                 screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider
 {
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
     [[PrivateSentrySDKOnly getReplayIntegration] configureReplayWith:breadcrumbConverter
                                                   screenshotProvider:screenshotProvider];
-#else
-    SENTRY_LOG_DEBUG(
-        @"SentrySessionReplayIntegration only works with UIKit enabled and target is "
-        @"not visionOS. Ensure you're using the right configuration of Sentry that links UIKit.");
-#endif
 }
+#endif
 
 + (NSString *__nullable)getReplayId
 {
@@ -357,7 +346,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes
 {
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
     [SentryViewPhotographer.shared addIgnoreClasses:classes];
 #else
     SENTRY_LOG_DEBUG(
@@ -368,7 +357,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes
 {
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
     [SentryViewPhotographer.shared addRedactClasses:classes];
 #else
     SENTRY_LOG_DEBUG(

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -306,7 +306,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [[SentryBreadcrumb alloc] initWithDictionary:dictionary];
 }
 
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 + (nullable SentrySessionReplayIntegration *)getReplayIntegration
 {
 

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -333,7 +333,6 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     [[PrivateSentrySDKOnly getReplayIntegration] configureReplayWith:breadcrumbConverter
                                                   screenshotProvider:screenshotProvider];
 }
-#endif
 
 + (NSString *__nullable)getReplayId
 {
@@ -346,24 +345,13 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes
 {
-#if SENTRY_REPLAY_AVAILABLE
     [SentryViewPhotographer.shared addIgnoreClasses:classes];
-#else
-    SENTRY_LOG_DEBUG(
-        @"PrivateSentrySDKOnly.addReplayIgnoreClasses only works with UIKit enabled and target is "
-        @"not visionOS. Ensure you're using the right configuration of Sentry that links UIKit.");
-#endif
 }
 
 + (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes
 {
-#if SENTRY_REPLAY_AVAILABLE
     [SentryViewPhotographer.shared addRedactClasses:classes];
-#else
-    SENTRY_LOG_DEBUG(
-        @"PrivateSentrySDKOnly.addReplayRedactClasses only works with UIKit enabled and target is "
-        @"not visionOS. Ensure you're using the right configuration of Sentry that links UIKit.");
-#endif
 }
+#endif
 
 @end

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -44,6 +44,12 @@
 #    define SENTRY_HAS_METRIC_KIT 0
 #endif
 
+#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#    define SENTRY_REPLAY_AVAILABLE 1
+#else
+#    define SENTRY_REPLAY_AVAILABLE 0
+#endif
+
 #define SENTRY_NO_INIT                                                                             \
     -(instancetype)init NS_UNAVAILABLE;                                                            \
     +(instancetype) new NS_UNAVAILABLE;

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -45,9 +45,9 @@
 #endif
 
 #if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
-#    define SENTRY_REPLAY_AVAILABLE 1
+#    define SENTRY_TARGET_REPLAY_SUPPORTED 1
 #else
-#    define SENTRY_REPLAY_AVAILABLE 0
+#    define SENTRY_TARGET_REPLAY_SUPPORTED 0
 #endif
 
 #define SENTRY_NO_INIT                                                                             \

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -4,7 +4,6 @@
 #import "SentryCrashIntegration.h"
 #import "SentryCrashMonitor_AppState.h"
 #import "SentryCrashMonitor_System.h"
-#import "SentryDefines.h"
 #import "SentryScope.h"
 #import <Foundation/Foundation.h>
 #import <SentryCrashCachedData.h>

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -182,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
     [deviceData setValue:locale forKey:LOCALE_KEY];
 
 // The UIWindowScene is unavailable on visionOS
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
     NSArray<UIWindow *> *appWindows = SentryDependencyContainer.sharedInstance.application.windows;
     if ([appWindows count] > 0) {

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -4,6 +4,7 @@
 #import "SentryCrashIntegration.h"
 #import "SentryCrashMonitor_AppState.h"
 #import "SentryCrashMonitor_System.h"
+#import "SentryDefines.h"
 #import "SentryScope.h"
 #import <Foundation/Foundation.h>
 #import <SentryCrashCachedData.h>
@@ -181,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
     [deviceData setValue:locale forKey:LOCALE_KEY];
 
 // The UIWindowScene is unavailable on visionOS
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 
     NSArray<UIWindow *> *appWindows = SentryDependencyContainer.sharedInstance.application.windows;
     if ([appWindows count] > 0) {

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -15,7 +15,7 @@
 #import "SentrySwift.h"
 #import "SentryTraceContext.h"
 
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -1,7 +1,6 @@
 #import "SentrySessionReplay.h"
 #import "SentryAttachment+Private.h"
 #import "SentryBreadcrumb+Private.h"
-#import "SentryDefines.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDisplayLinkWrapper.h"
 #import "SentryEnvelopeItemType.h"

--- a/Sources/Sentry/SentrySessionReplay.m
+++ b/Sources/Sentry/SentrySessionReplay.m
@@ -1,6 +1,7 @@
 #import "SentrySessionReplay.h"
 #import "SentryAttachment+Private.h"
 #import "SentryBreadcrumb+Private.h"
+#import "SentryDefines.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDisplayLinkWrapper.h"
 #import "SentryEnvelopeItemType.h"
@@ -14,7 +15,7 @@
 #import "SentrySwift.h"
 #import "SentryTraceContext.h"
 
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -1,4 +1,3 @@
-#import "SentryDefines.h"
 #import "SentrySessionReplayIntegration+Private.h"
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -1,7 +1,7 @@
 #import "SentryDefines.h"
 #import "SentrySessionReplayIntegration+Private.h"
 
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 #    import "SentryClient+Private.h"
 #    import "SentryDependencyContainer.h"

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -1,6 +1,7 @@
+#import "SentryDefines.h"
 #import "SentrySessionReplayIntegration+Private.h"
 
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 
 #    import "SentryClient+Private.h"
 #    import "SentryDependencyContainer.h"

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -164,7 +164,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 + (SentrySessionReplayIntegration *__nullable)getReplayIntegration;
 
 /**

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -164,7 +164,6 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 #endif // SENTRY_UIKIT_AVAILABLE
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
-+ (SentrySessionReplayIntegration *__nullable)getReplayIntegration;
 
 /**
  * Configure session replay with different breadcrumb converter

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -165,6 +165,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 #endif // SENTRY_UIKIT_AVAILABLE
 
 #if SENTRY_REPLAY_AVAILABLE
++ (SentrySessionReplayIntegration *__nullable)getReplayIntegration;
 
 /**
  * Configure session replay with different breadcrumb converter
@@ -174,17 +175,17 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 + (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
                 screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider;
 
++ (void)captureReplay;
++ (NSString *__nullable)getReplayId;
++ (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes;
++ (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes;
+
 #endif
 + (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans;
 
 + (SentryUser *)userWithDictionary:(NSDictionary *)dictionary;
 
 + (SentryBreadcrumb *)breadcrumbWithDictionary:(NSDictionary *)dictionary;
-
-+ (void)captureReplay;
-+ (NSString *__nullable)getReplayId;
-+ (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes;
-+ (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes;
 
 @end
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -1,5 +1,4 @@
 #import "PrivatesHeader.h"
-#import "SentryDefines.h"
 #import "SentryScreenFrames.h"
 
 @class SentryDebugMeta;

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -1,4 +1,5 @@
 #import "PrivatesHeader.h"
+#import "SentryDefines.h"
 #import "SentryScreenFrames.h"
 
 @class SentryDebugMeta;
@@ -163,7 +164,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 
 /**
  * Configure session replay with different breadcrumb converter

--- a/Sources/Sentry/include/SentrySessionReplay.h
+++ b/Sources/Sentry/include/SentrySessionReplay.h
@@ -1,7 +1,7 @@
 #import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 #    import <UIKit/UIKit.h>
 
 @class SentryReplayOptions;

--- a/Sources/Sentry/include/SentrySessionReplay.h
+++ b/Sources/Sentry/include/SentrySessionReplay.h
@@ -1,7 +1,7 @@
 #import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 #    import <UIKit/UIKit.h>
 
 @class SentryReplayOptions;

--- a/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
@@ -1,8 +1,9 @@
 #import "SentryBaseIntegration.h"
+#import "SentryDefines.h"
 #import "SentrySessionReplayIntegration.h"
 #import "SentrySwift.h"
 
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 
 @class SentrySessionReplay;
 

--- a/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
@@ -3,7 +3,7 @@
 #import "SentrySessionReplayIntegration.h"
 #import "SentrySwift.h"
 
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 @class SentrySessionReplay;
 

--- a/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
@@ -1,5 +1,4 @@
 #import "SentryBaseIntegration.h"
-#import "SentryDefines.h"
 #import "SentrySessionReplayIntegration.h"
 #import "SentrySwift.h"
 

--- a/Sources/Sentry/include/SentrySessionReplayIntegration.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration.h
@@ -3,7 +3,7 @@
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
-#if SENTRY_REPLAY_AVAILABLE
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 @protocol SentryReplayBreadcrumbConverter;
 @protocol SentryViewScreenshotProvider;
@@ -24,5 +24,5 @@ NS_ASSUME_NONNULL_BEGIN
          screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider;
 
 @end
-#endif // SENTRY_REPLAY_AVAILABLE
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentrySessionReplayIntegration.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration.h
@@ -3,7 +3,7 @@
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
-#if SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#if SENTRY_REPLAY_AVAILABLE
 
 @protocol SentryReplayBreadcrumbConverter;
 @protocol SentryViewScreenshotProvider;
@@ -24,5 +24,5 @@ NS_ASSUME_NONNULL_BEGIN
          screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider;
 
 @end
-#endif // SENTRY_HAS_UIKIT && !TARGET_OS_VISION
+#endif // SENTRY_REPLAY_AVAILABLE
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -271,18 +271,6 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
 
     #endif
 
-    func testCaptureReplayShouldNotFailIfMissingReplayIntegration() {
-        PrivateSentrySDKOnly.captureReplay()
-    }
-
-    func testAddReplayIgnoreClassesShouldNotFailIfMissingReplayIntegration() {
-        PrivateSentrySDKOnly.addReplayIgnoreClasses([])
-    }
-
-    func testAddReplayRedactShouldNotFailIfMissingReplayIntegration() {
-        PrivateSentrySDKOnly.addReplayRedactClasses([])
-    }
-
     #if canImport(UIKit)
     func testCaptureReplayShouldCallReplayIntegration() {
         guard #available(iOS 16.0, tvOS 16.0, *) else { return }


### PR DESCRIPTION
## :scroll: Description

This exposes a define `SENTRY_TARGET_REPLAY_SUPPORTED` (there's already `SENTRY_TARGET_PROFILING_SUPPORTED` so keeping the name format) for hybrid SDKs so they don't have to copy the specific check `SENTRY_HAS_UIKIT && !TARGET_OS_VISION` which may change in the future, e.g. when replay for macOS is made available. Also, while adding this, I've noticed that some replay functions were exported & then logged a warning if replay wasn't available, while some were not exported at all (see link below for the RN PR). I've unified this so that no functions are exported for hybrid SDKs if replay is not available.

## :bulb: Motivation and Context

Came up in a compilation fail for RN https://github.com/getsentry/sentry-react-native/pull/3846#issuecomment-2177952419

## :green_heart: How did you test it?

All the original code & tests should pass. Except for tests that tried if the interfaces didn't throw when replay isn't available, obviously, since those are removed now.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

Use this new define in RN and Flutter.

#skip-changelog because this change isn't for normal SDK consumers.
