### PR TITLE
test: convert remaining unchecked accesses to failable versions

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -50,8 +50,8 @@
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
-      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
@@ -95,7 +95,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.enableContinuousProfiling"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.wipe-data"
@@ -155,7 +155,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--disable-ui-tracing"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -694,6 +694,7 @@
 		84AC61D729F75A98009EEF61 /* SentryDispatchFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 84AC61D529F75A98009EEF61 /* SentryDispatchFactory.m */; };
 		84AC61D929F7643B009EEF61 /* TestDispatchFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AC61D829F7643B009EEF61 /* TestDispatchFactory.swift */; };
 		84AC61DB29F7654A009EEF61 /* TestDispatchSourceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AC61DA29F7654A009EEF61 /* TestDispatchSourceWrapper.swift */; };
+		84AEB46A2C2F97FC007E46E1 /* ArrayAccesses.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84AEB4682C2F9673007E46E1 /* ArrayAccesses.swift */; };
 		84AF45A629A7FFA500FBB177 /* SentryProfiledTracerConcurrency.h in Headers */ = {isa = PBXBuildFile; fileRef = 84AF45A429A7FFA500FBB177 /* SentryProfiledTracerConcurrency.h */; };
 		84AF45A729A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84AF45A529A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm */; };
 		84B7FA3529B285FC00AD93B1 /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 63AA759B1EB8AEF500D153DE /* Sentry.framework */; };
