### PR TITLE
fix: Missing mach info for crash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Skip UI crumbs when target or sender is nil (#4211)
 - Guard FramesTracker start and stop (#4224)
 - Long-lasting TTID/TTFD spans (#4225). Avoid long TTID spans when the FrameTracker isn't running, which is the case when the app is in the background.
+- Missing mach info for crash reports (#4230)
+
 
 ### Improvements
 

--- a/Sources/Sentry/include/SentryInternalCDefines.h
+++ b/Sources/Sentry/include/SentryInternalCDefines.h
@@ -40,6 +40,10 @@ typedef unsigned long long bytes;
 
 #include <TargetConditionals.h>
 
+#ifdef __APPLE__
+#    define SENTRY_HOST_APPLE 1
+#endif
+
 #ifndef TARGET_OS_VISION
 #    define TARGET_OS_VISION 0
 #endif

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -189,8 +189,8 @@ class SentryCrashReportTests: XCTestCase {
     // We parse JSON so it's fine to disable identifier_name
     // swiftlint:disable identifier_name
     struct CrashReport: Decodable {
-        let user: CrashReportUserInfo
-        let sentry_sdk_scope: CrashReportUserInfo
+        let user: CrashReportUserInfo?
+        let sentry_sdk_scope: CrashReportUserInfo?
         let crash: Crash
     }
     

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -118,6 +118,7 @@ class SentryCrashReportTests: XCTestCase {
     }
     
     func testCrashReportContainsMachInfo() throws {
+        serializeToCrashReport(scope: fixture.scope)
         
         var monitorContext = SentryCrash_MonitorContext()
         monitorContext.mach.type = EXC_BAD_ACCESS
@@ -139,6 +140,7 @@ class SentryCrashReportTests: XCTestCase {
     }
     
     func testCrashReportContainsStandardMachInfo_WhenMachInfoIsEmpty() throws {
+        serializeToCrashReport(scope: fixture.scope)
         writeCrashReport()
         
         let crashReportContents = try XCTUnwrap( FileManager.default.contents(atPath: fixture.reportPath))
@@ -220,6 +222,7 @@ class SentryCrashReportTests: XCTestCase {
     }
 
     struct CrashReportUserInfo: Decodable, Equatable {
+        let user: CrashReportUser?
         let dist: String?
         let context: [String: [String: String]]?
         let environment: String?
@@ -228,6 +231,14 @@ class SentryCrashReportTests: XCTestCase {
         let fingerprint: [String]?
         let level: String?
         let breadcrumbs: [CrashReportCrumb]?
+    }
+    
+    struct CrashReportUser: Decodable, Equatable {
+        let id: String
+        let email: String
+        let username: String
+        let ip_address: String
+        let data: [String: [String: String]]
     }
 
     struct CrashReportCrumb: Decodable, Equatable {

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -220,7 +220,6 @@ class SentryCrashReportTests: XCTestCase {
     }
 
     struct CrashReportUserInfo: Decodable, Equatable {
-        let user: CrashReportUser?
         let dist: String?
         let context: [String: [String: String]]?
         let environment: String?
@@ -229,14 +228,6 @@ class SentryCrashReportTests: XCTestCase {
         let fingerprint: [String]?
         let level: String?
         let breadcrumbs: [CrashReportCrumb]?
-    }
-
-    struct CrashReportUser: Decodable, Equatable {
-        let id: String
-        let email: String
-        let username: String
-        let ip_address: String
-        let data: [String: [String: String]]
     }
 
     struct CrashReportCrumb: Decodable, Equatable {

--- a/Tests/SentryTests/SentryKSCrashReportConverterTests.m
+++ b/Tests/SentryTests/SentryKSCrashReportConverterTests.m
@@ -75,11 +75,14 @@
         stringWithFormat:@"%@", [exception.mechanism.meta.signal valueForKeyPath:@"number"]];
     NSString *exc = [NSString
         stringWithFormat:@"%@", [exception.mechanism.meta.machException valueForKeyPath:@"name"]];
+
     XCTAssertEqualObjects(code, @"0");
     XCTAssertEqualObjects(number, @"10");
     XCTAssertEqualObjects(exc, @"EXC_BAD_ACCESS");
     XCTAssertEqualObjects(
         [exception.mechanism.data valueForKeyPath:@"relevant_address"], @"0x0000000102468000");
+    XCTAssertNotNil(exception.mechanism.handled);
+    XCTAssertFalse(exception.mechanism.handled.boolValue);
 
     XCTAssertTrue([NSJSONSerialization isValidJSONObject:[event serialize]]);
     XCTAssertNotNil([[event serialize] valueForKeyPath:@"exception.values"]);


### PR DESCRIPTION




## :scroll: Description

The SentryInternalCDefines didn't define the SENTRY_HOST_APPLE, which led to missing mach info for crash reports, as the SentryCrashReport relies on the SENTRY_HOST_APPLE to write that info. For reference, the SentryCrashCRASH_HOST_APPLE was changed to SENTRY_HOST_APPLE in GH-4101. The problem is fixed now by defining SENTRY_HOST_APPLE in SentryInternalCDefines.

## :bulb: Motivation and Context

Fixes GH-4227

## :green_heart: How did you test it?
Unit tests and checking crash reports of a simulator.

| Before | After |
|--------|--------|
| ![CleanShot 2024-08-05 at 09 42 52@2x](https://github.com/user-attachments/assets/67be215c-49ef-4539-a66b-91203b4c4cfb) | ![CleanShot 2024-08-05 at 09 43 23@2x](https://github.com/user-attachments/assets/8eab94ac-d10c-4531-9235-9a7190ffd037) |
| ![CleanShot 2024-08-05 at 09 43 44@2x](https://github.com/user-attachments/assets/651c4e46-cc99-4cb8-bca5-3123142ec731) | ![CleanShot 2024-08-05 at 09 44 08@2x](https://github.com/user-attachments/assets/d2878722-1d43-4d6f-9053-873f00ed2371) | 

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
