### PR TITLE
feat: Rename session replay `errorSampleRate` property to `onErrorSampleRate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Replay for crashes (#4171)
 - Redact web view from replay (#4203)
 - Add beforeCaptureViewHierarchy callback (#4210)
-- Rename session replay `errorSampleRate` property to `onErrorSampleRate` ()
+- Rename session replay `errorSampleRate` property to `onErrorSampleRate` (#4218)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Replay for crashes (#4171)
 - Redact web view from replay (#4203)
 - Add beforeCaptureViewHierarchy callback (#4210)
+- Rename session replay `errorSampleRate` property to `onErrorSampleRate` ()
 
 ### Fixes
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -37,7 +37,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.debug = true
             
             if #available(iOS 16.0, *), !args.contains("--disable-session-replay") {
-                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1, redactAllText: true, redactAllImages: true)
+                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1, redactAllText: true, redactAllImages: true)
                 options.experimental.sessionReplay.quality = .high
             }
             

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -144,7 +144,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     if (integrationOptions & kIntegrationOptionEnableReplay) {
         if (@available(iOS 16.0, tvOS 16.0, *)) {
-            if (options.experimental.sessionReplay.errorSampleRate == 0
+            if (options.experimental.sessionReplay.onErrorSampleRate == 0
                 && options.experimental.sessionReplay.sessionSampleRate == 0) {
                 [self logWithOptionName:@"sessionReplaySettings"];
                 return NO;

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -183,7 +183,7 @@ SentrySessionReplayIntegration ()
 {
     _startedAsFullSession = [self shouldReplayFullSession:_replayOptions.sessionSampleRate];
 
-    if (!_startedAsFullSession && _replayOptions.errorSampleRate == 0) {
+    if (!_startedAsFullSession && _replayOptions.onErrorSampleRate == 0) {
         return;
     }
 
@@ -281,7 +281,7 @@ SentrySessionReplayIntegration ()
 {
     NSDictionary *info = [[NSDictionary alloc] initWithObjectsAndKeys:sessionId.sentryIdString,
                                                @"replayId", path.lastPathComponent, @"path",
-                                               @(options.errorSampleRate), @"errorSampleRate", nil];
+                                               @(options.onErrorSampleRate), @"errorSampleRate", nil];
 
     NSData *data = [SentrySerialization dataWithJSONObject:info];
 
@@ -422,7 +422,7 @@ SentrySessionReplayIntegration ()
 - (BOOL)sessionReplayIsFullSession
 {
     return SentryDependencyContainer.sharedInstance.random.nextNumber
-        <= _replayOptions.errorSampleRate;
+        <= _replayOptions.onErrorSampleRate;
 }
 
 - (void)sessionReplayNewSegmentWithReplayEvent:(SentryReplayEvent *)replayEvent

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -42,7 +42,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * to the default.
      * - note: The default is 0.
      */
-    public var errorSampleRate: Float
+    public var onErrorSampleRate: Float
     
     /**
      * Indicates whether session replay should redact all text in the app
@@ -112,7 +112,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      */
     public override init() {
         self.sessionSampleRate = 0
-        self.errorSampleRate = 0
+        self.onErrorSampleRate = 0
     }
     
     /**
@@ -122,9 +122,9 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *  - errorSampleRate Indicates the percentage in which a 30 seconds replay will be send with
      * error events.
      */
-    public init(sessionSampleRate: Float = 0, errorSampleRate: Float = 0, redactAllText: Bool = true, redactAllImages: Bool = true) {
+    public init(sessionSampleRate: Float = 0, onErrorSampleRate: Float = 0, redactAllText: Bool = true, redactAllImages: Bool = true) {
         self.sessionSampleRate = sessionSampleRate
-        self.errorSampleRate = errorSampleRate
+        self.onErrorSampleRate = onErrorSampleRate
         self.redactAllText = redactAllText
         self.redactAllImages = redactAllImages
     }
@@ -134,6 +134,6 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
         let onErrorSampleRate = (dictionary["errorSampleRate"] as? NSNumber)?.floatValue ?? 0
         let redactAllText = (dictionary["redactAllText"] as? NSNumber)?.boolValue ?? true
         let redactAllImages = (dictionary["redactAllImages"] as? NSNumber)?.boolValue ?? true
-        self.init(sessionSampleRate: sessionSampleRate, errorSampleRate: onErrorSampleRate, redactAllText: redactAllText, redactAllImages: redactAllImages)
+        self.init(sessionSampleRate: sessionSampleRate, onErrorSampleRate: onErrorSampleRate, redactAllText: redactAllText, redactAllImages: redactAllImages)
     }
 }

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -4,7 +4,7 @@ public class SentryExperimentalOptions: NSObject {
     /**
      * Settings to configure the session replay.
      */
-    public var sessionReplay = SentryReplayOptions(sessionSampleRate: 0, errorSampleRate: 0)
+    public var sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 0)
     #endif
 
     func validateOptions(_ options: [String: Any]?) {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -45,7 +45,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true) {
         SentrySDK.start {
             $0.dsn = "https://user@test.com/test"
-            $0.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: sessionSampleRate, errorSampleRate: errorSampleRate)
+            $0.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: sessionSampleRate, onErrorSampleRate: errorSampleRate)
             $0.setIntegrations([SentrySessionReplayIntegration.self])
             $0.enableSwizzling = enableSwizzling
             $0.cacheDirectoryPath = FileManager.default.temporaryDirectory.path

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -71,7 +71,7 @@ class SentrySessionReplayTests: XCTestCase {
         var lastReplayId: SentryId?
         var currentScreen: String?
         
-        func getSut(options: SentryReplayOptions = .init(sessionSampleRate: 0, errorSampleRate: 0) ) -> SentrySessionReplay {
+        func getSut(options: SentryReplayOptions = .init(sessionSampleRate: 0, onErrorSampleRate: 0) ) -> SentrySessionReplay {
             return SentrySessionReplay(replayOptions: options,
                                        replayFolderPath: cacheFolder,
                                        screenshotProvider: screenshotProvider,
@@ -130,7 +130,7 @@ class SentrySessionReplayTests: XCTestCase {
     
     func testVideoSize() {
         let fixture = Fixture()
-        let options = SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1)
+        let options = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1)
         let sut = fixture.getSut(options: options)
         let view = fixture.rootView
         view.frame = CGRect(x: 0, y: 0, width: 320, height: 900)
@@ -143,7 +143,7 @@ class SentrySessionReplayTests: XCTestCase {
     func testSentReplay_FullSession() {
         let fixture = Fixture()
         
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: true)
         XCTAssertEqual(fixture.lastReplayId, sut.sessionReplayId)
         
@@ -171,7 +171,7 @@ class SentrySessionReplayTests: XCTestCase {
     
     func testReplayScreenNames() throws {
         let fixture = Fixture()
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: true)
         
         for i in 1...6 {
@@ -193,7 +193,7 @@ class SentrySessionReplayTests: XCTestCase {
     
     func testDontSentReplay_NotFullSession() {
         let fixture = Fixture()
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: false)
         
         XCTAssertNil(fixture.lastReplayId)
@@ -212,7 +212,7 @@ class SentrySessionReplayTests: XCTestCase {
     
     func testChangeReplayMode_forErrorEvent() {
         let fixture = Fixture()
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: false)
         XCTAssertNil(fixture.lastReplayId)
         let event = Event(error: NSError(domain: "Some error", code: 1))
@@ -225,7 +225,7 @@ class SentrySessionReplayTests: XCTestCase {
     
     func testDontChangeReplayMode_forNonErrorEvent() {
         let fixture = Fixture()
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: false)
         
         let event = Event(level: .info)
@@ -237,7 +237,7 @@ class SentrySessionReplayTests: XCTestCase {
     
     func testChangeReplayMode_forHybridSDKEvent() {
         let fixture = Fixture()
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: false)
 
         _ = sut.captureReplay()
@@ -248,7 +248,7 @@ class SentrySessionReplayTests: XCTestCase {
 
     func testSessionReplayMaximumDuration() {
         let fixture = Fixture()
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: true)
         
         Dynamic(sut).newFrame(nil)
@@ -264,7 +264,7 @@ class SentrySessionReplayTests: XCTestCase {
     func testSaveScreenShotInBufferMode() {
         let fixture = Fixture()
         
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 0, errorSampleRate: 1))
+        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1))
         sut.start(rootView: fixture.rootView, fullSession: false)
         fixture.dateProvider.advance(by: 1)
         Dynamic(sut).newFrame(nil)
@@ -276,7 +276,7 @@ class SentrySessionReplayTests: XCTestCase {
     func testDealloc_CallsStop() {
         let fixture = Fixture()
         func sutIsDeallocatedAfterCallingMe() {
-            _ = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, errorSampleRate: 1))
+            _ = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
         }
         sutIsDeallocatedAfterCallingMe()
         

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -682,7 +682,7 @@
     XCTAssertEqual(options.enablePreWarmedAppStartTracing, NO);
     XCTAssertEqual(options.attachViewHierarchy, NO);
     XCTAssertEqual(options.reportAccessibilityIdentifier, YES);
-    XCTAssertEqual(options.experimental.sessionReplay.errorSampleRate, 0);
+    XCTAssertEqual(options.experimental.sessionReplay.onErrorSampleRate, 0);
     XCTAssertEqual(options.experimental.sessionReplay.sessionSampleRate, 0);
 #endif // SENTRY_HAS_UIKIT
 #pragma clang diagnostic push
@@ -879,7 +879,7 @@
                 @ { @"sessionReplay" : @ { @"sessionSampleRate" : @2, @"errorSampleRate" : @4 } }
         }];
         XCTAssertEqual(options.experimental.sessionReplay.sessionSampleRate, 2);
-        XCTAssertEqual(options.experimental.sessionReplay.errorSampleRate, 4);
+        XCTAssertEqual(options.experimental.sessionReplay.onErrorSampleRate, 4);
     }
 }
 
@@ -888,7 +888,7 @@
     if (@available(iOS 16.0, tvOS 16.0, *)) {
         SentryOptions *options = [self getValidOptions:@{ @"sessionReplayOptions" : @ {} }];
         XCTAssertEqual(options.experimental.sessionReplay.sessionSampleRate, 0);
-        XCTAssertEqual(options.experimental.sessionReplay.errorSampleRate, 0);
+        XCTAssertEqual(options.experimental.sessionReplay.onErrorSampleRate, 0);
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

Rename session replay `errorSampleRate` property to `onErrorSampleRate`

## :bulb: Motivation and Context

close #4213 

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
