### PR TITLE
Fix issues with SentrySwiftUI sample app

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		84FB812A284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
 		84FB812B284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
 		8E8C57AF25EF16E6001CEEFA /* TraceTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */; };
+		924857562C89A86300774AC3 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 924857552C89A85F00774AC3 /* MainViewController.swift */; };
 		B70038852BB33E7700065A38 /* ReplaceContentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70038842BB33E7700065A38 /* ReplaceContentViewController.swift */; };
 		D80D021329EE93630084393D /* ErrorsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D021229EE93630084393D /* ErrorsViewController.swift */; };
 		D80D021A29EE936F0084393D /* ExtraViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80D021929EE936F0084393D /* ExtraViewController.swift */; };
@@ -53,7 +54,7 @@
 		D8269A3E274C095E00BD5BD5 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8269A3D274C095E00BD5BD5 /* SceneDelegate.swift */; };
 		D8269A43274C095F00BD5BD5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D8269A41274C095F00BD5BD5 /* Main.storyboard */; };
 		D8269A4E274C09A400BD5BD5 /* SwiftUIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4F33FA271EBE0C00C8591E /* SwiftUIViewController.swift */; };
-		D8269A4F274C09A400BD5BD5 /* SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4F33F7271EBD2500C8591E /* SwiftUI.swift */; };
+		D8269A4F274C09A400BD5BD5 /* SwiftUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B4F33F7271EBD2500C8591E /* SwiftUIView.swift */; };
 		D8269A50274C0F6800BD5BD5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB2243B02770034958B /* Assets.xcassets */; };
 		D8269A51274C0F6C00BD5BD5 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 637AFDB4243B02770034958B /* LaunchScreen.storyboard */; };
 		D8269A52274C0F7200BD5BD5 /* Tongariro.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 7B3427F725876A5200056519 /* Tongariro.jpg */; };
