### PR TITLE
ref(SentryClientTests): convert closure-based functions to just return their values

### DIFF
--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -186,13 +186,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(SentryLevel.info, actual.level)
-            XCTAssertEqual(fixture.message, actual.message)
+        let actual = try lastSentEvent()
+        XCTAssertEqual(SentryLevel.info, actual.level)
+        XCTAssertEqual(fixture.message, actual.message)
 
-            assertValidDebugMeta(actual: actual.debugMeta, forThreads: actual.threads)
-            assertValidThreads(actual: actual.threads)
-        }
+        assertValidDebugMeta(actual: actual.debugMeta, forThreads: actual.threads)
+        assertValidThreads(actual: actual.threads)
     }
 
     func testCaptureMessageWithoutStacktrace() throws {
@@ -201,13 +200,12 @@ class SentryClientTest: XCTestCase {
         }).capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(SentryLevel.info, actual.level)
-            XCTAssertEqual(fixture.message, actual.message)
-            XCTAssertNil(actual.debugMeta)
-            XCTAssertNil(actual.threads)
-            XCTAssertNotNil(actual.dist)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(SentryLevel.info, actual.level)
+        XCTAssertEqual(fixture.message, actual.message)
+        XCTAssertNil(actual.debugMeta)
+        XCTAssertNil(actual.threads)
+        XCTAssertNotNil(actual.dist)
     }
     
     func testCaptureEvent() throws {
@@ -220,16 +218,15 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(event: event, scope: scope)
         
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(event.level, actual.level)
-            XCTAssertEqual(event.message, actual.message)
-            XCTAssertNotNil(actual.debugMeta)
-            XCTAssertNotNil(actual.threads)
-            
-            XCTAssertNotNil(actual.tags)
-            if let actualTags = actual.tags {
-                XCTAssertEqual(expectedTags, actualTags)
-            }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(event.level, actual.level)
+        XCTAssertEqual(event.message, actual.message)
+        XCTAssertNotNil(actual.debugMeta)
+        XCTAssertNotNil(actual.threads)
+        
+        XCTAssertNotNil(actual.tags)
+        if let actualTags = actual.tags {
+            XCTAssertEqual(expectedTags, actualTags)
         }
     }
     
@@ -245,13 +242,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(event: event, scope: scope)
         
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            let serializedEvent = actual.serialize()
-            let tags = try! XCTUnwrap(serializedEvent["tags"] as? [String: String])
-            let extra = try! XCTUnwrap(serializedEvent["extra"] as? [String: String])
-            XCTAssertEqual(expectedTags, tags)
-            XCTAssertEqual(expectedExtra, extra)
-        }
+        let actual = try lastSentEvent()
+        let serializedEvent = actual.serialize()
+        let tags = try XCTUnwrap(serializedEvent["tags"] as? [String: String])
+        let extra = try XCTUnwrap(serializedEvent["extra"] as? [String: String])
+        XCTAssertEqual(expectedTags, tags)
+        XCTAssertEqual(expectedExtra, extra)
     }
         
     func testCaptureEventTypeTransactionDoesNotIncludeThreadAndDebugMeta() throws {
@@ -265,16 +261,15 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(event: event, scope: scope)
         
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(event.level, actual.level)
-            XCTAssertEqual(event.message, actual.message)
-            XCTAssertNil(actual.debugMeta)
-            XCTAssertNil(actual.threads)
-            
-            XCTAssertNotNil(actual.tags)
-            if let actualTags = actual.tags {
-                XCTAssertEqual(expectedTags, actualTags)
-            }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(event.level, actual.level)
+        XCTAssertEqual(event.message, actual.message)
+        XCTAssertNil(actual.debugMeta)
+        XCTAssertNil(actual.threads)
+        
+        XCTAssertNotNil(actual.tags)
+        if let actualTags = actual.tags {
+            XCTAssertEqual(expectedTags, actualTags)
         }
     }
       
