### PR TITLE
ref: Convert ANRV2Delegate to Swift

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		62872B5F2BA1B7F300A4FA7D /* NSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B5E2BA1B7F300A4FA7D /* NSLock.swift */; };
 		62872B632BA1B86100A4FA7D /* NSLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B622BA1B86100A4FA7D /* NSLockTests.swift */; };
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
+		6294774C2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
 		62991A8D2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62991A8C2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift */; };
@@ -1091,6 +1092,7 @@
 		62872B5E2BA1B7F300A4FA7D /* NSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLock.swift; sourceTree = "<group>"; };
 		62872B622BA1B86100A4FA7D /* NSLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLockTests.swift; sourceTree = "<group>"; };
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
+		6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryANRTrackerV2Delegate.swift; sourceTree = "<group>"; };
 		62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionContextTests.swift; sourceTree = "<group>"; };
 		629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReachabilitySwiftTests.swift; sourceTree = "<group>"; };
 		62991A8C2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsAPI.swift; sourceTree = "<group>"; };
@@ -2152,6 +2154,14 @@
 				62872B622BA1B86100A4FA7D /* NSLockTests.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		6294774A2C6F252F00846CBC /* ANR */ = {
+			isa = PBXGroup;
+			children = (
+				6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */,
+			);
+			path = ANR;
 			sourceTree = "<group>";
 		};
 		62B558AE2C6B9C3000C34FEC /* FramesTracking */ = {
@@ -3893,6 +3903,7 @@
 		D8CAC02D2BA0663E00E38F34 /* Integrations */ = {
 			isa = PBXGroup;
 			children = (
+				6294774A2C6F252F00846CBC /* ANR */,
 				62B558AE2C6B9C3000C34FEC /* FramesTracking */,
 				D8739CF72BECFF92007D2F66 /* Performance */,
 				D8CAC02C2BA0663E00E38F34 /* SessionReplay */,
@@ -4496,6 +4507,7 @@
 				7BD86ED1264A7CF6005439DB /* SentryAppStartMeasurement.m in Sources */,
 				D8F67AEE2BE0D19200C9197B /* UIImageHelper.swift in Sources */,
 				7DC27EC723997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m in Sources */,
+				6294774C2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift in Sources */,
 				D84D2CDF2C2BF9370011AF8A /* SentryReplayType.swift in Sources */,
 				63FE717B20DA4C1100CDBAE8 /* SentryCrashReport.c in Sources */,
 				D8F67B222BEAB6CC00C9197B /* SentryRRWebEvent.swift in Sources */,

--- a/Sources/Sentry/include/SentryANRTrackerV2.h
+++ b/Sources/Sentry/include/SentryANRTrackerV2.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentrySwift.h"
 
 #if SENTRY_HAS_UIKIT
 
@@ -8,8 +9,6 @@
 @class SentryFramesTracker;
 
 NS_ASSUME_NONNULL_BEGIN
-
-@protocol SentryANRTrackerV2Delegate;
 
 @interface SentryANRTrackerV2 : NSObject
 SENTRY_NO_INIT
@@ -26,17 +25,6 @@ SENTRY_NO_INIT
 
 // Function used for tests
 - (void)clear;
-
-@end
-
-/**
- * The ``SentryANRTrackerV2`` calls the methods from background threads.
- */
-@protocol SentryANRTrackerV2Delegate <NSObject>
-
-- (void)anrDetected;
-
-- (void)anrStopped;
 
 @end
 

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc
+protocol SentryANRTrackerV2Delegate {
+    func anrDetected()
+    func anrStopped()
+}


### PR DESCRIPTION
It's always better to have more code in Swift.

#skip-changelog