### PR TITLE
fix: Session replay not redacting buttons and other non UILabel texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Fixes
 
-- Session replay not redacting buttons and other non UILabel texts ()
+- Session replay not redacting buttons and other non UILabel texts (#4277)
 
 ## 8.33.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add replay quality option for Objective-C (#4267)
 
+### Fixes
+
+- Session replay not redacting buttons and other non UILabel texts ()
+
 ## 8.33.0
 
 This release fixes a bug (#4230) that we introduced with a refactoring (#4101) released in [8.30.1](https://github.com/getsentry/sentry-cocoa/releases/tag/8.30.1).

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -114,7 +114,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         workingQueue.dispatchAsync ({
             while let first = self._frames.first, first.time < date {
                 self._frames.removeFirst()
-               try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
+                try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
             }
         })
     }

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -114,7 +114,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         workingQueue.dispatchAsync ({
             while let first = self._frames.first, first.time < date {
                 self._frames.removeFirst()
-              //  try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
+               try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
             }
         })
     }

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -114,7 +114,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         workingQueue.dispatchAsync ({
             while let first = self._frames.first, first.time < date {
                 self._frames.removeFirst()
-                try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
+              //  try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
             }
         })
     }

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -76,12 +76,24 @@ class UIRedactBuilder {
         redactClassesIdentifiers = Set(redactClasses.map({ ObjectIdentifier($0) }))
     }
     
+    
+    private func checkForClass(_ target: AnyClass, inSet: Set<ObjectIdentifier>) -> Bool {
+        var currentClass: AnyClass? = target
+        while currentClass != nil && currentClass != UIView.self {
+            if let currentClass = currentClass, inSet.contains(ObjectIdentifier(currentClass)) {
+                return true
+            }
+            currentClass = currentClass?.superclass()
+        }
+        return false
+    }
+    
     func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {
-        return ignoreClassesIdentifiers.contains(ObjectIdentifier(ignoreClass))
+        return checkForClass(ignoreClass, inSet: ignoreClassesIdentifiers)
     }
     
     func containsRedactClass(_ redactClass: AnyClass) -> Bool {
-        return redactClassesIdentifiers.contains(ObjectIdentifier(redactClass))
+        return checkForClass(redactClass, inSet: redactClassesIdentifiers)
     }
     
     func addIgnoreClass(_ ignoreClass: AnyClass) {

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -76,24 +76,19 @@ class UIRedactBuilder {
         redactClassesIdentifiers = Set(redactClasses.map({ ObjectIdentifier($0) }))
     }
     
+    func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {
+        return  ignoreClassesIdentifiers.contains(ObjectIdentifier(ignoreClass))
+    }
     
-    private func checkForClass(_ target: AnyClass, inSet: Set<ObjectIdentifier>) -> Bool {
-        var currentClass: AnyClass? = target
+    func containsRedactClass(_ redactClass: AnyClass) -> Bool {
+        var currentClass: AnyClass? = redactClass
         while currentClass != nil && currentClass != UIView.self {
-            if let currentClass = currentClass, inSet.contains(ObjectIdentifier(currentClass)) {
+            if let currentClass = currentClass, redactClassesIdentifiers.contains(ObjectIdentifier(currentClass)) {
                 return true
             }
             currentClass = currentClass?.superclass()
         }
         return false
-    }
-    
-    func containsIgnoreClass(_ ignoreClass: AnyClass) -> Bool {
-        return checkForClass(ignoreClass, inSet: ignoreClassesIdentifiers)
-    }
-    
-    func containsRedactClass(_ redactClass: AnyClass) -> Bool {
-        return checkForClass(redactClass, inSet: redactClassesIdentifiers)
     }
     
     func addIgnoreClass(_ ignoreClass: AnyClass) {

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -146,24 +146,33 @@ class UIRedactBuilderTests: XCTestCase {
     }
     
     func testIgnoreClasses() {
-        class AnotherLabel: UILabel {
-        }
-        
         let sut = UIRedactBuilder()
-        sut.addIgnoreClass(AnotherLabel.self)
-        rootView.addSubview(AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40)))
+        sut.addIgnoreClass(UILabel.self)
+        rootView.addSubview(UILabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40)))
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         XCTAssertEqual(result.count, 0)
     }
     
-    func testRedactlasses() {
+    func testRedactClasses() {
         class AnotherView: UIView {
         }
         
         let sut = UIRedactBuilder()
         let view = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
         sut.addRedactClass(AnotherView.self)
+        rootView.addSubview(view)
+        
+        let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
+        XCTAssertEqual(result.count, 1)
+    }
+    
+    func testRedactSubClass() {
+        class AnotherView: UILabel {
+        }
+        
+        let sut = UIRedactBuilder()
+        let view = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
         rootView.addSubview(view)
         
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())


### PR DESCRIPTION
## :scroll: Description

Subclasses of classes that should be redacted were not.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
