### PR TITLE
Don’t force cast to `NSComparisonPredicate` in TERNARY operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - Long-lasting TTID/TTFD spans (#4225). Avoid long TTID spans when the FrameTracker isn't running, which is the case when the app is in the background.
 - Missing mach info for crash reports (#4230)
 - Crash reports not generated on visionOS (#4229)
-
+- Don’t force cast to `NSComparisonPredicate` in TERNARY operator (#4232)
 
 ### Improvements
 

--- a/Sources/Sentry/SentryPredicateDescriptor.m
+++ b/Sources/Sentry/SentryPredicateDescriptor.m
@@ -77,7 +77,7 @@
         if (@available(macOS 10.11, *)) {
             return [NSString
                 stringWithFormat:@"TERNARY(%@,%@,%@)",
-                [self comparisonPredicateDescription:(NSComparisonPredicate *)predicate.predicate],
+                [self predicateDescription:predicate.predicate],
                 [self expressionDescription:predicate.trueExpression],
                 [self expressionDescription:predicate.falseExpression]];
         } else {

--- a/Tests/SentryTests/SentryPredicateDescriptorTests.swift
+++ b/Tests/SentryTests/SentryPredicateDescriptorTests.swift
@@ -115,6 +115,11 @@ class SentryPredicateDescriptorTests: XCTestCase {
         assertPredicate(predicate: pred, expectedResult: "field1 == %@ AND (field3 == %@ OR field2 == %@)")
     }
     
+    func test_compoundInTenary() {
+        let pred = NSPredicate(format: "TERNARY(field1 > 10 AND field1 < 20, 1, 0) == 1")
+        assertPredicate(predicate: pred, expectedResult: "TERNARY(field1 > %@ AND field1 < %@,%@,%@) == %@")
+    }
+    
     func test_UNKNOWN() {
         let pred = NSPredicate { _, _ in
             return false


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Tenary operators can contain any type of predicate, not just comparison. Removed the force cast and called the parent method for the description.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes [#3553](https://github.com/getsentry/sentry-cocoa/issues/3553)

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
