### PR TITLE
ref(continuous profiling): clarify initial options values

### DIFF
--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -129,7 +129,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.tracesSampleRate = nil;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         _enableProfiling = NO;
-        self.profilesSampleRate = nil;
+        self.profilesSampleRate = SENTRY_INITIAL_PROFILES_SAMPLE_RATE;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -546,8 +546,10 @@ static NSDate *_Nullable startTimestamp = nil;
 {
     if (![currentHub.client.options isContinuousProfilingEnabled]) {
         SENTRY_LOG_WARN(
-            @"You must disable trace profiling by setting SentryOptions.profilesSampleRate to nil "
-            @"or 0 before using continuous profiling features.");
+            @"You must disable trace profiling by setting SentryOptions.profilesSampleRate and "
+            @"SentryOptions.profilesSampler to nil (which is the default initial value for both "
+            @"properties, so you can also just remove those lines from your configuration "
+            @"altogether) before attempting to start a continuous profiling session.");
         return;
     }
 
@@ -558,8 +560,10 @@ static NSDate *_Nullable startTimestamp = nil;
 {
     if (![currentHub.client.options isContinuousProfilingEnabled]) {
         SENTRY_LOG_WARN(
-            @"You must disable trace profiling by setting SentryOptions.profilesSampleRate to nil "
-            @"or 0 before using continuous profiling features.");
+            @"You must disable trace profiling by setting SentryOptions.profilesSampleRate and "
+            @"SentryOptions.profilesSampler to nil (which is the default initial value for both "
+            @"properties, so you can also just remove those lines from your configuration "
+            @"altogether) before attempting to stop a continuous profiling session.");
         return;
     }
 

--- a/Sources/Sentry/include/SentryInternalDefines.h
+++ b/Sources/Sentry/include/SentryInternalDefines.h
@@ -6,6 +6,17 @@ static NSString *const SentryPlatformName = @"cocoa";
 
 #define SENTRY_DEFAULT_SAMPLE_RATE @1
 #define SENTRY_DEFAULT_TRACES_SAMPLE_RATE @0
+
+/**
+ * The value we give when initializing the options object, and what it will be if a consumer never
+ * modifies it in their SDK config.
+ * */
+#define SENTRY_INITIAL_PROFILES_SAMPLE_RATE nil
+
+/**
+ * The default value we will give for profiles sample rate if an invalid value is supplied for the
+ * options property in config or returned from the sampler function.
+ */
 #define SENTRY_DEFAULT_PROFILES_SAMPLE_RATE @0
 
 /**

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1141,7 +1141,11 @@
 {
     SentryOptions *options = [self getValidOptions:@{}];
     XCTAssertNil(options.profilesSampleRate);
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertFalse(options.isProfilingEnabled);
+
     XCTAssert([options isContinuousProfilingEnabled]);
 }
 
@@ -1150,7 +1154,11 @@
     SentryOptions *options = [[SentryOptions alloc] init];
     options.profilesSampleRate = nil;
     XCTAssertNil(options.profilesSampleRate);
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertFalse(options.isProfilingEnabled);
+
     XCTAssert([options isContinuousProfilingEnabled]);
 }
 
@@ -1193,7 +1201,11 @@
 - (void)testIsProfilingEnabled_NothingSet_IsDisabled
 {
     SentryOptions *options = [[SentryOptions alloc] init];
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertFalse(options.isProfilingEnabled);
+
     XCTAssertNil(options.profilesSampleRate);
     XCTAssert([options isContinuousProfilingEnabled]);
 }
@@ -1202,7 +1214,11 @@
 {
     SentryOptions *options = [[SentryOptions alloc] init];
     options.profilesSampleRate = @0.00;
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertFalse(options.isProfilingEnabled);
+
     XCTAssertNotNil(options.profilesSampleRate);
     XCTAssertFalse([options isContinuousProfilingEnabled]);
 }
@@ -1211,7 +1227,11 @@
 {
     SentryOptions *options = [[SentryOptions alloc] init];
     options.profilesSampleRate = @0.01;
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertTrue(options.isProfilingEnabled);
+
     XCTAssertNotNil(options.profilesSampleRate);
     XCTAssertFalse([options isContinuousProfilingEnabled]);
 }
@@ -1223,7 +1243,11 @@
         XCTAssertNotNil(context);
         return @0.0;
     };
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertTrue(options.isProfilingEnabled);
+
     XCTAssertNil(options.profilesSampleRate);
     XCTAssertFalse([options isContinuousProfilingEnabled]);
 }
@@ -1235,7 +1259,11 @@
 #    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     options.enableProfiling = YES;
 #    pragma clang diagnostic pop
+
+    // This property now only refers to trace-based profiling, but renaming it would require a major
+    // rev
     XCTAssertTrue(options.isProfilingEnabled);
+
     XCTAssertNil(options.profilesSampleRate);
     XCTAssertFalse([options isContinuousProfilingEnabled]);
 }
@@ -1251,6 +1279,25 @@
 
     SentrySamplingContext *context = [[SentrySamplingContext alloc] init];
     XCTAssertEqual(options.profilesSampler(context), @1.0);
+    XCTAssertNil(options.profilesSampleRate);
+    XCTAssertFalse([options isContinuousProfilingEnabled]);
+}
+
+// this is a tricky part of the API, because while a profilesSampleRate of nil enables continuous
+// profiling, just having the profilesSampler set at all disables it, even if the sampler function
+// would return nil
+- (void)testProfilesSamplerReturnsNil_ContinuousProfilingNotEnabled
+{
+    SentryTracesSamplerCallback sampler = ^(SentrySamplingContext *context) {
+        XCTAssertNotNil(context);
+        NSNumber *result = nil;
+        return result;
+    };
+
+    SentryOptions *options = [self getValidOptions:@{ @"profilesSampler" : sampler }];
+
+    SentrySamplingContext *context = [[SentrySamplingContext alloc] init];
+    XCTAssertNil(options.profilesSampler(context));
     XCTAssertNil(options.profilesSampleRate);
     XCTAssertFalse([options isContinuousProfilingEnabled]);
 }


### PR DESCRIPTION
Disambiguated the initial value for profilesSampleRate and the default value to revert to in case of invalid configuration. Clarified the meaning of these in a few spots, including a new test.

See also https://www.notion.so/sentry/Continuous-Profiling-SDK-Options-46f8f4ce691a4fedbcc39c7f1e1e740e?pvs=4

#skip-changelog