@@ -1750,6 +1751,7 @@
 		84AC61D529F75A98009EEF61 /* SentryDispatchFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDispatchFactory.m; sourceTree = "<group>"; };
 		84AC61D829F7643B009EEF61 /* TestDispatchFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDispatchFactory.swift; sourceTree = "<group>"; };
 		84AC61DA29F7654A009EEF61 /* TestDispatchSourceWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDispatchSourceWrapper.swift; sourceTree = "<group>"; };
+		84AEB4682C2F9673007E46E1 /* ArrayAccesses.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayAccesses.swift; sourceTree = "<group>"; };
 		84AF45A429A7FFA500FBB177 /* SentryProfiledTracerConcurrency.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfiledTracerConcurrency.h; path = ../include/SentryProfiledTracerConcurrency.h; sourceTree = "<group>"; };
 		84AF45A529A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfiledTracerConcurrency.mm; sourceTree = "<group>"; };
 		84B7FA3B29B2866200AD93B1 /* SentryTestUtils-ObjC-BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryTestUtils-ObjC-BridgingHeader.h"; sourceTree = "<group>"; };
@@ -3449,6 +3451,7 @@
 		8431F00B29B284F200D8DC56 /* SentryTestUtils */ = {
 			isa = PBXGroup;
 			children = (
+				84AEB4682C2F9673007E46E1 /* ArrayAccesses.swift */,
 				841325DE2BFED0510029228F /* TestFramesTracker.swift */,
 				841325C42BF49EC40029228F /* SentryLaunchProfiling+Tests.h */,
 				7B4C817124D1BC2B0076ACE4 /* SentryFileManager+Test.h */,
@@ -5060,6 +5063,7 @@
 				84B7FA4229B28CDE00AD93B1 /* TestCurrentDateProvider.swift in Sources */,
 				62C25C862B075F4900C68CBD /* TestOptions.swift in Sources */,
 				62FC69362BEDFF18002D3EF2 /* SentryLogExtensions.swift in Sources */,
+				84AEB46A2C2F97FC007E46E1 /* ArrayAccesses.swift in Sources */,
 				84B7FA3F29B28BAD00AD93B1 /* TestTransport.swift in Sources */,
 				84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */,
 				62AB8C9E2BF3925700BFC2AC /* WeakReference.swift in Sources */,

--- a/SentryTestUtils/ArrayAccesses.swift
+++ b/SentryTestUtils/ArrayAccesses.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+public extension Array {
+    func element(at index: Int) -> Self.Element? {
+        guard count >= index else {
+            return nil
+        }
+        return self[index]
+    }
+}

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -196,8 +196,8 @@ private extension SentryContinuousProfilerTests {
 
         let frames = try XCTUnwrap(sampledProfile["frames"] as? [[String: Any]])
         XCTAssertFalse(frames.isEmpty)
-        XCTAssertFalse(try XCTUnwrap(frames[0]["instruction_addr"] as? String).isEmpty)
-        XCTAssertFalse(try XCTUnwrap(frames[0]["function"] as? String).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(frames.first?["instruction_addr"] as? String).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(frames.first?["function"] as? String).isEmpty)
 
         let stacks = try XCTUnwrap(sampledProfile["stacks"] as? [[Int]])
         var foundAtLeastOneNonEmptySample = false
@@ -288,7 +288,7 @@ private extension SentryContinuousProfilerTests {
             let actualValue = try XCTUnwrap(values[1]["value"] as? T)
             XCTAssertEqual(actualValue, expectedValue, "Wrong value for \(key)")
 
-            let timestamp = try XCTUnwrap(values[0]["timestamp"] as? TimeInterval)
+            let timestamp = try XCTUnwrap(values.first?["timestamp"] as? TimeInterval)
             try assertTimestampOccursWithinTransaction(timestamp: timestamp, chunkStartTime: chunkStartTime, chunkEndTime: chunkEndTime)
 
             let actualUnits = try XCTUnwrap(metricContainer["unit"] as? String)

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -285,7 +285,7 @@ private extension SentryContinuousProfilerTests {
         XCTAssertEqual(values.count, readingsPerBatch - (expectOneLessEnergyReading ? 1 : 0), "Wrong number of values under \(key); (expectOneLessEnergyReading: \(expectOneLessEnergyReading))")
 
         if let expectedValue = expectedValue {
-            let actualValue = try XCTUnwrap(values[1]["value"] as? T)
+            let actualValue = try XCTUnwrap(try XCTUnwrap(values.element(at: 1))["value"] as? T)
             XCTAssertEqual(actualValue, expectedValue, "Wrong value for \(key)")
 
             let timestamp = try XCTUnwrap(values.first?["timestamp"] as? TimeInterval)

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -178,7 +178,7 @@ private extension SentryContinuousProfilerTests {
         let debugMeta = try XCTUnwrap(profile["debug_meta"] as? [String: Any])
         let images = try XCTUnwrap(debugMeta["images"] as? [[String: Any]])
         XCTAssertFalse(images.isEmpty)
-        let firstImage = images[0]
+        let firstImage = try XCTUnwrap(images.first)
         XCTAssertFalse(try XCTUnwrap(firstImage["code_file"] as? String).isEmpty)
         XCTAssertFalse(try XCTUnwrap(firstImage["debug_id"] as? String).isEmpty)
         XCTAssertFalse(try XCTUnwrap(firstImage["image_addr"] as? String).isEmpty)

--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -464,7 +464,7 @@ private extension SentryTraceProfilerTests {
         XCTAssertEqual(values.count, numberOfReadings, "Wrong number of values under \(key)")
 
         if let expectedValue = expectedValue {
-            let actualValue = try XCTUnwrap(values[1]["value"] as? T)
+            let actualValue = try XCTUnwrap(values.element(at: 1)?["value"] as? T)
             XCTAssertEqual(actualValue, expectedValue, "Wrong value for \(key)")
 
             let timestamp = try XCTUnwrap(values.first?["elapsed_since_start_ns"] as? NSString)

--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -467,7 +467,7 @@ private extension SentryTraceProfilerTests {
             let actualValue = try XCTUnwrap(values[1]["value"] as? T)
             XCTAssertEqual(actualValue, expectedValue, "Wrong value for \(key)")
 
-            let timestamp = try XCTUnwrap(values[0]["elapsed_since_start_ns"] as? NSString)
+            let timestamp = try XCTUnwrap(values.first?["elapsed_since_start_ns"] as? NSString)
             try assertTimestampOccursWithinTransaction(timestamp: timestamp, transaction: transaction)
 
             let actualUnits = try XCTUnwrap(metricContainer["unit"] as? String)
@@ -555,8 +555,8 @@ private extension SentryTraceProfilerTests {
 
         let frames = try XCTUnwrap(sampledProfile["frames"] as? [[String: Any]])
         XCTAssertFalse(frames.isEmpty)
-        XCTAssertFalse(try XCTUnwrap(frames[0]["instruction_addr"] as? String).isEmpty)
-        XCTAssertFalse(try XCTUnwrap(frames[0]["function"] as? String).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(frames.first?["instruction_addr"] as? String).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(frames.first?["function"] as? String).isEmpty)
 
         let stacks = try XCTUnwrap(sampledProfile["stacks"] as? [[Int]])
         var foundAtLeastOneNonEmptySample = false

--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -527,7 +527,7 @@ private extension SentryTraceProfilerTests {
         let debugMeta = try XCTUnwrap(profile["debug_meta"] as? [String: Any])
         let images = try XCTUnwrap(debugMeta["images"] as? [[String: Any]])
         XCTAssertFalse(images.isEmpty)
-        let firstImage = images[0]
+        let firstImage = try XCTUnwrap(images.first)
         XCTAssertFalse(try XCTUnwrap(firstImage["code_file"] as? String).isEmpty)
         XCTAssertFalse(try XCTUnwrap(firstImage["debug_id"] as? String).isEmpty)
         XCTAssertFalse(try XCTUnwrap(firstImage["image_addr"] as? String).isEmpty)

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -131,7 +131,7 @@ class SentryFileManagerTests: XCTestCase {
         let envelopes = sut.getAllEnvelopes()
         XCTAssertEqual(1, envelopes.count)
         
-        let actualData = envelopes[0].contents
+        let actualData = try XCTUnwrap(envelopes.first).contents
         XCTAssertEqual(expectedData, actualData as Data)
     }
     
@@ -375,7 +375,7 @@ class SentryFileManagerTests: XCTestCase {
         assertSessionEnvelopesStored(count: 1)
     }
     
-    func testMigrateSessionInit_MovesInitFlagOnlyToFirstSessionUpdate() {
+    func testMigrateSessionInit_MovesInitFlagOnlyToFirstSessionUpdate() throws {
         sut.store(fixture.sessionEnvelope)
         for _ in 0...10 {
             sut.store(TestConstants.envelope)
@@ -388,8 +388,8 @@ class SentryFileManagerTests: XCTestCase {
         }
         
         assertSessionInitMoved(sut.getAllEnvelopes()[10])
-        assertSessionInitNotMoved(sut.getAllEnvelopes()[11])
-        assertSessionInitNotMoved(sut.getAllEnvelopes()[12])
+        try assertSessionInitNotMoved(sut.getAllEnvelopes()[11])
+        try assertSessionInitNotMoved(sut.getAllEnvelopes()[12])
         assertSessionEnvelopesStored(count: 3)
     }
     
@@ -919,11 +919,11 @@ private extension SentryFileManagerTests {
         XCTAssertEqual(fixture.expectedSessionUpdate, actualSession)
     }
     
-    func assertSessionInitNotMoved(_ actualSessionFileContents: SentryFileContents) {
+    func assertSessionInitNotMoved(_ actualSessionFileContents: SentryFileContents) throws {
         let actualSessionEnvelope = SentrySerialization.envelope(with: actualSessionFileContents.contents)
         XCTAssertEqual(2, actualSessionEnvelope?.items.count)
 
-        let actualSession = SentrySerialization.session(with: actualSessionEnvelope?.items[0].data ?? Data())
+        let actualSession = SentrySerialization.session(with: try XCTUnwrap(actualSessionEnvelope?.items.first).data)
         XCTAssertNotNil(actualSession)
 
         XCTAssertEqual(fixture.sessionUpdate, actualSession)

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -7,7 +7,7 @@ class SentrySerializationTests: XCTestCase {
         static var invalidData = "hi".data(using: .utf8)!
         static var traceContext = SentryTraceContext(trace: SentryId(), publicKey: "PUBLIC_KEY", releaseName: "RELEASE_NAME", environment: "TEST", transaction: "transaction", userSegment: "some segment", sampleRate: "0.25", sampled: "true", replayId: nil)
     }
-
+    
     func testSerializationFailsWithInvalidJSONObject() {
         let json: [String: Any] = [
             "valid object": "hi, i'm a valid object",
@@ -16,11 +16,11 @@ class SentrySerializationTests: XCTestCase {
         let data = SentrySerialization.data(withJSONObject: json)
         XCTAssertNil(data)
     }
-
-    func testSentryEnvelopeSerializer_WithSingleEvent() {
+    
+    func testSentryEnvelopeSerializer_WithSingleEvent() throws {
         // Arrange
         let event = Event()
-
+        
         let item = SentryEnvelopeItem(event: event)
         let envelope = SentryEnvelope(id: event.eventId, singleItem: item)
         envelope.header.sentAt = Date(timeIntervalSince1970: 9_001)
@@ -28,142 +28,135 @@ class SentrySerializationTests: XCTestCase {
         // Sanity check
         XCTAssertEqual(event.eventId, envelope.header.eventId)
         XCTAssertEqual(1, envelope.items.count)
-        XCTAssertEqual("event", envelope.items[0].header.type)
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertEqual(envelope.header.eventId, deserializedEnvelope.header.eventId)
-            assertDefaultSdkInfoSet(deserializedEnvelope: deserializedEnvelope)
-            XCTAssertEqual(1, deserializedEnvelope.items.count)
-            XCTAssertEqual("event", envelope.items[0].header.type)
-            XCTAssertEqual(envelope.items[0].header.length, deserializedEnvelope.items[0].header.length)
-            XCTAssertEqual(envelope.items[0].data, deserializedEnvelope.items[0].data)
-            XCTAssertNil(deserializedEnvelope.header.traceContext)
-            XCTAssertEqual(Date(timeIntervalSince1970: 9_001), deserializedEnvelope.header.sentAt)
-        }
+        XCTAssertEqual("event", try XCTUnwrap(envelope.items.first).header.type)
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertEqual(envelope.header.eventId, deserializedEnvelope.header.eventId)
+        assertDefaultSdkInfoSet(deserializedEnvelope: deserializedEnvelope)
+        XCTAssertEqual(1, deserializedEnvelope.items.count)
+        XCTAssertEqual("event", try XCTUnwrap(envelope.items.first).header.type)
+        XCTAssertEqual(try XCTUnwrap(envelope.items.first).header.length, try XCTUnwrap(deserializedEnvelope.items.first).header.length)
+        XCTAssertEqual(try XCTUnwrap(envelope.items.first).data, try XCTUnwrap(deserializedEnvelope.items.first).data)
+        XCTAssertNil(deserializedEnvelope.header.traceContext)
+        XCTAssertEqual(Date(timeIntervalSince1970: 9_001), deserializedEnvelope.header.sentAt)
     }
-
-    func testSentryEnvelopeSerializer_WithManyItems() {
+    
+    func testSentryEnvelopeSerializer_WithManyItems() throws {
         // Arrange
         let itemsCount = 15
         var items: [SentryEnvelopeItem] = []
         for i in 0..<itemsCount {
             let bodyChar = "\(i)"
             let bodyString = bodyChar.padding(
-                    toLength: i + 1,
-                    withPad: bodyChar,
-                    startingAt: 0)
-
+                toLength: i + 1,
+                withPad: bodyChar,
+                startingAt: 0)
+            
             let itemData = bodyString.data(using: .utf8)!
             let itemHeader = SentryEnvelopeItemHeader(type: bodyChar, length: UInt(itemData.count))
             let item = SentryEnvelopeItem(
-                    header: itemHeader,
-                    data: itemData)
+                header: itemHeader,
+                data: itemData)
             items.append(item)
         }
-
+        
         let envelope = SentryEnvelope(id: nil, items: items)
         // Sanity check
         XCTAssertNil(envelope.header.eventId)
         XCTAssertEqual(itemsCount, Int(envelope.items.count))
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertNil(deserializedEnvelope.header.eventId)
-            XCTAssertEqual(itemsCount, deserializedEnvelope.items.count)
-            assertDefaultSdkInfoSet(deserializedEnvelope: deserializedEnvelope)
-
-            for j in 0..<itemsCount {
-                XCTAssertEqual("\(j)", envelope.items[j].header.type)
-                XCTAssertEqual(
-                        envelope.items[j].header.length,
-                        deserializedEnvelope.items[j].header.length)
-                XCTAssertEqual(envelope.items[j].data, deserializedEnvelope.items[j].data)
-            }
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertNil(deserializedEnvelope.header.eventId)
+        XCTAssertEqual(itemsCount, deserializedEnvelope.items.count)
+        assertDefaultSdkInfoSet(deserializedEnvelope: deserializedEnvelope)
+        
+        for j in 0..<itemsCount {
+            XCTAssertEqual("\(j)", envelope.items[j].header.type)
+            XCTAssertEqual(
+                envelope.items[j].header.length,
+                deserializedEnvelope.items[j].header.length)
+            XCTAssertEqual(envelope.items[j].data, deserializedEnvelope.items[j].data)
         }
     }
-
-    func testSentryEnvelopeSerializesWithZeroByteItem() {
+    
+    func testSentryEnvelopeSerializesWithZeroByteItem() throws {
         // Arrange
         let itemData = Data()
         let itemHeader = SentryEnvelopeItemHeader(type: "attachment", length: UInt(itemData.count))
-
+        
         let item = SentryEnvelopeItem(header: itemHeader, data: itemData)
         let envelope = SentryEnvelope(id: nil, singleItem: item)
-
+        
         // Sanity check
         XCTAssertEqual(1, envelope.items.count)
-        XCTAssertEqual("attachment", envelope.items[0].header.type)
-        XCTAssertEqual(0, Int(envelope.items[0].header.length))
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertEqual(1, deserializedEnvelope.items.count)
-            XCTAssertEqual("attachment", deserializedEnvelope.items[0].header.type)
-            XCTAssertEqual(0, deserializedEnvelope.items[0].header.length)
-            XCTAssertEqual(0, deserializedEnvelope.items[0].data.count)
-            assertDefaultSdkInfoSet(deserializedEnvelope: deserializedEnvelope)
-        }
+        XCTAssertEqual("attachment", try XCTUnwrap(envelope.items.first).header.type)
+        XCTAssertEqual(0, Int(try XCTUnwrap(envelope.items.first).header.length))
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertEqual(1, deserializedEnvelope.items.count)
+        XCTAssertEqual("attachment", try XCTUnwrap(deserializedEnvelope.items.first).header.type)
+        XCTAssertEqual(0, try XCTUnwrap(deserializedEnvelope.items.first).header.length)
+        XCTAssertEqual(0, try XCTUnwrap(deserializedEnvelope.items.first).data.count)
+        assertDefaultSdkInfoSet(deserializedEnvelope: deserializedEnvelope)
     }
-
-    func testSentryEnvelopeSerializer_SdkInfo() {
+    
+    func testSentryEnvelopeSerializer_SdkInfo() throws {
         let sdkInfo = SentrySdkInfo(name: "sentry.cocoa", andVersion: "5.0.1")
         let envelopeHeader = SentryEnvelopeHeader(id: nil, sdkInfo: sdkInfo, traceContext: nil)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertEqual(sdkInfo, deserializedEnvelope.header.sdkInfo)
-        }
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertEqual(sdkInfo, deserializedEnvelope.header.sdkInfo)
     }
     
-    func testSentryEnvelopeSerializer_TraceState() {
+    func testSentryEnvelopeSerializer_TraceState() throws {
         let envelopeHeader = SentryEnvelopeHeader(id: nil, traceContext: Fixture.traceContext)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertNotNil(deserializedEnvelope.header.traceContext)
-            assertTraceState(firstTrace: Fixture.traceContext, secondTrace: deserializedEnvelope.header.traceContext!)
-        }
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertNotNil(deserializedEnvelope.header.traceContext)
+        assertTraceState(firstTrace: Fixture.traceContext, secondTrace: deserializedEnvelope.header.traceContext!)
     }
     
-    func testSentryEnvelopeSerializer_TraceStateWithoutUser() {
+    func testSentryEnvelopeSerializer_TraceStateWithoutUser() throws {
         let trace = SentryTraceContext(trace: SentryId(), publicKey: "PUBLIC_KEY", releaseName: "RELEASE_NAME", environment: "TEST", transaction: "transaction", userSegment: nil, sampleRate: nil, sampled: nil, replayId: nil)
         
         let envelopeHeader = SentryEnvelopeHeader(id: nil, traceContext: trace)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertNotNil(deserializedEnvelope.header.traceContext)
-            assertTraceState(firstTrace: trace, secondTrace: deserializedEnvelope.header.traceContext!)
-        }
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertNotNil(deserializedEnvelope.header.traceContext)
+        assertTraceState(firstTrace: trace, secondTrace: deserializedEnvelope.header.traceContext!)
     }
     
-    func testSentryEnvelopeSerializer_SdkInfoIsNil() {
+    func testSentryEnvelopeSerializer_SdkInfoIsNil() throws {
         let envelopeHeader = SentryEnvelopeHeader(id: nil, sdkInfo: nil, traceContext: nil)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
-
-        assertEnvelopeSerialization(envelope: envelope) { deserializedEnvelope in
-            XCTAssertNil(deserializedEnvelope.header.sdkInfo)
-        }
+        
+        let deserializedEnvelope = try XCTUnwrap(SentrySerialization.envelope(with: serializeEnvelope(envelope: envelope)))
+        XCTAssertNil(deserializedEnvelope.header.sdkInfo)
     }
-
+    
     func testSentryEnvelopeSerializer_ZeroByteItemReturnsEnvelope() {
         let itemData = "{}\n{\"length\":0,\"type\":\"attachment\"}\n".data(using: .utf8)!
         XCTAssertNotNil(SentrySerialization.envelope(with: itemData))
     }
-
-    func testSentryEnvelopeSerializer_EnvelopeWithHeaderAndItemWithAttachmet() {
+    
+    func testSentryEnvelopeSerializer_EnvelopeWithHeaderAndItemWithAttachmet() throws {
         let eventId = SentryId(uuidString: "12c2d058-d584-4270-9aa2-eca08bf20986")
         let payloadAsString = "helloworld"
-
+        
         let itemData = """
                        {\"event_id\":\"\(eventId)\"}
                        {\"length\":10,\"type\":\"attachment\"}
                        \(payloadAsString)
                        """.data(using: .utf8)!
-
+        
         if let envelope = SentrySerialization.envelope(with: itemData) {
             XCTAssertEqual(eventId, envelope.header.eventId!)
-
+            
             XCTAssertEqual(1, envelope.items.count)
-            let item = envelope.items[0]
+            let item = try XCTUnwrap(envelope.items.first)
             XCTAssertEqual(10, item.header.length)
             XCTAssertEqual("attachment", item.header.type)
             XCTAssertEqual(payloadAsString.data(using: .utf8), item.data)
@@ -171,17 +164,17 @@ class SentrySerializationTests: XCTestCase {
             XCTFail("Failed to deserialize envelope")
         }
     }
-
+    
     func testSentryEnvelopeSerializer_ItemWithoutTypeReturnsNil() {
         let itemData = "{}\n{\"length\":0}".data(using: .utf8)!
         XCTAssertNil(SentrySerialization.envelope(with: itemData))
     }
-
+    
     func testSentryEnvelopeSerializer_WithoutItemReturnsNil() {
         let itemData = "{}\n".data(using: .utf8)!
         XCTAssertNil(SentrySerialization.envelope(with: itemData))
     }
-
+    
     func testSentryEnvelopeSerializer_WithoutLineBreak() {
         let itemData = "{}".data(using: .utf8)!
         XCTAssertNil(SentrySerialization.envelope(with: itemData))
@@ -283,26 +276,13 @@ class SentrySerializationTests: XCTestCase {
         }
         return serializedEnvelope
     }
-
+    
     private func createItemWithEmptyAttachment() -> SentryEnvelopeItem {
         let itemData = Data()
         let itemHeader = SentryEnvelopeItemHeader(type: "attachment", length: UInt(itemData.count))
         return SentryEnvelopeItem(header: itemHeader, data: itemData)
     }
-
-    private func assertEnvelopeSerialization(
-            envelope: SentryEnvelope,
-            assert: (SentryEnvelope) -> Void
-    ) {
-        let serializedEnvelope = serializeEnvelope(envelope: envelope)
-
-        if let deserializedEnvelope = SentrySerialization.envelope(with: serializedEnvelope) {
-            assert(deserializedEnvelope)
-        } else {
-            XCTFail("Could not deserialize envelope.")
-        }
-    }
-
+    
     private func assertDefaultSdkInfoSet(deserializedEnvelope: SentryEnvelope) {
         let sdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, andVersion: SentryMeta.versionString)
         XCTAssertEqual(sdkInfo, deserializedEnvelope.header.sdkInfo)

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -64,13 +64,13 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertFalse(result)
     }
     
-    func testANRDetected_EventCaptured() {
+    func testANRDetected_EventCaptured() throws {
         givenInitializedTracker()
         setUpThreadInspector()
         
         Dynamic(sut).anrDetected()
         
-        assertEventWithScopeCaptured { event, _, _ in
+        try assertEventWithScopeCaptured { event, _, _ in
             XCTAssertNotNil(event)
             guard let ex = event?.exceptions?.first else {
                 XCTFail("ANR Exception not found")
@@ -83,7 +83,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             XCTAssertNotNil(ex.stacktrace)
             XCTAssertEqual(ex.stacktrace?.frames.first?.function, "main")
             XCTAssertEqual(ex.stacktrace?.snapshot?.boolValue, true)
-            XCTAssertEqual(event?.threads?[0].current?.boolValue, true)
+            XCTAssertEqual(try XCTUnwrap(event?.threads?.first).current?.boolValue, true)
             XCTAssertEqual(event?.isAppHangEvent, true)
             
             guard let threads = event?.threads else {
@@ -111,7 +111,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         assertNoEventCaptured()
     }
     
-    func testANRDetected_DetectingPausedResumed_EventCaptured() {
+    func testANRDetected_DetectingPausedResumed_EventCaptured() throws {
         givenInitializedTracker()
         setUpThreadInspector()
         sut.pauseAppHangTracking()
@@ -119,7 +119,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         
         Dynamic(sut).anrDetected()
         
-        assertEventWithScopeCaptured { event, _, _ in
+        try assertEventWithScopeCaptured { event, _, _ in
             XCTAssertNotNil(event)
             guard let ex = event?.exceptions?.first else {
                 XCTFail("ANR Exception not found")

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -81,7 +81,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         XCTAssertEqual(payloadData["state"] as? String, "cellular")
     }
 
-    func testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb() {
+    func testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb() throws {
         let testReachability = TestSentryReachability()
         
         // We already test the network breadcrumbs in a test above. Using the `TestReachability`
@@ -122,7 +122,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
             return
         }
 
-        let lifeCycleCrumb = crumbs[1]
+        let lifeCycleCrumb = try XCTUnwrap(crumbs.element(at: 1))
         XCTAssertEqual("navigation", lifeCycleCrumb.type)
         XCTAssertEqual("ui.lifecycle", lifeCycleCrumb.category)
         XCTAssertEqual("false", lifeCycleCrumb.data?["beingPresented"] as? String)
@@ -136,7 +136,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
     
     func testNavigationBreadcrumbForSessionReplay() throws {
         //Call the previous test to create the breadcrumb into the delegate
-        testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb()
+        try testSwizzlingStarted_ViewControllerAppears_AddsUILifeCycleBreadcrumb()
         
         let sut = SentrySRDefaultBreadcrumbConverter()
         

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
@@ -71,21 +71,21 @@ final class SentryMXCallStackTreeTests: XCTestCase {
         XCTAssertEqual(4_312_798_220, firstFrame.address)
         XCTAssertEqual(try XCTUnwrap(subFrameCount.first), firstFrame.subFrames?.count)
         
-        let secondFrame = try XCTUnwrap(callStack.flattenedRootFrames[1])
+        let secondFrame = try XCTUnwrap(try XCTUnwrap(callStack.flattenedRootFrames.element(at: 1)))
         XCTAssertEqual(UUID(uuidString: "CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF"), secondFrame.binaryUUID)
         XCTAssertEqual(46_380, secondFrame.offsetIntoBinaryTextSegment)
         XCTAssertEqual(1, secondFrame.sampleCount)
         XCTAssertEqual("iOS-Swift", secondFrame.binaryName)
         XCTAssertEqual(4_310_988_076, secondFrame.address)
-        XCTAssertEqual(subFrameCount[1], secondFrame.subFrames?.count)
+        XCTAssertEqual(try XCTUnwrap(subFrameCount.element(at: 1)), secondFrame.subFrames?.count)
         
-        let thirdFrame = try XCTUnwrap(callStack.flattenedRootFrames[2])
+        let thirdFrame = try XCTUnwrap(try XCTUnwrap(callStack.flattenedRootFrames.element(at: 2)))
         XCTAssertEqual(UUID(uuidString: "CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF"), thirdFrame.binaryUUID)
         XCTAssertEqual(46_370, thirdFrame.offsetIntoBinaryTextSegment)
         XCTAssertEqual(1, thirdFrame.sampleCount)
         XCTAssertEqual("iOS-Swift", thirdFrame.binaryName)
         XCTAssertEqual(4_310_988_026, thirdFrame.address)
-        XCTAssertEqual(subFrameCount[2], thirdFrame.subFrames?.count ?? 0)
+        XCTAssertEqual(try XCTUnwrap(subFrameCount.element(at: 2)), thirdFrame.subFrames?.count ?? 0)
         
         XCTAssertEqual(try XCTUnwrap(firstFrame.subFrames?.first), secondFrame)
     }

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
@@ -41,7 +41,7 @@ final class SentryMXCallStackTreeTests: XCTestCase {
         // Only validate some properties as this only validates that we can
         // decode a real payload
         XCTAssertEqual(16, callStackTree.callStacks.count)
-        XCTAssertEqual(27, callStackTree.callStacks[0].flattenedRootFrames.count)
+        XCTAssertEqual(27, try XCTUnwrap(callStackTree.callStacks.first).flattenedRootFrames.count)
     }
     
     func testDecodeCallStackTree_GarbagePayload() throws {
@@ -69,7 +69,7 @@ final class SentryMXCallStackTreeTests: XCTestCase {
         XCTAssertEqual(1, firstFrame.sampleCount)
         XCTAssertEqual("Sentry", firstFrame.binaryName)
         XCTAssertEqual(4_312_798_220, firstFrame.address)
-        XCTAssertEqual(subFrameCount[0], firstFrame.subFrames?.count)
+        XCTAssertEqual(try XCTUnwrap(subFrameCount.first), firstFrame.subFrames?.count)
         
         let secondFrame = try XCTUnwrap(callStack.flattenedRootFrames[1])
         XCTAssertEqual(UUID(uuidString: "CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF"), secondFrame.binaryUUID)

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMXCallStackTreeTests.swift
@@ -63,7 +63,7 @@ final class SentryMXCallStackTreeTests: XCTestCase {
         
         XCTAssertEqual(framesAmount, callStack.flattenedRootFrames.count)
         
-        let firstFrame = try XCTUnwrap(callStack.flattenedRootFrames[0])
+        let firstFrame = try XCTUnwrap(callStack.flattenedRootFrames.first)
         XCTAssertEqual(UUID(uuidString: "9E8D8DE6-EEC1-3199-8720-9ED68EE3F967"), firstFrame.binaryUUID)
         XCTAssertEqual(414_732, firstFrame.offsetIntoBinaryTextSegment)
         XCTAssertEqual(1, firstFrame.sampleCount)
@@ -87,7 +87,7 @@ final class SentryMXCallStackTreeTests: XCTestCase {
         XCTAssertEqual(4_310_988_026, thirdFrame.address)
         XCTAssertEqual(subFrameCount[2], thirdFrame.subFrames?.count ?? 0)
         
-        XCTAssertEqual(try XCTUnwrap(firstFrame.subFrames?[0]), secondFrame)
+        XCTAssertEqual(try XCTUnwrap(firstFrame.subFrames?.first), secondFrame)
     }
 }
 

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -96,7 +96,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let diagnostic = MXCrashDiagnostic()
             mxDelegate.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
-            assertEventWithScopeCaptured { _, scope, _ in
+            try assertEventWithScopeCaptured { _, scope, _ in
                 let diagnosticAttachment = scope?.attachments.first { $0.filename == "MXDiagnosticPayload.json" }
                 
                 XCTAssertEqual(diagnosticAttachment?.data, diagnostic.jsonRepresentation())
@@ -114,7 +114,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let diagnostic = MXCrashDiagnostic()
             mxDelegate.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
-            assertEventWithScopeCaptured { _, scope, _ in
+            try assertEventWithScopeCaptured { _, scope, _ in
                 let diagnosticAttachment = scope?.attachments.first { $0.filename == "MXDiagnosticPayload.json" }
                 
                 XCTAssertNil(diagnosticAttachment)
@@ -134,7 +134,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let mxDelegate = sut as SentryMXManagerDelegate
             mxDelegate.didReceiveCrashDiagnostic(MXCrashDiagnostic(), callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
-            assertEventWithScopeCaptured { event, _, _ in
+            try assertEventWithScopeCaptured { event, _, _ in
                 let stacktrace = try! XCTUnwrap( event?.threads?.first?.stacktrace)
                 
                 let inAppFramesCount = stacktrace.frames.filter { $0.inApp as? Bool ?? false }.count
@@ -193,7 +193,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let invocations = client.captureEventWithScopeInvocations.invocations
             XCTAssertEqual(2, client.captureEventWithScopeInvocations.count)
             
-            try assertEvent(event: invocations[0].event)
+            try assertEvent(event: try XCTUnwrap(invocations.first).event)
             try assertEvent(event: invocations[1].event)
             
             func assertEvent(event: Event) throws {
@@ -254,7 +254,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     private func assertPerThread(exceptionType: String, exceptionValue: String, exceptionMechanism: String, handled: Bool = true) throws {
-        assertEventWithScopeCaptured { event, scope, _ in
+        try assertEventWithScopeCaptured { event, scope, _ in
             XCTAssertEqual(1, scope?.attachments.count)
             
             XCTAssertEqual(callStackTreePerThread.callStacks.count, event?.threads?.count)
@@ -287,14 +287,14 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         let invocations = client.captureEventWithScopeInvocations.invocations
         XCTAssertEqual(4, client.captureEventWithScopeInvocations.count, "Client expected to capture 2 events.")
         
-        let firstEvent = invocations[0].event
+        let firstEvent = try XCTUnwrap(invocations.first).event
         let secondEvent = invocations[1].event
         let thirdEvent = invocations[2].event
         let fourthEvent = invocations[3].event
         
-        invocations.map { $0.event }.forEach {
-            XCTAssertEqual(timeStampBegin, $0.timestamp)
-            XCTAssertEqual(false, $0.threads?[0].crashed)
+        for event in invocations.map({ $0.event }) {
+            XCTAssertEqual(timeStampBegin, event.timestamp)
+            XCTAssertEqual(false, try XCTUnwrap(event.threads?.first).crashed)
         }
         
         let allFrames = try XCTUnwrap(callStackTreeNotPerThread.callStacks.first?.flattenedRootFrames, "CallStackTree has no call stack.")
@@ -357,10 +357,10 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             return
         }
         
-        XCTAssertEqual("macho", debugMeta[0].type)
-        XCTAssertEqual("9E8D8DE6-EEC1-3199-8720-9ED68EE3F967", debugMeta[0].debugID)
-        XCTAssertEqual("0x000000010109c000", debugMeta[0].imageAddress)
-        XCTAssertEqual("Sentry", debugMeta[0].codeFile)
+        XCTAssertEqual("macho", try XCTUnwrap(debugMeta.first).type)
+        XCTAssertEqual("9E8D8DE6-EEC1-3199-8720-9ED68EE3F967", try XCTUnwrap(debugMeta.first).debugID)
+        XCTAssertEqual("0x000000010109c000", try XCTUnwrap(debugMeta.first).imageAddress)
+        XCTAssertEqual("Sentry", try XCTUnwrap(debugMeta.first).codeFile)
         
         XCTAssertEqual("macho", debugMeta[1].type)
         XCTAssertEqual("CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF", debugMeta[1].debugID)

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -194,7 +194,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             XCTAssertEqual(2, client.captureEventWithScopeInvocations.count)
             
             try assertEvent(event: try XCTUnwrap(invocations.first).event)
-            try assertEvent(event: invocations[1].event)
+            try assertEvent(event: try XCTUnwrap(invocations.element(at: 1)).event)
             
             func assertEvent(event: Event) throws {
                 let sentryFrames = try XCTUnwrap(event.threads?.first?.stacktrace?.frames, "Event has no frames.")
@@ -288,9 +288,9 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertEqual(4, client.captureEventWithScopeInvocations.count, "Client expected to capture 2 events.")
         
         let firstEvent = try XCTUnwrap(invocations.first).event
-        let secondEvent = invocations[1].event
-        let thirdEvent = invocations[2].event
-        let fourthEvent = invocations[3].event
+        let secondEvent = try XCTUnwrap(invocations.element(at: 1)).event
+        let thirdEvent = try XCTUnwrap(invocations.element(at: 2)).event
+        let fourthEvent = try XCTUnwrap(invocations.element(at: 3)).event
         
         for event in invocations.map({ $0.event }) {
             XCTAssertEqual(timeStampBegin, event.timestamp)
@@ -362,10 +362,10 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertEqual("0x000000010109c000", try XCTUnwrap(debugMeta.first).imageAddress)
         XCTAssertEqual("Sentry", try XCTUnwrap(debugMeta.first).codeFile)
         
-        XCTAssertEqual("macho", debugMeta[1].type)
-        XCTAssertEqual("CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF", debugMeta[1].debugID)
-        XCTAssertEqual("0x0000000100f3c000", debugMeta[1].imageAddress)
-        XCTAssertEqual("iOS-Swift", debugMeta[1].codeFile)
+        XCTAssertEqual("macho", try XCTUnwrap(debugMeta.element(at: 1)).type)
+        XCTAssertEqual("CA12CAFA-91BA-3E1C-BE9C-E34DB96FE7DF", try XCTUnwrap(debugMeta.element(at: 1)).debugID)
+        XCTAssertEqual("0x0000000100f3c000", try XCTUnwrap(debugMeta.element(at: 1)).imageAddress)
+        XCTAssertEqual("iOS-Swift", try XCTUnwrap(debugMeta.element(at: 1)).codeFile)
     }
     
     private func assertFrame(mxFrame: SentryMXFrame, sentryFrame: Frame) {

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -186,7 +186,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
         
         XCTAssertEqual(transaction.children.count, 1)
         
-        guard let operations = transaction.children[0].data["operations"] as? [String: Any?] else {
+        guard let operations = try XCTUnwrap(transaction.children.first).data["operations"] as? [String: Any?] else {
             XCTFail("Transaction has no `operations` extra")
             return
         }
@@ -236,7 +236,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
         }
         
         XCTAssertEqual(transaction.children.count, 1)
-        XCTAssertEqual(transaction.children[0].status, .internalError)
+        XCTAssertEqual(try XCTUnwrap(transaction.children.first).status, .internalError)
     }
     
     func test_Request_with_Error_is_nil() throws {
@@ -252,7 +252,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
         })
         
         XCTAssertEqual(transaction.children.count, 1)
-        XCTAssertEqual(transaction.children[0].status, .internalError)
+        XCTAssertEqual(try XCTUnwrap(transaction.children.first).status, .internalError)
     }
     
     func test_save_with_Error() throws {
@@ -264,7 +264,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
         })
         
         XCTAssertEqual(transaction.children.count, 1)
-        XCTAssertEqual(transaction.children[0].status, .internalError)
+        XCTAssertEqual(try XCTUnwrap(transaction.children.first).status, .internalError)
     }
     
     func test_save_with_error_is_nil() throws {
@@ -277,7 +277,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
         }
         
         XCTAssertEqual(transaction.children.count, 1)
-        XCTAssertEqual(transaction.children[0].status, .internalError)
+        XCTAssertEqual(try XCTUnwrap(transaction.children.first).status, .internalError)
     }
     
     func test_Save_NoChanges() throws {

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -74,7 +74,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         try? stack.managedObjectContext.save()
         
         XCTAssertEqual(transaction.children.count, 1)
-        XCTAssertEqual(transaction.children[0].operation, "db.sql.transaction")
+        XCTAssertEqual(try XCTUnwrap(transaction.children.first).operation, "db.sql.transaction")
     }
     
     func test_Save_noChanges() throws {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -21,9 +21,9 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
             return result
         }
         
-        init() {
+        init() throws {
             let paths = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)
-            fileDirectory = paths[0]
+            fileDirectory = try XCTUnwrap(paths.first)
             fileURL = fileDirectory.appendingPathComponent("TestFile")
             filePath = fileURL?.path
         }
@@ -32,9 +32,9 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
     private var fixture: Fixture!
     var deleteFileDirectory = false
     
-    override func setUp() {
-        super.setUp()
-        fixture = Fixture()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        fixture = try Fixture()
         
         if  !FileManager.default.fileExists(atPath: fixture.fileDirectory.path) {
             try? FileManager.default.createDirectory(at: fixture.fileDirectory, withIntermediateDirectories: true, attributes: nil)

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -202,7 +202,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         let children = Dynamic(transaction).children as [SentrySpan]?
 
         XCTAssertEqual(children?.count, 1) //Span was created in task resume swizzle.
-        let networkSpan = children![0]
+        let networkSpan = try XCTUnwrap(children?.first)
 
         let expectedTraceHeader = networkSpan.toTraceHeader().value()
         XCTAssertEqual(expectedTraceHeader, response)

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -687,8 +687,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         let transaction = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
-        let children = Dynamic(transaction).children as [SentrySpan]?
-        let networkSpan = children![0]
+        let children = try XCTUnwrap(Dynamic(transaction).children.asArray as? [SentrySpan])
+        let networkSpan = try XCTUnwrap(children.first)
         let expectedTraceHeader = networkSpan.toTraceHeader().value()
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)
     }

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -258,7 +258,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         wait(for: [callbackExpectation], timeout: 0)
     }
     
-    func testReportFullyDisplayed() {
+    func testReportFullyDisplayed() throws {
         let sut = fixture.getSut()
         sut.enableWaitForFullDisplay = true
         let viewController = fixture.viewController
@@ -277,9 +277,9 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         reportFrame()
         let expectedTTFDTimestamp = fixture.dateProvider.date()
 
-        let ttfdSpan = tracer?.children[1]
-        XCTAssertEqual(ttfdSpan?.isFinished, true)
-        XCTAssertEqual(ttfdSpan?.timestamp, expectedTTFDTimestamp)
+        let ttfdSpan = try XCTUnwrap(tracer?.children.element(at: 1))
+        XCTAssertEqual(ttfdSpan.isFinished, true)
+        XCTAssertEqual(ttfdSpan.timestamp, expectedTTFDTimestamp)
     }
 
     func testSecondViewController() {
@@ -531,8 +531,8 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             tracer = self.getStack(tracker).first as? SentryTracer
         }
         XCTAssertEqual(tracer?.children.count, 3)
-        XCTAssertEqual(tracer?.children[1].operation, "ui.load.full_display")
-        XCTAssertEqual(tracer?.children[1].origin, "manual.ui.time_to_display")
+        XCTAssertEqual(try XCTUnwrap(tracer?.children.element(at: 1)).operation, "ui.load.full_display")
+        XCTAssertEqual(try XCTUnwrap(tracer?.children.element(at: 1)).origin, "manual.ui.time_to_display")
     }
 
     func test_dontWaitForFullDisplay() {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -151,7 +151,7 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         // UIScene is available from iOS 13 and above.
         if #available(iOS 13.0, tvOS 13.0, macCatalyst 13.0, *) {
             XCTAssertEqual(swizzler.viewControllers.count, 1)
-            XCTAssertTrue(swizzler.viewControllers[0] is TestViewController)
+            XCTAssertTrue(try XCTUnwrap(swizzler.viewControllers.first) is TestViewController)
         } else {
             XCTAssertEqual(swizzler.viewControllers.count, 0)
         }

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -178,16 +178,16 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         XCTAssertEqual(newAttachmentList.count, 3)
         XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).filename, "screenshot.png")
-        XCTAssertEqual(newAttachmentList[1].filename, "screenshot-2.png")
-        XCTAssertEqual(newAttachmentList[2].filename, "screenshot-3.png")
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.element(at: 1)).filename, "screenshot-2.png")
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.element(at: 2)).filename, "screenshot-3.png")
         
         XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).contentType, "image/png")
-        XCTAssertEqual(newAttachmentList[1].contentType, "image/png")
-        XCTAssertEqual(newAttachmentList[2].contentType, "image/png")
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.element(at: 1)).contentType, "image/png")
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.element(at: 2)).contentType, "image/png")
         
         XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).data?.count, 1)
-        XCTAssertEqual(newAttachmentList[1].data?.count, 2)
-        XCTAssertEqual(newAttachmentList[2].data?.count, 3)
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.element(at: 1)).data?.count, 2)
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.element(at: 2)).data?.count, 3)
         
     }
     

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -177,15 +177,15 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         let newAttachmentList = sut.processAttachments([], for: event) ?? []
         
         XCTAssertEqual(newAttachmentList.count, 3)
-        XCTAssertEqual(newAttachmentList[0].filename, "screenshot.png")
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).filename, "screenshot.png")
         XCTAssertEqual(newAttachmentList[1].filename, "screenshot-2.png")
         XCTAssertEqual(newAttachmentList[2].filename, "screenshot-3.png")
         
-        XCTAssertEqual(newAttachmentList[0].contentType, "image/png")
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).contentType, "image/png")
         XCTAssertEqual(newAttachmentList[1].contentType, "image/png")
         XCTAssertEqual(newAttachmentList[2].contentType, "image/png")
         
-        XCTAssertEqual(newAttachmentList[0].data?.count, 1)
+        XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).data?.count, 1)
         XCTAssertEqual(newAttachmentList[1].data?.count, 2)
         XCTAssertEqual(newAttachmentList[2].data?.count, 3)
         

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
@@ -4,12 +4,12 @@ import XCTest
 
 class SentryReplayRecordingTests: XCTestCase {
     
-    func test_serialize() {
+    func test_serialize() throws {
         let sut = SentryReplayRecording(segmentId: 3, size: 200, start: Date(timeIntervalSince1970: 2), duration: 5_000, frameCount: 5, frameRate: 1, height: 930, width: 390, extraEvents: nil)
       
         let data = sut.serialize()
         
-        let metaInfo = data[0]
+        let metaInfo = try XCTUnwrap(data.first)
         let metaInfoData = metaInfo["data"] as? [String: Any]
         
         let recordingInfo = data[1]

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
@@ -12,7 +12,7 @@ class SentryReplayRecordingTests: XCTestCase {
         let metaInfo = try XCTUnwrap(data.first)
         let metaInfoData = metaInfo["data"] as? [String: Any]
         
-        let recordingInfo = data[1]
+        let recordingInfo = try XCTUnwrap(data.element(at: 1))
         let recordingData = recordingInfo["data"] as? [String: Any]
         let recordingPayload = recordingData?["payload"] as? [String: Any]
         
@@ -38,7 +38,7 @@ class SentryReplayRecordingTests: XCTestCase {
         XCTAssertEqual(recordingPayload?["top"] as? Int, 0)
     }
     
-    func test_serializeWithExtra() {
+    func test_serializeWithExtra() throws {
         let date = Date(timeIntervalSince1970: 5)
         let sut = SentryReplayRecording(segmentId: 3, size: 200, start: Date(timeIntervalSince1970: 2), duration: 5_000, frameCount: 5, frameRate: 1, height: 930, width: 390, extraEvents: [
             SentryRRWebEvent(type: .custom, timestamp: date, data: nil)
@@ -46,7 +46,7 @@ class SentryReplayRecordingTests: XCTestCase {
       
         let data = sut.serialize()
         
-        let extraInfo = data[2]
+        let extraInfo = try XCTUnwrap(data.element(at: 2))
         XCTAssertEqual(extraInfo["type"] as? Int, 5)
         XCTAssertEqual(extraInfo["timestamp"] as? Int, 5_000)
     }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
@@ -140,7 +140,7 @@ class SentryTouchTrackerTests: XCTestCase {
         XCTAssertEqual(data?["source"] as? Int, 2)
     }
     
-    func testTrackTouchEventKeepSameIdAccrossEvents() {
+    func testTrackTouchEventKeepSameIdAccrossEvents() throws {
         let sut = getSut()
         let event = MockUIEvent(timestamp: 3)
         let touch = MockUITouch(phase: .began, location: CGPoint(x: 100, y: 100))
@@ -154,7 +154,7 @@ class SentryTouchTrackerTests: XCTestCase {
         sut.trackTouchFrom(event: event)
         
         let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
-        let firstEventFirstTouch = result[0].data
+        let firstEventFirstTouch = try XCTUnwrap(result.first).data
         let firstEventSecondTouch = result[1].data
         let secondEventFirstTouch = result[2].data
         let secondEventSecondTouch = result[3].data

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
@@ -155,9 +155,9 @@ class SentryTouchTrackerTests: XCTestCase {
         
         let result = sut.replayEvents(from: referenceDate, until: referenceDate.addingTimeInterval(5))
         let firstEventFirstTouch = try XCTUnwrap(result.first).data
-        let firstEventSecondTouch = result[1].data
-        let secondEventFirstTouch = result[2].data
-        let secondEventSecondTouch = result[3].data
+        let firstEventSecondTouch = try XCTUnwrap(result.element(at: 1)).data
+        let secondEventFirstTouch = try XCTUnwrap(result.element(at: 2)).data
+        let secondEventSecondTouch = try XCTUnwrap(result.element(at: 3)).data
         
         XCTAssertEqual(firstEventFirstTouch?["pointerId"] as? Int, secondEventFirstTouch?["pointerId"] as? Int)
         XCTAssertEqual(firstEventSecondTouch?["pointerId"] as? Int, secondEventSecondTouch?["pointerId"] as? Int)

--- a/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
@@ -74,7 +74,7 @@ class SentryEnvelopeRateLimitTests: XCTestCase {
         let actual = sut.removeRateLimitedItems(envelope)
         
         XCTAssertEqual(1, actual.items.count)
-        XCTAssertEqual(SentryEnvelopeItemTypeEvent, actual.items[0].header.type)
+        XCTAssertEqual(SentryEnvelopeItemTypeEvent, try XCTUnwrap(actual.items.first).header.type)
     }
     
     func getEnvelope() -> SentryEnvelope {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -444,7 +444,7 @@ class SentryHttpTransportTests: XCTestCase {
         let sessionRequest = try! SentryNSURLRequest(envelopeRequestWith: SentryHttpTransportTests.dsn(), andData: sessionData)
 
         if fixture.requestManager.requests.invocations.count > 3 {
-            XCTAssertEqual(sessionRequest.httpBody, fixture.requestManager.requests.invocations[3].httpBody, "Envelope with only session item should be sent.")
+            XCTAssertEqual(sessionRequest.httpBody, try XCTUnwrap(fixture.requestManager.requests.invocations.element(at: 3)).httpBody, "Envelope with only session item should be sent.")
         } else {
             XCTFail("Expected a fourth invocation")
         }
@@ -470,10 +470,10 @@ class SentryHttpTransportTests: XCTestCase {
 
         fixture.requestManager.waitForAllRequests()
         XCTAssertEqual(3, fixture.requestManager.requests.count)
-        XCTAssertEqual(fixture.eventWithAttachmentRequest.httpBody, fixture.requestManager.requests.invocations[1].httpBody, "Cached envelope was not sent first.")
+        XCTAssertEqual(fixture.eventWithAttachmentRequest.httpBody, try XCTUnwrap(fixture.requestManager.requests.invocations.element(at: 1)).httpBody, "Cached envelope was not sent first.")
 
         if fixture.requestManager.requests.invocations.count > 2 {
-            XCTAssertEqual(fixture.sessionRequest.httpBody, fixture.requestManager.requests.invocations[2].httpBody, "Cached envelope was not sent first.")
+            XCTAssertEqual(fixture.sessionRequest.httpBody, try XCTUnwrap(fixture.requestManager.requests.invocations.element(at: 2)).httpBody, "Cached envelope was not sent first.")
         } else {
             XCTFail("Expected a third invocation")
         }

--- a/Tests/SentryTests/Protocol/SentryClientReportTests.swift
+++ b/Tests/SentryTests/Protocol/SentryClientReportTests.swift
@@ -31,7 +31,7 @@ class SentryClientReportTests: XCTestCase {
             XCTAssertEqual(quantity, event["quantity"] as? UInt)
         }
         assertEvent(event: try XCTUnwrap(discardedEvents.first), reason: "sample_rate", category: "transaction", quantity: event1.quantity)
-        assertEvent(event: discardedEvents[1], reason: "before_send", category: "transaction", quantity: event2.quantity)
-        assertEvent(event: discardedEvents[2], reason: "ratelimit_backoff", category: "error", quantity: event3.quantity)
+        assertEvent(event: try XCTUnwrap(discardedEvents.element(at: 1)), reason: "before_send", category: "transaction", quantity: event2.quantity)
+        assertEvent(event: try XCTUnwrap(discardedEvents.element(at: 2)), reason: "ratelimit_backoff", category: "error", quantity: event3.quantity)
     }
 }

--- a/Tests/SentryTests/Protocol/SentryClientReportTests.swift
+++ b/Tests/SentryTests/Protocol/SentryClientReportTests.swift
@@ -30,7 +30,7 @@ class SentryClientReportTests: XCTestCase {
             XCTAssertEqual(category, event["category"] as? String)
             XCTAssertEqual(quantity, event["quantity"] as? UInt)
         }
-        assertEvent(event: discardedEvents[0], reason: "sample_rate", category: "transaction", quantity: event1.quantity)
+        assertEvent(event: try XCTUnwrap(discardedEvents.first), reason: "sample_rate", category: "transaction", quantity: event1.quantity)
         assertEvent(event: discardedEvents[1], reason: "before_send", category: "transaction", quantity: event2.quantity)
         assertEvent(event: discardedEvents[2], reason: "ratelimit_backoff", category: "error", quantity: event3.quantity)
     }

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -68,7 +68,7 @@ class SentryEnvelopeTests: XCTestCase {
 
     private let defaultSdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, andVersion: SentryMeta.versionString)
     
-    func testSentryEnvelopeFromEvent() {
+    func testSentryEnvelopeFromEvent() throws {
         let event = Event()
         
         let item = SentryEnvelopeItem(event: event)
@@ -76,11 +76,11 @@ class SentryEnvelopeTests: XCTestCase {
         
         XCTAssertEqual(event.eventId, envelope.header.eventId)
         XCTAssertEqual(1, envelope.items.count)
-        XCTAssertEqual("event", envelope.items[0].header.type)
+        XCTAssertEqual("event", try XCTUnwrap(envelope.items.first).header.type)
         
         let json = try! JSONSerialization.data(withJSONObject: event.serialize(), options: JSONSerialization.WritingOptions(rawValue: 0))
         
-        assertJsonIsEqual(actual: json, expected: envelope.items[0].data)
+        assertJsonIsEqual(actual: json, expected: try XCTUnwrap(envelope.items.first).data)
     }
     
     func testSentryEnvelopeWithExplicitInitMessages() {
@@ -96,10 +96,10 @@ class SentryEnvelopeTests: XCTestCase {
         
         XCTAssertEqual(envelopeId, envelope.header.eventId)
         XCTAssertEqual(1, envelope.items.count)
-        XCTAssertEqual("attachment", envelope.items[0].header.type)
-        XCTAssertEqual(attachment.count, Int(envelope.items[0].header.length))
+        XCTAssertEqual("attachment", try XCTUnwrap(envelope.items.first).header.type)
+        XCTAssertEqual(attachment.count, Int(try XCTUnwrap(envelope.items.first).header.length))
         
-        XCTAssertEqual(data, envelope.items[0].data)
+        XCTAssertEqual(data, try XCTUnwrap(envelope.items.first).data)
     }
     
     func testSentryEnvelopeWithExplicitInitMessagesMultipleItems() {

--- a/Tests/SentryTests/RedactRegionTests.swift
+++ b/Tests/SentryTests/RedactRegionTests.swift
@@ -30,7 +30,7 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 50, width: 100, height: 50))
-        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 0, width: 50, height: 50))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 0, y: 0, width: 50, height: 50))
     }
     
     func testSplitBySubtractingBottomLeft() {
@@ -40,7 +40,7 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(result.first?.rect, CGRect(x: 0, y: 0, width: 100, height: 50))
-        XCTAssertEqual(result[1].rect, CGRect(x: 50, y: 50, width: 50, height: 50))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 50, y: 50, width: 50, height: 50))
     }
     
     func testSplitBySubtractingMiddle() {
@@ -50,9 +50,9 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 4)
         XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 100, height: 25))
-        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
-        XCTAssertEqual(result[2].rect, CGRect(x: 0, y: 25, width: 25, height: 50))
-        XCTAssertEqual(result[3].rect, CGRect(x: 75, y: 25, width: 25, height: 50))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 0, y: 75, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 2)).rect, CGRect(x: 0, y: 25, width: 25, height: 50))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 3)).rect, CGRect(x: 75, y: 25, width: 25, height: 50))
     }
     
     func testSplitBySubtractingInHalfHorizontally() {
@@ -62,7 +62,7 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 100, height: 25))
-        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 0, y: 75, width: 100, height: 25))
     }
     
     func testSplitBySubtractingInHalfVertically() {
@@ -72,7 +72,7 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 25, height: 100))
-        XCTAssertEqual(result[1].rect, CGRect(x: 75, y: 0, width: 25, height: 100))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 75, y: 0, width: 25, height: 100))
     }
     
     func testSplitBySubtractingMiddleRight() {
@@ -82,8 +82,8 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 3)
         XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 100, height: 25))
-        XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
-        XCTAssertEqual(result[2].rect, CGRect(x: 0, y: 25, width: 25, height: 50))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 0, y: 75, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 2)).rect, CGRect(x: 0, y: 25, width: 25, height: 50))
     }
     
     func testSplitBySubtractingMiddleLeft() {
@@ -93,8 +93,8 @@ class RedactRegionTests: XCTestCase {
         
         XCTAssertEqual(result.count, 3)
         XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 50, y: 0, width: 100, height: 25))
