### PR TITLE
fix: put crash logger default local level back to none

### DIFF
--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.h
@@ -241,7 +241,7 @@ void i_sentrycrashlog_logCBasic(const char *fmt, ...);
 #endif
 
 #ifndef SentryCrashLogger_LocalLevel
-#    define SentryCrashLogger_LocalLevel SentryCrashLogger_Level_Trace
+#    define SentryCrashLogger_LocalLevel SentryCrashLogger_Level_None
 #endif
 
 #define a_SentryCrashLOG_FULL(LEVEL, FMT, ...)                                                     \


### PR DESCRIPTION
I accidentally left a change that I was using to debug in this PR: https://github.com/getsentry/sentry-cocoa/commit/1e803dcc7a1d6391e8ae84b498509fe27fe7e523#diff-242aeee1da34d09c29c968f7c11e8fc2a5cd9abe5e6cd0de3334d28cb06e8744R244

<img width="1083" alt="image" src="https://github.com/getsentry/sentry-cocoa/assets/3241469/44acef36-ac29-4226-9d28-bdb3a5e82546">

This should default to None.

#skip-changelog