### PR TITLE
test: convert some test code from crashable to failable

### DIFF
--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -428,10 +428,8 @@ private extension SentryTraceProfilerTests {
         }
     }
 
-    func printTimestamps(entries: [[String: Any]]) throws -> [NSString] {
-        try entries.reduce(into: [NSString](), { partialResult, entry in
-            partialResult.append(try XCTUnwrap(entry["elapsed_since_start_ns"] as? NSString))
-        })
+    func printTimestamps(entries: [[String: Any]]) -> [NSString] {
+        entries.compactMap({ $0["elapsed_since_start_ns"] as? NSString })
     }
 
     func assertMetricEntries(measurements: [String: Any], key: String, expectedEntries: [[String: Any]], transaction: Transaction) throws {
@@ -441,7 +439,7 @@ private extension SentryTraceProfilerTests {
         let sortedExpectedEntries = try sortedByTimestamps(expectedEntries)
 
         guard actualEntries.count == expectedEntries.count else {
-            try XCTFail("Wrong number of values under \(key). expected: \(printTimestamps(entries: sortedExpectedEntries)); actual: \(printTimestamps(entries: sortedActualEntries)); transaction start time: \(transaction.startSystemTime)")
+            XCTFail("Wrong number of values under \(key). expected: \(printTimestamps(entries: sortedExpectedEntries)); actual: \(printTimestamps(entries: sortedActualEntries)); transaction start time: \(transaction.startSystemTime)")
             return
         }
 

--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -428,9 +428,9 @@ private extension SentryTraceProfilerTests {
         }
     }
 
-    func printTimestamps(entries: [[String: Any]]) -> [NSString] {
-        entries.reduce(into: [NSString](), { partialResult, entry in
-            partialResult.append(entry["elapsed_since_start_ns"] as! NSString)
+    func printTimestamps(entries: [[String: Any]]) throws -> [NSString] {
+        try entries.reduce(into: [NSString](), { partialResult, entry in
+            partialResult.append(try XCTUnwrap(entry["elapsed_since_start_ns"] as? NSString))
         })
     }
 
@@ -441,7 +441,7 @@ private extension SentryTraceProfilerTests {
         let sortedExpectedEntries = try sortedByTimestamps(expectedEntries)
 
         guard actualEntries.count == expectedEntries.count else {
-            XCTFail("Wrong number of values under \(key). expected: \(printTimestamps(entries: sortedExpectedEntries)); actual: \(printTimestamps(entries: sortedActualEntries)); transaction start time: \(transaction.startSystemTime)")
+            try XCTFail("Wrong number of values under \(key). expected: \(printTimestamps(entries: sortedExpectedEntries)); actual: \(printTimestamps(entries: sortedActualEntries)); transaction start time: \(transaction.startSystemTime)")
             return
         }
 

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -665,7 +665,7 @@ class SentryFileManagerTests: XCTestCase {
     
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     
-    func testReadPreviousBreadcrumbs() {
+    func testReadPreviousBreadcrumbs() throws {
         let observer = SentryWatchdogTerminationScopeObserver(maxBreadcrumbs: 2, fileManager: sut)
         
         for count in 0..<3 {
@@ -677,14 +677,17 @@ class SentryFileManagerTests: XCTestCase {
         }
         
         sut.moveBreadcrumbsToPreviousBreadcrumbs()
-        let result = sut.readPreviousBreadcrumbs()
+        var result = sut.readPreviousBreadcrumbs()
+        
         XCTAssertEqual(result.count, 3)
-        XCTAssertEqual((result[0] as! NSDictionary)["message"] as! String, "0")
-        XCTAssertEqual((result[1] as! NSDictionary)["message"] as! String, "1")
-        XCTAssertEqual((result[2] as! NSDictionary)["message"] as! String, "2")
+        XCTAssertEqual(try XCTUnwrap(result.first as? NSDictionary)["message"] as? String, "0")
+        result = [Any](result.dropFirst())
+        XCTAssertEqual(try XCTUnwrap(result.first as? NSDictionary)["message"] as? String, "1")
+        result = [Any](result.dropFirst())
+        XCTAssertEqual(try XCTUnwrap(result.first as? NSDictionary)["message"] as? String, "2")
     }
     
-    func testReadPreviousBreadcrumbsCorrectOrderWhenFileTwoHasMoreCrumbs() {
+    func testReadPreviousBreadcrumbsCorrectOrderWhenFileTwoHasMoreCrumbs() throws {
         let observer = SentryWatchdogTerminationScopeObserver(maxBreadcrumbs: 2, fileManager: sut)
         
         for count in 0..<5 {
@@ -696,11 +699,14 @@ class SentryFileManagerTests: XCTestCase {
         }
         
         sut.moveBreadcrumbsToPreviousBreadcrumbs()
-        let result = sut.readPreviousBreadcrumbs()
+        var result = sut.readPreviousBreadcrumbs()
+        
         XCTAssertEqual(result.count, 3)
-        XCTAssertEqual((result[0] as! NSDictionary)["message"] as! String, "2")
-        XCTAssertEqual((result[1] as! NSDictionary)["message"] as! String, "3")
-        XCTAssertEqual((result[2] as! NSDictionary)["message"] as! String, "4")
+        XCTAssertEqual(try XCTUnwrap(result.first as? NSDictionary)["message"] as? String, "2")
+        result = [Any](result.dropFirst())
+        XCTAssertEqual(try XCTUnwrap(result.first as? NSDictionary)["message"] as? String, "3")
+        result = [Any](result.dropFirst())
+        XCTAssertEqual(try XCTUnwrap(result.first as? NSDictionary)["message"] as? String, "4")
     }
     
 #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -28,7 +28,7 @@ class SentryFileManagerTests: XCTestCase {
         var delegate: TestFileManagerDelegate!
         // swiftlint:enable weak_delegate
         
-        init() {
+        init() throws {
             currentDateProvider = TestCurrentDateProvider()
             dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
             
@@ -39,7 +39,7 @@ class SentryFileManagerTests: XCTestCase {
             
             sessionEnvelope = SentryEnvelope(session: session)
             
-            let sessionCopy = session.copy() as! SentrySession
+            let sessionCopy = try XCTUnwrap(session.copy() as? SentrySession)
             sessionCopy.incrementErrors()
             // We need to serialize in order to set the timestamp and the duration
             sessionUpdate = SentrySession(jsonObject: sessionCopy.serialize())!
@@ -48,7 +48,7 @@ class SentryFileManagerTests: XCTestCase {
             let items = [SentryEnvelopeItem(session: sessionUpdate), SentryEnvelopeItem(event: event)]
             sessionUpdateEnvelope = SentryEnvelope(id: event.eventId, items: items)
             
-            let sessionUpdateCopy = sessionUpdate.copy() as! SentrySession
+            let sessionUpdateCopy = try XCTUnwrap(sessionUpdate.copy() as? SentrySession)
             // We need to serialize in order to set the timestamp and the duration
             expectedSessionUpdate = SentrySession(jsonObject: sessionUpdateCopy.serialize())!
             // We can only set the init flag after serialize, because the duration is not set if the init flag is set
@@ -75,9 +75,9 @@ class SentryFileManagerTests: XCTestCase {
     private var fixture: Fixture!
     private var sut: SentryFileManager!
     
-    override func setUp() {
-        super.setUp()
-        fixture = Fixture()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        fixture = try Fixture()
         SentryDependencyContainer.sharedInstance().dateProvider = fixture.currentDateProvider
         
         sut = fixture.getSut()

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -171,14 +171,14 @@ class SentryCoreDataTrackerTests: XCTestCase {
         try assertSave("INSERTED 2 items, UPDATED 2 items, DELETED 2 items")
     }
     
-    func test_Operation_InData() {
+    func test_Operation_InData() throws {
         fixture.context.inserted = [fixture.testEntity(), fixture.testEntity(), fixture.secondTestEntity()]
         fixture.context.updated = [fixture.testEntity(), fixture.secondTestEntity(), fixture.secondTestEntity()]
         fixture.context.deleted = [fixture.testEntity(), fixture.testEntity(), fixture.secondTestEntity(), fixture.secondTestEntity(), fixture.secondTestEntity()]
         
         let sut = fixture.getSut()
         
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         
         XCTAssertNoThrow(try sut.managedObjectContext(fixture.context) { _ in
             return true
@@ -223,10 +223,10 @@ class SentryCoreDataTrackerTests: XCTestCase {
         XCTAssertEqual(updated["SecondTestEntity"] as? Int, 2)
     }
     
-    func test_Request_with_Error() {
+    func test_Request_with_Error() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         let sut = fixture.getSut()
         
         let context = fixture.context
@@ -239,10 +239,10 @@ class SentryCoreDataTrackerTests: XCTestCase {
         XCTAssertEqual(transaction.children[0].status, .internalError)
     }
     
-    func test_Request_with_Error_is_nil() {
+    func test_Request_with_Error_is_nil() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         let sut = fixture.getSut()
         
         let context = fixture.context
@@ -255,8 +255,8 @@ class SentryCoreDataTrackerTests: XCTestCase {
         XCTAssertEqual(transaction.children[0].status, .internalError)
     }
     
-    func test_save_with_Error() {
-        let transaction = startTransaction()
+    func test_save_with_Error() throws {
+        let transaction = try startTransaction()
         let sut = fixture.getSut()
         fixture.context.inserted = [fixture.testEntity()]
         XCTAssertThrowsError(try sut.managedObjectContext(fixture.context) { _ in
@@ -267,8 +267,8 @@ class SentryCoreDataTrackerTests: XCTestCase {
         XCTAssertEqual(transaction.children[0].status, .internalError)
     }
     
-    func test_save_with_error_is_nil() {
-        let transaction = startTransaction()
+    func test_save_with_error_is_nil() throws {
+        let transaction = try startTransaction()
         let sut = fixture.getSut()
         fixture.context.inserted = [fixture.testEntity()]
         
@@ -280,10 +280,10 @@ class SentryCoreDataTrackerTests: XCTestCase {
         XCTAssertEqual(transaction.children[0].status, .internalError)
     }
     
-    func test_Save_NoChanges() {
+    func test_Save_NoChanges() throws {
         let sut = fixture.getSut()
         
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         
         XCTAssertNoThrow(try sut.managedObjectContext(fixture.context) { _ in
             return true
@@ -299,7 +299,7 @@ private extension SentryCoreDataTrackerTests {
     func assertSave(_ expectedDescription: String, mainThread: Bool = true) throws {
         let sut = fixture.getSut()
         
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         
         XCTAssertNoThrow(try sut.managedObjectContext(fixture.context) { _ in
             return true
@@ -311,7 +311,7 @@ private extension SentryCoreDataTrackerTests {
     }
     
     func assertRequest(_ fetch: NSFetchRequest<TestEntity>, expectedDescription: String, mainThread: Bool = true) throws {
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         let sut = fixture.getSut()
         
         let context = fixture.context
@@ -350,8 +350,8 @@ private extension SentryCoreDataTrackerTests {
         }
     }
     
-    private func startTransaction() -> SentryTracer {
-        return SentrySDK.startTransaction(name: "TestTransaction", operation: "TestTransaction", bindToScope: true) as! SentryTracer
+    private func startTransaction() throws -> SentryTracer {
+        return try XCTUnwrap(SentrySDK.startTransaction(name: "TestTransaction", operation: "TestTransaction", bindToScope: true) as? SentryTracer)
     }
     
 }

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -56,19 +56,19 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         assert_DontInstall { $0.enableCoreDataTracing = false }
     }
     
-    func test_Fetch() {
+    func test_Fetch() throws {
         SentrySDK.start(options: fixture.options)
         let stack = fixture.coreDataStack
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         var _ = try? stack.managedObjectContext.fetch(fetch)
         XCTAssertEqual(transaction.children.count, 1)
     }
     
-    func test_Save() {
+    func test_Save() throws {
         SentrySDK.start(options: fixture.options)
         let stack = fixture.coreDataStack
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         let newEntity: TestEntity = stack.getEntity()
         newEntity.field1 = "Some Update"
         try? stack.managedObjectContext.save()
@@ -77,30 +77,30 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(transaction.children[0].operation, "db.sql.transaction")
     }
     
-    func test_Save_noChanges() {
+    func test_Save_noChanges() throws {
         SentrySDK.start(options: fixture.options)
         let stack = fixture.coreDataStack
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         
         try? stack.managedObjectContext.save()
         
         XCTAssertEqual(transaction.children.count, 0)
     }
     
-    func test_Fetch_StoppedSwizzling() {
+    func test_Fetch_StoppedSwizzling() throws {
         SentrySDK.start(options: fixture.options)
         let stack = fixture.coreDataStack
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         SentryCoreDataSwizzling.sharedInstance.stop()
         var _ = try? stack.managedObjectContext.fetch(fetch)
         XCTAssertEqual(transaction.children.count, 0)
     }
     
-    func test_Save_StoppedSwizzling() {
+    func test_Save_StoppedSwizzling() throws {
         SentrySDK.start(options: fixture.options)
         let stack = fixture.coreDataStack
-        let transaction = startTransaction()
+        let transaction = try startTransaction()
         let newEntity: TestEntity = stack.getEntity()
         newEntity.field1 = "Some Update"
         SentryCoreDataSwizzling.sharedInstance.stop()
@@ -116,7 +116,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.coreDataTracker)
     }
     
-    private func startTransaction() -> SentryTracer {
-        return SentrySDK.startTransaction(name: "TestTransaction", operation: "TestTransaction", bindToScope: true) as! SentryTracer
+    private func startTransaction() throws -> SentryTracer {
+        return try XCTUnwrap(SentrySDK.startTransaction(name: "TestTransaction", operation: "TestTransaction", bindToScope: true) as? SentryTracer)
     }
 }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -176,7 +176,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         let children = Dynamic(transaction).children as [Span]?
         
         XCTAssertEqual(children?.count, 1) //Span was created in task resume swizzle.
-        let networkSpan = children![0]
+        let networkSpan = try XCTUnwrap(children?.first)
         XCTAssertTrue(networkSpan.isFinished) //Span was finished in task setState swizzle.
         XCTAssertEqual(SENTRY_NETWORK_REQUEST_OPERATION, networkSpan.operation)
         XCTAssertEqual("GET \(SentryNetworkTrackerIntegrationTests.testBaggageURL)", networkSpan.spanDescription)

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -44,26 +44,26 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertNil(configuration.httpAdditionalHeaders)
     }
     
-    func testNetworkTrackerDisabled_WhenNetworkTrackingDisabled() {
-        assertNetworkTrackerDisabled { options in
+    func testNetworkTrackerDisabled_WhenNetworkTrackingDisabled() throws {
+        try assertNetworkTrackerDisabled { options in
             options.enableNetworkTracking = false
         }
     }
     
-    func testNetworkTrackerDisabled_WhenAutoPerformanceTrackingDisabled() {
-        assertNetworkTrackerDisabled { options in
+    func testNetworkTrackerDisabled_WhenAutoPerformanceTrackingDisabled() throws {
+        try assertNetworkTrackerDisabled { options in
             options.enableAutoPerformanceTracing = false
         }
     }
     
-    func testNetworkTrackerDisabled_WhenTracingDisabled() {
-        assertNetworkTrackerDisabled { options in
+    func testNetworkTrackerDisabled_WhenTracingDisabled() throws {
+        try assertNetworkTrackerDisabled { options in
             options.tracesSampleRate = 0.0
         }
     }
     
-    func testNetworkTrackerDisabled_WhenSwizzlingDisabled() {
-        assertNetworkTrackerDisabled { options in
+    func testNetworkTrackerDisabled_WhenSwizzlingDisabled() throws {
+        try assertNetworkTrackerDisabled { options in
             options.enableSwizzling = false
         }
     }
@@ -274,13 +274,13 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertEqual(sentryResponse?["status_code"] as? NSNumber, 400)
     }
     
-    private func assertNetworkTrackerDisabled(configureOptions: (Options) -> Void) {
+    private func assertNetworkTrackerDisabled(configureOptions: (Options) -> Void) throws {
         configureOptions(fixture.options)
         
         startSDK()
         
         let configuration = URLSessionConfiguration.default
-        _ = startTransactionBoundToScope()
+        _ = try startTransactionBoundToScope()
         XCTAssertNil(configuration.httpAdditionalHeaders)
     }
         
@@ -290,8 +290,8 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         SentrySDK.start(options: self.fixture.options)
     }
     
-    private func startTransactionBoundToScope() -> SentryTracer {
-        return SentrySDK.startTransaction(name: "Test", operation: "test", bindToScope: true) as! SentryTracer
+    private func startTransactionBoundToScope() throws -> SentryTracer {
+        return try XCTUnwrap(SentrySDK.startTransaction(name: "Test", operation: "test", bindToScope: true) as? SentryTracer)
     }
     
     private func assertRemovedIntegration(_ options: Options) {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -106,12 +106,12 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
     /**
      * Reproduces https://github.com/getsentry/sentry-cocoa/issues/1288
      */
-    func testCustomURLProtocol_BlocksAllRequests() {
+    func testCustomURLProtocol_BlocksAllRequests() throws {
         startSDK()
         
         let expect = expectation(description: "Callback Expectation")
         
-        let customConfiguration = URLSessionConfiguration.default.copy() as! URLSessionConfiguration
+        let customConfiguration = try XCTUnwrap(URLSessionConfiguration.default.copy() as? URLSessionConfiguration)
         customConfiguration.protocolClasses?.insert(BlockAllRequestsProtocol.self, at: 0)
         let session = URLSession(configuration: customConfiguration)
         
@@ -154,9 +154,9 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertEqual(1, breadcrumbs?.count)
     }
     
-    func testGetRequest_SpanCreatedAndBaggageHeaderAdded() {
+    func testGetRequest_SpanCreatedAndBaggageHeaderAdded() throws {
         startSDK()
-        let transaction = SentrySDK.startTransaction(name: "Test Transaction", operation: "TEST", bindToScope: true) as! SentryTracer
+        let transaction = try XCTUnwrap(SentrySDK.startTransaction(name: "Test Transaction", operation: "TEST", bindToScope: true) as? SentryTracer)
         let expect = expectation(description: "Request completed")
         let session = URLSession(configuration: URLSessionConfiguration.default)
 
@@ -184,9 +184,9 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         XCTAssertEqual("200", networkSpan.data["http.response.status_code"] as? String)
     }
 
-    func testGetRequest_CompareSentryTraceHeader() {
+    func testGetRequest_CompareSentryTraceHeader() throws {
         startSDK()
-        let transaction = SentrySDK.startTransaction(name: "Test Transaction", operation: "TEST", bindToScope: true) as! SentryTracer
+        let transaction = try XCTUnwrap(SentrySDK.startTransaction(name: "Test Transaction", operation: "TEST", bindToScope: true) as? SentryTracer)
         let expect = expectation(description: "Request completed")
         let session = URLSession(configuration: URLSessionConfiguration.default)
         var response: String?

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -332,12 +332,12 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb!.level, .info)
         XCTAssertEqual(breadcrumb!.type, "http")
         XCTAssertEqual(breadcrumbs!.count, 1)
-        XCTAssertEqual(breadcrumb!.data!["url"] as! String, SentryNetworkTrackerTests.testUrl)
-        XCTAssertEqual(breadcrumb!.data!["method"] as! String, "GET")
-        XCTAssertEqual(breadcrumb!.data!["status_code"] as! NSNumber, NSNumber(value: 200))
-        XCTAssertEqual(breadcrumb!.data!["reason"] as! String, HTTPURLResponse.localizedString(forStatusCode: 200))
-        XCTAssertEqual(breadcrumb!.data!["request_body_size"] as! Int64, DATA_BYTES_SENT)
-        XCTAssertEqual(breadcrumb!.data!["response_body_size"] as! Int64, DATA_BYTES_RECEIVED)
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["url"] as? String), SentryNetworkTrackerTests.testUrl)
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "GET")
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["status_code"] as? NSNumber), NSNumber(value: 200))
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["reason"] as? String), HTTPURLResponse.localizedString(forStatusCode: 200))
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["request_body_size"] as? Int64), DATA_BYTES_SENT)
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["response_body_size"] as? Int64), DATA_BYTES_RECEIVED)
         XCTAssertEqual(breadcrumb!.data!["http.query"] as? String, "query=value&query2=value2")
         XCTAssertEqual(breadcrumb!.data!["http.fragment"] as? String, "fragment")
         XCTAssertNotNil(breadcrumb!.data!["request_start"])
@@ -460,8 +460,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb!.category, "http")
         XCTAssertEqual(breadcrumb!.level, .info)
         XCTAssertEqual(breadcrumb!.type, "http")
-        XCTAssertEqual(breadcrumb!.data!["url"] as! String, SentryNetworkTrackerTests.testUrl)
-        XCTAssertEqual(breadcrumb!.data!["method"] as! String, "GET")
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["url"] as? String), SentryNetworkTrackerTests.testUrl)
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "GET")
     }
 
     func testBreadcrumbWithoutSpan() {
@@ -479,8 +479,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb!.level, .info)
         XCTAssertEqual(breadcrumb!.type, "http")
         XCTAssertEqual(breadcrumbs!.count, 1)
-        XCTAssertEqual(breadcrumb!.data!["url"] as! String, SentryNetworkTrackerTests.testUrl)
-        XCTAssertEqual(breadcrumb!.data!["method"] as! String, "GET")
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["url"] as? String), SentryNetworkTrackerTests.testUrl)
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "GET")
     }
 
     func testNoDuplicatedBreadcrumbs() {
@@ -518,8 +518,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumb = breadcrumbs!.first
 
-        XCTAssertEqual(breadcrumb!.data!["status_code"] as! NSNumber, NSNumber(value: 404))
-        XCTAssertEqual(breadcrumb!.data!["reason"] as! String, HTTPURLResponse.localizedString(forStatusCode: 404))
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["status_code"] as? NSNumber), NSNumber(value: 404))
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["reason"] as? String), HTTPURLResponse.localizedString(forStatusCode: 404))
     }
 
     func testBreadcrumbWithError_AndPerformanceTrackingNotEnabled() {
@@ -539,8 +539,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumb!.level, .error)
         XCTAssertEqual(breadcrumb!.type, "http")
         XCTAssertEqual(breadcrumbs!.count, 1)
-        XCTAssertEqual(breadcrumb!.data!["url"] as! String, SentryNetworkTrackerTests.testUrl)
-        XCTAssertEqual(breadcrumb!.data!["method"] as! String, "GET")
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["url"] as? String), SentryNetworkTrackerTests.testUrl)
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "GET")
         XCTAssertNil(breadcrumb!.data!["status_code"])
         XCTAssertNil(breadcrumb!.data!["reason"])
     }
@@ -554,7 +554,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumb = breadcrumbs!.first
 
-        XCTAssertEqual(breadcrumb!.data!["method"] as! String, "POST")
+        XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "POST")
     }
 
     func test_NoBreadcrumb_forSentryAPI() {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -655,10 +655,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(task.observationInfo)
     }
 
-    func testBaggageHeader() {
+    func testBaggageHeader() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
-        let transaction = startTransaction() as! SentryTracer
+        let transaction = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
         let expectedBaggageHeader = transaction.traceContext.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
@@ -677,10 +677,10 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["baggage"] ?? "", "sentry-trace_id=something")
     }
 
-    func testTraceHeader() {
+    func testTraceHeader() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
-        let transaction = startTransaction() as! SentryTracer
+        let transaction = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
         let children = Dynamic(transaction).children as [SentrySpan]?

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -71,11 +71,11 @@ class SentryNetworkTrackerTests: XCTestCase {
         clearTestState()
     }
 
-    func testCaptureCompletion() {
+    func testCaptureCompletion() throws {
         let task = createDataTask()
         let span = spanForTask(task: task)!
 
-        assertCompletedSpan(task, span)
+        try assertCompletedSpan(task, span)
     }
 
     func test_CallResumeTwice_OneSpan() {
@@ -108,21 +108,21 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(span)
     }
 
-    func testCaptureDownloadTask() {
+    func testCaptureDownloadTask() throws {
         let task = createDownloadTask()
         let span = spanForTask(task: task)
 
         XCTAssertNotNil(span)
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertTrue(span!.isFinished)
     }
 
-    func testCaptureUploadTask() {
+    func testCaptureUploadTask() throws {
         let task = createUploadTask()
         let span = spanForTask(task: task)
 
         XCTAssertNotNil(span)
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertTrue(span!.isFinished)
     }
 
@@ -186,7 +186,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(spans?.count, 0)
     }
 
-    func testCaptureRequestDuration() {
+    func testCaptureRequestDuration() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
         let tracer = SentryTracer(transactionContext: TransactionContext(name: SentryNetworkTrackerTests.transactionName,
@@ -203,7 +203,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         advanceTime(bySeconds: 5)
 
         XCTAssertFalse(span.isFinished)
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertTrue(span.isFinished)
 
         assertSpanDuration(span: span, expectedDuration: 5)
@@ -218,12 +218,12 @@ class SentryNetworkTrackerTests: XCTestCase {
         assertStatus(status: .aborted, state: .suspended, response: URLResponse())
     }
 
-    func testCaptureRequestWithError() {
+    func testCaptureRequestWithError() throws {
         let task = createDataTask()
         let span = spanForTask(task: task)!
 
         task.setError(NSError(domain: "Some Error", code: 1, userInfo: nil))
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
 
         XCTAssertEqual(span.status, .unknownError)
     }
@@ -251,7 +251,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(status, .undefined)
     }
 
-    func testSpanRemovedFromAssociatedObject() {
+    func testSpanRemovedFromAssociatedObject() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
         let transaction = startTransaction()
@@ -263,11 +263,11 @@ class SentryNetworkTrackerTests: XCTestCase {
 
         XCTAssertFalse(spans!.first!.isFinished)
 
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertFalse(spans!.first!.isFinished)
     }
 
-    func testTaskStateChangedForRunning() {
+    func testTaskStateChangedForRunning() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
         let transaction = startTransaction()
@@ -277,7 +277,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         task.state = .running
         XCTAssertFalse(spans!.first!.isFinished)
 
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertTrue(spans!.first!.isFinished)
     }
 
@@ -290,7 +290,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(task.observationInfo)
     }
 
-    func testObserverForAnotherProperty() {
+    func testObserverForAnotherProperty() throws {
         let sut = fixture.getSut()
         let task = createDataTask()
         let transaction = startTransaction()
@@ -302,7 +302,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         sut.urlSessionTask(task, setState: .running)
         XCTAssertFalse(spans!.first!.isFinished)
 
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertTrue(spans!.first!.isFinished)
     }
 
@@ -464,13 +464,13 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "GET")
     }
 
-    func testBreadcrumbWithoutSpan() {
+    func testBreadcrumbWithoutSpan() throws {
         let task = createDataTask()
         let _ = spanForTask(task: task)!
 
         objc_removeAssociatedObjects(task)
 
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumb = breadcrumbs!.first
@@ -483,15 +483,15 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "GET")
     }
 
-    func testNoDuplicatedBreadcrumbs() {
+    func testNoDuplicatedBreadcrumbs() throws {
         let task = createDataTask()
         let _ = spanForTask(task: task)!
 
         objc_removeAssociatedObjects(task)
 
-        setTaskState(task, state: .completed)
-        setTaskState(task, state: .running)
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
+        try setTaskState(task, state: .running)
+        try setTaskState(task, state: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let amount = breadcrumbs?.count ?? 0
@@ -499,14 +499,14 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(amount, 1)
     }
 
-    func testWhenNoSpan_RemoveObserver() {
+    func testWhenNoSpan_RemoveObserver() throws {
         let task = createDataTask()
         let _ = spanForTask(task: task)!
 
         objc_removeAssociatedObjects(task)
 
-        setTaskState(task, state: .completed)
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(1, breadcrumbs?.count)
@@ -522,7 +522,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["reason"] as? String), HTTPURLResponse.localizedString(forStatusCode: 404))
     }
 
-    func testBreadcrumbWithError_AndPerformanceTrackingNotEnabled() {
+    func testBreadcrumbWithError_AndPerformanceTrackingNotEnabled() throws {
         fixture.options.enableAutoPerformanceTracing = false
 
         let task = createDataTask()
@@ -530,7 +530,7 @@ class SentryNetworkTrackerTests: XCTestCase {
 
         task.setError(NSError(domain: "Some Error", code: 1, userInfo: nil))
 
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumb = breadcrumbs!.first
@@ -545,11 +545,11 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(breadcrumb!.data!["reason"])
     }
 
-    func testBreadcrumbPost() {
+    func testBreadcrumbPost() throws {
         let task = createDataTask(method: "POST")
         let _ = spanForTask(task: task)!
 
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         let breadcrumb = breadcrumbs!.first
@@ -557,47 +557,47 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(breadcrumb!.data!["method"] as? String), "POST")
     }
 
-    func test_NoBreadcrumb_forSentryAPI() {
+    func test_NoBreadcrumb_forSentryAPI() throws {
         let sut = fixture.getSut()
         let task = fixture.sentryTask
 
-        setTaskState(task, state: .running)
+        try setTaskState(task, state: .running)
         sut.urlSessionTask(task, setState: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(breadcrumbs?.count, 0)
     }
 
-    func test_NoBreadcrumb_WithoutURL() {
+    func test_NoBreadcrumb_WithoutURL() throws {
         let sut = fixture.getSut()
         let task = URLSessionDataTaskMock()
 
-        setTaskState(task, state: .running)
+        try setTaskState(task, state: .running)
         sut.urlSessionTask(task, setState: .completed)
 
         let breadcrumbs = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(breadcrumbs?.count, 0)
     }
 
-    func testResumeAfterCompleted_OnlyOneSpanCreated() {
+    func testResumeAfterCompleted_OnlyOneSpanCreated() throws {
         let task = createDataTask()
         let sut = fixture.getSut()
         let transaction = startTransaction()
 
         sut.urlSessionTaskResume(task)
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         sut.urlSessionTaskResume(task)
 
         assertOneSpanCreated(transaction)
     }
 
-    func testResumeAfterCancelled_OnlyOneSpanCreated() {
+    func testResumeAfterCancelled_OnlyOneSpanCreated() throws {
         let task = createDataTask()
         let sut = fixture.getSut()
         let transaction = startTransaction()
 
         sut.urlSessionTaskResume(task)
-        setTaskState(task, state: .canceling)
+        try setTaskState(task, state: .canceling)
         sut.urlSessionTaskResume(task)
 
         assertOneSpanCreated(transaction)
@@ -626,7 +626,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         assertOneSpanCreated(transaction)
     }
 
-    func testChangeStateMultipleTimesConcurrent_OneSpanFinished() {
+    func testChangeStateMultipleTimesConcurrent_OneSpanFinished() throws {
         let task = createDataTask()
         let sut = fixture.getSut()
         let transaction = startTransaction()
@@ -638,7 +638,11 @@ class SentryNetworkTrackerTests: XCTestCase {
         for _ in 0...100_000 {
             group.enter()
             queue.async {
-                self.setTaskState(task, state: .completed)
+                do {
+                    try self.setTaskState(task, state: .completed)
+                } catch {
+                    XCTFail("Failed to set task state: \(error)")
+                }
                 group.leave()
             }
         }
@@ -930,8 +934,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(fixture.hub.capturedEventsWithScopes.first)
     }
 
-    func setTaskState(_ task: URLSessionTaskMock, state: URLSessionTask.State) {
-        fixture.getSut().urlSessionTask(task as! URLSessionTask, setState: state)
+    func setTaskState(_ task: URLSessionTaskMock, state: URLSessionTask.State) throws {
+        fixture.getSut().urlSessionTask(try XCTUnwrap(task as? URLSessionTask), setState: state)
         task.state = state
     }
 
@@ -978,11 +982,11 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(task.observationInfo)
     }
 
-    private func assertCompletedSpan(_ task: URLSessionDataTaskMock, _ span: Span) {
+    private func assertCompletedSpan(_ task: URLSessionDataTaskMock, _ span: Span) throws {
         XCTAssertNotNil(span)
         XCTAssertFalse(span.isFinished)
         XCTAssertEqual(task.currentRequest?.value(forHTTPHeaderField: SENTRY_TRACE_HEADER), span.toTraceHeader().value())
-        setTaskState(task, state: .completed)
+        try setTaskState(task, state: .completed)
         XCTAssertTrue(span.isFinished)
 
         //Test if it has observers. Nil means no observers

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -702,12 +702,12 @@ class SentryNetworkTrackerTests: XCTestCase {
     }
 
     @available(*, deprecated)
-    func testDefaultHeadersWhenDisabled() {
+    func testDefaultHeadersWhenDisabled() throws {
         let sut = fixture.getSut()
         sut.disable()
 
         let task = createDataTask()
-        _ = startTransaction() as! SentryTracer
+        _ = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
         let expectedTraceHeader = SentrySDK.currentHub().scope.propagationContext.traceHeader.value()
@@ -730,12 +730,12 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)
     }
 
-    func testNoHeadersForWrongUrl() {
+    func testNoHeadersForWrongUrl() throws {
         fixture.options.tracePropagationTargets = ["www.example.com"]
 
         let sut = fixture.getSut()
         let task = createDataTask()
-        _ = startTransaction() as! SentryTracer
+        _ = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
         XCTAssertNil(task.currentRequest?.allHTTPHeaderFields?["baggage"])

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -39,11 +39,11 @@ class SentryPerformanceTrackerTests: XCTestCase {
         clearTestState()
     }
    
-    func testStartSpan_CheckScopeSpan() {
+    func testStartSpan_CheckScopeSpan() throws {
         let sut = fixture.getSut()
         let spanId = startSpan(tracker: sut)
         
-        let transaction = sut.getSpan(spanId) as! SentryTracer
+        let transaction = try XCTUnwrap(sut.getSpan(spanId) as? SentryTracer)
         
         let scopeSpan = fixture.scope.span
         

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -102,11 +102,11 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         assertContext(context: context)
     }
     
-    func testEndSessionAsCrashed_WithCurrentSession() {
+    func testEndSessionAsCrashed_WithCurrentSession() throws {
         let expectedCrashedSession = givenCrashedSession()
         SentrySDK.setCurrentHub(fixture.hub)
         
-        advanceTime(bySeconds: 10)
+        try advanceTime(bySeconds: 10)
         
         let sut = fixture.getSut()
         sut.install(with: Options())
@@ -115,14 +115,14 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     }
     
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-    func testEndSessionAsCrashed_WhenOOM_WithCurrentSession() {
+    func testEndSessionAsCrashed_WhenOOM_WithCurrentSession() throws {
         givenOOMAppState()
         SentrySDK.startInvocations = 1
         
         let expectedCrashedSession = givenCrashedSession()
         
         SentrySDK.setCurrentHub(fixture.hub)
-        advanceTime(bySeconds: 10)
+        try advanceTime(bySeconds: 10)
         
         let sut = fixture.sutWithoutCrash
         sut.install(with: fixture.options)
@@ -371,7 +371,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         XCTAssertEqual(locale, device["locale"] as? String)
     }
     
-    private func advanceTime(bySeconds: TimeInterval) {
-        (SentryDependencyContainer.sharedInstance().dateProvider as! TestCurrentDateProvider).setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))
+    private func advanceTime(bySeconds: TimeInterval) throws {
+        try XCTUnwrap(SentryDependencyContainer.sharedInstance().dateProvider as? TestCurrentDateProvider).setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))
     }
 }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsScopeObserverTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsScopeObserverTests.swift
@@ -63,13 +63,13 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
   
     // Test that we're storing the serialized breadcrumb in a proper JSON string
     func testStoreBreadcrumb() throws {
-        let breadcrumb = fixture.breadcrumb.serialize() as! [String: String]
+        let breadcrumb = try XCTUnwrap(fixture.breadcrumb.serialize() as? [String: String])
 
         sut.addSerializedBreadcrumb(breadcrumb)
 
         let fileOneContents = try String(contentsOfFile: fixture.fileManager.breadcrumbsFilePathOne)
         let firstLine = String(fileOneContents.split(separator: "\n").first!)
-        let dict = try JSONSerialization.jsonObject(with: firstLine.data(using: .utf8)!) as! [String: String]
+        let dict = try XCTUnwrap(try JSONSerialization.jsonObject(with: firstLine.data(using: .utf8)!) as? [String: String])
 
         XCTAssertEqual(dict, breadcrumb)
     }
@@ -141,12 +141,12 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.fileManager.breadcrumbsFilePathTwo))
     }
     
-    func testWritingToClosedFile() {
-            let breadcrumb = fixture.breadcrumb.serialize() as! [String: String]
+    func testWritingToClosedFile() throws {
+            let breadcrumb = try XCTUnwrap(fixture.breadcrumb.serialize() as? [String: String])
 
             sut.addSerializedBreadcrumb(breadcrumb)
 
-            let fileHandle = Dynamic(sut).fileHandle.asObject as! FileHandle
+            let fileHandle = try XCTUnwrap(Dynamic(sut).fileHandle.asObject as? FileHandle)
             fileHandle.closeFile()
 
             sut.addSerializedBreadcrumb(breadcrumb)
@@ -155,8 +155,8 @@ class SentryWatchdogTerminationScopeObserverTests: XCTestCase {
             XCTAssertEqual(1, fixture.fileManager.readPreviousBreadcrumbs().count)
         }
 
-        func testWritingToFullFileSystem() {
-            let breadcrumb = fixture.breadcrumb.serialize() as! [String: String]
+        func testWritingToFullFileSystem() throws {
+            let breadcrumb = try XCTUnwrap(fixture.breadcrumb.serialize() as? [String: String])
 
             sut.addSerializedBreadcrumb(breadcrumb)
 

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -6,7 +6,7 @@ class SentryTransportFactoryTests: XCTestCase {
     
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentryTransportFactoryTests")
 
-    func testIntegration_UrlSessionDelegate_PassedToRequestManager() {
+    func testIntegration_UrlSessionDelegate_PassedToRequestManager() throws {
         let urlSessionDelegateSpy = UrlSessionDelegateSpy()
         
         let expect = expectation(description: "UrlSession Delegate of Options called in RequestManager")
@@ -21,7 +21,7 @@ class SentryTransportFactoryTests: XCTestCase {
         let fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
         let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager, currentDateProvider: TestCurrentDateProvider())
         let httpTransport = transports.first
-        let requestManager = Dynamic(httpTransport).requestManager.asObject as! SentryQueueableRequestManager
+        let requestManager = try XCTUnwrap(Dynamic(httpTransport).requestManager.asObject as? SentryQueueableRequestManager)
         
         let imgUrl = URL(string: "https://github.com")!
         let request = URLRequest(url: imgUrl)
@@ -47,7 +47,7 @@ class SentryTransportFactoryTests: XCTestCase {
         let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager, currentDateProvider: TestCurrentDateProvider())
                 
         let httpTransport = transports.first
-        let requestManager = Dynamic(httpTransport).requestManager.asObject as! SentryQueueableRequestManager
+        let requestManager = try XCTUnwrap(Dynamic(httpTransport).requestManager.asObject as? SentryQueueableRequestManager)
         
         let imgUrl = URL(string: "https://github.com")!
         let request = URLRequest(url: imgUrl)

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -35,8 +35,8 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         
         XCTAssertEqual(0, hub.startSessionInvocations)
         // Assert crashed session was attached to the envelope
-        XCTAssertEqual(sessionToBeCrashed!.sessionId.uuidString, attachedSession["sid"] as! String)
-        XCTAssertEqual("crashed", attachedSession["status"] as! String)
+        XCTAssertEqual(sessionToBeCrashed!.sessionId.uuidString, try XCTUnwrap(attachedSession["sid"] as? String))
+        XCTAssertEqual("crashed", try XCTUnwrap(attachedSession["status"] as? String))
     }
     
     func testCaptureEnvelope() {
@@ -67,8 +67,8 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         // Assert new session was started
         XCTAssertEqual(1, hub.startSessionInvocations)
         // Assert crashed session was attached to the envelope
-        XCTAssertEqual(sessionToBeCrashed!.sessionId.uuidString, attachedSession["sid"] as! String)
-        XCTAssertEqual("crashed", attachedSession["status"] as! String)
+        XCTAssertEqual(sessionToBeCrashed!.sessionId.uuidString, try XCTUnwrap(attachedSession["sid"] as? String))
+        XCTAssertEqual("crashed", try XCTUnwrap(attachedSession["status"] as? String))
     }
 
     func testSetSdkName() {

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -19,7 +19,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(envelope, client?.storedEnvelopeInvocations.first)
     }
     
-    func testStoreEnvelopeWithUndhandled_MarksSessionAsCrashedAndDoesNotStartNewSession() {
+    func testStoreEnvelopeWithUndhandled_MarksSessionAsCrashedAndDoesNotStartNewSession() throws {
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: nil)
         SentrySDK.setCurrentHub(hub)
@@ -31,7 +31,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         
         let storedEnvelope = client?.storedEnvelopeInvocations.first
         let attachedSessionData = storedEnvelope!.items.last!.data
-        let attachedSession = try! JSONSerialization.jsonObject(with: attachedSessionData) as! [String: Any]
+        let attachedSession = try XCTUnwrap(try! JSONSerialization.jsonObject(with: attachedSessionData) as? [String: Any])
         
         XCTAssertEqual(0, hub.startSessionInvocations)
         // Assert crashed session was attached to the envelope
@@ -50,7 +50,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         XCTAssertEqual(envelope, client?.captureEnvelopeInvocations.first)
     }
     
-    func testCaptureEnvelopeWithUndhandled_MarksSessionAsCrashedAndStartsNewSession() {
+    func testCaptureEnvelopeWithUndhandled_MarksSessionAsCrashedAndStartsNewSession() throws {
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: nil)
         SentrySDK.setCurrentHub(hub)
@@ -62,7 +62,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
 
         let capturedEnvelope = client?.captureEnvelopeInvocations.first
         let attachedSessionData = capturedEnvelope!.items.last!.data
-        let attachedSession = try! JSONSerialization.jsonObject(with: attachedSessionData) as! [String: Any]
+        let attachedSession = try XCTUnwrap(try! JSONSerialization.jsonObject(with: attachedSessionData) as? [String: Any])
         
         // Assert new session was started
         XCTAssertEqual(1, hub.startSessionInvocations)

--- a/Tests/SentryTests/Protocol/SentryClientReportTests.swift
+++ b/Tests/SentryTests/Protocol/SentryClientReportTests.swift
@@ -10,7 +10,7 @@ class SentryClientReportTests: XCTestCase {
         clearTestState()
     }
 
-    func testSerialize() {
+    func testSerialize() throws {
         SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
         
         let event1 = SentryDiscardedEvent(reason: .sampleRate, category: .transaction, quantity: 2)
@@ -23,7 +23,7 @@ class SentryClientReportTests: XCTestCase {
         
         XCTAssertEqual(SentryDependencyContainer.sharedInstance().dateProvider.date().timeIntervalSince1970, actual["timestamp"] as? TimeInterval)
         
-        let discardedEvents = actual["discarded_events"] as! [[String: Any]]
+        let discardedEvents = try XCTUnwrap(actual["discarded_events"] as? [[String: Any]])
         
         func assertEvent(event: [String: Any], reason: String, category: String, quantity: UInt) {
             XCTAssertEqual(reason, event["reason"] as? String)

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -56,8 +56,8 @@ class SentryEventTests: XCTestCase {
         let context = actual["contexts"] as? [String: [String: Any]]
         XCTAssertEqual(context?.count, 1)
         XCTAssertEqual(context?["context"]?.count, 2)
-        XCTAssertEqual(context?["context"]?["c"] as! String, "a")
-        XCTAssertEqual(context?["context"]?["date"] as! String, "1970-01-01T00:00:10.000Z")
+        XCTAssertEqual(try XCTUnwrap(context?["context"]?["c"] as? String), "a")
+        XCTAssertEqual(try XCTUnwrap(context?["context"]?["date"] as? String), "1970-01-01T00:00:10.000Z")
         
         XCTAssertNotNil(actual["message"] as? [String: Any])
         

--- a/Tests/SentryTests/Protocol/SentryExceptionTests.swift
+++ b/Tests/SentryTests/Protocol/SentryExceptionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 class SentryExceptionTests: XCTestCase {
 
-    func testSerialize() {
+    func testSerialize() throws {
         let exception = TestData.exception
         
         let actual = exception.serialize()
@@ -15,13 +15,13 @@ class SentryExceptionTests: XCTestCase {
         XCTAssertEqual(expected.type, actual["type"] as! String)
         XCTAssertEqual(expected.value, actual["value"] as! String)
         
-        let mechanism = actual["mechanism"] as! [String: Any]
+        let mechanism = try XCTUnwrap(actual["mechanism"] as? [String: Any])
         XCTAssertEqual(TestData.mechanism.desc, mechanism["description"] as? String)
         
         XCTAssertEqual(expected.module, actual["module"] as? String)
         XCTAssertEqual(expected.threadId, actual["thread_id"] as? NSNumber)
         
-        let stacktrace = actual["stacktrace"] as! [String: Any]
+        let stacktrace = try XCTUnwrap(actual["stacktrace"] as? [String: Any])
         XCTAssertEqual(TestData.stacktrace.registers, stacktrace["registers"] as? [String: String])
     }
 }

--- a/Tests/SentryTests/Protocol/SentryExceptionTests.swift
+++ b/Tests/SentryTests/Protocol/SentryExceptionTests.swift
@@ -12,8 +12,8 @@ class SentryExceptionTests: XCTestCase {
         exception.stacktrace?.registers = [:]
 
         let expected = TestData.exception
-        XCTAssertEqual(expected.type, actual["type"] as! String)
-        XCTAssertEqual(expected.value, actual["value"] as! String)
+        XCTAssertEqual(expected.type, try XCTUnwrap(actual["type"] as? String))
+        XCTAssertEqual(expected.value, try XCTUnwrap(actual["value"] as? String))
         
         let mechanism = try XCTUnwrap(actual["mechanism"] as? [String: Any])
         XCTAssertEqual(TestData.mechanism.desc, mechanism["description"] as? String)

--- a/Tests/SentryTests/Protocol/SentryGeoTests.swift
+++ b/Tests/SentryTests/Protocol/SentryGeoTests.swift
@@ -1,8 +1,8 @@
 import XCTest
 
 class SentryGeoTests: XCTestCase {
-    func testSerializationWithAllProperties() {
-        let geo = TestData.geo.copy() as! Geo
+    func testSerializationWithAllProperties() throws {
+        let geo = try XCTUnwrap(TestData.geo.copy() as? Geo)
         let actual = geo.serialize()
 
         // Changing the original doesn't modify the serialized
@@ -36,21 +36,21 @@ class SentryGeoTests: XCTestCase {
         XCTAssertEqual(TestData.geo, TestData.geo.copy() as! Geo)
     }
     
-    func testNotIsEqual() {
-        testIsNotEqual { geo in geo.city = "" }
-        testIsNotEqual { geo in geo.countryCode = "" }
-        testIsNotEqual { geo in geo.region = "" }
+    func testNotIsEqual() throws {
+        try testIsNotEqual { geo in geo.city = "" }
+        try testIsNotEqual { geo in geo.countryCode = "" }
+        try testIsNotEqual { geo in geo.region = "" }
     }
     
-    func testIsNotEqual(block: (Geo) -> Void ) {
-        let geo = TestData.geo.copy() as! Geo
+    func testIsNotEqual(block: (Geo) -> Void) throws {
+        let geo = try XCTUnwrap(TestData.geo.copy() as? Geo)
         block(geo)
         XCTAssertNotEqual(TestData.geo, geo)
     }
     
-    func testCopyWithZone_CopiesDeepCopy() {
+    func testCopyWithZone_CopiesDeepCopy() throws {
         let geo = TestData.geo
-        let copiedGeo = geo.copy() as! Geo
+        let copiedGeo = try XCTUnwrap(geo.copy() as? Geo)
         
         // Modifying the original does not change the copy
         geo.city = ""

--- a/Tests/SentryTests/Protocol/SentryGeoTests.swift
+++ b/Tests/SentryTests/Protocol/SentryGeoTests.swift
@@ -33,7 +33,7 @@ class SentryGeoTests: XCTestCase {
     }
     
     func testIsEqualToCopy() {
-        XCTAssertEqual(TestData.geo, TestData.geo.copy() as! Geo)
+        XCTAssertEqual(TestData.geo, try XCTUnwrap(TestData.geo.copy() as? Geo))
     }
     
     func testNotIsEqual() throws {

--- a/Tests/SentryTests/Protocol/SentryMeasurementUnitTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMeasurementUnitTests.swift
@@ -13,16 +13,16 @@ final class SentryMeasurementUnitTests: XCTestCase {
         XCTAssertEqual("", MeasurementUnit.none.unit)
     }
     
-    func testCopy() {
+    func testCopy() throws {
         let unit = "custom"
-        let sut = MeasurementUnit(unit: unit).copy() as! MeasurementUnit
+        let sut = try XCTUnwrap(MeasurementUnit(unit: unit).copy() as? MeasurementUnit)
 
         XCTAssertEqual(unit, sut.unit)
     }
     
-    func testCopyOfSubclass() {
+    func testCopyOfSubclass() throws {
         let unit = "custom"
-        let sut = MeasurementUnitDuration(unit: unit).copy() as! MeasurementUnitDuration
+        let sut = try XCTUnwrap(MeasurementUnitDuration(unit: unit).copy() as? MeasurementUnitDuration)
 
         XCTAssertEqual(unit, sut.unit)
     }

--- a/Tests/SentryTests/Protocol/SentryMechanismMetaTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismMetaTests.swift
@@ -27,19 +27,19 @@ class SentryMechanismMetaTests: XCTestCase {
             XCTFail("The serialization doesn't contain signal")
             return
         }
-        XCTAssertEqual(expected.signal?["number"] as! Int, signal["number"] as! Int)
-        XCTAssertEqual(expected.signal?["code"] as! Int, signal["code"] as! Int)
-        XCTAssertEqual(expected.signal?["name"] as! String, signal["name"] as! String)
-        XCTAssertEqual(expected.signal?["code_name"] as! String, signal["code_name"] as! String)
+        XCTAssertEqual(expected.signal?["number"] as! Int, try XCTUnwrap(signal["number"] as? Int))
+        XCTAssertEqual(expected.signal?["code"] as! Int, try XCTUnwrap(signal["code"] as? Int))
+        XCTAssertEqual(expected.signal?["name"] as! String, try XCTUnwrap(signal["name"] as? String))
+        XCTAssertEqual(expected.signal?["code_name"] as! String, try XCTUnwrap(signal["code_name"] as? String))
         
         guard let machException = actual["mach_exception"] as? [String: Any] else {
             XCTFail("The serialization doesn't contain mach_exception")
             return
         }
-        XCTAssertEqual(expected.machException?["name"] as! String, machException["name"] as! String)
-        XCTAssertEqual(expected.machException?["exception"] as! Int, machException["exception"] as! Int)
-        XCTAssertEqual(expected.machException?["subcode"] as! Int, machException["subcode"] as! Int)
-        XCTAssertEqual(expected.machException?["code"] as! Int, machException["code"] as! Int)
+        XCTAssertEqual(expected.machException?["name"] as! String, try XCTUnwrap(machException["name"] as? String))
+        XCTAssertEqual(expected.machException?["exception"] as! Int, try XCTUnwrap(machException["exception"] as? Int))
+        XCTAssertEqual(expected.machException?["subcode"] as! Int, try XCTUnwrap(machException["subcode"] as? Int))
+        XCTAssertEqual(expected.machException?["code"] as! Int, try XCTUnwrap(machException["code"] as? Int))
     }
     
     func testSerialize_CallsSanitize() {
@@ -52,10 +52,10 @@ class SentryMechanismMetaTests: XCTestCase {
         XCTAssertNotNil(actual)
         
         let machException = actual["mach_exception"] as? [String: Any]
-        XCTAssertEqual(self.description, machException?["a"]  as! String)
+        XCTAssertEqual(self.description, try XCTUnwrap(machException?["a"]  as? String))
         
         let signal = actual["signal"] as? [String: Any]
-        XCTAssertEqual(self.description, signal?["a"]  as! String)
+        XCTAssertEqual(self.description, try XCTUnwrap(signal?["a"]  as? String))
     }
 
 }

--- a/Tests/SentryTests/Protocol/SentryMechanismMetaTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismMetaTests.swift
@@ -27,19 +27,19 @@ class SentryMechanismMetaTests: XCTestCase {
             XCTFail("The serialization doesn't contain signal")
             return
         }
-        XCTAssertEqual(expected.signal?["number"] as! Int, try XCTUnwrap(signal["number"] as? Int))
-        XCTAssertEqual(expected.signal?["code"] as! Int, try XCTUnwrap(signal["code"] as? Int))
-        XCTAssertEqual(expected.signal?["name"] as! String, try XCTUnwrap(signal["name"] as? String))
-        XCTAssertEqual(expected.signal?["code_name"] as! String, try XCTUnwrap(signal["code_name"] as? String))
+        XCTAssertEqual(try XCTUnwrap(expected.signal?["number"] as? Int), try XCTUnwrap(signal["number"] as? Int))
+        XCTAssertEqual(try XCTUnwrap(expected.signal?["code"] as? Int), try XCTUnwrap(signal["code"] as? Int))
+        XCTAssertEqual(try XCTUnwrap(expected.signal?["name"] as? String), try XCTUnwrap(signal["name"] as? String))
+        XCTAssertEqual(try XCTUnwrap(expected.signal?["code_name"] as? String), try XCTUnwrap(signal["code_name"] as? String))
         
         guard let machException = actual["mach_exception"] as? [String: Any] else {
             XCTFail("The serialization doesn't contain mach_exception")
             return
         }
-        XCTAssertEqual(expected.machException?["name"] as! String, try XCTUnwrap(machException["name"] as? String))
-        XCTAssertEqual(expected.machException?["exception"] as! Int, try XCTUnwrap(machException["exception"] as? Int))
-        XCTAssertEqual(expected.machException?["subcode"] as! Int, try XCTUnwrap(machException["subcode"] as? Int))
-        XCTAssertEqual(expected.machException?["code"] as! Int, try XCTUnwrap(machException["code"] as? Int))
+        XCTAssertEqual(try XCTUnwrap(expected.machException?["name"] as? String), try XCTUnwrap(machException["name"] as? String))
+        XCTAssertEqual(try XCTUnwrap(expected.machException?["exception"] as? Int), try XCTUnwrap(machException["exception"] as? Int))
+        XCTAssertEqual(try XCTUnwrap(expected.machException?["subcode"] as? Int), try XCTUnwrap(machException["subcode"] as? Int))
+        XCTAssertEqual(try XCTUnwrap(expected.machException?["code"] as? Int), try XCTUnwrap(machException["code"] as? Int))
     }
     
     func testSerialize_CallsSanitize() {

--- a/Tests/SentryTests/Protocol/SentryMechanismTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismTests.swift
@@ -13,7 +13,7 @@ class SentryMechanismTests: XCTestCase {
         mechanism.meta = nil
 
         let expected = TestData.mechanism
-        XCTAssertEqual(expected.type, actual["type"] as! String)
+        XCTAssertEqual(expected.type, try XCTUnwrap(actual["type"] as? String))
         XCTAssertEqual(expected.desc, actual["description"] as? String)
         XCTAssertEqual(expected.handled, actual["handled"] as? NSNumber)
         XCTAssertEqual(expected.synthetic, actual["synthetic"] as? NSNumber)

--- a/Tests/SentryTests/Protocol/SentryThreadTests.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadTests.swift
@@ -10,7 +10,7 @@ class SentryThreadTests: XCTestCase {
         // Changing the original doesn't modify the serialized
         thread.stacktrace = nil
         
-        XCTAssertEqual(TestData.thread.threadId, actual["id"] as! NSNumber)
+        XCTAssertEqual(TestData.thread.threadId, try XCTUnwrap(actual["id"] as? NSNumber))
         XCTAssertFalse(actual["crashed"] as! Bool)
         XCTAssertTrue(actual["current"] as! Bool)
         XCTAssertEqual(TestData.thread.name, actual["name"] as? String)

--- a/Tests/SentryTests/Protocol/SentryThreadTests.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadTests.swift
@@ -11,11 +11,11 @@ class SentryThreadTests: XCTestCase {
         thread.stacktrace = nil
         
         XCTAssertEqual(TestData.thread.threadId, try XCTUnwrap(actual["id"] as? NSNumber))
-        XCTAssertFalse(actual["crashed"] as! Bool)
-        XCTAssertTrue(actual["current"] as! Bool)
-        XCTAssertEqual(TestData.thread.name, actual["name"] as? String)
+        XCTAssertFalse(try XCTUnwrap(actual["crashed"] as? Bool))
+        XCTAssertTrue(try XCTUnwrap(actual["current"] as? Bool))
+        XCTAssertEqual(TestData.thread.name, try XCTUnwrap(actual["name"] as? String))
         XCTAssertNotNil(actual["stacktrace"])
-        XCTAssertTrue(actual["main"] as! Bool)
+        XCTAssertTrue(try XCTUnwrap(actual["main"] as? Bool))
     }
     
     func testSerialize_ThreadNameNil() {

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -91,7 +91,7 @@ class SentryUserTests: XCTestCase {
     }
     
     func testIsEqualToCopy() {
-        XCTAssertEqual(TestData.user, TestData.user.copy() as! User)
+        XCTAssertEqual(TestData.user, try XCTUnwrap(TestData.user.copy() as? User))
     }
     
     func testNotIsEqual() throws {

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -26,8 +26,8 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(user.value(forKey: "unknown") as? NSDictionary, ["foo": "bar"])
     }
     
-    func testSerializationWithAllProperties() {
-        let user = TestData.user.copy() as! User
+    func testSerializationWithAllProperties() throws {
+        let user = try XCTUnwrap(TestData.user.copy() as? User)
         user.setValue(["some": "data"], forKey: "unknown")
         
         let actual = user.serialize()
@@ -94,26 +94,26 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(TestData.user, TestData.user.copy() as! User)
     }
     
-    func testNotIsEqual() {
-        testIsNotEqual { user in user.userId = "" }
-        testIsNotEqual { user in user.email = "" }
-        testIsNotEqual { user in user.username = "" }
-        testIsNotEqual { user in user.ipAddress = "" }
-        testIsNotEqual { user in user.segment = "" }
-        testIsNotEqual { user in user.name = "" }
-        testIsNotEqual { user in user.geo = Geo() }
-        testIsNotEqual { user in user.data?.removeAll() }
+    func testNotIsEqual() throws {
+        try testIsNotEqual { user in user.userId = "" }
+        try testIsNotEqual { user in user.email = "" }
+        try testIsNotEqual { user in user.username = "" }
+        try testIsNotEqual { user in user.ipAddress = "" }
+        try testIsNotEqual { user in user.segment = "" }
+        try testIsNotEqual { user in user.name = "" }
+        try testIsNotEqual { user in user.geo = Geo() }
+        try testIsNotEqual { user in user.data?.removeAll() }
     }
     
-    func testIsNotEqual(block: (User) -> Void ) {
-        let user = TestData.user.copy() as! User
+    func testIsNotEqual(block: (User) -> Void ) throws {
+        let user = try XCTUnwrap(TestData.user.copy() as? User)
         block(user)
         XCTAssertNotEqual(TestData.user, user)
     }
     
-    func testCopyWithZone_CopiesDeepCopy() {
+    func testCopyWithZone_CopiesDeepCopy() throws {
         let user = TestData.user
-        let copiedUser = user.copy() as! User
+        let copiedUser = try XCTUnwrap(user.copy() as? User)
         
         // Modifying the original does not change the copy
         user.userId = ""
@@ -128,11 +128,11 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(TestData.user, copiedUser)
     }
     
-    func testModifyingFromMultipleThreads() {
+    func testModifyingFromMultipleThreads() throws {
         let queue = DispatchQueue(label: "SentryUserTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
         let group = DispatchGroup()
         
-        let user = TestData.user.copy() as! User
+        let user = try XCTUnwrap(TestData.user.copy() as? User)
         
         for i in 0...20 {
             group.enter()

--- a/Tests/SentryTests/SentryCrash/CrashReport.swift
+++ b/Tests/SentryTests/SentryCrash/CrashReport.swift
@@ -17,6 +17,6 @@ extension XCTestCase {
     
     func getCrashReport(resource: String) throws -> [String: Any] {
         let jsonData = try jsonDataOfResource(resource: resource)
-        return try JSONSerialization.jsonObject(with: jsonData, options: []) as! [String: Any]
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: jsonData, options: []) as? [String: Any])
     }
 }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -354,30 +354,30 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(span.sampled, .no)
     }
     
-    func testCaptureTransaction_CapturesEventAsync() {
+    func testCaptureTransaction_CapturesEventAsync() throws {
         let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .yes))
         
         let trans = Dynamic(transaction).toTransaction().asAnyObject
-        sut.capture(trans as! Transaction, with: Scope())
+        sut.capture(try XCTUnwrap(trans as? Transaction), with: Scope())
         
         XCTAssertEqual(self.fixture.client.captureEventWithScopeInvocations.count, 1)
         XCTAssertEqual(self.fixture.dispatchQueueWrapper.dispatchAsyncInvocations.count, 1)
     }
     
-    func testCaptureSampledTransaction_DoesNotCaptureEvent() {
+    func testCaptureSampledTransaction_DoesNotCaptureEvent() throws {
         let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no))
         
         let trans = Dynamic(transaction).toTransaction().asAnyObject
-        sut.capture(trans as! Transaction, with: Scope())
+        sut.capture(try XCTUnwrap(trans as? Transaction), with: Scope())
         
         XCTAssertEqual(self.fixture.client.captureEventWithScopeInvocations.count, 0)
     }
     
-    func testCaptureSampledTransaction_RecordsLostEvent() {
+    func testCaptureSampledTransaction_RecordsLostEvent() throws {
         let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no))
         
         let trans = Dynamic(transaction).toTransaction().asAnyObject
-        sut.capture(trans as! Transaction, with: Scope())
+        sut.capture(try XCTUnwrap(trans as? Transaction), with: Scope())
         
         XCTAssertEqual(1, fixture.client.recordLostEvents.count)
         let lostEvent = fixture.client.recordLostEvents.first

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1155,7 +1155,7 @@ class SentryHubTests: XCTestCase {
     private func givenEnvelopeWithModifiedEvent(modifyEventDict: (inout [String: Any]) -> Void) throws -> SentryEnvelope {
         let event = TestData.event
         let envelopeItem = SentryEnvelopeItem(event: event)
-        var eventDict = try JSONSerialization.jsonObject(with: envelopeItem.data) as! [String: Any]
+        var eventDict = try XCTUnwrap(JSONSerialization.jsonObject(with: envelopeItem.data) as? [String: Any])
         
         modifyEventDict(&eventDict)
         

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -238,28 +238,28 @@ class SentryHubTests: XCTestCase {
         }
     }
     
-    func testStartTransactionWithNameOperation() {
+    func testStartTransactionWithNameOperation() throws {
         let span = fixture.getSut().startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation)
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
         XCTAssertEqual(span.operation, fixture.transactionOperation)
         XCTAssertEqual(SentryTransactionNameSource.custom, tracer.transactionContext.nameSource)
         XCTAssertEqual("manual", tracer.transactionContext.origin)
     }
     
-    func testStartTransactionWithContext() {
+    func testStartTransactionWithContext() throws {
         let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(
             name: fixture.transactionName,
             operation: fixture.transactionOperation
         ))
         
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
         XCTAssertEqual(span.operation, fixture.transactionOperation)
         XCTAssertEqual("manual", tracer.transactionContext.origin)
     }
     
-    func testStartTransactionWithNameSource() {
+    func testStartTransactionWithNameSource() throws {
         let span = fixture.getSut().startTransaction(transactionContext: TransactionContext(
             name: fixture.transactionName,
             nameSource: .url,
@@ -267,7 +267,7 @@ class SentryHubTests: XCTestCase {
             origin: fixture.traceOrigin
         ))
         
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         XCTAssertEqual(tracer.transactionContext.name, fixture.transactionName)
         XCTAssertEqual(tracer.transactionContext.nameSource, SentryTransactionNameSource.url)
         XCTAssertEqual(span.operation, fixture.transactionOperation)
@@ -791,7 +791,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(envelope, fixture.client.captureEnvelopeInvocations.first)
     }
     
-    func testCaptureEnvelope_WithUnhandledException() {
+    func testCaptureEnvelope_WithUnhandledException() throws {
         sut.startSession()
         
         fixture.currentDateProvider.setDate(date: Date(timeIntervalSince1970: 2))
@@ -806,7 +806,7 @@ class SentryHubTests: XCTestCase {
         let envelope = fixture.client.captureEnvelopeInvocations.first
         let sessionEnvelopeItem = envelope?.items.first(where: { $0.header.type == "session" })
         
-        let json = (try! JSONSerialization.jsonObject(with: sessionEnvelopeItem!.data)) as! [String: Any]
+        let json = try XCTUnwrap((try! JSONSerialization.jsonObject(with: sessionEnvelopeItem!.data)) as? [String: Any])
         
         XCTAssertEqual(json["timestamp"] as? String, "1970-01-01T00:00:02.000Z")
         XCTAssertEqual(json["status"] as? String, "crashed")
@@ -1039,7 +1039,7 @@ class SentryHubTests: XCTestCase {
         let sut = fixture.getSut(options)
         
         let span = sut.startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation, bindToScope: true)
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         
         sut.metrics.increment(key: "key")
         
@@ -1065,7 +1065,7 @@ class SentryHubTests: XCTestCase {
         let sut = fixture.getSut(options)
         
         let span = sut.startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation, bindToScope: true)
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         
         sut.metrics.increment(key: "key", tags: ["my": "tag", "release": "overwritten"])
         
@@ -1087,7 +1087,7 @@ class SentryHubTests: XCTestCase {
         let sut = fixture.getSut(options)
         
         let span = sut.startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation, bindToScope: true)
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         
         sut.metrics.increment(key: "key", tags: ["my": "tag"])
         
@@ -1111,7 +1111,7 @@ class SentryHubTests: XCTestCase {
         let sut = fixture.getSut(options)
         
         let span = sut.startTransaction(name: fixture.transactionName, operation: fixture.transactionOperation, bindToScope: true)
-        let tracer = span as! SentryTracer
+        let tracer = try XCTUnwrap(span as? SentryTracer)
         
         sut.metrics.increment(key: "key", tags: ["my": "tag"])
         

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -147,7 +147,7 @@ class SentryScopeSwiftTests: XCTestCase {
         cloned.setEnvironment("a789")
 
         XCTAssertEqual(scope.serialize() as! [String: AnyHashable], snapshot)
-        XCTAssertNotEqual(scope.serialize() as! [String: AnyHashable], cloned.serialize() as! [String: AnyHashable])
+        XCTAssertNotEqual(scope.serialize() as! [String: AnyHashable], try XCTUnwrap(cloned.serialize() as? [String: AnyHashable]))
     }
     
     func testApplyToEvent() {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -126,7 +126,7 @@ class SentryScopeSwiftTests: XCTestCase {
         let snapshot = try XCTUnwrap(scope.serialize() as? [String: AnyHashable])
 
         let cloned = Scope(scope: scope)
-        XCTAssertEqual(cloned.serialize() as! [String: AnyHashable], snapshot)
+        XCTAssertEqual(try XCTUnwrap(cloned.serialize() as? [String: AnyHashable]), snapshot)
 
         let (event1, event2) = (Event(), Event())
         (event1.timestamp, event2.timestamp) = (fixture.date, fixture.date)
@@ -146,8 +146,8 @@ class SentryScopeSwiftTests: XCTestCase {
         cloned.setDist("a456")
         cloned.setEnvironment("a789")
 
-        XCTAssertEqual(scope.serialize() as! [String: AnyHashable], snapshot)
-        XCTAssertNotEqual(scope.serialize() as! [String: AnyHashable], try XCTUnwrap(cloned.serialize() as? [String: AnyHashable]))
+        XCTAssertEqual(try XCTUnwrap(scope.serialize() as? [String: AnyHashable]), snapshot)
+        XCTAssertNotEqual(try XCTUnwrap(scope.serialize() as? [String: AnyHashable]), try XCTUnwrap(cloned.serialize() as? [String: AnyHashable]))
     }
     
     func testApplyToEvent() {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -119,11 +119,11 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertNotNil(actual["breadcrumbs"])
     }
 
-    func testInitWithScope() {
+    func testInitWithScope() throws {
         let scope = fixture.scope
         scope.span = fixture.transaction
 
-        let snapshot = scope.serialize() as! [String: AnyHashable]
+        let snapshot = try XCTUnwrap(scope.serialize() as? [String: AnyHashable])
 
         let cloned = Scope(scope: scope)
         XCTAssertEqual(cloned.serialize() as! [String: AnyHashable], snapshot)

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -134,8 +134,8 @@ class SentryScopeSwiftTests: XCTestCase {
         scope.applyTo(event: event1, maxBreadcrumbs: 10)
         cloned.applyTo(event: event2, maxBreadcrumbs: 10)
         XCTAssertEqual(
-            event1.serialize() as! [String: AnyHashable],
-            event2.serialize() as! [String: AnyHashable]
+            try XCTUnwrap(event1.serialize() as? [String: AnyHashable]),
+            try XCTUnwrap(event2.serialize() as? [String: AnyHashable])
         )
 
         cloned.setExtras(["aa": "b"])
@@ -601,7 +601,10 @@ class SentryScopeSwiftTests: XCTestCase {
         sut.addBreadcrumb(crumb)
         
         XCTAssertEqual(
-            [crumb.serialize() as! [String: AnyHashable], crumb.serialize() as! [String: AnyHashable]],
+            [
+                try XCTUnwrap(crumb.serialize() as? [String: AnyHashable]),
+                try XCTUnwrap(crumb.serialize() as? [String: AnyHashable])
+            ],
             observer.crumbs
         )
     }
@@ -719,7 +722,10 @@ class SentryScopeSwiftTests: XCTestCase {
         
         var crumbs: [[String: AnyHashable]] = []
         func addSerializedBreadcrumb(_ crumb: [String: Any]) {
-            crumbs.append(crumb as! [String: AnyHashable])
+            guard let typedCrumb = crumb as? [String: AnyHashable] else {
+                return
+            }
+            crumbs.append(typedCrumb)
         }
 
         var clearBreadcrumbInvocations = 0

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -43,13 +43,13 @@ class SentrySessionTestsSwift: XCTestCase {
         XCTAssertEqual(2, duration)
     }
 
-    func testCopySession() {
+    func testCopySession() throws {
         let user = User()
         user.email = "someone@sentry.io"
 
         let session = SentrySession(releaseName: "1.0.0", distinctId: "some-id")
         session.user = user
-        let copiedSession = session.copy() as! SentrySession
+        let copiedSession = try XCTUnwrap(session.copy() as? SentrySession)
 
         XCTAssertEqual(session, copiedSession)
 

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -367,8 +367,8 @@ class SentrySpanTests: XCTestCase {
         let lastEvent = try XCTUnwrap(client.captureEventWithScopeInvocations.invocations.first).event
         let serializedData = lastEvent.serialize()
         
-        let spans = serializedData["spans"] as! [Any]
-        let serializedChild = spans[0] as! [String: Any]
+        let spans = try XCTUnwrap(serializedData["spans"] as? [Any])
+        let serializedChild = try XCTUnwrap(spans[0] as? [String: Any])
         
         XCTAssertEqual(serializedChild["span_id"] as? String, childSpan.spanId.sentrySpanIdString)
         XCTAssertEqual(serializedChild["parent_span_id"] as? String, span.spanId.sentrySpanIdString)

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -432,7 +432,7 @@ class SentrySpanTests: XCTestCase {
         span.setData(value: fixture.extraValue, key: fixture.extraKey)
         
         XCTAssertEqual(span.data.count, 3)
-        XCTAssertEqual(span.data[fixture.extraKey] as! String, fixture.extraValue)
+        XCTAssertEqual(try XCTUnwrap(span.data[fixture.extraKey] as? String), fixture.extraValue)
         
         span.removeData(key: fixture.extraKey)
         XCTAssertEqual(span.data.count, 2, "Only expected thread.name and thread.id in data.")
@@ -479,8 +479,8 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNotNil(serialization["tags"])
         
         let data = serialization["data"] as? [String: Any]
-        XCTAssertEqual(data?[fixture.extraKey] as! String, fixture.extraValue)
-        XCTAssertEqual((serialization["tags"] as! Dictionary)[fixture.extraKey], fixture.extraValue)
+        XCTAssertEqual(try XCTUnwrap(data?[fixture.extraKey] as? String), fixture.extraValue)
+        XCTAssertEqual((try XCTUnwrap(serialization["tags"] as? Dictionary)[fixture.extraKey]), fixture.extraValue)
         XCTAssertEqual("manual", serialization["origin"] as? String)
     }
     

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -265,10 +265,11 @@ class SentrySpanTests: XCTestCase {
             
             expect.fulfill()
         }
-        XCTAssertEqual(NSNumber(value: try XCTUnwrap(threadId)), try XCTUnwrap(spanData?["thread.id"] as? NSNumber))
-        XCTAssertEqual(threadName, try XCTUnwrap(spanData?["thread.name"] as? String))
         
         wait(for: [expect], timeout: 1.0)
+        
+        XCTAssertEqual(NSNumber(value: try XCTUnwrap(threadId)), try XCTUnwrap(spanData?["thread.id"] as? NSNumber))
+        XCTAssertEqual(threadName, try XCTUnwrap(spanData?["thread.name"] as? String))
     }
     
     func testInit_SetsThreadInfoAsSpanData_FromBackgroundThreadWithNoName() {
@@ -285,10 +286,11 @@ class SentrySpanTests: XCTestCase {
             
             expect.fulfill()
         }
-        XCTAssertNil(try XCTUnwrap(spanData)["thread.name"])
-        XCTAssertEqual(NSNumber(value: try XCTUnwrap(threadId)), try XCTUnwrap(spanData?["thread.id"] as? NSNumber))
         
         wait(for: [expect], timeout: 1.0)
+        
+        XCTAssertNil(try XCTUnwrap(spanData)["thread.name"])
+        XCTAssertEqual(NSNumber(value: try XCTUnwrap(threadId)), try XCTUnwrap(spanData?["thread.id"] as? NSNumber))
     }
     
     func testFinish() throws {

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -165,7 +165,7 @@ class SentryTracerTests: XCTestCase {
         assertOneTransactionCaptured(sut)
         
         let serialization = try getSerializedTransaction()
-        let spans = serialization["spans"]! as! [[String: Any]]
+        let spans = try XCTUnwrap(serialization["spans"]! as? [[String: Any]])
         
         let tracerTimestamp: NSDate = sut.timestamp! as NSDate
         
@@ -191,7 +191,7 @@ class SentryTracerTests: XCTestCase {
         assertOneTransactionCaptured(sut)
     
         let serialization = try getSerializedTransaction()
-        let spans = serialization["spans"]! as! [[String: Any]]
+        let spans = try XCTUnwrap(serialization["spans"]! as? [[String: Any]])
         
         let tracerTimestamp: NSDate = sut.timestamp! as NSDate
         
@@ -728,7 +728,7 @@ class SentryTracerTests: XCTestCase {
 
         try assertMeasurements(["app_start_cold": ["value": fixture.appStartDuration * 1_000]])
 
-        let transaction = fixture.hub.capturedEventsWithScopes.first!.event as! Transaction
+        let transaction = try XCTUnwrap(fixture.hub.capturedEventsWithScopes.first!.event as? Transaction)
         assertAppStartsSpanAdded(transaction: transaction, startType: "Cold Start", operation: fixture.appStartColdOperation, appStartMeasurement: appStartMeasurement)
     }
     #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
@@ -790,7 +790,7 @@ class SentryTracerTests: XCTestCase {
 
         try assertMeasurements(["app_start_cold": ["value": fixture.appStartDuration * 1_000]])
 
-        let transaction = fixture.hub.capturedEventsWithScopes.first!.event as! Transaction
+        let transaction = try XCTUnwrap(fixture.hub.capturedEventsWithScopes.first!.event as? Transaction)
         assertPreWarmedAppStartsSpanAdded(transaction: transaction, startType: "Cold Start", operation: fixture.appStartColdOperation, appStartMeasurement: appStartMeasurement)
     }
 
@@ -916,7 +916,7 @@ class SentryTracerTests: XCTestCase {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
         SentrySDK.setAppStartMeasurement(appStartMeasurement)
         
-        let sut = fixture.hub.startTransaction(transactionContext: TransactionContext(name: "custom", operation: "custom")) as! SentryTracer
+        let sut = try XCTUnwrap(fixture.hub.startTransaction(transactionContext: TransactionContext(name: "custom", operation: "custom")) as? SentryTracer)
         sut.finish()
         
         XCTAssertNotNil(SentrySDK.getAppStartMeasurement())
@@ -928,7 +928,7 @@ class SentryTracerTests: XCTestCase {
         
         XCTAssertNil(measurements)
         
-        let spans = serializedTransaction["spans"]! as! [[String: Any]]
+        let spans = try XCTUnwrap(serializedTransaction["spans"]! as? [[String: Any]])
         XCTAssertEqual(0, spans.count)
     }
     
@@ -1114,7 +1114,7 @@ class SentryTracerTests: XCTestCase {
         
         assertOneTransactionCaptured(sut)
         
-        let spans = try getSerializedTransaction()["spans"]! as! [[String: Any]]
+        let spans = try XCTUnwrap(try getSerializedTransaction()["spans"]! as? [[String: Any]])
         XCTAssertEqual(spans.count, children * (grandchildren + 1) + 1)
     }
 
@@ -1188,7 +1188,7 @@ class SentryTracerTests: XCTestCase {
         queue.activate()
         group.wait()
         
-        let spans = try getSerializedTransaction()["spans"]! as! [[String: Any]]
+        let spans = try XCTUnwrap(try getSerializedTransaction()["spans"]! as? [[String: Any]])
         XCTAssertGreaterThanOrEqual(spans.count, children)
     }
     
@@ -1385,7 +1385,7 @@ class SentryTracerTests: XCTestCase {
         let serializedTransaction = try XCTUnwrap(fixture.hub.capturedEventsWithScopes.first).event.serialize()
         XCTAssertNil(serializedTransaction["measurements"])
         
-        let spans = serializedTransaction["spans"]! as! [[String: Any]]
+        let spans = try XCTUnwrap(serializedTransaction["spans"]! as? [[String: Any]])
         XCTAssertEqual(0, spans.count)
     }
 

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -298,10 +298,10 @@ class SentryTracerTests: XCTestCase {
         weak var weakSut: SentryTracer?
         
         // Added internal function so the tracer gets deallocated after executing this function.
-        func startTracer() {
+        func startTracer() throws {
             let sut = fixture.getSut()
             
-            timer = Dynamic(sut).deadlineTimer.asObject as! Timer?
+            timer = try XCTUnwrap(Dynamic(sut).deadlineTimer.asObject as? Timer)
             weakSut = sut
             
             // The TestHub keeps a reference to the tracer in capturedEventsWithScopes.
@@ -309,7 +309,7 @@ class SentryTracerTests: XCTestCase {
             sut.hub = nil
             sut.finish()
         }
-        startTracer()
+        try startTracer()
         
         XCTAssertNil(weakSut, "sut was not deallocated")
 

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -143,7 +143,7 @@ class SentryTransactionTests: XCTestCase {
         let serializedTransactionExtra = try! XCTUnwrap(serializedTransaction["extra"] as? [String: Any])
         
         // then
-        XCTAssertEqual(serializedTransactionExtra[fixture.testKey] as! String, fixture.testValue)
+        XCTAssertEqual(try XCTUnwrap(serializedTransactionExtra[fixture.testKey] as? String), fixture.testValue)
     }
     
     func testSerialize_shouldPreserveExtraFromScope() {
@@ -160,7 +160,7 @@ class SentryTransactionTests: XCTestCase {
         let serializedTransactionExtra = try! XCTUnwrap(serializedTransaction["extra"] as? [String: Any])
         
         // then
-        XCTAssertEqual(serializedTransactionExtra[fixture.testKey] as! String, fixture.testValue)
+        XCTAssertEqual(try XCTUnwrap(serializedTransactionExtra[fixture.testKey] as? String), fixture.testValue)
     }
     
     func testSerializeOrigin() throws {

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -69,8 +69,8 @@ class SentryTransactionTests: XCTestCase {
         XCTAssertNotNil(actualMeasurements)
         
         let coldStartMeasurement = actualMeasurements?[name]
-        XCTAssertEqual(value, coldStartMeasurement?["value"] as! NSNumber)
-        XCTAssertEqual(unit.unit, coldStartMeasurement?["unit"] as! String)
+        XCTAssertEqual(value, try XCTUnwrap(coldStartMeasurement?["value"] as? NSNumber))
+        XCTAssertEqual(unit.unit, try XCTUnwrap(coldStartMeasurement?["unit"] as? String))
     }
     
     func testSerializeMeasurements_MultipleMeasurements() {
@@ -92,12 +92,12 @@ class SentryTransactionTests: XCTestCase {
         XCTAssertNotNil(actualMeasurements)
         
         let frameMeasurement = actualMeasurements?[frameName]
-        XCTAssertEqual(frameValue, frameMeasurement?["value"] as! NSNumber)
+        XCTAssertEqual(frameValue, try XCTUnwrap(frameMeasurement?["value"] as? NSNumber))
         XCTAssertNil(frameMeasurement?["unit"])
         
         let customMeasurement = actualMeasurements?[customName]
-        XCTAssertEqual(customValue, customMeasurement?["value"] as! NSNumber)
-        XCTAssertEqual(customUnit.unit, customMeasurement?["unit"] as! String)
+        XCTAssertEqual(customValue, try XCTUnwrap(customMeasurement?["value"] as? NSNumber))
+        XCTAssertEqual(customUnit.unit, try XCTUnwrap(customMeasurement?["unit"] as? String))
     }
     
     func testSerialize_Tags() {


### PR DESCRIPTION
Helps fix #3576 

I hit one of these today so just went through and removed some easy ones. There are still almost 603 uses of the force unwrap operator and 154 unchecked array indexes in the test code after these changes.

<img width="287" alt="image" src="https://github.com/getsentry/sentry-cocoa/assets/3241469/6f0c5c8e-467b-4525-977e-fd1faf924692">
<img width="295" alt="image" src="https://github.com/getsentry/sentry-cocoa/assets/3241469/1afe3dcb-b32c-4cad-a637-e05812925bd2">


#skip-changelog