### PR TITLE
fix: add profiler_id to the correct contexts keypath

### DIFF
--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -39,6 +39,12 @@ NS_ASSUME_NONNULL_BEGIN
         [mutableContext addEntriesFromDictionary:serializedData[@"contexts"]];
     }
 
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+    NSMutableDictionary *profileContextData = [NSMutableDictionary dictionary];
+    profileContextData[@"profiler_id"] = self.trace.profileSessionID;
+    mutableContext[@"profile"] = profileContextData;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
     // The metrics summary must be on the root level of the serialized transaction. For SentrySpans,
     // the metrics summary is on the span level. As the tracer inherits from SentrySpan the metrics
     // summary ends up in the serialized tracer dictionary. We grab it from there and move it to the
@@ -49,12 +55,6 @@ NS_ASSUME_NONNULL_BEGIN
         serializedData[@"_metrics_summary"] = metricsSummary;
         [serializedTrace removeObjectForKey:@"_metrics_summary"];
     }
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-    NSMutableDictionary *traceDataEntry =
-        [serializedTrace[@"data"] mutableCopy] ?: [NSMutableDictionary dictionary];
-    traceDataEntry[@"profiler_id"] = self.trace.profileSessionID;
-    serializedTrace[@"data"] = traceDataEntry;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
     mutableContext[@"trace"] = serializedTrace;
 
     [serializedData setValue:mutableContext forKey:@"contexts"];

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -222,9 +222,6 @@ class SentryTransactionTests: XCTestCase {
     }
     
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-    // test that when a trace runs concurrently with the continuous profiler
-    // and is serialized to a transaction, that it contains the profile id at
-    // the keypath contexts.trace.data.profile_id
     func testTransactionWithContinuousProfile() throws {
         SentrySDK.setStart(Options())
         let transaction = fixture.getTransaction()
@@ -232,9 +229,8 @@ class SentryTransactionTests: XCTestCase {
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let serialized = transaction.serialize()
         let contexts = try XCTUnwrap(serialized["contexts"] as? [String: Any])
-        let trace = try XCTUnwrap(contexts["trace"] as? [String: Any])
-        let data = try XCTUnwrap(trace["data"] as? [String: Any])
-        let profileIdFromContexts = try XCTUnwrap(data["profiler_id"] as? String)
+        let profileData = try XCTUnwrap(contexts["profile"] as? [String: Any])
+        let profileIdFromContexts = try XCTUnwrap(profileData["profiler_id"] as? String)
         XCTAssertEqual(profileId, profileIdFromContexts)
     }
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)


### PR DESCRIPTION
As part of #3555; #skip-changelog

Discovered that we were linking the profiler ID in the wrong place in the transaction payload. It should be at the location specified here: https://www.notion.so/sentry/Continuous-Profiling-SDK-design-86441dc859564a2abd9e0804f3c5deed?pvs=4#ffef96c3ab3747cc90f2db1779f5f506

Here is a transaction payload I captured after making the fix: 
[txn.json](https://github.com/user-attachments/files/16058381/txn.json)