@@ -291,7 +292,7 @@
 		637AFDB7243B02770034958B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		63F93AA9245AC91600A500DB /* iOS-Swift.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "iOS-Swift.entitlements"; sourceTree = "<group>"; };
 		7B3427F725876A5200056519 /* Tongariro.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = Tongariro.jpg; sourceTree = "<group>"; };
-		7B4F33F7271EBD2500C8591E /* SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI.swift; sourceTree = "<group>"; };
+		7B4F33F7271EBD2500C8591E /* SwiftUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIView.swift; sourceTree = "<group>"; };
 		7B4F33FA271EBE0C00C8591E /* SwiftUIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewController.swift; sourceTree = "<group>"; };
 		7B5525B22938B5B5006A2932 /* DiskWriteException.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskWriteException.swift; sourceTree = "<group>"; };
 		7B64386826A6C544000D0F65 /* iOS-Swift-UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "iOS-Swift-UITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -318,6 +319,7 @@
 		84FB8129284001B800F3A94A /* SentryBenchmarking.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryBenchmarking.mm; sourceTree = "<group>"; };
 		84FB812C2840021B00F3A94A /* iOS-Swift-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "iOS-Swift-Bridging-Header.h"; sourceTree = "<group>"; };
 		8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTestViewController.swift; sourceTree = "<group>"; };
+		924857552C89A85F00774AC3 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		B70038842BB33E7700065A38 /* ReplaceContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceContentViewController.swift; sourceTree = "<group>"; };
 		D80D021229EE93630084393D /* ErrorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorsViewController.swift; sourceTree = "<group>"; };
 		D80D021929EE936F0084393D /* ExtraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraViewController.swift; sourceTree = "<group>"; };
@@ -536,11 +538,12 @@
 		D8269A3A274C095E00BD5BD5 /* iOS13-Swift */ = {
 			isa = PBXGroup;
 			children = (
+				924857552C89A85F00774AC3 /* MainViewController.swift */,
 				D8269A5C274C108100BD5BD5 /* iOS13-Swift.entitlements */,
 				D8269A3B274C095E00BD5BD5 /* AppDelegate.swift */,
 				D8269A3D274C095E00BD5BD5 /* SceneDelegate.swift */,
 				7B4F33FA271EBE0C00C8591E /* SwiftUIViewController.swift */,
-				7B4F33F7271EBD2500C8591E /* SwiftUI.swift */,
+				7B4F33F7271EBD2500C8591E /* SwiftUIView.swift */,
 				D8269A41274C095F00BD5BD5 /* Main.storyboard */,
 				D8269A49274C096000BD5BD5 /* Info.plist */,
 				D88E666D28732B6700153425 /* iOS13-Swift-Bridging-Header.h */,
@@ -996,8 +999,9 @@
 				D8444E56275F79590042F4DE /* UIViewExtension.swift in Sources */,
 				D8269A57274C0FA100BD5BD5 /* NibViewController.swift in Sources */,
 				D8269A4E274C09A400BD5BD5 /* SwiftUIViewController.swift in Sources */,
-				D8269A4F274C09A400BD5BD5 /* SwiftUI.swift in Sources */,
+				D8269A4F274C09A400BD5BD5 /* SwiftUIView.swift in Sources */,
 				D8444E57275F795D0042F4DE /* UIViewControllerExtension.swift in Sources */,
+				924857562C89A86300774AC3 /* MainViewController.swift in Sources */,
 				D8F3D058274E57D600B56F8C /* TableViewController.swift in Sources */,
 				7B5525B62938B644006A2932 /* DiskWriteException.swift in Sources */,
 				D8269A58274C0FC700BD5BD5 /* TransactionsViewController.swift in Sources */,

--- a/Samples/iOS-Swift/iOS13-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS13-Swift/Base.lproj/Main.storyboard
@@ -24,7 +24,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-AD-9ZR">
-                                <rect key="frame" x="16" y="136.5" width="382" height="120"/>
+                                <rect key="frame" x="16" y="136.5" width="382" height="150"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gup-Ip-5r6">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="30"/>
@@ -47,8 +47,15 @@
                                             <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="p2Y-rq-BX4"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ANQ-Az-4NG" userLabel="Show SwiftUI">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="0ZK-9G-NBW">
                                         <rect key="frame" x="0.0" y="90" width="382" height="30"/>
+                                        <state key="normal" title="crash"/>
+                                        <connections>
+                                            <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Zoz-fJ-17Y"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ANQ-Az-4NG" userLabel="Show SwiftUI">
+                                        <rect key="frame" x="0.0" y="120" width="382" height="30"/>
                                         <state key="normal" title="Show SwiftUI"/>
                                         <connections>
                                             <segue destination="F5J-3Y-bGd" kind="show" id="ZFh-G7-YHg"/>

--- a/Samples/iOS-Swift/iOS13-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS13-Swift/Base.lproj/Main.storyboard
@@ -1,107 +1,54 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="b3U-zQ-JdB">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23091" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="b3U-zQ-JdB">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23079"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Main View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="iOS13_Swift" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="MainViewController" customModule="iOS13_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sentry Test App (Swift)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AHQ-Ck-5RQ">
-                                <rect key="frame" x="119" y="108" width="176.5" height="20.5"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Sentry Test App (SwiftUI)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AHQ-Ck-5RQ">
+                                <rect key="frame" x="110.5" y="108" width="193" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="YCS-AD-9ZR">
-                                <rect key="frame" x="16" y="136.5" width="382" height="360"/>
+                                <rect key="frame" x="16" y="136.5" width="382" height="120"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eIG-uJ-5RR">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="30"/>
-                                        <state key="normal" title="add Breadcrumb"/>
-                                        <connections>
-                                            <action selector="addBreadcrumb:" destination="BYZ-38-t0r" eventType="touchUpInside" id="mO7-vz-uGe"/>
-                                        </connections>
-                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gup-Ip-5r6">
-                                        <rect key="frame" x="0.0" y="30" width="382" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="30"/>
                                         <state key="normal" title="captureMessage"/>
                                         <connections>
-                                            <action selector="captureMessage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Aci-mk-MuI"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4AC-C3-6dT">
-                                        <rect key="frame" x="0.0" y="60" width="382" height="30"/>
-                                        <state key="normal" title="captureUserFeedback"/>
-                                        <connections>
-                                            <action selector="captureUserFeedback:" destination="BYZ-38-t0r" eventType="touchUpInside" id="gY1-mx-Q1W"/>
+                                            <action selector="captureMessage:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ac3-qb-QmZ"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yU3-L3-OGp">
-                                        <rect key="frame" x="0.0" y="90" width="382" height="30"/>
+                                        <rect key="frame" x="0.0" y="30" width="382" height="30"/>
                                         <state key="normal" title="captureError"/>
                                         <connections>
-                                            <action selector="captureError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Qhv-IR-QcG"/>
+                                            <action selector="captureError:" destination="BYZ-38-t0r" eventType="touchUpInside" id="xoq-xg-ecS"/>
                                         </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="a1M-92-mXt">
-                                        <rect key="frame" x="0.0" y="120" width="382" height="30"/>
-                                        <state key="normal" title="captureNSException"/>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SjB-JA-mRa">
-                                        <rect key="frame" x="0.0" y="150" width="382" height="30"/>
-                                        <state key="normal" title="Capture Transaction"/>
+                                        <rect key="frame" x="0.0" y="60" width="382" height="30"/>
+                                        <state key="normal" title="captureTransaction"/>
                                         <connections>
-                                            <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Bwd-yk-eqs"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="bIu-uc-hAg">
-                                        <rect key="frame" x="0.0" y="180" width="382" height="30"/>
-                                        <state key="normal" title="Test Navigation Transaction"/>
-                                        <connections>
-                                            <segue destination="PtQ-0z-qNf" kind="show" id="7GE-y1-oAV"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cea-tX-5Y5">
-                                        <rect key="frame" x="0.0" y="210" width="382" height="30"/>
-                                        <state key="normal" title="crash"/>
-                                        <connections>
-                                            <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="o7F-FN-TNC"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mpZ-pA-1Ig">
-                                        <rect key="frame" x="0.0" y="240" width="382" height="30"/>
-                                        <state key="normal" title="OOM crash"/>
-                                        <connections>
-                                            <action selector="oomCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="HgN-BU-qBa"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="W4r-nP-FEf">
-                                        <rect key="frame" x="0.0" y="270" width="382" height="30"/>
-                                        <state key="normal" title="async crash"/>
-                                        <connections>
-                                            <action selector="asyncCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ktH-BR-gLI"/>
-                                        </connections>
-                                    </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rED-Nm-eYB">
-                                        <rect key="frame" x="0.0" y="300" width="382" height="30"/>
-                                        <state key="normal" title="Show Nib"/>
-                                        <connections>
-                                            <action selector="showNibController:" destination="BYZ-38-t0r" eventType="touchUpInside" id="fat-pm-Wl8"/>
+                                            <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="p2Y-rq-BX4"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ANQ-Az-4NG" userLabel="Show SwiftUI">
-                                        <rect key="frame" x="0.0" y="330" width="382" height="30"/>
+                                        <rect key="frame" x="0.0" y="90" width="382" height="30"/>
                                         <state key="normal" title="Show SwiftUI"/>
                                         <connections>
                                             <segue destination="F5J-3Y-bGd" kind="show" id="ZFh-G7-YHg"/>
@@ -125,7 +72,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="112" y="86"/>
+            <point key="canvasLocation" x="-72" y="72"/>
         </scene>
         <!--SwiftUI View Controller-->
         <scene sceneID="48d-6X-7fM">
@@ -141,39 +88,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="PrT-Lt-aep" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="893" y="806"/>
-        </scene>
-        <!--Trace Test View Controller-->
-        <scene sceneID="zmX-pp-oSn">
-            <objects>
-                <viewController id="PtQ-0z-qNf" customClass="TraceTestViewController" customModule="iOS13_Swift" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="46I-Br-ZCs">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="xu7-rn-FBt">
-                                <rect key="frame" x="87" y="357" width="240" height="240"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="240" id="3Vs-1C-xUg"/>
-                                    <constraint firstAttribute="width" constant="240" id="kf0-QZ-UDv"/>
-                                </constraints>
-                            </imageView>
-                        </subviews>
-                        <viewLayoutGuide key="safeArea" id="eXc-Dy-sAl"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstItem="xu7-rn-FBt" firstAttribute="centerY" secondItem="eXc-Dy-sAl" secondAttribute="centerY" id="91U-xm-z5M"/>
-                            <constraint firstItem="xu7-rn-FBt" firstAttribute="centerX" secondItem="eXc-Dy-sAl" secondAttribute="centerX" id="rVU-2s-fOn"/>
-                        </constraints>
-                    </view>
-                    <navigationItem key="navigationItem" id="mDf-pL-uuO"/>
-                    <connections>
-                        <outlet property="imageView" destination="xu7-rn-FBt" id="BC6-M2-Cb4"/>
-                    </connections>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="H0S-G1-AE3" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="913" y="49"/>
+            <point key="canvasLocation" x="588" y="72"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="7KY-f4-PyN">

--- a/Samples/iOS-Swift/iOS13-Swift/MainViewController.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/MainViewController.swift
@@ -1,0 +1,56 @@
+import UIKit
+import Sentry
+
+class MainViewController: UIViewController {
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        SentrySDK.reportFullyDisplayed()
+    }
+    
+    @IBAction func captureMessage(_ sender: UIButton) {
+        highlightButton(sender)
+        let eventId = SentrySDK.capture(message: "Yeah captured a message")
+        // Returns eventId in case of successfull processed event
+        // otherwise nil
+        print("\(String(describing: eventId))")
+    }
+    
+    @IBAction func captureError(_ sender: UIButton) {
+        highlightButton(sender)
+        do {
+            try RandomErrorGenerator.generate()
+        } catch {
+            SentrySDK.capture(error: error) { (scope) in
+                // Changes in here will only be captured for this event
+                // The scope in this callback is a clone of the current scope
+                // It contains all data but mutations only influence the event being sent
+                scope.setTag(value: "value", key: "myTag")
+            }
+        }
+    }
+    
+    @IBAction func captureTransaction(_ sender: UIButton) {
+        highlightButton(sender)
+        let transaction = SentrySDK.startTransaction(name: "Some Transaction", operation: "Some Operation")
+        
+        transaction.setMeasurement(name: "duration", value: 44, unit: MeasurementUnitDuration.nanosecond)
+        transaction.setMeasurement(name: "information", value: 44, unit: MeasurementUnitInformation.bit)
+        transaction.setMeasurement(name: "duration-custom", value: 22, unit: MeasurementUnit(unit: "custom"))
+        
+        let span = transaction.startChild(operation: "user", description: "calls out")
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: {
+            span.finish()
+        })
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + Double.random(in: 0.4...0.6), execute: {
+            transaction.finish()
+        })
+    }
+    
+    @IBAction func crash(_ sender: UIButton) {
+        SentrySDK.crash()
+    }
+    
+}

