### PR TITLE
fix: Session replay crash when writing the replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Session replay crash when writing the replay (#4186)
+
 ## 8.31.1
 
 ### Fixes

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -137,5 +137,26 @@ class SentryOnDemandReplayTests: XCTestCase {
         XCTAssertEqual(sut.frames.count, 0)
     }
     
+    func testInvalidWriter() {
+        let queue = SentryDispatchQueueWrapper()
+        let sut = SentryOnDemandReplay(outputPath: outputPath.path,
+                                       workingQueue: queue,
+                                       dateProvider: dateProvider)
+        let expect = expectation(description: "Video render")
+        
+        let start = dateProvider.date()
+        sut.addFrameAsync(image: UIImage.add)
+        dateProvider.advance(by: 1)
+        let end = dateProvider.date()
+        
+        try? sut.createVideoWith(beginning: start, end: end, outputFileURL: URL(fileURLWithPath: "/invalidPath/video.mp3")) { _, error in
+            XCTAssertNotNil(error)
+            XCTAssertEqual(error as? SentryOnDemandReplayError, SentryOnDemandReplayError.assetWriterNotReady)
+            expect.fulfill()
+        }
+        
+        wait(for: [expect], timeout: 1)
+    }
+    
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

Checks the status of the asset writer before using it.

## :bulb: Motivation and Context

closes #4185 

## :green_heart: How did you test it?

Sample and unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