@@ -455,10 +450,9 @@ class SentryClientTest: XCTestCase {
         let event = givenEventWithDebugMeta()
         sut.capture(event: event)
         
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(event.debugMeta, actual.debugMeta)
-            assertValidThreads(actual: actual.threads)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(event.debugMeta, actual.debugMeta)
+        assertValidThreads(actual: actual.threads)
     }
     
     func testCaptureEventWithAttachedThreads_KeepsThreads() throws {
@@ -469,10 +463,9 @@ class SentryClientTest: XCTestCase {
         let event = givenEventWithThreads()
         sut.capture(event: event)
         
-        try assertLastSentEvent { actual in
-            assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
-            XCTAssertEqual(event.threads, actual.threads)
-        }
+        let actual = try lastSentEvent()
+        assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
+        XCTAssertEqual(event.threads, actual.threads)
     }
     
     func testCaptureEventWithAttachStacktrace() throws {
@@ -483,12 +476,11 @@ class SentryClientTest: XCTestCase {
         }).capture(event: event)
         
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(event.level, actual.level)
-            XCTAssertEqual(event.message, actual.message)
-            assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
-            assertValidThreads(actual: actual.threads)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(event.level, actual.level)
+        XCTAssertEqual(event.message, actual.message)
+        assertValidDebugMeta(actual: actual.debugMeta, forThreads: event.threads)
+        assertValidThreads(actual: event.threads)
     }
     
     func testCaptureErrorWithoutAttachStacktrace() throws {
@@ -506,9 +498,8 @@ class SentryClientTest: XCTestCase {
 
         eventId.assertIsNotEmpty()
         let error = TestError.invalidTest as NSError
-        try assertLastSentEvent { actual in
-            try assertValidErrorEvent(actual, error, exceptionValue: "invalidTest (Code: 0)")
-        }
+        let actual = try lastSentEvent()
+        try assertValidErrorEvent(actual, error, exceptionValue: "invalidTest (Code: 0)")
     }
 
     func testCaptureErrorUsesErrorDebugDescriptionWhenSet() throws {
@@ -520,10 +511,9 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(error: error)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            let exceptions = try XCTUnwrap(actual.exceptions)
-            XCTAssertEqual("Custom error description (Code: 999)", try XCTUnwrap(exceptions.first).value)
-        }
+        let actual = try lastSentEvent()
+        let exceptions = try XCTUnwrap(actual.exceptions)
+        XCTAssertEqual("Custom error description (Code: 999)", try XCTUnwrap(exceptions.first).value)
     }
 
     func testCaptureErrorUsesErrorCodeAsDescriptionIfNoCustomDescriptionProvided() throws {
@@ -535,13 +525,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(error: error)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            do {
-                let exceptions = try XCTUnwrap(actual.exceptions)
-                XCTAssertEqual("Code: 999", try XCTUnwrap(exceptions.first).value)
-            } catch {
-                XCTFail("Exception expected but was nil")
-            }
+        let actual = try lastSentEvent()
+        do {
+            let exceptions = try XCTUnwrap(actual.exceptions)
+            XCTAssertEqual("Code: 999", try XCTUnwrap(exceptions.first).value)
+        } catch {
+            XCTFail("Exception expected but was nil")
         }
     }
     
@@ -549,13 +538,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(error: SentryClientError.someError)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            do {
-                let exceptions = try XCTUnwrap(actual.exceptions)
-                XCTAssertEqual("someError (Code: 1)", try XCTUnwrap(exceptions.first).value)
-            } catch {
-                XCTFail("Exception expected but was nil")
-            }
+        let actual = try lastSentEvent()
+        do {
+            let exceptions = try XCTUnwrap(actual.exceptions)
+            XCTAssertEqual("someError (Code: 1)", try XCTUnwrap(exceptions.first).value)
+        } catch {
+            XCTFail("Exception expected but was nil")
         }
     }
     
@@ -563,13 +551,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(error: XMLParsingError(line: 10, column: 12, kind: .internalError))
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            do {
-                let exceptions = try XCTUnwrap(actual.exceptions)
-                XCTAssertEqual("XMLParsingError(line: 10, column: 12, kind: SentryTests.XMLParsingError.ErrorKind.internalError) (Code: 1)", try XCTUnwrap(exceptions.first).value)
-            } catch {
-                XCTFail("Exception expected but was nil")
-            }
+        let actual = try lastSentEvent()
+        do {
+            let exceptions = try XCTUnwrap(actual.exceptions)
+            XCTAssertEqual("XMLParsingError(line: 10, column: 12, kind: SentryTests.XMLParsingError.ErrorKind.internalError) (Code: 1)", try XCTUnwrap(exceptions.first).value)
+        } catch {
+            XCTFail("Exception expected but was nil")
         }
     }
     
