### PR TITLE
feat: Add a replay quality option for Objc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add replay quality option for Objective-c ()
+
 ## 8.33.0
 
 This release fixes a bug (#4230) that we introduced with a refactoring (#4101) released in [8.30.1](https://github.com/getsentry/sentry-cocoa/releases/tag/8.30.1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add replay quality option for Objective-c (#4267)
+- Add replay quality option for Objective-C (#4267)
 
 ## 8.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add replay quality option for Objective-c ()
+- Add replay quality option for Objective-c (#4267)
 
 ## 8.33.0
 

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -31,7 +31,7 @@ AppDelegate ()
         options.experimental.sessionReplay.redactAllImages = true;
         options.experimental.sessionReplay.sessionSampleRate = 0;
         options.experimental.sessionReplay.onErrorSampleRate = 1;
-        
+
         options.initialScope = ^(SentryScope *scope) {
             [scope setTagValue:@"" forKey:@""];
             return scope;

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -26,6 +26,12 @@ AppDelegate ()
             [[SentryHttpStatusCodeRange alloc] initWithMin:400 max:599];
         options.failedRequestStatusCodes = @[ httpStatusCodeRange ];
 
+        options.experimental.sessionReplay.quality = SentryReplayQualityMedium;
+        options.experimental.sessionReplay.redactAllText = true;
+        options.experimental.sessionReplay.redactAllImages = true;
+        options.experimental.sessionReplay.sessionSampleRate = 0;
+        options.experimental.sessionReplay.onErrorSampleRate = 1;
+        
         options.initialScope = ^(SentryScope *scope) {
             [scope setTagValue:@"" forKey:@""];
             return scope;

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -1,11 +1,12 @@
 import Foundation
 
-@objcMembers
+@objc
 public class SentryReplayOptions: NSObject, SentryRedactOptions {
     
     /**
      * Enum to define the quality of the session replay.
      */
+    @objc
     public enum SentryReplayQuality: Int {
         /**
          * Video Scale: 80%
@@ -33,7 +34,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * to the default.
      * - note:  The default is 0.
      */
-    public var sessionSampleRate: Float
+    @objc public var sessionSampleRate: Float
 
     /**
      * Indicates the percentage in which a 30 seconds replay will be send with error events.
@@ -42,7 +43,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * to the default.
      * - note: The default is 0.
      */
-    public var onErrorSampleRate: Float
+    @objc public var onErrorSampleRate: Float
     
     /**
      * Indicates whether session replay should redact all text in the app
@@ -50,7 +51,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - note: The default is true
      */
-    public var redactAllText = true
+    @objc public var redactAllText = true
     
     /**
      * Indicates whether session replay should redact all non-bundled image
@@ -58,27 +59,27 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - note: The default is true
      */
-    public var redactAllImages = true
+    @objc public var redactAllImages = true
     
     /**
      * Indicates the quality of the replay.
      * The higher the quality, the higher the CPU and bandwidth usage.
      */
-    public var quality = SentryReplayQuality.low
+    @objc public var quality = SentryReplayQuality.low
     
     /**
      * A list of custom UIView subclasses that need 
      * to be masked during session replay.
      * By default Sentry already mask text elements from UIKit
      */
-    public var redactViewTypes = [AnyClass]()
+    @objc public var redactViewTypes = [AnyClass]()
     
     /**
      * A list of custom UIView subclasses to be ignored
      * during masking step of the session replay.
      * The view itself and any child will be ignored and not masked.
      */
-    public var ignoreRedactViewTypes = [AnyClass]()
+    @objc public var ignoreRedactViewTypes = [AnyClass]()
     
     /**
      * Defines the quality of the session replay.

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc
+@objcMembers
 public class SentryReplayOptions: NSObject, SentryRedactOptions {
     
     /**
@@ -34,7 +34,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * to the default.
      * - note:  The default is 0.
      */
-    @objc public var sessionSampleRate: Float
+    public var sessionSampleRate: Float
 
     /**
      * Indicates the percentage in which a 30 seconds replay will be send with error events.
@@ -43,7 +43,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * to the default.
      * - note: The default is 0.
      */
-    @objc public var onErrorSampleRate: Float
+    public var onErrorSampleRate: Float
     
     /**
      * Indicates whether session replay should redact all text in the app
@@ -51,7 +51,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - note: The default is true
      */
-    @objc public var redactAllText = true
+    public var redactAllText = true
     
     /**
      * Indicates whether session replay should redact all non-bundled image
@@ -59,27 +59,27 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - note: The default is true
      */
-    @objc public var redactAllImages = true
+    public var redactAllImages = true
     
     /**
      * Indicates the quality of the replay.
      * The higher the quality, the higher the CPU and bandwidth usage.
      */
-    @objc public var quality = SentryReplayQuality.low
+    public var quality = SentryReplayQuality.low
     
     /**
      * A list of custom UIView subclasses that need 
      * to be masked during session replay.
      * By default Sentry already mask text elements from UIKit
      */
-    @objc public var redactViewTypes = [AnyClass]()
+    public var redactViewTypes = [AnyClass]()
     
     /**
      * A list of custom UIView subclasses to be ignored
      * during masking step of the session replay.
      * The view itself and any child will be ignored and not masked.
      */
-    @objc public var ignoreRedactViewTypes = [AnyClass]()
+    public var ignoreRedactViewTypes = [AnyClass]()
     
     /**
      * Defines the quality of the session replay.


### PR DESCRIPTION
## :scroll: Description

Quality options was not exposed to Objc.

## :green_heart: How did you test it?

Sample

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
