### PR TITLE
fix: Session replay video duration from seconds to milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Session replay video duration from seconds to milliseconds () 
+- Session replay video duration from seconds to milliseconds (#4163) 
 
 ## 8.31.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session replay video duration from seconds to milliseconds () 
+
 ## 8.31.0
 
 ### Features

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebVideoEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebVideoEvent.swift
@@ -9,7 +9,7 @@ class SentryRRWebVideoEvent: SentryRRWebCustomEvent {
             "timestamp": timestamp.timeIntervalSince1970,
             "segmentId": segmentId,
             "size": size,
-            "duration": Int(duration * 1000),
+            "duration": Int(duration * 1_000),
             "encoding": encoding,
             "container": container,
             "height": height,

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebVideoEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebVideoEvent.swift
@@ -9,7 +9,7 @@ class SentryRRWebVideoEvent: SentryRRWebCustomEvent {
             "timestamp": timestamp.timeIntervalSince1970,
             "segmentId": segmentId,
             "size": size,
-            "duration": duration,
+            "duration": Int(duration * 1000),
             "encoding": encoding,
             "container": container,
             "height": height,


### PR DESCRIPTION
Fix required for the front player.

Fixes https://github.com/getsentry/sentry/issues/74289