### PR TITLE
chore: Support for non-fully-blocking app hangs

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Tools/TriggerAppHang.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/TriggerAppHang.swift
@@ -2,14 +2,17 @@ import Foundation
 import UIKit
 
 /// Triggers a non-fully blocking app hang by blocking the app for 0.5 seconds,
-/// then allowing it to draw a couple of frames, and blocking it again. While the app
+/// then allowing it to draw one or two frames, and blocking it again. While the app
 /// is not fully blocked because it renders a few frames, it still seems blocked to the
-/// user and should be considered an app hang.
+/// user and should be considered an app hang. We have to pick a low timer interval
+/// for the Thread.sleep on the background thread, because otherwise the app renders
+/// too many frames and is able to still handle user input, such as navigating to a
+/// different screen.
 func triggerNonFullyBlockingAppHang() {
     
     DispatchQueue.global().async {
         for _ in 0...10 {
-            Thread.sleep(forTimeInterval: 0.001)
+            Thread.sleep(forTimeInterval: 0.0001)
             DispatchQueue.main.sync {
                 Thread.sleep(forTimeInterval: 0.5)
             }

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -106,6 +106,7 @@
 		62872B5F2BA1B7F300A4FA7D /* NSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B5E2BA1B7F300A4FA7D /* NSLock.swift */; };
 		62872B632BA1B86100A4FA7D /* NSLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B622BA1B86100A4FA7D /* NSLockTests.swift */; };
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
+		6294774C2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
 		62991A8D2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62991A8C2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift */; };
@@ -1091,6 +1092,7 @@
 		62872B5E2BA1B7F300A4FA7D /* NSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLock.swift; sourceTree = "<group>"; };
 		62872B622BA1B86100A4FA7D /* NSLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLockTests.swift; sourceTree = "<group>"; };
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
+		6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryANRTrackerV2Delegate.swift; sourceTree = "<group>"; };
 		62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionContextTests.swift; sourceTree = "<group>"; };
 		629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReachabilitySwiftTests.swift; sourceTree = "<group>"; };
 		62991A8C2BAC1B4A0078A8B8 /* SentryMetricsAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryMetricsAPI.swift; sourceTree = "<group>"; };
@@ -2152,6 +2154,14 @@
 				62872B622BA1B86100A4FA7D /* NSLockTests.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		6294774A2C6F252F00846CBC /* ANR */ = {
+			isa = PBXGroup;
+			children = (
+				6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */,
+			);
+			path = ANR;
 			sourceTree = "<group>";
 		};
 		62B558AE2C6B9C3000C34FEC /* FramesTracking */ = {
@@ -3893,6 +3903,7 @@
 		D8CAC02D2BA0663E00E38F34 /* Integrations */ = {
 			isa = PBXGroup;
 			children = (
+				6294774A2C6F252F00846CBC /* ANR */,
 				62B558AE2C6B9C3000C34FEC /* FramesTracking */,
 				D8739CF72BECFF92007D2F66 /* Performance */,
 				D8CAC02C2BA0663E00E38F34 /* SessionReplay */,
@@ -4496,6 +4507,7 @@
 				7BD86ED1264A7CF6005439DB /* SentryAppStartMeasurement.m in Sources */,
 				D8F67AEE2BE0D19200C9197B /* UIImageHelper.swift in Sources */,
 				7DC27EC723997EB7006998B5 /* SentryAutoBreadcrumbTrackingIntegration.m in Sources */,
+				6294774C2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift in Sources */,
 				D84D2CDF2C2BF9370011AF8A /* SentryReplayType.swift in Sources */,
 				63FE717B20DA4C1100CDBAE8 /* SentryCrashReport.c in Sources */,
 				D8F67B222BEAB6CC00C9197B /* SentryRRWebEvent.swift in Sources */,

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -173,7 +173,17 @@ SentryANRTrackerV2 ()
             SENTRY_LOG_WARN(@"App Hang detected: fully-blocking.");
 
             reported = YES;
-            [self ANRDetected];
+            [self ANRDetected:SentryANRTypeFullyBlocking];
+        }
+
+        NSTimeInterval nonFullyBlockingFramesDelayThreshold = self.timeoutInterval * 0.99;
+        if (!isFullyBlocking
+            && framesDelayForTimeInterval.delayDuration > nonFullyBlockingFramesDelayThreshold) {
+
+            SENTRY_LOG_WARN(@"App Hang detected: non-fully-blocking.");
+
+            reported = YES;
+            [self ANRDetected:SentryANRTypeNonFullyBlocking];
         }
     }
 
@@ -183,7 +193,7 @@ SentryANRTrackerV2 ()
     }
 }
 
-- (void)ANRDetected
+- (void)ANRDetected:(enum SentryANRType)type
 {
     NSArray *localListeners;
     @synchronized(self.listeners) {
@@ -191,7 +201,7 @@ SentryANRTrackerV2 ()
     }
 
     for (id<SentryANRTrackerV2Delegate> target in localListeners) {
-        [target anrDetected];
+        [target anrDetectedWithType:type];
     }
 }
 

