### PR TITLE
test: Disable logs for verbose tracer tests

### DIFF
--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -73,7 +73,7 @@ class UIRedactBuilder {
 #else
         ignoreClassesIdentifiers = []
 #endif
-        redactClassesIdentifiers = Set(redactClasses.map( { ObjectIdentifier($0) }))
+        redactClassesIdentifiers = Set(redactClasses.map({ ObjectIdentifier($0) }))
     }
     
     func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {


### PR DESCRIPTION
Disable logs for SentryTracerTests
* testAddingSpansOnDifferentThread_WhileFinishing_DoesNotCrash
* testFinish_ShouldIgnoreWaitForChildrenCallback_DoesNotCrash
* testFinishAsync

because they can log around 10K log messages.

#skip-changelog