### PR TITLE
chore: Double check lock extension for NSLock

### DIFF
--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -20,7 +20,7 @@ extension NSLock {
     /// Only runs the closure if the flag is false, then updates the flag to true.
     /// - Parameter toRun: The closure to run.
     ///
-    /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
+    /// - Returns: `true` if the closure was invoked, otherwise `false`.
     func setFlag(_ flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
         if flag { return false }
         self.lock()
@@ -38,7 +38,7 @@ extension NSLock {
     /// Only runs the closure if the flag is true, then updates the flag to false.
     /// - Parameter toRun: The closure to run.
     ///
-    /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
+    /// - Returns: `true` if the closure was invoked, otherwise `false`.
     func unsetFlag(_ flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
         if !flag { return false }
         self.lock()

--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -12,4 +12,23 @@ extension NSLock {
         self.lock()
         return try closure()
     }
+    
+    /// Executes the closure if the flag is false while acquiring the lock.
+    /// Updates the flag to true. This can be used as double-check lock.
+    ///
+    /// - Parameter flag: A flag that will be double check to make sure closure should be invoked.
+    /// Only runs the closure if the flag is false, then updates the flag to indicate the closure was called.
+    /// - Parameter toRun: The closure to run.
+    ///
+    /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
+    func checkFlag(flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
+        if flag { return false }
+        self.lock()
+        defer { self.unlock() }
+        if flag { return false }
+        try closure()
+        flag = true
+        return true
+    }
+        
 }

--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -21,7 +21,7 @@ extension NSLock {
     /// - Parameter toRun: The closure to run.
     ///
     /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
-    func setFlag(flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
+    func setFlag(_ flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
         if flag { return false }
         self.lock()
         defer { self.unlock() }
@@ -39,7 +39,7 @@ extension NSLock {
     /// - Parameter toRun: The closure to run.
     ///
     /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
-    func unsetFlag(flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
+    func unsetFlag(_ flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
         if !flag { return false }
         self.lock()
         defer { self.unlock() }

--- a/Sources/Swift/Extensions/NSLock.swift
+++ b/Sources/Swift/Extensions/NSLock.swift
@@ -17,17 +17,35 @@ extension NSLock {
     /// Updates the flag to true. This can be used as double-check lock.
     ///
     /// - Parameter flag: A flag that will be double check to make sure closure should be invoked.
-    /// Only runs the closure if the flag is false, then updates the flag to indicate the closure was called.
+    /// Only runs the closure if the flag is false, then updates the flag to true.
     /// - Parameter toRun: The closure to run.
     ///
     /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
-    func checkFlag(flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
+    func setFlag(flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
         if flag { return false }
         self.lock()
         defer { self.unlock() }
         if flag { return false }
         try closure()
         flag = true
+        return true
+    }
+    
+    /// Executes the closure if the flag is true while acquiring the lock.
+    /// Updates the flag to false. This can be used as double-check lock.
+    ///
+    /// - Parameter flag: A flag that will be double check to make sure closure should be invoked.
+    /// Only runs the closure if the flag is true, then updates the flag to false.
+    /// - Parameter toRun: The closure to run.
+    ///
+    /// - Returns: The value the closure generated or `nil` if the flag was enabled already.
+    func unsetFlag(flag: inout Bool, toRun closure: () throws -> Void) rethrows -> Bool {
+        if !flag { return false }
+        self.lock()
+        defer { self.unlock() }
+        if !flag { return false }
+        try closure()
+        flag = false
         return true
     }
         

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -61,7 +61,7 @@ class SentrySessionReplay: NSObject {
     }
 
     func start(rootView: UIView, fullSession: Bool) {
-        guard lock.setFlag(flag: &isRunning, toRun: {
+        guard lock.setFlag(&isRunning, toRun: {
             displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
         }) else { return }
         
@@ -87,7 +87,7 @@ class SentrySessionReplay: NSObject {
     }
 
     func stop() {
-        guard lock.unsetFlag(flag: &isRunning, toRun: {
+        guard lock.unsetFlag(&isRunning, toRun: {
             displayLink.invalidate()
         }) else { return }
         

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -61,7 +61,7 @@ class SentrySessionReplay: NSObject {
     }
 
     func start(rootView: UIView, fullSession: Bool) {
-        guard lock.checkFlag(flag: &isRunning, toRun: {
+        guard lock.setFlag(flag: &isRunning, toRun: {
             displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
         }) else { return }
         
@@ -87,8 +87,7 @@ class SentrySessionReplay: NSObject {
     }
 
     func stop() {
-        
-        guard lock.checkFlag(flag: &isRunning, toRun: {
+        guard lock.unsetFlag(flag: &isRunning, toRun: {
             displayLink.invalidate()
         }) else { return }
         

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -61,8 +61,6 @@ class SentrySessionReplay: NSObject {
     }
 
     func start(rootView: UIView, fullSession: Bool) {
-        guard !isRunning else { return }
-        
         guard lock.checkFlag(flag: &isRunning, toRun: {
             displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
         }) else { return }

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -45,6 +45,40 @@ final class NSLockTests: XCTestCase {
         
         wait(for: [expectation], timeout: 0.1)
     }
+    
+    func testCheckFlagIsFalse() {
+        var flag = false
+        var executed = false
+        let lock = NSLock()
+        _ = lock.checkFlag(flag: &flag) {
+            executed = true
+        }
+        XCTAssertTrue(executed)
+        XCTAssertTrue(flag)
+    }
+    
+    func testCheckFlagIsTrue() {
+        var flag = true
+        var skipped = true
+        let lock = NSLock()
+        _ = lock.checkFlag(flag: &flag) {
+            skipped = false
+        }
+        XCTAssertTrue(skipped)
+        XCTAssertTrue(flag)
+    }
+    
+    func testStressFlag() {
+        let lock = NSLock()
+        var flag = false
+        var value = 0
+        
+        testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 9, writeWork: { _ in
+            _ = lock.checkFlag(flag: &flag) { value += 1 }
+        })
+        
+        XCTAssertEqual(value, 1)
+    }
 
     enum NSLockError: Error {
         case runtimeError(String)

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -46,11 +46,11 @@ final class NSLockTests: XCTestCase {
         wait(for: [expectation], timeout: 0.1)
     }
     
-    func testCheckFlagIsFalse() {
+    func testSetFlag_FalseFlag() {
         var flag = false
         var executed = false
         let lock = NSLock()
-        let result = lock.checkFlag(flag: &flag) {
+        let result = lock.setFlag(flag: &flag) {
             executed = true
         }
         XCTAssertTrue(result)
@@ -58,11 +58,11 @@ final class NSLockTests: XCTestCase {
         XCTAssertTrue(flag)
     }
     
-    func testCheckFlagIsTrue() {
+    func testSetFlag_TrueFlag() {
         var flag = true
         var skipped = true
         let lock = NSLock()
-        let result = lock.checkFlag(flag: &flag) {
+        let result = lock.setFlag(flag: &flag) {
             skipped = false
         }
         XCTAssertFalse(result)
@@ -70,14 +70,53 @@ final class NSLockTests: XCTestCase {
         XCTAssertTrue(flag)
     }
     
-    func testStressFlag() {
+    func testStressSetFlag() {
         let lock = NSLock()
         var flag = false
         var closureCalls = 0
         var correctGuard = 0
         
         testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 9, writeWork: { _ in
-            guard lock.checkFlag(flag: &flag, toRun: { closureCalls += 1 }) else { return }
+            guard lock.setFlag(flag: &flag, toRun: { closureCalls += 1 }) else { return }
+            correctGuard += 1
+        })
+        
+        XCTAssertEqual(closureCalls, 1)
+        XCTAssertEqual(correctGuard, 1)
+    }
+    
+    func testUnsetFlag_TrueFlag() {
+        var flag = true
+        var executed = false
+        let lock = NSLock()
+        let result = lock.unsetFlag(flag: &flag) {
+            executed = true
+        }
+        XCTAssertTrue(result)
+        XCTAssertTrue(executed)
+        XCTAssertFalse(flag)
+    }
+    
+    func testUnsetFlag_FalseFlag() {
+        var flag = false
+        var skipped = true
+        let lock = NSLock()
+        let result = lock.unsetFlag(flag: &flag) {
+            skipped = false
+        }
+        XCTAssertFalse(result)
+        XCTAssertTrue(skipped)
+        XCTAssertFalse(flag)
+    }
+    
+    func testStressUnsetFlag() {
+        let lock = NSLock()
+        var flag = true
+        var closureCalls = 0
+        var correctGuard = 0
+        
+        testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 9, writeWork: { _ in
+            guard lock.unsetFlag(flag: &flag, toRun: { closureCalls += 1 }) else { return }
             correctGuard += 1
         })
         

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -50,7 +50,7 @@ final class NSLockTests: XCTestCase {
         var flag = false
         var executed = false
         let lock = NSLock()
-        let result = lock.setFlag(flag: &flag) {
+        let result = lock.setFlag(&flag) {
             executed = true
         }
         XCTAssertTrue(result)
@@ -62,7 +62,7 @@ final class NSLockTests: XCTestCase {
         var flag = true
         var skipped = true
         let lock = NSLock()
-        let result = lock.setFlag(flag: &flag) {
+        let result = lock.setFlag(&flag) {
             skipped = false
         }
         XCTAssertFalse(result)
@@ -77,7 +77,7 @@ final class NSLockTests: XCTestCase {
         var correctGuard = 0
         
         testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 9, writeWork: { _ in
-            guard lock.setFlag(flag: &flag, toRun: { closureCalls += 1 }) else { return }
+            guard lock.setFlag(&flag, toRun: { closureCalls += 1 }) else { return }
             correctGuard += 1
         })
         
@@ -89,7 +89,7 @@ final class NSLockTests: XCTestCase {
         var flag = true
         var executed = false
         let lock = NSLock()
-        let result = lock.unsetFlag(flag: &flag) {
+        let result = lock.unsetFlag(&flag) {
             executed = true
         }
         XCTAssertTrue(result)
@@ -101,7 +101,7 @@ final class NSLockTests: XCTestCase {
         var flag = false
         var skipped = true
         let lock = NSLock()
-        let result = lock.unsetFlag(flag: &flag) {
+        let result = lock.unsetFlag(&flag) {
             skipped = false
         }
         XCTAssertFalse(result)
@@ -116,7 +116,7 @@ final class NSLockTests: XCTestCase {
         var correctGuard = 0
         
         testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 9, writeWork: { _ in
-            guard lock.unsetFlag(flag: &flag, toRun: { closureCalls += 1 }) else { return }
+            guard lock.unsetFlag(&flag, toRun: { closureCalls += 1 }) else { return }
             correctGuard += 1
         })
         


### PR DESCRIPTION
Writing double check lock in swift is weird, and it's not possible to use the `.synchronized` extension, so I added a little NSLock extension that can be used with a `guard` statement. 

_#skip-changelog_