### PR TITLE
ref(logging): use SentryLog instead of SentryAsyncSafeLog for objc stuff

### DIFF
--- a/Sources/Sentry/SentryAsyncSafeLog.h
+++ b/Sources/Sentry/SentryAsyncSafeLog.h
@@ -169,31 +169,13 @@ extern "C" {
 
 #include <stdbool.h>
 
-#ifdef __OBJC__
-
-#    import <CoreFoundation/CoreFoundation.h>
-
-void sentry_asyncLogObjC(
-    const char *level, const char *file, int line, const char *function, CFStringRef fmt, ...);
-
-void sentry_asyncLogObjCBasic(CFStringRef fmt, ...);
-
-#    define i_SENTRY_ASYNC_SAFE_LOG_FULL(LEVEL, FILE, LINE, FUNCTION, FMT, ...)                    \
-        sentry_asyncLogObjC(LEVEL, FILE, LINE, FUNCTION, (__bridge CFStringRef)FMT, ##__VA_ARGS__)
-#    define i_SENTRY_ASYNC_SAFE_LOG_BASIC(FMT, ...)                                                \
-        sentry_asyncLogObjCBasic((__bridge CFStringRef)FMT, ##__VA_ARGS__)
-
-#else // __OBJC__
-
 void sentry_asyncLogC(
     const char *level, const char *file, int line, const char *function, const char *fmt, ...);
 
 void sentry_asyncLogCBasic(const char *fmt, ...);
 
-#    define i_SENTRY_ASYNC_SAFE_LOG_FULL sentry_asyncLogC
-#    define i_SENTRY_ASYNC_SAFE_LOG_BASIC sentry_asyncLogCBasic
-
-#endif // __OBJC__
+#define i_SENTRY_ASYNC_SAFE_LOG_FULL sentry_asyncLogC
+#define i_SENTRY_ASYNC_SAFE_LOG_BASIC sentry_asyncLogCBasic
 
 /* Back up any existing defines by the same name */
 #ifdef SENTRY_ASYNC_SAFE_LOG_NONE

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -34,7 +34,7 @@
 #import "SentryCrashSysCtl.h"
 #import "SentryCrashSystemCapabilities.h"
 
-#import "SentryAsyncSafeLog.h"
+#import "SentryLog.h"
 
 #import "SentryDefines.h"
 
@@ -177,14 +177,14 @@ VMStats(vm_statistics_data_t *const vmStats, vm_size_t *const pageSize)
     const mach_port_t hostPort = mach_host_self();
 
     if ((kr = host_page_size(hostPort, pageSize)) != KERN_SUCCESS) {
-        SENTRY_ASYNC_SAFE_LOG_ERROR(@"host_page_size: %s", mach_error_string(kr));
+        SENTRY_LOG_ERROR(@"host_page_size: %s", mach_error_string(kr));
         return false;
     }
 
     mach_msg_type_number_t hostSize = sizeof(*vmStats) / sizeof(natural_t);
     kr = host_statistics(hostPort, HOST_VM_INFO, (host_info_t)vmStats, &hostSize);
     if (kr != KERN_SUCCESS) {
-        SENTRY_ASYNC_SAFE_LOG_ERROR(@"host_statistics: %s", mach_error_string(kr));
+        SENTRY_LOG_ERROR(@"host_statistics: %s", mach_error_string(kr));
         return false;
     }
 

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -42,7 +42,7 @@
 #import "SentryNSNotificationCenterWrapper.h"
 #import <SentryNSDataUtils.h>
 
-#import "SentryAsyncSafeLog.h"
+#import "SentryLog.h"
 
 #if SENTRY_HAS_UIKIT
 #    import <UIKit/UIKit.h>
@@ -122,7 +122,7 @@ SentryCrash ()
                                      options:SentryCrashJSONEncodeOptionSorted
                                        error:&error]);
             if (error != NULL) {
-                SENTRY_ASYNC_SAFE_LOG_ERROR(@"Could not serialize user info: %@", error);
+                SENTRY_LOG_ERROR(@"Could not serialize user info: %@", error);
                 return;
             }
         }