--- a/Sources/Sentry/SentryANRTrackingIntegrationV2.m
+++ b/Sources/Sentry/SentryANRTrackingIntegrationV2.m
@@ -76,7 +76,7 @@ SentryANRTrackingIntegrationV2 ()
     [self uninstall];
 }
 
-- (void)anrDetected
+- (void)anrDetectedWithType:(enum SentryANRType)type
 {
     if (self.reportAppHangs == NO) {
         SENTRY_LOG_DEBUG(@"AppHangTracking paused. Ignoring reported app hang.")

--- a/Sources/Sentry/include/SentryANRTrackerV2.h
+++ b/Sources/Sentry/include/SentryANRTrackerV2.h
@@ -10,6 +10,16 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ * This class detects ANRs with a dedicated watchdog thread. It periodically checks the frame delay.
+ * If the app cannot render a single frame and the frame delay is 100%, then it reports a
+ * fully-blocking app hang. If the frame delay exceeds 99%, then this class reports a
+ * non-fully-blocking app hang. We pick an extra high threshold of 99% because only then the app
+ * seems to be hanging. With a lower threshold, the logic would overreport. Even when the app hangs
+ * for 0.5 seconds and has a chance to render around five frames and then hangs again for 0.5
+ * seconds, it can still respond to user input to navigate to a different screen, for example. In
+ * that scenario, the frame delay is around 97%.
+ */
 @interface SentryANRTrackerV2 : NSObject
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/include/SentryANRTrackerV2.h
+++ b/Sources/Sentry/include/SentryANRTrackerV2.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentrySwift.h"
 
 #if SENTRY_HAS_UIKIT
 
@@ -8,8 +9,6 @@
 @class SentryFramesTracker;
 
 NS_ASSUME_NONNULL_BEGIN
-
-@protocol SentryANRTrackerV2Delegate;
 
 @interface SentryANRTrackerV2 : NSObject
 SENTRY_NO_INIT
@@ -26,17 +25,6 @@ SENTRY_NO_INIT
 
 // Function used for tests
 - (void)clear;
-
-@end
-
-/**
- * The ``SentryANRTrackerV2`` calls the methods from background threads.
- */
-@protocol SentryANRTrackerV2Delegate <NSObject>
-
-- (void)anrDetected;
-
-- (void)anrStopped;
 
 @end
 

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -2,6 +2,12 @@ import Foundation
 
 @objc
 protocol SentryANRTrackerV2Delegate {
-    func anrDetected()
+    func anrDetected(type: SentryANRType)
     func anrStopped()
+}
+
+@objc
+enum SentryANRType: Int {
+    case fullyBlocking
+    case nonFullyBlocking
 }

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+@objc
+protocol SentryANRTrackerV2Delegate {
+    func anrDetected()
+    func anrStopped()
+}

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -161,7 +161,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         setUpThreadInspector()
         SentryDependencyContainer.sharedInstance().application = BackgroundSentryUIApplication()
 
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrsDetected()
 
         assertNoEventCaptured()
     }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationV2Tests.swift
@@ -1,3 +1,5 @@
+@testable import _SentryPrivate
+@testable import Sentry
 import SentryTestUtils
 import XCTest
 
@@ -69,7 +71,7 @@ class SentryANRTrackingIntegrationV2Tests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker()
         setUpThreadInspector()
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         
         try assertEventWithScopeCaptured { event, _, _ in
             XCTAssertNotNil(event)
@@ -107,7 +109,7 @@ class SentryANRTrackingIntegrationV2Tests: SentrySDKIntegrationTestsBase {
         setUpThreadInspector()
         sut.pauseAppHangTracking()
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         
         assertNoEventCaptured()
     }
@@ -118,7 +120,7 @@ class SentryANRTrackingIntegrationV2Tests: SentrySDKIntegrationTestsBase {
         sut.pauseAppHangTracking()
         sut.resumeAppHangTracking()
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         
         try assertEventWithScopeCaptured { event, _, _ in
             XCTAssertNotNil(event)
@@ -136,10 +138,10 @@ class SentryANRTrackingIntegrationV2Tests: SentrySDKIntegrationTestsBase {
         
         testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 10, writeWork: {_ in
             self.sut.pauseAppHangTracking()
-            Dynamic(self.sut).anrDetected()
+            Dynamic(self.sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         }, readWork: {
             self.sut.resumeAppHangTracking()
-            Dynamic(self.sut).anrDetected()
+            Dynamic(self.sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         })
     }
     
@@ -147,7 +149,7 @@ class SentryANRTrackingIntegrationV2Tests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker()
         setUpThreadInspector(addThreads: false)
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         
         assertNoEventCaptured()
     }
@@ -162,7 +164,7 @@ class SentryANRTrackingIntegrationV2Tests: SentrySDKIntegrationTestsBase {
         setUpThreadInspector()
         SentryDependencyContainer.sharedInstance().application = BackgroundSentryUIApplication()
 
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.fullyBlocking)
 
         assertNoEventCaptured()
     }


### PR DESCRIPTION

## :scroll: Description

Add the logic for non-fully-blocking app hangs when the frame delay exceeds 99%. 

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/4285.

#skip-changelog

## :bulb: Motivation and Context

This is required for GH-3492.

## :green_heart: How did you test it?
Running on a real device and unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
