### PR TITLE
fix: Long-lasting TTID/TTFD spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Skip UI crumbs when target or sender is nil (#4211)
 - Guard FramesTracker start and stop (#4224)
+- Long-lasting TTID/TTFD spans (#4225). Avoid long TTID spans when the FrameTracker isn't running, which is the case when the app is in the background.
 
 ## 8.32.0
 

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -54,8 +54,14 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
     return self;
 }
 
-- (void)startForTracer:(SentryTracer *)tracer
+- (BOOL)startForTracer:(SentryTracer *)tracer
 {
+    if (SentryDependencyContainer.sharedInstance.framesTracker.isRunning == NO) {
+        SENTRY_LOG_DEBUG(@"Skipping TTID/TTFD spans, because can't report them correctly when the "
+                         @"frames tracker isn't running.");
+        return NO;
+    }
+
     SENTRY_LOG_DEBUG(@"Starting initial display span");
     self.initialDisplaySpan = [tracer
         startChildWithOperation:SentrySpanOperationUILoadInitialDisplay
@@ -116,6 +122,8 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
             stringWithFormat:@"%@ - Deadline Exceeded", self.fullDisplaySpan.spanDescription];
         [self addTimeToDisplayMeasurement:self.fullDisplaySpan name:@"time_to_full_display"];
     }];
+
+    return YES;
 }
 
 - (void)reportInitialDisplay

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -147,11 +147,14 @@ SentryUIViewControllerPerformanceTracker ()
                                            waitForFullDisplay:self.enableWaitForFullDisplay
                                          dispatchQueueWrapper:_dispatchQueueWrapper];
 
-    objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER, ttdTracker,
-        OBJC_ASSOCIATION_ASSIGN);
-    [ttdTracker startForTracer:(SentryTracer *)vcSpan];
+    if ([ttdTracker startForTracer:(SentryTracer *)vcSpan]) {
+        objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER, ttdTracker,
+            OBJC_ASSOCIATION_ASSIGN);
 
-    self.currentTTDTracker = ttdTracker;
+        self.currentTTDTracker = ttdTracker;
+    } else {
+        self.currentTTDTracker = nil;
+    }
 }
 
 - (void)reportFullyDisplayed

--- a/Sources/Sentry/include/SentryTimeToDisplayTracker.h
+++ b/Sources/Sentry/include/SentryTimeToDisplayTracker.h
@@ -29,7 +29,7 @@ SENTRY_NO_INIT
                waitForFullDisplay:(BOOL)waitForFullDisplay
              dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 
-- (void)startForTracer:(SentryTracer *)tracer;
+- (BOOL)startForTracer:(SentryTracer *)tracer;
 
 - (void)reportInitialDisplay;
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -47,6 +47,24 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         super.tearDown()
         clearTestState()
     }
+    
+    /// This can happen when a UIViewController is presented when the app is in the background.
+    func testNoSpansCreated_WhenFramesTrackerNotRunning() throws {
+        fixture.framesTracker.stop()
+        
+        let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: false)
+        
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
+        let tracer = try fixture.getTracer()
+        
+        XCTAssertFalse(sut.start(for: tracer))
+        
+        sut.reportInitialDisplay()
+        sut.reportFullyDisplayed()
+        
+        fixture.framesTracker.start()
+        XCTAssertEqual(tracer.children.count, 0)
+    }
 
     func testReportInitialDisplay_notWaitingForFullDisplay() throws {
         let sut = fixture.getSut(for: UIViewController(), waitForFullDisplay: false)
@@ -54,7 +72,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
         let tracer = try fixture.getTracer()
 
-        sut.start(for: tracer)
+        XCTAssertTrue(sut.start(for: tracer))
         XCTAssertEqual(tracer.children.count, 1)
         XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 1)
 


### PR DESCRIPTION

## :scroll: Description

Presenting a UIViewController when going to the background could lead to long-lasting TTID/TTFD spans. This is fixed now by not creating TTID/TTFD spans when the FramesTracker isn't running.

Docs PR: https://github.com/getsentry/sentry-docs/pull/10960.

## :bulb: Motivation and Context

A customer reported to get long lasting TTID/TTFD spans for UIViewControllers presented when the `didEnterBackgroundNotification` is posted. They do this due to privacy reasons.

## :green_heart: How did you test it?
Added a small sample to present an UIViewController when the `didEnterBackgroundNotification` is posted and could sometimes reproduce the problem. This PR fixes that problem. I didn't add the sample as a UITest, because it isn't reliable and this PR addresses an edge case. Furthermore, I added unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
