### PR TITLE
fix: don't run swiftlint for SPM dependencies

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -8,6 +8,7 @@ excluded:
   - test-server/.build/
   - Tests/Perf
   - SentryTestUtils/Dynamic/**
+  - .build/**
 
 only_rules:
   - class_delegate_protocol


### PR DESCRIPTION
This kept interrupting me when I was trying to create commits.

#skip-changelog