@@ -577,13 +564,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(error: SentryClientError.invalidInput("hello"))
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            do {
-                let exceptions = try XCTUnwrap(actual.exceptions)
-                XCTAssertEqual("invalidInput(\"hello\") (Code: 0)", try XCTUnwrap(exceptions.first).value)
-            } catch {
-                XCTFail("Exception expected but was nil")
-            }
+        let actual = try lastSentEvent()
+        do {
+            let exceptions = try XCTUnwrap(actual.exceptions)
+            XCTAssertEqual("invalidInput(\"hello\") (Code: 0)", try XCTUnwrap(exceptions.first).value)
+        } catch {
+            XCTFail("Exception expected but was nil")
         }
     }
     
@@ -591,13 +577,12 @@ class SentryClientTest: XCTestCase {
         let eventId = fixture.getSut().capture(error: SentryClientErrorWithDebugDescription.someError)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            do {
-                let exceptions = try XCTUnwrap(actual.exceptions)
-                XCTAssertEqual("anotherError (Code: 0)", try XCTUnwrap(exceptions.first).value)
-            } catch {
-                XCTFail("Exception expected but was nil")
-            }
+        let actual = try lastSentEvent()
+        do {
+            let exceptions = try XCTUnwrap(actual.exceptions)
+            XCTAssertEqual("anotherError (Code: 0)", try XCTUnwrap(exceptions.first).value)
+        } catch {
+            XCTFail("Exception expected but was nil")
         }
     }
 
