### PR TITLE
ci: Remove unit tests Xcode 14 for tvOS and macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -104,11 +104,8 @@ jobs:
             xcode: "13.4.1"
             test-destination-os: "latest"
 
-          # macOS 13
-          - runs-on: macos-13
-            platform: "macOS"
-            xcode: "14.3"
-            test-destination-os: "latest"
+          # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
+          # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.
 
           # macOS 14
           - runs-on: macos-14
@@ -130,11 +127,8 @@ jobs:
             xcode: "13.4.1"
             test-destination-os: "16.1"
 
-          # tvOS 16
-          - runs-on: macos-13
-            platform: "tvOS"
-            xcode: "14.3"
-            test-destination-os: "17.2"
+          # We don't run the unit tests on tvOS 16 cause we run them on all on GH actions available iOS versions.
+          # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, tvOS 15 or tvOS 16 is minimal.
 
           # tvOS 17
           - runs-on: macos-14


### PR DESCRIPTION
Both tvOS and macOS were using Xcode 14.3 on macos-13, which hasn't been available for a while now. So, the tests were actually running on Xcode 15.2, which uses tvOS 17.2 instead of tvOS 16 and macOS 14.2 instead of macOS 13. We never noticed this. Furthermore, I think it's not worth the computation time to run tests on these OS versions compared to the small risk of finding bugs. We run the tests on tvOS 15 and macOS 12, which should be sufficient.

#skip-changelog
