### PR TITLE
ref(iOS-Sample): improved DSN display/changing UX

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -2148,7 +2148,7 @@
 			repositoryURL = "https://github.com/SwiftKickMobile/SwiftMessages";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 10.0.0;
+				minimumVersion = 9.0.9;
 			};
 		};
 		84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */ = {

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -41,6 +41,10 @@
 		84BA71EC2C8BC3B90045B828 /* SwiftMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71EB2C8BC3B90045B828 /* SwiftMessages */; };
 		84BA71EF2C8BC3C40045B828 /* Anchorage in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71EE2C8BC3C40045B828 /* Anchorage */; };
 		84BA71F12C8BC55A0045B828 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71F02C8BC55A0045B828 /* Toasts.swift */; };
+		84BA71F22C8F73FD0045B828 /* DSNDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71E32C8BBBEC0045B828 /* DSNDisplayViewController.swift */; };
+		84BA71F32C8F74080045B828 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71F02C8BC55A0045B828 /* Toasts.swift */; };
+		84BA71F52C8F74660045B828 /* SwiftMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71F42C8F74660045B828 /* SwiftMessages */; };
+		84BA71F72C8F74660045B828 /* Anchorage in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71F62C8F74660045B828 /* Anchorage */; };
 		84BE546F287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE546E287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m */; };
 		84BE547E287645B900ACC735 /* SentryProcessInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE54792876451D00ACC735 /* SentryProcessInfo.m */; };
 		84FB812A284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
@@ -407,6 +411,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8269A59274C100300BD5BD5 /* Sentry.framework in Frameworks */,
+				84BA71F72C8F74660045B828 /* Anchorage in Frameworks */,
+				84BA71F52C8F74660045B828 /* SwiftMessages in Frameworks */,
 				D8105B61297E824C00299F03 /* SentrySwiftUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -729,6 +735,10 @@
 			dependencies = (
 			);
 			name = "iOS13-Swift";
+			packageProductDependencies = (
+				84BA71F42C8F74660045B828 /* SwiftMessages */,
+				84BA71F62C8F74660045B828 /* Anchorage */,
+			);
 			productName = "iOS13-Swift";
 			productReference = D8269A39274C095E00BD5BD5 /* iOS13-Swift.app */;
 			productType = "com.apple.product-type.application";
@@ -1016,6 +1026,7 @@
 			files = (
 				D8832B1A2AF5000F00C522B0 /* TopViewControllerInspector.swift in Sources */,
 				D8AE48CF2C57E0BD0092A2A6 /* WebViewController.swift in Sources */,
+				84BA71F22C8F73FD0045B828 /* DSNDisplayViewController.swift in Sources */,
 				D8444E56275F79590042F4DE /* UIViewExtension.swift in Sources */,
 				D8269A57274C0FA100BD5BD5 /* NibViewController.swift in Sources */,
 				D8269A4E274C09A400BD5BD5 /* SwiftUIViewController.swift in Sources */,
@@ -1042,6 +1053,7 @@
 				D8444E54275F794D0042F4DE /* SpanObserver.swift in Sources */,
 				D8269A55274C0F9A00BD5BD5 /* TraceTestViewController.swift in Sources */,
 				D80D021C29EE9E400084393D /* ExtraViewController.swift in Sources */,
+				84BA71F32C8F74080045B828 /* Toasts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2156,6 +2168,16 @@
 			productName = SwiftMessages;
 		};
 		84BA71EE2C8BC3C40045B828 /* Anchorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */;
+			productName = Anchorage;
+		};
+		84BA71F42C8F74660045B828 /* SwiftMessages */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */;
+			productName = SwiftMessages;
+		};
+		84BA71F62C8F74660045B828 /* Anchorage */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */;
 			productName = Anchorage;

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -38,16 +38,12 @@
 		84B527B928DD24BA00475E8D /* SentryDeviceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84B527B728DD24BA00475E8D /* SentryDeviceTests.mm */; };
 		84B527BD28DD25E400475E8D /* SentryDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84B527BC28DD25E400475E8D /* SentryDevice.mm */; };
 		84BA71E42C8BBBEC0045B828 /* DSNDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71E32C8BBBEC0045B828 /* DSNDisplayViewController.swift */; };
-		84BA72A72C93698E0045B828 /* GitInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA72A52C93698E0045B828 /* GitInjections.swift */; };
-		84BA71EC2C8BC3B90045B828 /* SwiftMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71EB2C8BC3B90045B828 /* SwiftMessages */; };
-		84BA71EF2C8BC3C40045B828 /* Anchorage in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71EE2C8BC3C40045B828 /* Anchorage */; };
 		84BA71F12C8BC55A0045B828 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71F02C8BC55A0045B828 /* Toasts.swift */; };
 		84BA71F22C8F73FD0045B828 /* DSNDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71E32C8BBBEC0045B828 /* DSNDisplayViewController.swift */; };
+		84BA71F32C8F74080045B828 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71F02C8BC55A0045B828 /* Toasts.swift */; };
+		84BA72A72C93698E0045B828 /* GitInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA72A52C93698E0045B828 /* GitInjections.swift */; };
 		84BA72A82C93698E0045B828 /* GitInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA72A52C93698E0045B828 /* GitInjections.swift */; };
 		84BA72DE2C9391920045B828 /* GitInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA72A52C93698E0045B828 /* GitInjections.swift */; };
-		84BA71F32C8F74080045B828 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71F02C8BC55A0045B828 /* Toasts.swift */; };
-		84BA71F52C8F74660045B828 /* SwiftMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71F42C8F74660045B828 /* SwiftMessages */; };
-		84BA71F72C8F74660045B828 /* Anchorage in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71F62C8F74660045B828 /* Anchorage */; };
 		84BE546F287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE546E287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m */; };
 		84BE547E287645B900ACC735 /* SentryProcessInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE54792876451D00ACC735 /* SentryProcessInfo.m */; };
 		84FB812A284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
@@ -389,8 +385,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				84BA71EF2C8BC3C40045B828 /* Anchorage in Frameworks */,
-				84BA71EC2C8BC3B90045B828 /* SwiftMessages in Frameworks */,
 				630853532440C60F00DDE4CE /* Sentry.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -415,8 +409,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				D8269A59274C100300BD5BD5 /* Sentry.framework in Frameworks */,
-				84BA71F72C8F74660045B828 /* Anchorage in Frameworks */,
-				84BA71F52C8F74660045B828 /* SwiftMessages in Frameworks */,
 				D8105B61297E824C00299F03 /* SentrySwiftUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -688,8 +680,6 @@
 			);
 			name = "iOS-Swift";
 			packageProductDependencies = (
-				84BA71EB2C8BC3B90045B828 /* SwiftMessages */,
-				84BA71EE2C8BC3C40045B828 /* Anchorage */,
 			);
 			productName = "iOS-Swift";
 			productReference = 637AFDA6243B02760034958B /* iOS-Swift.app */;
@@ -754,8 +744,6 @@
 			);
 			name = "iOS13-Swift";
 			packageProductDependencies = (
-				84BA71F42C8F74660045B828 /* SwiftMessages */,
-				84BA71F62C8F74660045B828 /* Anchorage */,
 			);
 			productName = "iOS13-Swift";
 			productReference = D8269A39274C095E00BD5BD5 /* iOS13-Swift.app */;
@@ -842,8 +830,6 @@
 			);
 			mainGroup = 637AFD9D243B02760034958B;
 			packageReferences = (
-				84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */,
-				84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */,
 			);
 			productRefGroup = 637AFDA7243B02760034958B /* Products */;
 			projectDirPath = "";
