### PR TITLE
fix: Signals on visionOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Guard FramesTracker start and stop (#4224)
 - Long-lasting TTID/TTFD spans (#4225). Avoid long TTID spans when the FrameTracker isn't running, which is the case when the app is in the background.
 - Missing mach info for crash reports (#4230)
+- Crash reports not generated on visionOS (#4229)
 
 
 ### Improvements

--- a/Sources/Sentry/include/SentryInternalCDefines.h
+++ b/Sources/Sentry/include/SentryInternalCDefines.h
@@ -59,7 +59,7 @@ typedef unsigned long long bytes;
 
 // Mach APIs are explicitly marked as unavailable in tvOS and watchOS.
 // See https://github.com/getsentry/sentry-cocoa/issues/406#issuecomment-1171872518
-#if SENTRY_HOST_IOS || SENTRY_HOST_MAC
+#if SENTRY_HOST_IOS || SENTRY_HOST_MAC || SENTRY_HOST_VISION
 #    define SENTRY_HAS_MACH 1
 #else
 #    define SENTRY_HAS_MACH 0
@@ -67,19 +67,19 @@ typedef unsigned long long bytes;
 
 // signal APIs are explicitly marked as unavailable in watchOS.
 // See https://github.com/getsentry/sentry-cocoa/issues/406#issuecomment-1171872518
-#if SENTRY_HOST_IOS || SENTRY_HOST_MAC || SENTRY_HOST_TV
+#if SENTRY_HOST_IOS || SENTRY_HOST_MAC || SENTRY_HOST_TV || SENTRY_HOST_VISION
 #    define SENTRY_HAS_SIGNAL 1
 #else
 #    define SENTRY_HAS_SIGNAL 0
 #endif
 
-#if SENTRY_HOST_MAC || SENTRY_HOST_IOS
+#if SENTRY_HOST_MAC || SENTRY_HOST_IOS || SENTRY_HOST_VISION
 #    define SENTRY_HAS_SIGNAL_STACK 1
 #else
 #    define SENTRY_HAS_SIGNAL_STACK 0
 #endif
 
-#if SENTRY_HOST_MAC || SENTRY_HOST_IOS || SENTRY_HOST_TV
+#if SENTRY_HOST_MAC || SENTRY_HOST_IOS || SENTRY_HOST_TV || SENTRY_HOST_VISION
 #    define SENTRY_HAS_THREADS_API 1
 #else
 #    define SENTRY_HAS_THREADS_API 0


### PR DESCRIPTION
## :scroll: Description

Fix capability checks on visionOS.

#skip-changelog

## :bulb: Motivation and Context

This fixes issue #4217

## :green_heart: How did you test it?

Crashed the visionOS sample app and verified on the console that the event was sent.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

❓
