### PR TITLE
fix: take copy of SentryOptions on SDK start

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -104,6 +104,9 @@
                   Identifier = "SentrySubClassFinderTests/testActOnSubclassesOfViewController()">
                </Test>
                <Test
+                  Identifier = "SentryThreadInspectorTests/testGetCurrentThreadsWithStacktrace_WithSymbolication()">
+               </Test>
+               <Test
                   Identifier = "SentryThreadInspectorTests/testStacktraceHasFrames_forEveryThread()">
                </Test>
                <Test

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -8,7 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryExperimentalOptions;
 
 NS_SWIFT_NAME(Options)
-@interface SentryOptions : NSObject
+@interface SentryOptions : NSObject <NSCopying>
 
 /**
  * The DSN tells the SDK where to send the events to. If this value is not provided, the SDK will

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -33,6 +33,8 @@ SENTRY_NO_INIT
  *
  * @discussion Call this method on the main thread. When calling it from a background thread, the
  * SDK starts on the main thread async.
+ *
+ * @warning Once called, do not attempt to modify @c options . The Sentry SDK takes an internal copy of the object, so any changes you try to make will have no effect.
  */
 + (void)startWithOptions:(SentryOptions *)options NS_SWIFT_NAME(start(options:));
 
@@ -42,6 +44,8 @@ SENTRY_NO_INIT
  *
  * @discussion Call this method on the main thread. When calling it from a background thread, the
  * SDK starts on the main thread async.
