### PR TITLE
feat: Add options to redact or ignore view for Replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Redact web view from replay (#4203)
 - Add beforeCaptureViewHierarchy callback (#4210)
 - Rename session replay `errorSampleRate` property to `onErrorSampleRate` (#4218)
+- Add options to redact or ignore view for Replay ()
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Redact web view from replay (#4203)
 - Add beforeCaptureViewHierarchy callback (#4210)
 - Rename session replay `errorSampleRate` property to `onErrorSampleRate` (#4218)
-- Add options to redact or ignore view for Replay ()
+- Add options to redact or ignore view for Replay (#4228)
 
 ### Fixes
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -870,6 +870,7 @@
 		D8AE48B02C5782EC0092A2A6 /* SentryLogOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AE48AF2C5782EC0092A2A6 /* SentryLogOutput.swift */; };
 		D8AE48BF2C578D540092A2A6 /* SentryLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AE48BE2C578D540092A2A6 /* SentryLog.swift */; };
 		D8AE48C12C57B1550092A2A6 /* SentryLevelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AE48C02C57B1550092A2A6 /* SentryLevelTests.swift */; };
+		D8AE49182C5D09720092A2A6 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AE49172C5D09720092A2A6 /* UIViewExtensions.swift */; };
 		D8AFC0012BD252B900118BE1 /* SentryOnDemandReplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AFC0002BD252B900118BE1 /* SentryOnDemandReplayTests.swift */; };
 		D8AFC01A2BD7A20B00118BE1 /* SentryViewScreenshotProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AFC0192BD7A20B00118BE1 /* SentryViewScreenshotProvider.swift */; };
 		D8AFC03D2BDA79BF00118BE1 /* SentryReplayVideoMaker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8AFC03C2BDA79BF00118BE1 /* SentryReplayVideoMaker.swift */; };
@@ -1931,6 +1932,7 @@
 		D8AE48B12C5786AA0092A2A6 /* SentryLogC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryLogC.h; path = include/SentryLogC.h; sourceTree = "<group>"; };
 		D8AE48BE2C578D540092A2A6 /* SentryLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLog.swift; sourceTree = "<group>"; };
 		D8AE48C02C57B1550092A2A6 /* SentryLevelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLevelTests.swift; sourceTree = "<group>"; };
+		D8AE49172C5D09720092A2A6 /* UIViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
 		D8AFC0002BD252B900118BE1 /* SentryOnDemandReplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryOnDemandReplayTests.swift; sourceTree = "<group>"; };
 		D8AFC0192BD7A20B00118BE1 /* SentryViewScreenshotProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewScreenshotProvider.swift; sourceTree = "<group>"; };
 		D8AFC03C2BDA79BF00118BE1 /* SentryReplayVideoMaker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReplayVideoMaker.swift; sourceTree = "<group>"; };
@@ -3886,6 +3888,7 @@
 				D8F016B52B962548007B9AFB /* StringExtensions.swift */,
 				62872B5E2BA1B7F300A4FA7D /* NSLock.swift */,
 				D8BC28C92BFF68CA0054DA4D /* NumberExtensions.swift */,
+				D8AE49172C5D09720092A2A6 /* UIViewExtensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -4683,6 +4686,7 @@
 				0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */,
 				D84D2CDD2C2BF7370011AF8A /* SentryReplayEvent.swift in Sources */,
 				D8BC28CC2BFF78220054DA4D /* SentryRRWebTouchEvent.swift in Sources */,
+				D8AE49182C5D09720092A2A6 /* UIViewExtensions.swift in Sources */,
 				8EA1ED0B2668F8C400E62B98 /* SentryUIViewControllerSwizzling.m in Sources */,
 				7B98D7CF25FB650F00C5A389 /* SentryWatchdogTerminationTrackingIntegration.m in Sources */,
 				8E5D38DD261D4A3E000D363D /* SentryPerformanceTrackingIntegration.m in Sources */,

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -5,6 +5,7 @@
 @class SentryOptions, SentryEvent, SentryBreadcrumb, SentryScope, SentryUser, SentryId,
     SentryUserFeedback, SentryTransactionContext;
 @class SentryMetricsAPI;
