### PR TITLE
fix: remove object_literal from swiftlint rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -44,7 +44,6 @@ only_rules:
   - mark
   - nimble_operator
   - number_separator
-  - object_literal
   - opening_brace
   - operator_usage_whitespace
   - operator_whitespace


### PR DESCRIPTION
I am unable to make actual use of `#colorLiteral` as it just shows a broken image (and Xcode support for them in general is very poor) 
![image](https://github.com/user-attachments/assets/cd8b124c-d131-4d15-a201-a37e8a39edd5)


and we don't have a need for image literals, we should just remove this rule

#skip-changelog