### PR TITLE
Chore: Remove extraneous whitespace

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -14,9 +14,9 @@ protocol SentrySessionReplayDelegate: NSObjectProtocol {
 
 @objcMembers
 class SentrySessionReplay: NSObject {
-    private (set) var isRunning = false
-    private (set) var isFullSession = false
-    private (set) var sessionReplayId: SentryId?
+    private(set) var isRunning = false
+    private(set) var isFullSession = false
+    private(set) var sessionReplayId: SentryId?
 
     private var urlToCache: URL?
     private var rootView: UIView?


### PR DESCRIPTION
Remove extraneous whitespace that will be an error with Swift 6 mode.

closes #4173 

_#skip-changelog_