@@ -2275,48 +2261,6 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
-
-/* Begin XCRemoteSwiftPackageReference section */
-		84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SwiftKickMobile/SwiftMessages";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 9.0.9;
-			};
-		};
-		84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/Rightpoint/Anchorage";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.5.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		84BA71EB2C8BC3B90045B828 /* SwiftMessages */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */;
-			productName = SwiftMessages;
-		};
-		84BA71EE2C8BC3C40045B828 /* Anchorage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */;
-			productName = Anchorage;
-		};
-		84BA71F42C8F74660045B828 /* SwiftMessages */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */;
-			productName = SwiftMessages;
-		};
-		84BA71F62C8F74660045B828 /* Anchorage */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */;
-			productName = Anchorage;
-		};
-/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		D845F35927BAD4CC00A4D7A2 /* SentryData.xcdatamodeld */ = {

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -37,6 +37,10 @@
 		84ACC4432A73CD0700932A18 /* ProfilingCPUWork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ACC4422A73CD0700932A18 /* ProfilingCPUWork.swift */; };
 		84B527B928DD24BA00475E8D /* SentryDeviceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84B527B728DD24BA00475E8D /* SentryDeviceTests.mm */; };
 		84B527BD28DD25E400475E8D /* SentryDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84B527BC28DD25E400475E8D /* SentryDevice.mm */; };
+		84BA71E42C8BBBEC0045B828 /* DSNDisplayViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71E32C8BBBEC0045B828 /* DSNDisplayViewController.swift */; };
+		84BA71EC2C8BC3B90045B828 /* SwiftMessages in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71EB2C8BC3B90045B828 /* SwiftMessages */; };
+		84BA71EF2C8BC3C40045B828 /* Anchorage in Frameworks */ = {isa = PBXBuildFile; productRef = 84BA71EE2C8BC3C40045B828 /* Anchorage */; };
+		84BA71F12C8BC55A0045B828 /* Toasts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BA71F02C8BC55A0045B828 /* Toasts.swift */; };
 		84BE546F287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE546E287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m */; };
 		84BE547E287645B900ACC735 /* SentryProcessInfo.m in Sources */ = {isa = PBXBuildFile; fileRef = 84BE54792876451D00ACC735 /* SentryProcessInfo.m */; };
 		84FB812A284001B800F3A94A /* SentryBenchmarking.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84FB8129284001B800F3A94A /* SentryBenchmarking.mm */; };
@@ -312,6 +316,8 @@
 		84B527B728DD24BA00475E8D /* SentryDeviceTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryDeviceTests.mm; path = ../../../Tests/SentryTests/Helper/SentryDeviceTests.mm; sourceTree = "<group>"; };
 		84B527BB28DD25E400475E8D /* SentryDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryDevice.h; path = ../../../Sources/Sentry/include/SentryDevice.h; sourceTree = "<group>"; };
 		84B527BC28DD25E400475E8D /* SentryDevice.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryDevice.mm; path = ../../../Sources/Sentry/SentryDevice.mm; sourceTree = "<group>"; };
+		84BA71E32C8BBBEC0045B828 /* DSNDisplayViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSNDisplayViewController.swift; sourceTree = "<group>"; };
+		84BA71F02C8BC55A0045B828 /* Toasts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toasts.swift; sourceTree = "<group>"; };
 		84BE546E287503F100ACC735 /* SentrySDKPerformanceBenchmarkTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySDKPerformanceBenchmarkTests.m; sourceTree = "<group>"; };
 		84BE54782876451D00ACC735 /* SentryProcessInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryProcessInfo.h; sourceTree = "<group>"; };
 		84BE54792876451D00ACC735 /* SentryProcessInfo.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProcessInfo.m; sourceTree = "<group>"; };
@@ -375,6 +381,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				84BA71EF2C8BC3C40045B828 /* Anchorage in Frameworks */,
+				84BA71EC2C8BC3B90045B828 /* SwiftMessages in Frameworks */,
 				630853532440C60F00DDE4CE /* Sentry.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -613,6 +621,8 @@
 				D8832B192AF4FE2000C522B0 /* SentryUIApplication.h */,
 				629EC8AC2B0B537400858855 /* TriggerAppHang.swift */,
 				D82915932C889F1800A6CDD4 /* SentryCocoaPrivate.h */,
+				84BA71E32C8BBBEC0045B828 /* DSNDisplayViewController.swift */,
+				84BA71F02C8BC55A0045B828 /* Toasts.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -655,6 +665,10 @@
 				D840D533273A07F600CDF142 /* PBXTargetDependency */,
 			);
 			name = "iOS-Swift";
+			packageProductDependencies = (
+				84BA71EB2C8BC3B90045B828 /* SwiftMessages */,
+				84BA71EE2C8BC3C40045B828 /* Anchorage */,
+			);
 			productName = "iOS-Swift";
 			productReference = 637AFDA6243B02760034958B /* iOS-Swift.app */;
 			productType = "com.apple.product-type.application";
@@ -798,6 +812,8 @@
 			);
 			mainGroup = 637AFD9D243B02760034958B;
 			packageReferences = (
+				84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */,
+				84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */,
 			);
 			productRefGroup = 637AFDA7243B02760034958B /* Products */;
 			projectDirPath = "";
@@ -938,6 +954,7 @@
 				637AFDAE243B02760034958B /* TransactionsViewController.swift in Sources */,
 				D8832B132AF4F7FE00C522B0 /* TopViewControllerInspector.swift in Sources */,
 				0AABE2EA28855FF80057ED69 /* PermissionsViewController.swift in Sources */,
+				84BA71E42C8BBBEC0045B828 /* DSNDisplayViewController.swift in Sources */,
 				7B5525B32938B5B5006A2932 /* DiskWriteException.swift in Sources */,
 				D8F3D062274EBD4800B56F8C /* SpanExtension.swift in Sources */,
 				637AFDAA243B02760034958B /* AppDelegate.swift in Sources */,
@@ -959,6 +976,7 @@
 				7B79000429028C7300A7F467 /* MetricKitManager.swift in Sources */,
 				D8D7BB4A2750067900044146 /* UIAssert.swift in Sources */,
 				D8F3D057274E574200B56F8C /* LoremIpsumViewController.swift in Sources */,
+				84BA71F12C8BC55A0045B828 /* Toasts.swift in Sources */,
 				629EC8AD2B0B537400858855 /* TriggerAppHang.swift in Sources */,
 				D8AE48C92C57DC2F0092A2A6 /* WebViewController.swift in Sources */,
 				D8DBDA78274D5FC400007380 /* SplitViewController.swift in Sources */,
@@ -1258,7 +1276,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
 				INFOPLIST_FILE = "iOS-Swift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1287,7 +1305,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
 				INFOPLIST_FILE = "iOS-Swift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1473,7 +1491,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
 				INFOPLIST_FILE = "iOS-Swift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1698,7 +1716,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 97JCY7859U;
 				INFOPLIST_FILE = "iOS-Swift/Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2111,6 +2129,38 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SwiftKickMobile/SwiftMessages";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.0.0;
