### PR TITLE
chore: Adds SentryFileManager and SentrySerialization to dangerous files

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -10,3 +10,6 @@ high_risk_code: &high_risk_code
   - 'Sources/Sentry/SentrySwizzleWrapper.m'
   - 'Sources/Sentry/include/SentrySwizzle.h'
   - 'Sources/Sentry/SentrySwizzle.m'
+  - 'Sources/Sentry/SentryFileManager.m'
+  - 'Sources/Sentry/SentrySerialization.m'
+  - 'Sources/Sentry/SentrySerialization.h'


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

Adds SentryFileManager and SentrySerialization to list of dangerous files. A recent (GH-4219) change in these files is the likely root cause of invalid envelopes that subsequently caused crashes.

#skip-changelog

## :green_heart: How did you test it?

n/a

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] ~~I added tests to verify the changes.~~
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] ~~I updated the docs if needed.~~
- [ ] ~~Review from the native team if needed.~~
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
