### PR TITLE
fix: Rarely reporting too long frame delays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Session replay not redacting buttons and other non UILabel texts (#4277)
+- Rarely reporting too long frame delays (#4278) by fixing a race condition in the frames tracking logic.
 
 ## 8.33.0
 

--- a/SentryTestUtils/TestDisplayLinkWrapper.swift
+++ b/SentryTestUtils/TestDisplayLinkWrapper.swift
@@ -114,6 +114,11 @@ public class TestDisplayLinkWrapper: SentryDisplayLinkWrapper {
         call()
         return fastestFrozenFrameDuration
     }
+    
+    public func frameWith(delay: Double) {
+        dateProvider.advance(by: currentFrameRate.tickDuration + delay)
+        call()
+    }
 
     /// There's no upper bound for a frozen frame, except maybe for the watchdog time limit.
     /// - parameter extraTime: the additional time to add to the frozen frame threshold when simulating a frozen frame.

--- a/Sources/Sentry/SentryDelayedFramesTracker.m
+++ b/Sources/Sentry/SentryDelayedFramesTracker.m
@@ -3,6 +3,7 @@
 #if SENTRY_HAS_UIKIT
 
 #    import "SentryDelayedFrame.h"
+#    import "SentryInternalCDefines.h"
 #    import "SentryLog.h"
 #    import "SentrySwift.h"
 #    import "SentryTime.h"
@@ -15,6 +16,8 @@ SentryDelayedFramesTracker ()
 @property (nonatomic, assign) CFTimeInterval keepDelayedFramesDuration;
 @property (nonatomic, strong, readonly) SentryCurrentDateProvider *dateProvider;
 @property (nonatomic, strong) NSMutableArray<SentryDelayedFrame *> *delayedFrames;
+@property (nonatomic) uint64_t lastDelayedFrameSystemTimestamp;
+@property (nonatomic) uint64_t previousFrameSystemTimestamp;
 
 @end
 
@@ -31,6 +34,20 @@ SentryDelayedFramesTracker ()
     return self;
 }
 
+- (void)setPreviousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp
+    SENTRY_DISABLE_THREAD_SANITIZER("We don't want to synchronize the access to this property to "
+                                    "avoid slowing down the main thread.")
+{
+    _previousFrameSystemTimestamp = previousFrameSystemTimestamp;
+}
+
+- (uint64_t)getPreviousFrameSystemTimestamp SENTRY_DISABLE_THREAD_SANITIZER(
+    "We don't want to synchronize the access to this property to avoid slowing down the main "
+    "thread.")
+{
+    return _previousFrameSystemTimestamp;
+}
+
 - (void)resetDelayedFramesTimeStamps
 {
     _delayedFrames = [NSMutableArray array];
@@ -42,9 +59,13 @@ SentryDelayedFramesTracker ()
 }
 
 - (void)recordDelayedFrame:(uint64_t)startSystemTimestamp
-          expectedDuration:(CFTimeInterval)expectedDuration
-            actualDuration:(CFTimeInterval)actualDuration
+    thisFrameSystemTimestamp:(uint64_t)thisFrameSystemTimestamp
+            expectedDuration:(CFTimeInterval)expectedDuration
+              actualDuration:(CFTimeInterval)actualDuration
 {
+    // This @synchronized block only gets called for delayed frames.
+    // We accept the tradeoff of slowing down the main thread a bit to
+    // record the frame delay data.
     @synchronized(self.delayedFrames) {
         [self removeOldDelayedFrames];
 
@@ -53,6 +74,8 @@ SentryDelayedFramesTracker ()
                                               expectedDuration:expectedDuration
                                                 actualDuration:actualDuration];
         [self.delayedFrames addObject:delayedFrame];
+        self.lastDelayedFrameSystemTimestamp = thisFrameSystemTimestamp;
+        self.previousFrameSystemTimestamp = thisFrameSystemTimestamp;
     }
 }
 
@@ -92,7 +115,6 @@ SentryDelayedFramesTracker ()
 - (CFTimeInterval)getFramesDelay:(uint64_t)startSystemTimestamp
               endSystemTimestamp:(uint64_t)endSystemTimestamp
                        isRunning:(BOOL)isRunning
