### PR TITLE
ci: Bump Xcode 15.2 to 15.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           # iOS 17
           - runs-on: macos-14
             platform: "iOS"
-            xcode: "15.2"
+            xcode: "15.4"
             test-destination-os: "17.2"
             device: "iPhone 15"
 
@@ -113,7 +113,7 @@ jobs:
           # macOS 14
           - runs-on: macos-14
             platform: "macOS"
-            xcode: "15.2"
+            xcode: "15.4"
             test-destination-os: "latest"
 
           # Catalyst. We only test the latest version, as
@@ -121,7 +121,7 @@ jobs:
           # on an older iOS or macOS version is low.
           - runs-on: macos-14
             platform: "Catalyst"
-            xcode: "15.2"
+            xcode: "15.4"
             test-destination-os: "latest"
 
           # tvOS 15
@@ -133,13 +133,13 @@ jobs:
           # tvOS 16
           - runs-on: macos-13
             platform: "tvOS"
-            xcode: "14.3"
+            xcode: "14.3.1"
             test-destination-os: "17.2"
 
           # tvOS 17
           - runs-on: macos-14
             platform: "tvOS"
-            xcode: "15.2"
+            xcode: "15.4"
             test-destination-os: "17.5"
 
     steps:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -122,7 +122,7 @@ jobs:
             device: "iPhone 14 (16.4)"
 
           - runs-on: macos-14
-            xcode: "15.2"
+            xcode: "15.4"
             device: "iPhone 15 (17.2)"
 
     steps:


### PR DESCRIPTION
Bump Xcode 15.2 to 15.4 for jobs running on macos-14.

Xcode 15.4 is available for macos-14, see https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md.