### PR TITLE
feat: Add beforeSendSpan callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Restart replay session with mobile session (#4085)
 - Add pause and resume AppHangTracking API (#4077). You can now pause and resume app hang tracking with `SentrySDK.pauseAppHangTracking()` and `SentrySDK.resumeAppHangTracking()`.
+- Add `beforeSendSpan` callback (#4095)
 
 ### Fixes
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -24,6 +24,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.beforeSend = { event in
                 return event
             }
+            options.beforeSendSpan = { span in
+                return span
+            }
             options.enableSigtermReporting = true
             options.beforeCaptureScreenshot = { _ in
                 return true

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -88,6 +88,12 @@ typedef SentryBreadcrumb *_Nullable (^SentryBeforeBreadcrumbCallback)(
 typedef SentryEvent *_Nullable (^SentryBeforeSendEventCallback)(SentryEvent *_Nonnull event);
 
 /**
+ * Use this block to drop or modify a span before the SDK sends it to Sentry. Return @c nil to drop
+ * the span.
+ */
+typedef id<SentrySpan> _Nullable (^SentryBeforeSendSpanCallback)(id<SentrySpan> _Nonnull span);
+
+/**
  * Block can be used to decide if the SDK should capture a screenshot or not. Return @c true if the
  * SDK should capture a screenshot, return @c false if not. This callback doesn't work for crashes.
  */

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -118,6 +118,12 @@ NS_SWIFT_NAME(Options)
 @property (nullable, nonatomic, copy) SentryBeforeSendEventCallback beforeSend;
 
 /**
+ * Use this callback to drop or modify a span before the SDK sends it to Sentry. Return @c nil to
+ * drop the span.
+ */
+@property (nullable, nonatomic, copy) SentryBeforeSendSpanCallback beforeSendSpan;
+
+/**
  * This block can be used to modify the event before it will be serialized and sent.
  */
 @property (nullable, nonatomic, copy) SentryBeforeBreadcrumbCallback beforeBreadcrumb;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -343,6 +343,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.beforeSend = options[@"beforeSend"];
     }
 
+    if ([self isBlock:options[@"beforeSendSpan"]]) {
+        self.beforeSendSpan = options[@"beforeSendSpan"];
+    }
+
     if ([self isBlock:options[@"beforeBreadcrumb"]]) {
         self.beforeBreadcrumb = options[@"beforeBreadcrumb"];
     }

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -9,13 +9,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryTransaction ()
-
-@property (nonatomic, strong) NSArray<id<SentrySpan>> *spans;
-
-@end
-
 @implementation SentryTransaction
 
 - (instancetype)initWithTrace:(SentryTracer *)trace children:(NSArray<id<SentrySpan>> *)children

--- a/Sources/Sentry/include/SentryTransaction.h
+++ b/Sources/Sentry/include/SentryTransaction.h
@@ -12,6 +12,7 @@ SENTRY_NO_INIT
 
 @property (nonatomic, strong) SentryTracer *trace;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *viewNames;
+@property (nonatomic, strong) NSArray<id<SentrySpan>> *spans;
 
 - (instancetype)initWithTrace:(SentryTracer *)trace children:(NSArray<id<SentrySpan>> *)children;
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1104,6 +1104,7 @@ class SentryClientTest: XCTestCase {
         }
     }
     
+    /// Ensure that you can't start and finish new spans in the beforeSendSpan Callback
     func testBeforeSendSpan_StartSpan_ReturnsNoOpSpan() throws {
         let tracer = fixture.trace
         let span = getSpan(operation: "operation", tracer: tracer)

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1065,6 +1065,7 @@ class SentryClientTest: XCTestCase {
         let spanOne = getSpan(operation: "operation.one", tracer: fixture.trace)
         let spanTwo = getSpan(operation: "operation.two", tracer: fixture.trace)
         let transaction = Transaction(trace: fixture.trace, children: [spanOne, spanTwo])
+        
         fixture.getSut(configureOptions: { options in
             options.beforeSendSpan = { span in
                 if span.operation == "operation.one" {
@@ -1769,7 +1770,7 @@ class SentryClientTest: XCTestCase {
     
     private func getSpan(operation: String, tracer: SentryTracer) -> Span {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-        return SentrySpan(tracer: tracer, context: SpanContext(operation: "operation"), framesTracker: nil)
+        return SentrySpan(tracer: tracer, context: SpanContext(operation: operation), framesTracker: nil)
 #else
         return  SentrySpan(tracer: tracer, context: SpanContext(operation: operation))
         #endif

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -2,6 +2,7 @@
 #import "SentryError.h"
 #import "SentryOptions+HybridSDKs.h"
 #import "SentrySDK.h"
+#import "SentrySpan.h"
 #import "SentryTests-Swift.h"
 #import <XCTest/XCTest.h>
 @import Nimble;
@@ -297,6 +298,21 @@
     SentryOptions *options = [self getValidOptions:@{ @"beforeSend" : [NSNull null] }];
 
     XCTAssertFalse([options.beforeSend isEqual:[NSNull null]]);
+}
+
+- (void)testBeforeSendSpan
+{
+    SentryBeforeSendSpanCallback callback = ^(id<SentrySpan> span) { return span; };
+    SentryOptions *options = [self getValidOptions:@{ @"beforeSendSpan" : callback }];
+
+    XCTAssertEqual(callback, options.beforeSendSpan);
+}
+
+- (void)testDefaultBeforeSendSpan
+{
+    SentryOptions *options = [self getValidOptions:@{}];
+
+    XCTAssertNil(options.beforeSendSpan);
 }
 
 - (void)testBeforeBreadcrumb


### PR DESCRIPTION
## :scroll: Description

Add a callback to drop or change spans of a transaction.

## :bulb: Motivation and Context

Fixes GH-4083

## :green_heart: How did you test it?
Unit tests and sample app.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