-    previousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp
               slowFrameThreshold:(CFTimeInterval)slowFrameThreshold
 {
     CFTimeInterval cantCalculateFrameDelayReturnValue = -1.0;
@@ -114,13 +136,20 @@ SentryDelayedFramesTracker ()
         return cantCalculateFrameDelayReturnValue;
     }
 
-    if (previousFrameSystemTimestamp == 0) {
-        SENTRY_LOG_DEBUG(@"Not calculating frames delay because no frames yet recorded.");
-        return cantCalculateFrameDelayReturnValue;
-    }
+    // Make a local copy because this method can be called on a background thread and the value
+    // could change.
+    uint64_t localPreviousFrameSystemTimestamp;
 
     NSMutableArray<SentryDelayedFrame *> *frames;
     @synchronized(self.delayedFrames) {
+
+        localPreviousFrameSystemTimestamp = self.previousFrameSystemTimestamp;
+
+        if (localPreviousFrameSystemTimestamp == 0) {
+            SENTRY_LOG_DEBUG(@"Not calculating frames delay because no frames yet recorded.");
+            return cantCalculateFrameDelayReturnValue;
+        }
+
         uint64_t oldestDelayedFrameStartTimestamp = UINT64_MAX;
         SentryDelayedFrame *oldestDelayedFrame = self.delayedFrames.firstObject;
         if (oldestDelayedFrame != nil) {
@@ -139,10 +168,10 @@ SentryDelayedFramesTracker ()
 
     // Add a delayed frame for a potentially ongoing but not recorded delayed frame
     SentryDelayedFrame *currentFrameDelay = [[SentryDelayedFrame alloc]
-        initWithStartTimestamp:previousFrameSystemTimestamp
+        initWithStartTimestamp:localPreviousFrameSystemTimestamp
               expectedDuration:slowFrameThreshold
                 actualDuration:nanosecondsToTimeInterval(
-                                   endSystemTimestamp - previousFrameSystemTimestamp)];
+                                   endSystemTimestamp - localPreviousFrameSystemTimestamp)];
 
     [frames addObject:currentFrameDelay];
 

--- a/Sources/Sentry/include/SentryDelayedFramesTracker.h
+++ b/Sources/Sentry/include/SentryDelayedFramesTracker.h
@@ -23,8 +23,11 @@ SENTRY_NO_INIT
 - (void)resetDelayedFramesTimeStamps;
 
 - (void)recordDelayedFrame:(uint64_t)startSystemTimestamp
-          expectedDuration:(CFTimeInterval)expectedDuration
-            actualDuration:(CFTimeInterval)actualDuration;
+    thisFrameSystemTimestamp:(uint64_t)thisFrameSystemTimestamp
+            expectedDuration:(CFTimeInterval)expectedDuration
+              actualDuration:(CFTimeInterval)actualDuration;
+
+- (void)setPreviousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp;
 
 /**
  * This method returns the duration of all delayed frames between startSystemTimestamp and
@@ -44,7 +47,6 @@ SENTRY_NO_INIT
  * delay.
  * @param endSystemTimestamp The end system time stamp for the time interval to query frames delay.
  * @param isRunning Wether the frames tracker is running or not.
- * @param previousFrameSystemTimestamp The system timestamp of the previous frame.
  * @param slowFrameThreshold The threshold for a slow frame. For 60 fps this is roughly 16.67 ms.
  *
  * @return the frames delay duration or -1 if it can't calculate the frames delay.
@@ -52,7 +54,6 @@ SENTRY_NO_INIT
 - (CFTimeInterval)getFramesDelay:(uint64_t)startSystemTimestamp
               endSystemTimestamp:(uint64_t)endSystemTimestamp
                        isRunning:(BOOL)isRunning
-    previousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp
               slowFrameThreshold:(CFTimeInterval)slowFrameThreshold;
 
 @end


### PR DESCRIPTION


## :scroll: Description

Fix a race condition in the SentryFramesTracker and SentryDelayedFramesTracker that sometimes leads to frame delay durations longer than the queried interval of start and end time. This is fixed by moving the previousFrameSystemTimestamp down to the SentryDelayedFramesTracker so we can adequately synchronize it without acquiring extra locks on the main thread.

## :bulb: Motivation and Context
 
Came up while working on GH-3492.

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
