### PR TITLE
ref(logging): reconfigure async log sinks

### DIFF
--- a/Sources/Sentry/SentryAsyncSafeLog.h
+++ b/Sources/Sentry/SentryAsyncSafeLog.h
@@ -122,39 +122,9 @@
  * // SENTRY_ASYNC_SAFE_LOG_LOCAL_LEVEL, if defined, MUST come BEFORE including
  * SentryAsyncSafeLog.h #define SENTRY_ASYNC_SAFE_LOG_LOCAL_LEVEL TRACE #import
  * "SentryAsyncSafeLog.h"
- *
- *
- * ===============
- * IMPORTANT NOTES
- * ===============
- *
- * The C logger changes its behavior depending on the value of the preprocessor
- * define @c SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE.
- *
- * If @c SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE is > 0, the C logger will behave in an
- * async-safe manner, calling write() instead of printf(). Any log messages that
- * exceed the length specified by SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE will be
- * truncated.
- *
- * If @c SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE == 0, the C logger will use printf(), and
- * there will be no limit on the log message length.
- *
- * @c SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE can only be set as a preprocessor define, and
- * will default to 1024 if not specified during compilation.
  */
 
-/** The buffer size to use when writing log entries.
- *
- * If this value is > 0, any log entries that expand beyond this length will
- * be truncated.
- * If this value = 0, the logging system will dynamically allocate memory
- * and never truncate. However, the log functions won't be async-safe.
- *
- * Unless you're logging from within signal handlers, it's safe to set it to 0.
- */
-#ifndef SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE
 #define SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE 1024
-#endif
 
 // ============================================================================
 #pragma mark - (internal) -

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -53,9 +53,7 @@
 /** True if SentryCrash has been installed. */
 static volatile bool g_installed = 0;
 
-#if SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE > 0
 static char g_consoleLogPath[SentryCrashFU_MAX_PATH_LENGTH];
-#endif // SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE > 0
 
 static SentryCrashMonitorType g_monitoring = SentryCrashMonitorTypeProductionSafeMinimal;
 static char g_lastCrashReportFilePath[SentryCrashFU_MAX_PATH_LENGTH];
@@ -80,9 +78,7 @@ onCrash(struct SentryCrash_MonitorContext *monitorContext)
     SENTRY_ASYNC_SAFE_LOG_DEBUG("Updating application state to note crash.");
     sentrycrashstate_notifyAppCrash();
 
-#if SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE > 0
     monitorContext->consoleLogPath = g_consoleLogPath;
-#endif // SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE > 0
 
     if (monitorContext->crashedDuringCrashHandling) {
         sentrycrashreport_writeRecrashReport(monitorContext, g_lastCrashReportFilePath);
@@ -141,10 +137,8 @@ sentrycrash_install(const char *appName, const char *const installPath)
     snprintf(path, sizeof(path), "%s/Data/CrashState.json", installPath);
     sentrycrashstate_initialize(path);
 
-#if SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE > 0
     snprintf(g_consoleLogPath, sizeof(g_consoleLogPath), "%s/Data/ConsoleLog.txt", installPath);
     sentry_asyncLogSetFileName(g_consoleLogPath, true);
-#endif // SENTRY_ASYNC_SAFE_LOG_C_BUFFER_SIZE > 0
 
     sentrycrashccd_init(60);
 


### PR DESCRIPTION
Following #4102, combine the sinks that used to be configurable in the KSCrash logger. It was originally set up so that, depending on the buffer size specified, it would either write to a file or to the console. Now it always writes to a file, and additionally to the console, if we detect the presence of a debugger.