### PR TITLE
chore: Deprecate options.enableTracing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Deprecated
 
-- options.enableTracing was deprecated. Use options.tracesSampleRate or options.tracesSampler instead. ()
+- options.enableTracing was deprecated. Use options.tracesSampleRate or options.tracesSampler instead. (#4182)
 
 ## 8.31.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Deprecated
+
+- options.enableTracing was deprecated. Use options.tracesSampleRate or options.tracesSampler instead. ()
+
 ## 8.31.1
 
 ### Fixes

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -59,7 +59,8 @@ sentry_shouldProfileNextLaunch(SentryOptions *options)
     if (options.enableAppLaunchProfiling && [options isContinuousProfilingEnabled]) {
         return (SentryLaunchProfileConfig) { YES, nil, nil };
     }
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     BOOL shouldProfileNextLaunch = options.enableAppLaunchProfiling && options.enableTracing;
     if (!shouldProfileNextLaunch) {
         SENTRY_LOG_DEBUG(@"Won't profile next launch due to specified options configuration: "
@@ -67,7 +68,7 @@ sentry_shouldProfileNextLaunch(SentryOptions *options)
             options.enableAppLaunchProfiling, options.enableTracing);
         return (SentryLaunchProfileConfig) { NO, nil, nil };
     }
-
+#pragma clang diagnostic pop
     SentryTransactionContext *transactionContext =
         [[SentryTransactionContext alloc] initWithName:@"app.launch" operation:@"profile"];
     transactionContext.forNextAppLaunch = YES;

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -59,8 +59,8 @@ sentry_shouldProfileNextLaunch(SentryOptions *options)
     if (options.enableAppLaunchProfiling && [options isContinuousProfilingEnabled]) {
         return (SentryLaunchProfileConfig) { YES, nil, nil };
     }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     BOOL shouldProfileNextLaunch = options.enableAppLaunchProfiling && options.enableTracing;
     if (!shouldProfileNextLaunch) {
         SENTRY_LOG_DEBUG(@"Won't profile next launch due to specified options configuration: "
@@ -68,7 +68,7 @@ sentry_shouldProfileNextLaunch(SentryOptions *options)
             options.enableAppLaunchProfiling, options.enableTracing);
         return (SentryLaunchProfileConfig) { NO, nil, nil };
     }
-#pragma clang diagnostic pop
+#    pragma clang diagnostic pop
     SentryTransactionContext *transactionContext =
         [[SentryTransactionContext alloc] initWithName:@"app.launch" operation:@"profile"];
     transactionContext.forNextAppLaunch = YES;

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -334,7 +334,8 @@ NS_SWIFT_NAME(Options)
  * @c tracesSampler are @c nil. Changing either @c tracesSampleRate or @c tracesSampler to a value
  * other then @c nil will enable this in case this was never changed before.
  */
-@property (nonatomic) BOOL enableTracing DEPRECATED_MSG_ATTRIBUTE("Use tracesSampleRate or tracesSampler instead");
+@property (nonatomic)
+    BOOL enableTracing DEPRECATED_MSG_ATTRIBUTE("Use tracesSampleRate or tracesSampler instead");
 
 /**
  * Indicates the percentage of the tracing data that is collected.

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -334,7 +334,7 @@ NS_SWIFT_NAME(Options)
  * @c tracesSampler are @c nil. Changing either @c tracesSampleRate or @c tracesSampler to a value
  * other then @c nil will enable this in case this was never changed before.
  */
-@property (nonatomic) BOOL enableTracing;
+@property (nonatomic) BOOL enableTracing DEPRECATED_MSG_ATTRIBUTE("Use tracesSampleRate or tracesSampler instead");
 
 /**
  * Indicates the percentage of the tracing data that is collected.
@@ -360,8 +360,8 @@ NS_SWIFT_NAME(Options)
 
 /**
  * If tracing is enabled or not.
- * @discussion @c YES if @c enabledTracing is @c YES and @c tracesSampleRate
- * is > @c 0 and \<= @c 1 or a @c tracesSampler is set, otherwise @c NO.
+ * @discussion @c YES if @c tracesSampleRateis > @c 0 and \<= @c 1
+ * or a @c tracesSampler is set, otherwise @c NO.
  */
 @property (nonatomic, assign, readonly) BOOL isTracingEnabled;
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -448,10 +448,12 @@ NSString *const kSentryDefaultEnvironment = @"production";
     if ([self isBlock:options[@"tracesSampler"]]) {
         self.tracesSampler = options[@"tracesSampler"];
     }
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([options[@"enableTracing"] isKindOfClass:NSNumber.self]) {
         self.enableTracing = [options[@"enableTracing"] boolValue];
     }
+#pragma clang diagnostic pop
 
     if ([options[@"inAppIncludes"] isKindOfClass:[NSArray class]]) {
         NSArray<NSString *> *inAppIncludes =

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -293,7 +293,7 @@ final class SentryAppLaunchProfilingSwiftTests: XCTestCase {
         ] {
             let options = Options()
             options.enableAppLaunchProfiling = testCase.enableAppLaunchProfiling
-            options.enableTracing = testCase.enableTracing
+            Dynamic(options).enableTracing = testCase.enableTracing
             options.tracesSampleRate = NSNumber(value: testCase.tracesSampleRate)
             if let profilesSampleRate = testCase.profilesSampleRate {
                 options.profilesSampleRate = NSNumber(value: profilesSampleRate)

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -957,7 +957,6 @@
     XCTAssertEqual(options.tracesSampleRate.doubleValue, 0.5);
 }
 
-
 - (void)testChanging_tracesSampler_afterSetting_enableTracing
 {
     SentryTracesSamplerCallback sampler

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -659,7 +659,10 @@
     XCTAssertEqual(options.experimental.sessionReplay.errorSampleRate, 0);
     XCTAssertEqual(options.experimental.sessionReplay.sessionSampleRate, 0);
 #endif // SENTRY_HAS_UIKIT
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertFalse(options.enableTracing);
+#pragma clang diagnostic pop
     XCTAssertTrue(options.enableAppHangTracking);
     XCTAssertEqual(options.appHangTimeoutInterval, 2);
     XCTAssertEqual(YES, options.enableNetworkTracking);
@@ -909,6 +912,8 @@
     XCTAssertEqualObjects(expected, options.swizzleClassNameExcludes);
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testEnableTracing
 {
     SentryOptions *options = [self getValidOptions:@{ @"enableTracing" : @YES }];
@@ -952,6 +957,7 @@
     XCTAssertEqual(options.tracesSampleRate.doubleValue, 0.5);
 }
 
+
 - (void)testChanging_tracesSampler_afterSetting_enableTracing
 {
     SentryTracesSamplerCallback sampler
@@ -976,6 +982,7 @@
     XCTAssertEqual(options.tracesSampleRate.doubleValue, 0.1);
     XCTAssertTrue(options.enableTracing);
 }
+#pragma clang diagnostic pop
 
 - (void)testDefaultTracesSampleRate
 {
@@ -1028,6 +1035,8 @@
     return 0.1;
 }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testTracesSampler
 {
     SentryTracesSamplerCallback sampler = ^(SentrySamplingContext *context) {
@@ -1041,6 +1050,7 @@
     XCTAssertEqual(options.tracesSampler(context), @1.0);
     XCTAssertTrue(options.enableTracing);
 }
+#pragma clang diagnostic pop
 
 - (void)testDefaultTracesSampler
 {


### PR DESCRIPTION
Deprecating `options.enableTracing` in order to completely remove it in the next major.

Closes #4177 