### PR TITLE
fix: Accessing UI API on bg thread in enrichScope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Missing mach info for crash reports (#4230)
 - Crash reports not generated on visionOS (#4229)
 - Don’t force cast to `NSComparisonPredicate` in TERNARY operator (#4232)
+- Fix accessing UI API on bg thread in enrichScope (#4245)
 
 ### Improvements
 

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -15,6 +15,7 @@
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryUIApplication.h"
+#    import <UIKit/UIKit.h>
 #endif
 
 static NSString *const DEVICE_KEY = @"device";

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -15,7 +15,6 @@
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryUIApplication.h"
-#    import <UIKit/UIKit.h>
 #endif
 
 static NSString *const DEVICE_KEY = @"device";

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -5,6 +5,7 @@
 #import "SentryCrashMonitor_AppState.h"
 #import "SentryCrashMonitor_System.h"
 #import "SentryScope.h"
+#import "SentryUIDeviceWrapper.h"
 #import <Foundation/Foundation.h>
 #import <SentryCrashCachedData.h>
 #import <SentryCrashDebug.h>
@@ -126,7 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
     // For MacCatalyst the UIDevice returns the current version of MacCatalyst and not the
     // macOSVersion. Therefore we have to use NSProcessInfo.
 #if SENTRY_HAS_UIKIT && !TARGET_OS_MACCATALYST
-    [osData setValue:[UIDevice currentDevice].systemVersion forKey:@"version"];
+    [osData setValue:[SentryDependencyContainer.sharedInstance.uiDeviceWrapper getSystemVersion]
+              forKey:@"version"];
 #else
     NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
     NSString *systemVersion = [NSString stringWithFormat:@"%d.%d.%d", (int)version.majorVersion,

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -198,11 +198,10 @@ static NSObject *sentryDependencyContainerLock;
     }
 }
 
-#if TARGET_OS_IOS
+#if SENTRY_HAS_UIKIT
 - (SentryUIDeviceWrapper *)uiDeviceWrapper SENTRY_DISABLE_THREAD_SANITIZER(
     "double-checked lock produce false alarms")
 {
-#    if SENTRY_HAS_UIKIT
     if (_uiDeviceWrapper == nil) {
         @synchronized(sentryDependencyContainerLock) {
             if (_uiDeviceWrapper == nil) {
@@ -211,14 +210,9 @@ static NSObject *sentryDependencyContainerLock;
         }
     }
     return _uiDeviceWrapper;
-#    else
-    SENTRY_LOG_DEBUG(
-        @"SentryDependencyContainer.uiDeviceWrapper only works with UIKit enabled. Ensure you're "
-        @"using the right configuration of Sentry that links UIKit.");
-    return nil;
-#    endif // SENTRY_HAS_UIKIT
 }
-#endif // TARGET_OS_IOS
+
+#endif // SENTRY_HAS_UIKIT
 
 #if SENTRY_UIKIT_AVAILABLE
 - (SentryScreenshot *)screenshot SENTRY_DISABLE_THREAD_SANITIZER(

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -225,7 +225,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
         // The UIDeviceWrapper needs to start before the Hub, because the Hub
         // enriches the scope, which calls the UIDeviceWrapper.
-#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+#if SENTRY_HAS_UIKIT
         [SentryDependencyContainer.sharedInstance.uiDeviceWrapper start];
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -218,28 +218,33 @@ static NSDate *_Nullable startTimestamp = nil;
 
     SentryScope *scope
         = options.initialScope([[SentryScope alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs]);
-    // The Hub needs to be initialized with a client so that closing a session
-    // can happen.
-    SentryHub *hub = [[SentryHub alloc] initWithClient:newClient andScope:scope];
-    [SentrySDK setCurrentHub:hub];
-    SENTRY_LOG_DEBUG(@"SDK initialized! Version: %@", SentryMeta.versionString);
 
     SENTRY_LOG_DEBUG(@"Dispatching init work required to run on main thread.");
     [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchAsyncOnMainQueue:^{
         SENTRY_LOG_DEBUG(@"SDK main thread init started...");
 
+        // The UIDeviceWrapper needs to start before the Hub, because the Hub
+        // enriches the scope, which calls the UIDeviceWrapper.
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+        [SentryDependencyContainer.sharedInstance.uiDeviceWrapper start];
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+        // The Hub needs to be initialized with a client so that closing a session
+        // can happen.
+        SentryHub *hub = [[SentryHub alloc] initWithClient:newClient andScope:scope];
+        [SentrySDK setCurrentHub:hub];
+
         [SentryCrashWrapper.sharedInstance startBinaryImageCache];
         [SentryDependencyContainer.sharedInstance.binaryImageCache start];
 
         [SentrySDK installIntegrations];
-#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
-        [SentryDependencyContainer.sharedInstance.uiDeviceWrapper start];
-#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         sentry_manageTraceProfilerOnStartSDK(options, hub);
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }];
+
+    SENTRY_LOG_DEBUG(@"SDK initialized! Version: %@", SentryMeta.versionString);
 }
 
 + (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions

--- a/Sources/Sentry/SentryUIDeviceWrapper.m
+++ b/Sources/Sentry/SentryUIDeviceWrapper.m
@@ -10,6 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 SentryUIDeviceWrapper ()
 @property (nonatomic) BOOL cleanupDeviceOrientationNotifications;
 @property (nonatomic) BOOL cleanupBatteryMonitoring;
+@property (nonatomic, copy) NSString *systemVersion;
 @end
 
 @implementation SentryUIDeviceWrapper
@@ -27,6 +28,8 @@ SentryUIDeviceWrapper ()
             self.cleanupBatteryMonitoring = YES;
             UIDevice.currentDevice.batteryMonitoringEnabled = YES;
         }
+
+        self.systemVersion = [UIDevice currentDevice].systemVersion;
     }];
 }
 
@@ -68,6 +71,11 @@ SentryUIDeviceWrapper ()
 - (float)batteryLevel
 {
     return [UIDevice currentDevice].batteryLevel;
+}
+
+- (NSString *)getSystemVersion
+{
+    return self.systemVersion;
 }
 
 @end

--- a/Sources/Sentry/SentryUIDeviceWrapper.m
+++ b/Sources/Sentry/SentryUIDeviceWrapper.m
@@ -2,7 +2,7 @@
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchQueueWrapper.h"
 
-#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+#if SENTRY_HAS_UIKIT
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,6 +18,8 @@ SentryUIDeviceWrapper ()
 - (void)start
 {
     [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchAsyncOnMainQueue:^{
+
+#    if TARGET_OS_IOS
         if (!UIDevice.currentDevice.isGeneratingDeviceOrientationNotifications) {
             self.cleanupDeviceOrientationNotifications = YES;
             [UIDevice.currentDevice beginGeneratingDeviceOrientationNotifications];
@@ -28,6 +30,7 @@ SentryUIDeviceWrapper ()
             self.cleanupBatteryMonitoring = YES;
             UIDevice.currentDevice.batteryMonitoringEnabled = YES;
         }
+#    endif
 
         self.systemVersion = [UIDevice currentDevice].systemVersion;
     }];
@@ -35,6 +38,7 @@ SentryUIDeviceWrapper ()
 
 - (void)stop
 {
+#    if TARGET_OS_IOS
     BOOL needsCleanUp = self.cleanupDeviceOrientationNotifications;
     BOOL needsDisablingBattery = self.cleanupBatteryMonitoring;
     UIDevice *device = [UIDevice currentDevice];
@@ -46,6 +50,7 @@ SentryUIDeviceWrapper ()
             device.batteryMonitoringEnabled = NO;
         }
     }];
+#    endif // TARGET_OS_IOS
 }
 
 - (void)dealloc
