### PR TITLE
fix: Session replay in buffer mode not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - Properly handle invalid value for `NSUnderlyingErrorKey` (#4144)
-- Session replay in buffer mode not working ()
+- Session replay in buffer mode not working (#4160)
 
 ## 8.30.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Properly handle invalid value for `NSUnderlyingErrorKey` (#4144)
+- Session replay in buffer mode not working ()
 
 ## 8.30.1
 

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -170,11 +170,11 @@ class SentrySessionReplay: NSObject {
 
     @objc 
     private func newFrame(_ sender: CADisplayLink) {
-        guard let sessionStart = sessionStart, let lastScreenShot = lastScreenShot, isRunning else { return }
+        guard let lastScreenShot = lastScreenShot, isRunning else { return }
 
         let now = dateProvider.date()
         
-        if isFullSession && now.timeIntervalSince(sessionStart) > replayOptions.maximumDuration {
+        if let sessionStart = sessionStart, isFullSession && now.timeIntervalSince(sessionStart) > replayOptions.maximumDuration {
             reachedMaximumDuration = true
             stop()
             return

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -7,8 +7,10 @@ import XCTest
 class SentrySessionReplayTests: XCTestCase {
     
     private class ScreenshotProvider: NSObject, SentryViewScreenshotProvider {
+        var lastImageCall : (view: UIView, options: SentryRedactOptions)?
         func image(view: UIView, options: Sentry.SentryRedactOptions, onComplete: @escaping Sentry.ScreenshotCallback) {
             onComplete(UIImage.add)
+            lastImageCall = (view, options)
         }
     }
      
@@ -233,7 +235,6 @@ class SentrySessionReplayTests: XCTestCase {
         assertFullSession(sut, expected: false)
     }
     
-    @available(iOS 16.0, tvOS 16, *)
     func testChangeReplayMode_forHybridSDKEvent() {
         let fixture = Fixture()
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
@@ -245,7 +246,6 @@ class SentrySessionReplayTests: XCTestCase {
         assertFullSession(sut, expected: true)
     }
 
-    @available(iOS 16.0, tvOS 16, *)
     func testSessionReplayMaximumDuration() {
         let fixture = Fixture()
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
@@ -259,6 +259,17 @@ class SentrySessionReplayTests: XCTestCase {
         Dynamic(sut).newFrame(nil)
         
         XCTAssertFalse(sut.isRunning)
+    }
+    
+    func testSaveScreenShotInBufferMode() {
+        let fixture = Fixture()
+        
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 0, errorSampleRate: 1))
+        sut.start(rootView: fixture.rootView, fullSession: false)
+        fixture.dateProvider.advance(by: 1)
+        Dynamic(sut).newFrame(nil)
+        
+        XCTAssertNotNil(fixture.screenshotProvider.lastImageCall)
     }
     
     @available(iOS 16.0, tvOS 16, *)


### PR DESCRIPTION
The frames during buffer mode were not being saved to disk.

_#skip-changelog_