+			};
+		};
+		84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Rightpoint/Anchorage";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 4.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		84BA71EB2C8BC3B90045B828 /* SwiftMessages */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84BA71EA2C8BC3B90045B828 /* XCRemoteSwiftPackageReference "SwiftMessages" */;
+			productName = SwiftMessages;
+		};
+		84BA71EE2C8BC3C40045B828 /* Anchorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 84BA71ED2C8BC3C40045B828 /* XCRemoteSwiftPackageReference "Anchorage" */;
+			productName = Anchorage;
+		};
+/* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
 		D845F35927BAD4CC00A4D7A2 /* SentryData.xcdatamodeld */ = {

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -16,8 +16,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let env = ProcessInfo.processInfo.environment
         
         // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
-        let dsn = env["--io.sentry.dsn"] ?? DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
-        DSNStorage.shared.saveDSN(dsn: dsn)
+        var dsn: String?
+        do {
+            if let dsn = env["--io.sentry.dsn"] {
+                try DSNStorage.shared.saveDSN(dsn: dsn)
+            }
+            dsn = try DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
+        } catch {
+            print("[iOS-Swift] Error encountered while reading stored DSN: \(error)")
+        }
         
         SentrySDK.start(configureOptions: { options in
             options.dsn = dsn

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -18,19 +18,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pz1-pf-f37">
+                                <rect key="frame" x="0.0" y="64" width="320" height="70"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="LJQ-LC-noq"/>
+                                </constraints>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Cod-iq-tSj">
-                                <rect key="frame" x="30.5" y="109.5" width="259" height="364"/>
+                                <rect key="frame" x="30.5" y="134" width="259" height="315"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cdR-H3-8fr">
-                                        <rect key="frame" x="0.0" y="0.0" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cdR-H3-8fr">
+                                        <rect key="frame" x="0.0" y="0.0" width="259" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Capture Transaction"/>
                                         <connections>
                                             <action selector="captureTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kff-pT-Uf4"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I38-4R-JYf">
-                                        <rect key="frame" x="0.0" y="28" width="259" height="28"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="I38-4R-JYf">
+                                        <rect key="frame" x="0.0" y="0.0" width="259" height="28"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="60A-0I-s24">
                                                 <rect key="frame" x="0.0" y="0.0" width="187" height="28"/>
@@ -53,8 +60,8 @@
                                             </button>
                                         </subviews>
                                     </stackView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M4W-xc-mEo">
-                                        <rect key="frame" x="0.0" y="56" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M4W-xc-mEo">
+                                        <rect key="frame" x="0.0" y="28" width="259" height="7"/>
                                         <accessibility key="accessibilityConfiguration" identifier="stopTransaction"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -63,8 +70,8 @@
                                             <action selector="stopTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="r2S-U5-Af9"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LvU-yx-01i">
-                                        <rect key="frame" x="0.0" y="84" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LvU-yx-01i">
+                                        <rect key="frame" x="0.0" y="35" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="appHangFullyBlocking"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="AppHangFullyBlocking"/>
@@ -72,8 +79,8 @@
                                             <action selector="appHangFullyBlocking:" destination="BYZ-38-t0r" eventType="touchUpInside" id="uqP-sv-C4a"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5IM-MG-9GW">
-                                        <rect key="frame" x="0.0" y="112" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5IM-MG-9GW">
+                                        <rect key="frame" x="0.0" y="63" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="showNibButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Nib Controller"/>
@@ -81,8 +88,8 @@
                                             <action selector="showNibController:" destination="BYZ-38-t0r" eventType="touchUpInside" id="KQh-0W-Thz"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RjO-LN-eHj">
-                                        <rect key="frame" x="0.0" y="140" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RjO-LN-eHj">
+                                        <rect key="frame" x="0.0" y="91" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="showTableViewButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Table Controller"/>
@@ -90,8 +97,8 @@
                                             <action selector="showTableViewController:" destination="BYZ-38-t0r" eventType="touchUpInside" id="u6U-9d-UMi"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ok0-hq-2kK">
-                                        <rect key="frame" x="0.0" y="168" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ok0-hq-2kK">
+                                        <rect key="frame" x="0.0" y="119" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="showSplitViewButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Split Controller"/>
@@ -99,8 +106,8 @@
                                             <segue destination="DGj-BO-BQ5" kind="presentation" animates="NO" id="G2z-UO-upZ"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jwi-v3-e8T">
-                                        <rect key="frame" x="0.0" y="196" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jwi-v3-e8T">
+                                        <rect key="frame" x="0.0" y="147" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="loremIpsumButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Lorem Ipsum Controller"/>
@@ -108,8 +115,8 @@
                                             <segue destination="2jd-n4-Ihk" kind="show" id="wcP-y8-kPR"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cTC-V8-T1j">
-                                        <rect key="frame" x="0.0" y="224" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cTC-V8-T1j">
+                                        <rect key="frame" x="0.0" y="175" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="useCoreData"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Core Data Tests "/>
@@ -117,8 +124,8 @@
                                             <action selector="useCoreData:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Ycl-fG-7Bk"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8CV-WC-ffq">
-                                        <rect key="frame" x="0.0" y="252" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8CV-WC-ffq">
+                                        <rect key="frame" x="0.0" y="203" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="testNavigationTransactionButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Load Image Controller"/>
@@ -126,8 +133,8 @@
                                             <segue destination="cay-7M-Gvd" kind="show" id="boD-GG-VVF"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mjD-vZ-Wtp" userLabel="UIClick Transaction">
-                                        <rect key="frame" x="0.0" y="280" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mjD-vZ-Wtp" userLabel="UIClick Transaction">
+                                        <rect key="frame" x="0.0" y="231" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="uiClickTransactionButton"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="UIClick Transaction"/>
@@ -135,8 +142,8 @@
                                             <action selector="uiClickTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="JCq-Fy-ciF"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PdX-TT-kn8" userLabel="Page Controller">
-                                        <rect key="frame" x="0.0" y="308" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="PdX-TT-kn8" userLabel="Page Controller">
+                                        <rect key="frame" x="0.0" y="259" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="pageControllerBtn"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Page Controller"/>
@@ -145,8 +152,8 @@
                                             <action selector="uiClickTransaction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UJy-CY-NIQ"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="csA-q7-7fD" userLabel="Page Controller">
-                                        <rect key="frame" x="0.0" y="336" width="259" height="28"/>
+                                    <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="csA-q7-7fD" userLabel="Page Controller">
+                                        <rect key="frame" x="0.0" y="287" width="259" height="28"/>
                                         <accessibility key="accessibilityConfiguration" identifier="pageControllerBtn"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                         <state key="normal" title="Container Controller"/>
@@ -160,14 +167,19 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="Cod-iq-tSj" firstAttribute="top" secondItem="pz1-pf-f37" secondAttribute="bottom" id="INM-n1-m80"/>
                             <constraint firstItem="Cod-iq-tSj" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="OaO-Ca-jim"/>
                             <constraint firstItem="Cod-iq-tSj" firstAttribute="centerY" secondItem="6Tk-OE-BBY" secondAttribute="centerY" id="ViO-xX-9xw"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="pz1-pf-f37" secondAttribute="trailing" id="Z9g-Kh-IbA"/>
+                            <constraint firstItem="pz1-pf-f37" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="evw-EC-bu2"/>
+                            <constraint firstItem="pz1-pf-f37" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" id="sSb-b9-bFU"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Transactions" image="clock.fill" catalog="system" selectedImage="clock.fill" id="ypv-KA-BBe"/>
                     <navigationItem key="navigationItem" title="Sentry Test App (Swift)" id="Ddh-Ww-vzM"/>
                     <connections>
                         <outlet property="appHangFullyBlockingButton" destination="LvU-yx-01i" id="Epa-mo-uMP"/>
+                        <outlet property="dsnView" destination="pz1-pf-f37" id="bw1-tV-9gl"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
@@ -182,8 +194,116 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="b1f-aG-VcS">
+                                <rect key="frame" x="0.0" y="64" width="320" height="70"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="waU-m0-7H1"/>
+                                </constraints>
+                            </view>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="hFG-bX-qLp">
+                                <rect key="frame" x="8" y="134" width="304" height="159.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Work threads:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t2C-jL-6qO">
+                                        <rect key="frame" x="99" y="0.0" width="106.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ai4-M1-xyO">
+                                        <rect key="frame" x="0.0" y="20.5" width="304" height="34"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sCM-tI-skI">
+                                                <rect key="frame" x="0.0" y="0.0" width="40" height="34"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="40" id="HUq-OB-eh7"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="minWorkThreadCountChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="SDs-Yb-IF4"/>
+                                                </connections>
+                                            </textField>
+                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="fwl-wl-SDe">
+                                                <rect key="frame" x="48" y="2" width="208" height="31"/>
+                                                <connections>
+                                                    <action selector="workThreadSliderChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="Rew-Gy-nZe"/>
+                                                </connections>
+                                            </slider>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="COd-X5-alN">
+                                                <rect key="frame" x="264" y="0.0" width="40" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="maxWorkThreadCountChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="j2G-qv-7Qg"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="COd-X5-alN" secondAttribute="trailing" id="Lsa-dP-A8V"/>
+                                            <constraint firstItem="sCM-tI-skI" firstAttribute="leading" secondItem="Ai4-M1-xyO" secondAttribute="leading" id="T97-kH-inU"/>
+                                            <constraint firstItem="COd-X5-alN" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" id="sOx-nV-5kZ"/>
+                                        </constraints>
+                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Work interval (µs):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cAO-gr-3HC">
+                                        <rect key="frame" x="82.5" y="54.5" width="139.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qkf-ZZ-JCy">
+                                        <rect key="frame" x="0.0" y="75" width="304" height="34"/>
+                                        <subviews>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="1" translatesAutoresizingMaskIntoConstraints="NO" id="CuN-wx-fvQ">
+                                                <rect key="frame" x="0.0" y="0.0" width="60" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="minWorkIntervalChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="2o8-oq-ZNn"/>
+                                                </connections>
+                                            </textField>
+                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="N8m-ny-upJ">
+                                                <rect key="frame" x="68" y="2" width="188" height="31"/>
+                                                <connections>
+                                                    <action selector="workIntensityChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="bWc-Br-JcO"/>
+                                                </connections>
+                                            </slider>
+                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rJh-QS-fAl">
+                                                <rect key="frame" x="264" y="0.0" width="40" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                                <connections>
+                                                    <action selector="maxWorkIntervalChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="rT8-Wz-1cO"/>
+                                                </connections>
+                                            </textField>
+                                        </subviews>
+                                    </stackView>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View bg brightness" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hdg-8E-uP2">
+                                        <rect key="frame" x="79" y="109" width="146.5" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="5og-4W-kmj">
+                                        <rect key="frame" x="-2" y="129.5" width="308" height="31"/>
+                                        <connections>
+                                            <action selector="bgBrightnessChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="HTb-Ef-kcz"/>
+                                        </connections>
+                                    </slider>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="5og-4W-kmj" firstAttribute="leading" secondItem="sCM-tI-skI" secondAttribute="leading" id="2oe-oE-v6n"/>
+                                    <constraint firstItem="CuN-wx-fvQ" firstAttribute="leading" secondItem="sCM-tI-skI" secondAttribute="leading" id="Eqy-0C-Ec8"/>
+                                    <constraint firstItem="rJh-QS-fAl" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" id="jbh-kK-Uqg"/>
+                                    <constraint firstAttribute="trailing" secondItem="Ai4-M1-xyO" secondAttribute="trailing" id="lge-1I-CHo"/>
+                                    <constraint firstItem="Ai4-M1-xyO" firstAttribute="leading" secondItem="hFG-bX-qLp" secondAttribute="leading" id="p7y-qK-zxD"/>
+                                    <constraint firstItem="CuN-wx-fvQ" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" constant="20" id="wLW-8j-3SX"/>
+                                    <constraint firstItem="rJh-QS-fAl" firstAttribute="trailing" secondItem="COd-X5-alN" secondAttribute="trailing" id="yrz-2U-h8b"/>
+                                    <constraint firstItem="5og-4W-kmj" firstAttribute="trailing" secondItem="COd-X5-alN" secondAttribute="trailing" id="ywM-eJ-0Ii"/>
+                                </constraints>
+                            </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jya-5z-xKN">
-                                <rect key="frame" x="0.0" y="64" width="320" height="218"/>
+                                <rect key="frame" x="0.0" y="293.5" width="320" height="218"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="DsI-9S-jdi">
                                         <rect key="frame" x="71.5" y="0.0" width="177" height="28"/>
@@ -318,117 +438,26 @@
                                     </textField>
                                 </subviews>
                             </stackView>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="hFG-bX-qLp">
-                                <rect key="frame" x="10" y="336" width="300" height="159.5"/>
-                                <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Work threads:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="t2C-jL-6qO">
-                                        <rect key="frame" x="97" y="0.0" width="106.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Ai4-M1-xyO">
-                                        <rect key="frame" x="0.0" y="20.5" width="300" height="34"/>
-                                        <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sCM-tI-skI">
-                                                <rect key="frame" x="0.0" y="0.0" width="40" height="34"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="40" id="HUq-OB-eh7"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                                <connections>
-                                                    <action selector="minWorkThreadCountChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="SDs-Yb-IF4"/>
-                                                </connections>
-                                            </textField>
-                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="fwl-wl-SDe">
-                                                <rect key="frame" x="48" y="2" width="204" height="31"/>
-                                                <connections>
-                                                    <action selector="workThreadSliderChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="Rew-Gy-nZe"/>
-                                                </connections>
-                                            </slider>
-                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="COd-X5-alN">
-                                                <rect key="frame" x="260" y="0.0" width="40" height="34"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                                <connections>
-                                                    <action selector="maxWorkThreadCountChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="j2G-qv-7Qg"/>
-                                                </connections>
-                                            </textField>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstItem="COd-X5-alN" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" id="sOx-nV-5kZ"/>
-                                        </constraints>
-                                    </stackView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Work interval (µs):" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cAO-gr-3HC">
-                                        <rect key="frame" x="80.5" y="54.5" width="139.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="qkf-ZZ-JCy">
-                                        <rect key="frame" x="0.0" y="75" width="300" height="34"/>
-                                        <subviews>
-                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="1" translatesAutoresizingMaskIntoConstraints="NO" id="CuN-wx-fvQ">
-                                                <rect key="frame" x="0.0" y="0.0" width="60" height="34"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                                <connections>
-                                                    <action selector="minWorkIntervalChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="2o8-oq-ZNn"/>
-                                                </connections>
-                                            </textField>
-                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="N8m-ny-upJ">
-                                                <rect key="frame" x="68" y="2" width="184" height="31"/>
-                                                <connections>
-                                                    <action selector="workIntensityChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="bWc-Br-JcO"/>
-                                                </connections>
-                                            </slider>
-                                            <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rJh-QS-fAl">
-                                                <rect key="frame" x="260" y="0.0" width="40" height="34"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                                <connections>
-                                                    <action selector="maxWorkIntervalChanged:" destination="NZr-bH-g9o" eventType="editingChanged" id="rT8-Wz-1cO"/>
-                                                </connections>
-                                            </textField>
-                                        </subviews>
-                                    </stackView>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View bg brightness" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Hdg-8E-uP2">
-                                        <rect key="frame" x="77" y="109" width="146.5" height="20.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                        <nil key="textColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
-                                    <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="1" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="5og-4W-kmj">
-                                        <rect key="frame" x="28" y="129.5" width="244" height="31"/>
-                                        <connections>
-                                            <action selector="bgBrightnessChanged:" destination="NZr-bH-g9o" eventType="valueChanged" id="HTb-Ef-kcz"/>
-                                        </connections>
-                                    </slider>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstItem="rJh-QS-fAl" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" id="jbh-kK-Uqg"/>
-                                    <constraint firstItem="CuN-wx-fvQ" firstAttribute="width" secondItem="sCM-tI-skI" secondAttribute="width" constant="20" id="wLW-8j-3SX"/>
-                                </constraints>
-                            </stackView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="3iU-yQ-Fps"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="qkf-ZZ-JCy" firstAttribute="width" secondItem="3iU-yQ-Fps" secondAttribute="width" constant="-20" id="4Tm-cW-EjA"/>
-                            <constraint firstItem="hFG-bX-qLp" firstAttribute="top" secondItem="jya-5z-xKN" secondAttribute="bottom" constant="54" id="8eK-Fm-Btg"/>
                             <constraint firstItem="uTM-T7-Gv6" firstAttribute="width" secondItem="3iU-yQ-Fps" secondAttribute="width" id="F6o-He-EMh"/>
-                            <constraint firstItem="5og-4W-kmj" firstAttribute="width" secondItem="3iU-yQ-Fps" secondAttribute="width" multiplier="0.75" id="H7T-Y6-UFg"/>
+                            <constraint firstItem="hFG-bX-qLp" firstAttribute="trailing" secondItem="3iU-yQ-Fps" secondAttribute="trailing" constant="-8" id="GHF-BR-qwJ"/>
                             <constraint firstItem="3iU-yQ-Fps" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="jya-5z-xKN" secondAttribute="bottom" id="Ne1-tD-tNR"/>
-                            <constraint firstItem="hFG-bX-qLp" firstAttribute="centerX" secondItem="jya-5z-xKN" secondAttribute="centerX" id="SeD-eQ-6Mz"/>
-                            <constraint firstItem="Ai4-M1-xyO" firstAttribute="width" secondItem="3iU-yQ-Fps" secondAttribute="width" constant="-20" id="Zt5-vm-5U0"/>
-                            <constraint firstItem="jya-5z-xKN" firstAttribute="top" secondItem="3iU-yQ-Fps" secondAttribute="top" id="a34-ae-yTP"/>
+                            <constraint firstItem="b1f-aG-VcS" firstAttribute="top" secondItem="3iU-yQ-Fps" secondAttribute="top" id="OCJ-kf-88y"/>
+                            <constraint firstItem="jya-5z-xKN" firstAttribute="top" secondItem="hFG-bX-qLp" secondAttribute="bottom" id="fc4-d5-NkB"/>
+                            <constraint firstItem="hFG-bX-qLp" firstAttribute="top" secondItem="b1f-aG-VcS" secondAttribute="bottom" id="giR-Mk-j5r"/>
+                            <constraint firstItem="hFG-bX-qLp" firstAttribute="leading" secondItem="3iU-yQ-Fps" secondAttribute="leading" constant="8" id="jUa-xc-9m4"/>
                             <constraint firstItem="3iU-yQ-Fps" firstAttribute="trailing" secondItem="jya-5z-xKN" secondAttribute="trailing" id="kai-Nr-BEU"/>
+                            <constraint firstItem="b1f-aG-VcS" firstAttribute="leading" secondItem="3iU-yQ-Fps" secondAttribute="leading" id="rIM-vY-mjh"/>
                             <constraint firstItem="jya-5z-xKN" firstAttribute="leading" secondItem="3iU-yQ-Fps" secondAttribute="leading" id="u9N-bz-wPj"/>
+                            <constraint firstItem="3iU-yQ-Fps" firstAttribute="trailing" secondItem="b1f-aG-VcS" secondAttribute="trailing" id="wMq-Vr-pZ5"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Profiling" image="flame.fill" catalog="system" selectedImage="flame.fill" id="Wfx-IJ-h9f"/>
                     <connections>
+                        <outlet property="dsnView" destination="b1f-aG-VcS" id="cP6-26-jVy"/>
                         <outlet property="launchProfilingMarkerFileCheckButton" destination="keL-m5-7hv" id="s2U-XE-Flv"/>
                         <outlet property="maxThreadsTextField" destination="COd-X5-alN" id="6Pn-Be-aUe"/>
                         <outlet property="maxWorkIntensityTextField" destination="rJh-QS-fAl" id="u9q-Sj-6SY"/>
@@ -710,8 +739,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="sSP-cf-2tc">
+                                <rect key="frame" x="0.0" y="64" width="320" height="70"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="AeU-pQ-WsH"/>
+                                </constraints>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="40A-vG-dFA">
-                                <rect key="frame" x="0.0" y="64" width="320" height="268"/>
+                                <rect key="frame" x="0.0" y="134" width="320" height="268"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="fn9-mQ-2PY">
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
@@ -814,22 +850,26 @@
                         <viewLayoutGuide key="safeArea" id="RXi-Ac-EvL"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
+                            <constraint firstItem="RXi-Ac-EvL" firstAttribute="trailing" secondItem="sSP-cf-2tc" secondAttribute="trailing" id="3IF-SE-RjG"/>
                             <constraint firstItem="RXi-Ac-EvL" firstAttribute="trailing" secondItem="40A-vG-dFA" secondAttribute="trailing" id="F6g-4H-flU"/>
                             <constraint firstItem="RXi-Ac-EvL" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="40A-vG-dFA" secondAttribute="bottom" id="LHx-sF-kk2"/>
                             <constraint firstItem="40A-vG-dFA" firstAttribute="leading" secondItem="RXi-Ac-EvL" secondAttribute="leading" id="TI2-tA-bEz"/>
-                            <constraint firstItem="40A-vG-dFA" firstAttribute="top" secondItem="RXi-Ac-EvL" secondAttribute="top" id="rSc-zl-KDj"/>
+                            <constraint firstItem="sSP-cf-2tc" firstAttribute="leading" secondItem="RXi-Ac-EvL" secondAttribute="leading" id="XOA-TO-rbQ"/>
+                            <constraint firstItem="RXi-Ac-EvL" firstAttribute="top" secondItem="sSP-cf-2tc" secondAttribute="top" id="anF-vB-5zY"/>
+                            <constraint firstItem="40A-vG-dFA" firstAttribute="top" secondItem="sSP-cf-2tc" secondAttribute="bottom" id="vnw-Tv-qWp"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Errors" image="exclamationmark.triangle.fill" catalog="system" id="u05-ZO-4bg">
                         <imageReference key="selectedImage" image="exclamationmark.triangle.fill" catalog="system"/>
                     </tabBarItem>
                     <connections>
+                        <outlet property="dsnView" destination="sSP-cf-2tc" id="A1F-Rz-Cfv"/>
                         <outlet property="imageView" destination="1zm-ho-TCr" id="JvD-Tf-Vwc"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="0Fg-3B-Ecy" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-278" y="-824"/>
+            <point key="canvasLocation" x="-246" y="-827"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="Utg-a8-6kx">
@@ -860,8 +900,15 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="R19-6T-z1w">
+                                <rect key="frame" x="0.0" y="64" width="320" height="70"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="70" id="I1r-2C-nBv"/>
+                                </constraints>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zhO-zJ-CAt">
-                                <rect key="frame" x="8" y="80" width="304" height="455"/>
+                                <rect key="frame" x="8" y="134" width="304" height="401"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Yzg-QH-aPg">
                                         <rect key="frame" x="0.0" y="0.0" width="304" height="252"/>
@@ -1027,44 +1074,23 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="omd-Rj-xhq">
-                                        <rect key="frame" x="0.0" y="252" width="304" height="203"/>
+                                        <rect key="frame" x="0.0" y="252" width="304" height="149"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMF-4u-JGE">
-                                                <rect key="frame" x="8" y="32" width="288" height="24.5"/>
+                                                <rect key="frame" x="8" y="32" width="288" height="31"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DSN  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FXp-oI-RdR">
-                                                <rect key="frame" x="8" y="56.5" width="288" height="24.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <textField opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="wzO-lb-yFR">
-                                                <rect key="frame" x="8" y="81" width="288" height="24.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                                <connections>
-                                                    <action selector="dsnChanged:" destination="VqS-l1-kwe" eventType="editingChanged" id="XYW-iO-EtQ"/>
-                                                </connections>
-                                            </textField>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="te3-IR-L1y">
-                                                <rect key="frame" x="8" y="105.5" width="288" height="24.5"/>
-                                                <state key="normal" title="Reset DSN"/>
-                                                <connections>
-                                                    <action selector="resetDSN:" destination="VqS-l1-kwe" eventType="touchUpInside" id="3LJ-al-JGc"/>
-                                                </connections>
-                                            </button>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Frames" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xua-qE-dXN" userLabel="frames">
-                                                <rect key="frame" x="8" y="130" width="288" height="24.5"/>
+                                                <rect key="frame" x="8" y="63" width="288" height="31"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="framesStatsLabel"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last breadcrumb" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4M5-qM-BM9" userLabel="breadcrumb">
-                                                <rect key="frame" x="8" y="154.5" width="288" height="24.5"/>
+                                                <rect key="frame" x="8" y="94" width="288" height="31"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="breadcrumbLabel"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
@@ -1080,7 +1106,10 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="zhO-zJ-CAt" firstAttribute="leading" secondItem="QWh-GD-7Cl" secondAttribute="leading" constant="8" id="Asm-Ny-qaW"/>
-                            <constraint firstItem="QWh-GD-7Cl" firstAttribute="top" secondItem="zhO-zJ-CAt" secondAttribute="top" constant="-16" id="TtS-yc-lSm"/>
+                            <constraint firstItem="R19-6T-z1w" firstAttribute="top" secondItem="QWh-GD-7Cl" secondAttribute="top" id="Bmx-MB-vSd"/>
+                            <constraint firstItem="R19-6T-z1w" firstAttribute="leading" secondItem="QWh-GD-7Cl" secondAttribute="leading" id="Kjy-OD-Jzd"/>
+                            <constraint firstItem="zhO-zJ-CAt" firstAttribute="top" secondItem="R19-6T-z1w" secondAttribute="bottom" id="RhY-kn-aF6"/>
+                            <constraint firstItem="QWh-GD-7Cl" firstAttribute="trailing" secondItem="R19-6T-z1w" secondAttribute="trailing" id="coe-Va-qvL"/>
                             <constraint firstItem="QWh-GD-7Cl" firstAttribute="trailing" secondItem="zhO-zJ-CAt" secondAttribute="trailing" constant="8" id="eGG-ja-YO9"/>
                             <constraint firstItem="zhO-zJ-CAt" firstAttribute="bottom" secondItem="QWh-GD-7Cl" secondAttribute="bottom" constant="16" id="ezv-Y5-lKd"/>
                             <constraint firstItem="zhO-zJ-CAt" firstAttribute="centerX" secondItem="QWh-GD-7Cl" secondAttribute="centerX" id="rW3-yv-lJt"/>
@@ -1091,7 +1120,7 @@
                         <outlet property="anrFillingRunLoopButton" destination="2e4-48-rLl" id="MXb-mV-5SL"/>
                         <outlet property="anrFullyBlockingButton" destination="rpD-Rf-xbz" id="jF4-7m-26n"/>
                         <outlet property="breadcrumbLabel" destination="4M5-qM-BM9" id="rDd-LH-T9l"/>
-                        <outlet property="dsnTextField" destination="wzO-lb-yFR" id="8Oz-V5-VTq"/>
+                        <outlet property="dsnView" destination="R19-6T-z1w" id="XLU-qD-eFO"/>
                         <outlet property="framesLabel" destination="xua-qE-dXN" id="vP2-XG-wBW"/>
                         <outlet property="uiTestNameLabel" destination="eMF-4u-JGE" id="YVe-Un-zF9"/>
                     </connections>

--- a/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
@@ -8,9 +8,11 @@ class ErrorsViewController: UIViewController {
     private let dispatchQueue = DispatchQueue(label: "ErrorsViewController", attributes: .concurrent)
     private let diskWriteException = DiskWriteException()
     
+    @IBOutlet weak var dsnView: UIView!
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         SentrySDK.reportFullyDisplayed()
+        addDSNDisplay(self, vcview: dsnView)
     }
 
     @IBAction func useAfterFree(_ sender: UIButton) {

--- a/Samples/iOS-Swift/iOS-Swift/Extensions/UIViewExtension.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Extensions/UIViewExtension.swift
@@ -8,4 +8,15 @@ extension UIView {
         translatesAutoresizingMaskIntoConstraints = false
         return self
     }
+    
+    func matchEdgeAnchors(from other: UIView, leadingPad: CGFloat = 0, trailingPad: CGFloat = 0, topPad: CGFloat = 0, bottomPad: CGFloat = 0) {
+        self.translatesAutoresizingMaskIntoConstraints = false
+        other.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            leadingAnchor.constraint(equalTo: other.leadingAnchor, constant: leadingPad),
+            trailingAnchor.constraint(equalTo: other.trailingAnchor, constant: trailingPad),
+            topAnchor.constraint(equalTo: other.topAnchor, constant: topPad),
+            bottomAnchor.constraint(equalTo: other.bottomAnchor, constant: bottomPad)
+        ])
+    }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
@@ -4,27 +4,17 @@ import UIKit
 
 class ExtraViewController: UIViewController {
 
-    @IBOutlet weak var dsnTextField: UITextField!
     @IBOutlet weak var framesLabel: UILabel!
     @IBOutlet weak var breadcrumbLabel: UILabel!
     @IBOutlet weak var uiTestNameLabel: UILabel!
     @IBOutlet weak var anrFullyBlockingButton: UIButton!
     @IBOutlet weak var anrFillingRunLoopButton: UIButton!
 
+    @IBOutlet weak var dsnView: UIView!
     private let dispatchQueue = DispatchQueue(label: "ExtraViewControllers", attributes: .concurrent)
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        dispatchQueue.async {
-            let dsn = DSNStorage.shared.getDSN()
-
-            DispatchQueue.main.async {
-                self.dsnTextField.text = dsn
-                self.dsnTextField.backgroundColor = UIColor.systemGreen
-            }
-        }
-
         if let uiTestName = ProcessInfo.processInfo.environment["--io.sentry.ui-test.test-name"] {
             uiTestNameLabel.text = uiTestName
         }
@@ -54,35 +44,8 @@ class ExtraViewController: UIViewController {
         }
         
         SentrySDK.reportFullyDisplayed()
-    }
-
-    @IBAction func dsnChanged(_ sender: UITextField) {
-        let options = Options()
-        options.dsn = sender.text
-
-        if let dsn = options.dsn {
-            sender.backgroundColor = UIColor.systemGreen
-
-            dispatchQueue.async {
-                DSNStorage.shared.saveDSN(dsn: dsn)
-            }
-        } else {
-            sender.backgroundColor = UIColor.systemRed
-
-            dispatchQueue.async {
-                DSNStorage.shared.deleteDSN()
-            }
-        }
-    }
-
-    @IBAction func resetDSN(_ sender: UIButton) {
-        highlightButton(sender)
-        self.dsnTextField.text = AppDelegate.defaultDSN
-        self.dsnTextField.backgroundColor = UIColor.systemGreen
-
-        dispatchQueue.async {
-            DSNStorage.shared.saveDSN(dsn: AppDelegate.defaultDSN)
-        }
+        
+        addDSNDisplay(self, vcview: dsnView)
     }
 
     @IBAction func anrFullyBlocking(_ sender: UIButton) {

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -18,7 +18,8 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
     @IBOutlet weak var launchProfilingMarkerFileCheckButton: UIButton!
     @IBOutlet weak var profilingUITestDataMarshalingTextField: UITextField!
     @IBOutlet weak var profilingUITestDataMarshalingStatus: UILabel!
-    
+        
+    @IBOutlet weak var dsnView: UIView!
     override func viewDidLoad() {
         super.viewDidLoad()
         minWorkIntensityTextField.text = String(defaultLongestIntervalMicros)
@@ -35,6 +36,8 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         SentrySDK.reportFullyDisplayed()
+        
+        addDSNDisplay(self, vcview: dsnView)
     }
     
     @IBAction func startBenchmark(_ sender: UIButton) {

--- a/Samples/iOS-Swift/iOS-Swift/Tools/DSNDisplayViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/DSNDisplayViewController.swift
@@ -1,0 +1,174 @@
+import Anchorage
+import SwiftMessages
+import UIKit
+
+let fontSize: CGFloat = 12
+
+func addDSNDisplay(_ vc: UIViewController, vcview: UIView) {
+    let dsnVC = DSNDisplayViewController(nibName: nil, bundle: nil)
+    vcview.addSubview(dsnVC.view)
+    dsnVC.view.edgeAnchors == vcview.edgeAnchors
+    vc.addChild(dsnVC)
+}
+
+class DSNDisplayViewController: UIViewController {
+    let dispatchQueue = DispatchQueue(label: "io.sentry.iOS-Swift.queue.dsn-management", attributes: .concurrent)
+    let label = UILabel(frame: .zero)
+    
+    override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+        
+        if #available(iOS 13.0, *) {
+            view.backgroundColor = .systemFill
+        } else {
+            view.backgroundColor = .lightGray.withAlphaComponent(0.5)
+        }
+        
+        label.numberOfLines = 0
+        label.lineBreakMode = .byCharWrapping
+        label.textAlignment = .center
+        
+        let changeButton = UIButton(type: .roundedRect)
+        changeButton.setTitle("Change", for: .normal)
+        changeButton.addTarget(self, action: #selector(changeDSN), for: .touchUpInside)
+        
+        let resetButton = UIButton(type: .roundedRect)
+        resetButton.setTitle("Reset", for: .normal)
+        resetButton.addTarget(self, action: #selector(resetDSN), for: .touchUpInside)
+        
+        let buttonStack = UIStackView(arrangedSubviews: [
+            changeButton,
+            resetButton
+        ])
+        buttonStack.axis = .vertical
+        buttonStack.distribution = .fillEqually
+        
+        let stack = UIStackView(arrangedSubviews: [
+            label,
+            buttonStack
+        ])
+        
+        view.addSubview(stack)
+        stack.edgeAnchors == view.edgeAnchors
+        buttonStack.widthAnchor == view.widthAnchor / 3
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        updateDSNLabel()
+    }
+    
+    @objc func dsnChanged(_ newDSN: String) {
+        let options = Options()
+        options.dsn = newDSN
+
+        if let dsn = options.dsn {
+            dispatchQueue.async {
+                do {
+                    try DSNStorage.shared.saveDSN(dsn: dsn)
+                    DispatchQueue.main.async {
+                        showToast(in: self.view, type: .success, message: "DSN changed!")
+                    }
+                } catch {
+                    SentrySDK.capture(error: error)
+                    DispatchQueue.main.async {
+                        showToast(in: self.view, type: .error, message: error.localizedDescription)
+                    }
+                }
+                DispatchQueue.main.async {
+                    self.updateDSNLabel()
+                }
+            }
+        } else {
+            showToast(in: self.view, type: .warning, message: "Invalid DSN, reverting to the default.")
+            self.dispatchQueue.async {
+                do {
+                    try DSNStorage.shared.deleteDSN()
+                } catch {
+                    SentrySDK.capture(error: error)
+                    DispatchQueue.main.async {
+                        showToast(in: self.view, type: .error, message: error.localizedDescription)
+                    }
+                }
+                DispatchQueue.main.async {
+                    self.updateDSNLabel()
+                }
+            }
+        }
+    }
+    
+    @objc func changeDSN() {
+        let alert = UIAlertController(title: "Change DSN", message: nil, preferredStyle: .alert)
+        var configuredTextField: UITextField?
+        alert.addTextField { textField in
+            configuredTextField = textField
+        }
+        alert.addAction(.init(title: "Save", style: .default, handler: { _ in
+            guard let dsn = configuredTextField?.text else {
+                return
+            }
+            self.dsnChanged(dsn)
+        }))
+        alert.addAction(.init(title: "Cancel", style: .destructive))
+        present(alert, animated: true)
+    }
+
+    @objc func resetDSN() {
+        self.dispatchQueue.async {
+            do {
+                try DSNStorage.shared.deleteDSN()
+                DispatchQueue.main.async {
+                    showToast(in: self.view, type: .success, message: "DSN reset to default!")
+                }
+            } catch {
+                SentrySDK.capture(error: error)
+                DispatchQueue.main.async {
+                    showToast(in: self.view, type: .error, message: "Failed to reset DSN: \(error)")
+                }
+            }
+            DispatchQueue.main.async {
+                self.updateDSNLabel()
+            }
+        }
+    }
+    
+    func updateDSNLabel() {
+        do {
+            let dsn = try DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
+            self.label.attributedText = dsnFieldTitleString(dsn: dsn)
+        } catch {
+            SentrySDK.capture(error: error)
+            DispatchQueue.main.async {
+                showToast(in: self.view, type: .error, message: "Failed to read DSN: \(error)")
+            }
+        }
+    }
+    
+    func dsnFieldTitleString(dsn: String) -> NSAttributedString {
+        let defaultAnnotation = "(default)"
+        let overriddenAnnotation = "(overridden)"
+        guard dsn != AppDelegate.defaultDSN else {
+            let title = "DSN \(defaultAnnotation):"
+            let stringContents = "\(title): \(dsn)"
+            let attributedString = NSMutableAttributedString(string: stringContents)
+            attributedString.setAttributes([.font: UIFont.boldSystemFont(ofSize: fontSize)], range: (stringContents as NSString).range(of: title))
+            attributedString.setAttributes([.font: UIFont.systemFont(ofSize: fontSize)], range: (stringContents as NSString).range(of: dsn))
+            return attributedString
+        }
+        
+        let title = "DSN \(overriddenAnnotation)"
+        let stringContents = "\(title): \(dsn)"
+        let attributedString = NSMutableAttributedString(string: stringContents)
+        
+        // attributes are stacked as last-one-wins since ranges overlap
+        attributedString.setAttributes([.font: UIFont.boldSystemFont(ofSize: fontSize)], range: (stringContents as NSString).range(of: title))
+        attributedString.setAttributes([.foregroundColor: UIColor.red, .font: UIFont.boldSystemFont(ofSize: fontSize)], range: (stringContents as NSString).range(of: overriddenAnnotation))
+        
+        attributedString.setAttributes([.font: UIFont.systemFont(ofSize: fontSize)], range: (stringContents as NSString).range(of: dsn))
+        return attributedString
+    }
+}

--- a/Samples/iOS-Swift/iOS-Swift/Tools/DSNDisplayViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/DSNDisplayViewController.swift
@@ -1,5 +1,3 @@
-import Anchorage
-import SwiftMessages
 import UIKit
 
 let fontSize: CGFloat = 12
@@ -7,7 +5,7 @@ let fontSize: CGFloat = 12
 func addDSNDisplay(_ vc: UIViewController, vcview: UIView) {
     let dsnVC = DSNDisplayViewController(nibName: nil, bundle: nil)
     vcview.addSubview(dsnVC.view)
-    dsnVC.view.edgeAnchors == vcview.edgeAnchors
+    dsnVC.view.matchEdgeAnchors(from: vcview)
     vc.addChild(dsnVC)
 }
 
@@ -49,8 +47,9 @@ class DSNDisplayViewController: UIViewController {
         ])
         
         view.addSubview(stack)
-        stack.edgeAnchors == view.edgeAnchors
-        buttonStack.widthAnchor == view.widthAnchor / 3
+        stack.matchEdgeAnchors(from: view, leadingPad: 20)
+        buttonStack.translatesAutoresizingMaskIntoConstraints = false
+        buttonStack.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.3).isActive = true
     }
     
     required init?(coder: NSCoder) {
@@ -71,12 +70,12 @@ class DSNDisplayViewController: UIViewController {
                 do {
                     try DSNStorage.shared.saveDSN(dsn: dsn)
                     DispatchQueue.main.async {
-                        showToast(in: self.view, type: .success, message: "DSN changed!")
+                        showToast(in: self, type: .success, message: "DSN changed!")
                     }
                 } catch {
                     SentrySDK.capture(error: error)
                     DispatchQueue.main.async {
-                        showToast(in: self.view, type: .error, message: error.localizedDescription)
+                        showToast(in: self, type: .error, message: error.localizedDescription)
                     }
                 }
                 DispatchQueue.main.async {
@@ -84,14 +83,14 @@ class DSNDisplayViewController: UIViewController {
                 }
             }
         } else {
-            showToast(in: self.view, type: .warning, message: "Invalid DSN, reverting to the default.")
+            showToast(in: self, type: .warning, message: "Invalid DSN, reverting to the default.")
             self.dispatchQueue.async {
                 do {
                     try DSNStorage.shared.deleteDSN()
                 } catch {
                     SentrySDK.capture(error: error)
                     DispatchQueue.main.async {
-                        showToast(in: self.view, type: .error, message: error.localizedDescription)
+                        showToast(in: self, type: .error, message: error.localizedDescription)
                     }
                 }
                 DispatchQueue.main.async {
@@ -122,12 +121,12 @@ class DSNDisplayViewController: UIViewController {
             do {
                 try DSNStorage.shared.deleteDSN()
                 DispatchQueue.main.async {
-                    showToast(in: self.view, type: .success, message: "DSN reset to default!")
+                    showToast(in: self, type: .success, message: "DSN reset to default!")
                 }
             } catch {
                 SentrySDK.capture(error: error)
                 DispatchQueue.main.async {
-                    showToast(in: self.view, type: .error, message: "Failed to reset DSN: \(error)")
+                    showToast(in: self, type: .error, message: "Failed to reset DSN: \(error)")
                 }
             }
             DispatchQueue.main.async {
@@ -143,7 +142,7 @@ class DSNDisplayViewController: UIViewController {
         } catch {
             SentrySDK.capture(error: error)
             DispatchQueue.main.async {
-                showToast(in: self.view, type: .error, message: "Failed to read DSN: \(error)")
+                showToast(in: self, type: .error, message: "Failed to read DSN: \(error)")
             }
         }
     }

--- a/Samples/iOS-Swift/iOS-Swift/Tools/DSNStorage.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/DSNStorage.swift
@@ -17,37 +17,25 @@ class DSNStorage {
         dsnFile = cachesDirectory.appendingPathComponent("dsn")
     }
     
-    func saveDSN(dsn: String) {
-        do {
-            deleteDSN()
-            try dsn.write(to: dsnFile, atomically: true, encoding: .utf8)
-        } catch {
-            SentrySDK.capture(error: error)
-        }
+    func saveDSN(dsn: String) throws {
+        try deleteDSN()
+        try dsn.write(to: dsnFile, atomically: true, encoding: .utf8)
     }
     
-    func getDSN() -> String? {
+    func getDSN() throws -> String? {
         let fileManager = FileManager.default
-        do {
-            if fileManager.fileExists(atPath: dsnFile.path) {
-                return try String(contentsOfFile: dsnFile.path)
-            }
-        } catch {
-            SentrySDK.capture(error: error)
+        
+        guard fileManager.fileExists(atPath: dsnFile.path) else {
+            return nil
         }
         
-        return nil
+        return try String(contentsOfFile: dsnFile.path)
     }
     
-    func deleteDSN() {
+    func deleteDSN() throws {
         let fileManager = FileManager.default
-        do {
-            
-            if fileManager.fileExists(atPath: dsnFile.path) {
-                try fileManager.removeItem(at: dsnFile)
-            }
-        } catch {
-            SentrySDK.capture(error: error)
+        if fileManager.fileExists(atPath: dsnFile.path) {
+            try fileManager.removeItem(at: dsnFile)
         }
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/Tools/Toasts.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/Toasts.swift
@@ -1,6 +1,7 @@
 import SwiftMessages
+import UIKit
 
-@MainActor func showToast(in view: UIView, type: Theme, message: String) {
+@MainActor public func showToast(in view: UIView, type: Theme, message: String) {
     let view = MessageView.viewFromNib(layout: .statusLine)
     view.configureTheme(type)
     let iconText: String

--- a/Samples/iOS-Swift/iOS-Swift/Tools/Toasts.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/Toasts.swift
@@ -1,0 +1,28 @@
+import SwiftMessages
+
+@MainActor func showToast(in view: UIView, type: Theme, message: String) {
+    let view = MessageView.viewFromNib(layout: .statusLine)
+    view.configureTheme(type)
+    let iconText: String
+    let title: String
+    switch type {
+    case .info: 
+        title = "OBTW"
+        iconText = "ℹ️"
+    case .success: 
+        title = "Success!"
+        iconText = "🥳"
+    case .warning: 
+        title = "Warning"
+        iconText = "⚠️"
+    case .error:
+        title = "Error"
+        iconText = "🤡"
+    }
+    view.configureContent(title: title, body: message, iconText: iconText)
+    
+    view.layoutMarginAdditions = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+    (view.backgroundView as? CornerRoundingView)?.cornerRadius = 10
+    
+    SwiftMessages.show(view: view)
+}

--- a/Samples/iOS-Swift/iOS-Swift/Tools/Toasts.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/Toasts.swift
@@ -1,29 +1,42 @@
-import SwiftMessages
 import UIKit
 
-@MainActor public func showToast(in view: UIView, type: Theme, message: String) {
-    let view = MessageView.viewFromNib(layout: .statusLine)
-    view.configureTheme(type)
-    let iconText: String
+public enum ToastType {
+    case info
+    case success
+    case warning
+    case error
+}
+
+public func showToast(in vc: UIViewController, type: ToastType, message: String) {
     let title: String
+    var action: UIAlertAction?
     switch type {
-    case .info: 
+    case .info:
         title = "OBTW"
-        iconText = "ℹ️"
-    case .success: 
+    case .success:
         title = "Success!"
-        iconText = "🥳"
-    case .warning: 
+    case .warning:
         title = "Warning"
-        iconText = "⚠️"
+        action = .init(title: "OK", style: .default, handler: { _ in
+            
+        })
     case .error:
         title = "Error"
-        iconText = "🤡"
+        action = .init(title: "OK", style: .default, handler: { _ in
+            
+        })
     }
-    view.configureContent(title: title, body: message, iconText: iconText)
-    
-    view.layoutMarginAdditions = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
-    (view.backgroundView as? CornerRoundingView)?.cornerRadius = 10
-    
-    SwiftMessages.show(view: view)
+    let alert = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
+    if let action = action {
+        alert.addAction(action)
+    }
+    vc.present(alert, animated: true) {
+        switch type {
+        case .info, .success:
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                vc.dismiss(animated: true)
+            }
+        default: break
+        }
+    }
 }

--- a/Samples/iOS-Swift/iOS-Swift/TransactionsViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/TransactionsViewController.swift
@@ -7,7 +7,8 @@ class TransactionsViewController: UIViewController {
     
     private let dispatchQueue = DispatchQueue(label: "ViewController", attributes: .concurrent)
     private var timer: Timer?
-
+    @IBOutlet weak var dsnView: UIView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         SentrySDK.reportFullyDisplayed()
@@ -16,6 +17,8 @@ class TransactionsViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         periodicallyDoWork()
+        
+        addDSNDisplay(self, vcview: dsnView)
     }
     
     override func viewDidDisappear(_ animated: Bool) {

--- a/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
@@ -8,8 +8,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     static func startSentry() {
         // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
-        let dsn = DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
-        DSNStorage.shared.saveDSN(dsn: dsn)
+        let dsn: String? = nil
+        do {
+            let dsn = try DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
+            try DSNStorage.shared.saveDSN(dsn: dsn)
+        } catch {
+            print("[iOS-Swift] Failed to read/write DSN: \(error)")
+        }
         
         SentrySDK.start { options in
             options.dsn = dsn


### PR DESCRIPTION
I lost some time because I launched the sample app in a simulator that I'd previously changed the DSN in, and didn't realize it, wondering why I wasn't seeing data coming in for my tests.

I made it so that every main screen in the tab bar shows the current dsn, and calls out if it is overridden. I also improved the UX for changing/resetting. Including how errors are propagated and displayed.

<img width="559" alt="image" src="https://github.com/user-attachments/assets/47a68a2b-4acb-4ae2-854d-4970f88366e6">
<img width="559" alt="image" src="https://github.com/user-attachments/assets/42c1dc93-203d-4946-bdc2-612954ae5534">
<img width="559" alt="image" src="https://github.com/user-attachments/assets/0601cbe6-7755-421d-87c4-eb5491ae3744">
<img width="559" alt="image" src="https://github.com/user-attachments/assets/1aa26048-493a-453b-880d-189c7c6629a1">
<img width="559" alt="image" src="https://github.com/user-attachments/assets/38ccd776-00d0-4dc7-b5fd-23cf91763924">


#skip-changelog