### PR TITLE
fix: Crash deserializing empty envelope length>0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Fixes
 
 - Session replay not redacting buttons and other non UILabel texts (#4277)
+- Crash deserializing empty envelope length>0 (#4281]
+
 
 ## 8.33.0
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -162,9 +162,6 @@ NS_ASSUME_NONNULL_BEGIN
     NSUInteger endOfEnvelope = data.length - 1;
     for (NSInteger i = itemHeaderStart; i <= endOfEnvelope; ++i) {
         if (bytes[i] == '\n' || i == endOfEnvelope) {
-            if (endOfEnvelope == i) {
-                i++; // 0 byte attachment
-            }
 
             NSData *itemHeaderData =
                 [data subdataWithRange:NSMakeRange(itemHeaderStart, i - itemHeaderStart)];
@@ -222,6 +219,9 @@ NS_ASSUME_NONNULL_BEGIN
                 itemHeader = [[SentryEnvelopeItemHeader alloc] initWithType:type length:bodyLength];
             }
 
+            if (endOfEnvelope == i) {
+                i++; // 0 byte attachment
+            }
             NSData *itemBody = [data subdataWithRange:NSMakeRange(i + 1, bodyLength)];
 #ifdef DEBUG
             if ([SentryEnvelopeItemTypeEvent isEqual:type] ||

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -114,6 +114,11 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         let itemData = "{}\n{\"length\":0,\"type\":\"attachment\"}\n".data(using: .utf8)!
         XCTAssertNotNil(PrivateSentrySDKOnly.envelope(with: itemData))
     }
+    
+    func testEnvelopeWithDataLengthGtZero() throws {
+        let itemData = "{}\n{\"length\":1,\"type\":\"attachment\"}\n".data(using: .utf8)!
+        XCTAssertNil(PrivateSentrySDKOnly.envelope(with: itemData))
+    }
 
     func testGetDebugImages() {
         let images = PrivateSentrySDKOnly.getDebugImages()


### PR DESCRIPTION
## :scroll: Description

Deserializing empty envelope with length != 0 crashes SDK during init. Unsure what the root cause (creating this kind of invalid payload) is. 

However, it seems we already had [code for that exact case](https://github.com/getsentry/sentry-cocoa/pull/4281/files?diff=split#diff-b1a03b0a05f5b53fc2dcfa9bdeebe0d6285541a37b2eb9b93733b1c2a7e5af58L199) in place but it didn't catch it because the iterator was incremented at the beginning of the loop, so the if checking for whether end of envelope is reached didn't work.

Least intrusive solution is to move incrementing to right before we use the iterator to avoid side effects.

## :bulb: Motivation and Context

fix GH-4280

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] ~~I updated the docs if needed.~~
- [x] ~~Review from the native team if needed.~~
- [x] ~~No breaking change or entry added to the changelog.~~
- [x] ~~No breaking change for hybrid SDKs or communicated to hybrid SDKs.~~

## :crystal_ball: Next steps