+@class UIView;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -332,6 +333,21 @@ SENTRY_NO_INIT
  * @c SentryOptions.shutdownTimeInterval .
  */
 + (void)close;
+
+#if SENTRY_HAS_UIKIT
+
+/**
+ * Marks this view to be redacted during replays.
+ */
++ (void)replayRedactView:(UIView *)view;
+
+/**
+ * Marks this view to be ignored during redact step
+ * of session replay. All its content will be visible in the replay.
+ */
++ (void)replayIgnoreView:(UIView *)view;
+
+#endif
 
 @end
 

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -337,11 +337,15 @@ SENTRY_NO_INIT
 #if SENTRY_HAS_UIKIT
 
 /**
+ * @warning This is an experimental feature and may still have bugs.
+ *
  * Marks this view to be redacted during replays.
  */
 + (void)replayRedactView:(UIView *)view;
 
 /**
+ * @warning This is an experimental feature and may still have bugs.
+ *
  * Marks this view to be ignored during redact step
  * of session replay. All its content will be visible in the replay.
  */

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -567,6 +567,18 @@ static NSDate *_Nullable startTimestamp = nil;
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
+#if SENTRY_HAS_UIKIT
++ (void)replayRedactView:(UIView *)view
+{
+    [SentryRedactViewHelper redactView:view];
+}
+
++ (void)replayIgnoreView:(UIView *)view
+{
+    [SentryRedactViewHelper ignoreView:view];
+}
+#endif
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -74,6 +74,9 @@ SentrySessionReplayIntegration ()
             return event;
         }];
 
+    [SentryViewPhotographer.shared addIgnoreClasses:_replayOptions.ignoreRedactViewTypes];
+    [SentryViewPhotographer.shared addRedactClasses:_replayOptions.redactViewTypes];
+
     return YES;
 }
 

--- a/Sources/Swift/Extensions/UIViewExtensions.swift
+++ b/Sources/Swift/Extensions/UIViewExtensions.swift
@@ -1,0 +1,25 @@
+#if canImport(UIKit) && !SENTRY_NO_UIKIT
+#if os(iOS) || os(tvOS)
+import Foundation
+import UIKit
+
+public extension UIView {
+    
+    /**
+     * Marks this view to be redacted during replays.
+     */
+    func sentryReplayRedact() {
+        SentryRedactViewHelper.redactView(self)
+    }
+    
+    /**
+     * Marks this view to be ignored during redact step
+     * of session replay. All its content will be visible in the replay.
+     */
+    func sentryReplayIgnore() {
+        SentryRedactViewHelper.ignoreView(self)
+    }
+}
+
+#endif
+#endif

