### PR TITLE
fix: pass through captureReplay

### DIFF
--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -187,7 +187,7 @@ SentrySessionReplayIntegration ()
 
 - (void)captureReplay
 {
-    //[self.sessionReplay captureReplay];
+    [self.sessionReplay captureReplay];
 }
 
 - (void)configureReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -133,6 +133,7 @@ class SentrySessionReplay: NSObject {
         setEventContext(event: event)
     }
 
+    @discardableResult
     func captureReplay() -> Bool {
         guard isRunning else { return false }
         guard !isFullSession else { return true }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayRecordingTests.swift
@@ -5,7 +5,7 @@ import XCTest
 class SentryReplayRecordingTests: XCTestCase {
     
     func test_serialize() throws {
-        let sut = SentryReplayRecording(segmentId: 3, size: 200, start: Date(timeIntervalSince1970: 2), duration: 5_000, frameCount: 5, frameRate: 1, height: 930, width: 390, extraEvents: nil)
+        let sut = SentryReplayRecording(segmentId: 3, size: 200, start: Date(timeIntervalSince1970: 2), duration: 5, frameCount: 5, frameRate: 1, height: 930, width: 390, extraEvents: nil)
       
         let data = sut.serialize()
         
@@ -26,7 +26,7 @@ class SentryReplayRecordingTests: XCTestCase {
         XCTAssertEqual(recordingData?["tag"] as? String, "video")
         XCTAssertEqual(recordingPayload?["segmentId"] as? Int, 3)
         XCTAssertEqual(recordingPayload?["size"] as? Int, 200)
-        XCTAssertEqual(recordingPayload?["duration"] as? Double, 5_000)
+        XCTAssertEqual(recordingPayload?["duration"] as? Int, 5_000)
         XCTAssertEqual(recordingPayload?["encoding"] as? String, "h264")
         XCTAssertEqual(recordingPayload?["container"] as? String, "mp4")
         XCTAssertEqual(recordingPayload?["height"] as? Int, 930)


### PR DESCRIPTION
Uncomment a commented code left behind for tests.

_#skip-changelog_ 