### PR TITLE
Add include for missing ucontext64_t type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Missing mach info for crash reports (#4230)
 - Crash reports not generated on visionOS (#4229)
 - Don’t force cast to `NSComparisonPredicate` in TERNARY operator (#4232)
+- Missing '#include <sys/_types/_ucontext64.h>' (#4244)
 
 ### Improvements
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -38,6 +38,7 @@
 #include "SentryAsyncSafeLog.h"
 
 #ifdef __arm64__
+#include <sys/_types/_ucontext64.h>
 #    define UC_MCONTEXT uc_mcontext64
 typedef ucontext64_t SignalUserContext;
 #else


### PR DESCRIPTION
## :scroll: Description

Compiling `main` under Xcode 16.0 beta 5 produces the following error:

```
Missing '#include <sys/_types/_ucontext64.h>'; 'ucontext64_t' must be declared before it is used
```

This PR adds the aforementioned include.

## :bulb: Motivation and Context

It allows users to continue building their apps that use Sentry under Xcode 16.0 beta 5.

## :green_heart: How did you test it?

I compiled under Xcode 16.0 beta 5 on an arm64 Mac.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
