### PR TITLE
fix: Don't redact clipped views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Resumes replay when the app becomes active (#4303)
 - Session replay redact view with transformation (#4308)
+- Don't redact clipped views ()
 
 ## 8.36.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Resumes replay when the app becomes active (#4303)
 - Session replay redact view with transformation (#4308)
-- Don't redact clipped views ()
+- Don't redact clipped views (#4325)
 
 ## 8.36.0
 

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -1138,6 +1138,27 @@
                                     <constraint firstAttribute="height" constant="30" id="WuH-r4-icd"/>
                                     <constraint firstAttribute="width" constant="240" id="dn8-bG-2cz"/>
                                 </constraints>
+                            </view>
+                            <view clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nXU-s5-VDP">
+                                <rect key="frame" x="40" y="90" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="This should not appear" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Cuu-no-Hgq">
+                                        <rect key="frame" x="33" y="150" width="175" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="A label inside a clip view" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TkV-ad-u0T">
+                                        <rect key="frame" x="28" y="54" width="184" height="21"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Qfh-TT-5mw"/>

--- a/Tests/SentryTests/SentryViewPhotographerTests.swift
+++ b/Tests/SentryTests/SentryViewPhotographerTests.swift
@@ -140,6 +140,42 @@ class SentryViewPhotographerTests: XCTestCase {
         assertColor(pixel2, .green)
     }
     
+    func testDontRedactClippedLabel() throws {
+        let label = UILabel(frame: CGRect(x: 0, y: 25, width: 50, height: 25))
+        label.text = "Test"
+        
+        let labelParent = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 25))
+        labelParent.backgroundColor = .green
+        labelParent.clipsToBounds = true
+        labelParent.addSubview(label)
+        
+        let image = try XCTUnwrap(prepare(views: [labelParent]))
+        let pixel1 = color(at: CGPoint(x: 10, y: 10), in: image)
+        
+        assertColor(pixel1, .green)
+        
+        let pixel2 = color(at: CGPoint(x: 10, y: 30), in: image)
+        assertColor(pixel2, .white)
+    }
+    
+    func testRedactLabelInsideClippedView() throws {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 50, height: 25))
+        label.text = "Test"
+        
+        let labelParent = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 25))
+        labelParent.backgroundColor = .green
+        labelParent.clipsToBounds = true
+        labelParent.addSubview(label)
+        
+        let image = try XCTUnwrap(prepare(views: [labelParent]))
+        let pixel1 = color(at: CGPoint(x: 10, y: 10), in: image)
+        
+        assertColor(pixel1, .black)
+        
+        let pixel2 = color(at: CGPoint(x: 10, y: 30), in: image)
+        assertColor(pixel2, .white)
+    }
+    
     private func assertColor(_ color1: UIColor, _ color2: UIColor) {
         let sRGBColor1 = color1.cgColor.converted(to: CGColorSpace(name: CGColorSpace.sRGB)!, intent: .defaultIntent, options: nil)
         let sRGBColor2 = color2.cgColor.converted(to: CGColorSpace(name: CGColorSpace.sRGB)!, intent: .defaultIntent, options: nil)

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -134,7 +134,7 @@ class UIRedactBuilderTests: XCTestCase {
         let result = sut.redactRegionsFor(view: rootView, options: RedactOptions())
         
         XCTAssertEqual(result.count, 1)
-        XCTAssertEqual(result.first?.type, .clip)
+        XCTAssertEqual(result.first?.type, .clipOut)
         XCTAssertEqual(result.first?.transform, CGAffineTransform(a: 1, b: 0, c: 0, d: 1, tx: 10, ty: 10))
     }
     


### PR DESCRIPTION
## :scroll: Description

A label that is outside of bounds of a view with clipBounds true is no longer being redacted.

|Screen|Before|After|
|-|-|-|
|![image](https://github.com/user-attachments/assets/d79ff780-f4c1-421e-8d7e-236446bd9ea2)|![747730062 107031 copy](https://github.com/user-attachments/assets/0fdead56-941e-4d51-9fc9-a9acae9b78f1)|![747729969 339359](https://github.com/user-attachments/assets/523969d3-eba3-4efb-9ea7-908298ff5c5e)|

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
