### PR TITLE
feat: Add BeforeCaptureViewHierarchy Callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Replay for crashes (#4171)
 - Redact web view from replay (#4203)
+- Add beforeCaptureViewHierarchy callback (#4210)
 
 ## 8.32.0
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -31,6 +31,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.beforeCaptureScreenshot = { _ in
                 return true
             }
+            options.beforeCaptureViewHierarchy = { _ in
+                return true
+            }
             options.debug = true
             
             if #available(iOS 16.0, *), !args.contains("--disable-session-replay") {

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -100,6 +100,13 @@ typedef id<SentrySpan> _Nullable (^SentryBeforeSendSpanCallback)(id<SentrySpan> 
 typedef BOOL (^SentryBeforeCaptureScreenshotCallback)(SentryEvent *_Nonnull event);
 
 /**
+ * Block can be used to decide if the SDK should capture a view hierarchy or not. Return @c true if
+ * the SDK should capture a view hierarchy, return @c false if not. This callback doesn't work for
+ * crashes.
+ */
+typedef BOOL (^SentryBeforeCaptureViewHierarchyCallback)(SentryEvent *_Nonnull event);
+
+/**
  * A callback to be notified when the last program execution terminated with a crash.
  */
 typedef void (^SentryOnCrashedLastRunCallback)(SentryEvent *_Nonnull event);

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -137,6 +137,14 @@ NS_SWIFT_NAME(Options)
 @property (nullable, nonatomic, copy) SentryBeforeCaptureScreenshotCallback beforeCaptureScreenshot;
 
 /**
+ * You can use this callback to decide if the SDK should capture a view hierarchy or not. Return @c
+ * true if the SDK should capture a view hierarchy, return @c false if not. This callback doesn't
+ * work for crashes.
+ */
+@property (nullable, nonatomic, copy)
+    SentryBeforeCaptureScreenshotCallback beforeCaptureViewHierarchy;
+
+/**
  * A block called shortly after the initialization of the SDK when the last program execution
  * terminated with a crash.
  * @discussion This callback is only executed once during the entire run of the program to avoid

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -354,6 +354,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.beforeCaptureScreenshot = options[@"beforeCaptureScreenshot"];
     }
 
+    if ([self isBlock:options[@"beforeCaptureViewHierarchy"]]) {
+        self.beforeCaptureViewHierarchy = options[@"beforeCaptureViewHierarchy"];
+    }
+
     if ([self isBlock:options[@"onCrashedLastRun"]]) {
         self.onCrashedLastRun = options[@"onCrashedLastRun"];
     }

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -27,6 +27,13 @@ saveViewHierarchy(const char *reportDirectoryPath)
     [SentryDependencyContainer.sharedInstance.viewHierarchy saveViewHierarchy:reportPath];
 }
 
+@interface
+SentryViewHierarchyIntegration ()
+
+@property (nonatomic, strong) SentryOptions *options;
+
+@end
+
 @implementation SentryViewHierarchyIntegration
 
 - (BOOL)installWithOptions:(nonnull SentryOptions *)options
@@ -34,6 +41,8 @@ saveViewHierarchy(const char *reportDirectoryPath)
     if (![super installWithOptions:options]) {
         return NO;
     }
+
+    self.options = options;
 
     SentryClient *client = [SentrySDK.currentHub getClient];
     [client addAttachmentProcessor:self];
@@ -74,6 +83,11 @@ saveViewHierarchy(const char *reportDirectoryPath)
     // If the event is an App hanging event, we cant take the
     // view hierarchy because the main thread it's blocked.
     if (event.isAppHangEvent) {
+        return attachments;
+    }
+
+    if (self.options.beforeCaptureViewHierarchy
+        && !self.options.beforeCaptureViewHierarchy(event)) {
         return attachments;
     }
 

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -111,6 +111,27 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
         XCTAssertEqual(newAttachmentList?.count, 0)
     }
 #endif // os(iOS) || targetEnvironment(macCatalyst)
+    
+    func test_noViewHierarchy_WhenDiscardedInCallback() {
+        let sut = fixture.getSut()
+
+        let expectation = expectation(description: "BeforeCaptureViewHierarchy must be called.")
+
+        let options = Options()
+        options.attachViewHierarchy = true
+        options.beforeCaptureViewHierarchy = { _ in
+            expectation.fulfill()
+            return false
+        }
+
+        sut.install(with: options)
+
+        let newAttachmentList = sut.processAttachments([], for: Event(error: NSError(domain: "", code: -1)))
+
+        wait(for: [expectation], timeout: 1.0)
+
+        XCTAssertEqual(newAttachmentList?.count, 0)
+    }
 
     func test_noViewHierarchy_keepAttachment() {
         let sut = fixture.getSut()

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -351,6 +351,27 @@
     XCTAssertNil(options.beforeCaptureScreenshot);
 }
 
+- (void)testBeforeCaptureViewHierarchy
+{
+    SentryBeforeCaptureScreenshotCallback callback = ^(SentryEvent *event) {
+        if (event.level == kSentryLevelFatal) {
+            return NO;
+        }
+
+        return YES;
+    };
+    SentryOptions *options = [self getValidOptions:@{ @"beforeCaptureViewHierarchy" : callback }];
+
+    XCTAssertEqual(callback, options.beforeCaptureViewHierarchy);
+}
+
+- (void)testDefaultBeforeCaptureViewHierarchy
+{
+    SentryOptions *options = [self getValidOptions:@{}];
+
+    XCTAssertNil(options.beforeCaptureViewHierarchy);
+}
+
 - (void)testTracePropagationTargets
 {
     SentryOptions *options =


### PR DESCRIPTION



## :scroll: Description

Add a callback to the options to decide if the SDK should capture a view hierarchy or not.

Related to https://github.com/getsentry/sentry-cocoa/pull/4016.
Docs PR: https://github.com/getsentry/sentry-docs/pull/10913.

## :bulb: Motivation and Context

Fixes GH-4004

## :green_heart: How did you test it?
Unit tests and sample app.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
