### PR TITLE
fix: Crash when reading corrupted envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixes
 
-- Crash when reading corrupted envelope ()
+- Crash when reading corrupted envelope (#4297)
 
 ## 8.35.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## Unreleased
+
+### Fixes
+
+- Crash when reading corrupted envelope ()
+
 ## 8.35.0
 
 ### Features

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
             if (bodyLength > 0 && data.length < (i + 1 + bodyLength)) {
                 SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
                                  @"bytes by skiping %li from a buffer of %li bytes.",
-                                 (unsigned long)data.length, bodyLength, i + 1);
+                    (unsigned long)data.length, bodyLength, i + 1);
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
             if (bodyLength > 0 && data.length < (i + 1 + bodyLength)) {
                 SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
                                  @"bytes by skiping %li from a buffer of %li bytes.",
-                    (unsigned long)data.length, bodyLength, i + 1);
+                    (unsigned long)data.length, bodyLength, (long)(i + 1));
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -210,7 +210,9 @@ NS_ASSUME_NONNULL_BEGIN
             }
 
             if (data.length < (i + 1 + bodyLength)) {
-                SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li bytes by skiping %li from a buffer of %li bytes.", data.length, bodyLength, i + 1);
+                SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
+                                 @"bytes by skiping %li from a buffer of %li bytes.",
+                    data.length, bodyLength, i + 1);
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
             if (bodyLength > 0 && data.length < (i + 1 + bodyLength)) {
                 SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
                                  @"bytes by skiping %li from a buffer of %li bytes.",
-                    data.length, bodyLength, i + 1);
+                                 (NSUInteger)data.length, bodyLength, i + 1);
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -209,7 +209,7 @@ NS_ASSUME_NONNULL_BEGIN
                 i++; // 0 byte attachment
             }
 
-            if (data.length < (i + 1 + bodyLength)) {
+            if (bodyLength > 0 && data.length < (i + 1 + bodyLength)) {
                 SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
                                  @"bytes by skiping %li from a buffer of %li bytes.",
                     data.length, bodyLength, i + 1);

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
             if (bodyLength > 0 && data.length < (i + 1 + bodyLength)) {
                 SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
                                  @"bytes by skiping %li from a buffer of %li bytes.",
-                    (unsigned long)data.length, bodyLength, (long)(i + 1));
+                    (unsigned long)data.length, (unsigned long)bodyLength, (long)(i + 1));
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -210,7 +210,7 @@ NS_ASSUME_NONNULL_BEGIN
             }
 
             if (data.length < (i + 1 + bodyLength)) {
-                SENTRY_LOG_DEBUG(@"Envelope is corrupted or has invalid data.")
+                SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li bytes by skiping %li from a buffer of %li bytes.", data.length, bodyLength, i + 1);
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -212,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
             if (bodyLength > 0 && data.length < (i + 1 + bodyLength)) {
                 SENTRY_LOG_ERROR(@"Envelope is corrupted or has invalid data. Trying to read %li "
                                  @"bytes by skiping %li from a buffer of %li bytes.",
-                                 (NSUInteger)data.length, bodyLength, i + 1);
+                                 (unsigned long)data.length, bodyLength, i + 1);
                 return nil;
             }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -208,6 +208,12 @@ NS_ASSUME_NONNULL_BEGIN
             if (endOfEnvelope == i) {
                 i++; // 0 byte attachment
             }
+            
+            if (data.length < (i+1+bodyLength)) {
+                SENTRY_LOG_DEBUG(@"Envelope is corrupted or has invalid data.")
+                return nil;
+            }
+            
             NSData *itemBody = [data subdataWithRange:NSMakeRange(i + 1, bodyLength)];
             SentryEnvelopeItem *envelopeItem = [[SentryEnvelopeItem alloc] initWithHeader:itemHeader
                                                                                      data:itemBody];

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -267,6 +267,17 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertNil(actual)
     }
     
+    func testReturnNilForCorruptedEnvelope() throws {
+        let envelope = SentryEnvelope(event: Event(error: NSError(domain: "test", code: -1, userInfo: nil)))
+        let data = try XCTUnwrap(SentrySerialization.data(with: envelope))
+        
+        let corruptedData = data[0..<data.count - 1]
+        
+        let unserialized = SentrySerialization.envelope(with: corruptedData)
+        
+        XCTAssertNil(unserialized)
+    }
+    
     private func serializeEnvelope(envelope: SentryEnvelope) -> Data {
         var serializedEnvelope: Data = Data()
         do {


### PR DESCRIPTION
## :scroll: Description

Added a safe guard to prevent crashing when reading corrupted envelope

## :bulb: Motivation and Context

This was mentioned in #4280

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
