### PR TITLE
test: remove Nimble

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
-		62986F032B03D250008E2D62 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 62986F022B03D250008E2D62 /* Nimble */; };
 		62991A8D2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62991A8C2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift */; };
 		62991A8F2BAC24ED0078A8B8 /* SentryMetricsAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62991A8E2BAC24ED0078A8B8 /* SentryMetricsAPITests.swift */; };
 		62A2F43E2BA9AC10000C9FDD /* DistributionMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62A2F43D2BA9AC10000C9FDD /* DistributionMetric.swift */; };
@@ -2017,7 +2016,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				62986F032B03D250008E2D62 /* Nimble in Frameworks */,
 				8431F01C29B2854200D8DC56 /* libSentryTestUtils.a in Frameworks */,
 				D84DAD592B1742C1003CF120 /* SentryTestUtilsDynamic.framework in Frameworks */,
 				63AA766A1EB8CB2F00D153DE /* Sentry.framework in Frameworks */,
@@ -4291,7 +4289,6 @@
 			);
 			name = SentryTests;
 			packageProductDependencies = (
-				62986F022B03D250008E2D62 /* Nimble */,
 			);
 			productName = "Tests-iOS";
 			productReference = 63AA76651EB8CB2F00D153DE /* SentryTests.xctest */;
@@ -4420,7 +4417,6 @@
 			);
 			mainGroup = 6327C5C91EB8A783004E799B;
 			packageReferences = (
-				62986F012B03D250008E2D62 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 6327C5D41EB8A783004E799B /* Products */;
 			projectDirPath = "";
@@ -7032,25 +7028,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		62986F012B03D250008E2D62 /* XCRemoteSwiftPackageReference "Nimble" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Quick/Nimble";
-			requirement = {
-				kind = exactVersion;
-				version = 10.0.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		62986F022B03D250008E2D62 /* Nimble */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 62986F012B03D250008E2D62 /* XCRemoteSwiftPackageReference "Nimble" */;
-			productName = Nimble;
-		};
-/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 6327C5CA1EB8A783004E799B /* Project object */;
 }

--- a/Tests/SentryTests/Categories/SentryNSDataUtilsTests.swift
+++ b/Tests/SentryTests/Categories/SentryNSDataUtilsTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import Sentry
 import XCTest
 
@@ -7,13 +6,13 @@ final class SentryNSDataUtilsTests: XCTestCase {
     func testCRC32OfString_SameString_ReturnsSameResult() throws {
         let result1 = sentry_crc32ofString("test-string")
         let result2 = sentry_crc32ofString("test-string")
-        expect(result1) == result2
+        XCTAssertEqual(result1, result2)
     }
     
     func testCRC32OfString_DifferentString_ReturnsDifferentResult() throws {
         let result1 = sentry_crc32ofString("test-string")
         let result2 = sentry_crc32ofString("test-string1")
-        expect(result1) != result2
+        XCTAssertNotEqual(result1, result2)
     }
 
 }

--- a/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
@@ -109,7 +109,7 @@ class SentryAppStateManagerTests: XCTestCase {
     func testUpdateAppState() {
         sut.storeCurrentAppState()
 
-        XCTAssertEqual(fixture.fileManager.readAppState()!.wasTerminated, false)
+        XCTAssertFalse(fixture.fileManager.readAppState()!.wasTerminated)
 
         sut.updateAppState { state in
             state.wasTerminated = true

--- a/Tests/SentryTests/Helper/SentryAppStateTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import XCTest
 
 class SentryAppStateTests: XCTestCase {
@@ -23,7 +22,7 @@ class SentryAppStateTests: XCTestCase {
         
         let actual = appState.serialize()
         
-        expect(actual["release_name"]) == nil
+        XCTAssertNil(actual["release_name"])
     }
     
     func testInitWithJSON_ReleaseNameIsNil_DoesNotAddReleaseName() {
@@ -31,7 +30,7 @@ class SentryAppStateTests: XCTestCase {
         
         let actual = SentryAppState(jsonObject: appState.serialize())
         
-        expect(actual?.releaseName) == nil
+        XCTAssertNil(actual?.releaseName)
     }
     
     func testInitWithJSON_AllFields() throws {

--- a/Tests/SentryTests/Helper/SentryDateUtilTests.swift
+++ b/Tests/SentryTests/Helper/SentryDateUtilTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -60,7 +59,7 @@ class SentryDateUtilTests: XCTestCase {
         let testDate = Date(timeIntervalSince1970: 60)
         let timestamp = SentryDateUtil.millisecondsSince1970(testDate)
         
-        expect(timestamp) == 60_000
+        XCTAssertEqual(timestamp, 60_000)
     }
     
 }

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
@@ -9,7 +8,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         framesTracker.start()
         SentryDependencyContainer.reset()
         
-        expect(framesTracker.isRunning) == false
+        XCTAssertFalse(framesTracker.isRunning)
     }
 }
 #endif

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -29,13 +29,11 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
         
-        XCTAssertEqual(features, [
-            "captureFailedRequests",
-            "performanceV2",
-            "timeToFullDisplayTracing",
-            "swiftAsyncStacktraces",
-            "metrics"
-        ])
+        XCTAssert(features.contains("captureFailedRequests"))
+        XCTAssert(features.contains("performanceV2"))
+        XCTAssert(features.contains("timeToFullDisplayTracing"))
+        XCTAssert(features.contains("swiftAsyncStacktraces"))
+        XCTAssert(features.contains("metrics"))
         
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
         XCTAssert(features.contains("appLaunchProfiling"))

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -7,7 +6,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
     func testDefaultFeatures() throws {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: Options())
         
-        expect(features) == ["captureFailedRequests"]
+        XCTAssertEqual(features, ["captureFailedRequests"])
     }
     
     func testEnableAllFeatures() throws {
@@ -30,23 +29,21 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
         
-        expect(features).to(contain([
+        XCTAssertEqual(features, [
             "captureFailedRequests",
             "performanceV2",
             "timeToFullDisplayTracing",
             "swiftAsyncStacktraces",
             "metrics"
-        ]))
+        ])
         
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-        expect(features).to(contain(["appLaunchProfiling"]))
+        XCTAssert(features.contains("appLaunchProfiling"))
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     
 #if os(iOS) || os(tvOS)
 #if canImport(UIKit) && !SENTRY_NO_UIKIT
-        expect(features).to(contain([
-            "preWarmedAppStartTracing"
-        ]))
+        XCTAssert(features.contains("preWarmedAppStartTracing"))
 #endif // canImport(UIKit)
 #endif // os(iOS) || os(tvOS)
     }

--- a/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
+++ b/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
@@ -45,7 +45,7 @@ final class SentryExtraContextProviderTests: XCTestCase {
         XCTAssertEqual(app?["app_memory"] as? UInt64, fixture.crashWrapper.internalAppMemorySize)
     }
     
-    func testExtraDeviceInfo() {
+    func testExtraDeviceInfo() throws {
 #if os(iOS) || targetEnvironment(macCatalyst)
         let sut = fixture.getSut()
         fixture.deviceWrapper.internalOrientation = .landscapeLeft
@@ -56,7 +56,7 @@ final class SentryExtraContextProviderTests: XCTestCase {
         let device = actualContext["device"] as? [String: Any]
         
         XCTAssertEqual(device?["orientation"] as? String, "landscape")
-        XCTAssertEqual(device?["charging"] as? Bool, false)
+        XCTAssertFalse(try XCTUnwrap(device?["charging"] as? Bool))
         XCTAssertEqual(device?["battery_level"] as? UInt, 44)
 #endif // os(iOS) || targetEnvironment(macCatalyst)
     }

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -153,7 +152,7 @@ class SentryFileManagerTests: XCTestCase {
         let dsStoreFile = "\(sut.basePath)/.DS_Store"
         
         let result = FileManager.default.createFile(atPath: dsStoreFile, contents: "some data".data(using: .utf8))
-        expect(result) == true
+        XCTAssertEqual(result, true)
         
         sut.deleteOldEnvelopeItems()
         
@@ -161,7 +160,7 @@ class SentryFileManagerTests: XCTestCase {
             $0.contains("[Sentry] [debug]") &&
             $0.contains("Ignoring .DS_Store file when building envelopes path at path: \(dsStoreFile)")
         }
-        expect(logMessages.count) == 1
+        XCTAssertEqual(logMessages.count, 1)
         
         try FileManager.default.removeItem(atPath: dsStoreFile)
     }
@@ -176,7 +175,7 @@ class SentryFileManagerTests: XCTestCase {
         let textFilePath = "\(sut.basePath)/something.txt"
         
         let result = FileManager.default.createFile(atPath: textFilePath, contents: "some data".data(using: .utf8))
-        expect(result) == true
+        XCTAssertEqual(result, true)
         
         sut.deleteOldEnvelopeItems()
         
@@ -184,7 +183,7 @@ class SentryFileManagerTests: XCTestCase {
             $0.contains("[Sentry] [debug]") &&
             $0.contains("Ignoring non directory when deleting old envelopes at path: \(textFilePath)")
         }
-        expect(logMessages.count) == 1
+        XCTAssertEqual(logMessages.count, 1)
         
         try FileManager.default.removeItem(atPath: textFilePath)
     }
@@ -199,13 +198,13 @@ class SentryFileManagerTests: XCTestCase {
         let nonExistentFile = "nonExistentFile.txt"
         let nonExistentFileFullPath = "\(sut.basePath)/\(nonExistentFile)"
         
-        expect(sut.getEnvelopesPath(nonExistentFile)) == nil
+        XCTAssertNil(sut.getEnvelopesPath(nonExistentFile))
         
         let logMessages = logOutput.loggedMessages.filter {
             $0.contains("[Sentry] [warning]") &&
             $0.contains("Could not get attributes of item at path: \(nonExistentFileFullPath)")
         }
-        expect(logMessages.count) == 1
+        XCTAssertEqual(logMessages.count, 1)
     }
     
     func testDeleteOldEnvelopes_WithEmptyDSN() throws {
@@ -546,11 +545,11 @@ class SentryFileManagerTests: XCTestCase {
         sut.getAllEnvelopes()
         
         let debugLogMessages = logOutput.loggedMessages.filter { $0.contains("[Sentry] [info]") && $0.contains("Returning empty files list, as folder doesn't exist at path:") }
-        expect(debugLogMessages.count) == 1
+        XCTAssertEqual(debugLogMessages.count, 1)
         
         let errorMessages = logOutput.loggedMessages.filter { $0.contains("[Sentry] [error]") }
         
-        expect(errorMessages.count) == 0
+        XCTAssertEqual(errorMessages.count, 0)
     }
     
     func testReadStoreDeleteAppState() {
@@ -718,13 +717,13 @@ extension SentryFileManagerTests {
     // if app launch profiling was configured to take place
     func testAppLaunchProfileConfigFileExists_fileExists() throws {
         try ensureAppLaunchProfileConfig()
-        expect(appLaunchProfileConfigFileExists()) == true
+        XCTAssertEqual(appLaunchProfileConfigFileExists(), true)
     }
     
     // if app launch profiling was not configured to take place
     func testAppLaunchProfileConfigFileExists_fileDoesNotExist() throws {
         try ensureAppLaunchProfileConfig(exists: false)
-        expect(appLaunchProfileConfigFileExists()) == false
+        XCTAssertFalse(appLaunchProfileConfigFileExists())
     }
     
     func testAppLaunchProfileConfiguration() throws {
@@ -734,14 +733,14 @@ extension SentryFileManagerTests {
         let config = appLaunchProfileConfiguration()
         let actualTracesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRate]).doubleValue
         let actualProfilesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyProfilesSampleRate]).doubleValue
-        expect(actualTracesSampleRate) == expectedTracesSampleRate
-        expect(actualProfilesSampleRate) == expectedProfilesSampleRate
+        XCTAssertEqual(actualTracesSampleRate, expectedTracesSampleRate)
+        XCTAssertEqual(actualProfilesSampleRate, expectedProfilesSampleRate)
     }
     
     // if a file isn't present when we expect it to be, like if there was an issue when we went to write it to disk
     func testAppLaunchProfileConfiguration_noConfigurationExists() throws {
         try ensureAppLaunchProfileConfig(exists: false)
-        expect(appLaunchProfileConfiguration()) == nil
+        XCTAssertNil(appLaunchProfileConfiguration())
     }
     
     func testWriteAppLaunchProfilingConfigFile_noCurrentFileExists() throws {
@@ -758,8 +757,8 @@ extension SentryFileManagerTests {
         
         let actualTracesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRate] as? NSNumber).doubleValue
         let actualProfilesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyProfilesSampleRate] as? NSNumber).doubleValue
-        expect(actualTracesSampleRate) == expectedTracesSampleRate
-        expect(actualProfilesSampleRate) == expectedProfilesSampleRate
+        XCTAssertEqual(actualTracesSampleRate, expectedTracesSampleRate)
+        XCTAssertEqual(actualProfilesSampleRate, expectedProfilesSampleRate)
     }
     
     // if a file is still present in the primary location, like if a crash occurred before it could be removed, or an error occurred when trying to remove it or move it to the backup location, make sure we overwrite it
@@ -777,23 +776,23 @@ extension SentryFileManagerTests {
         
         let actualTracesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRate] as? NSNumber).doubleValue
         let actualProfilesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyProfilesSampleRate] as? NSNumber).doubleValue
-        expect(actualTracesSampleRate) == expectedTracesSampleRate
-        expect(actualProfilesSampleRate) == expectedProfilesSampleRate
+        XCTAssertEqual(actualTracesSampleRate, expectedTracesSampleRate)
+        XCTAssertEqual(actualProfilesSampleRate, expectedProfilesSampleRate)
     }
     
     func testRemoveAppLaunchProfilingConfigFile() throws {
         try ensureAppLaunchProfileConfig(exists: true)
-        expect(NSDictionary(contentsOf: launchProfileConfigFileURL())) != nil
+        XCTAssertNotNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
         removeAppLaunchProfilingConfigFile()
-        expect(NSDictionary(contentsOf: launchProfileConfigFileURL())) == nil
+        XCTAssertNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
     }
     
     // if there's not a file when we expect one, just make sure we don't crash
     func testRemoveAppLaunchProfilingConfigFile_noFileExists() throws {
         try ensureAppLaunchProfileConfig(exists: false)
-        expect(NSDictionary(contentsOf: launchProfileConfigFileURL())) == nil
+        XCTAssertNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
         removeAppLaunchProfilingConfigFile()
-        expect(NSDictionary(contentsOf: launchProfileConfigFileURL())) == nil
+        XCTAssertNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
     }
     
     func testCheckForLaunchProfilingConfigFile_URLDoesNotExist() {
@@ -804,7 +803,7 @@ extension SentryFileManagerTests {
         sentryLaunchConfigFileURL = nil
 
         // make sure we return a default-off value and also don't crash the call to access()
-        expect(appLaunchProfileConfigFileExists()) == false
+        XCTAssertFalse(appLaunchProfileConfigFileExists())
         
         // set the original value back so other tests don't crash
         sentryLaunchConfigFileURL = (originalURL as NSURL)

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -245,7 +244,7 @@ class SentrySerializationTests: XCTestCase {
         
         let serialized = String(data: data, encoding: .utf8)
         
-        expect(serialized) == "{\"segment_id\":5}\n[{\"KEY\":\"VALUE\"}]"
+        XCTAssertEqual(serialized, "{\"segment_id\":5}\n[{\"KEY\":\"VALUE\"}]")
     }
     
     func testLevelFromEventData() {

--- a/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
+++ b/Tests/SentryTests/Helper/SentryTimeSwiftTests.swift
@@ -1,21 +1,20 @@
-import Nimble
 import XCTest
 
 final class SentryTimeSwiftTests: XCTestCase {
     
     func testTimeIntervalToNanoseconds() {
-        expect(timeIntervalToNanoseconds(0.0)) == UInt64(0)
-        expect(timeIntervalToNanoseconds(0.5)) == UInt64(500_000_000)
-        expect(timeIntervalToNanoseconds(1.0)) == UInt64(1_000_000_000)
-        expect(timeIntervalToNanoseconds(1.123456789)) == UInt64(1_123_456_789)
-        expect(timeIntervalToNanoseconds(123_456_789.123456)) == UInt64(123_456_789_123_456_000)
+        XCTAssertEqual(timeIntervalToNanoseconds(0.0), UInt64(0))
+        XCTAssertEqual(timeIntervalToNanoseconds(0.5), UInt64(500_000_000))
+        XCTAssertEqual(timeIntervalToNanoseconds(1.0), UInt64(1_000_000_000))
+        XCTAssertEqual(timeIntervalToNanoseconds(1.123456789), UInt64(1_123_456_789))
+        XCTAssertEqual(timeIntervalToNanoseconds(123_456_789.123456), UInt64(123_456_789_123_456_000))
     }
 
     func testNanosecondsToTimeInterval() {
-        expect(nanosecondsToTimeInterval(0)).to(beCloseTo(0.0, within: 1e-9))
-        expect(nanosecondsToTimeInterval(500_000_000)).to(beCloseTo(0.5, within: 1e-9))
-        expect(nanosecondsToTimeInterval(1_000_000_000)).to(beCloseTo(1.0, within: 1e-9))
-        expect(nanosecondsToTimeInterval(1_123_456_789)).to(beCloseTo(1.123456789, within: 1e-9))
-        expect(nanosecondsToTimeInterval(123_456_789_123_456_000)).to(beCloseTo(123_456_789.123456, within: 1e-9))
+        XCTAssertEqual(nanosecondsToTimeInterval(0), 0.0, accuracy: 1e-9)
+        XCTAssertEqual(nanosecondsToTimeInterval(500_000_000), 0.5, accuracy: 1e-9)
+        XCTAssertEqual(nanosecondsToTimeInterval(1_000_000_000), 1.0, accuracy: 1e-9)
+        XCTAssertEqual(nanosecondsToTimeInterval(1_123_456_789), 1.123456789, accuracy: 1e-9)
+        XCTAssertEqual(nanosecondsToTimeInterval(123_456_789_123_456_000), 123_456_789.123456, accuracy: 1e-9)
     }
 }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -78,14 +77,14 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
                 return
             }
             
-            expect(ex.mechanism?.type) == "AppHang"
-            expect(ex.type) == "App Hanging"
-            expect(ex.value) == "App hanging for at least 4500 ms."
-            expect(ex.stacktrace) != nil
-            expect(ex.stacktrace?.frames.first?.function) == "main"
-            expect(ex.stacktrace?.snapshot?.boolValue) == true
-            expect(event?.threads?[0].current?.boolValue) == true
-            expect(event?.isAppHangEvent) == true
+            XCTAssertEqual(ex.mechanism?.type, "AppHang")
+            XCTAssertEqual(ex.type, "App Hanging")
+            XCTAssertEqual(ex.value, "App hanging for at least 4500 ms.")
+            XCTAssertNotNil(ex.stacktrace)
+            XCTAssertEqual(ex.stacktrace?.frames.first?.function, "main")
+            XCTAssertEqual(ex.stacktrace?.snapshot?.boolValue, true)
+            XCTAssertEqual(event?.threads?[0].current?.boolValue, true)
+            XCTAssertEqual(event?.isAppHangEvent, true)
             
             guard let threads = event?.threads else {
                 XCTFail("ANR Exception not found")
@@ -127,7 +126,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
                 return
             }
             
-            expect(ex.mechanism?.type) == "AppHang"
+            XCTAssertEqual(ex.mechanism?.type, "AppHang")
         }
     }
     
@@ -188,7 +187,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
     }
 
     func testEventIsNotANR() {
-        expect(Event().isAppHangEvent) == false
+        XCTAssertFalse(Event().isAppHangEvent)
     }
     
     private func givenInitializedTracker(isBeingTraced: Bool = false) {

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -128,7 +127,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         
         postBatteryLevelNotification(uiDevice: nil)
         
-        expect(self.fixture.delegate.addCrumbInvocations.count) == 0
+        XCTAssertEqual(self.fixture.delegate.addCrumbInvocations.count, 0)
     }
     
     func testBatteryBreadcrumbForSessionReplay() throws {
@@ -315,8 +314,8 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
         sut.timezoneEventTriggered()
 
         assertBreadcrumbAction(action: "TIMEZONE_CHANGE") { data in
-            expect(data["previous_seconds_from_gmt"]) == nil
-            expect(data["current_seconds_from_gmt"] as? Int64) == 7_200
+            XCTAssertNil(data["previous_seconds_from_gmt"])
+            XCTAssertEqual(data["current_seconds_from_gmt"] as? Int64, 7_200)
         }
     }
 

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -438,7 +437,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
         
         let expectedAppStartDuration = expectedDuration ?? fixture.appStartDuration
         let actualAppStartDuration = appStartMeasurement.duration
-        expect(actualAppStartDuration).to(beCloseTo(expectedAppStartDuration, within: 0.0001))
+        XCTAssertEqual(actualAppStartDuration, expectedAppStartDuration, accuracy: 0.0001)
         
         if preWarmed {
             XCTAssertEqual(fixture.moduleInitializationTimestamp, appStartMeasurement.appStartTimestamp)
@@ -446,12 +445,12 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
             XCTAssertEqual(fixture.sysctl.processStartTimestamp, appStartMeasurement.appStartTimestamp)
         }
 
-        expect(appStartMeasurement.moduleInitializationTimestamp) == fixture.sysctl.moduleInitializationTimestamp
-        expect(appStartMeasurement.runtimeInitTimestamp) == fixture.runtimeInitTimestamp
+        XCTAssertEqual(appStartMeasurement.moduleInitializationTimestamp, fixture.sysctl.moduleInitializationTimestamp)
+        XCTAssertEqual(appStartMeasurement.runtimeInitTimestamp, fixture.runtimeInitTimestamp)
         