--- a/Sources/Swift/Extensions/UIViewExtensions.swift
+++ b/Sources/Swift/Extensions/UIViewExtensions.swift
@@ -7,6 +7,7 @@ public extension UIView {
     
     /**
      * Marks this view to be redacted during replays.
+     * - warning:  This is an experimental feature and may still have bugs.
      */
     func sentryReplayRedact() {
         SentryRedactViewHelper.redactView(self)
@@ -15,6 +16,7 @@ public extension UIView {
     /**
      * Marks this view to be ignored during redact step
      * of session replay. All its content will be visible in the replay.
+     * - warning:  This is an experimental feature and may still have bugs.
      */
     func sentryReplayIgnore() {
         SentryRedactViewHelper.ignoreView(self)

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -67,6 +67,20 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     public var quality = SentryReplayQuality.low
     
     /**
+     * A list of custom UIView subclasses that need 
+     * to be masked during session replay.
+     * By default Sentry already mask text elements from UIKit
+     */
+    public var redactViewTypes = [AnyClass]()
+    
+    /**
+     * A list of custom UIView subclasses to be ignored
+     * during masking step of the session replay.
+     * The view itself and any child will be ignored and not masked.
+     */
+    public var ignoreRedactViewTypes = [AnyClass]()
+    
+    /**
      * Defines the quality of the session replay.
      * Higher bit rates better quality, but also bigger files to transfer.
      */

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -10,7 +10,7 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     
     static let shared = SentryViewPhotographer()
     
-    let redactBuilder = UIRedactBuilder()
+    private let redactBuilder = UIRedactBuilder()
         
     func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback ) {
         let image = UIGraphicsImageRenderer(size: view.bounds.size).image { _ in
@@ -42,6 +42,13 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     func addRedactClasses(classes: [AnyClass]) {
         redactBuilder.addRedactClasses(classes)
     }
+    
+#if TEST || TESTCI
+    func getRedactBuild() -> UIRedactBuilder {
+        redactBuilder
+    }
+#endif
+    
 }
 
 #endif // os(iOS) || os(tvOS)

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -10,8 +10,7 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     
     static let shared = SentryViewPhotographer()
     
-    //This is a list of UIView subclasses that will be ignored during redact process
-    private var redactBuilder = UIRedactBuilder()
+    let redactBuilder = UIRedactBuilder()
         
     func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback ) {
         let image = UIGraphicsImageRenderer(size: view.bounds.size).image { _ in
@@ -36,12 +35,12 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     
     @objc(addIgnoreClasses:)
     func addIgnoreClasses(classes: [AnyClass]) {
-        redactBuilder.ignoreClasses += classes
+        redactBuilder.addIgnoreClasses(classes)
     }
 
     @objc(addRedactClasses:)
     func addRedactClasses(classes: [AnyClass]) {
-        redactBuilder.redactClasses += classes
+        redactBuilder.addRedactClasses(classes)
     }
 }
 

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -76,11 +76,11 @@ class UIRedactBuilder {
         redactClassesIdentifiers = Set(redactClasses.map( { ObjectIdentifier($0) }))
     }
     
-    func hasIgnoreClass(_ ignoreClass: AnyClass) -> Bool {
+    func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {
         return ignoreClassesIdentifiers.contains(ObjectIdentifier(ignoreClass))
     }
     
-    func hasRedactClass(_ redactClass: AnyClass) -> Bool {
+    func containsRedactClass(_ redactClass: AnyClass) -> Bool {
         return redactClassesIdentifiers.contains(ObjectIdentifier(redactClass))
     }
     
@@ -114,7 +114,7 @@ class UIRedactBuilder {
     }
         
     private func shouldIgnore(view: UIView) -> Bool {
-        return SentryRedactViewHelper.shouldIgnoreView(view) || hasIgnoreClass(type(of: view))
+        return SentryRedactViewHelper.shouldIgnoreView(view) || containsIgnoreClass(type(of: view))
     }
     
     private func shouldRedact(view: UIView, redactText: Bool, redactImage: Bool) -> Bool {
@@ -124,7 +124,7 @@ class UIRedactBuilder {
         if redactImage, let imageView = view as? UIImageView {
             return shouldRedact(imageView: imageView)
         }
-        return redactText && hasRedactClass(type(of: view))
+        return redactText && containsRedactClass(type(of: view))
     }
     
     private func shouldRedact(imageView: UIImageView) -> Bool {

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -1,6 +1,7 @@
 #if canImport(UIKit) && !SENTRY_NO_UIKIT
 #if os(iOS) || os(tvOS)
 import Foundation
+import ObjectiveC.NSObjCRuntime
 import UIKit
 #if os(iOS)
 import WebKit
@@ -53,13 +54,13 @@ struct RedactRegion {
 class UIRedactBuilder {
     
     //This is a list of UIView subclasses that will be ignored during redact process
-    var ignoreClasses: [AnyClass] 
+    private var ignoreClassesIdentifiers: Set<ObjectIdentifier>
     //This is a list of UIView subclasses that need to be redacted from screenshot
-    var redactClasses: [AnyClass]
+    private var redactClassesIdentifiers: Set<ObjectIdentifier>
     
     init() {
         
-        redactClasses = [ UILabel.self, UITextView.self, UITextField.self ] +
+        var redactClasses = [ UILabel.self, UITextView.self, UITextField.self ] +
         //this classes are used by SwiftUI to display images.
         ["_TtCOCV7SwiftUI11DisplayList11ViewUpdater8Platform13CGDrawingView",
             "_TtC7SwiftUIP33_A34643117F00277B93DEBAB70EC0697122_UIShapeHitTestingView",
@@ -68,10 +69,35 @@ class UIRedactBuilder {
         
 #if os(iOS)
         redactClasses += [ WKWebView.self ]
-        ignoreClasses = [ UISlider.self, UISwitch.self ]
+        ignoreClassesIdentifiers = [ ObjectIdentifier(UISlider.self), ObjectIdentifier(UISwitch.self) ]
 #else
-        ignoreClasses = []
+        ignoreClassesIdentifiers = []
 #endif
+        redactClassesIdentifiers = Set(redactClasses.map( { ObjectIdentifier($0) }))
+    }
+    
+    func hasIgnoreClass(_ ignoreClass: AnyClass) -> Bool {
+        return ignoreClassesIdentifiers.contains(ObjectIdentifier(ignoreClass))
+    }
+    
+    func hasRedactClass(_ redactClass: AnyClass) -> Bool {
+        return redactClassesIdentifiers.contains(ObjectIdentifier(redactClass))
+    }
+    
+    func addIgnoreClass(_ ignoreClass: AnyClass) {
+        ignoreClassesIdentifiers.insert(ObjectIdentifier(ignoreClass))
+    }
+    
+    func addRedactClass(_ redactClass: AnyClass) {
+        redactClassesIdentifiers.insert(ObjectIdentifier(redactClass))
+    }
+    
+    func addIgnoreClasses(_ ignoreClasses: [AnyClass]) {
+        ignoreClasses.forEach(addIgnoreClass(_:))
+    }
+    
+    func addRedactClasses(_ redactClasses: [AnyClass]) {
+        redactClasses.forEach(addRedactClass(_:))
     }
     
     func redactRegionsFor(view: UIView, options: SentryRedactOptions?) -> [RedactRegion] {
@@ -86,16 +112,19 @@ class UIRedactBuilder {
         
         return redactingRegions
     }
-    
+        
     private func shouldIgnore(view: UIView) -> Bool {
-        ignoreClasses.contains { view.isKind(of: $0) }
+        return SentryRedactViewHelper.shouldIgnoreView(view) || hasIgnoreClass(type(of: view))
     }
     
     private func shouldRedact(view: UIView, redactText: Bool, redactImage: Bool) -> Bool {
+        if SentryRedactViewHelper.shouldRedactView(view) {
+            return true
+        }
         if redactImage, let imageView = view as? UIImageView {
             return shouldRedact(imageView: imageView)
         }
-        return redactText && redactClasses.contains { view.isKind(of: $0) }
+        return redactText && hasRedactClass(type(of: view))
     }
     
     private func shouldRedact(imageView: UIImageView) -> Bool {
@@ -137,6 +166,28 @@ class UIRedactBuilder {
     private func hasBackground(_ view: UIView) -> Bool {
         //Anything with an alpha greater than 0.9 is opaque enough that it's impossible to see anything behind it.
         return view.backgroundColor != nil && (view.backgroundColor?.cgColor.alpha ?? 0) > 0.9
+    }
+}
+
+@objcMembers
+class SentryRedactViewHelper: NSObject {
+    private static var associatedRedactObjectHandle: UInt8 = 0
+    private static var associatedIgnoreObjectHandle: UInt8 = 0
+
+    static func shouldRedactView(_ view: UIView) -> Bool {
+        (objc_getAssociatedObject(view, &associatedRedactObjectHandle) as? NSNumber)?.boolValue ?? false
+    }
+    
+    static func shouldIgnoreView(_ view: UIView) -> Bool {
+        (objc_getAssociatedObject(view, &associatedIgnoreObjectHandle) as? NSNumber)?.boolValue ?? false
+    }
+    
+    static func redactView(_ view: UIView) {
+        objc_setAssociatedObject(view, &associatedRedactObjectHandle, true, .OBJC_ASSOCIATION_ASSIGN)
+    }
+    
+    static func ignoreView(_ view: UIView) {
+        objc_setAssociatedObject(view, &associatedIgnoreObjectHandle, true, .OBJC_ASSOCIATION_ASSIGN)
     }
 }
 

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -269,8 +269,8 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
             options.experimental.sessionReplay.redactViewTypes = [AnotherLabel.self]
         }
     
-        let redactBuilder = SentryViewPhotographer.shared.redactBuilder
-        XCTAssertTrue(redactBuilder.hasRedactClass(AnotherLabel.self))
+        let redactBuilder = SentryViewPhotographer.shared.getRedactBuild()
+        XCTAssertTrue(redactBuilder.containsRedactClass(AnotherLabel.self))
     }
     
     func testIgnoreViewFromSDK() {
@@ -281,8 +281,8 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
             options.experimental.sessionReplay.ignoreRedactViewTypes = [AnotherLabel.self]
         }
     
-        let redactBuilder = SentryViewPhotographer.shared.redactBuilder
-        XCTAssertTrue(redactBuilder.hasIgnoreClass(AnotherLabel.self))
+        let redactBuilder = SentryViewPhotographer.shared.getRedactBuild()
+        XCTAssertTrue(redactBuilder.containsIgnoreClass(AnotherLabel.self))
     }
     
     func createLastSessionReplay(writeSessionInfo: Bool = true, errorSampleRate: Double = 1) throws {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -42,13 +42,14 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         return try XCTUnwrap(SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
     }
     
-    private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true) {
+    private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true, configure: ((Options) -> Void)? = nil) {
         SentrySDK.start {
             $0.dsn = "https://user@test.com/test"
             $0.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: sessionSampleRate, onErrorSampleRate: errorSampleRate)
             $0.setIntegrations([SentrySessionReplayIntegration.self])
             $0.enableSwizzling = enableSwizzling
             $0.cacheDirectoryPath = FileManager.default.temporaryDirectory.path
+            configure?($0)
         }
         SentrySDK.currentHub().startSession()
     }
@@ -258,6 +259,30 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(hub.capturedReplayRecordingVideo.count, 0)
+    }
+    
+    func testMaskViewFromSDK() {
+        class AnotherLabel: UILabel {
+        }
+            
+        startSDK(sessionSampleRate: 1, errorSampleRate: 1) { options in
+            options.experimental.sessionReplay.redactViewTypes = [AnotherLabel.self]
+        }
+    
+        let redactBuilder = SentryViewPhotographer.shared.redactBuilder
+        XCTAssertTrue(redactBuilder.hasRedactClass(AnotherLabel.self))
+    }
+    
+    func testIgnoreViewFromSDK() {
+        class AnotherLabel: UILabel {
+        }
+            
+        startSDK(sessionSampleRate: 1, errorSampleRate: 1) { options in
+            options.experimental.sessionReplay.ignoreRedactViewTypes = [AnotherLabel.self]
+        }
+    
+        let redactBuilder = SentryViewPhotographer.shared.redactBuilder
+        XCTAssertTrue(redactBuilder.hasIgnoreClass(AnotherLabel.self))
     }
     
     func createLastSessionReplay(writeSessionInfo: Bool = true, errorSampleRate: Double = 1) throws {

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -230,7 +230,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let sut = UIRedactBuilder()
         expectedList.forEach { element in
-            XCTAssertTrue(sut.hasRedactClass(element), "\(element) not found")
+            XCTAssertTrue(sut.containsRedactClass(element), "\(element) not found")
         }
     }
     
@@ -239,7 +239,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let sut = UIRedactBuilder()
         expectedList.forEach { element in
-            XCTAssertTrue(sut.hasIgnoreClass(element), "\(element) not found")
+            XCTAssertTrue(sut.containsIgnoreClass(element), "\(element) not found")
         }
     }
 }

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -176,7 +176,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let sut = UIRedactBuilder()
         let label = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
-        SentrySDK.ignoreView(forReplay: label)
+        SentrySDK.replayIgnore(label)
         rootView.addSubview(label)
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
@@ -189,7 +189,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let sut = UIRedactBuilder()
         let view = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
-        SentrySDK.redactView(forReplay: view)
+        SentrySDK.replayRedactView(view)
         rootView.addSubview(view)
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -1,6 +1,7 @@
 #if os(iOS)
 import Foundation
 @testable import Sentry
+import SentryTestUtils
 import UIKit
 import XCTest
 
@@ -149,11 +150,76 @@ class UIRedactBuilderTests: XCTestCase {
         }
         
         let sut = UIRedactBuilder()
-        sut.ignoreClasses.append(AnotherLabel.self)
+        sut.addIgnoreClass(AnotherLabel.self)
         rootView.addSubview(AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40)))
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         XCTAssertEqual(result.count, 0)
+    }
+    
+    func testRedactlasses() {
+        class AnotherView: UIView {
+        }
+        
+        let sut = UIRedactBuilder()
+        let view = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        sut.addRedactClass(AnotherView.self)
+        rootView.addSubview(view)
+        
+        let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
+        XCTAssertEqual(result.count, 1)
+    }
+    
+    func testIgnoreView() {
+        class AnotherLabel: UILabel {
+        }
+        
+        let sut = UIRedactBuilder()
+        let label = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        SentrySDK.ignoreView(forReplay: label)
+        rootView.addSubview(label)
+        
+        let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
+        XCTAssertEqual(result.count, 0)
+    }
+    
+    func testRedactView() {
+        class AnotherView: UIView {
+        }
+        
+        let sut = UIRedactBuilder()
+        let view = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        SentrySDK.redactView(forReplay: view)
+        rootView.addSubview(view)
+        
+        let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
+        XCTAssertEqual(result.count, 1)
+    }
+    
+    func testIgnoreViewWithExtension() {
+        class AnotherLabel: UILabel {
+        }
+        
+        let sut = UIRedactBuilder()
+        let label = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        label.sentryReplayIgnore()
+        rootView.addSubview(label)
+        
+        let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
+        XCTAssertEqual(result.count, 0)
+    }
+    
+    func testRedactViewWithExtension() {
+        class AnotherView: UIView {
+        }
+        
+        let sut = UIRedactBuilder()
+        let view = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        view.sentryReplayRedact()
+        rootView.addSubview(view)
+        
+        let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
+        XCTAssertEqual(result.count, 1)
     }
     
     func testRedactList() {
@@ -164,7 +230,7 @@ class UIRedactBuilderTests: XCTestCase {
         
         let sut = UIRedactBuilder()
         expectedList.forEach { element in
-            XCTAssertTrue(sut.redactClasses.contains { element == $0 }, "\(element) not found")
+            XCTAssertTrue(sut.hasRedactClass(element), "\(element) not found")
         }
     }
     
@@ -173,10 +239,9 @@ class UIRedactBuilderTests: XCTestCase {
         
         let sut = UIRedactBuilder()
         expectedList.forEach { element in
-            XCTAssertTrue(sut.ignoreClasses.contains { element == $0 }, "\(element) not found")
+            XCTAssertTrue(sut.hasIgnoreClass(element), "\(element) not found")
         }
     }
-    
 }
 
 #endif


### PR DESCRIPTION
## :scroll: Description

Added options to ReplayOptions for users to specify which classes to redact or ignore during replay. 
Also added functions to SentrySDK and a UIView extension to choose specific views to redact or ignore.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
