### PR TITLE
ref: Remove double-checked lock for flush

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -184,12 +184,6 @@ SentryHttpTransport ()
     dispatch_time_t delta = (int64_t)(timeout * (NSTimeInterval)NSEC_PER_SEC);
     dispatch_time_t dispatchTimeout = dispatch_time(DISPATCH_TIME_NOW, delta);
 
-    // Double-Checked Locking to avoid acquiring unnecessary locks.
-    if (_isFlushing) {
-        SENTRY_LOG_DEBUG(@"Already flushing.");
-        return kSentryFlushResultAlreadyFlushing;
-    }
-
     @synchronized(self) {
         if (_isFlushing) {
             SENTRY_LOG_DEBUG(@"Already flushing.");

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -906,7 +906,7 @@ class SentryHttpTransportTests: XCTestCase {
             ensureFlushingGroup.waitWithTimeout()
             
             // Now the transport should also have left the synchronized block, and the
-            // double-checked lock, should return immediately.
+            // flush should return immediately.
             
             let initiallyInactiveQueue = fixture.queue
             for _ in 0..<2 {

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -913,7 +913,7 @@ class SentryHttpTransportTests: XCTestCase {
                 allFlushCallsGroup.enter()
                 initiallyInactiveQueue.async {
                     for _ in 0..<10 {
-                        XCTAssertEqual(.alreadyFlushing, self.sut.flush(flushTimeout), "Double checked lock should have returned immediately")
+                        XCTAssertEqual(.alreadyFlushing, self.sut.flush(flushTimeout), "Flush should have returned immediately")
                     }
                     
                     allFlushCallsGroup.leave()


### PR DESCRIPTION
The SentryHttpTransport used a double-checked lock in flush, which isn't required because it's doubtful that somebody calls flush in a tight loop from multiple threads, and when they do, it's acceptable to block them for a bit longer.

#skip-changelog