-        XCTAssertEqual(result[1].rect, CGRect(x: 50, y: 75, width: 100, height: 25))
-        XCTAssertEqual(result[2].rect, CGRect(x: 100, y: 25, width: 50, height: 50))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 1)).rect, CGRect(x: 50, y: 75, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.element(at: 2)).rect, CGRect(x: 100, y: 25, width: 50, height: 50))
     }
 
     func testSplitBySubtracting_TopIsWider() {

--- a/Tests/SentryTests/RedactRegionTests.swift
+++ b/Tests/SentryTests/RedactRegionTests.swift
@@ -49,7 +49,7 @@ class RedactRegionTests: XCTestCase {
         let result = sut.splitBySubtracting(region: CGRect(x: 25, y: 25, width: 50, height: 50))
         
         XCTAssertEqual(result.count, 4)
-        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 100, height: 25))
         XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
         XCTAssertEqual(result[2].rect, CGRect(x: 0, y: 25, width: 25, height: 50))
         XCTAssertEqual(result[3].rect, CGRect(x: 75, y: 25, width: 25, height: 50))
@@ -61,7 +61,7 @@ class RedactRegionTests: XCTestCase {
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 25, width: 100, height: 50))
         
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 100, height: 25))
         XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
     }
     
@@ -71,7 +71,7 @@ class RedactRegionTests: XCTestCase {
         let result = sut.splitBySubtracting(region: CGRect(x: 25, y: 0, width: 50, height: 100))
         
         XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 25, height: 100))
