### PR TITLE
fix: EXC_BAD_ACCESS in SentryMetricProfiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 - Missing mach info for crash reports (#4230)
 - Crash reports not generated on visionOS (#4229)
 - Don’t force cast to `NSComparisonPredicate` in TERNARY operator (#4232)
+- EXC_BAD_ACCESS in SentryMetricProfiler (#4242)
+
+Add missing synchronize block around the clear method.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@
 - Don’t force cast to `NSComparisonPredicate` in TERNARY operator (#4232)
 - EXC_BAD_ACCESS in SentryMetricProfiler (#4242)
 
-Add missing synchronize block around the clear method.
-
 ### Improvements
 
 - Reduce memory usage of storing envelopes (#4219)

--- a/Sources/Sentry/SentryMetricProfiler.mm
+++ b/Sources/Sentry/SentryMetricProfiler.mm
@@ -113,7 +113,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 - (instancetype)initWithMode:(SentryProfilerMode)mode
 {
     if (self = [super init]) {
-        [self clear];
+        [self clearNotThreadSafe];
         _mode = mode;
     }
     return self;
@@ -210,6 +210,13 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 }
 
 - (void)clear
+{
+    @synchronized(self) {
+        [self clearNotThreadSafe];
+    }
+}
+
+- (void)clearNotThreadSafe
 {
     _cpuUsage = [NSMutableArray<SentryMetricReading *> array];
     _memoryFootprint = [NSMutableArray<SentryMetricReading *> array];

--- a/Sources/Sentry/SentryMetricProfiler.mm
+++ b/Sources/Sentry/SentryMetricProfiler.mm
@@ -113,6 +113,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 - (instancetype)initWithMode:(SentryProfilerMode)mode
 {
     if (self = [super init]) {
+        // It doesn't make sense to acquire a lock in the init.
         [self clearNotThreadSafe];
         _mode = mode;
     }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -38,7 +38,7 @@
 #include "SentryAsyncSafeLog.h"
 
 #ifdef __arm64__
-#include <sys/_types/_ucontext64.h>
+#    include <sys/_types/_ucontext64.h>
 #    define UC_MCONTEXT uc_mcontext64
 typedef ucontext64_t SignalUserContext;
 #else

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -73,7 +73,7 @@ class UIRedactBuilder {
 #else
         ignoreClassesIdentifiers = []
 #endif
-        redactClassesIdentifiers = Set(redactClasses.map( { ObjectIdentifier($0) }))
+        redactClassesIdentifiers = Set(redactClasses.map({ ObjectIdentifier($0) }))
     }
     
     func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {


### PR DESCRIPTION


## :scroll: Description

Add missing synchronize block around the clear method.

## :bulb: Motivation and Context

I detected this problem when running the unit tests locally. We also see a couple of occurrences in our [internal SDK crash detection](https://sentry.sentry.io/issues/?project=4505469596663808&query=is%3Aunresolved+sentrymetricprofiler&referrer=issue-list&sort=user&statsPeriod=14d).

## :green_heart: How did you test it?

Running SentrySpanTests repeatedly. Previously the `SentrySpanTests` sometimes crashed with `EXC_BAD_ACCESS` in `SentryMetricProfiler`. Now they don't.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
