### PR TITLE
test: Remove metrics API from the iOS-Swift sample

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -155,8 +155,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 return scope
             }
         })
-        
-        SentrySDK.metrics.increment(key: "app.start", value: 1.0, tags: ["view": "app-delegate"])
 
     }
     //swiftlint:enable function_body_length cyclomatic_complexity
@@ -171,11 +169,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         if !ProcessInfo.processInfo.arguments.contains("--skip-sentry-init") {
             AppDelegate.startSentry()
-        }
-        
-        randomDistributionTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { _ in
-            let random = Double.random(in: 0..<1_000)
-            SentrySDK.metrics.distribution(key: "random.distribution", value: random)
         }
         
         if #available(iOS 15.0, *) {

--- a/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
@@ -11,12 +11,6 @@ class ErrorsViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         SentrySDK.reportFullyDisplayed()
-        
-        SentrySDK.metrics.increment(key: "load.errors.view.controller")
-        
-        SentrySDK.metrics.timing(key: "timing.some.delayed") {
-            Thread.sleep(forTimeInterval: 0.01)
-        }
     }
 
     @IBAction func useAfterFree(_ sender: UIButton) {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -38,7 +38,7 @@
 #include "SentryAsyncSafeLog.h"
 
 #ifdef __arm64__
-#include <sys/_types/_ucontext64.h>
+#    include <sys/_types/_ucontext64.h>
 #    define UC_MCONTEXT uc_mcontext64
 typedef ucontext64_t SignalUserContext;
 #else


### PR DESCRIPTION
We plan on deprecating the existing metrics API. Therefore, we can
already remove the usages in the iOS-Swift sample app to minimize side
effects for UI tests.

#skip-changelog