+        XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 25, height: 100))
         XCTAssertEqual(result[1].rect, CGRect(x: 75, y: 0, width: 25, height: 100))
     }
     
@@ -81,7 +81,7 @@ class RedactRegionTests: XCTestCase {
         let result = sut.splitBySubtracting(region: CGRect(x: 25, y: 25, width: 100, height: 50))
         
         XCTAssertEqual(result.count, 3)
-        XCTAssertEqual(result[0].rect, CGRect(x: 0, y: 0, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 0, y: 0, width: 100, height: 25))
         XCTAssertEqual(result[1].rect, CGRect(x: 0, y: 75, width: 100, height: 25))
         XCTAssertEqual(result[2].rect, CGRect(x: 0, y: 25, width: 25, height: 50))
     }
@@ -92,7 +92,7 @@ class RedactRegionTests: XCTestCase {
         let result = sut.splitBySubtracting(region: CGRect(x: 0, y: 25, width: 100, height: 50))
         
         XCTAssertEqual(result.count, 3)
-        XCTAssertEqual(result[0].rect, CGRect(x: 50, y: 0, width: 100, height: 25))
+        XCTAssertEqual(try XCTUnwrap(result.first).rect, CGRect(x: 50, y: 0, width: 100, height: 25))
         XCTAssertEqual(result[1].rect, CGRect(x: 50, y: 75, width: 100, height: 25))
         XCTAssertEqual(result[2].rect, CGRect(x: 100, y: 25, width: 50, height: 50))
     }

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -33,13 +33,13 @@ class SentryBinaryImageCacheTests: XCTestCase {
         sut.binaryImageAdded(&binaryImage2)
         XCTAssertEqual(sut.cache.count, 3)
         XCTAssertEqual(sut.cache.first?.name, "Expected Name at 100")
-        XCTAssertEqual(sut.cache[1].name, "Expected Name at 200")
+        XCTAssertEqual(try XCTUnwrap(sut.cache.element(at: 1)).name, "Expected Name at 200")
         XCTAssertEqual(sut.cache.last?.name, "Expected Name at 400")
 
         sut.binaryImageAdded(&binaryImage0)
         XCTAssertEqual(sut.cache.count, 4)
         XCTAssertEqual(sut.cache.first?.name, "Expected Name at 0")
-        XCTAssertEqual(sut.cache[1].name, "Expected Name at 100")
+        XCTAssertEqual(try XCTUnwrap(sut.cache.element(at: 1)).name, "Expected Name at 100")
     }
     
     func testBinaryImageAdded_IsNull() {

--- a/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
@@ -55,17 +55,17 @@ class SentryDebugImageProviderTests: XCTestCase {
     
     private let fixture = Fixture()
     
-    func testThreeImages() {
+    func testThreeImages() throws {
         let sut = fixture.getSut(images: fixture.getTestImages())
         let actual = sut.getDebugImagesCrashed(false)
         
         XCTAssertEqual(3, actual.count)
         
-        XCTAssertEqual("dyld_sim", actual[0].codeFile)
+        XCTAssertEqual("dyld_sim", try XCTUnwrap(actual.first).codeFile)
         XCTAssertEqual("UIKit", actual[1].codeFile)
         XCTAssertEqual("CoreData", actual[2].codeFile)
         
-        let debugMeta = actual[0]
+        let debugMeta = try XCTUnwrap(actual.first)
         XCTAssertEqual("84BAEBDA-AD1A-33F4-B35D-8A45F5DAF322", debugMeta.debugID)
         XCTAssertEqual("0x0000000105705000", debugMeta.imageAddress)
         XCTAssertEqual("0x00007fff51af0000", debugMeta.imageVmAddress)
@@ -79,7 +79,7 @@ class SentryDebugImageProviderTests: XCTestCase {
         let sut = fixture.getSut(images: [image])
         let actual = sut.getDebugImagesCrashed(false)
         
-        XCTAssertNil(actual[0].imageVmAddress)
+        XCTAssertNil(try XCTUnwrap(actual.first).imageVmAddress)
     }
     
     func testImageSize() {
@@ -87,7 +87,7 @@ class SentryDebugImageProviderTests: XCTestCase {
             let image = SentryDebugImageProviderTests.createSentryCrashBinaryImage(size: value)
             let sut = fixture.getSut(images: [image])
             let actual = sut.getDebugImagesCrashed(false)
-            XCTAssertEqual(NSNumber(value: value), actual[0].imageSize)
+            XCTAssertEqual(NSNumber(value: value), try XCTUnwrap(actual.first).imageSize)
         }
         
         testWith(value: 0)
@@ -95,22 +95,22 @@ class SentryDebugImageProviderTests: XCTestCase {
         testWith(value: UINT64_MAX)
     }
     
-    func testImageAddress() {
-        func testWith(value: UInt64, expected: String) {
+    func testImageAddress() throws {
+        func testWith(value: UInt64, expected: String) throws {
             let image = SentryDebugImageProviderTests.createSentryCrashBinaryImage(address: value)
             let sut = fixture.getSut(images: [image])
             let actual = sut.getDebugImagesCrashed(false)
             
             XCTAssertEqual(1, actual.count)
             
-            let debugMeta = actual[0]
+            let debugMeta = try XCTUnwrap(actual.first)
             XCTAssertEqual(expected, debugMeta.imageAddress)
         }
         
-        testWith(value: UINT64_MAX, expected: "0xffffffffffffffff")
-        testWith(value: 0, expected: "0x0000000000000000")
-        testWith(value: 0, expected: "0x0000000000000000")
-        testWith(value: 4_361_940_992, expected: "0x0000000103fdf000")
+        try testWith(value: UINT64_MAX, expected: "0xffffffffffffffff")
+        try testWith(value: 0, expected: "0x0000000000000000")
+        try testWith(value: 0, expected: "0x0000000000000000")
+        try testWith(value: 4_361_940_992, expected: "0x0000000103fdf000")
     }
     
     func testNoImages() {
@@ -130,8 +130,8 @@ class SentryDebugImageProviderTests: XCTestCase {
         var actual = sut.getDebugImages(for: [thread], isCrash: false)
         
         XCTAssertEqual(actual.count, 1)
-        XCTAssertEqual(actual[0].codeFile, "dyld_sim")
-        XCTAssertEqual(actual[0].imageAddress, "0x0000000105705000")
+        XCTAssertEqual(try XCTUnwrap(actual.first).codeFile, "dyld_sim")
+        XCTAssertEqual(try XCTUnwrap(actual.first).imageAddress, "0x0000000105705000")
         
         let frame2 = Sentry.Frame()
         frame2.imageAddress = "0x00000001410b1a00"
@@ -142,8 +142,8 @@ class SentryDebugImageProviderTests: XCTestCase {
         actual = sut.getDebugImages(for: [thread], isCrash: false)
         
         XCTAssertEqual(actual.count, 2)
-        XCTAssertEqual(actual[0].codeFile, "UIKit")
-        XCTAssertEqual(actual[0].imageAddress, "0x00000001410b1a00")
+        XCTAssertEqual(try XCTUnwrap(actual.first).codeFile, "UIKit")
+        XCTAssertEqual(try XCTUnwrap(actual.first).imageAddress, "0x00000001410b1a00")
         
         XCTAssertEqual(actual[1].codeFile, "CoreData")
         XCTAssertEqual(actual[1].imageAddress, "0x000000017ca5e400")

--- a/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
@@ -62,8 +62,8 @@ class SentryDebugImageProviderTests: XCTestCase {
         XCTAssertEqual(3, actual.count)
         
         XCTAssertEqual("dyld_sim", try XCTUnwrap(actual.first).codeFile)
-        XCTAssertEqual("UIKit", actual[1].codeFile)
-        XCTAssertEqual("CoreData", actual[2].codeFile)
+        XCTAssertEqual("UIKit", try XCTUnwrap(actual.element(at: 1)).codeFile)
+        XCTAssertEqual("CoreData", try XCTUnwrap(actual.element(at: 2)).codeFile)
         
         let debugMeta = try XCTUnwrap(actual.first)
         XCTAssertEqual("84BAEBDA-AD1A-33F4-B35D-8A45F5DAF322", debugMeta.debugID)
@@ -145,8 +145,8 @@ class SentryDebugImageProviderTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(actual.first).codeFile, "UIKit")
         XCTAssertEqual(try XCTUnwrap(actual.first).imageAddress, "0x00000001410b1a00")
         
-        XCTAssertEqual(actual[1].codeFile, "CoreData")
-        XCTAssertEqual(actual[1].imageAddress, "0x000000017ca5e400")
+        XCTAssertEqual(try XCTUnwrap(actual.element(at: 1)).codeFile, "CoreData")
+        XCTAssertEqual(try XCTUnwrap(actual.element(at: 1)).imageAddress, "0x000000017ca5e400")
     }
     
     func test_NoImage_ForThread_WithoutStackTrace() {

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -183,8 +183,8 @@ class SentryThreadInspectorTests: XCTestCase {
         XCTAssertEqual(true, try XCTUnwrap(actual.first).current)
         XCTAssertNotNil(try XCTUnwrap(actual.first).stacktrace)
         
-        XCTAssertEqual(false, actual[1].current)
-        XCTAssertNil(actual[1].stacktrace)
+        XCTAssertEqual(false, try XCTUnwrap(actual.element(at: 1)).current)
+        XCTAssertNil(try XCTUnwrap(actual.element(at: 1)).stacktrace)
     }
     
     func testOnlyFirstThreadIsCurrent() throws {
@@ -274,7 +274,7 @@ class SentryThreadInspectorTests: XCTestCase {
         let threads = sut.getCurrentThreads()
         
         XCTAssertEqual(try XCTUnwrap(threads.first).name, "main")
-        XCTAssertEqual(threads[1].name, "Second Thread")
+        XCTAssertEqual(try XCTUnwrap(threads.element(at: 1)).name, "Second Thread")
     }
 
     func testOnlyOneThreadIsMain() {

--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -39,9 +39,9 @@ class SentryThreadInspectorTests: XCTestCase {
         XCTAssertEqual(0, actual.count)
     }
     
-    func testStacktraceHasFrames() {
+    func testStacktraceHasFrames() throws {
         let actual = fixture.getSut(testWithRealMachineContextWrapper: true).getCurrentThreads()
-        let stacktrace = actual[0].stacktrace
+        let stacktrace = try XCTUnwrap(actual.first).stacktrace
         
         // The stacktrace has usually more than 40 frames. Feel free to change the number if the tests are failing
         XCTAssertTrue(30 < stacktrace?.frames.count ?? 0, "Not enough stacktrace frames.")
@@ -178,19 +178,19 @@ class SentryThreadInspectorTests: XCTestCase {
         XCTAssertEqual(stackTrace.frames.first?.function, "<redacted>")
     }
 
-    func testOnlyCurrentThreadHasStacktrace() {
+    func testOnlyCurrentThreadHasStacktrace() throws {
         let actual = fixture.getSut(testWithRealMachineContextWrapper: true).getCurrentThreads()
-        XCTAssertEqual(true, actual[0].current)
-        XCTAssertNotNil(actual[0].stacktrace)
+        XCTAssertEqual(true, try XCTUnwrap(actual.first).current)
+        XCTAssertNotNil(try XCTUnwrap(actual.first).stacktrace)
         
         XCTAssertEqual(false, actual[1].current)
         XCTAssertNil(actual[1].stacktrace)
     }
     
-    func testOnlyFirstThreadIsCurrent() {
+    func testOnlyFirstThreadIsCurrent() throws {
         let actual = fixture.getSut(testWithRealMachineContextWrapper: true).getCurrentThreads()
         
-        let thread0 = actual[0]
+        let thread0 = try XCTUnwrap(actual.first)
         XCTAssertEqual(true, thread0.current)
         
         let threadCount = actual.count
@@ -199,10 +199,10 @@ class SentryThreadInspectorTests: XCTestCase {
         }
     }
     
-    func testStacktraceOnlyForCurrentThread() {
+    func testStacktraceOnlyForCurrentThread() throws {
         let actual = fixture.getSut(testWithRealMachineContextWrapper: true).getCurrentThreads()
         
-        XCTAssertNotNil(actual[0].stacktrace)
+        XCTAssertNotNil(try XCTUnwrap(actual.first).stacktrace)
         
         let threadCount = actual.count
         for i in 1..<threadCount {
@@ -227,21 +227,21 @@ class SentryThreadInspectorTests: XCTestCase {
         
         let actual = fixture.getSut().getCurrentThreads()
         
-        XCTAssertEqual(threadName, actual[0].name)
+        XCTAssertEqual(threadName, try XCTUnwrap(actual.first).name)
     }
     
-    func testGetThreadName_EmptyThreadName() {
+    func testGetThreadName_EmptyThreadName() throws {
         fixture.testMachineContextWrapper.threadName = ""
         fixture.testMachineContextWrapper.threadCount = 1
         
         let actual = fixture.getSut().getCurrentThreads()
         XCTAssertEqual(1, actual.count)
         
-        let thread = actual[0]
+        let thread = try XCTUnwrap(actual.first)
         XCTAssertNil(thread.name)
     }
     
-    func testGetThreadNameFails() {
+    func testGetThreadNameFails() throws {
         fixture.testMachineContextWrapper.threadName = ""
         fixture.testMachineContextWrapper.getThreadNameSucceeds = false
         fixture.testMachineContextWrapper.threadCount = 1
@@ -249,11 +249,11 @@ class SentryThreadInspectorTests: XCTestCase {
         let actual = fixture.getSut().getCurrentThreads()
         XCTAssertEqual(1, actual.count)
         
-        let thread = actual[0]
+        let thread = try XCTUnwrap(actual.first)
         XCTAssertNil(thread.name)
     }
     
-    func testLongThreadName() {
+    func testLongThreadName() throws {
         let threadName = String(repeating: "1", count: 127)
         fixture.testMachineContextWrapper.threadName = threadName
         fixture.testMachineContextWrapper.threadCount = 1
@@ -261,7 +261,7 @@ class SentryThreadInspectorTests: XCTestCase {
         let actual = fixture.getSut().getCurrentThreads()
         XCTAssertEqual(1, actual.count)
         
-        let thread = actual[0]
+        let thread = try XCTUnwrap(actual.first)
         XCTAssertEqual(threadName, thread.name)
     }
     
@@ -273,7 +273,7 @@ class SentryThreadInspectorTests: XCTestCase {
         let sut = fixture.getSut()
         let threads = sut.getCurrentThreads()
         
-        XCTAssertEqual(threads[0].name, "main")
+        XCTAssertEqual(try XCTUnwrap(threads.first).name, "main")
         XCTAssertEqual(threads[1].name, "Second Thread")
     }
 

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -696,10 +696,10 @@ class SentryHubTests: XCTestCase {
         assertSessionWithIncrementedErrorCountedAdded()
     }
     
-    func testCaptureEnvelope_WithEventWithoutExceptionMechanism() {
+    func testCaptureEnvelope_WithEventWithoutExceptionMechanism() throws {
         sut.startSession()
         
-        captureFatalEventWithoutExceptionMechanism()
+        try captureFatalEventWithoutExceptionMechanism()
         
         assertSessionWithIncrementedErrorCountedAdded()
     }
@@ -1132,10 +1132,10 @@ class SentryHubTests: XCTestCase {
         sut.capture(SentryEnvelope(event: event))
     }
     
-    private func captureFatalEventWithoutExceptionMechanism() {
+    private func captureFatalEventWithoutExceptionMechanism() throws {
         let event = TestData.event
         event.level = SentryLevel.fatal
-        event.exceptions?[0].mechanism = nil
+        try XCTUnwrap(event.exceptions?.first).mechanism = nil
         sut.capture(SentryEnvelope(event: event))
     }
     

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -688,12 +688,12 @@ class SentryHubTests: XCTestCase {
         assertNoEventsSent()
     }
     
-    func testCaptureEnvelope_WithEventWithError() {
+    func testCaptureEnvelope_WithEventWithError() throws {
         sut.startSession()
         
         captureEventEnvelope(level: SentryLevel.error)
         
-        assertSessionWithIncrementedErrorCountedAdded()
+        try assertSessionWithIncrementedErrorCountedAdded()
     }
     
     func testCaptureEnvelope_WithEventWithoutExceptionMechanism() throws {
@@ -701,15 +701,15 @@ class SentryHubTests: XCTestCase {
         
         try captureFatalEventWithoutExceptionMechanism()
         
-        assertSessionWithIncrementedErrorCountedAdded()
+        try assertSessionWithIncrementedErrorCountedAdded()
     }
     
-    func testCaptureEnvelope_WithEventWithFatal() {
+    func testCaptureEnvelope_WithEventWithFatal() throws {
         sut.startSession()
         
         captureEventEnvelope(level: SentryLevel.fatal)
         
-        assertSessionWithIncrementedErrorCountedAdded()
+        try assertSessionWithIncrementedErrorCountedAdded()
     }
     
     func testCaptureEnvelope_WithEventWithNoLevel() throws {
@@ -720,7 +720,7 @@ class SentryHubTests: XCTestCase {
         }
         sut.capture(envelope)
         
-        assertSessionWithIncrementedErrorCountedAdded()
+        try assertSessionWithIncrementedErrorCountedAdded()
     }
     
     func testCaptureEnvelope_WithEventWithGarbageLevel() throws {
@@ -731,7 +731,7 @@ class SentryHubTests: XCTestCase {
         }
         sut.capture(envelope)
         
-        assertSessionWithIncrementedErrorCountedAdded()
+        try assertSessionWithIncrementedErrorCountedAdded()
     }
     
     func testCaptureEnvelope_WithEventWithFatal_SessionNotStarted() {
@@ -1218,11 +1218,11 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(event?.environment, scopeEnvironment)
     }
     
-    private func assertSessionWithIncrementedErrorCountedAdded() {
+    private func assertSessionWithIncrementedErrorCountedAdded() throws {
         XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
         let envelope = fixture.client.captureEnvelopeInvocations.first!
         XCTAssertEqual(2, envelope.items.count)
-        let session = SentrySerialization.session(with: envelope.items[1].data)
+        let session = SentrySerialization.session(with: try XCTUnwrap(envelope.items.element(at: 1)).data)
         XCTAssertEqual(1, session?.errors)
     }
     

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -52,7 +52,7 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         callback(client.captureEventInvocations.first)
     }
     
-    func assertEventWithScopeCaptured(_ callback: (Event?, Scope?, [SentryEnvelopeItem]?) -> Void) {
+    func assertEventWithScopeCaptured(_ callback: (Event?, Scope?, [SentryEnvelopeItem]?) throws -> Void) throws {
         guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
@@ -60,7 +60,7 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         
         XCTAssertEqual(1, client.captureEventWithScopeInvocations.count, "More than one `Event` captured.")
         let capture = client.captureEventWithScopeInvocations.first
-        callback(capture?.event, capture?.scope, capture?.additionalEnvelopeItems)
+        try callback(capture?.event, capture?.scope, capture?.additionalEnvelopeItems)
     }
     
     func lastErrorWithScopeCaptured(_ callback: (Error?, Scope?) -> Void) {

--- a/Tests/SentryTests/SentryScreenShotTests.swift
+++ b/Tests/SentryTests/SentryScreenShotTests.swift
@@ -68,12 +68,12 @@ class SentryScreenShotTests: XCTestCase {
         XCTAssertTrue(drawSecondWindow)
     }
     
-    func test_image_size() {
+    func test_image_size() throws {
         let testWindow = TestWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         fixture.uiApplication.windows = [testWindow]
         
         let data = self.fixture.sut.appScreenshots()
-        let image = UIImage(data: data[0])
+        let image = UIImage(data: try XCTUnwrap(data.first))
         
         XCTAssertEqual(image?.size.width, 10)
         XCTAssertEqual(image?.size.height, 10)

--- a/Tests/SentryTests/StringExtensionTests.swift
+++ b/Tests/SentryTests/StringExtensionTests.swift
@@ -6,7 +6,7 @@ class StringExtensionTests: XCTestCase {
     
     func testSingleCharacterSubscript() {
         let testString = "Hello, World!"
-        XCTAssertEqual(testString[0], "H")
+        XCTAssertEqual(try XCTUnwrap(testString.first), "H")
         XCTAssertEqual(testString[7], "W")
         XCTAssertEqual(testString[12], "!")
     }

--- a/Tests/SentryTests/Swift/Metrics/BucketMetricsAggregatorTests.swift
+++ b/Tests/SentryTests/Swift/Metrics/BucketMetricsAggregatorTests.swift
@@ -219,7 +219,7 @@ final class BucketMetricsAggregatorTests: XCTestCase {
         sut.increment(key: "key5", value: 1.0, unit: MeasurementUnitDuration.day, tags: [:])
 
         XCTAssertEqual(metricsClient.captureInvocations.count, 2)
-        let buckets2 = try XCTUnwrap(metricsClient.captureInvocations.invocations[1])
+        let buckets2 = try XCTUnwrap(try XCTUnwrap(metricsClient.captureInvocations.invocations.element(at: 1)))
 
         XCTAssertEqual(buckets2.count, 1)
         let bucket = try XCTUnwrap(buckets2.first)

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -376,7 +376,7 @@ class SentrySpanTests: XCTestCase {
         let serializedData = lastEvent.serialize()
         
         let spans = try XCTUnwrap(serializedData["spans"] as? [Any])
-        let serializedChild = try XCTUnwrap(spans[0] as? [String: Any])
+        let serializedChild = try XCTUnwrap(spans.first as? [String: Any])
         
         XCTAssertEqual(serializedChild["span_id"] as? String, childSpan.spanId.sentrySpanIdString)
         XCTAssertEqual(serializedChild["parent_span_id"] as? String, span.spanId.sentrySpanIdString)


### PR DESCRIPTION
Along with #4125, convert some test code that can crash to code that just fails the tests if an assumption is broken, this time targeting the remaining unchecked array indexes.

Helps with #3576.

Two test cases called through to a function that appeared to make assertions, but because they were in an if let block that never was entered, the assertions were not even needed. One of those tests was even incomplete, it should have had an inverted test expectation to ensure a block was never executed.