--- a/Samples/iOS-Swift/iOS13-Swift/SwiftUIView.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/SwiftUIView.swift
@@ -1,7 +1,7 @@
 import SentrySwiftUI
 import SwiftUI
 
-struct SwiftUI: View {
+struct SwiftUIView: View {
     var body: some View {
         SentryTracedView("SwiftUI View") {
             Text("SwiftUI!")
@@ -9,8 +9,8 @@ struct SwiftUI: View {
     }
 }
 
-struct SwiftUI_Previews: PreviewProvider {
+struct SwiftUIView_Previews: PreviewProvider {
     static var previews: some View {
-        SwiftUI()
+        SwiftUIView()
     }
 }

--- a/Samples/iOS-Swift/iOS13-Swift/SwiftUIViewController.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/SwiftUIViewController.swift
@@ -5,7 +5,7 @@ import UIKit
 
 class SwiftUIViewController: UIViewController {
     
-    let swiftUIView = UIHostingController(rootView: SwiftUI())
+    let swiftUIView = UIHostingController(rootView: SwiftUIView())
         
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

<!--- Describe your changes in detail -->

- The files in interface builder were referencing a view controller that did not exist anymore
- Created a basic view controller with message/error/transaction calls
- Changed name of `SwiftUI` to `SwiftUIView`, so we don't clash with autogenerated `SwiftUI` prefixes

<img width="546" alt="Bildschirmfoto 2024-09-05 um 10 59 16" src="https://github.com/user-attachments/assets/05e9492a-0fc6-4c21-bc5c-3775aab7843c">

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Have a working sample app which includes `SentrySwiftUI` where we can do manual tests for [#4300](https://github.com/getsentry/sentry-cocoa/issues/4300)

## :green_heart: How did you test it?

Run tests locally and on ci

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.