@@ -722,10 +707,9 @@ class SentryClientTest: XCTestCase {
         
         _ = fixture.getSut().captureCrash(oomEvent, with: Scope())
 
-        try assertLastSentEvent { event in
-            XCTAssertEqual(oomEvent.eventId, event.eventId)
-            XCTAssertEqual(oomEvent.context?.count, event.context?.count)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(oomEvent.eventId, actual.eventId)
+        XCTAssertEqual(oomEvent.context?.count, actual.context?.count)
     }
     
     func testCaptureOOMEvent_WithNoDeviceContext_ContextNotModified() throws {
@@ -735,10 +719,9 @@ class SentryClientTest: XCTestCase {
         
         _ = fixture.getSut().captureCrash(oomEvent, with: scope)
 
-        try assertLastSentEvent { event in
-            XCTAssertEqual(oomEvent.eventId, event.eventId)
-            XCTAssertEqual(oomEvent.context?.count, event.context?.count)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(oomEvent.eventId, actual.eventId)
+        XCTAssertEqual(oomEvent.context?.count, actual.context?.count)
     }
     
     func testCaptureCrash_DoesntOverideStacktraceFor() throws {
@@ -775,32 +758,30 @@ class SentryClientTest: XCTestCase {
 
         sut.capture(event: TestData.event)
 
-        try assertLastSentEvent { actual in
-            let eventFreeMemory = actual.context?["device"]?[SentryDeviceContextFreeMemoryKey] as? Int
-            XCTAssertEqual(eventFreeMemory, 123_456)
+        let actual = try lastSentEvent()
+        let eventFreeMemory = actual.context?["device"]?[SentryDeviceContextFreeMemoryKey] as? Int
+        XCTAssertEqual(eventFreeMemory, 123_456)
 
-            let eventAppMemory = actual.context?["app"]?["app_memory"] as? Int
-            XCTAssertEqual(eventAppMemory, 234_567)
+        let eventAppMemory = actual.context?["app"]?["app_memory"] as? Int
+        XCTAssertEqual(eventAppMemory, 234_567)
 
-            let cpuCoreCount = actual.context?["device"]?["processor_count"] as? UInt
-            XCTAssertEqual(fixture.processWrapper.processorCount, cpuCoreCount)
-        }
+        let cpuCoreCount = actual.context?["device"]?["processor_count"] as? UInt
+        XCTAssertEqual(fixture.processWrapper.processorCount, cpuCoreCount)
     }
     
 #if os(iOS) || targetEnvironment(macCatalyst)
     func testCaptureEvent_DeviceProperties() throws {
         fixture.getSut().capture(event: TestData.event)
 
-        try assertLastSentEvent { actual in
-            let orientation = actual.context?["device"]?["orientation"] as? String
-            XCTAssertEqual(orientation, "portrait")
+        let actual = try assertLastSentEvent()
+        let orientation = actual.context?["device"]?["orientation"] as? String
+        XCTAssertEqual(orientation, "portrait")
 
-            let charging = actual.context?["device"]?["charging"] as? Bool
-            XCTAssertEqual(charging, true)
+        let charging = actual.context?["device"]?["charging"] as? Bool
+        XCTAssertEqual(charging, true)
 
-            let batteryLevel = actual.context?["device"]?["battery_level"] as? Int
-            XCTAssertEqual(batteryLevel, 60)
-        }
+        let batteryLevel = actual.context?["device"]?["battery_level"] as? Int
+        XCTAssertEqual(batteryLevel, 60)
     }
 
     func testCaptureEvent_DeviceProperties_OtherValues() throws {
@@ -809,43 +790,42 @@ class SentryClientTest: XCTestCase {
 
         fixture.getSut().capture(event: TestData.event)
 
-        try assertLastSentEvent { actual in
-            let orientation = actual.context?["device"]?["orientation"] as? String
-            XCTAssertEqual(orientation, "landscape")
+        let actual = try assertLastSentEvent()
+        let orientation = actual.context?["device"]?["orientation"] as? String
+        XCTAssertEqual(orientation, "landscape")
 
-            let charging = actual.context?["device"]?["charging"] as? Bool
-            XCTAssertEqual(charging, false)
-        }
+        let charging = actual.context?["device"]?["charging"] as? Bool
+        XCTAssertEqual(charging, false)
     }
-#endif // os(iOS) || targetEnvironment(macCatalyst)
+#endif
 
     func testCaptureEvent_AddCurrentCulture() throws {
         fixture.getSut().capture(event: TestData.event)
 
-        try assertLastSentEvent { actual in
-            let culture = actual.context?["culture"]
-            
-            if #available(iOS 10, macOS 10.12, watchOS 3, tvOS 10, *) {
-                
-                let expectedCalendar = fixture.locale.localizedString(for: fixture.locale.calendar.identifier)
-                XCTAssertEqual(culture?["calendar"] as? String, expectedCalendar)
-                XCTAssertEqual(culture?["display_name"] as? String, fixture.locale.localizedString(forIdentifier: fixture.locale.identifier))
-            }
-                
-            XCTAssertEqual(culture?["locale"] as? String, fixture.locale.identifier)
-            XCTAssertEqual(culture?["is_24_hour_format"] as? Bool, SentryLocale.timeIs24HourFormat())
-            XCTAssertEqual(culture?["timezone"] as? String, fixture.timezone.identifier)
+        let actual = try lastSentEvent()
+        let culture = actual.context?["culture"]
+        
+        if #available(iOS 10, macOS 10.12, watchOS 3, tvOS 10, *) {
+            let expectedCalendar = fixture.locale.localizedString(for: fixture.locale.calendar.identifier)
+            XCTAssertEqual(culture?["calendar"] as? String, expectedCalendar)
+            XCTAssertEqual(culture?["display_name"] as? String, fixture.locale.localizedString(forIdentifier: fixture.locale.identifier))
         }
+            
+        XCTAssertEqual(culture?["locale"] as? String, fixture.locale.identifier)
+        XCTAssertEqual(culture?["is_24_hour_format"] as? Bool, SentryLocale.timeIs24HourFormat())
+        XCTAssertEqual(culture?["timezone"] as? String, fixture.timezone.identifier)
     }
 
     func testCaptureErrorWithUserInfo() throws {
         let expectedValue = "val"
         let error = NSError(domain: "domain", code: 0, userInfo: ["key": expectedValue])
-        let eventId = fixture.getSut().capture(error: error, scope: fixture.scope)
+        let eventId = fixture.getSut().capture(error: error,
+
+ scope: fixture.scope)
 
         eventId.assertIsNotEmpty()
-        let actual = try lastSentEventWithAttachment()
-        XCTAssertEqual(expectedValue, actual.context!["user info"]!["key"] as? String)
+        let actual = try lastSentEvent()
+        XCTAssertEqual(expectedValue, actual.context?["user info"]?["key"] as? String)
     }
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
@@ -856,10 +836,9 @@ class SentryClientTest: XCTestCase {
         
         let event = TestData.event
         fixture.getSut().capture(event: event)
-        try assertLastSentEvent { actual in
-            let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-            XCTAssertEqual(inForeground, true)
-        }
+        let actual = try assertLastSentEvent()
+        let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
+        XCTAssertEqual(inForeground, true)
     }
 
     func testCaptureExceptionWithAppStateInForegroudWhenAppIsInBackground() throws {
@@ -869,10 +848,9 @@ class SentryClientTest: XCTestCase {
         
         let event = TestData.event
         fixture.getSut().capture(event: event)
-        try assertLastSentEvent { actual in
-            let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-            XCTAssertEqual(inForeground, false)
-        }
+        let actual = try assertLastSentEvent()
+        let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
+        XCTAssertEqual(inForeground, false)
     }
     
     func testCaptureExceptionWithAppStateInForegroudWhenAppIsInactive() throws {
@@ -882,10 +860,9 @@ class SentryClientTest: XCTestCase {
         
         let event = TestData.event
         fixture.getSut().capture(event: event)
-        try assertLastSentEvent { actual in
-            let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-            XCTAssertEqual(inForeground, false)
-        }
+        let actual = try assertLastSentEvent()
+        let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
+        XCTAssertEqual(inForeground, false)
     }
     
     func testCaptureExceptionWithAppStateInForegroundDoNotOverwriteExistingValue() throws {
@@ -894,14 +871,13 @@ class SentryClientTest: XCTestCase {
         SentryDependencyContainer.sharedInstance().application = app
         
         let event = TestData.event
-        event.context!["app"] = [ "in_foreground": "keep-value" ]
+        event.context?["app"] = ["in_foreground": "keep-value"]
         fixture.getSut().capture(event: event)
-        try assertLastSentEvent { actual in
-            let inForeground = actual.context?["app"]?["in_foreground"] as? String
-            XCTAssertEqual(inForeground, "keep-value")
-        }
+        let actual = try assertLastSentEvent()
+        let inForeground = try XCTUnwrap(actual.context?["app"]?["in_foreground"] as? String)
+        XCTAssertEqual(inForeground, "keep-value")
     }
-#endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+#endif
 
     func testCaptureExceptionWithoutAttachStacktrace() throws {
         let eventId = fixture.getSut(configureOptions: { options in
@@ -1015,10 +991,9 @@ class SentryClientTest: XCTestCase {
         }).capture(message: fixture.messageAsString)
 
         XCTAssertEqual(newEvent.eventId, eventId)
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(newEvent.eventId, actual.eventId)
-            XCTAssertNil(actual.releaseName)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(newEvent.eventId, actual.eventId)
+        XCTAssertNil(actual.releaseName)
     }
     
     func testBeforeSendModifiesEvent_ModifiedEventSent() throws {
@@ -1031,10 +1006,9 @@ class SentryClientTest: XCTestCase {
             options.attachStacktrace = true
         }).capture(message: fixture.messageAsString)
 
-        try assertLastSentEvent { actual in
-            XCTAssertEqual([], actual.debugMeta)
-            XCTAssertEqual([], actual.threads)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual([], actual.debugMeta)
+        XCTAssertEqual([], actual.threads)
     }
     
     func testBeforeSendSpanDitchOneSpan_OtherChangedSpanSent() throws {
@@ -1048,20 +1022,16 @@ class SentryClientTest: XCTestCase {
                     span.operation = "changed"
                     return span
                 }
-                
                 return nil
             }
         }).capture(event: transaction)
         
-        try assertLastSentEvent { actual in
-            let serialized = actual.serialize()
-            let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
-            XCTAssertEqual(1, serializedSpans.count)
-            
-            let serializedSpan = try XCTUnwrap(serializedSpans.first)
-            
-            XCTAssertEqual("changed", serializedSpan["op"]  as? String)
-        }
+        let actual = try lastSentEvent()
+        let serialized = actual.serialize()
+        let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
+        XCTAssertEqual(1, serializedSpans.count)
+        let serializedSpan = try XCTUnwrap(serializedSpans.first)
+        XCTAssertEqual("changed", serializedSpan["op"] as? String)
     }
     
     func testBeforeSendSpanIsNil_SpansUntouched() throws {
@@ -1070,15 +1040,12 @@ class SentryClientTest: XCTestCase {
         let transaction = Transaction(trace: fixture.trace, children: [span])
         fixture.getSut().capture(event: transaction)
         
-        try assertLastSentEvent { actual in
-            
-            let serialized = actual.serialize()
-            let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
-            XCTAssertEqual(1, serializedSpans.count)
-            let serializedSpan = try XCTUnwrap(serializedSpans.first)
-            
-            XCTAssertEqual("operation", serializedSpan["op"]  as? String)
-        }
+        let actual = try lastSentEvent()
+        let serialized = actual.serialize()
+        let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
+        XCTAssertEqual(1, serializedSpans.count)
+        let serializedSpan = try XCTUnwrap(serializedSpans.first)
+        XCTAssertEqual("operation", serializedSpan["op"] as? String)
     }
     
     /// Ensure that you can't start and finish new spans in the beforeSendSpan Callback
@@ -1099,12 +1066,10 @@ class SentryClientTest: XCTestCase {
             }
         }).capture(event: transaction)
         
-        try assertLastSentEvent { actual in
-            
-            let serialized = actual.serialize()
-            let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
-            XCTAssertEqual(1, serializedSpans.count)
-        }
+        let actual = try lastSentEvent()
+        let serialized = actual.serialize()
+        let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
+        XCTAssertEqual(1, serializedSpans.count)
     }
 
     func testNoDsn_MessageNotSent() {
@@ -1206,9 +1171,8 @@ class SentryClientTest: XCTestCase {
             assertNothingSent()
         } else {
             eventId.assertIsNotEmpty()
-            try assertLastSentEvent { actual in
-                XCTAssertEqual(eventId, actual.eventId)
-            }
+            let actual = try lastSentEvent()
+            XCTAssertEqual(eventId, actual.eventId)
         }
     }
     
@@ -1220,9 +1184,8 @@ class SentryClientTest: XCTestCase {
         }).capture(event: fixture.transaction)
         
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(eventId, actual.eventId)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(eventId, actual.eventId)
     }
     
     func testEventSampled_RecordsLostEvent() {
@@ -1274,18 +1237,16 @@ class SentryClientTest: XCTestCase {
         }).capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(dist, actual.dist)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(dist, actual.dist)
     }
     
     func testEnvironmentDefaultToProduction() throws {
         let eventId = fixture.getSut().capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual("production", actual.environment)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual("production", actual.environment)
     }
     
     func testEnvironmentIsSetViaOptions() throws {
@@ -1295,9 +1256,8 @@ class SentryClientTest: XCTestCase {
         }).capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(environment, actual.environment)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(environment, actual.environment)
     }
     
     func testEnvironmentIsSetInEventTakesPrecedenceOverOptions() throws {
@@ -1324,9 +1284,8 @@ class SentryClientTest: XCTestCase {
         }).capture(event: event)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            XCTAssertEqual("event", actual.environment)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual("event", actual.environment)
     }
     
     func testSetSDKIntegrations() throws {
@@ -1341,12 +1300,11 @@ class SentryClientTest: XCTestCase {
             expectedIntegrations = ["ANRTracking"] + expectedIntegrations
         }
         
-        try assertLastSentEvent { actual in
-            assertArrayEquals(
-                expected: expectedIntegrations,
-                actual: actual.sdk?["integrations"] as? [String]
-            )
-        }
+        let actual = try lastSentEvent()
+        assertArrayEquals(
+            expected: expectedIntegrations,
+            actual: actual.sdk?["integrations"] as? [String]
+        )
     }
     
     func testSetSDKFeatures() throws {
@@ -1356,10 +1314,8 @@ class SentryClientTest: XCTestCase {
         
         sut.capture(message: "message")
         
-        try assertLastSentEvent { actual in
-            expect(actual.sdk?["features"] as? [String]).to(contain("performanceV2", "captureFailedRequests"))
-            
-        }
+        let actual = try lastSentEvent()
+        expect(actual.sdk?["features"] as? [String]).to(contain("performanceV2", "captureFailedRequests"))
     }
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
@@ -1378,17 +1334,16 @@ class SentryClientTest: XCTestCase {
         }).capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            var expectedIntegrations = ["AutoBreadcrumbTracking", "AutoSessionTracking", "Crash", "NetworkTracking", integrationName]
