### PR TITLE
test: Fix testSkipCrumbs_WhenSenderOrTargetIsNil

### DIFF
--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -195,8 +195,10 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         swizzlingWrapper.execute(action: "methodPressed:", target: nil, sender: self, event: nil)
         swizzlingWrapper.execute(action: "methodPressed:", target: self, sender: nil, event: nil)
         
-        // The tracker adds 1 enabled crumb when being started
-        XCTAssertEqual(1, delegate.addCrumbInvocations.invocations.count)
+        let touchCrumbs = delegate.addCrumbInvocations.invocations.filter { crumb in
+            return crumb.category == "touch"
+        }
+        XCTAssertEqual(0, touchCrumbs.count)
     }
     
     func testTouchBreadcrumbForSessionReplay() throws {


### PR DESCRIPTION
The testSkipCrumbs_WhenSenderOrTargetIsNil failed, because a connectivity crumb popped up during the test. This is fixed now by only validating that the crumbs don't contain any touch crumbs.

The test failed here https://github.com/getsentry/sentry-cocoa/actions/runs/10285151696/job/28463067103?pr=4249

```
Test Case '-[SentryTests.SentryBreadcrumbTrackerTests testSkipCrumbs_WhenSenderOrTargetIsNil]' started.
crumb: <SentryBreadcrumb: 0x60000b26a240, {
    category = started;
    level = info;
    message = "Breadcrumb Tracking";
    timestamp = "2024-08-07T13:41:11.539Z";
    type = debug;
}>
[Sentry] [debug] [SentryReachability:179] Adding observer: <SentryBreadcrumbTracker: 0x6000025bd1d0>
[Sentry] [debug] [SentryReachability:181] Synchronized to add observer: <SentryBreadcrumbTracker: 0x6000025bd1d0>
[Sentry] [debug] [SentryReachability:211] registering callback for reachability ref <SCNetworkReachability 0x7fb485996cd0 [0x1113331d0]> {name = sentry.io}
[Sentry] [debug] [SentryReachability:137] SentryConnectivityCallback called with target: <SCNetworkReachability 0x7fb485996cd0 [0x1113331d0]> {name = sentry.io (complete, 35.186.247.156), flags = 0x00000002, if_index = 5}; flags: 2
[Sentry] [debug] [SentryReachability:102] Entered synchronized region of SentryConnectivityCallback with flags: 2
[Sentry] [debug] [SentryReachability:118] Notifying observers...
[Sentry] [debug] [SentryReachability:120] Notifying <SentryBreadcrumbTracker: 0x6000025bd1d0>
crumb: <SentryBreadcrumb: 0x60000b27a140, {
    category = "device.connectivity";
    data =     {
        connectivity = wifi;
    };
    level = info;
    timestamp = "2024-08-07T13:41:11.542Z";
    type = connectivity;
}>
[Sentry] [debug] [SentryReachability:124] Finished notifying observers.
/Users/runner/work/sentry-cocoa/sentry-cocoa/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift:199: error: -[SentryTests.SentryBreadcrumbTrackerTests testSkipCrumbs_WhenSenderOrTargetIsNil] : XCTAssertEqual failed: ("1") is not equal to ("2")
```

#skip-changelog