### PR TITLE
fix(SentryOptions): correct explanation of environment

### DIFF
--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -48,7 +48,7 @@ NS_SWIFT_NAME(Options)
 @property (nullable, nonatomic, copy) NSString *dist;
 
 /**
- * The environment used for this event.
+ * The environment used for events if no environment is set on the current scope.
  * @note Default value is @c @"production".
  */
 @property (nonatomic, copy) NSString *environment;


### PR DESCRIPTION
Noticed this had been copypasta'd in https://github.com/getsentry/sentry-cocoa/pull/290

#skip-changelog