### PR TITLE
impr: Skip enriching scope when nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Improvements
 
 - Reduce memory usage of storing envelopes (#4219)
+- Skip enriching scope when nil (#4243)
 
 ## 8.32.0
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -56,10 +56,24 @@ SentryHub () <SentryMetricsAPIDelegate>
 - (instancetype)initWithClient:(nullable SentryClient *)client
                       andScope:(nullable SentryScope *)scope
 {
+    return [self initWithClient:client
+                       andScope:scope
+                andCrashWrapper:SentryDependencyContainer.sharedInstance.crashWrapper
+               andDispatchQueue:SentryDependencyContainer.sharedInstance.dispatchQueueWrapper];
+}
+
+/** Internal constructor for testing */
+- (instancetype)initWithClient:(nullable SentryClient *)client
+                      andScope:(nullable SentryScope *)scope
+               andCrashWrapper:(SentryCrashWrapper *)crashWrapper
+              andDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
+{
+
     if (self = [super init]) {
         _client = client;
         _scope = scope;
-        _dispatchQueue = SentryDependencyContainer.sharedInstance.dispatchQueueWrapper;
+        _crashWrapper = crashWrapper;
+        _dispatchQueue = dispatchQueue;
         SentryStatsdClient *statsdClient = [[SentryStatsdClient alloc] initWithClient:client];
         SentryMetricsClient *metricsClient =
             [[SentryMetricsClient alloc] initWithClient:statsdClient];
@@ -76,23 +90,12 @@ SentryHub () <SentryMetricsAPIDelegate>
         _integrationsLock = [[NSObject alloc] init];
         _installedIntegrations = [[NSMutableArray alloc] init];
         _installedIntegrationNames = [[NSMutableSet alloc] init];
-        _crashWrapper = [SentryCrashWrapper sharedInstance];
         _errorsBeforeSession = 0;
 
-        [SentryDependencyContainer.sharedInstance.crashWrapper enrichScope:scope];
+        if (_scope) {
+            [_crashWrapper enrichScope:_scope];
+        }
     }
-    return self;
-}
-
-/** Internal constructor for testing */
-- (instancetype)initWithClient:(nullable SentryClient *)client
-                      andScope:(nullable SentryScope *)scope
-               andCrashWrapper:(SentryCrashWrapper *)crashWrapper
-              andDispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
-{
-    self = [self initWithClient:client andScope:scope];
-    _crashWrapper = crashWrapper;
-    _dispatchQueue = dispatchQueue;
 
     return self;
 }
@@ -538,7 +541,7 @@ SentryHub () <SentryMetricsAPIDelegate>
                 _scope = [[SentryScope alloc] init];
             }
 
-            [SentryDependencyContainer.sharedInstance.crashWrapper enrichScope:_scope];
+            [_crashWrapper enrichScope:_scope];
         }
         return _scope;
     }

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -73,7 +73,7 @@ class UIRedactBuilder {
 #else
         ignoreClassesIdentifiers = []
 #endif
-        redactClassesIdentifiers = Set(redactClasses.map( { ObjectIdentifier($0) }))
+        redactClassesIdentifiers = Set(redactClasses.map({ ObjectIdentifier($0) }))
     }
     
     func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.h
@@ -35,6 +35,8 @@ SENTRY_NO_INIT
 
 @property (nonatomic) BOOL binaryCacheStopped;
 
+@property (nonatomic) BOOL enrichScopeCalled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
@@ -17,6 +17,7 @@
     instance.uninstallAsyncHooksCalled = NO;
     instance.internalFreeMemorySize = 0;
     instance.internalAppMemorySize = 0;
+    instance.enrichScopeCalled = NO;
     return instance;
 }
 
@@ -85,6 +86,12 @@
 - (bytes)appMemorySize
 {
     return self.internalAppMemorySize;
+}
+
+- (void)enrichScope:(SentryScope *)scope
+{
+    self.enrichScopeCalled = YES;
+    [super enrichScope:scope];
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description

Skip enriching the scope in the hub initializer when it is nil, as enrich scope expects a non nil scope.

## :bulb: Motivation and Context

This came up while investigating flaky tests.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