@@ -53,6 +58,7 @@ SentryUIDeviceWrapper ()
     [self stop];
 }
 
+#    if TARGET_OS_IOS
 - (UIDeviceOrientation)orientation
 {
     return (UIDeviceOrientation)[UIDevice currentDevice].orientation;
@@ -72,6 +78,7 @@ SentryUIDeviceWrapper ()
 {
     return [UIDevice currentDevice].batteryLevel;
 }
+#    endif // TARGET_OS_IOS
 
 - (NSString *)getSystemVersion
 {
@@ -82,4 +89,4 @@ SentryUIDeviceWrapper ()
 
 NS_ASSUME_NONNULL_END
 
-#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
+#endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -32,7 +32,7 @@
 @class SentryViewHierarchy;
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if TARGET_OS_IOS
+#if SENTRY_HAS_UIKIT
 @class SentryUIDeviceWrapper;
 #endif // TARGET_OS_IOS
 
@@ -80,7 +80,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryUIApplication *application;
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if TARGET_OS_IOS
+#if SENTRY_HAS_UIKIT
 @property (nonatomic, strong) SentryUIDeviceWrapper *uiDeviceWrapper;
 #endif // TARGET_OS_IOS
 

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -12,10 +12,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)start;
 - (void)stop;
+
 - (UIDeviceOrientation)orientation;
 - (BOOL)isBatteryMonitoringEnabled;
 - (UIDeviceBatteryState)batteryState;
 - (float)batteryLevel;
+- (NSString *)getSystemVersion;
 
 @end
 

--- a/Sources/Sentry/include/SentryUIDeviceWrapper.h
+++ b/Sources/Sentry/include/SentryUIDeviceWrapper.h
@@ -1,26 +1,27 @@
 #import "SentryDefines.h"
 
-#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+#if SENTRY_HAS_UIKIT
 
 #    import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
-
-@class SentryDispatchQueueWrapper;
 
 @interface SentryUIDeviceWrapper : NSObject
 
 - (void)start;
 - (void)stop;
 
+#    if TARGET_OS_IOS
 - (UIDeviceOrientation)orientation;
 - (BOOL)isBatteryMonitoringEnabled;
 - (UIDeviceBatteryState)batteryState;
 - (float)batteryLevel;
+#    endif // TARGET_OS_IOS
+
 - (NSString *)getSystemVersion;
 
 @end
 
 NS_ASSUME_NONNULL_END
 
-#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
+#endif // SENTRY_HAS_UIKIT

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -38,7 +38,7 @@
 #include "SentryAsyncSafeLog.h"
 
 #ifdef __arm64__
-#include <sys/_types/_ucontext64.h>
+#    include <sys/_types/_ucontext64.h>
 #    define UC_MCONTEXT uc_mcontext64
 typedef ucontext64_t SignalUserContext;
 #else

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -296,6 +296,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     }
     
     private func givenSutWithGlobalHubAndCrashWrapper() -> (SentryCrashIntegration, SentryHub) {
+        SentryDependencyContainer.sharedInstance().uiDeviceWrapper.start()
         let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         let hub = fixture.hub
         SentrySDK.setCurrentHub(hub)

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -296,7 +296,9 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     }
     
     private func givenSutWithGlobalHubAndCrashWrapper() -> (SentryCrashIntegration, SentryHub) {
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         SentryDependencyContainer.sharedInstance().uiDeviceWrapper.start()
+#endif
         let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         let hub = fixture.hub
         SentrySDK.setCurrentHub(hub)

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -706,8 +706,9 @@ class SentrySDKTests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
         
         let os = try XCTUnwrap (SentrySDK.currentHub().scope.contextDictionary["os"] as? [String: Any])
-        
+#if !targetEnvironment(macCatalyst)
         XCTAssertEqual(UIDevice.current.systemVersion, os["version"] as? String)
+#endif
     }
 #endif
     

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -691,6 +691,24 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.close()
         XCTAssertFalse(deviceWrapper.started)
     }
+    
+    /// Ensure to start the UIDeviceWrapper before initializing the hub, so enrich scope sets the correct OS version.
+    func testStartSDK_ScopeContextContainsOSVersion() throws {
+        let expectation = expectation(description: "MainThreadTestIntegration install called")
+        MainThreadTestIntegration.expectation = expectation
+        
+        DispatchQueue.global(qos: .background).async {
+            SentrySDK.start { options in
+                options.integrations = [ NSStringFromClass(MainThreadTestIntegration.self) ]
+            }
+        }
+        
+        wait(for: [expectation], timeout: 1.0)
+        
+        let os = try XCTUnwrap (SentrySDK.currentHub().scope.contextDictionary["os"] as? [String: Any])
+        
+        XCTAssertEqual(UIDevice.current.systemVersion, os["version"] as? String)
+    }
 #endif
     
     func testResumeAndPauseAppHangTracking() {


### PR DESCRIPTION


## :scroll: Description

Fix accessing UIDevice in enrich scope, which could be called on a background thread by caching the system version in the SentryUIDeviceWrapper.

## :bulb: Motivation and Context

Came up in https://github.com/getsentry/sentry-cocoa/issues/3836#issuecomment-2110605384 and while investigating flaky tests.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
