### PR TITLE
Fix: `testCorruptEnvelope` flakeness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
       - "Tests/**"
       - "SentryTestUtils/**"
       - "test-server/**"
-      - "Samples/**"
       - ".github/workflows/test.yml"
       - "fastlane/**"
       - "scripts/tests-with-thread-sanitizer.sh"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -14,8 +14,7 @@ on:
       - 'scripts/ci-select-xcode.sh'
 
       # run the workflow any time an Xcode scheme changes for one of the sample apps with a UI test suite we run in saucelabs
-      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift-UITests.xcscheme'
-      - 'Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme'
+      - 'Samples/iOS-Swift/**'
 
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -12,8 +12,6 @@ on:
       - 'fastlane/**'
       - '.sauce/config.yml'
       - 'scripts/ci-select-xcode.sh'
-
-      # run the workflow any time an Xcode scheme changes for one of the sample apps with a UI test suite we run in saucelabs
       - 'Samples/iOS-Swift/**'
 
 

--- a/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
@@ -103,7 +103,6 @@ class LaunchUITests: BaseUITest {
         
         app.launch()
         app.tabBars.firstMatch.waitForExistence("App did not open again")
-        XCTAssertEqual(app.state, .runningForeground)
     }
     
     func testCheckTotalFrames() {

--- a/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
@@ -99,8 +99,7 @@ class LaunchUITests: BaseUITest {
         // 8.35.0+ reverts to writing envelopes atomically, so that in this scenario no envelope is written, as is expected.
         // By opening the app again we can check whether the SDK can handle such scenario.
         app.buttons["Corrupt Envelope"].tap()
-        Thread.sleep(forTimeInterval: 1) // Give the test a second for the tap to take effect.
-        XCTAssertFalse(app.exists)
+        app.waitForNonExistence("The app did not closed")
         
         app.launch()
         app.waitForExistence("App did not open again")

--- a/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
@@ -99,10 +99,12 @@ class LaunchUITests: BaseUITest {
         // 8.35.0+ reverts to writing envelopes atomically, so that in this scenario no envelope is written, as is expected.
         // By opening the app again we can check whether the SDK can handle such scenario.
         app.buttons["Corrupt Envelope"].tap()
-        XCTAssertEqual(app.state, .notRunning)
+        Thread.sleep(forTimeInterval: 1) // Give the test a second for the tap to take effect.
+        XCTAssertFalse(app.exists)
         
         app.launch()
-        app.tabBars.firstMatch.waitForExistence("App did not open again")
+        app.waitForExistence("App did not open again")
+        XCTAssertEqual(app.state, .runningForeground)
     }
     
     func testCheckTotalFrames() {

--- a/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
@@ -99,7 +99,7 @@ class LaunchUITests: BaseUITest {
         // 8.35.0+ reverts to writing envelopes atomically, so that in this scenario no envelope is written, as is expected.
         // By opening the app again we can check whether the SDK can handle such scenario.
         app.buttons["Corrupt Envelope"].tap()
-        app.waitForNonExistence("The app did not closed")
+        app.tabBars.firstMatch.waitForNonExistence("The app did not closed")
         
         app.launch()
         app.waitForExistence("App did not open again")

--- a/Samples/iOS-Swift/iOS-Swift-UITests/UITestHelpers.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/UITestHelpers.swift
@@ -4,6 +4,18 @@ extension XCUIElement {
     func waitForExistence(_ message: String) {
         XCTAssertTrue(self.waitForExistence(timeout: TimeInterval(10)), message)
     }
+    
+    func waitForNonExistence(_ message: String) {
+        var retry = 0
+        while self.exists && retry < 10 {
+            retry += 1
+            Thread.sleep(forTimeInterval: 1)
+        }
+        
+        if retry == 10 {
+            XCTFail(message)
+        }
+    }
 
     func afterWaitingForExistence(_ failureMessage: String) -> XCUIElement {
         waitForExistence(failureMessage)


### PR DESCRIPTION
`XCTAssertEqual(app.state, .runningForeground)` is flake on CI

_#skip-changelog_