### PR TITLE
ref(crash reporting): remove unused prefilter method

### DIFF
--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.h
@@ -60,13 +60,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)sendAllReportsWithCompletion:(nullable SentryCrashReportFilterCompletion)onCompletion;
 
-/** Add a filter that gets executed before all normal filters.
- * Prepended filters will be executed in the order in which they were added.
- *
- * @param filter the filter to prepend.
- */
-- (void)addPreFilter:(id<SentryCrashReportFilter>)filter;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -62,7 +62,6 @@ SentryCrashInstallation ()
 @property (nonatomic, readwrite, retain) NSMutableData *crashHandlerDataBacking;
 @property (nonatomic, readwrite, retain) NSMutableDictionary *fields;
 @property (nonatomic, readwrite, retain) NSArray *requiredProperties;
-@property (nonatomic, readwrite, retain) SentryCrashReportFilterPipeline *prependedFilters;
 
 @end
 
@@ -72,7 +71,6 @@ SentryCrashInstallation ()
 @synthesize crashHandlerDataBacking = _crashHandlerDataBacking;
 @synthesize fields = _fields;
 @synthesize requiredProperties = _requiredProperties;
-@synthesize prependedFilters = _prependedFilters;
 
 - (id)init
 {
@@ -91,7 +89,6 @@ SentryCrashInstallation ()
                            + sizeof(*self.crashHandlerData->reportFields) * kMaxProperties];
         self.fields = [NSMutableDictionary dictionary];
         self.requiredProperties = requiredProperties;
-        self.prependedFilters = [SentryCrashReportFilterPipeline filterWithFilters:nil];
     }
     return self;
 }
@@ -207,16 +204,11 @@ SentryCrashInstallation ()
         return;
     }
 
-    sink = [SentryCrashReportFilterPipeline filterWithFilters:self.prependedFilters, sink, nil];
+    sink = [SentryCrashReportFilterPipeline filterWithFilters:sink, nil];
 
     SentryCrash *handler = SentryDependencyContainer.sharedInstance.crashReporter;
     handler.sink = sink;
     [handler sendAllReportsWithCompletion:onCompletion];
-}
-
-- (void)addPreFilter:(id<SentryCrashReportFilter>)filter
-{
-    [self.prependedFilters addFilter:filter];
 }
 
 - (id<SentryCrashReportFilter>)sink


### PR DESCRIPTION
I noticed this method was unused. As it's not customer-facing, should be safe to remove it.

#skip-changelog