### PR TITLE
ref: Remove logging serialized event

### DIFF
--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -223,14 +223,6 @@ NS_ASSUME_NONNULL_BEGIN
                 i++; // 0 byte attachment
             }
             NSData *itemBody = [data subdataWithRange:NSMakeRange(i + 1, bodyLength)];
-#ifdef DEBUG
-            if ([SentryEnvelopeItemTypeEvent isEqual:type] ||
-                [SentryEnvelopeItemTypeSession isEqual:type]) {
-                NSString *event = [[NSString alloc] initWithData:itemBody
-                                                        encoding:NSUTF8StringEncoding];
-                SENTRY_LOG_DEBUG(@"Event %@", event);
-            }
-#endif
             SentryEnvelopeItem *envelopeItem = [[SentryEnvelopeItem alloc] initWithHeader:itemHeader
                                                                                      data:itemBody];
             [items addObject:envelopeItem];


### PR DESCRIPTION
Remove super noisy logging of serializing events.

I personally find that super noisy and I never use it. For me, it just spams the logs.

#skip-changelog