### PR TITLE
test: Increase timeout for ANR tests

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -5,7 +5,7 @@ import XCTest
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class SentryANRTrackerV2Tests: XCTestCase {
     
-    private let waitTimeout: TimeInterval = 0.5
+    private let waitTimeout: TimeInterval = 1.0
     private let timeoutInterval: TimeInterval = 2
         
     private func getSut() throws -> (SentryANRTrackerV2, TestCurrentDateProvider, TestDisplayLinkWrapper, TestSentryCrashWrapper, SentryTestThreadWrapper, SentryFramesTracker) {


### PR DESCRIPTION
Some test time out in CI. Increase the timeout a bit to avoid that.

#skip-changelog