### PR TITLE
fix(iOS-Swift): remove old check and set for continuous profiling

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -89,7 +89,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.enableTimeToFullDisplayTracing = true
             options.enablePerformanceV2 = true
             options.enableMetrics = !args.contains("--disable-metrics")
-            options.profilesSampleRate = ProcessInfo.processInfo.arguments.contains("--io.sentry.enable-continuous-profiling") ? nil : 1
             
             options.add(inAppInclude: "iOS_External")
 


### PR DESCRIPTION
I noticed this trying to generate a test. It was an old version of the config option and was resetting the sample rate to 1 even when using the newer option (`--io.sentry.enableContinuousProfiling`).