@@ -217,8 +217,8 @@ SentryCrash ()
 - (BOOL)install
 {
     if (self.basePath == nil) {
-        SENTRY_ASYNC_SAFE_LOG_ERROR(@"Failed to initialize crash handler. Crash "
-                                    @"reporting disabled.");
+        SENTRY_LOG_ERROR(@"Failed to initialize crash handler. Crash "
+                         @"reporting disabled.");
         return NO;
     }
 
@@ -308,13 +308,13 @@ SentryCrash ()
 {
     NSArray *reports = [self allReports];
 
-    SENTRY_ASYNC_SAFE_LOG_INFO(@"Sending %d crash reports", [reports count]);
+    SENTRY_LOG_INFO(@"Sending %lu crash reports", (unsigned long)[reports count]);
 
     [self sendReports:reports
          onCompletion:^(NSArray *filteredReports, BOOL completed, NSError *error) {
-             SENTRY_ASYNC_SAFE_LOG_DEBUG(@"Process finished with completion: %d", completed);
+             SENTRY_LOG_DEBUG(@"Process finished with completion: %d", completed);
              if (error != nil) {
-                 SENTRY_ASYNC_SAFE_LOG_ERROR(@"Failed to send reports: %@", error);
+                 SENTRY_LOG_ERROR(@"Failed to send reports: %@", error);
              }
              if ((self.deleteBehaviorAfterSendAll == SentryCrashCDeleteOnSucess && completed)
                  || self.deleteBehaviorAfterSendAll == SentryCrashCDeleteAlways) {
@@ -453,11 +453,11 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
                                error:&error];
 
     if (error != nil) {
-        SENTRY_ASYNC_SAFE_LOG_ERROR(
+        SENTRY_LOG_ERROR(
             @"Encountered error loading crash report %" PRIx64 ": %@", reportID, error);
     }
     if (crashReport == nil) {
-        SENTRY_ASYNC_SAFE_LOG_ERROR(@"Could not load crash report");
+        SENTRY_LOG_ERROR(@"Could not load crash report");
         return nil;
     }
 

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -30,7 +30,7 @@
 #import "SentryCrashVarArgs.h"
 #import "SentryDictionaryDeepSearch.h"
 
-#import "SentryAsyncSafeLog.h"
+#import "SentryLog.h"
 
 @implementation SentryCrashReportFilterPassthrough
 
@@ -77,7 +77,7 @@ SentryCrashReportFilterCombine ()
     SentryCrashVA_Block block = ^(id entry) {
         if (isKey) {
             if (entry == nil) {
-                SENTRY_ASYNC_SAFE_LOG_ERROR(@"key entry was nil");
+                SENTRY_LOG_ERROR(@"key entry was nil");
             } else {
                 [keys addObject:entry];
             }
@@ -86,7 +86,7 @@ SentryCrashReportFilterCombine ()
                 entry = [SentryCrashReportFilterPipeline filterWithFilters:entry, nil];
             }
             if (![entry conformsToProtocol:@protocol(SentryCrashReportFilter)]) {
-                SENTRY_ASYNC_SAFE_LOG_ERROR(@"Not a filter: %@", entry);
+                SENTRY_LOG_ERROR(@"Not a filter: %@", entry);
                 // Cause next key entry to fail as well.
                 return;
             } else {


### PR DESCRIPTION
There was some implementation in the old Sentry crash logger that split logging between C and ObjC capabilities. Remove the ObjC capabilities and just use regular SentryLog for the places that were using it, which are just a couple crash handling set up and report processing facilities in ObjC sources. Those are not async-safe anyways due to their usage of ObC, so this is a safe change to make.

Follows #4101; skip-changelog