+ *
+ * @warning Once called, do not attempt to take a reference to @c options for later modification. The Sentry SDK takes an internal copy of the object, so any changes you try to make will have no effect.
  */
 + (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions
     NS_SWIFT_NAME(start(configureOptions:));

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -34,7 +34,8 @@ SENTRY_NO_INIT
  * @discussion Call this method on the main thread. When calling it from a background thread, the
  * SDK starts on the main thread async.
  *
- * @warning Once called, do not attempt to modify @c options . The Sentry SDK takes an internal copy of the object, so any changes you try to make will have no effect.
+ * @warning Once called, do not attempt to modify @c options . The Sentry SDK takes an internal copy
+ * of the object, so any changes you try to make will have no effect.
  */
 + (void)startWithOptions:(SentryOptions *)options NS_SWIFT_NAME(start(options:));
 
@@ -45,7 +46,9 @@ SENTRY_NO_INIT
  * @discussion Call this method on the main thread. When calling it from a background thread, the
  * SDK starts on the main thread async.
  *
- * @warning Once called, do not attempt to take a reference to @c options for later modification. The Sentry SDK takes an internal copy of the object, so any changes you try to make will have no effect.
+ * @warning Once called, do not attempt to take a reference to @c options for later modification.
+ * The Sentry SDK takes an internal copy of the object, so any changes you try to make will have no
+ * effect.
  */
 + (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions
     NS_SWIFT_NAME(start(configureOptions:));

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -39,7 +39,8 @@ NSString *const kSentryDefaultEnvironment = @"production";
     BOOL _enableTracingManual;
 }
 
-- (id)copyWithZone:(nullable NSZone *)zone {
+- (id)copyWithZone:(nullable NSZone *)zone
+{
     SentryOptions *copy = [[SentryOptions alloc] init];
     copy.dsn = _dsn;
     copy.parsedDsn = _parsedDsn;
@@ -96,10 +97,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
     copy.enableAppLaunchProfiling = _enableAppLaunchProfiling;
     copy.profilesSampleRate = _profilesSampleRate;
     copy.profilesSampler = _profilesSampler;
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     copy.enableProfiling = _enableProfiling;
-#    pragma clang diagnostic pop
+#pragma clang diagnostic pop
     copy.sendClientReports = _sendClientReports;
     copy.enableAppHangTracking = _enableAppHangTracking;
     copy.appHangTimeoutInterval = _appHangTimeoutInterval;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -39,6 +39,92 @@ NSString *const kSentryDefaultEnvironment = @"production";
     BOOL _enableTracingManual;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone {
+    SentryOptions *copy = [[SentryOptions alloc] init];
+    copy.dsn = _dsn;
+    copy.parsedDsn = _parsedDsn;
+    copy.debug = _debug;
+    copy.diagnosticLevel = _diagnosticLevel;
+    copy.releaseName = _releaseName;
+    copy.dist = _dist;
+    copy.environment = _environment;
+    copy.enabled = _enabled;
+    copy.shutdownTimeInterval = _shutdownTimeInterval;
+    copy.enableCrashHandler = _enableCrashHandler;
+    copy.enableSigtermReporting = _enableSigtermReporting;
+    copy.maxBreadcrumbs = _maxBreadcrumbs;
+    copy.enableNetworkBreadcrumbs = _enableNetworkBreadcrumbs;
+    copy.maxCacheItems = _maxCacheItems;
+    copy.beforeSend = _beforeSend;
+    copy.beforeBreadcrumb = _beforeBreadcrumb;
+    copy.beforeCaptureScreenshot = _beforeCaptureScreenshot;
+    copy.onCrashedLastRun = _onCrashedLastRun;
+    copy.integrations = _integrations;
+    copy.sampleRate = _sampleRate;
+    copy.enableAutoSessionTracking = _enableAutoSessionTracking;
+    copy.enableGraphQLOperationTracking = _enableGraphQLOperationTracking;
+    copy.enableWatchdogTerminationTracking = _enableWatchdogTerminationTracking;
+    copy.sessionTrackingIntervalMillis = _sessionTrackingIntervalMillis;
+    copy.attachStacktrace = _attachStacktrace;
+    copy.maxAttachmentSize = _maxAttachmentSize;
+    copy.sendDefaultPii = _sendDefaultPii;
+    copy.enableAutoPerformanceTracing = _enableAutoPerformanceTracing;
+    copy.enablePerformanceV2 = _enablePerformanceV2;
+    copy.initialScope = [_initialScope copy];
+    copy.enableUIViewControllerTracing = _enableUIViewControllerTracing;
+    copy.attachScreenshot = _attachScreenshot;
+    copy.attachViewHierarchy = _attachViewHierarchy;
+    copy.enableUserInteractionTracing = _enableUserInteractionTracing;
+    copy.idleTimeout = _idleTimeout;
+    copy.enablePreWarmedAppStartTracing = _enablePreWarmedAppStartTracing;
+    copy.enableNetworkTracking = _enableNetworkTracking;
+    copy.enableFileIOTracing = _enableFileIOTracing;
+    copy.enableTracing = _enableTracing;
+    copy.tracesSampleRate = _tracesSampleRate;
+    copy.tracesSampler = _tracesSampler;
+    for (NSString *include in _inAppExcludes) {
+        [copy addInAppInclude:include];
+    }
+    for (NSString *exclude in _inAppExcludes) {
+        [copy addInAppExclude:exclude];
+    }
+    copy.urlSessionDelegate = _urlSessionDelegate;
+    copy.urlSession = _urlSession;
+    copy.enableSwizzling = _enableSwizzling;
+    copy.swizzleClassNameExcludes = _swizzleClassNameExcludes;
+    copy.enableCoreDataTracing = _enableCoreDataTracing;
+    copy.enableAppLaunchProfiling = _enableAppLaunchProfiling;
+    copy.profilesSampleRate = _profilesSampleRate;
+    copy.profilesSampler = _profilesSampler;
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    copy.enableProfiling = _enableProfiling;
+#    pragma clang diagnostic pop
+    copy.sendClientReports = _sendClientReports;
+    copy.enableAppHangTracking = _enableAppHangTracking;
+    copy.appHangTimeoutInterval = _appHangTimeoutInterval;
+    copy.enableAutoBreadcrumbTracking = _enableAutoBreadcrumbTracking;
+    copy.tracePropagationTargets = _tracePropagationTargets;
+    copy.enableCaptureFailedRequests = _enableCaptureFailedRequests;
+    copy.failedRequestStatusCodes = _failedRequestStatusCodes;
+    copy.failedRequestTargets = _failedRequestTargets;
+    if (@available(iOS 15.0, *)) {
+        copy.enableMetricKit = _enableMetricKit;
+        copy.enableMetricKitRawPayload = _enableMetricKitRawPayload;
+    }
+    copy.enableTimeToFullDisplayTracing = _enableTimeToFullDisplayTracing;
+    copy.swiftAsyncStacktraces = _swiftAsyncStacktraces;
+    copy.cacheDirectoryPath = _cacheDirectoryPath;
+    copy.enableSpotlight = _enableSpotlight;
+    copy.spotlightUrl = _spotlightUrl;
+    copy.enableMetrics = _enableMetrics;
+    copy.enableDefaultTagsForMetrics = _enableDefaultTagsForMetrics;
+    copy.enableSpanLocalMetricAggregation = _enableSpanLocalMetricAggregation;
+    copy.beforeEmitMetric = _beforeEmitMetric;
+    copy.experimental.sessionReplay = _experimental.sessionReplay;
+    return copy;
+}
+
 - (void)setMeasurement:(SentryMeasurementValue *)measurement
 {
 }

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -193,7 +193,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)startWithOptions:(SentryOptions *)options
 {
-    startOption = options;
+    startOption = [options copy];
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
     // We accept the tradeoff that the SDK might not be fully initialized directly after

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -4,6 +4,8 @@
 #import "SentrySDK.h"
 #import "SentryTests-Swift.h"
 #import <XCTest/XCTest.h>
+#import "SentryDefines.h"
+#import "SentryProfilingConditionals.h"
 @import Nimble;
 
 @interface SentryOptionsTest : XCTestCase
@@ -11,6 +13,179 @@
 @end
 
 @implementation SentryOptionsTest
+
+- (void)testSentryOptionsCopy {
+    // Create an instance of SentryOptions with non-default values
+    SentryOptions *originalOptions = [[SentryOptions alloc] init];
+    originalOptions.dsn = @"https://examplePublicKey@o0.ingest.sentry.io/0";
+    originalOptions.debug = YES;
+    originalOptions.diagnosticLevel = kSentryLevelError;
+    originalOptions.releaseName = @"1.0.0";
+    originalOptions.dist = @"100";
+    originalOptions.environment = @"staging";
+    originalOptions.enabled = NO;
+    originalOptions.shutdownTimeInterval = 5.0;
+    originalOptions.enableCrashHandler = NO;
+#if !TARGET_OS_WATCH
+    originalOptions.enableSigtermReporting = YES;
+#endif
+    originalOptions.maxBreadcrumbs = 50;
+    originalOptions.enableNetworkBreadcrumbs = NO;
+    originalOptions.maxCacheItems = 10;
+    originalOptions.sampleRate = @0.5;
+    originalOptions.enableAutoSessionTracking = NO;
+    originalOptions.enableGraphQLOperationTracking = YES;
+    originalOptions.enableWatchdogTerminationTracking = NO;
+    originalOptions.sessionTrackingIntervalMillis = 60000;
+    originalOptions.attachStacktrace = NO;
+    originalOptions.maxAttachmentSize = 10 * 1024 * 1024;
+    originalOptions.sendDefaultPii = YES;
+    originalOptions.enableAutoPerformanceTracing = NO;
+    originalOptions.enablePerformanceV2 = YES;
+#if SENTRY_UIKIT_AVAILABLE
+    originalOptions.enableUIViewControllerTracing = NO;
+    originalOptions.attachScreenshot = YES;
+    originalOptions.attachViewHierarchy = YES;
+    originalOptions.enableUserInteractionTracing = NO;
+    originalOptions.idleTimeout = 10.0;
+    originalOptions.enablePreWarmedAppStartTracing = YES;
+#endif
+    originalOptions.enableNetworkTracking = NO;
+    originalOptions.enableFileIOTracing = NO;
+    originalOptions.enableTracing = YES;
+    originalOptions.tracesSampleRate = @0.2;
+    originalOptions.enableAppLaunchProfiling = YES;
+    originalOptions.profilesSampleRate = @0.3;
+    originalOptions.sendClientReports = NO;
+    originalOptions.enableAppHangTracking = NO;
+    originalOptions.appHangTimeoutInterval = 1.0;
+    originalOptions.enableAutoBreadcrumbTracking = NO;
+    originalOptions.tracePropagationTargets = @[@"example.com"];
+    originalOptions.enableCaptureFailedRequests = NO;
+    originalOptions.failedRequestStatusCodes = @[[[SentryHttpStatusCodeRange alloc] initWithMin:400 max:499]];
+    originalOptions.failedRequestTargets = @[@"example.com"];
+#if SENTRY_HAS_METRIC_KIT
+    if (@available(iOS 15.0, *)) {
+        originalOptions.enableMetricKit = YES;
+        originalOptions.enableMetricKitRawPayload = YES;
+    }
+#endif
+    originalOptions.enableTimeToFullDisplayTracing = YES;
+    originalOptions.swiftAsyncStacktraces = YES;
+    originalOptions.cacheDirectoryPath = @"/tmp/sentry";
+    originalOptions.enableSpotlight = YES;
+    originalOptions.spotlightUrl = @"http://localhost:1234";
+    originalOptions.enableMetrics = YES;
+    originalOptions.enableDefaultTagsForMetrics = NO;
+    originalOptions.enableSpanLocalMetricAggregation = NO;
+    originalOptions.enableProfiling_DEPRECATED_TEST_ONLY = YES;
+    
+    SentryEvent *_Nullable(^beforeSend)(SentryEvent *_Nonnull) = ^(SentryEvent *_Nonnull __unused event) {
+        return nil;
+    };
+    
+    originalOptions.beforeSend = beforeSend;
+    originalOptions.beforeBreadcrumb
+    originalOptions.beforeCaptureScreenshot
+    originalOptions.onCrashedLastRun
+
+    
+    [self assertNonDefaultValuesForSentryOptions:originalOptions];
+
+    // Create a copy of the original options
+    SentryOptions *copiedOptions = [originalOptions copy];
+
+    // Test that the copied options have the same property values as the original
+    XCTAssertEqualObjects(originalOptions.dsn, copiedOptions.dsn);
+    XCTAssertEqual(originalOptions.debug, copiedOptions.debug);
+    XCTAssertEqual(originalOptions.diagnosticLevel, copiedOptions.diagnosticLevel);
+    XCTAssertEqualObjects(originalOptions.releaseName, copiedOptions.releaseName);
+    XCTAssertEqualObjects(originalOptions.dist, copiedOptions.dist);
+    XCTAssertEqualObjects(originalOptions.environment, copiedOptions.environment);
+    XCTAssertEqual(originalOptions.enabled, copiedOptions.enabled);
+    XCTAssertEqual(originalOptions.shutdownTimeInterval, copiedOptions.shutdownTimeInterval);
+    XCTAssertEqual(originalOptions.enableCrashHandler, copiedOptions.enableCrashHandler);
+#if !TARGET_OS_WATCH
+    XCTAssertEqual(originalOptions.enableSigtermReporting, copiedOptions.enableSigtermReporting);
+#endif
+    XCTAssertEqual(originalOptions.maxBreadcrumbs, copiedOptions.maxBreadcrumbs);
+    XCTAssertEqual(originalOptions.enableNetworkBreadcrumbs, copiedOptions.enableNetworkBreadcrumbs);
+    XCTAssertEqual(originalOptions.maxCacheItems, copiedOptions.maxCacheItems);
+    XCTAssertEqualObjects(originalOptions.sampleRate, copiedOptions.sampleRate);
+    XCTAssertEqual(originalOptions.enableAutoSessionTracking, copiedOptions.enableAutoSessionTracking);
+    XCTAssertEqual(originalOptions.enableGraphQLOperationTracking, copiedOptions.enableGraphQLOperationTracking);
+    XCTAssertEqual(originalOptions.enableWatchdogTerminationTracking, copiedOptions.enableWatchdogTerminationTracking);
+    XCTAssertEqual(originalOptions.sessionTrackingIntervalMillis, copiedOptions.sessionTrackingIntervalMillis);
+    XCTAssertEqual(originalOptions.attachStacktrace, copiedOptions.attachStacktrace);
+    XCTAssertEqual(originalOptions.maxAttachmentSize, copiedOptions.maxAttachmentSize);
+    XCTAssertEqual(originalOptions.sendDefaultPii, copiedOptions.sendDefaultPii);
+    XCTAssertEqual(originalOptions.enableAutoPerformanceTracing, copiedOptions.enableAutoPerformanceTracing);
+    XCTAssertEqual(originalOptions.enablePerformanceV2, copiedOptions.enablePerformanceV2);
+#if SENTRY_UIKIT_AVAILABLE
+    XCTAssertEqual(originalOptions.enableUIViewControllerTracing, copiedOptions.enableUIViewControllerTracing);
+    XCTAssertEqual(originalOptions.attachScreenshot, copiedOptions.attachScreenshot);
+    XCTAssertEqual(originalOptions.attachViewHierarchy, copiedOptions.attachViewHierarchy);
+    XCTAssertEqual(originalOptions.enableUserInteractionTracing, copiedOptions.enableUserInteractionTracing);
+    XCTAssertEqual(originalOptions.idleTimeout, copiedOptions.idleTimeout);
+    XCTAssertEqual(originalOptions.enablePreWarmedAppStartTracing, copiedOptions.enablePreWarmedAppStartTracing);
+#endif
+    XCTAssertEqual(originalOptions.enableNetworkTracking, copiedOptions.enableNetworkTracking);
+    XCTAssertEqual(originalOptions.enableFileIOTracing, copiedOptions.enableFileIOTracing);
+    XCTAssertEqual(originalOptions.enableTracing, copiedOptions.enableTracing);
+    XCTAssertEqualObjects(originalOptions.tracesSampleRate, copiedOptions.tracesSampleRate);
+    XCTAssertEqual(originalOptions.enableAppLaunchProfiling, copiedOptions.enableAppLaunchProfiling);
+    XCTAssertEqualObjects(originalOptions.profilesSampleRate, copiedOptions.profilesSampleRate);
+    XCTAssertEqual(originalOptions.sendClientReports, copiedOptions.sendClientReports);
+    XCTAssertEqual(originalOptions.enableAppHangTracking, copiedOptions.enableAppHangTracking);
+    XCTAssertEqual(originalOptions.appHangTimeoutInterval, copiedOptions.appHangTimeoutInterval);
+    XCTAssertEqual(originalOptions.enableAutoBreadcrumbTracking, copiedOptions.enableAutoBreadcrumbTracking);
+    XCTAssertEqualObjects(originalOptions.tracePropagationTargets, copiedOptions.tracePropagationTargets);
+    XCTAssertEqual(originalOptions.enableCaptureFailedRequests, copiedOptions.enableCaptureFailedRequests);
+    XCTAssertEqualObjects(originalOptions.failedRequestStatusCodes, copiedOptions.failedRequestStatusCodes);
+    XCTAssertEqualObjects(originalOptions.failedRequestTargets, copiedOptions.failedRequestTargets);
+#if SENTRY_HAS_METRIC_KIT
+    if (@available(iOS 15.0, *)) {
+        XCTAssertEqual(originalOptions.enableMetricKit, copiedOptions.enableMetricKit);
+        XCTAssertEqual(originalOptions.enableMetricKitRawPayload, copiedOptions.enableMetricKitRawPayload);
+    }
+#endif
+    XCTAssertEqual(originalOptions.enableTimeToFullDisplayTracing, copiedOptions.enableTimeToFullDisplayTracing);
+    XCTAssertEqual(originalOptions.swiftAsyncStacktraces, copiedOptions.swiftAsyncStacktraces);
+    XCTAssertEqualObjects(originalOptions.cacheDirectoryPath, copiedOptions.cacheDirectoryPath);
+    XCTAssertEqual(originalOptions.enableSpotlight, copiedOptions.enableSpotlight);
+    XCTAssertEqualObjects(originalOptions.spotlightUrl, copiedOptions.spotlightUrl);
+    XCTAssertEqual(originalOptions.enableMetrics, copiedOptions.enableMetrics);
+    XCTAssertEqual(originalOptions.enableDefaultTagsForMetrics, copiedOptions.enableDefaultTagsForMetrics);
+    XCTAssertEqual(originalOptions.enableSpanLocalMetricAggregation, copiedOptions.enableSpanLocalMetricAggregation);
+}
+
+/**
+ * this method dynamically checks every property in an options, instance and ensures that it is not the default value for that property. This helps to ensure that when we make a copy, we are able to check that all values are copied over, and that were not simply comparing the default value in a new instance to a default value that was there from the start, and never changed.
+ */
+- (void)assertNonDefaultValuesForSentryOptions:(SentryOptions *)options {
+    SentryOptions *defaultOptions = [[SentryOptions alloc] init];
+    unsigned int outCount, i;
+    objc_property_t *properties = class_copyPropertyList([SentryOptions class], &outCount);
+    for (i = 0; i < outCount; i++) {
+        objc_property_t property = properties[i];
+        const char *propName = property_getName(property);
+        NSString *propertyName = [NSString stringWithUTF8String:propName];
+        
+        id defaultValue = [defaultOptions valueForKey:propertyName];
+        id nonDefaultValue = [options valueForKey:propertyName];
+        
+        if (defaultValue == nil) {
+            XCTAssertNotNil(nonDefaultValue, @"Property %@ should not be nil", propertyName);
+        } else if (nonDefaultValue == nil) {
+            XCTAssertNotNil(nonDefaultValue, @"Property %@ should not be nil", propertyName);
+        } else if ([defaultValue isKindOfClass:[NSNumber class]] || [defaultValue isKindOfClass:[NSString class]]) {
+            XCTAssertNotEqualObjects(defaultValue, nonDefaultValue, @"Property %@ should have a non-default value", propertyName);
+        } else {
+            XCTAssertNotEqualObjects(defaultValue, nonDefaultValue, @"Property %@ should have a non-default value", propertyName);
+        }
+    }
+    free(properties);
+}
 
 - (void)testEmptyDsn
 {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1,11 +1,11 @@
 #import "SentryOptions.h"
+#import "SentryDefines.h"
 #import "SentryError.h"
 #import "SentryOptions+HybridSDKs.h"
+#import "SentryProfilingConditionals.h"
 #import "SentrySDK.h"
 #import "SentryTests-Swift.h"
 #import <XCTest/XCTest.h>
-#import "SentryDefines.h"
-#import "SentryProfilingConditionals.h"
 @import Nimble;
 
 @interface SentryOptionsTest : XCTestCase
@@ -14,7 +14,8 @@
 
 @implementation SentryOptionsTest
 
-- (void)testSentryOptionsCopy {
+- (void)testSentryOptionsCopy
+{
     // Create an instance of SentryOptions with non-default values
     SentryOptions *originalOptions = [[SentryOptions alloc] init];
     originalOptions.dsn = @"https://examplePublicKey@o0.ingest.sentry.io/0";
@@ -60,10 +61,11 @@
     originalOptions.enableAppHangTracking = NO;
     originalOptions.appHangTimeoutInterval = 1.0;
     originalOptions.enableAutoBreadcrumbTracking = NO;
-    originalOptions.tracePropagationTargets = @[@"example.com"];
+    originalOptions.tracePropagationTargets = @[ @"example.com" ];
     originalOptions.enableCaptureFailedRequests = NO;
-    originalOptions.failedRequestStatusCodes = @[[[SentryHttpStatusCodeRange alloc] initWithMin:400 max:499]];
-    originalOptions.failedRequestTargets = @[@"example.com"];
+    originalOptions.failedRequestStatusCodes =
+        @[ [[SentryHttpStatusCodeRange alloc] initWithMin:400 max:499] ];
+    originalOptions.failedRequestTargets = @[ @"example.com" ];
 #if SENTRY_HAS_METRIC_KIT
     if (@available(iOS 15.0, *)) {
         originalOptions.enableMetricKit = YES;
@@ -79,18 +81,15 @@
     originalOptions.enableDefaultTagsForMetrics = NO;
     originalOptions.enableSpanLocalMetricAggregation = NO;
     originalOptions.enableProfiling_DEPRECATED_TEST_ONLY = YES;
-    
-    SentryEvent *_Nullable(^beforeSend)(SentryEvent *_Nonnull) = ^(SentryEvent *_Nonnull __unused event) {
-        return nil;
-    };
-    
-    originalOptions.beforeSend = beforeSend;
-    originalOptions.beforeBreadcrumb
-    originalOptions.beforeCaptureScreenshot
-    originalOptions.onCrashedLastRun
 
-    
-    [self assertNonDefaultValuesForSentryOptions:originalOptions];
+    SentryEvent *_Nullable (^beforeSend)(SentryEvent *_Nonnull)
+        = ^(SentryEvent *_Nonnull __unused event) { return nil; };
+
+    originalOptions.beforeSend = beforeSend;
+    originalOptions.beforeBreadcrumb originalOptions.beforeCaptureScreenshot originalOptions
+        .onCrashedLastRun
+
+        [self assertNonDefaultValuesForSentryOptions:originalOptions];
 
     // Create a copy of the original options
     SentryOptions *copiedOptions = [originalOptions copy];
@@ -109,60 +108,82 @@
     XCTAssertEqual(originalOptions.enableSigtermReporting, copiedOptions.enableSigtermReporting);
 #endif
     XCTAssertEqual(originalOptions.maxBreadcrumbs, copiedOptions.maxBreadcrumbs);
-    XCTAssertEqual(originalOptions.enableNetworkBreadcrumbs, copiedOptions.enableNetworkBreadcrumbs);
+    XCTAssertEqual(
+        originalOptions.enableNetworkBreadcrumbs, copiedOptions.enableNetworkBreadcrumbs);
     XCTAssertEqual(originalOptions.maxCacheItems, copiedOptions.maxCacheItems);
     XCTAssertEqualObjects(originalOptions.sampleRate, copiedOptions.sampleRate);
-    XCTAssertEqual(originalOptions.enableAutoSessionTracking, copiedOptions.enableAutoSessionTracking);
-    XCTAssertEqual(originalOptions.enableGraphQLOperationTracking, copiedOptions.enableGraphQLOperationTracking);
-    XCTAssertEqual(originalOptions.enableWatchdogTerminationTracking, copiedOptions.enableWatchdogTerminationTracking);
-    XCTAssertEqual(originalOptions.sessionTrackingIntervalMillis, copiedOptions.sessionTrackingIntervalMillis);
+    XCTAssertEqual(
+        originalOptions.enableAutoSessionTracking, copiedOptions.enableAutoSessionTracking);
+    XCTAssertEqual(originalOptions.enableGraphQLOperationTracking,
+        copiedOptions.enableGraphQLOperationTracking);
+    XCTAssertEqual(originalOptions.enableWatchdogTerminationTracking,
+        copiedOptions.enableWatchdogTerminationTracking);
+    XCTAssertEqual(
+        originalOptions.sessionTrackingIntervalMillis, copiedOptions.sessionTrackingIntervalMillis);
     XCTAssertEqual(originalOptions.attachStacktrace, copiedOptions.attachStacktrace);
     XCTAssertEqual(originalOptions.maxAttachmentSize, copiedOptions.maxAttachmentSize);
     XCTAssertEqual(originalOptions.sendDefaultPii, copiedOptions.sendDefaultPii);
-    XCTAssertEqual(originalOptions.enableAutoPerformanceTracing, copiedOptions.enableAutoPerformanceTracing);
+    XCTAssertEqual(
+        originalOptions.enableAutoPerformanceTracing, copiedOptions.enableAutoPerformanceTracing);
     XCTAssertEqual(originalOptions.enablePerformanceV2, copiedOptions.enablePerformanceV2);
 #if SENTRY_UIKIT_AVAILABLE
-    XCTAssertEqual(originalOptions.enableUIViewControllerTracing, copiedOptions.enableUIViewControllerTracing);
+    XCTAssertEqual(
+        originalOptions.enableUIViewControllerTracing, copiedOptions.enableUIViewControllerTracing);
     XCTAssertEqual(originalOptions.attachScreenshot, copiedOptions.attachScreenshot);
     XCTAssertEqual(originalOptions.attachViewHierarchy, copiedOptions.attachViewHierarchy);
-    XCTAssertEqual(originalOptions.enableUserInteractionTracing, copiedOptions.enableUserInteractionTracing);
+    XCTAssertEqual(
+        originalOptions.enableUserInteractionTracing, copiedOptions.enableUserInteractionTracing);
     XCTAssertEqual(originalOptions.idleTimeout, copiedOptions.idleTimeout);
-    XCTAssertEqual(originalOptions.enablePreWarmedAppStartTracing, copiedOptions.enablePreWarmedAppStartTracing);
+    XCTAssertEqual(originalOptions.enablePreWarmedAppStartTracing,
+        copiedOptions.enablePreWarmedAppStartTracing);
 #endif
     XCTAssertEqual(originalOptions.enableNetworkTracking, copiedOptions.enableNetworkTracking);
     XCTAssertEqual(originalOptions.enableFileIOTracing, copiedOptions.enableFileIOTracing);
     XCTAssertEqual(originalOptions.enableTracing, copiedOptions.enableTracing);
     XCTAssertEqualObjects(originalOptions.tracesSampleRate, copiedOptions.tracesSampleRate);
-    XCTAssertEqual(originalOptions.enableAppLaunchProfiling, copiedOptions.enableAppLaunchProfiling);
+    XCTAssertEqual(
+        originalOptions.enableAppLaunchProfiling, copiedOptions.enableAppLaunchProfiling);
     XCTAssertEqualObjects(originalOptions.profilesSampleRate, copiedOptions.profilesSampleRate);
     XCTAssertEqual(originalOptions.sendClientReports, copiedOptions.sendClientReports);
     XCTAssertEqual(originalOptions.enableAppHangTracking, copiedOptions.enableAppHangTracking);
     XCTAssertEqual(originalOptions.appHangTimeoutInterval, copiedOptions.appHangTimeoutInterval);
-    XCTAssertEqual(originalOptions.enableAutoBreadcrumbTracking, copiedOptions.enableAutoBreadcrumbTracking);
-    XCTAssertEqualObjects(originalOptions.tracePropagationTargets, copiedOptions.tracePropagationTargets);
-    XCTAssertEqual(originalOptions.enableCaptureFailedRequests, copiedOptions.enableCaptureFailedRequests);
-    XCTAssertEqualObjects(originalOptions.failedRequestStatusCodes, copiedOptions.failedRequestStatusCodes);
+    XCTAssertEqual(
+        originalOptions.enableAutoBreadcrumbTracking, copiedOptions.enableAutoBreadcrumbTracking);
+    XCTAssertEqualObjects(
+        originalOptions.tracePropagationTargets, copiedOptions.tracePropagationTargets);
+    XCTAssertEqual(
+        originalOptions.enableCaptureFailedRequests, copiedOptions.enableCaptureFailedRequests);
+    XCTAssertEqualObjects(
+        originalOptions.failedRequestStatusCodes, copiedOptions.failedRequestStatusCodes);
     XCTAssertEqualObjects(originalOptions.failedRequestTargets, copiedOptions.failedRequestTargets);
 #if SENTRY_HAS_METRIC_KIT
     if (@available(iOS 15.0, *)) {
         XCTAssertEqual(originalOptions.enableMetricKit, copiedOptions.enableMetricKit);
-        XCTAssertEqual(originalOptions.enableMetricKitRawPayload, copiedOptions.enableMetricKitRawPayload);
+        XCTAssertEqual(
+            originalOptions.enableMetricKitRawPayload, copiedOptions.enableMetricKitRawPayload);
     }
 #endif
-    XCTAssertEqual(originalOptions.enableTimeToFullDisplayTracing, copiedOptions.enableTimeToFullDisplayTracing);
+    XCTAssertEqual(originalOptions.enableTimeToFullDisplayTracing,
+        copiedOptions.enableTimeToFullDisplayTracing);
     XCTAssertEqual(originalOptions.swiftAsyncStacktraces, copiedOptions.swiftAsyncStacktraces);
     XCTAssertEqualObjects(originalOptions.cacheDirectoryPath, copiedOptions.cacheDirectoryPath);
     XCTAssertEqual(originalOptions.enableSpotlight, copiedOptions.enableSpotlight);
     XCTAssertEqualObjects(originalOptions.spotlightUrl, copiedOptions.spotlightUrl);
     XCTAssertEqual(originalOptions.enableMetrics, copiedOptions.enableMetrics);
-    XCTAssertEqual(originalOptions.enableDefaultTagsForMetrics, copiedOptions.enableDefaultTagsForMetrics);
-    XCTAssertEqual(originalOptions.enableSpanLocalMetricAggregation, copiedOptions.enableSpanLocalMetricAggregation);
+    XCTAssertEqual(
+        originalOptions.enableDefaultTagsForMetrics, copiedOptions.enableDefaultTagsForMetrics);
+    XCTAssertEqual(originalOptions.enableSpanLocalMetricAggregation,
+        copiedOptions.enableSpanLocalMetricAggregation);
 }
 
 /**
- * this method dynamically checks every property in an options, instance and ensures that it is not the default value for that property. This helps to ensure that when we make a copy, we are able to check that all values are copied over, and that were not simply comparing the default value in a new instance to a default value that was there from the start, and never changed.
+ * this method dynamically checks every property in an options, instance and ensures that it is not
+ * the default value for that property. This helps to ensure that when we make a copy, we are able
+ * to check that all values are copied over, and that were not simply comparing the default value in
+ * a new instance to a default value that was there from the start, and never changed.
  */
-- (void)assertNonDefaultValuesForSentryOptions:(SentryOptions *)options {
+- (void)assertNonDefaultValuesForSentryOptions:(SentryOptions *)options
+{
     SentryOptions *defaultOptions = [[SentryOptions alloc] init];
     unsigned int outCount, i;
     objc_property_t *properties = class_copyPropertyList([SentryOptions class], &outCount);
@@ -170,18 +191,21 @@
         objc_property_t property = properties[i];
         const char *propName = property_getName(property);
         NSString *propertyName = [NSString stringWithUTF8String:propName];
-        
+
         id defaultValue = [defaultOptions valueForKey:propertyName];
         id nonDefaultValue = [options valueForKey:propertyName];
-        
+
         if (defaultValue == nil) {
             XCTAssertNotNil(nonDefaultValue, @"Property %@ should not be nil", propertyName);
         } else if (nonDefaultValue == nil) {
             XCTAssertNotNil(nonDefaultValue, @"Property %@ should not be nil", propertyName);
-        } else if ([defaultValue isKindOfClass:[NSNumber class]] || [defaultValue isKindOfClass:[NSString class]]) {
-            XCTAssertNotEqualObjects(defaultValue, nonDefaultValue, @"Property %@ should have a non-default value", propertyName);
+        } else if ([defaultValue isKindOfClass:[NSNumber class]] ||
+            [defaultValue isKindOfClass:[NSString class]]) {
+            XCTAssertNotEqualObjects(defaultValue, nonDefaultValue,
+                @"Property %@ should have a non-default value", propertyName);
         } else {
-            XCTAssertNotEqualObjects(defaultValue, nonDefaultValue, @"Property %@ should have a non-default value", propertyName);
+            XCTAssertNotEqualObjects(defaultValue, nonDefaultValue,
+                @"Property %@ should have a non-default value", propertyName);
         }
     }
     free(properties);


### PR DESCRIPTION
## :bulb: Motivation and Context

I've seen questions over time about what happens when a customer changes a value in the options object after starting the SDK. The response is always that it's not supported, yet it is possible in the code, allowing misconfiguration to occur. This will help prevent surprising effects (even though it might itself be surprising that changes are reflected–this will need to be documented better).

## :green_heart: How did you test it?

Old tests pass and modified where needed. New tests written to ensure that any time a new option is added, that it is also copied correctly.