### PR TITLE
ref: Remove unused NSError in Serialization

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -312,7 +312,7 @@ SentryFileManager ()
 
 - (NSString *)storeEnvelope:(SentryEnvelope *)envelope
 {
-    NSData *envelopeData = [SentrySerialization dataWithEnvelope:envelope error:nil];
+    NSData *envelopeData = [SentrySerialization dataWithEnvelope:envelope];
 
     @synchronized(self) {
         NSString *path =

--- a/Sources/Sentry/SentryMigrateSessionInit.m
+++ b/Sources/Sentry/SentryMigrateSessionInit.m
@@ -99,8 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
                                          items:envelopeItemsWithUpdatedSession];
 
     NSError *error;
-    NSData *envelopeWithInitFlagData = [SentrySerialization dataWithEnvelope:envelopeWithInitFlag
-                                                                       error:&error];
+    NSData *envelopeWithInitFlagData = [SentrySerialization dataWithEnvelope:envelopeWithInitFlag];
     [envelopeWithInitFlagData writeToFile:envelopeFilePath
                                   options:NSDataWritingAtomic
                                     error:&error];

--- a/Sources/Sentry/SentryNSURLRequestBuilder.m
+++ b/Sources/Sentry/SentryNSURLRequestBuilder.m
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return [[SentryNSURLRequest alloc]
         initEnvelopeRequestWithDsn:dsn
-                           andData:[SentrySerialization dataWithEnvelope:envelope error:error]
+                           andData:[SentrySerialization dataWithEnvelope:envelope]
                   didFailWithError:error];
 }
 
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return [[SentryNSURLRequest alloc]
         initEnvelopeRequestWithURL:url
-                           andData:[SentrySerialization dataWithEnvelope:envelope error:error]
+                           andData:[SentrySerialization dataWithEnvelope:envelope]
                         authHeader:nil
                   didFailWithError:error];
 }

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -33,9 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 + (NSData *_Nullable)dataWithEnvelope:(SentryEnvelope *)envelope
-                                error:(NSError *_Nullable *_Nullable)error
 {
-
     NSMutableData *envelopeData = [[NSMutableData alloc] init];
     NSMutableDictionary *serializedData = [NSMutableDictionary new];
     if (nil != envelope.header.eventId) {

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -12,8 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (SentrySession *_Nullable)sessionWithData:(NSData *)sessionData;
 
-+ (NSData *_Nullable)dataWithEnvelope:(SentryEnvelope *)envelope
-                                error:(NSError *_Nullable *_Nullable)error;
++ (NSData *_Nullable)dataWithEnvelope:(SentryEnvelope *)envelope;
 
 + (NSData *)dataWithReplayRecording:(SentryReplayRecording *)replayRecording;
 

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -126,7 +126,7 @@ class SentryFileManagerTests: XCTestCase {
         let envelope = TestConstants.envelope
         sut.store(envelope)
         
-        let expectedData = try SentrySerialization.data(with: envelope)
+        let expectedData = try XCTUnwrap(SentrySerialization.data(with: envelope))
         
         let envelopes = sut.getAllEnvelopes()
         XCTAssertEqual(1, envelopes.count)

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -270,7 +270,7 @@ class SentrySerializationTests: XCTestCase {
     private func serializeEnvelope(envelope: SentryEnvelope) -> Data {
         var serializedEnvelope: Data = Data()
         do {
-            serializedEnvelope = try SentrySerialization.data(with: envelope)
+            serializedEnvelope = try XCTUnwrap(SentrySerialization.data(with: envelope))
         } catch {
             XCTFail("Could not serialize envelope.")
         }

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -149,7 +149,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
 
     class func buildRequest(_ envelope: SentryEnvelope) -> SentryNSURLRequest {
-        let envelopeData = try! SentrySerialization.data(with: envelope)
+        let envelopeData = try! XCTUnwrap(SentrySerialization.data(with: envelope))
         return try! SentryNSURLRequest(envelopeRequestWith: dsn(), andData: envelopeData)
     }
 
@@ -447,7 +447,7 @@ class SentryHttpTransportTests: XCTestCase {
         XCTAssertEqual(fixture.dispatchQueueWrapper.dispatchAfterInvocations.first?.interval, 0.0)
     }
 
-    func testActiveRateLimitForSomeCachedEnvelopeItems() {
+    func testActiveRateLimitForSomeCachedEnvelopeItems() throws {
         givenNoInternetConnection()
         sendEvent()
         sut.send(envelope: fixture.eventWithSessionEnvelope)
@@ -461,7 +461,7 @@ class SentryHttpTransportTests: XCTestCase {
 
         let sessionEnvelope = SentryEnvelope(id: fixture.event.eventId, singleItem: SentryEnvelopeItem(session: fixture.session))
         sessionEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
-        let sessionData = try! SentrySerialization.data(with: sessionEnvelope)
+        let sessionData = try XCTUnwrap(SentrySerialization.data(with: sessionEnvelope))
         let sessionRequest = try! SentryNSURLRequest(envelopeRequestWith: SentryHttpTransportTests.dsn(), andData: sessionData)
 
         if fixture.requestManager.requests.invocations.count > 3 {

--- a/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
@@ -143,7 +143,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
     }
     
     private func getSerializedGzippedData(envelope: SentryEnvelope) throws -> Data {
-        let expectedData = try SentrySerialization.data(with: envelope) as NSData
+        let expectedData = try XCTUnwrap(SentrySerialization.data(with: envelope)) as NSData
         return sentry_gzippedWithCompressionLevel(expectedData as Data, -1, nil) ?? Data()
     }
 

--- a/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportAdapterTests.swift
@@ -96,7 +96,7 @@ class SentryTransportAdapterTests: XCTestCase {
             XCTAssertTrue(containsData, "Envelope data with type:\(expectedHeader.type) doesn't match.")
         }
         
-        let actualSerialized = try SentrySerialization.data(with: actual)
-        XCTAssertEqual(try SentrySerialization.data(with: expected), actualSerialized)
+        let actualSerialized = try XCTUnwrap(SentrySerialization.data(with: actual))
+        XCTAssertEqual(try XCTUnwrap(SentrySerialization.data(with: expected)), actualSerialized)
     }
 }


### PR DESCRIPTION
Remove the error parameter for dataWithEnvelope which the method doesn't use.

#skip-changelog