### PR TITLE
feat: Add reportAccessibilityIdentifier option

### DIFF
--- a/.sauce/benchmarking-config.yml
+++ b/.sauce/benchmarking-config.yml
@@ -14,13 +14,13 @@ xcuitest:
 suites:
   - name: "High-end device"
     devices:
-      - name: "iPad Pro 12.9 2021"
-        platformVersion: "15"
+      - name: "iPad Pro 11 2024"
+        platformVersion: "17"
   - name: "Mid-range device"
+    devices:
+      - name: "iPhone 13 Mini"
+        platformVersion: "17"
+  - name: "Low-end device"
     devices:
       - name: "iPhone 8"
         platformVersion: "14"
-  - name: "Low-end device"
-    devices:
-      - name: "iPhone 6S"
-        platformVersion: "15"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add `reportAccessibilityIdentifier` option ()
+- Add `reportAccessibilityIdentifier` option (#4183)
 
 ## 8.31.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add `reportAccessibilityIdentifier` option ()
+
 ## 8.31.1
 
 ### Fixes

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -279,7 +279,7 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachViewHierarchy;
 
 /**
- * @brief If enabled, view hierarchy attachment will containt view `accessibilityIdentifier`.
+ * @brief If enabled, view hierarchy attachment will contain view `accessibilityIdentifier`.
  * Set it to @c NO if your project uses `accessibilityIdentifier` for PII.
  * @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit
  * configurations even when targeting iOS or tvOS platforms.

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -279,6 +279,15 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL attachViewHierarchy;
 
 /**
+ * @brief If enabled, view hierarchy attachment will containt view `accessibilityIdentifier`.
+ * Set it to @c NO if your project uses `accessibilityIdentifier` for PII.
+ * @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit
+ * configurations even when targeting iOS or tvOS platforms.
+ * @note Default value is @c YES.
+ */
+@property (nonatomic, assign) BOOL reportAccessibilityIdentifier;
+
+/**
  * When enabled, the SDK creates transactions for UI events like buttons clicks, switch toggles,
  * and other ui elements that uses UIControl @c sendAction:to:forEvent:
  * @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -416,7 +416,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[@"attachViewHierarchy"]
             block:^(BOOL value) { self->_attachViewHierarchy = value; }];
-    
+
     [self setBool:options[@"reportAccessibilityIdentifier"]
             block:^(BOOL value) { self->_reportAccessibilityIdentifier = value; }];
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -114,6 +114,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enableUIViewControllerTracing = YES;
         self.attachScreenshot = NO;
         self.attachViewHierarchy = NO;
+        self.reportAccessibilityIdentifier = YES;
         self.enableUserInteractionTracing = YES;
         self.idleTimeout = SentryTracerDefaultTimeout;
         self.enablePreWarmedAppStartTracing = NO;
@@ -415,6 +416,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
     [self setBool:options[@"attachViewHierarchy"]
             block:^(BOOL value) { self->_attachViewHierarchy = value; }];
+    
+    [self setBool:options[@"reportAccessibilityIdentifier"]
+            block:^(BOOL value) { self->_reportAccessibilityIdentifier = value; }];
 
     [self setBool:options[@"enableUserInteractionTracing"]
             block:^(BOOL value) { self->_enableUserInteractionTracing = value; }];

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -119,7 +119,8 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
     tryJson(sentrycrashjson_addStringElement(
         context, "type", viewClassName, SentryCrashJSON_SIZE_AUTOMATIC));
 
-    if (self.reportAccessibilityIdentifier && view.accessibilityIdentifier && view.accessibilityIdentifier.length != 0) {
+    if (self.reportAccessibilityIdentifier && view.accessibilityIdentifier
+        && view.accessibilityIdentifier.length != 0) {
         tryJson(sentrycrashjson_addStringElement(context, "identifier",
             view.accessibilityIdentifier.UTF8String, SentryCrashJSON_SIZE_AUTOMATIC));
     }

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -29,6 +29,13 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
 
 @implementation SentryViewHierarchy
 
+- (instancetype)init {
+    if (self = [super init]) {
+        self.reportAccessibilityIdentifier = YES;
+    }
+    return self;
+}
+
 - (BOOL)saveViewHierarchy:(NSString *)filePath
 {
     NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -119,7 +119,7 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
     tryJson(sentrycrashjson_addStringElement(
         context, "type", viewClassName, SentryCrashJSON_SIZE_AUTOMATIC));
 
-    if (view.accessibilityIdentifier && view.accessibilityIdentifier.length != 0) {
+    if (self.reportAccessibilityIdentifier && view.accessibilityIdentifier && view.accessibilityIdentifier.length != 0) {
         tryJson(sentrycrashjson_addStringElement(context, "identifier",
             view.accessibilityIdentifier.UTF8String, SentryCrashJSON_SIZE_AUTOMATIC));
     }

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -40,7 +40,8 @@ saveViewHierarchy(const char *reportDirectoryPath)
 
     sentrycrash_setSaveViewHierarchy(&saveViewHierarchy);
 
-    SentryDependencyContainer.sharedInstance.viewHierarchy.reportAccessibilityIdentifier = options.reportAccessibilityIdentifier;
+    SentryDependencyContainer.sharedInstance.viewHierarchy.reportAccessibilityIdentifier
+        = options.reportAccessibilityIdentifier;
     return YES;
 }
 

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -40,6 +40,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
 
     sentrycrash_setSaveViewHierarchy(&saveViewHierarchy);
 
+    SentryDependencyContainer.sharedInstance.viewHierarchy.reportAccessibilityIdentifier = options.reportAccessibilityIdentifier;
     return YES;
 }
 

--- a/Sources/Sentry/include/SentryViewHierarchy.h
+++ b/Sources/Sentry/include/SentryViewHierarchy.h
@@ -7,6 +7,11 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryViewHierarchy : NSObject
 
 /**
+ * Whether we should add `accessibilityIdentifier` to the view hierarchy.
+ */
+@property (nonatomic) BOOL reportAccessibilityIdentifier;
+
+/**
  Get the view hierarchy in a json format.
  Always runs in the main thread.
  */

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -146,6 +146,23 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
         
         wait(for: [ex], timeout: 1)
     }