-            if !SentryDependencyContainer.sharedInstance().crashWrapper.isBeingTraced() {
-                expectedIntegrations = ["ANRTracking"] + expectedIntegrations
-            }
-            
-            assertArrayEquals(
-                expected: expectedIntegrations,
-                actual: actual.sdk?["integrations"] as? [String]
-            )
+        let actual = try lastSentEvent()
+        var expectedIntegrations = ["AutoBreadcrumbTracking", "AutoSessionTracking", "Crash", "NetworkTracking", integrationName]
+        if !SentryDependencyContainer.sharedInstance().crashWrapper.isBeingTraced() {
+            expectedIntegrations = ["ANRTracking"] + expectedIntegrations
         }
+        
+        assertArrayEquals(
+            expected: expectedIntegrations,
+            actual: actual.sdk?["integrations"] as? [String]
+        )
     }
     
     func testSetSDKIntegrations_NoIntegrations() throws {
@@ -1399,9 +1354,8 @@ class SentryClientTest: XCTestCase {
         }).capture(message: fixture.messageAsString)
 
         eventId.assertIsNotEmpty()
-        try assertLastSentEvent { actual in
-            assertArrayEquals(expected: expected, actual: actual.sdk?["integrations"] as? [String])
-        }
+        let actual = try lastSentEvent()
+        assertArrayEquals(expected: expected, actual: actual.sdk?["integrations"] as? [String])
     }
 
     func testFileManagerCantBeInit() {
@@ -1419,9 +1373,8 @@ class SentryClientTest: XCTestCase {
     func testInstallationIdSetWhenNoUserId() throws {
         fixture.getSut().capture(message: "any message")
         
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(SentryInstallation.id(withCacheDirectoryPath: PrivateSentrySDKOnly.options.cacheDirectoryPath), actual.user?.userId)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(SentryInstallation.id(withCacheDirectoryPath: PrivateSentrySDKOnly.options.cacheDirectoryPath), actual.user?.userId)
     }
     
     func testInstallationIdNotSetWhenUserIsSetWithoutId() throws {
@@ -1441,10 +1394,9 @@ class SentryClientTest: XCTestCase {
         scope.setUser(user)
         fixture.getSut().capture(message: "any message", scope: scope)
         
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(user.userId, actual.user?.userId)
-            XCTAssertEqual(fixture.user.email, actual.user?.email)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(user.userId, actual.user?.userId)
+        XCTAssertEqual(fixture.user.email, actual.user?.email)
     }
     
     func testSendDefaultPiiEnabled_GivenNoIP_AutoIsSet() throws {
@@ -1452,9 +1404,8 @@ class SentryClientTest: XCTestCase {
             options.sendDefaultPii = true
         }).capture(message: "any")
         
-        try assertLastSentEvent { actual in
-            XCTAssertEqual("{{auto}}", actual.user?.ipAddress)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual("{{auto}}", actual.user?.ipAddress)
     }
     
     func testSendDefaultPiiEnabled_GivenIP_IPAddressNotChanged() throws {
@@ -1465,9 +1416,8 @@ class SentryClientTest: XCTestCase {
             options.sendDefaultPii = true
         }).capture(message: "any", scope: scope)
         
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(fixture.user.ipAddress, actual.user?.ipAddress)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(fixture.user.ipAddress, actual.user?.ipAddress)
     }
     
     func testSendDefaultPiiDisabled_GivenIP_IPAddressNotChanged() throws {
@@ -1476,9 +1426,8 @@ class SentryClientTest: XCTestCase {
         
         fixture.getSut().capture(message: "any", scope: scope)
         
-        try assertLastSentEvent { actual in
-            XCTAssertEqual(fixture.user.ipAddress, actual.user?.ipAddress)
-        }
+        let actual = try lastSentEvent()
+        XCTAssertEqual(fixture.user.ipAddress, actual.user?.ipAddress)
     }
     
     func testStoreEnvelope_StoresEnvelopeToDisk() {
@@ -1769,11 +1718,10 @@ class SentryClientTest: XCTestCase {
         XCTAssertFalse(eventWasSent)
     }
 
-    private func assertLastSentEvent(assert: (Event) throws -> Void) throws {
+    private func lastSentEvent() throws -> Event {
         XCTAssertNotNil(fixture.transportAdapter.sendEventWithTraceStateInvocations.last)
-        if let lastSentEventArguments = fixture.transportAdapter.sendEventWithTraceStateInvocations.last {
-            try assert(lastSentEventArguments.event)
-        }
+        let lastSentEventArguments = try XCTUnwrap(fixture.transportAdapter.sendEventWithTraceStateInvocations.last)
+        return lastSentEventArguments.event
     }
     
     private func lastSentEventWithAttachment() throws -> Event {


### PR DESCRIPTION
I noticed this pattern being used in https://github.com/getsentry/sentry-cocoa/pull/4110 and found it unnecessary. we can just return the value instead of requiring a closure to pass it to.

#skip-changelog