### PR TITLE
Fix: Build crash after merging #4228

### DIFF
--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -334,7 +334,7 @@ SENTRY_NO_INIT
  */
 + (void)close;
 
-#if SENTRY_HAS_UIKIT
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 /**
  * @warning This is an experimental feature and may still have bugs.

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -571,7 +571,7 @@ static NSDate *_Nullable startTimestamp = nil;
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-#if SENTRY_HAS_UIKIT
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 + (void)replayRedactView:(UIView *)view
 {
     [SentryRedactViewHelper redactView:view];


### PR DESCRIPTION
#4228 broke framework building on main. I guess it was due to some merging not being taken into account.

_#skip-changelog_