+    
+    func testReportAccessibilityIdentifierTrue() {
+        SentrySDK.start {
+            $0.attachViewHierarchy = true
+            $0.setIntegrations([SentryViewHierarchyIntegration.self])
+        }
+        XCTAssertTrue(SentryDependencyContainer.sharedInstance().viewHierarchy.reportAccessibilityIdentifier)
+    }
+    
+    func testReportAccessibilityIdentifierFalse() {
+        SentrySDK.start {
+            $0.attachViewHierarchy = true
+            $0.reportAccessibilityIdentifier = false
+            $0.setIntegrations([SentryViewHierarchyIntegration.self])
+        }
+        XCTAssertFalse(SentryDependencyContainer.sharedInstance().viewHierarchy.reportAccessibilityIdentifier)
+    }
 }
 
 #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -656,6 +656,7 @@
     XCTAssertEqual(options.enableUserInteractionTracing, YES);
     XCTAssertEqual(options.enablePreWarmedAppStartTracing, NO);
     XCTAssertEqual(options.attachViewHierarchy, NO);
+    XCTAssertEqual(options.reportAccessibilityIdentifier, YES);
     XCTAssertEqual(options.experimental.sessionReplay.errorSampleRate, 0);
     XCTAssertEqual(options.experimental.sessionReplay.sessionSampleRate, 0);
 #endif // SENTRY_HAS_UIKIT
@@ -803,6 +804,11 @@
 - (void)testAttachScreenshot
 {
     [self testBooleanField:@"attachScreenshot" defaultValue:NO];
+}
+
+- (void)testReportAccessibilityIdentifier
+{
+    [self testBooleanField:@"reportAccessibilityIdentifier" defaultValue:YES];
 }
 
 - (void)testEnableUserInteractionTracing

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -156,8 +156,9 @@ class SentryViewHierarchyTests: XCTestCase {
         fixture.uiApplication.windows = [window]
 
         let path = FileManager.default.temporaryDirectory.appendingPathComponent("view.json").path
-        self.fixture.sut.reportAccessibilityIdentifier = false
-        self.fixture.sut.save(path)
+        let sut = self.fixture.sut
+        sut.reportAccessibilityIdentifier = false
+        sut.save(path)
 
         let descriptions = (try? String(contentsOfFile: path)) ?? ""
 

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -149,7 +149,7 @@ class SentryViewHierarchyTests: XCTestCase {
         XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"WindowId\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
     }
     
-    func test_ViewHierarchy_save_noIdentifier() {
+    func test_ViewHierarchy_save_noIdentifier() throws {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         window.accessibilityIdentifier = "WindowId"
 

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -160,7 +160,7 @@ class SentryViewHierarchyTests: XCTestCase {
         sut.reportAccessibilityIdentifier = false
         sut.save(path)
 
-        let descriptions = (try? String(contentsOfFile: path)) ?? ""
+        let descriptions = try XCTUnwrap(String(contentsOfFile: path))
 
         XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
     }

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -148,6 +148,21 @@ class SentryViewHierarchyTests: XCTestCase {
 
         XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"identifier\":\"WindowId\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
     }
+    
+    func test_ViewHierarchy_save_noIdentifier() {
+        let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
+        window.accessibilityIdentifier = "WindowId"
+
+        fixture.uiApplication.windows = [window]
+
+        let path = FileManager.default.temporaryDirectory.appendingPathComponent("view.json").path
+        self.fixture.sut.reportAccessibilityIdentifier = false
+        self.fixture.sut.save(path)
+
+        let descriptions = (try? String(contentsOfFile: path)) ?? ""
+
+        XCTAssertEqual(descriptions, "{\"rendering_system\":\"UIKIT\",\"windows\":[{\"type\":\"UIWindow\",\"width\":10,\"height\":10,\"x\":0,\"y\":0,\"alpha\":1,\"visible\":false,\"children\":[]}]}")
+    }
 
     func test_invalidFilePath() {
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))


### PR DESCRIPTION
## :scroll: Description

Added an option to choose whether to report accessibilityIdentifier with the view hierarchy.

## :bulb: Motivation and Context

close #4037 

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
