### PR TITLE
test: disable hanging testGetCurrentThreadsWithStacktrace_WithSymbolication

### DIFF
--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -104,6 +104,9 @@
                   Identifier = "SentrySubClassFinderTests/testActOnSubclassesOfViewController()">
                </Test>
                <Test
+                  Identifier = "SentryThreadInspectorTests/testGetCurrentThreadsWithStacktrace_WithSymbolication()">
+               </Test>
+               <Test
                   Identifier = "SentryThreadInspectorTests/testStacktraceHasFrames_forEveryThread()">
                </Test>
                <Test


### PR DESCRIPTION
This test frequently hangs Xcode when I run locally, preventing the test suite from completing.

#skip-changelog