-        expect(appStartMeasurement.sdkStartTimestamp) == fixture.sdkStartTimestamp
-        expect(appStartMeasurement.didFinishLaunchingTimestamp) == fixture.didFinishLaunchingTimestamp
-        expect(appStartMeasurement.isPreWarmed) == preWarmed
+        XCTAssertEqual(appStartMeasurement.sdkStartTimestamp, fixture.sdkStartTimestamp)
+        XCTAssertEqual(appStartMeasurement.didFinishLaunchingTimestamp, fixture.didFinishLaunchingTimestamp)
+        XCTAssertEqual(appStartMeasurement.isPreWarmed, preWarmed)
     }
     
     private func assertValidHybridStart(type: SentryAppStartType) {

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -1,5 +1,4 @@
 import _SentryPrivate
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -115,16 +114,16 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
         let options = fixture.options
         options.enablePerformanceV2 = true
         
-        expect(self.sut.install(with: options)) == true
+        XCTAssertEqual(self.sut.install(with: options), true)
         
         let tracker = Dynamic(sut).tracker.asAnyObject as? SentryAppStartTracker
-        expect(Dynamic(tracker).enablePerformanceV2.asBool) == true
+        XCTAssertEqual(Dynamic(tracker).enablePerformanceV2.asBool, true)
     }
 
     func assertTrackerSetupAndRunning(_ tracker: SentryAppStartTracker) throws {
         _ = try XCTUnwrap(Dynamic(tracker).dispatchQueue.asAnyObject as? SentryDispatchQueueWrapper, "Tracker does not have a dispatch queue.")
         
-        expect(Dynamic(tracker).enablePerformanceV2.asBool) == false
+        XCTAssertFalse(try XCTUnwrap(Dynamic(tracker).enablePerformanceV2.asBool))
 
         let appStateManager = Dynamic(tracker).appStateManager.asObject as? SentryAppStateManager
 

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -1,5 +1,4 @@
 import _SentryPrivate
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -34,13 +33,13 @@ class SentryFramesTrackerTests: XCTestCase {
     }
 
     func testIsNotRunning_WhenNotStarted() {
-        expect(self.fixture.sut.isRunning) == false
+        XCTAssertFalse(self.fixture.sut.isRunning)
     }
 
     func testIsRunning_WhenStarted() {
         let sut = fixture.sut
         sut.start()
-        expect(self.fixture.sut.isRunning) == true
+        XCTAssertEqual(self.fixture.sut.isRunning, true)
     }
     
     func testStartTwice_SubscribesOnceToDisplayLink() {
@@ -48,7 +47,7 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
         sut.start()
         
-        expect(self.fixture.displayLinkWrapper.linkInvocations.count) == 1
+        XCTAssertEqual(self.fixture.displayLinkWrapper.linkInvocations.count, 1)
     }
 
     func testIsNotRunning_WhenStopped() {
@@ -56,7 +55,7 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.start()
         sut.stop()
         
-        expect(self.fixture.sut.isRunning) == false
+        XCTAssertFalse(self.fixture.sut.isRunning)
     }
     
     func testKeepFrames_WhenStopped() throws {
@@ -78,8 +77,8 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.stop()
         sut.start()
         
-        expect(sut.isRunning) == true
-        expect(self.fixture.displayLinkWrapper.linkInvocations.count) == 2
+        XCTAssertEqual(sut.isRunning, true)
+        XCTAssertEqual(self.fixture.displayLinkWrapper.linkInvocations.count, 2)
     }
 
     func testSlowFrame() throws {
@@ -182,7 +181,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let expectedDelay = displayLink.timeEpsilon + displayLink.slowestSlowFrameDuration - slowFrameThreshold(displayLink.currentFrameRate.rawValue)
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     /**
@@ -209,7 +208,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let expectedDelay = delayWithoutFrameRecord - slowFrameThreshold(displayLink.currentFrameRate.rawValue)
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     /**
@@ -277,7 +276,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let endSystemTime = fixture.dateProvider.systemTime()
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay) == -1
+        XCTAssertEqual(actualFrameDelay, -1)
     }
     
     func testDelayedFrames_NoRecordedDelayedFrames_ReturnsZero() {
@@ -296,7 +295,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let endSystemTime = fixture.dateProvider.systemTime()
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(0.0, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, 0.0, accuracy: 0.0001)
     }
     
     func testDelayedFrames_NoRecordedDelayedFrames_ButFrameIsDelayed_ReturnsDelay() {
@@ -318,7 +317,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let expectedDelay = delay - slowFrameThreshold(fixture.displayLinkWrapper.currentFrameRate.rawValue)
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     func testDelayedFrames_FrameIsDelayedSmallerThanSlowFrameThreshold_ReturnsDelay() {
@@ -343,7 +342,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let expectedDelay = delay
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     private func testFrameDelay(timeIntervalAfterFrameStart: TimeInterval = 0.0, timeIntervalBeforeFrameEnd: TimeInterval = 0.0, expectedDelay: TimeInterval) {
@@ -361,7 +360,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let startSystemTime = slowFrameStartSystemTime + timeIntervalToNanoseconds(timeIntervalAfterFrameStart)
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     /**
@@ -389,7 +388,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let expectedDelay = displayLink.slowestSlowFrameDuration - slowFrameThreshold(displayLink.currentFrameRate.rawValue)
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     func testFrameDelay_WithStartBeforeEnd_ReturnsMinusOne() {
@@ -401,7 +400,7 @@ class SentryFramesTrackerTests: XCTestCase {
         _ = displayLink.slowestSlowFrame()
         
         let actualFrameDelay = sut.getFramesDelay(1, endSystemTimestamp: 0)
-        expect(actualFrameDelay) == -1.0
+        XCTAssertEqual(actualFrameDelay, -1.0)
     }
     
     func testFrameDelay_LongestTimeStamp_ReturnsMinusOne() {
@@ -413,7 +412,7 @@ class SentryFramesTrackerTests: XCTestCase {
         _ = displayLink.slowestSlowFrame()
 
         let actualFrameDelay = sut.getFramesDelay(0, endSystemTimestamp: UInt64.max)
-        expect(actualFrameDelay) == -1.0
+        XCTAssertEqual(actualFrameDelay, -1.0)
     }
     
     func testFrameDelay_KeepAddingSlowFrames_OnlyTheMaxDurationFramesReturned() {
@@ -425,7 +424,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let endSystemTime = fixture.dateProvider.systemTime()
 
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     func testFrameDelay_MoreThanMaxDuration_FrameInformationMissing_DelayReturned() {
@@ -443,7 +442,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let expectedDelay = slowFramesDelay + delayNotRecorded
 
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(actualFrameDelay, expectedDelay, accuracy: 0.0001)
     }
     
     func testFrameDelay_MoreThanMaxDuration_StartTimeTooEarly_ReturnsMinusOne() {
@@ -455,7 +454,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let endSystemTime = fixture.dateProvider.systemTime()
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime - 1, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay).to(beCloseTo(-1, within: 0.0001), description: "startSystemTimeStamp starts one nanosecond before the oldest slow frame. Therefore the frame delay can't be calculated and should me 0.")
+        XCTAssertEqual(actualFrameDelay, -1, accuracy: 0.0001, "startSystemTimeStamp starts one nanosecond before the oldest slow frame. Therefore the frame delay can't be calculated and should me 0.")
     }
     
     func testFrameDelay_FramesTrackerNotRunning_ReturnsMinusOne() {
@@ -473,7 +472,7 @@ class SentryFramesTrackerTests: XCTestCase {
         sut.stop()
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay) == -1.0
+        XCTAssertEqual(actualFrameDelay, -1.0)
     }
     
     func testFrameDelay_RestartTracker_ReturnsMinusOne() {
@@ -488,7 +487,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let endSystemTime = fixture.dateProvider.systemTime()
         
         let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
-        expect(actualFrameDelay) == -1.0
+        XCTAssertEqual(actualFrameDelay, -1.0)
     }
     
     func testFrameDelay_GetInfoFromBackgroundThreadWhileAdding() {
@@ -507,7 +506,7 @@ class SentryFramesTrackerTests: XCTestCase {
                 
                 let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
                 
-                expect(actualFrameDelay) >= -1
+                XCTAssertGreaterThan(actualFrameDelay, -1)
                 
                 expectation.fulfill()
             }
@@ -532,11 +531,11 @@ class SentryFramesTrackerTests: XCTestCase {
         var expectedFrameDate = fixture.dateProvider.date()
         expectedFrameDate.addTimeInterval(-fixture.dateProvider.driftTimeInterval)
 
-        expect(listener1.newFrameInvocations.count) == 1
-        expect(listener1.newFrameInvocations.first?.timeIntervalSince1970) == expectedFrameDate.timeIntervalSince1970
+        XCTAssertEqual(listener1.newFrameInvocations.count, 1)
+        XCTAssertEqual(listener1.newFrameInvocations.first?.timeIntervalSince1970, expectedFrameDate.timeIntervalSince1970)
         
-        expect(listener2.newFrameInvocations.count) == 1
-        expect(listener2.newFrameInvocations.first?.timeIntervalSince1970) == expectedFrameDate.timeIntervalSince1970
+        XCTAssertEqual(listener2.newFrameInvocations.count, 1)
+        XCTAssertEqual(listener2.newFrameInvocations.first?.timeIntervalSince1970, expectedFrameDate.timeIntervalSince1970)
     }
 
     func testRemoveListener() {
@@ -548,7 +547,7 @@ class SentryFramesTrackerTests: XCTestCase {
 
         fixture.displayLinkWrapper.normalFrame()
 
-        expect(listener.newFrameInvocations.count) == 0
+        XCTAssertEqual(listener.newFrameInvocations.count, 0)
     }
     
     func testListenerNotCalledAfterCallingStop() {
@@ -563,8 +562,8 @@ class SentryFramesTrackerTests: XCTestCase {
 
         fixture.displayLinkWrapper.normalFrame()
 
-        expect(listener1.newFrameInvocations.count) == 0
-        expect(listener2.newFrameInvocations.count) == 1
+        XCTAssertEqual(listener1.newFrameInvocations.count, 0)
+        XCTAssertEqual(listener2.newFrameInvocations.count, 1)
     }
 
     func testReleasedListener() {
@@ -601,7 +600,7 @@ class SentryFramesTrackerTests: XCTestCase {
         
         fixture.notificationCenter.post(Notification(name: SentryNSNotificationCenterWrapper.willResignActiveNotificationName))
         
-        expect(sut.isRunning) == false
+        XCTAssertFalse(sut.isRunning)
     }
     
     func testFrameTrackerUnpauses_WhenAppGoesToForeground() {
@@ -621,9 +620,9 @@ class SentryFramesTrackerTests: XCTestCase {
         
         // Ensure to keep listeners when moving to background
         fixture.displayLinkWrapper.normalFrame()
-        expect(callbackCalls) == 1
+        XCTAssertEqual(callbackCalls, 1)
         
-        expect(sut.isRunning) == true
+        XCTAssertEqual(sut.isRunning, true)
     }
     
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
@@ -685,13 +684,13 @@ private extension SentryFramesTrackerTests {
     func assert(slow: UInt? = nil, frozen: UInt? = nil, total: UInt? = nil, frameRates: UInt? = nil) throws {
         let currentFrames = fixture.sut.currentFrames()
         if let total = total {
-            expect(currentFrames.total) == total
+            XCTAssertEqual(currentFrames.total, total)
         }
         if let slow = slow {
-            expect(currentFrames.slow) == slow
+            XCTAssertEqual(currentFrames.slow, slow)
         }
         if let frozen = frozen {
-            expect(currentFrames.frozen) == frozen
+            XCTAssertEqual(currentFrames.frozen, frozen)
         }
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -506,7 +506,7 @@ class SentryFramesTrackerTests: XCTestCase {
                 
                 let actualFrameDelay = sut.getFramesDelay(startSystemTime, endSystemTimestamp: endSystemTime)
                 
-                XCTAssertGreaterThan(actualFrameDelay, -1)
+                XCTAssertGreaterThanOrEqual(actualFrameDelay, -1)
                 
                 expectation.fulfill()
             }

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackingIntegrationTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -56,29 +55,29 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
-        expect(tracer.children.count) == 1
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 1
+        XCTAssertEqual(tracer.children.count, 1)
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 1)
 
         let ttidSpan = try XCTUnwrap(tracer.children.first, "Expected a TTID span")
-        expect(ttidSpan.startTimestamp) == fixture.dateProvider.date()
+        XCTAssertEqual(ttidSpan.startTimestamp, fixture.dateProvider.date())
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
         sut.reportInitialDisplay()
-        expect(ttidSpan.timestamp) == nil
-        expect(ttidSpan.isFinished) == false
+        XCTAssertNil(ttidSpan.timestamp)
+        XCTAssertFalse(ttidSpan.isFinished)
         
         fixture.displayLinkWrapper.normalFrame()
         tracer.finish()
 
-        expect(ttidSpan.timestamp) == fixture.dateProvider.date()
-        expect(ttidSpan.isFinished) == true
-        expect(ttidSpan.spanDescription) == "UIViewController initial display"
-        expect(ttidSpan.operation) == SentrySpanOperationUILoadInitialDisplay
-        expect(ttidSpan.origin) == "auto.ui.time_to_display"
+        XCTAssertEqual(ttidSpan.timestamp, fixture.dateProvider.date())
+        XCTAssertEqual(ttidSpan.isFinished, true)
+        XCTAssertEqual(ttidSpan.spanDescription, "UIViewController initial display")
+        XCTAssertEqual(ttidSpan.operation, SentrySpanOperationUILoadInitialDisplay)
+        XCTAssertEqual(ttidSpan.origin, "auto.ui.time_to_display")
 
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
 
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
 
     func testReportInitialDisplay_waitForFullDisplay() throws {
@@ -88,28 +87,28 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
-        expect(tracer.children.count) == 2
+        XCTAssertEqual(tracer.children.count, 2)
 
         let ttidSpan = sut.initialDisplaySpan
-        expect(ttidSpan?.startTimestamp) == fixture.dateProvider.date()
+        XCTAssertEqual(ttidSpan?.startTimestamp, fixture.dateProvider.date())
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
         sut.reportInitialDisplay()
         fixture.displayLinkWrapper.normalFrame()
 
-        expect(ttidSpan?.isFinished) == true
-        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 9)
-        expect(tracer.measurements["time_to_initial_display"]) == nil
+        XCTAssertEqual(ttidSpan?.isFinished, true)
+        XCTAssertEqual(ttidSpan?.timestamp, Date(timeIntervalSince1970: 9))
+        XCTAssertNil(tracer.measurements["time_to_initial_display"])
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 11))
         sut.reportFullyDisplayed()
         
         // TTFD not reported yet cause we wait for the next frame
-        expect(sut.fullDisplaySpan?.startTimestamp) == ttidSpan?.startTimestamp
-        expect(sut.fullDisplaySpan?.timestamp) == nil
-        expect(tracer.measurements["time_to_full_display"]) == nil
+        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, ttidSpan?.startTimestamp)
+        XCTAssertNil(sut.fullDisplaySpan?.timestamp)
+        XCTAssertNil(tracer.measurements["time_to_full_display"])
         
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 1
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 1)
     }
 
     func testReportFullDisplay_notWaitingForFullDisplay() throws {
@@ -123,11 +122,11 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
         sut.reportFullyDisplayed()
 
-        expect(sut.fullDisplaySpan) == nil
-        expect(tracer.children.count) == 1
-        expect(tracer.measurements["time_to_full_display"]) == nil
+        XCTAssertNil(sut.fullDisplaySpan)
+        XCTAssertEqual(tracer.children.count, 1)
+        XCTAssertNil(tracer.measurements["time_to_full_display"])
         
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
     
     func testReportFullDisplay_waitingForFullDisplay() throws {
@@ -151,18 +150,18 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 13))
         tracer.finish()
 
-        expect(sut.fullDisplaySpan) != nil
-        expect(sut.fullDisplaySpan?.startTimestamp) == Date(timeIntervalSince1970: 9)
-        expect(sut.fullDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 12)
-        expect(sut.fullDisplaySpan?.status) == .ok
+        XCTAssertNotNil(sut.fullDisplaySpan)
+        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, Date(timeIntervalSince1970: 9))
+        XCTAssertEqual(sut.fullDisplaySpan?.timestamp, Date(timeIntervalSince1970: 12))
+        XCTAssertEqual(sut.fullDisplaySpan?.status, .ok)
 
-        expect(sut.fullDisplaySpan?.spanDescription) == "UIViewController full display"
-        expect(sut.fullDisplaySpan?.operation) == SentrySpanOperationUILoadFullDisplay
-        expect(sut.fullDisplaySpan?.origin) == "manual.ui.time_to_display"
+        XCTAssertEqual(sut.fullDisplaySpan?.spanDescription, "UIViewController full display")
+        XCTAssertEqual(sut.fullDisplaySpan?.operation, SentrySpanOperationUILoadFullDisplay)
+        XCTAssertEqual(sut.fullDisplaySpan?.origin, "manual.ui.time_to_display")
         
         assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)
         
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
     
     func testWaitingForFullDisplay_ReportFullDisplayBeforeInitialDisplay() throws {
@@ -179,29 +178,31 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         
         fixture.displayLinkWrapper.normalFrame()
 
-        expect(sut.fullDisplaySpan?.isFinished) == false
-        expect(sut.initialDisplaySpan?.isFinished) == false
+        XCTAssertFalse(try XCTUnwrap(sut.fullDisplaySpan?.isFinished))
+        XCTAssertFalse(try XCTUnwrap(sut.initialDisplaySpan?.isFinished))
         
         sut.reportInitialDisplay()
         
-        expect(sut.fullDisplaySpan?.isFinished) == false
-        expect(sut.initialDisplaySpan?.isFinished) == false
+        XCTAssertFalse(try XCTUnwrap(sut.fullDisplaySpan?.isFinished))
+        XCTAssertFalse(try XCTUnwrap(sut.initialDisplaySpan?.isFinished))
         
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 12))
         fixture.displayLinkWrapper.normalFrame()
         tracer.finish()
         
-        expect(sut.initialDisplaySpan?.isFinished) == true
-        expect(sut.initialDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 12)
-        expect(sut.initialDisplaySpan?.status) == .ok
+        let initialDisplaySpan = try XCTUnwrap(sut.initialDisplaySpan)
+        let fullDisplaySpan = try XCTUnwrap(sut.fullDisplaySpan)
+        XCTAssert(initialDisplaySpan.isFinished)
+        XCTAssertEqual(initialDisplaySpan.timestamp, Date(timeIntervalSince1970: 12))
+        XCTAssertEqual(initialDisplaySpan.status, .ok)
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 3_000)
         
-        expect(sut.fullDisplaySpan?.isFinished) == true
-        expect(sut.fullDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 12)
-        expect(sut.fullDisplaySpan?.status) == .ok
+        XCTAssert(fullDisplaySpan.isFinished)
+        XCTAssertEqual(fullDisplaySpan.timestamp, Date(timeIntervalSince1970: 12))
+        XCTAssertEqual(fullDisplaySpan.status, .ok)
         assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)
         
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
     
     func testTracerFinishesBeforeReportInitialDisplay_FinishesInitialDisplaySpan() throws {
@@ -211,24 +212,24 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         let tracer = try fixture.getTracer()
 
         sut.start(for: tracer)
-        expect(tracer.children.count) == 1
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 1
+        XCTAssertEqual(tracer.children.count, 1)
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 1)
 
         let ttidSpan = try XCTUnwrap(tracer.children.first, "Expected a TTID span")
-        expect(ttidSpan.startTimestamp) == fixture.dateProvider.date()
+        XCTAssertEqual(ttidSpan.startTimestamp, fixture.dateProvider.date())
 
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
         
         tracer.finish()
 
-        expect(ttidSpan.timestamp) == fixture.dateProvider.date()
-        expect(ttidSpan.isFinished) == true
-        expect(ttidSpan.spanDescription) == "UIViewController initial display"
-        expect(ttidSpan.status) == .ok
+        XCTAssertEqual(ttidSpan.timestamp, fixture.dateProvider.date())
+        XCTAssertEqual(ttidSpan.isFinished, true)
+        XCTAssertEqual(ttidSpan.spanDescription, "UIViewController initial display")
+        XCTAssertEqual(ttidSpan.status, .ok)
 
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
 
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
 
     func testCheckInitialTime() throws {
@@ -240,9 +241,9 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
 
         sut.start(for: tracer)
 
-        expect(sut.fullDisplaySpan) != nil
-        expect(sut.fullDisplaySpan?.startTimestamp) == tracer.startTimestamp
-        expect(sut.initialDisplaySpan?.startTimestamp) == tracer.startTimestamp
+        XCTAssertNotNil(sut.fullDisplaySpan)
+        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, tracer.startTimestamp)
+        XCTAssertEqual(sut.initialDisplaySpan?.startTimestamp, tracer.startTimestamp)
     }
     
     func testReportFullyDisplayed_AfterTracerTimesOut() throws {
@@ -267,18 +268,18 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         sut.reportFullyDisplayed()
         
         let ttidSpan = sut.initialDisplaySpan
-        expect(ttidSpan?.startTimestamp) == Date(timeIntervalSince1970: 9)
-        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 10)
-        expect(ttidSpan?.status) == .ok
+        XCTAssertEqual(ttidSpan?.startTimestamp, Date(timeIntervalSince1970: 9))
+        XCTAssertEqual(ttidSpan?.timestamp, Date(timeIntervalSince1970: 10))
+        XCTAssertEqual(ttidSpan?.status, .ok)
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 1_000)
         
         let ttfdSpan = sut.fullDisplaySpan
-        expect(ttfdSpan?.startTimestamp) == ttidSpan?.startTimestamp
-        expect(ttfdSpan?.timestamp) == ttidSpan?.timestamp
-        expect(ttfdSpan?.status) == .deadlineExceeded
-        expect(ttfdSpan?.spanDescription) == "UIViewController full display - Deadline Exceeded"
-        expect(ttfdSpan?.operation) == SentrySpanOperationUILoadFullDisplay
-        expect(ttfdSpan?.origin) == "manual.ui.time_to_display"
+        XCTAssertEqual(ttfdSpan?.startTimestamp, ttidSpan?.startTimestamp)
+        XCTAssertEqual(ttfdSpan?.timestamp, ttidSpan?.timestamp)
+        XCTAssertEqual(ttfdSpan?.status, .deadlineExceeded)
+        XCTAssertEqual(ttfdSpan?.spanDescription, "UIViewController full display - Deadline Exceeded")
+        XCTAssertEqual(ttfdSpan?.operation, SentrySpanOperationUILoadFullDisplay)
+        XCTAssertEqual(ttfdSpan?.origin, "manual.ui.time_to_display")
         
         assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 1_000)
     }
@@ -292,7 +293,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         sut.reportFullyDisplayed()
         
         let expectedInvocations = invocationsBefore + 1
-        expect(dispatchQueueWrapper.blockOnMainInvocations.count).to(equal(expectedInvocations), description: "reportFullyDisplayed should be dispatched on the main queue. ")
+        XCTAssertEqual(dispatchQueueWrapper.blockOnMainInvocations.count, expectedInvocations, "reportFullyDisplayed should be dispatched on the main queue. ")
     }
     
     func testNotWaitingForFullyDisplayed_AfterTracerTimesOut() throws {
@@ -318,12 +319,12 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 1_000)
         let ttidSpan = sut.initialDisplaySpan
-        expect(ttidSpan?.startTimestamp) == Date(timeIntervalSince1970: 9)
-        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 10)
-        expect(ttidSpan?.status) == .ok
+        XCTAssertEqual(ttidSpan?.startTimestamp, Date(timeIntervalSince1970: 9))
+        XCTAssertEqual(ttidSpan?.timestamp, Date(timeIntervalSince1970: 10))
+        XCTAssertEqual(ttidSpan?.status, .ok)
         
-        expect(sut.fullDisplaySpan) == nil
-        expect(tracer.measurements["time_to_full_display"]) == nil
+        XCTAssertNil(sut.fullDisplaySpan)
+        XCTAssertNil(tracer.measurements["time_to_full_display"])
     }
     
     func testTracerWithAppStartData_notWaitingForFullDisplay() throws {
@@ -348,15 +349,15 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         tracer.finish()
         
         let ttidSpan = sut.initialDisplaySpan
-        expect(ttidSpan?.isFinished) == true
-        expect(ttidSpan?.startTimestamp) == tracer.startTimestamp
-        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 8)
+        XCTAssertEqual(ttidSpan?.isFinished, true)
+        XCTAssertEqual(ttidSpan?.startTimestamp, tracer.startTimestamp)
+        XCTAssertEqual(ttidSpan?.timestamp, Date(timeIntervalSince1970: 8))
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
 
-        expect(sut.fullDisplaySpan) == nil
-        expect(tracer.measurements["time_to_full_display"]) == nil
+        XCTAssertNil(sut.fullDisplaySpan)
+        XCTAssertNil(tracer.measurements["time_to_full_display"])
         
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
     
     func testTracerWithAppStartData_waitingForFullDisplay() throws {
@@ -382,21 +383,21 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         
         let ttidSpan = sut.initialDisplaySpan
 
-        expect(ttidSpan?.isFinished) == true
-        expect(ttidSpan?.startTimestamp) == tracer.startTimestamp
-        expect(ttidSpan?.timestamp) == Date(timeIntervalSince1970: 8)
+        XCTAssertEqual(ttidSpan?.isFinished, true)
+        XCTAssertEqual(ttidSpan?.startTimestamp, tracer.startTimestamp)
+        XCTAssertEqual(ttidSpan?.timestamp, Date(timeIntervalSince1970: 8))
         assertMeasurement(tracer: tracer, name: "time_to_initial_display", duration: 2_000)
 
-        expect(sut.fullDisplaySpan?.startTimestamp) == ttidSpan?.startTimestamp
-        expect(sut.fullDisplaySpan?.timestamp) == Date(timeIntervalSince1970: 9)
+        XCTAssertEqual(sut.fullDisplaySpan?.startTimestamp, ttidSpan?.startTimestamp)
+        XCTAssertEqual(sut.fullDisplaySpan?.timestamp, Date(timeIntervalSince1970: 9))
         assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)
         
-        expect(Dynamic(self.fixture.framesTracker).listeners.count) == 0
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
 
     func assertMeasurement(tracer: SentryTracer, name: String, duration: TimeInterval) {
-        expect(tracer.measurements[name]?.value) == NSNumber(value: duration)
-        expect(tracer.measurements[name]?.unit?.unit) == "millisecond"
+        XCTAssertEqual(tracer.measurements[name]?.value, NSNumber(value: duration))
+        XCTAssertEqual(tracer.measurements[name]?.unit?.unit, "millisecond")
     }
 }
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -1,6 +1,5 @@
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
-import Nimble
 import ObjectiveC
 @testable import Sentry
 import SentryTestUtils
@@ -279,8 +278,8 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         let expectedTTFDTimestamp = fixture.dateProvider.date()
 
         let ttfdSpan = tracer?.children[1]
-        expect(ttfdSpan?.isFinished) == true
-        expect(ttfdSpan?.timestamp) == expectedTTFDTimestamp
+        XCTAssertEqual(ttfdSpan?.isFinished, true)
+        XCTAssertEqual(ttfdSpan?.timestamp, expectedTTFDTimestamp)
     }
 
     func testSecondViewController() {
@@ -607,7 +606,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         let timestamp = try XCTUnwrap(span.timestamp)
         let startTimestamp = try XCTUnwrap(span.startTimestamp)
         let duration = timestamp.timeIntervalSince(startTimestamp)
-        expect(duration).to(beCloseTo(expectedDuration, within: 0.001))
+        XCTAssertEqual(duration, expectedDuration, accuracy: 0.001)
     }
     
     private func assertTrackerIsEmpty(_ tracker: SentryPerformanceTracker) {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -83,9 +82,9 @@ class SentryCrashReportTests: XCTestCase {
 
         let crashReport: CrashReport = try XCTUnwrap( JSONDecoder().decode(CrashReport.self, from: crashReportContents))
             
-        expect(crashReport.crash.error.type) == "nsexception"
-        expect(crashReport.crash.error.reason) == reason
-        expect(crashReport.crash.error.nsexception?.reason) == reason
+        XCTAssertEqual(crashReport.crash.error.type, "nsexception")
+        XCTAssertEqual(crashReport.crash.error.reason, reason)
+        XCTAssertEqual(crashReport.crash.error.nsexception?.reason, reason)
     }
     
     func testShouldNotWriteReason_WhenWritingNSException() {
@@ -100,9 +99,9 @@ class SentryCrashReportTests: XCTestCase {
         do {
             let crashReport: CrashReport = try JSONDecoder().decode(CrashReport.self, from: crashReportContents)
             
-            expect(crashReport.crash.error.type) == "nsexception"
-            expect(crashReport.crash.error.reason) == nil
-            expect(crashReport.crash.error.nsexception?.reason) == nil
+            XCTAssertEqual(crashReport.crash.error.type, "nsexception")
+            XCTAssertNil(crashReport.crash.error.reason)
+            XCTAssertNil(crashReport.crash.error.nsexception?.reason)
         } catch {
             XCTFail("Couldn't decode crash report: \(error)")
         }
@@ -113,9 +112,9 @@ class SentryCrashReportTests: XCTestCase {
         
         let crashReportContents = FileManager.default.contents(atPath: fixture.reportPath) ?? Data()
         
-        let crashReportContentsAsString = String(data: crashReportContents, encoding: .ascii)
+        let crashReportContentsAsString = try XCTUnwrap(String(data: crashReportContents, encoding: .ascii))
         
-        expect(crashReportContentsAsString).toNot(contain("boot_time"), description: "The crash report must not contain boot_time because Apple forbids sending this information off device see: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.")
+        XCTAssertFalse(crashReportContentsAsString.contains("boot_time"), "The crash report must not contain boot_time because Apple forbids sending this information off device see: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.")
     }
     
     private func writeCrashReport() {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -22,12 +21,12 @@ class SentryOnDemandReplayTests: XCTestCase {
         sut.addFrameAsync(image: UIImage.add)
        
         guard let frame = sut.frames.first else {
-            fail("Frame was not saved")
+            XCTFail("Frame was not saved")
             return
         }
         
-        expect(FileManager.default.fileExists(atPath: frame.imagePath)) == true
-        expect(frame.imagePath.hasPrefix(self.outputPath.path)) == true
+        XCTAssertEqual(FileManager.default.fileExists(atPath: frame.imagePath), true)
+        XCTAssertEqual(frame.imagePath.hasPrefix(self.outputPath.path), true)
     }
     
     func testReleaseFrames() {
@@ -42,9 +41,9 @@ class SentryOnDemandReplayTests: XCTestCase {
         
         let frames = sut.frames
         
-        expect(frames.count) == 5
-        expect(frames.first?.time) == Date(timeIntervalSinceReferenceDate: 5)
-        expect(frames.last?.time) == Date(timeIntervalSinceReferenceDate: 9)
+        XCTAssertEqual(frames.count, 5)
+        XCTAssertEqual(frames.first?.time, Date(timeIntervalSinceReferenceDate: 5))
+        XCTAssertEqual(frames.last?.time, Date(timeIntervalSinceReferenceDate: 9))
     }
     
     func testGenerateVideo() {
@@ -60,13 +59,13 @@ class SentryOnDemandReplayTests: XCTestCase {
         let videoExpectation = expectation(description: "Wait for video render")
         
         try? sut.createVideoWith(duration: 10, beginning: Date(timeIntervalSinceReferenceDate: 0), outputFileURL: output) { info, error in
-            expect(error) == nil
+            XCTAssertNil(error)
             
-            expect(info?.duration) == 10
-            expect(info?.start) == Date(timeIntervalSinceReferenceDate: 0)
-            expect(info?.end) == Date(timeIntervalSinceReferenceDate: 10)
+            XCTAssertEqual(info?.duration, 10)
+            XCTAssertEqual(info?.start, Date(timeIntervalSinceReferenceDate: 0))
+            XCTAssertEqual(info?.end, Date(timeIntervalSinceReferenceDate: 10))
             
-            expect(FileManager.default.fileExists(atPath: output.path)) == true
+            XCTAssertEqual(FileManager.default.fileExists(atPath: output.path), true)
             videoExpectation.fulfill()
             try? FileManager.default.removeItem(at: output)
         }
@@ -94,7 +93,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         
         group.wait()
         queue.queue.sync {} //Wait for all enqueued operation to finish
-        expect(sut.frames.map({ ($0.imagePath as NSString).lastPathComponent })) == (0..<10).map { "\($0).png" }
+        XCTAssertEqual(sut.frames.map({ ($0.imagePath as NSString).lastPathComponent }), (0..<10).map { "\($0).png" })
     }
     
     func testReleaseIsThreadSafe() {
@@ -118,7 +117,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         group.wait()
         
         queue.queue.sync {} //Wait for all enqueued operation to finish
-        expect(sut.frames.count) == 0
+        XCTAssertEqual(sut.frames.count, 0)
     }
     
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayEventTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayEventTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 import XCTest
 
 class SentryReplayEventTests: XCTestCase {
@@ -19,12 +18,12 @@ class SentryReplayEventTests: XCTestCase {
         
         let result = sut.serialize()
         
-        expect(result["urls"] as? [String]) == ["Screen 1", "Screen 2"]
-        expect(result["replay_start_timestamp"] as? Int) == 1
-        expect(result["trace_ids"] as? [String]) == [ traceIds[0].sentryIdString, traceIds[1].sentryIdString]
-        expect(result["replay_id"] as? String) == replayId.sentryIdString
-        expect(result["segment_id"] as? Int) == 3
-        expect(result["replay_type"] as? String) == "buffer"
+        XCTAssertEqual(result["urls"] as? [String], ["Screen 1", "Screen 2"])
+        XCTAssertEqual(result["replay_start_timestamp"] as? Int, 1)
+        XCTAssertEqual(result["trace_ids"] as? [String], [ traceIds[0].sentryIdString, traceIds[1].sentryIdString])
+        XCTAssertEqual(result["replay_id"] as? String, replayId.sentryIdString)
+        XCTAssertEqual(result["segment_id"] as? Int, 3)
+        XCTAssertEqual(result["replay_type"] as? String, "buffer")
     }
     
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -17,26 +16,26 @@ class SentryReplayRecordingTests: XCTestCase {
         let recordingData = recordingInfo["data"] as? [String: Any]
         let recordingPayload = recordingData?["payload"] as? [String: Any]
         
-        expect(metaInfo["type"] as? Int) == 4
-        expect(metaInfo["timestamp"] as? Int) == 2_000
-        expect(metaInfoData?["href"] as? String) == ""
-        expect(metaInfoData?["height"] as? Int) == 930
-        expect(metaInfoData?["width"] as? Int) == 390
-        expect(recordingInfo["type"] as? Int) == 5
-        expect(recordingInfo["timestamp"] as? Int) == 2_000
-        expect(recordingData?["tag"] as? String) == "video"
-        expect(recordingPayload?["segmentId"] as? Int) == 3
-        expect(recordingPayload?["size"] as? Int) == 200
-        expect(recordingPayload?["duration"] as? Double) == 5_000
-        expect(recordingPayload?["encoding"] as? String) == "h264"
-        expect(recordingPayload?["container"] as? String) == "mp4"
-        expect(recordingPayload?["height"] as? Int) == 930
-        expect(recordingPayload?["width"] as? Int) == 390
-        expect(recordingPayload?["frameCount"] as? Int) == 5
-        expect(recordingPayload?["frameRateType"] as? String) == "constant"
-        expect(recordingPayload?["frameRate"] as? Int) == 1
-        expect(recordingPayload?["left"] as? Int) == 0
-        expect(recordingPayload?["top"] as? Int) == 0
+        XCTAssertEqual(metaInfo["type"] as? Int, 4)
+        XCTAssertEqual(metaInfo["timestamp"] as? Int, 2_000)
+        XCTAssertEqual(metaInfoData?["href"] as? String, "")
+        XCTAssertEqual(metaInfoData?["height"] as? Int, 930)
+        XCTAssertEqual(metaInfoData?["width"] as? Int, 390)
+        XCTAssertEqual(recordingInfo["type"] as? Int, 5)
+        XCTAssertEqual(recordingInfo["timestamp"] as? Int, 2_000)
+        XCTAssertEqual(recordingData?["tag"] as? String, "video")
+        XCTAssertEqual(recordingPayload?["segmentId"] as? Int, 3)
+        XCTAssertEqual(recordingPayload?["size"] as? Int, 200)
+        XCTAssertEqual(recordingPayload?["duration"] as? Double, 5_000)
+        XCTAssertEqual(recordingPayload?["encoding"] as? String, "h264")
+        XCTAssertEqual(recordingPayload?["container"] as? String, "mp4")
+        XCTAssertEqual(recordingPayload?["height"] as? Int, 930)
+        XCTAssertEqual(recordingPayload?["width"] as? Int, 390)
+        XCTAssertEqual(recordingPayload?["frameCount"] as? Int, 5)
+        XCTAssertEqual(recordingPayload?["frameRateType"] as? String, "constant")
+        XCTAssertEqual(recordingPayload?["frameRate"] as? Int, 1)
+        XCTAssertEqual(recordingPayload?["left"] as? Int, 0)
+        XCTAssertEqual(recordingPayload?["top"] as? Int, 0)
     }
     
     func test_serializeWithExtra() {
@@ -48,7 +47,7 @@ class SentryReplayRecordingTests: XCTestCase {
         let data = sut.serialize()
         
         let extraInfo = data[2]
-        expect(extraInfo["type"] as? Int) == 5
-        expect(extraInfo["timestamp"] as? Int) == 5_000
+        XCTAssertEqual(extraInfo["type"] as? Int, 5)
+        XCTAssertEqual(extraInfo["timestamp"] as? Int, 5_000)
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -110,7 +109,7 @@ class SentrySessionReplayTests: XCTestCase {
         fixture.dateProvider.advance(by: 5)
         Dynamic(sut).newFrame(nil)
         
-        expect(fixture.hub.lastEvent) == nil
+        XCTAssertNil(fixture.hub.lastEvent)
     }
     
     func testVideoSize() {
@@ -130,7 +129,7 @@ class SentrySessionReplayTests: XCTestCase {
         
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
         sut.start(fixture.rootView, fullSession: true)
-        expect(fixture.hub.scope.replayId) == sut.sessionReplayId.sentryIdString
+        XCTAssertEqual(fixture.hub.scope.replayId, sut.sessionReplayId.sentryIdString)
         
         fixture.dateProvider.advance(by: 1)
         
@@ -141,16 +140,16 @@ class SentrySessionReplayTests: XCTestCase {
         Dynamic(sut).newFrame(nil)
         
         guard let videoArguments = fixture.replayMaker.lastCallToCreateVideo else {
-            fail("Replay maker create video was not called")
+            XCTFail("Replay maker create video was not called")
             return
         }
         
-        expect(videoArguments.duration) == 5
-        expect(videoArguments.beginning) == startEvent
-        expect(videoArguments.outputFileURL) == fixture.cacheFolder.appendingPathComponent("segments/0.mp4")
+        XCTAssertEqual(videoArguments.duration, 5)
+        XCTAssertEqual(videoArguments.beginning, startEvent)
+        XCTAssertEqual(videoArguments.outputFileURL, fixture.cacheFolder.appendingPathComponent("segments/0.mp4"))
         
-        expect(fixture.hub.lastRecording) != nil
-        expect(fixture.hub.lastVideo) == videoArguments.outputFileURL
+        XCTAssertNotNil(fixture.hub.lastRecording)
+        XCTAssertEqual(fixture.hub.lastVideo, videoArguments.outputFileURL)
         assertFullSession(sut, expected: true)
     }
     
@@ -159,7 +158,7 @@ class SentrySessionReplayTests: XCTestCase {
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
         sut.start(fixture.rootView, fullSession: false)
         
-        expect(fixture.hub.scope.replayId) == nil
+        XCTAssertNil(fixture.hub.scope.replayId)
         
         fixture.dateProvider.advance(by: 1)
         
@@ -169,7 +168,7 @@ class SentrySessionReplayTests: XCTestCase {
         
         let videoArguments = fixture.replayMaker.lastCallToCreateVideo
         
-        expect(videoArguments) == nil
+        XCTAssertNil(videoArguments)
         assertFullSession(sut, expected: false)
     }
     
@@ -177,12 +176,12 @@ class SentrySessionReplayTests: XCTestCase {
         let fixture = startFixture()
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
         sut.start(fixture.rootView, fullSession: false)
-        expect(fixture.hub.scope.replayId) == nil
+        XCTAssertNil(fixture.hub.scope.replayId)
         let event = Event(error: NSError(domain: "Some error", code: 1))
         
         sut.capture(for: event)
-        expect(fixture.hub.scope.replayId) == sut.sessionReplayId.sentryIdString
-        expect(event.context?["replay"]?["replay_id"] as? String) == sut.sessionReplayId.sentryIdString
+        XCTAssertEqual(fixture.hub.scope.replayId, sut.sessionReplayId.sentryIdString)
+        XCTAssertEqual(event.context?["replay"]?["replay_id"] as? String, sut.sessionReplayId.sentryIdString)
         assertFullSession(sut, expected: true)
     }
     
@@ -206,7 +205,7 @@ class SentrySessionReplayTests: XCTestCase {
 
         sut.capture()
 
-        expect(fixture.hub.scope.replayId) == sut.sessionReplayId.sentryIdString
+        XCTAssertEqual(fixture.hub.scope.replayId, sut.sessionReplayId.sentryIdString)
         assertFullSession(sut, expected: true)
     }
 
@@ -219,11 +218,11 @@ class SentrySessionReplayTests: XCTestCase {
         Dynamic(sut).newFrame(nil)
         fixture.dateProvider.advance(by: 5)
         Dynamic(sut).newFrame(nil)
-        expect(Dynamic(sut).isRunning) == true
+        XCTAssertEqual(Dynamic(sut).isRunning, true)
         fixture.dateProvider.advance(by: 3_600)
         Dynamic(sut).newFrame(nil)
         
-        expect(Dynamic(sut).isRunning) == false
+        XCTAssertFalse(try XCTUnwrap(Dynamic(sut).isRunning.asBool))
     }
     
     @available(iOS 16.0, tvOS 16, *)
@@ -234,11 +233,11 @@ class SentrySessionReplayTests: XCTestCase {
         }
         sutIsDeallocatedAfterCallingMe()
         
-        expect(fixture.displayLink.invalidateInvocations.count) == 1
+        XCTAssertEqual(fixture.displayLink.invalidateInvocations.count, 1)
     }
 
     func assertFullSession(_ sessionReplay: SentrySessionReplay, expected: Bool) {
-        expect(Dynamic(sessionReplay).isFullSession) == expected
+        XCTAssertEqual(Dynamic(sessionReplay).isFullSession, expected)
     }
 }
 

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -1,6 +1,5 @@
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
-import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsTrackerTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest

--- a/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryDefaultRateLimitsTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -174,41 +173,41 @@ class SentryDefaultRateLimitsTests: XCTestCase {
         let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:metric_bucket:::custom")
         
         sut.update(response)
-        expect(self.sut.isRateLimitActive(SentryDataCategory.metricBucket)) == true
+        XCTAssertEqual(self.sut.isRateLimitActive(SentryDataCategory.metricBucket), true)
     }
     
     func testMetricBucket_NoNamespace() {
         let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:metric_bucket::")
         
         sut.update(response)
-        expect(self.sut.isRateLimitActive(SentryDataCategory.metricBucket)) == true
+        XCTAssertEqual(self.sut.isRateLimitActive(SentryDataCategory.metricBucket), true)
     }
     
     func testMetricBucket_EmptyNamespace() {
         let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:metric_bucket:::")
         
         sut.update(response)
-        expect(self.sut.isRateLimitActive(SentryDataCategory.metricBucket)) == true
+        XCTAssertEqual(self.sut.isRateLimitActive(SentryDataCategory.metricBucket), true)
     }
     
     func testMetricBucket_NamespaceExclusivelyThanOtherCustom() {
         let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:metric_bucket:organization:quota_exceeded:customs;cust")
         
         sut.update(response)
-        expect(self.sut.isRateLimitActive(SentryDataCategory.metricBucket)) == false
+        XCTAssertFalse(self.sut.isRateLimitActive(SentryDataCategory.metricBucket))
     }
     
     func testMetricBucket_EmptyNamespaces() {
         let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:metric_bucket:::;")
         
         sut.update(response)
-        expect(self.sut.isRateLimitActive(SentryDataCategory.metricBucket)) == false
+        XCTAssertFalse(self.sut.isRateLimitActive(SentryDataCategory.metricBucket))
     }
     
     func testIgnoreNamespaceForNonMetricBucket() {
         let response = TestResponseFactory.createRateLimitResponse(headerValue: "1:error:::customs;cust")
         
         sut.update(response)
-        expect(self.sut.isRateLimitActive(SentryDataCategory.error)) == true
+        XCTAssertEqual(self.sut.isRateLimitActive(SentryDataCategory.error), true)
     }
 }

--- a/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
+++ b/Tests/SentryTests/Networking/SentryDataCategoryMapperTests.swift
@@ -1,67 +1,66 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
 class SentryDataCategoryMapperTests: XCTestCase {
     
     func testEnvelopeItemType() {
-        expect(sentryDataCategoryForEnvelopItemType("event")) == .error
-        expect(sentryDataCategoryForEnvelopItemType("session")) == .session
-        expect(sentryDataCategoryForEnvelopItemType("transaction")) == .transaction
-        expect(sentryDataCategoryForEnvelopItemType("attachment")) == .attachment
-        expect(sentryDataCategoryForEnvelopItemType("profile")) == .profile
-        expect(sentryDataCategoryForEnvelopItemType("profile_chunk")) == .profileChunk
-        expect(sentryDataCategoryForEnvelopItemType("statsd")) == .metricBucket
-        expect(sentryDataCategoryForEnvelopItemType("replay_video")) == .replay
-        expect(sentryDataCategoryForEnvelopItemType("unknown item type")) == .default
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("event"), .error)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("session"), .session)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("transaction"), .transaction)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("attachment"), .attachment)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("profile"), .profile)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("profile_chunk"), .profileChunk)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("statsd"), .metricBucket)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("replay_video"), .replay)
+        XCTAssertEqual(sentryDataCategoryForEnvelopItemType("unknown item type"), .default)
     }
 
     func testMapIntegerToCategory() {
-        expect(sentryDataCategoryForNSUInteger(0)) == .all
-        expect(sentryDataCategoryForNSUInteger(1)) == .default
-        expect(sentryDataCategoryForNSUInteger(2)) == .error
-        expect(sentryDataCategoryForNSUInteger(3)) == .session
-        expect(sentryDataCategoryForNSUInteger(4)) == .transaction
-        expect(sentryDataCategoryForNSUInteger(5)) == .attachment
-        expect(sentryDataCategoryForNSUInteger(6)) == .userFeedback
-        expect(sentryDataCategoryForNSUInteger(7)) == .profile
-        expect(sentryDataCategoryForNSUInteger(8)) == .metricBucket
-        expect(sentryDataCategoryForNSUInteger(9)) == .replay
-        expect(sentryDataCategoryForNSUInteger(10)) == .profileChunk
-        expect(sentryDataCategoryForNSUInteger(11)) == .unknown
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(0), .all)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(1), .default)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(2), .error)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(3), .session)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(4), .transaction)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(5), .attachment)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(6), .userFeedback)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(7), .profile)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(8), .metricBucket)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(9), .replay)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(10), .profileChunk)
+        XCTAssertEqual(sentryDataCategoryForNSUInteger(11), .unknown)
 
         XCTAssertEqual(.unknown, sentryDataCategoryForNSUInteger(11), "Failed to map unknown category number to case .unknown")
     }
     
     func testMapStringToCategory() {
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameAll)) == .all
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameDefault)) == .default
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameError)) == .error
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameSession)) == .session
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameTransaction)) == .transaction
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameAttachment)) == .attachment
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameUserFeedback)) == .userFeedback
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameProfile)) == .profile
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameProfileChunk)) == .profileChunk
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameMetricBucket)) == .metricBucket
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameReplay)) == .replay
-        expect(sentryDataCategoryForString(kSentryDataCategoryNameUnknown)) == .unknown
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameAll), .all)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameDefault), .default)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameError), .error)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameSession), .session)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameTransaction), .transaction)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameAttachment), .attachment)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameUserFeedback), .userFeedback)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameProfile), .profile)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameProfileChunk), .profileChunk)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameMetricBucket), .metricBucket)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameReplay), .replay)
+        XCTAssertEqual(sentryDataCategoryForString(kSentryDataCategoryNameUnknown), .unknown)
 
         XCTAssertEqual(.unknown, sentryDataCategoryForString("gdfagdfsa"), "Failed to map unknown category name to case .unknown")
     }
 
     func testMapCategoryToString() {
-        expect(nameForSentryDataCategory(.all)) == kSentryDataCategoryNameAll
-        expect(nameForSentryDataCategory(.default)) == kSentryDataCategoryNameDefault
-        expect(nameForSentryDataCategory(.error)) == kSentryDataCategoryNameError
-        expect(nameForSentryDataCategory(.session)) == kSentryDataCategoryNameSession
-        expect(nameForSentryDataCategory(.transaction)) == kSentryDataCategoryNameTransaction
-        expect(nameForSentryDataCategory(.attachment)) == kSentryDataCategoryNameAttachment
-        expect(nameForSentryDataCategory(.userFeedback)) == kSentryDataCategoryNameUserFeedback
-        expect(nameForSentryDataCategory(.profile)) == kSentryDataCategoryNameProfile
-        expect(nameForSentryDataCategory(.profileChunk)) == kSentryDataCategoryNameProfileChunk
-        expect(nameForSentryDataCategory(.metricBucket)) == kSentryDataCategoryNameMetricBucket
-        expect(nameForSentryDataCategory(.replay)) == kSentryDataCategoryNameReplay
-        expect(nameForSentryDataCategory(.unknown)) == kSentryDataCategoryNameUnknown
+        XCTAssertEqual(nameForSentryDataCategory(.all), kSentryDataCategoryNameAll)
+        XCTAssertEqual(nameForSentryDataCategory(.default), kSentryDataCategoryNameDefault)
+        XCTAssertEqual(nameForSentryDataCategory(.error), kSentryDataCategoryNameError)
+        XCTAssertEqual(nameForSentryDataCategory(.session), kSentryDataCategoryNameSession)
+        XCTAssertEqual(nameForSentryDataCategory(.transaction), kSentryDataCategoryNameTransaction)
+        XCTAssertEqual(nameForSentryDataCategory(.attachment), kSentryDataCategoryNameAttachment)
+        XCTAssertEqual(nameForSentryDataCategory(.userFeedback), kSentryDataCategoryNameUserFeedback)
+        XCTAssertEqual(nameForSentryDataCategory(.profile), kSentryDataCategoryNameProfile)
+        XCTAssertEqual(nameForSentryDataCategory(.profileChunk), kSentryDataCategoryNameProfileChunk)
+        XCTAssertEqual(nameForSentryDataCategory(.metricBucket), kSentryDataCategoryNameMetricBucket)
+        XCTAssertEqual(nameForSentryDataCategory(.replay), kSentryDataCategoryNameReplay)
+        XCTAssertEqual(nameForSentryDataCategory(.unknown), kSentryDataCategoryNameUnknown)
     }
 }

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -569,7 +568,7 @@ class SentryHttpTransportTests: XCTestCase {
 
         waitForAllRequests()
 
-        expect(self.fixture.requestManager.requests.count) == 21
+        XCTAssertEqual(self.fixture.requestManager.requests.count, 21)
     }
     
     func testBuildingRequestFails_DeletesEnvelopeAndSendsNext() {
@@ -732,15 +731,14 @@ class SentryHttpTransportTests: XCTestCase {
             
             for _ in  0..<flushInvocations {
                 let beforeFlush = getAbsoluteTime()
-                expect(sut.flush(self.fixture.flushTimeout)).to(equal(.success), description: "Flush should not time out.")
+                XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
                 let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
                 
                 blockingDurationSum += blockingDuration
             }
             
             let blockingDurationAverage = blockingDurationSum / Double(flushInvocations)
-            
-            expect(blockingDurationAverage) < 0.1
+            XCTAssertLessThan(blockingDurationAverage, 0.1)
             
         }
     }
@@ -760,15 +758,14 @@ class SentryHttpTransportTests: XCTestCase {
             
             for _ in  0..<flushInvocations {
                 let beforeFlush = getAbsoluteTime()
-                expect(sut.flush(self.fixture.flushTimeout)).to(equal(.success), description: "Flush should not time out.")
+                XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
                 let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
                 
                 blockingDurationSum += blockingDuration
             }
             
             let blockingDurationAverage = blockingDurationSum / Double(flushInvocations)
-            
-            expect(blockingDurationAverage) < 0.1
+            XCTAssertLessThan(blockingDurationAverage, 0.1)
         }
     }
     
@@ -780,9 +777,9 @@ class SentryHttpTransportTests: XCTestCase {
             for _ in 0..<10 {
                 sut.send(envelope: fixture.eventEnvelope)
                 
-                expect(sut.flush(self.fixture.flushTimeout)).to(equal(.success), description: "Flush should not time out.")
+                XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
                 
-                expect(self.fixture.fileManager.getAllEnvelopes().count) == 0
+                XCTAssertEqual(self.fixture.fileManager.getAllEnvelopes().count, 0)
             }
         }
     }

--- a/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -56,13 +55,13 @@ final class SentrySpotlightTransportTests: XCTestCase {
         
         sut.send(envelope: eventEnvelope)
         
-        expect(self.requestManager.requests.count) == 1
+        XCTAssertEqual(self.requestManager.requests.count, 1)
         
         let request = try XCTUnwrap(requestManager.requests.first)
-        expect(request.url?.absoluteString) == options.spotlightUrl
+        XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
         
         let expectedData = try getSerializedGzippedData(envelope: eventEnvelope)
-        expect(request.httpBody) == expectedData
+        XCTAssertEqual(request.httpBody, expectedData)
     }
     
     func testShouldSendTransactionEnvelope() throws {
@@ -71,13 +70,13 @@ final class SentrySpotlightTransportTests: XCTestCase {
         
         sut.send(envelope: transactionEnvelope)
         
-        expect(self.requestManager.requests.count) == 1
+        XCTAssertEqual(self.requestManager.requests.count, 1)
         
         let request = try XCTUnwrap(requestManager.requests.first)
-        expect(request.url?.absoluteString) == options.spotlightUrl
+        XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
         
         let expectedData = try getSerializedGzippedData(envelope: transactionEnvelope)
-        expect(request.httpBody) == expectedData
+        XCTAssertEqual(request.httpBody, expectedData)
     }
     
     func testShouldRemoveAttachmentsFromEventEnvelope() throws {
@@ -86,10 +85,10 @@ final class SentrySpotlightTransportTests: XCTestCase {
         
         sut.send(envelope: eventEnvelope)
         
-        expect(self.requestManager.requests.count) == 1
+        XCTAssertEqual(self.requestManager.requests.count, 1)
         
         let request = try XCTUnwrap(requestManager.requests.first)
-        expect(request.url?.absoluteString) == options.spotlightUrl
+        XCTAssertEqual(request.url?.absoluteString, options.spotlightUrl)
         
         let expectedData = try getSerializedGzippedData(envelope: givenEventEnvelope())
         let expectedDataCountLower = expectedData.count - 20
@@ -97,7 +96,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
         
         // Compressing with GZip doesn't always produce the same results
         // We only want to know if the attachment got removed. Therefore, a comparison with a range is acceptable.
-        expect(request.httpBody?.count).to(beWithin(expectedDataCountLower...expectedDataCountUpper))
+        XCTAssert((expectedDataCountLower...expectedDataCountUpper).contains(try XCTUnwrap(request.httpBody?.count)))
     }
     
     func testShouldNotSendEnvelope_WhenMalformedURL() throws {
@@ -108,7 +107,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
         sut.send(envelope: eventEnvelope)
         
         requestManager.waitForAllRequests()
-        expect(self.requestManager.requests.count) == 0
+        XCTAssertEqual(self.requestManager.requests.count, 0)
     }
     
     func testShouldNotSendEnvelope_WhenRequestError() throws {
@@ -119,7 +118,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
         sut.send(envelope: eventEnvelope)
         
         requestManager.waitForAllRequests()
-        expect(self.requestManager.requests.count) == 0
+        XCTAssertEqual(self.requestManager.requests.count, 0)
     }
     
     func testShouldLogError_WhenRequestManagerCompletesWithError() throws {
@@ -140,7 +139,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
             $0.contains("Error while performing request")
         }
         
-        expect(logMessages.count) == 1
+        XCTAssertEqual(logMessages.count, 1)
     }
     
     private func getSerializedGzippedData(envelope: SentryEnvelope) throws -> Data {

--- a/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -71,15 +70,15 @@ class SentryTransportAdapterTests: XCTestCase {
     }
     
     private func assertEnvelope(expected: SentryEnvelope) throws {
-        expect(self.fixture.transport1.sentEnvelopes.count) == 1
-        expect(self.fixture.transport2.sentEnvelopes.count) == 1
+        XCTAssertEqual(self.fixture.transport1.sentEnvelopes.count, 1)
+        XCTAssertEqual(self.fixture.transport2.sentEnvelopes.count, 1)
         
         let actual = fixture.transport1.sentEnvelopes.first!
-        expect(actual) != nil
+        XCTAssertNotNil(actual)
         
-        expect(expected.header.eventId) == actual.header.eventId
-        expect(expected.header.sdkInfo) == actual.header.sdkInfo
-        expect(expected.items.count) == actual.items.count
+        XCTAssertEqual(expected.header.eventId, actual.header.eventId)
+        XCTAssertEqual(expected.header.sdkInfo, actual.header.sdkInfo)
+        XCTAssertEqual(expected.items.count, actual.items.count)
         
         expected.items.forEach { expectedItem in
             let expectedHeader = expectedItem.header
@@ -88,16 +87,16 @@ class SentryTransportAdapterTests: XCTestCase {
                 expectedHeader.contentType == expectedItem.header.contentType
             }
             
-            expect(containsHeader).to(beTrue(), description: "Envelope doesn't contain item with type:\(expectedHeader.type).")
+            XCTAssertTrue(containsHeader, "Envelope doesn't contain item with type:\(expectedHeader.type).")
 
             let containsData = actual.items.contains { actualItem in
                 actualItem.data == expectedItem.data
             }
             
-            expect(containsData).to(beTrue(), description: "Envelope data with type:\(expectedHeader.type) doesn't match.")
+            XCTAssertTrue(containsData, "Envelope data with type:\(expectedHeader.type) doesn't match.")
         }
         
         let actualSerialized = try SentrySerialization.data(with: actual)
-        expect(try SentrySerialization.data(with: expected)) == actualSerialized
+        XCTAssertEqual(try SentrySerialization.data(with: expected), actualSerialized)
     }
 }

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import Sentry
 import SentryTestUtils
 import XCTest
@@ -63,13 +62,13 @@ class SentryTransportFactoryTests: XCTestCase {
         options.enableSpotlight = true
         let transports = TransportInitializer.initTransports(options, sentryFileManager: try SentryFileManager(options: options), currentDateProvider: TestCurrentDateProvider())
         
-        expect(transports.contains {
+        XCTAssert(transports.contains {
             $0.isKind(of: SentrySpotlightTransport.self)
-        }) == true
+        })
         
-        expect(transports.contains {
+        XCTAssert(transports.contains {
             $0.isKind(of: SentryHttpTransport.self)
-        }) == true
+        })
     }
     
 }

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -20,9 +19,9 @@ class SentryTransportInitializerTests: XCTestCase {
         let options = try Options(dict: ["dsn": SentryTransportInitializerTests.dsnAsString])
     
         let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager, currentDateProvider: TestCurrentDateProvider())
-        expect(result.count) == 1
+        XCTAssertEqual(result.count, 1)
         
         let firstTransport = result.first
-        expect(firstTransport?.isKind(of: SentryHttpTransport.self)) == true
+        XCTAssertEqual(firstTransport?.isKind(of: SentryHttpTransport.self), true)
     }
 }

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -239,8 +238,8 @@ class SentryEnvelopeTests: XCTestCase {
     
     func testEmptyHeader() {
         let sut = SentryEnvelopeHeader.empty()
-        expect(sut.eventId) == nil
-        expect(sut.traceContext) == nil
+        XCTAssertNil(sut.eventId)
+        XCTAssertNil(sut.traceContext)
     }
     
     func testInitWithFileAttachment() {
@@ -318,34 +317,34 @@ class SentryEnvelopeTests: XCTestCase {
         let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10)
 
         let data = header.serialize()
-        expect(data.count) == 2
         XCTAssertEqual(data.count, 2)
-        expect(data["type"] as? String) == "SomeType"
-        expect(data["length"] as? Int) == 10
-        expect(data["filename"]) == nil
-        expect(data["content_type"]) == nil
+        XCTAssertEqual(data.count, 2)
+        XCTAssertEqual(data["type"] as? String, "SomeType")
+        XCTAssertEqual(data["length"] as? Int, 10)
+        XCTAssertNil(data["filename"])
+        XCTAssertNil(data["content_type"])
     }
     
     func test_SentryEnvelopeItemHeaderSerialization_WithoutFileName() {
         let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10, contentType: "text/html")
 
         let data = header.serialize()
-        expect(data["type"] as? String) == "SomeType"
-        expect(data["length"] as? Int) == 10
-        expect(data["filename"]) == nil
-        expect(data["content_type"] as? String) == "text/html"
-        expect(data.count) == 3
+        XCTAssertEqual(data["type"] as? String, "SomeType")
+        XCTAssertEqual(data["length"] as? Int, 10)
+        XCTAssertNil(data["filename"])
+        XCTAssertEqual(data["content_type"] as? String, "text/html")
+        XCTAssertEqual(data.count, 3)
     }
     
     func test_SentryEnvelopeItemHeaderSerialization_AllParameters() {
         let header = SentryEnvelopeItemHeader(type: "SomeType", length: 10, filenname: "SomeFileName", contentType: "text/html")
         
         let data = header.serialize()
-        expect(data["type"] as? String) == "SomeType"
-        expect(data["length"] as? Int) == 10
-        expect(data["filename"] as? String) == "SomeFileName"
-        expect(data["content_type"] as? String) == "text/html"
-        expect(data.count) == 4
+        XCTAssertEqual(data["type"] as? String, "SomeType")
+        XCTAssertEqual(data["length"] as? Int, 10)
+        XCTAssertEqual(data["filename"] as? String, "SomeFileName")
+        XCTAssertEqual(data["content_type"] as? String, "text/html")
+        XCTAssertEqual(data.count, 4)
     }
     
     func testInitWithDataAttachment_MaxAttachmentSize() {

--- a/Tests/SentryTests/Protocol/SentryUserFeedbackTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserFeedbackTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import XCTest
 
 class SentryUserFeedbackTests: XCTestCase {
@@ -6,9 +5,9 @@ class SentryUserFeedbackTests: XCTestCase {
     func testPropertiesAreSetToEmptyString() {
         let userFeedback = UserFeedback(eventId: SentryId())
         
-        expect(userFeedback.comments).to(beEmpty())
-        expect(userFeedback.email).to(beEmpty())
-        expect(userFeedback.name).to(beEmpty())
+        XCTAssertEqual(userFeedback.comments, "")
+        XCTAssertEqual(userFeedback.email, "")
+        XCTAssertEqual(userFeedback.name, "")
     }
     
     func testSerialize() {
@@ -19,10 +18,10 @@ class SentryUserFeedbackTests: XCTestCase {
         
         let actual = userFeedback.serialize()
         
-        expect(actual["event_id"] as? String).to(match(userFeedback.eventId.sentryIdString))
-        expect(actual["comments"] as? String).to(match(userFeedback.comments))
-        expect(actual["email"] as? String).to(match(userFeedback.email))
-        expect(actual["name"] as? String).to(match(userFeedback.name))
+        XCTAssertEqual(actual["event_id"] as? String, userFeedback.eventId.sentryIdString)
+        XCTAssertEqual(actual["comments"] as? String, userFeedback.comments)
+        XCTAssertEqual(actual["email"] as? String, userFeedback.email)
+        XCTAssertEqual(actual["name"] as? String, userFeedback.name)
     }
     
     func testSerialize_WithoutSettingProperties_AllAreEmptyStrings() {
@@ -30,8 +29,8 @@ class SentryUserFeedbackTests: XCTestCase {
         
         let actual = userFeedback.serialize()
         
-        expect(actual["comments"] as? String).to(beEmpty())
-        expect(actual["email"] as? String).to(beEmpty())
-        expect(actual["name"] as? String).to(beEmpty())
+        XCTAssertEqual(actual["comments"] as? String, "")
+        XCTAssertEqual(actual["email"] as? String, "")
+        XCTAssertEqual(actual["name"] as? String, "")
     }
 }

--- a/Tests/SentryTests/RedactRegionTests.swift
+++ b/Tests/SentryTests/RedactRegionTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 @testable import Sentry
 import XCTest
 #if os(iOS) || os(tvOS)
@@ -10,9 +9,9 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 50, width: 100, height: 50))
         
-        expect(result.count) == 1
-        expect(result.first?.rect) == CGRect(x: 0, y: 0, width: 100, height: 50)
-        expect(result.first?.color) == .red
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 0, width: 100, height: 50))
+        XCTAssertEqual(result.first?.color, .red)
     }
     
     func testSplitBySubtractingTop() {
@@ -20,8 +19,8 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 0, width: 100, height: 50))
         
-        expect(result.count) == 1
-        expect(result.first?.rect) == CGRect(x: 0, y: 50, width: 100, height: 50)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 50, width: 100, height: 50))
     }
     
     func testSplitBySubtractingTopRight() {
@@ -29,9 +28,9 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 50, y: 0, width: 50, height: 50))
         
-        expect(result.count) == 2
-        expect(result.first?.rect) == CGRect(x: 0, y: 50, width: 100, height: 50)
-        expect(result[1].rect) == CGRect(x: 0, y: 0, width: 50, height: 50)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 50, width: 100, height: 50))
+        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 0, width: 50, height: 50))
     }
     
     func testSplitBySubtractingBottomLeft() {
@@ -39,9 +38,9 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 50, width: 50, height: 50))
         
-        expect(result.count) == 2
-        expect(result.first?.rect) == CGRect(x: 0, y: 0, width: 100, height: 50)
-        expect(result[1].rect) == CGRect(x: 50, y: 50, width: 50, height: 50)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 0, width: 100, height: 50))
+        XCTAssertEqual(result[1].rect, CGRect(x: 50, y: 50, width: 50, height: 50))
     }
     
     func testSplitBySubtractingMiddle() {
@@ -49,11 +48,11 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 25, y: 25, width: 50, height: 50))
         
-        expect(result.count) == 4
-        expect(result[0].rect) == CGRect(x: 0, y: 0, width: 100, height: 25)
-        expect(result[1].rect) == CGRect(x: 0, y: 75, width: 100, height: 25)
-        expect(result[2].rect) == CGRect(x: 0, y: 25, width: 25, height: 50)
-        expect(result[3].rect) == CGRect(x: 75, y: 25, width: 25, height: 50)
+        XCTAssertEqual(result.count, 4)
+        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 100, height: 25))
+        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
+        XCTAssertEqual(result[2].rect, CGRect(x: 0, y: 25, width: 25, height: 50))
+        XCTAssertEqual(result[3].rect, CGRect(x: 75, y: 25, width: 25, height: 50))
     }
     
     func testSplitBySubtractingInHalfHorizontally() {
@@ -61,9 +60,9 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 25, width: 100, height: 50))
         
-        expect(result.count) == 2
-        expect(result[0].rect) == CGRect(x: 0, y: 0, width: 100, height: 25)
-        expect(result[1].rect) == CGRect(x: 0, y: 75, width: 100, height: 25)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 100, height: 25))
+        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
     }
     
     func testSplitBySubtractingInHalfVertically() {
@@ -71,9 +70,9 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 25, y: 0, width: 50, height: 100))
         
-        expect(result.count) == 2
-        expect(result[0].rect) == CGRect(x: 0, y: 0, width: 25, height: 100)
-        expect(result[1].rect) == CGRect(x: 75, y: 0, width: 25, height: 100)
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 25, height: 100))
+        XCTAssertEqual(result[1].rect, CGRect(x: 75, y: 0, width: 25, height: 100))
     }
     
     func testSplitBySubtractingMiddleRight() {
@@ -81,10 +80,10 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 25, y: 25, width: 100, height: 50))
         
-        expect(result.count) == 3
-        expect(result[0].rect) == CGRect(x: 0, y: 0, width: 100, height: 25)
-        expect(result[1].rect) == CGRect(x: 0, y: 75, width: 100, height: 25)
-        expect(result[2].rect) == CGRect(x: 0, y: 25, width: 25, height: 50)
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 100, height: 25))
+        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
+        XCTAssertEqual(result[2].rect, CGRect(x: 0, y: 25, width: 25, height: 50))
     }
     
     func testSplitBySubtractingMiddleLeft() {
@@ -92,51 +91,51 @@ class RedactRegionTests: XCTestCase {
         
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 25, width: 100, height: 50))
         
-        expect(result.count) == 3
-        expect(result[0].rect) == CGRect(x: 50, y: 0, width: 100, height: 25)
-        expect(result[1].rect) == CGRect(x: 50, y: 75, width: 100, height: 25)
-        expect(result[2].rect) == CGRect(x: 100, y: 25, width: 50, height: 50)
+        XCTAssertEqual(result.count, 3)
+        XCTAssertEqual(result[0].rect, CGRect(x: 50, y: 0, width: 100, height: 25))
+        XCTAssertEqual(result[1].rect, CGRect(x: 50, y: 75, width: 100, height: 25))
+        XCTAssertEqual(result[2].rect, CGRect(x: 100, y: 25, width: 50, height: 50))
     }
 
     func testSplitBySubtracting_TopIsWider() {
         let sut = RedactRegion(rect: CGRect(x: 0, y: 0, width: 100, height: 100), color: .red)
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 0, width: 150, height: 50))
         
-        expect(result.count) == 1
-        expect(result.first?.rect) == CGRect(x: 0, y: 50, width: 100, height: 50)
-        expect(result.first?.color) == .red
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 50, width: 100, height: 50))
+        XCTAssertEqual(result.first?.color, .red)
     }
     
     func testSplitBySubtracting_BottomIsWider() {
         let sut = RedactRegion(rect: CGRect(x: 0, y: 0, width: 100, height: 100), color: .red) 
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 50, width: 150, height: 50))
         
-        expect(result.count) == 1
-        expect(result.first?.rect) == CGRect(x: 0, y: 0, width: 100, height: 50)
-        expect(result.first?.color) == .red
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 0, width: 100, height: 50))
+        XCTAssertEqual(result.first?.color, .red)
     }
     
     func testNoResultForEqualRegion() {
         let sut = RedactRegion(rect: CGRect(x: 0, y: 0, width: 100, height: 100), color: .red)
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 0, width: 100, height: 100))
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
 
     func testNoResultForLargerRegion() {
         let sut = RedactRegion(rect: CGRect(x: 50, y: 50, width: 100, height: 100), color: .red)
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 0, width: 200, height: 200))
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testSameRegionForOutsideOfBounds() {
         let sut = RedactRegion(rect: CGRect(x: 0, y: 0, width: 100, height: 100), color: .red)
         let result = sut.splitBySubtracting(region: CGRect(x: 110, y: 110, width: 200, height: 200))
         
-        expect(result.count) == 1
-        expect(result.first?.rect) == sut.rect
-        expect(result.first?.color) == .red
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.rect, sut.rect)
+        XCTAssertEqual(result.first?.color, .red)
     }
     
 }

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -46,7 +45,7 @@ class SentryBinaryImageCacheTests: XCTestCase {
     func testBinaryImageAdded_IsNull() {
         sut.binaryImageAdded(nil)
         
-        expect(self.sut.cache.count) == 0
+        XCTAssertEqual(self.sut.cache.count, 0)
     }
 
     func testBinaryImageRemoved() {
@@ -88,7 +87,7 @@ class SentryBinaryImageCacheTests: XCTestCase {
         
         sut.binaryImageRemoved(nil)
         
-        expect(self.sut.cache.count) == 1
+        XCTAssertEqual(self.sut.cache.count, 1)
     }
 
     func testImageNameByAddress() {
@@ -120,16 +119,16 @@ class SentryBinaryImageCacheTests: XCTestCase {
         sut.binaryImageAdded(&binaryImage2)
         
         let path = sut.pathFor(inAppInclude: "Expected Name at 0")
-        expect(path) == "Expected Name at 0"
+        XCTAssertEqual(path, "Expected Name at 0")
         
         let path2 = sut.pathFor(inAppInclude: "Expected Name at 1")
-        expect(path2) == "Expected Name at 1"
+        XCTAssertEqual(path2, "Expected Name at 1")
         
         let path3 = sut.pathFor(inAppInclude: "Expected")
-        expect(path3) == "Expected Name at 0"
+        XCTAssertEqual(path3, "Expected Name at 0")
         
         let didNotFind = sut.pathFor(inAppInclude: "Name at 0")
-        expect(didNotFind) == nil
+        XCTAssertNil(didNotFind)
     }
     
     func testBinaryImageWithNULLName_DoesNotAddImage() {
@@ -151,8 +150,8 @@ class SentryBinaryImageCacheTests: XCTestCase {
         )
         
         sut.binaryImageAdded(&binaryImage)
-        expect(self.sut.image(byAddress: address)) == nil
-        expect(self.sut.cache.count) == 0
+        XCTAssertNil(self.sut.image(byAddress: address))
+        XCTAssertEqual(self.sut.cache.count, 0)
     }
     
     func testBinaryImageNameDifferentEncoding_DoesNotAddImage() {
@@ -178,8 +177,8 @@ class SentryBinaryImageCacheTests: XCTestCase {
         )
         
         sut.binaryImageAdded(&binaryImage)
-        expect(self.sut.image(byAddress: address)) == nil
-        expect(self.sut.cache.count) == 0
+        XCTAssertNil(self.sut.image(byAddress: address))
+        XCTAssertEqual(self.sut.cache.count, 0)
     }
     
     func testAddingImagesWhileStoppingAndStartingOnDifferentThread() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -166,7 +165,7 @@ class SentryClientTest: XCTestCase {
         options.cacheDirectoryPath = "\(options.cacheDirectoryPath)/cache"
         _ = SentryClient(options: options)
         
-        expect(dispatchQueue.dispatchAsyncInvocations.count) == 1
+        XCTAssertEqual(dispatchQueue.dispatchAsyncInvocations.count, 1)
         
         let nonCachedID = SentryInstallation.id(withCacheDirectoryPathNonCached: options.cacheDirectoryPath)
         
@@ -175,7 +174,7 @@ class SentryClientTest: XCTestCase {
         
         let cachedID = SentryInstallation.id(withCacheDirectoryPath: options.cacheDirectoryPath)
         
-        expect(cachedID) == nonCachedID
+        XCTAssertEqual(cachedID, nonCachedID)
     }
     
     func testClientIsEnabled() {
@@ -826,8 +825,8 @@ class SentryClientTest: XCTestCase {
         let orientation = actual.context?["device"]?["orientation"] as? String
         XCTAssertEqual(orientation, "landscape")
 
-        let charging = actual.context?["device"]?["charging"] as? Bool
-        XCTAssertEqual(charging, false)
+        let charging = try XCTUnwrap(actual.context?["device"]?["charging"] as? Bool)
+        XCTAssertFalse(charging)
     }
 #endif
 
@@ -881,8 +880,8 @@ class SentryClientTest: XCTestCase {
         let event = TestData.event
         fixture.getSut().capture(event: event)
         let actual = try lastSentEvent()
-        let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-        XCTAssertEqual(inForeground, false)
+        let inForeground = try XCTUnwrap(actual.context?["app"]?["in_foreground"] as? Bool)
+        XCTAssertFalse(inForeground)
     }
     
     func testCaptureExceptionWithAppStateInForegroudWhenAppIsInactive() throws {
@@ -893,8 +892,8 @@ class SentryClientTest: XCTestCase {
         let event = TestData.event
         fixture.getSut().capture(event: event)
         let actual = try lastSentEvent()
-        let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
-        XCTAssertEqual(inForeground, false)
+        let inForeground = try XCTUnwrap(actual.context?["app"]?["in_foreground"] as? Bool)
+        XCTAssertFalse(inForeground)
     }
     
     func testCaptureExceptionWithAppStateInForegroundDoNotOverwriteExistingValue() throws {
@@ -1330,7 +1329,9 @@ class SentryClientTest: XCTestCase {
         sut.capture(message: "message")
         
         let actual = try lastSentEvent()
-        expect(actual.sdk?["features"] as? [String]).to(contain("performanceV2", "captureFailedRequests"))
+        let features = try XCTUnwrap(actual.sdk?["features"] as? [String])
+        XCTAssert(features.contains("performanceV2"))
+        XCTAssert(features.contains("captureFailedRequests"))
     }
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
@@ -1617,7 +1618,7 @@ class SentryClientTest: XCTestCase {
         
         sut.capture(replayEvent, replayRecording: replayRecording, video: movieUrl!, with: Scope())
         let envelope = fixture.transport.sentEnvelopes.first
-        expect(envelope?.items[0].header.type) == SentryEnvelopeItemTypeReplayVideo
+        XCTAssertEqual(envelope?.items[0].header.type, SentryEnvelopeItemTypeReplayVideo)
     }
     
     func testCaptureReplayEvent_WrongEventFromEventProcessor() {
@@ -1633,7 +1634,7 @@ class SentryClientTest: XCTestCase {
         sut.capture(replayEvent, replayRecording: replayRecording, video: movieUrl!, with: Scope())
         
         //Nothing should be captured because beforeSend returned a non ReplayEvent
-        expect(self.fixture.transport.sentEnvelopes.count) == 0
+        XCTAssertEqual(self.fixture.transport.sentEnvelopes.count, 0)
     }
     
     func testCaptureReplayEvent_DontCaptureNilEvent() {
@@ -1649,7 +1650,7 @@ class SentryClientTest: XCTestCase {
         sut.capture(replayEvent, replayRecording: replayRecording, video: movieUrl!, with: Scope())
         
         //Nothing should be captured because beforeSend returned nil
-        expect(self.fixture.transport.sentEnvelopes.count) == 0
+        XCTAssertEqual(self.fixture.transport.sentEnvelopes.count, 0)
     }
     
     func testCaptureReplayEvent_InvalidFile() {
@@ -1665,7 +1666,7 @@ class SentryClientTest: XCTestCase {
         sut.capture(replayEvent, replayRecording: replayRecording, video: movieUrl, with: Scope())
         
         //Nothing should be captured because beforeSend returned nil
-        expect(self.fixture.transport.sentEnvelopes.count) == 0
+        XCTAssertEqual(self.fixture.transport.sentEnvelopes.count, 0)
     }
     
     func testCaptureReplayEvent_noBradcrumbsThreadsDebugMeta() {
@@ -1682,9 +1683,9 @@ class SentryClientTest: XCTestCase {
         
         sut.capture(replayEvent, replayRecording: replayRecording, video: movieUrl!, with: scope)
         
-        expect(replayEvent.breadcrumbs) == nil
-        expect(replayEvent.threads) == nil
-        expect(replayEvent.debugMeta) == nil
+        XCTAssertNil(replayEvent.breadcrumbs)
+        XCTAssertNil(replayEvent.threads)
+        XCTAssertNil(replayEvent.debugMeta)
     }
 }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -21,11 +20,11 @@ class SentryCrashInstallationReporterTests: XCTestCase {
         try givenStoredSentryCrashReport(resource: "Resources/crash-report-1")
 
         sut.sendAllReports { filteredReports, _, _ in
-            expect(filteredReports?.count) == 1
+            XCTAssertEqual(filteredReports?.count, 1)
         }
         
-        expect(self.testClient.captureCrashEventInvocations.count) == 1
-        expect(sentrycrash_getReportCount()) == 0
+        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 1)
+        XCTAssertEqual(sentrycrash_getReportCount(), 0)
     }
     
     /**
@@ -37,16 +36,16 @@ class SentryCrashInstallationReporterTests: XCTestCase {
         try givenStoredSentryCrashReport(resource: "Resources/crash-report-legacy-storage-info")
 
         sut.sendAllReports { filteredReports, _, _ in
-            expect(filteredReports?.count) == 1
+            XCTAssertEqual(filteredReports?.count, 1)
         }
         
-        expect(self.testClient.captureCrashEventInvocations.count) == 1
-        expect(sentrycrash_getReportCount()) == 0
+        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 1)
+        XCTAssertEqual(sentrycrash_getReportCount(), 0)
         
         let event = self.testClient.captureCrashEventInvocations.last?.event
-        expect(event?.context?["device"]?["free_storage"] as? Int) == 278_914_420_736
+        XCTAssertEqual(event?.context?["device"]?["free_storage"] as? Int, 278_914_420_736)
         // total_storage got converted to storage_size
-        expect(event?.context?["device"]?["storage_size"] as? Int) == 994_662_584_320
+        XCTAssertEqual(event?.context?["device"]?["storage_size"] as? Int, 994_662_584_320)
     }
     
     func testShouldCaptureCrashReportWithoutDeviceContext() throws {
@@ -55,15 +54,15 @@ class SentryCrashInstallationReporterTests: XCTestCase {
         try givenStoredSentryCrashReport(resource: "Resources/crash-report-without-device-context")
 
         sut.sendAllReports { filteredReports, _, _ in
-            expect(filteredReports?.count) == 1
+            XCTAssertEqual(filteredReports?.count, 1)
         }
         
-        expect(self.testClient.captureCrashEventInvocations.count) == 1
-        expect(sentrycrash_getReportCount()) == 0
+        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 1)
+        XCTAssertEqual(sentrycrash_getReportCount(), 0)
         
         let event = self.testClient.captureCrashEventInvocations.last?.event
-        expect(event?.context?["device"]) == nil
-        expect(event?.context?["app"]?["app_name"] as? String) == "iOS-Swift"
+        XCTAssertNil(event?.context?["device"])
+        XCTAssertEqual(event?.context?["app"]?["app_name"] as? String, "iOS-Swift")
     }
     
     func testFaultyReportIsNotSentAndDeleted() throws {
@@ -72,11 +71,11 @@ class SentryCrashInstallationReporterTests: XCTestCase {
         try givenStoredSentryCrashReport(resource: "Resources/Crash-faulty-report")
 
         sut.sendAllReports { filteredReports, _, _ in
-            expect(filteredReports?.count) == 0
+            XCTAssertEqual(filteredReports?.count, 0)
         }
         
-        expect(self.testClient.captureCrashEventInvocations.count) == 0
-        expect(sentrycrash_getReportCount()) == 0
+        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 0)
+        XCTAssertEqual(sentrycrash_getReportCount(), 0)
     }
     
     private func givenSutWithStartedSDK() {

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -69,7 +68,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
         
         filterReportWithAttachment()
         
-        expect(SentrySDK.detectedStartUpCrash) == true
+        XCTAssertEqual(SentrySDK.detectedStartUpCrash, true)
     }
     
     func testAppStartCrash_UpperBound_CallsFlush() {

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -181,10 +180,10 @@ class SentryHubTests: XCTestCase {
     
     func testScopeEnriched() {
         let hub = fixture.getSut(fixture.options, Scope())
-        expect(hub.scope.contextDictionary.allValues.isEmpty) == false
-        expect(hub.scope.contextDictionary["os"]) != nil
-        expect(hub.scope.contextDictionary["device"]) != nil
-        expect(hub.scope.contextDictionary["app"]) != nil
+        XCTAssertFalse(hub.scope.contextDictionary.allValues.isEmpty)
+        XCTAssertNotNil(hub.scope.contextDictionary["os"])
+        XCTAssertNotNil(hub.scope.contextDictionary["device"])
+        XCTAssertNotNil(hub.scope.contextDictionary["app"])
     }
     
     func testAddBreadcrumb_WithCallbackModifies() {
@@ -361,8 +360,8 @@ class SentryHubTests: XCTestCase {
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.capture(trans as! Transaction, with: Scope())
         
-        expect(self.fixture.client.captureEventWithScopeInvocations.count) == 1
-        expect(self.fixture.dispatchQueueWrapper.dispatchAsyncInvocations.count) == 1
+        XCTAssertEqual(self.fixture.client.captureEventWithScopeInvocations.count, 1)
+        XCTAssertEqual(self.fixture.dispatchQueueWrapper.dispatchAsyncInvocations.count, 1)
     }
     
     func testCaptureSampledTransaction_DoesNotCaptureEvent() {
@@ -371,7 +370,7 @@ class SentryHubTests: XCTestCase {
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.capture(trans as! Transaction, with: Scope())
         
-        expect(self.fixture.client.captureEventWithScopeInvocations.count) == 0
+        XCTAssertEqual(self.fixture.client.captureEventWithScopeInvocations.count, 0)
     }
     
     func testCaptureSampledTransaction_RecordsLostEvent() {
@@ -778,10 +777,10 @@ class SentryHubTests: XCTestCase {
         sut.bindClient(mockClient)
         sut.capture(replayEvent, replayRecording: replayRecording, video: videoUrl)
         
-        expect(mockClient?.replayEvent) == replayEvent
-        expect(mockClient?.replayRecording) == replayRecording
-        expect(mockClient?.videoUrl) == videoUrl
-        expect(mockClient?.scope) == sut.scope
+        XCTAssertEqual(mockClient?.replayEvent, replayEvent)
+        XCTAssertEqual(mockClient?.replayRecording, replayRecording)
+        XCTAssertEqual(mockClient?.videoUrl, videoUrl)
+        XCTAssertEqual(mockClient?.scope, sut.scope)
     }
     
     func testCaptureEnvelope_WithSession() {
@@ -1009,7 +1008,7 @@ class SentryHubTests: XCTestCase {
         sut.metrics.increment(key: "key")
         sut.close()
         
-        expect(self.fixture.client.captureEnvelopeInvocations.count) == 0
+        XCTAssertEqual(self.fixture.client.captureEnvelopeInvocations.count, 0)
     }
     
     func testMetrics_IncrementOneValue() throws {
@@ -1021,17 +1020,17 @@ class SentryHubTests: XCTestCase {
         sut.flush(timeout: 1.0)
         
         let client = self.fixture.client
-        expect(client.captureEnvelopeInvocations.count) == 1
+        XCTAssertEqual(client.captureEnvelopeInvocations.count, 1)
         
         let envelope = try XCTUnwrap(client.captureEnvelopeInvocations.first)
-        expect(envelope.header.eventId) != nil
+        XCTAssertNotNil(envelope.header.eventId)
 
         // We only check if it's an envelope with a statsd envelope item.
         // We validate the contents of the envelope in SentryMetricsClientTests
-        expect(envelope.items.count) == 1
+        XCTAssertEqual(envelope.items.count, 1)
         let envelopeItem = try XCTUnwrap(envelope.items.first)
-        expect(envelopeItem.header.type) == SentryEnvelopeItemTypeStatsd
-        expect(envelopeItem.header.contentType) == "application/octet-stream"
+        XCTAssertEqual(envelopeItem.header.type, SentryEnvelopeItemTypeStatsd)
+        XCTAssertEqual(envelopeItem.header.contentType, "application/octet-stream")
     }
     
     func testAddIncrementMetric_GetsLocalMetricsAggregatorFromCurrentSpan() throws {
@@ -1047,15 +1046,15 @@ class SentryHubTests: XCTestCase {
         let aggregator = tracer.getLocalMetricsAggregator()
         
         let metricsSummary = aggregator.serialize()
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["c:key"])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 1
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 1)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
     
     func testAddIncrementMetric_AddsDefaultTags() throws {
@@ -1073,12 +1072,12 @@ class SentryHubTests: XCTestCase {
         let aggregator = tracer.getLocalMetricsAggregator()
         
         let metricsSummary = aggregator.serialize()
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["c:key"])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["tags"] as? [String: String]) == ["my": "tag", "release": "overwritten", "environment": options.environment]
+        XCTAssertEqual(metric["tags"] as? [String: String], ["my": "tag", "release": "overwritten", "environment": options.environment])
     }
     
     func testAddIncrementMetric_ReleaseNameNil() throws {
@@ -1095,12 +1094,12 @@ class SentryHubTests: XCTestCase {
         let aggregator = tracer.getLocalMetricsAggregator()
         
         let metricsSummary = aggregator.serialize()
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["c:key"])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["tags"] as? [String: String]) == ["my": "tag", "environment": options.environment]
+        XCTAssertEqual(metric["tags"] as? [String: String], ["my": "tag", "environment": options.environment])
     }
     
     func testAddIncrementMetric_DefaultTagsDisabled() throws {
@@ -1119,12 +1118,12 @@ class SentryHubTests: XCTestCase {
         let aggregator = tracer.getLocalMetricsAggregator()
         
         let metricsSummary = aggregator.serialize()
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["c:key"])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["tags"] as? [String: String]) == ["my": "tag"]
+        XCTAssertEqual(metric["tags"] as? [String: String], ["my": "tag"])
     }
     
     private func captureEventEnvelope(level: SentryLevel) {
@@ -1216,7 +1215,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(fixture.options.environment, session?.environment)
         
         let event = argument?.scope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
-        expect(event?.environment) == scopeEnvironment
+        XCTAssertEqual(event?.environment, scopeEnvironment)
     }
     
     private func assertSessionWithIncrementedErrorCountedAdded() {

--- a/Tests/SentryTests/SentryNSURLRequestTests.swift
+++ b/Tests/SentryTests/SentryNSURLRequestTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -10,23 +9,25 @@ class SentryNSURLRequestTests: XCTestCase {
         try TestConstants.dsn(username: "SentryNSURLRequestTests")
     }
     
-    func testRequestWithEnvelopeEndpoint() {
-        let request = try! SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        expect(request.url!.absoluteString).to(endWith("/envelope/"))
+    func testRequestWithEnvelopeEndpoint() throws {
+        let request = try SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
+        let string = try XCTUnwrap(request.url?.absoluteString as? NSString)
+        XCTAssert(string.hasSuffix("/envelope/"))
     }
     
-    func testRequestWithStoreEndpoint() {
+    func testRequestWithStoreEndpoint() throws {
         let request = try! SentryNSURLRequest(storeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        expect(request.url!.absoluteString).to(endWith("/store/"))
+        let string = try XCTUnwrap(request.url?.absoluteString as? NSString)
+        XCTAssert(string.hasSuffix("/store/"))
     }
     
     func testRequestWithEnvelopeEndpoint_hasUserAgentWithSdkNameAndVersion() {
         let request = try! SentryNSURLRequest(envelopeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        expect(request.allHTTPHeaderFields?["User-Agent"]) == "\(SentryMeta.sdkName)/\(SentryMeta.versionString)"
+        XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "\(SentryMeta.sdkName)/\(SentryMeta.versionString)")
     }
     
     func testRequestWithStoreEndpoint_hasUserAgentWithSdkNameAndVersion() {
         let request = try! SentryNSURLRequest(storeRequestWith: SentryNSURLRequestTests.dsn(), andData: Data())
-        expect(request.allHTTPHeaderFields?["User-Agent"]) == "\(SentryMeta.sdkName)/\(SentryMeta.versionString)"
+        XCTAssertEqual(request.allHTTPHeaderFields?["User-Agent"], "\(SentryMeta.sdkName)/\(SentryMeta.versionString)")
     }
 }

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -5,7 +5,6 @@
 #import "SentrySpan.h"
 #import "SentryTests-Swift.h"
 #import <XCTest/XCTest.h>
-@import Nimble;
 
 @interface SentryOptionsTest : XCTestCase
 

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -196,19 +195,19 @@ class SentrySDKTests: XCTestCase {
     }
     
     func testCrashedLastRun() {
-        expect(SentryDependencyContainer.sharedInstance().crashReporter.crashedLastLaunch) == SentrySDK.crashedLastRun
+        XCTAssertEqual(SentryDependencyContainer.sharedInstance().crashReporter.crashedLastLaunch, SentrySDK.crashedLastRun)
     }
     
     func testDetectedStartUpCrash_DefaultValue() {
-        expect(SentrySDK.detectedStartUpCrash) == false
+        XCTAssertFalse(SentrySDK.detectedStartUpCrash)
     }
     
     func testDetectedStartUpCrash() {
         SentrySDK.setDetectedStartUpCrash(true)
-        expect(SentrySDK.detectedStartUpCrash) == true
+        XCTAssertEqual(SentrySDK.detectedStartUpCrash, true)
         
         SentrySDK.setDetectedStartUpCrash(false)
-        expect(SentrySDK.detectedStartUpCrash) == false
+        XCTAssertFalse(SentrySDK.detectedStartUpCrash)
     }
     
     func testCaptureCrashEvent() {
@@ -563,17 +562,17 @@ class SentrySDKTests: XCTestCase {
         let currentDateProvider = TestCurrentDateProvider()
         SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
         
-        expect(SentrySDK.startTimestamp) == nil
+        XCTAssertNil(SentrySDK.startTimestamp)
         
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
             options.removeAllIntegrations()
         }
         
-        expect(SentrySDK.startTimestamp) == currentDateProvider.date()
+        XCTAssertEqual(SentrySDK.startTimestamp, currentDateProvider.date())
         
         SentrySDK.close()
-        expect(SentrySDK.startTimestamp) == nil
+        XCTAssertNil(SentrySDK.startTimestamp)
     }
     
     func testIsEnabled() {
@@ -817,17 +816,17 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.metrics.increment(key: "key")
         SentrySDK.flush(timeout: 1.0)
         
-        expect(client.captureEnvelopeInvocations.count) == 1
+        XCTAssertEqual(client.captureEnvelopeInvocations.count, 1)
         
         let envelope = try XCTUnwrap(client.captureEnvelopeInvocations.first)
-        expect(envelope.header.eventId) != nil
+        XCTAssertNotNil(envelope.header.eventId)
 
         // We only check if it's an envelope with a statsd envelope item.
         // We validate the contents of the envelope in SentryMetricsClientTests
-        expect(envelope.items.count) == 1
+        XCTAssertEqual(envelope.items.count, 1)
         let envelopeItem = try XCTUnwrap(envelope.items.first)
-        expect(envelopeItem.header.type) == SentryEnvelopeItemTypeStatsd
-        expect(envelopeItem.header.contentType) == "application/octet-stream"
+        XCTAssertEqual(envelopeItem.header.type, SentryEnvelopeItemTypeStatsd)
+        XCTAssertEqual(envelopeItem.header.contentType, "application/octet-stream")
     }
     
     func testMetrics_BeforeEmitMetricCallback_DiscardEveryThing() throws {
@@ -843,7 +842,7 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.metrics.increment(key: "key")
         SentrySDK.flush(timeout: 1.0)
         
-        expect(client.captureEnvelopeInvocations.count) == 0
+        XCTAssertEqual(client.captureEnvelopeInvocations.count, 0)
     }
 
 #if SENTRY_HAS_UIKIT
@@ -992,7 +991,7 @@ class SentrySDKWithSetupTests: XCTestCase {
                 
                 concurrentQueue.async {
                     let hub = SentryHub(client: nil, andScope: nil)
-                    expect(hub) != nil
+                    XCTAssertNotNil(hub)
                     
                     expectation.fulfill()
                 }

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -312,7 +311,7 @@ class SentryScopeSwiftTests: XCTestCase {
         scope.addBreadcrumb(fixture.breadcrumb)
         
         let serialized = scope.serialize()
-        expect(serialized["breadcrumbs"]) == nil
+        XCTAssertNil(serialized["breadcrumbs"])
     }
     
     func testMaxBreadcrumbs_IsNegative() {
@@ -321,7 +320,7 @@ class SentryScopeSwiftTests: XCTestCase {
         scope.addBreadcrumb(fixture.breadcrumb)
         
         let serialized = scope.serialize()
-        expect(serialized["breadcrumbs"]) == nil
+        XCTAssertNil(serialized["breadcrumbs"])
     }
     
     func testUseSpanForClear() {

--- a/Tests/SentryTests/State/SentryInstallationTests.swift
+++ b/Tests/SentryTests/State/SentryInstallationTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -50,7 +49,7 @@ final class SentryInstallationTests: XCTestCase {
         
         SentryInstallation.cacheIDAsync(withCacheDirectoryPath: basePath)
         
-        expect(dispatchQueue.dispatchAsyncInvocations.count) == 1
+        XCTAssertEqual(dispatchQueue.dispatchAsyncInvocations.count, 1)
     }
     
     func testCacheIDAsync_CashesID() throws {
@@ -65,11 +64,11 @@ final class SentryInstallationTests: XCTestCase {
         try FileManager().removeItem(atPath: basePath)
         
         let nonCachedIDAfterDeletingFile = SentryInstallation.id(withCacheDirectoryPathNonCached: basePath)
-        expect(nonCachedIDAfterDeletingFile) == nil
+        XCTAssertNil(nonCachedIDAfterDeletingFile)
         
         let cachedID = SentryInstallation.id(withCacheDirectoryPath: basePath)
         
-        expect(cachedID) == nonCachedID
+        XCTAssertEqual(cachedID, nonCachedID)
 
     }
 }

--- a/Tests/SentryTests/StringExtensionTests.swift
+++ b/Tests/SentryTests/StringExtensionTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -7,39 +6,39 @@ class StringExtensionTests: XCTestCase {
     
     func testSingleCharacterSubscript() {
         let testString = "Hello, World!"
-        expect(testString[0]) == "H"
-        expect(testString[7]) == "W"
-        expect(testString[12]) == "!"
+        XCTAssertEqual(testString[0], "H")
+        XCTAssertEqual(testString[7], "W")
+        XCTAssertEqual(testString[12], "!")
     }
     
     func testRangeOfCharactersSubscript() {
         let testString = "Hello, World!"
-        expect(testString[1..<5]) == "ello"
-        expect(testString[7...11]) == "World"
-        expect(testString[3...3]) == "l"
-        expect(testString[1...5]) == "ello,"
-        expect(testString[7...11]) == "World"
-        expect(testString[0...0]) == "H"
+        XCTAssertEqual(testString[1..<5], "ello")
+        XCTAssertEqual(testString[7...11], "World")
+        XCTAssertEqual(testString[3...3], "l")
+        XCTAssertEqual(testString[1...5], "ello,")
+        XCTAssertEqual(testString[7...11], "World")
+        XCTAssertEqual(testString[0...0], "H")
     }
     
     func testPartialRangeThroughSubscript() {
         let testString = "Hello, World!"
-        expect(testString[...5]) == "Hello,"
-        expect(testString[...4]) == "Hello"
-        expect(testString[...0]) == "H"
+        XCTAssertEqual(testString[...5], "Hello,")
+        XCTAssertEqual(testString[...4], "Hello")
+        XCTAssertEqual(testString[...0], "H")
     }
     
     func testPartialRangeFromSubscript() {
         let testString = "Hello, World!"
-        expect(testString[7...]) == "World!"
-        expect(testString[0...]) == "Hello, World!"
-        expect(testString[5...]) == ", World!"
+        XCTAssertEqual(testString[7...], "World!")
+        XCTAssertEqual(testString[0...], "Hello, World!")
+        XCTAssertEqual(testString[5...], ", World!")
     }
     
     func testPartialRangeUpToSubscript() {
         let testString = "Hello, World!"
-        expect(testString[..<5]) == "Hello"
-        expect(testString[..<4]) == "Hell"
-        expect(testString[..<0]) == ""
+        XCTAssertEqual(testString[..<5], "Hello")
+        XCTAssertEqual(testString[..<4], "Hell")
+        XCTAssertEqual(testString[..<0], "")
     }
 }

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -14,14 +13,14 @@ final class NSLockTests: XCTestCase {
                 value += 1
                 return 10
             }
-            expect(returnValue) == 10
+            XCTAssertEqual(returnValue, 10)
             
             lock.synchronized {
                 value += 1
             }
         })
         
-        expect(value) == 200
+        XCTAssertEqual(value, 200)
     }
     
     func testUnlockWhenThrowing() throws {
@@ -33,7 +32,7 @@ final class NSLockTests: XCTestCase {
                 throw NSLockError.runtimeError(errorMessage)
             }
         } catch NSLockError.runtimeError(let actualErrorMessage) {
-            expect(actualErrorMessage) == errorMessage
+            XCTAssertEqual(actualErrorMessage, errorMessage)
         }
         
         let expectation = expectation(description: "Lock should be non blocking")

--- a/Tests/SentryTests/Swift/Metrics/BucketMetricsAggregatorTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/BucketMetricsAggregatorTests.swift
@@ -1,5 +1,4 @@
 @testable import _SentryPrivate
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -23,17 +22,18 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         sut.flush(force: true)
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
 
         let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let counterMetric = try XCTUnwrap(bucket.first as? DistributionMetric)
 
-        expect(counterMetric.key) == "key"
-        expect(counterMetric.serialize()).to(contain(["1.0", "1.1"]))
-        expect(counterMetric.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(counterMetric.tags) == [:]
+        XCTAssertEqual(counterMetric.key, "key")
+        XCTAssert(counterMetric.serialize().contains("1.0"))
+        XCTAssert(counterMetric.serialize().contains("1.1"))
+        XCTAssertEqual(counterMetric.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(counterMetric.tags, [:])
     }
 
     func testFlushShift_MetricsUsuallyInSameBucket_AreInDifferent() throws {
@@ -47,7 +47,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         // Not flushing yet
         currentDate.setDate(date: currentDate.date().addingTimeInterval( 1.0))
         sut.flush(force: false)
-        expect(metricsClient.captureInvocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.count, 0)
 
         // This ends up in a different bucket
         sut.gauge(key: "key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
@@ -56,18 +56,18 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         currentDate.setDate(date: currentDate.date().addingTimeInterval( 0.01))
         sut.flush(force: false)
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
 
         let previousBucketTimestamp = currentDate.bucketTimestamp - 10
         let bucket = try XCTUnwrap(buckets[previousBucketTimestamp])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? GaugeMetric)
 
-        expect(metric.key) == "key"
-        expect(metric.serialize()) == ["-1.0", "-1.0", "1.0", "0.0", "2"]
-        expect(metric.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(metric.tags) == [:]
+        XCTAssertEqual(metric.key, "key")
+        XCTAssertEqual(metric.serialize(), ["-1.0", "-1.0", "1.0", "0.0", "2"])
+        XCTAssertEqual(metric.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(metric.tags, [:])
     }
 
     func testDifferentMetrics_NotInSameBucket() throws {
@@ -78,23 +78,23 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         sut.flush(force: true)
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
 
         let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
-        expect(bucket.count) == 2
+        XCTAssertEqual(bucket.count, 2)
 
         let metric1 = try XCTUnwrap(bucket.first { $0.key == "key1" } as? SetMetric)
-        expect(metric1.key) == "key1"
-        expect(metric1.serialize()) == ["1"]
-        expect(metric1.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(metric1.tags) == ["some": "tag", "and": "another-one"]
+        XCTAssertEqual(metric1.key, "key1")
+        XCTAssertEqual(metric1.serialize(), ["1"])
+        XCTAssertEqual(metric1.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(metric1.tags, ["some": "tag", "and": "another-one"])
 
         let metric2 = try XCTUnwrap(bucket.first { $0.key == "key2" } as? SetMetric)
-        expect(metric2.key) == "key2"
-        expect(metric2.serialize()) == ["2"]
-        expect(metric2.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(metric2.tags) == ["some": "tag", "and": "another-one"]
+        XCTAssertEqual(metric2.key, "key2")
+        XCTAssertEqual(metric2.serialize(), ["2"])
+        XCTAssertEqual(metric2.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(metric2.tags, ["some": "tag", "and": "another-one"])
     }
 
     func testSameMetricDifferentTag_NotInSameBucket() throws {
@@ -105,23 +105,23 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         sut.flush(force: true)
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
 
         let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
-        expect(bucket.count) == 2
+        XCTAssertEqual(bucket.count, 2)
 
         let counterMetric1 = try XCTUnwrap(bucket.first { $0.tags == ["some": "tag"] } as? CounterMetric)
-        expect(counterMetric1.key) == "key"
-        expect(counterMetric1.serialize()) == ["1.0"]
-        expect(counterMetric1.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(counterMetric1.tags) == ["some": "tag"]
+        XCTAssertEqual(counterMetric1.key, "key")
+        XCTAssertEqual(counterMetric1.serialize(), ["1.0"])
+        XCTAssertEqual(counterMetric1.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(counterMetric1.tags, ["some": "tag"])
 
         let counterMetric2 = try XCTUnwrap(bucket.first { $0.tags == ["some": "other-tag"] } as? CounterMetric)
-        expect(counterMetric2.key) == "key"
-        expect(counterMetric2.serialize()) == ["2.0"]
-        expect(counterMetric2.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(counterMetric2.tags) == ["some": "other-tag"]
+        XCTAssertEqual(counterMetric2.key, "key")
+        XCTAssertEqual(counterMetric2.serialize(), ["2.0"])
+        XCTAssertEqual(counterMetric2.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(counterMetric2.tags, ["some": "other-tag"])
     }
 
     func testSameMetricNotAggregated_WhenNotInSameBucket() throws {
@@ -133,27 +133,27 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         sut.flush(force: true)
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
 
-        expect(buckets.count) == 2
+        XCTAssertEqual(buckets.count, 2)
 
         let bucket1 = try XCTUnwrap(buckets.values.first)
-        expect(bucket1.count) == 1
+        XCTAssertEqual(bucket1.count, 1)
         let counterMetric1 = try XCTUnwrap(bucket1.first as? CounterMetric)
 
-        expect(counterMetric1.key) == "key"
-        expect(counterMetric1.serialize()) == ["1.0"]
-        expect(counterMetric1.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(counterMetric1.tags) == [:]
+        XCTAssertEqual(counterMetric1.key, "key")
+        XCTAssertEqual(counterMetric1.serialize(), ["1.0"])
+        XCTAssertEqual(counterMetric1.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(counterMetric1.tags, [:])
 
         let bucket2 = try XCTUnwrap(Array(buckets.values).last)
         let counterMetric2 = try XCTUnwrap(bucket2.first as? CounterMetric)
 
-        expect(counterMetric2.key) == "key"
-        expect(counterMetric2.serialize()) == ["1.0"]
-        expect(counterMetric2.unit.unit) == MeasurementUnitDuration.day.unit
-        expect(counterMetric2.tags) == [:]
+        XCTAssertEqual(counterMetric2.key, "key")
+        XCTAssertEqual(counterMetric2.serialize(), ["1.0"])
+        XCTAssertEqual(counterMetric2.unit.unit, MeasurementUnitDuration.day.unit)
+        XCTAssertEqual(counterMetric2.tags, [:])
     }
 
     func testCallFlushWhenOverweight() throws {
@@ -161,7 +161,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         let expectation = expectation(description: "Before capture block called")
         metricsClient.afterRecordingCaptureInvocationBlock = {
-            expect(Thread.isMainThread).to(equal(false), description: "Flush must be called on a background thread, but was called on the main thread.")
+            XCTAssertFalse(Thread.isMainThread, "Flush must be called on a background thread, but was called on the main thread.")
             expectation.fulfill()
         }
 
@@ -169,7 +169,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.increment(key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
 
         wait(for: [expectation], timeout: 1.0)
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
     }
     
     func testConvenienceInit_SetsCorrectMaxWeight() throws {
@@ -182,12 +182,12 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         
         // Total weight is now 999 because the bucket counts for one
         // So nothing should be sent
-        expect(metricsClient.captureInvocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.count, 0)
         
         // Now we pass the 1000 threshold
         sut.increment(key: "another key", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
     }
 
     func testFlushOnlyWhenNeeded() throws {
@@ -196,19 +196,19 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.increment(key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
 
         sut.flush(force: false)
-        expect(metricsClient.captureInvocations.invocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.invocations.count, 0)
 
         currentDate.setDate(date: currentDate.date().addingTimeInterval( 9.99))
         sut.flush(force: false)
-        expect(metricsClient.captureInvocations.invocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.invocations.count, 0)
 
         currentDate.setDate(date: currentDate.date().addingTimeInterval( 0.01))
         sut.increment(key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
 
         sut.flush(force: false)
         let buckets1 = try XCTUnwrap(metricsClient.captureInvocations.first)
-        expect(buckets1.count) == 1
-        expect(buckets1.values.count) == 1
+        XCTAssertEqual(buckets1.count, 1)
+        XCTAssertEqual(buckets1.values.count, 1)
 
         // Key2 wasn't flushed. We increment it to 2.0
         sut.increment( key: "key2", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
@@ -218,18 +218,18 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.increment(key: "key4", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
         sut.increment(key: "key5", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
 
-        expect(metricsClient.captureInvocations.count) == 2
+        XCTAssertEqual(metricsClient.captureInvocations.count, 2)
         let buckets2 = try XCTUnwrap(metricsClient.captureInvocations.invocations[1])
 
-        expect(buckets2.count) == 1
+        XCTAssertEqual(buckets2.count, 1)
         let bucket = try XCTUnwrap(buckets2.first)
 
         // All 4 metrics should be in the bucket
-        expect(bucket.value.count) == 4
+        XCTAssertEqual(bucket.value.count, 4)
 
         // Check that key2 was incremented
         let counterMetric = try XCTUnwrap(bucket.value.first { $0.key == "key2" } as? CounterMetric)
-        expect(counterMetric.serialize()) == ["2.0"]
+        XCTAssertEqual(counterMetric.serialize(), ["2.0"])
     }
     
     func testWeightWithMultipleDifferent() throws {
@@ -240,19 +240,19 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         
         // Weight should be 3, no flush yet
         sut.flush(force: false)
-        expect(metricsClient.captureInvocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.count, 0)
         
         // Time passed, must flush
         currentDate.setDate(date: currentDate.date().addingTimeInterval(10.0))
         sut.flush(force: false)
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         
         sut.distribution(key: "key", value: 1.0, unit: .none, tags: [:])
         sut.distribution(key: "key", value: 1.0, unit: .none, tags: [:])
         sut.distribution(key: "key", value: 1.0, unit: .none, tags: [:])
         
         // Reached overweight, must flush
-        expect(metricsClient.captureInvocations.count) == 2
+        XCTAssertEqual(metricsClient.captureInvocations.count, 2)
     }
 
     func testInitStartsRepeatingTimer() throws {
@@ -279,7 +279,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
             
             wait(for: [expectation], timeout: 1.0)
             
-            expect(metricsClient.captureInvocations.count).to(beGreaterThan(0), description: "Repeating flush timer should send some metrics.")
+            XCTAssertGreaterThan(metricsClient.captureInvocations.count, 0, "Repeating flush timer should send some metrics.")
         }
     }
 
@@ -308,7 +308,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
 
-        expect(metricsClient.captureInvocations.count).to(equal(0), description: "No metrics should be sent cause the flush timer should be cancelled.")
+        XCTAssertEqual(metricsClient.captureInvocations.count, 0, "No metrics should be sent cause the flush timer should be cancelled.")
     }
 
     func testFlushCalledOnCallingThread() throws {
@@ -316,7 +316,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         let expectation = expectation(description: "Before capture block called")
         metricsClient.afterRecordingCaptureInvocationBlock = {
-            expect(Thread.isMainThread).to(equal(true), description: "Flush must be called on the calling thread, but was called on a background thread.")
+            XCTAssertEqual(Thread.isMainThread, true, "Flush must be called on the calling thread, but was called on a background thread.")
             expectation.fulfill()
         }
 
@@ -326,7 +326,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.flush(force: true)
 
         wait(for: [expectation], timeout: 1.0)
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
     }
 
     func testCloseCallsFlush() throws {
@@ -337,7 +337,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         sut.close()
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
     }
     
     func testWriteMultipleMetricsInParallel_NonForceFlush_DoesNotCrash() throws {
@@ -373,17 +373,17 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.increment(key: "key1", value: 1.0, unit: MeasurementUnitDuration.day, tags: ["some": "tag"], localMetricsAggregator: localMetricsAggregator)
         
         let serialized = localMetricsAggregator.serialize()
-        expect(serialized.count) == 1
+        XCTAssertEqual(serialized.count, 1)
         let bucket = try XCTUnwrap(serialized["c:key1@day"])
         
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
         
-        expect(metric["tags"] as? [String: String]) == ["some": "tag"]
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 1
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric["tags"] as? [String: String], ["some": "tag"])
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 1)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
     
     func testSetMetricOnlyForwardsAddedWeight() throws {
@@ -395,18 +395,18 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.set(key: "key1", value: 1, unit: MeasurementUnitDuration.day, tags: ["some": "tag"], localMetricsAggregator: localMetricsAggregator)
         
         let serialized = localMetricsAggregator.serialize()
-        expect(serialized.count) == 1
+        XCTAssertEqual(serialized.count, 1)
         let bucket = try XCTUnwrap(serialized["s:key1@day"])
         
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
         
-        expect(metric["tags"] as? [String: String]) == ["some": "tag"]
+        XCTAssertEqual(metric["tags"] as? [String: String], ["some": "tag"])
         // When no weight added the value is 0.0
-        expect(metric["min"] as? Double) == 0.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 2
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric["min"] as? Double, 0.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 2)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
     
     func testBeforeEmitMetricCallback() throws {
@@ -436,15 +436,15 @@ final class BucketMetricsAggregatorTests: XCTestCase {
 
         sut.flush(force: true)
 
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
 
         let bucket = try XCTUnwrap(buckets[currentDate.bucketTimestamp])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? DistributionMetric)
 
-        expect(metric.key) == "key1"
-        expect(metric.tags.isEmpty) == true
+        XCTAssertEqual(metric.key, "key1")
+        XCTAssertEqual(metric.tags.isEmpty, true)
     }
 
 }

--- a/Tests/SentryTests/Swift/Metrics/CounterMetricTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/CounterMetricTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -11,25 +10,25 @@ final class CounterMetricTests: XCTestCase {
         sut.add(value: -1.0)
         sut.add(value: 2.0)
         
-        expect(sut.serialize()) == ["3.0"]
+        XCTAssertEqual(sut.serialize(), ["3.0"])
     }
     
     func testType() {
         let sut = CounterMetric(first: 0.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.type) == .counter
+        XCTAssertEqual(sut.type, .counter)
     }
     
     func testWeight() {
         let sut = CounterMetric(first: 0.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.weight) == 1
+        XCTAssertEqual(sut.weight, 1)
         
         sut.add(value: 5.0)
         sut.add(value: 5.0)
         
         // The weight stays the same
-        expect(sut.weight) == 1
+        XCTAssertEqual(sut.weight, 1)
     }
 
 }

--- a/Tests/SentryTests/Swift/Metrics/DistributionMetricTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/DistributionMetricTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -11,25 +10,25 @@ final class DistributionMetricTests: XCTestCase {
         sut.add(value: -1.0)
         sut.add(value: 2.0)
         
-        expect(sut.serialize()).to(contain(["1.0", "0.0", "-1.0", "2.0"]))
+        XCTAssertEqual(sut.serialize(), ["1.0", "0.0", "-1.0", "2.0"])
     }
     
     func testType() {
         let sut = DistributionMetric(first: 0.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.type) == .distribution
+        XCTAssertEqual(sut.type, .distribution)
     }
     
     func testWeight() {
         let sut = DistributionMetric(first: 0.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.weight) == 1
+        XCTAssertEqual(sut.weight, 1)
         
         for _ in 0..<100 {
             sut.add(value: 5.0)
         }
         
-        expect(sut.weight) == 101
+        XCTAssertEqual(sut.weight, 101)
     }
 
 }

--- a/Tests/SentryTests/Swift/Metrics/GaugeMetricTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/GaugeMetricTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -7,7 +6,7 @@ final class GaugeMetricTests: XCTestCase {
     func testAddingValues() throws {
         let sut = GaugeMetric(first: 1.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.serialize()).to(contain(["1.0", "1.0", "1.0", "1.0", "1"]))
+        XCTAssertEqual(sut.serialize(), ["1.0", "1.0", "1.0", "1.0", "1"])
         
         sut.add(value: 5.0)
         sut.add(value: 4.0)
@@ -16,30 +15,30 @@ final class GaugeMetricTests: XCTestCase {
         sut.add(value: 2.5)
         sut.add(value: 1.0)
         
-        expect(sut.serialize()) == [
+        XCTAssertEqual(sut.serialize(), [
             "1.0", // last
             "1.0", // min
             "5.0", // max
             "18.5", // sum
             "7"    // count
-        ]
+        ])
     }
     
     func testType() {
         let sut = GaugeMetric(first: 1.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.type) == .gauge
+        XCTAssertEqual(sut.type, .gauge)
     }
     
     func testWeight() {
         let sut = GaugeMetric(first: 1.0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.weight) == 5
+        XCTAssertEqual(sut.weight, 5)
         
         sut.add(value: 5.0)
         sut.add(value: 5.0)
         
         // The weight stays the same
-        expect(sut.weight) == 5
+        XCTAssertEqual(sut.weight, 5)
     }
 }

--- a/Tests/SentryTests/Swift/Metrics/LocalMetricsAggregatorTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/LocalMetricsAggregatorTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -10,17 +9,17 @@ final class LocalMetricsAggregatorTests: XCTestCase {
         sut.add(type: .counter, key: "key", value: 1.0, unit: MeasurementUnitDuration.second, tags: [:])
         
         let serialized = sut.serialize()
-        expect(serialized.count) == 1
+        XCTAssertEqual(serialized.count, 1)
         let bucket = try XCTUnwrap(serialized["c:key@second"])
         
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
         
-        expect(metric["tags"]) == nil
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 1
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertNil(metric["tags"])
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 1)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
 
     func testAddTwoSameDistributionMetrics() throws {
@@ -30,17 +29,17 @@ final class LocalMetricsAggregatorTests: XCTestCase {
         sut.add(type: .distribution, key: "key", value: 1.1, unit: .none, tags: [:])
         
         let serialized = sut.serialize()
-        expect(serialized.count) == 1
+        XCTAssertEqual(serialized.count, 1)
         let bucket = try XCTUnwrap(serialized["d:key"])
         
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
         
-        expect(metric["tags"]) == nil
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.1
-        expect(metric["count"] as? Int) == 2
-        expect(metric["sum"] as? Double) == 2.1
+        XCTAssertNil(metric["tags"])
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.1)
+        XCTAssertEqual(metric["count"] as? Int, 2)
+        XCTAssertEqual(metric["sum"] as? Double, 2.1)
     }
     
     func testAddTwoGaugeMetrics_WithDifferentTags() throws {
@@ -50,23 +49,23 @@ final class LocalMetricsAggregatorTests: XCTestCase {
         sut.add(type: .gauge, key: "key", value: 10.0, unit: MeasurementUnitDuration.second, tags: ["some1": "tag1"])
         
         let serialized = sut.serialize()
-        expect(serialized.count) == 1
+        XCTAssertEqual(serialized.count, 1)
         let bucket = try XCTUnwrap(serialized["g:key@second"])
         
-        expect(bucket.count) == 2
+        XCTAssertEqual(bucket.count, 2)
         let metric0 = try XCTUnwrap(bucket.first { $0.contains { $0.value as? [String: String] == ["some0": "tag0"] } })
         
-        expect(metric0["min"] as? Double) == 1.0
-        expect(metric0["max"] as? Double) == 1.0
-        expect(metric0["count"] as? Int) == 1
-        expect(metric0["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric0["min"] as? Double, 1.0)
+        XCTAssertEqual(metric0["max"] as? Double, 1.0)
+        XCTAssertEqual(metric0["count"] as? Int, 1)
+        XCTAssertEqual(metric0["sum"] as? Double, 1.0)
         
         let metric1 = try XCTUnwrap(bucket.first { $0.contains { $0.value as? [String: String] == ["some1": "tag1"] } })
         
-        expect(metric1["min"] as? Double) == 10.0
-        expect(metric1["max"] as? Double) == 10.0
-        expect(metric1["count"] as? Int) == 1
-        expect(metric1["sum"] as? Double) == 10.0
+        XCTAssertEqual(metric1["min"] as? Double, 10.0)
+        XCTAssertEqual(metric1["max"] as? Double, 10.0)
+        XCTAssertEqual(metric1["count"] as? Int, 1)
+        XCTAssertEqual(metric1["sum"] as? Double, 10.0)
     }
     
     func testAddTwoDifferentMetrics() throws {
@@ -77,23 +76,23 @@ final class LocalMetricsAggregatorTests: XCTestCase {
         sut.add(type: .gauge, key: "key", value: -10.0, unit: MeasurementUnitDuration.second, tags: ["some1": "tag1"])
         
         let serialized = sut.serialize()
-        expect(serialized.count) == 2
+        XCTAssertEqual(serialized.count, 2)
         let dayBucket = try XCTUnwrap(serialized["g:key@day"])
         
-        expect(dayBucket.count) == 1
+        XCTAssertEqual(dayBucket.count, 1)
         let dayMetric = try XCTUnwrap(dayBucket.first)
-        expect(dayMetric["min"] as? Double) == 1.0
-        expect(dayMetric["max"] as? Double) == 1.0
-        expect(dayMetric["count"] as? Int) == 1
-        expect(dayMetric["sum"] as? Double) == 1.0
+        XCTAssertEqual(dayMetric["min"] as? Double, 1.0)
+        XCTAssertEqual(dayMetric["max"] as? Double, 1.0)
+        XCTAssertEqual(dayMetric["count"] as? Int, 1)
+        XCTAssertEqual(dayMetric["sum"] as? Double, 1.0)
         
         let secondBucket = try XCTUnwrap(serialized["g:key@second"])
-        expect(secondBucket.count) == 1
+        XCTAssertEqual(secondBucket.count, 1)
         let secondMetric = try XCTUnwrap(secondBucket.first)
-        expect(secondMetric["min"] as? Double) == -10.0
-        expect(secondMetric["max"] as? Double) == 10.0
-        expect(secondMetric["count"] as? Int) == 2
-        expect(secondMetric["sum"] as? Double) == 0.0
+        XCTAssertEqual(secondMetric["min"] as? Double, -10.0)
+        XCTAssertEqual(secondMetric["max"] as? Double, 10.0)
+        XCTAssertEqual(secondMetric["count"] as? Int, 2)
+        XCTAssertEqual(secondMetric["sum"] as? Double, 0.0)
     }
     
     func testWriteMultipleMetricsInParallel_DoesNotCrash() throws {
@@ -105,7 +104,7 @@ final class LocalMetricsAggregatorTests: XCTestCase {
             sut.add(type: .distribution, key: "key\(i)", value: 1.1, unit: .none, tags: ["some": "tag"])
             sut.add(type: .set, key: "key\(i)", value: 1.1, unit: .none, tags: ["some": "tag"])
         }, readWork: {
-            expect(sut.serialize()) != nil
+            XCTAssertNotNil(sut.serialize())
         })
     }
 }

--- a/Tests/SentryTests/Swift/Metrics/SentryMetricsAPITests.swift
+++ b/Tests/SentryTests/Swift/Metrics/SentryMetricsAPITests.swift
@@ -1,5 +1,4 @@
 import _SentryPrivate
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -40,7 +39,7 @@ final class SentryMetricsAPITests: XCTestCase {
         
         sut.close()
         
-        expect(metricsClient.captureInvocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.count, 0)
     }
     
     func testIncrement_EmitsIncrementMetric() throws {
@@ -52,17 +51,17 @@ final class SentryMetricsAPITests: XCTestCase {
         
         sut.flush()
         
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
         
         let bucket = try XCTUnwrap(buckets.first?.value)
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? CounterMetric)
         
-        expect(metric.key) == "key"
-        expect(metric.serialize()).to(contain(["1.0"]))
-        expect(metric.unit.unit) == MeasurementUnitFraction.percent.unit
-        expect(metric.tags) == ["yeah": "sentry", "some": "tag"]
+        XCTAssertEqual(metric.key, "key")
+        XCTAssert(metric.serialize().contains("1.0"))
+        XCTAssertEqual(metric.unit.unit, MeasurementUnitFraction.percent.unit)
+        XCTAssertEqual(metric.tags, ["yeah": "sentry", "some": "tag"])
     }
     
     func testGauge_EmitsGaugeMetric() throws {
@@ -74,17 +73,17 @@ final class SentryMetricsAPITests: XCTestCase {
         
         sut.flush()
         
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
         
         let bucket = try XCTUnwrap(buckets.first?.value)
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? GaugeMetric)
         
-        expect(metric.key) == "key"
-        expect(metric.serialize()) == ["1.0", "1.0", "1.0", "1.0", "1"]
-        expect(metric.unit.unit) == MeasurementUnitFraction.percent.unit
-        expect(metric.tags) == ["yeah": "sentry", "some": "tag"]
+        XCTAssertEqual(metric.key, "key")
+        XCTAssertEqual(metric.serialize(), ["1.0", "1.0", "1.0", "1.0", "1"])
+        XCTAssertEqual(metric.unit.unit, MeasurementUnitFraction.percent.unit)
+        XCTAssertEqual(metric.tags, ["yeah": "sentry", "some": "tag"])
     }
     
     func testDistribution_EmitsDistributionMetric() throws {
@@ -97,17 +96,17 @@ final class SentryMetricsAPITests: XCTestCase {
         
         sut.flush()
         
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
         
         let bucket = try XCTUnwrap(buckets.first?.value)
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? DistributionMetric)
         
-        expect(metric.key) == "key"
-        expect(metric.serialize()) == ["1.0", "12.0"]
-        expect(metric.unit.unit) == MeasurementUnitFraction.percent.unit
-        expect(metric.tags) == ["yeah": "sentry", "some": "tag"]
+        XCTAssertEqual(metric.key, "key")
+        XCTAssertEqual(metric.serialize(), ["1.0", "12.0"])
+        XCTAssertEqual(metric.unit.unit, MeasurementUnitFraction.percent.unit)
+        XCTAssertEqual(metric.tags, ["yeah": "sentry", "some": "tag"])
     }
     
     func testSet_EmitsSetMetric() throws {
@@ -121,17 +120,18 @@ final class SentryMetricsAPITests: XCTestCase {
         
         sut.flush()
         
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
         
         let bucket = try XCTUnwrap(buckets.first?.value)
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? SetMetric)
         
-        expect(metric.key) == "key"
-        expect(metric.serialize()).to(contain(["2445898635", "2725604442"]))
-        expect(metric.unit.unit) == MeasurementUnitFraction.percent.unit
-        expect(metric.tags) == ["yeah": "sentry", "some": "tag"]
+        XCTAssertEqual(metric.key, "key")
+        XCTAssert(metric.serialize().contains("2445898635"))
+        XCTAssert(metric.serialize().contains("2725604442"))
+        XCTAssertEqual(metric.unit.unit, MeasurementUnitFraction.percent.unit)
+        XCTAssertEqual(metric.tags, ["yeah": "sentry", "some": "tag"])
     }
     
     func testTiming_WhenNoCurrentSpan_NoSpanCreatedAndNoMetricEmitted() throws {
@@ -145,10 +145,10 @@ final class SentryMetricsAPITests: XCTestCase {
                 throw MetricsAPIError.runtimeError(errorMessage)
             }
         } catch MetricsAPIError.runtimeError(let actualErrorMessage) {
-            expect(actualErrorMessage) == errorMessage
+            XCTAssertEqual(actualErrorMessage, errorMessage)
         }
         
-        expect(metricsClient.captureInvocations.count) == 0
+        XCTAssertEqual(metricsClient.captureInvocations.count, 0)
     }
     
     func testTiming_WithCurrentSpan_CapturesGaugeMetric() throws {
@@ -163,23 +163,23 @@ final class SentryMetricsAPITests: XCTestCase {
                 throw MetricsAPIError.runtimeError(errorMessage)
             }
         } catch MetricsAPIError.runtimeError(let actualErrorMessage) {
-            expect(actualErrorMessage) == errorMessage
+            XCTAssertEqual(actualErrorMessage, errorMessage)
         }
         
         sut.flush()
         transaction.finish()
         
-        expect(metricsClient.captureInvocations.count) == 1
+        XCTAssertEqual(metricsClient.captureInvocations.count, 1)
         let buckets = try XCTUnwrap(metricsClient.captureInvocations.first)
         
         let bucket = try XCTUnwrap(buckets.first?.value)
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first as? DistributionMetric)
         
-        expect(metric.key) == "key"
-        expect(metric.serialize()) == ["1.0"]
-        expect(metric.unit.unit) == MeasurementUnitDuration.second.unit
-        expect(metric.tags) == ["some": "tag", "release": options.releaseName, "environment": options.environment]
+        XCTAssertEqual(metric.key, "key")
+        XCTAssertEqual(metric.serialize(), ["1.0"])
+        XCTAssertEqual(metric.unit.unit, MeasurementUnitDuration.second.unit)
+        XCTAssertEqual(metric.tags, ["some": "tag", "release": options.releaseName, "environment": options.environment])
     }
     
     func testTiming_WithCurrentSpan_CreatesSpanWithMetricsSummary() throws {
@@ -193,32 +193,32 @@ final class SentryMetricsAPITests: XCTestCase {
         
         transaction.finish()
         
-        expect(testHub.capturedTransactionsWithScope.count) == 1
+        XCTAssertEqual(testHub.capturedTransactionsWithScope.count, 1)
         let serializedTransaction = try XCTUnwrap(testHub.capturedTransactionsWithScope.first?.transaction)
-        expect(serializedTransaction.count) != 0
+        XCTAssertNotEqual(serializedTransaction.count, 0)
         
         let spans = try XCTUnwrap(serializedTransaction["spans"] as? [[String: Any]])
-        expect(spans.count) == 1
+        XCTAssertEqual(spans.count, 1)
         let span = try XCTUnwrap(spans.first)
         
-        expect(span["op"] as? String) == "metric.timing"
-        expect(span["description"] as? String) == "key"
-        expect(span["origin"] as? String) == "manual"
-        expect(span["start_timestamp"] as? Int) == 978_307_200
-        expect(span["timestamp"] as? Int) == 978_307_201
-        expect(span["parent_span_id"] as? String) == transaction.spanId.sentrySpanIdString
-        expect(span["tags"] as? [String: String]) == ["some": "tag", "release": options.releaseName, "environment": options.environment]
+        XCTAssertEqual(span["op"] as? String, "metric.timing")
+        XCTAssertEqual(span["description"] as? String, "key")
+        XCTAssertEqual(span["origin"] as? String, "manual")
+        XCTAssertEqual(span["start_timestamp"] as? Int, 978_307_200)
+        XCTAssertEqual(span["timestamp"] as? Int, 978_307_201)
+        XCTAssertEqual(span["parent_span_id"] as? String, transaction.spanId.sentrySpanIdString)
+        XCTAssertEqual(try XCTUnwrap(span["tags"] as? [String: String]), ["some": "tag", "release": options.releaseName, "environment": options.environment])
         
         let metricsSummary = try XCTUnwrap(span["_metrics_summary"] as? [String: [[String: Any]]])
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["d:key@second"] )
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 1
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 1)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
     
     enum MetricsAPIError: Error {

--- a/Tests/SentryTests/Swift/Metrics/SentryMetricsClientTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/SentryMetricsClientTests.swift
@@ -1,5 +1,4 @@
 import _SentryPrivate
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -18,17 +17,17 @@ final class SentryMetricsClientTests: XCTestCase {
         
         sut.capture(flushableBuckets: flushableBuckets)
 
-        expect(testClient.captureEnvelopeInvocations.count) == 1
+        XCTAssertEqual(testClient.captureEnvelopeInvocations.count, 1)
 
         let envelope = try XCTUnwrap(testClient.captureEnvelopeInvocations.first)
-        expect(envelope.header.eventId) != nil
+        XCTAssertNotNil(envelope.header.eventId)
 
-        expect(envelope.items.count) == 1
+        XCTAssertEqual(envelope.items.count, 1)
         let envelopeItem = try XCTUnwrap(envelope.items.first)
-        expect(envelopeItem.header.type) == SentryEnvelopeItemTypeStatsd
-        expect(envelopeItem.header.contentType) == "application/octet-stream"
-        expect(envelopeItem.header.length) == UInt(encodedMetricsData.count)
-        expect(envelopeItem.data) == encodedMetricsData
+        XCTAssertEqual(envelopeItem.header.type, SentryEnvelopeItemTypeStatsd)
+        XCTAssertEqual(envelopeItem.header.contentType, "application/octet-stream")
+        XCTAssertEqual(envelopeItem.header.length, UInt(encodedMetricsData.count))
+        XCTAssertEqual(envelopeItem.data, encodedMetricsData)
     }
 
     func testCaptureMetricsWithNoMetrics() throws {
@@ -39,7 +38,7 @@ final class SentryMetricsClientTests: XCTestCase {
         let flushableBuckets: [BucketTimestamp: [CounterMetric]] = [:]
         sut.capture(flushableBuckets: flushableBuckets)
 
-        expect(testClient.captureEnvelopeInvocations.count) == 0
+        XCTAssertEqual(testClient.captureEnvelopeInvocations.count, 0)
     }
 
 }

--- a/Tests/SentryTests/Swift/Metrics/SetMetricTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/SetMetricTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -11,7 +10,10 @@ final class SetMetricTests: XCTestCase {
         sut.add(value: 1)
         sut.add(value: 2)
         
-        expect(sut.serialize()).to(contain(["1", "0", "2"]))
+        let serialized = sut.serialize()
+        XCTAssert(serialized.contains("0"))
+        XCTAssert(serialized.contains("1"))
+        XCTAssert(serialized.contains("2"))
     }
     
     func testAddUIntMax() {
@@ -19,19 +21,19 @@ final class SetMetricTests: XCTestCase {
         
         sut.add(value: UInt.max)
         
-        expect(sut.serialize()).to(contain(["\(UInt.max)"]))
+            XCTAssert(sut.serialize().contains("\(UInt.max)"))
     }
     
     func testType() {
         let sut = SetMetric(first: 0, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.type) == .set
+        XCTAssertEqual(sut.type, .set)
     }
     
     func testWeight() {
         let sut = SetMetric(first: 1, key: "key", unit: MeasurementUnitDuration.hour, tags: [:])
         
-        expect(sut.weight) == 1
+        XCTAssertEqual(sut.weight, 1)
         
         for _ in 0..<10 {
             sut.add(value: 5)
@@ -40,7 +42,7 @@ final class SetMetricTests: XCTestCase {
         sut.add(value: 3)
         sut.add(value: 2)
         
-        expect(sut.weight) == 4
+        XCTAssertEqual(sut.weight, 4)
     }
 
 }

--- a/Tests/SentryTests/Transaction/SentrySpanContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanContextTests.swift
@@ -82,7 +82,7 @@ class SentrySpanContextTests: XCTestCase {
         
         let data = spanContext.serialize()
         
-        XCTAssertEqual(data["sampled"] as? NSNumber, false)
+        XCTAssertFalse(try XCTUnwrap(data["sampled"] as? Bool))
     }
     
     func testSampleUndecidedSerialization() {

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -531,7 +530,7 @@ class SentrySpanTests: XCTestCase {
         let sut = fixture.getSut()
         
         let serialized = sut.serialize()
-        expect(serialized["_metrics_summary"]) == nil
+        XCTAssertNil(serialized["_metrics_summary"])
     }
     
     func testLocalMetricsAggregator_GetsSerializedAsMetricsSummary() throws {
@@ -543,15 +542,15 @@ class SentrySpanTests: XCTestCase {
         let serialized = sut.serialize()
         
         let metricsSummary = try XCTUnwrap(serialized["_metrics_summary"] as? [String: [[String: Any]]])
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["c:key"])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 1
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 1)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
     
     func testTraceHeaderNotSampled() {
@@ -682,9 +681,9 @@ class SentrySpanTests: XCTestCase {
         
         sut.finish()
         
-        expect(sut.data["frames.total"] as? NSNumber) == NSNumber(value: slow + frozen + normal)
-        expect(sut.data["frames.slow"] as? NSNumber) == NSNumber(value: slow)
-        expect(sut.data["frames.frozen"] as? NSNumber) == NSNumber(value: frozen)
+        XCTAssertEqual(sut.data["frames.total"] as? NSNumber, NSNumber(value: slow + frozen + normal))
+        XCTAssertEqual(sut.data["frames.slow"] as? NSNumber, NSNumber(value: slow))
+        XCTAssertEqual(sut.data["frames.frozen"] as? NSNumber, NSNumber(value: frozen))
     }
     
     func testDontAddAllZeroSlowFrozenFramesToData() {
@@ -694,9 +693,9 @@ class SentrySpanTests: XCTestCase {
         
         sut.finish()
         
-        expect(sut.data["frames.total"]) == nil
-        expect(sut.data["frames.slow"]) == nil
-        expect(sut.data["frames.frozen"]) == nil
+        XCTAssertNil(sut.data["frames.total"])
+        XCTAssertNil(sut.data["frames.slow"])
+        XCTAssertNil(sut.data["frames.frozen"])
     }
     
     func testAddFrameStatisticsToData_WithPreexistingCounts() {
@@ -718,14 +717,14 @@ class SentrySpanTests: XCTestCase {
         
         sut.finish()
         
-        expect(sut.data["frames.total"] as? NSNumber) == NSNumber(value: totalFrames)
-        expect(sut.data["frames.slow"] as? NSNumber) == NSNumber(value: slowFrames)
-        expect(sut.data["frames.frozen"] as? NSNumber) == NSNumber(value: frozenFrames)
+        XCTAssertEqual(sut.data["frames.total"] as? NSNumber, NSNumber(value: totalFrames))
+        XCTAssertEqual(sut.data["frames.slow"] as? NSNumber, NSNumber(value: slowFrames))
+        XCTAssertEqual(sut.data["frames.frozen"] as? NSNumber, NSNumber(value: frozenFrames))
         
         let expectedFrameDuration = slowFrameThreshold(displayLinkWrapper.currentFrameRate.rawValue)
         let expectedDelay = displayLinkWrapper.slowestSlowFrameDuration + displayLinkWrapper.fastestFrozenFrameDuration - expectedFrameDuration * 2 as NSNumber
         
-        expect(sut.data["frames.delay"] as? NSNumber).to(beCloseTo(expectedDelay, within: 0.0001))
+        XCTAssertEqual(try XCTUnwrap(sut.data["frames.delay"] as? NSNumber).doubleValue, expectedDelay.doubleValue, accuracy: 0.0001)
     }
     
     func testNoFramesTracker_NoFramesAddedToData() {
@@ -733,10 +732,10 @@ class SentrySpanTests: XCTestCase {
         
         sut.finish()
         
-        expect(sut.data["frames.total"]) == nil
-        expect(sut.data["frames.slow"]) == nil
-        expect(sut.data["frames.frozen"]) == nil
-        expect(sut.data["frames.delay"]) == nil
+        XCTAssertNil(sut.data["frames.total"])
+        XCTAssertNil(sut.data["frames.slow"])
+        XCTAssertNil(sut.data["frames.frozen"])
+        XCTAssertNil(sut.data["frames.delay"])
     }
     
     func givenFramesTracker() -> (TestDisplayLinkWrapper, SentryFramesTracker) {

--- a/Tests/SentryTests/Transaction/SentryTraceStateTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTraceStateTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 import SentryTestUtils
 import XCTest
 
@@ -143,25 +142,25 @@ class SentryTraceContextTests: XCTestCase {
         
         let baggage = traceContext.toBaggage()
         
-        expect(baggage.traceId) == fixture.traceId
-        expect(baggage.publicKey) == fixture.publicKey
-        expect(baggage.releaseName) == fixture.releaseName
-        expect(baggage.environment) == fixture.environment
-        expect(baggage.userSegment) == fixture.userSegment
-        expect(baggage.sampleRate) == fixture.sampleRate
-        expect(baggage.sampled) == fixture.sampled
-        expect(baggage.replayId) == fixture.replayId
+        XCTAssertEqual(baggage.traceId, fixture.traceId)
+        XCTAssertEqual(baggage.publicKey, fixture.publicKey)
+        XCTAssertEqual(baggage.releaseName, fixture.releaseName)
+        XCTAssertEqual(baggage.environment, fixture.environment)
+        XCTAssertEqual(baggage.userSegment, fixture.userSegment)
+        XCTAssertEqual(baggage.sampleRate, fixture.sampleRate)
+        XCTAssertEqual(baggage.sampled, fixture.sampled)
+        XCTAssertEqual(baggage.replayId, fixture.replayId)
     }
         
     func assertTraceState(traceContext: SentryTraceContext) {
-        expect(traceContext.traceId) == fixture.traceId
-        expect(traceContext.publicKey) == fixture.publicKey
-        expect(traceContext.releaseName) == fixture.releaseName
-        expect(traceContext.environment) == fixture.environment
-        expect(traceContext.transaction) == fixture.transactionName
-        expect(traceContext.userSegment) == fixture.userSegment
-        expect(traceContext.sampled) == fixture.sampled
-        expect(traceContext.replayId) == fixture.replayId
+        XCTAssertEqual(traceContext.traceId, fixture.traceId)
+        XCTAssertEqual(traceContext.publicKey, fixture.publicKey)
+        XCTAssertEqual(traceContext.releaseName, fixture.releaseName)
+        XCTAssertEqual(traceContext.environment, fixture.environment)
+        XCTAssertEqual(traceContext.transaction, fixture.transactionName)
+        XCTAssertEqual(traceContext.userSegment, fixture.userSegment)
+        XCTAssertEqual(traceContext.sampled, fixture.sampled)
+        XCTAssertEqual(traceContext.replayId, fixture.replayId)
     }
     
 }

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -1,4 +1,3 @@
-import Nimble
 @testable import Sentry
 import SentryTestUtils
 import XCTest
@@ -201,15 +200,15 @@ class SentryTransactionTests: XCTestCase {
         let serialized = sut.serialize()
         
         let metricsSummary = try XCTUnwrap(serialized["_metrics_summary"] as? [String: [[String: Any]]])
-        expect(metricsSummary.count) == 1
+        XCTAssertEqual(metricsSummary.count, 1)
         
         let bucket = try XCTUnwrap(metricsSummary["c:key"])
-        expect(bucket.count) == 1
+        XCTAssertEqual(bucket.count, 1)
         let metric = try XCTUnwrap(bucket.first)
-        expect(metric["min"] as? Double) == 1.0
-        expect(metric["max"] as? Double) == 1.0
-        expect(metric["count"] as? Int) == 1
-        expect(metric["sum"] as? Double) == 1.0
+        XCTAssertEqual(metric["min"] as? Double, 1.0)
+        XCTAssertEqual(metric["max"] as? Double, 1.0)
+        XCTAssertEqual(metric["count"] as? Int, 1)
+        XCTAssertEqual(metric["sum"] as? Double, 1.0)
     }
     
     func testSerializedSpanData() throws {

--- a/Tests/SentryTests/UIImageHelperTests.swift
+++ b/Tests/SentryTests/UIImageHelperTests.swift
@@ -1,6 +1,5 @@
 #if canImport(UIKit)
 import Foundation
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -15,7 +14,7 @@ class UIImageHelperTests: XCTestCase {
             context.fill(testFrame)
         }
         
-        expect(UIImageHelper.averageColor(of: image, at: self.testFrame)) == .red
+        XCTAssertEqual(UIImageHelper.averageColor(of: image, at: self.testFrame), .red)
         
         let end = Date()
         print("Duration = \(end.timeIntervalSince(begin))")
@@ -27,7 +26,7 @@ class UIImageHelperTests: XCTestCase {
             context.fill(testFrame)
         }
         
-        expect(UIImageHelper.averageColor(of: image, at: self.testFrame)) == .green
+        XCTAssertEqual(UIImageHelper.averageColor(of: image, at: self.testFrame), .green)
     }
     
     func testAverageColorBlue() {
@@ -36,7 +35,7 @@ class UIImageHelperTests: XCTestCase {
             context.fill(testFrame)
         }
         
-        expect(UIImageHelper.averageColor(of: image, at: self.testFrame)) == .blue
+        XCTAssertEqual(UIImageHelper.averageColor(of: image, at: self.testFrame), .blue)
     }
     
     func testAverageColorYellow() {
@@ -45,7 +44,7 @@ class UIImageHelperTests: XCTestCase {
             context.fill(testFrame)
         }
         
-        expect(UIImageHelper.averageColor(of: image, at: self.testFrame)) == .yellow
+        XCTAssertEqual(UIImageHelper.averageColor(of: image, at: self.testFrame), .yellow)
     }
     
     func testGreenAreaInARedImage() {
@@ -58,7 +57,7 @@ class UIImageHelperTests: XCTestCase {
             context.fill(focusArea)
         }
         
-        expect(UIImageHelper.averageColor(of: image, at: focusArea)) == .green
+        XCTAssertEqual(UIImageHelper.averageColor(of: image, at: focusArea), .green)
     }
 }
 

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -1,6 +1,5 @@
 #if os(iOS)
 import Foundation
-import Nimble
 @testable import Sentry
 import UIKit
 import XCTest
@@ -25,7 +24,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testRedactALabel() {
@@ -36,9 +35,9 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
-        expect(result.count) == 1
-        expect(result.first?.color) == .purple
-        expect(result.first?.rect) == CGRect(x: 20, y: 20, width: 40, height: 40)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.color, .purple)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 20, y: 20, width: 40, height: 40))
     }
     
     func testDontRedactALabelOptionDisabled() {
@@ -49,7 +48,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions(redactAllText: false))
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testRedactAImage() {
@@ -65,9 +64,9 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
-        expect(result.count) == 1
-        expect(result.first?.color) == nil
-        expect(result.first?.rect) == CGRect(x: 20, y: 20, width: 40, height: 40)
+        XCTAssertEqual(result.count, 1)
+        XCTAssertNil(result.first?.color)
+        XCTAssertEqual(result.first?.rect, CGRect(x: 20, y: 20, width: 40, height: 40))
     }
     
     func testDontRedactAImageOptionDisabled() {
@@ -83,7 +82,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions(redactAllImages: false))
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testDontRedactABundleImage() {
@@ -98,7 +97,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testDontRedactAHiddenView() {
@@ -109,7 +108,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testDontRedactATransparentView() {
@@ -120,7 +119,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testDontRedactALabelBehindAOpaqueView() {
@@ -131,7 +130,7 @@ class UIRedactBuilderTests: XCTestCase {
         topView.backgroundColor = .white
         rootView.addSubview(topView)
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
     func testRedactALabelBehindATransparentView() {
@@ -142,7 +141,7 @@ class UIRedactBuilderTests: XCTestCase {
         topView.backgroundColor = .clear
         rootView.addSubview(topView)
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
-        expect(result.count) == 1
+        XCTAssertEqual(result.count, 1)
     }
     
     func testIgnoreClasses() {
@@ -154,7 +153,7 @@ class UIRedactBuilderTests: XCTestCase {
         rootView.addSubview(AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40)))
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
-        expect(result.count) == 0
+        XCTAssertEqual(result.count, 0)
     }
     
 }

--- a/Tests/SentryTests/URLSessionTaskHelperTests.swift
+++ b/Tests/SentryTests/URLSessionTaskHelperTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Nimble
 @testable import Sentry
 import XCTest
 
@@ -13,7 +12,7 @@ final class URLSessionTaskHelperTests: XCTestCase {
 
         let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: task)
 
-        expect(operationName) == nil
+        XCTAssertNil(operationName)
     }
 
     func testHTTPBodyDataInvalid() {
@@ -24,7 +23,7 @@ final class URLSessionTaskHelperTests: XCTestCase {
 
         let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: task)
 
-        expect(operationName) == nil
+        XCTAssertNil(operationName)
     }
 
     func testHTTPBodyDataMissing() {
@@ -35,7 +34,7 @@ final class URLSessionTaskHelperTests: XCTestCase {
 
         let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: task)
 
-        expect(operationName) == nil
+        XCTAssertNil(operationName)
     }
 
     func testHTTPBodyDataValidGraphQL() {
@@ -54,7 +53,7 @@ final class URLSessionTaskHelperTests: XCTestCase {
 
         let operationName = URLSessionTaskHelper.getGraphQLOperationName(from: task)
 
-        expect(operationName) == "MyOperation"
+        XCTAssertEqual(operationName, "MyOperation")
     }
 
 }


### PR DESCRIPTION
This was added as a team experiment, but recently we decided not to move forward with it.

Lately, it has been causing me pain on every branch switch. Because SPM still has so many problems in Xcode, I would have to manually re-resolve packages to be able to run tests again. No network connection? Well, now you can't resolve the packages, so local testing ¯\\_(ツ)_/¯ This is the only thing we use SPM for in our SDK project, so will be a marked improvement to jettison.

There are several other reasons we decided not to move forward with Nimble, but I'm not going to repeat them here at this time.

Contains a couple other small fixes, like converting some more IUOs to `try XCTunwrap`, `XCTAssertTrue`->`XCTAssert`, `XCTAssertEqual(..., nil)`->`XCTAssertNil` etc

#skip-changelog