### PR TITLE
test: Remove clearTestState in FileManagerTests

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -94,7 +94,6 @@ class SentryFileManagerTests: XCTestCase {
         sut.deleteAllFolders()
         sut.deleteTimestampLastInForeground()
         sut.deleteAppState()
-        clearTestState()
     }
     
     func testInitDoesNotOverrideDirectories() {


### PR DESCRIPTION
The tests also succeed without `clearTestState`, so we can remove the extra work.

#skip-changelog