### PR TITLE
fix: Guard FramesTracker start and stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixes
 
 - Skip UI crumbs when target or sender is nil (#4211)
+- Guard FramesTracker start and stop (#4224)
 
 ## 8.32.0
 

--- a/SentryTestUtils/TestDisplayLinkWrapper.swift
+++ b/SentryTestUtils/TestDisplayLinkWrapper.swift
@@ -39,11 +39,14 @@ public class TestDisplayLinkWrapper: SentryDisplayLinkWrapper {
         fastestFrozenFrameDuration = frozenFrameThreshold + timeEpsilon
     }
 
+    public var ignoreLinkInvocations = false
     public var linkInvocations = Invocations<Void>()
     public override func link(withTarget target: Any, selector sel: Selector) {
-        linkInvocations.record(Void())
-        self.target = target as AnyObject
-        self.selector = sel
+        if ignoreLinkInvocations == false {
+            linkInvocations.record(Void())
+            self.target = target as AnyObject
+            self.selector = sel
+        }
     }
 
     public override var timestamp: CFTimeInterval {

--- a/SentryTestUtils/TestNSNotificationCenterWrapper.swift
+++ b/SentryTestUtils/TestNSNotificationCenterWrapper.swift
@@ -4,6 +4,7 @@ import Sentry
 @objcMembers public class TestNSNotificationCenterWrapper: SentryNSNotificationCenterWrapper {
     
     public var ignoreRemoveObserver = false
+    public var ignoreAddObserver = false
     
     public var addObserverInvocations = Invocations<(observer: WeakReference<NSObject>, selector: Selector, name: NSNotification.Name)>()
     public var addObserverInvocationsCount: Int {
@@ -11,7 +12,9 @@ import Sentry
     }
 
     public override func addObserver(_ observer: NSObject, selector aSelector: Selector, name aName: NSNotification.Name) {
-        addObserverInvocations.record((WeakReference(value: observer), aSelector, aName))
+        if ignoreAddObserver == false {
+            addObserverInvocations.record((WeakReference(value: observer), aSelector, aName))
+        }
     }
 
     public var removeObserverWithNameInvocations = Invocations< NSNotification.Name>()

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -31,6 +31,8 @@ static CFTimeInterval const SentryPreviousFrameInitialValue = -1;
 @interface
 SentryFramesTracker ()
 
+@property (nonatomic, assign, readonly) BOOL isStarted;
+
 @property (nonatomic, strong, readonly) SentryDisplayLinkWrapper *displayLinkWrapper;
 @property (nonatomic, strong, readonly) SentryCurrentDateProvider *dateProvider;
 @property (nonatomic, strong, readonly) SentryDispatchQueueWrapper *dispatchQueueWrapper;
@@ -71,6 +73,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 {
     if (self = [super init]) {
         _isRunning = NO;
+        _isStarted = NO;
         _displayLinkWrapper = displayLinkWrapper;
         _dateProvider = dateProvider;
         _dispatchQueueWrapper = dispatchQueueWrapper;
@@ -141,6 +144,12 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
 - (void)start
 {
+    if (_isStarted) {
+        return;
+    }
+
+    _isStarted = YES;
+
     [self.notificationCenter
         addObserver:self
            selector:@selector(didBecomeActive)
@@ -331,6 +340,12 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
 - (void)stop
 {
+    if (!_isStarted) {
+        return;
+    }
+
+    _isStarted = NO;
+
     [self pause];
     [self.delayedFramesTracker resetDelayedFramesTimeStamps];
 


### PR DESCRIPTION


## :scroll: Description

Profiling starts the frames tracker if it's not running, but the frames tracker again subscribes to the didBecomeActive and willResignActive notifications. To fix this, the start operation is a NoOp now if the frames tracker has already started. The same applies to stop.

## :bulb: Motivation and Context

This came up while investigating long TTID spans for a customer.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
