### PR TITLE
Fix extraneous whitespace error in Swift 6 compiler

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -14,9 +14,9 @@ protocol SentrySessionReplayDelegate: NSObjectProtocol {
 
 @objcMembers
 class SentrySessionReplay: NSObject {
-    private (set) var isRunning = false
-    private (set) var isFullSession = false
-    private (set) var sessionReplayId: SentryId?
+    private(set) var isRunning = false
+    private(set) var isFullSession = false
+    private(set) var sessionReplayId: SentryId?
 
     private var urlToCache: URL?
     private var rootView: UIView?


### PR DESCRIPTION
## :scroll: Description

The Swift 6 language module does not allow for the extraneous whitespace between the attribute name and '('.
Therefore we're removing it to adhere to the compiler.

## :bulb: Motivation and Context

This happens with the current Swift 6 Development Snapshot (Jul 15th) and is likely to become an issue in one of the next Xcode betas once the nightlies make it into the beta.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
