### PR TITLE
chore: Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
 ### Fixes
 
 - Fix potential deadlock in app hang detection (#4063)
-- Swizzling of view controllers `loadView` that don`t implement `loadView` (#4071)
+- Swizzling of view controllers `loadView` that don't implement `loadView` (#4071)
 
 ## 8.29.0
 


### PR DESCRIPTION
#skip-changelog

Before
![CleanShot 2024-08-01 at 10 11 00@2x](https://github.com/user-attachments/assets/b44301e6-bff0-4a83-bc72-f0bea024c0c8)


Now
![CleanShot 2024-08-01 at 10 11 18@2x](https://github.com/user-attachments/assets/14751591-3bcc-4bef-baac-e08a07a666c0)
