### PR TITLE
chore: Formating code with clang-format 19

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -4,8 +4,7 @@
 
 #import "iOS_ObjectiveC-Swift.h"
 
-@interface
-AppDelegate ()
+@interface AppDelegate ()
 @end
 
 @implementation AppDelegate

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -2,8 +2,7 @@
 
 @import Sentry;
 
-@interface
-ViewController ()
+@interface ViewController ()
 
 @end
 

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/NSObject+SentryAppSetup.h
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/NSObject+SentryAppSetup.h
@@ -9,8 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  * have started the launch profiler by the time this runs. This must be done in Objective-C because
  * Swift does not allow implementation of `NSObject.load()`.
  */
-@interface
-NSObject (SentryAppSetup)
+@interface NSObject (SentryAppSetup)
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/NSObject+SentryAppSetup.m
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/NSObject+SentryAppSetup.m
@@ -1,7 +1,6 @@
 #import "NSObject+SentryAppSetup.h"
 
-@implementation
-NSObject (SentryAppSetup)
+@implementation NSObject (SentryAppSetup)
 + (void)load
 {
     NSLog(@"[iOS-Swift] Starting app launch work");

--- a/Samples/iOS-Swift/iOS-Swift/Tools/SentryBenchmarking.mm
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/SentryBenchmarking.mm
@@ -148,7 +148,7 @@ dispatch_queue_t queue;
         = ((NSNumber *)[userTimeTotals.allValues valueForKeyPath:@"@sum.self"]).integerValue;
 
     return [NSString stringWithFormat:@"%ld,%ld,%ld,%ld", profilerSystemTime, profilerUserTime,
-                     appSystemTime, appUserTime];
+        appSystemTime, appUserTime];
 }
 
 @end

--- a/SentryTestUtils/SentryFileManager+Test.h
+++ b/SentryTestUtils/SentryFileManager+Test.h
@@ -5,8 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_EXTERN NSURL *launchProfileConfigFileURL(void);
 SENTRY_EXTERN NSURL *_Nullable sentryLaunchConfigFileURL;
 
-@interface
-SentryFileManager ()
+@interface SentryFileManager ()
 
 @property (nonatomic, copy) NSString *eventsPath;
 @property (nonatomic, copy) NSString *envelopesPath;

--- a/SentryTestUtils/SentryHub+Test.h
+++ b/SentryTestUtils/SentryHub+Test.h
@@ -7,8 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Expose the internal test init for testing. */
-@interface
-SentryHub ()
+@interface SentryHub ()
 
 - (instancetype)initWithClient:(SentryClient *_Nullable)client
                       andScope:(SentryScope *_Nullable)scope

--- a/Sources/Sentry/Profiling/SentryProfilerState.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerState.mm
@@ -127,7 +127,7 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
 
         const auto stack = [NSMutableArray<NSNumber *> array];
         for (std::vector<uintptr_t>::size_type backtraceAddressIdx = 0;
-             backtraceAddressIdx < backtrace.addresses.size(); backtraceAddressIdx++) {
+            backtraceAddressIdx < backtrace.addresses.size(); backtraceAddressIdx++) {
             const auto instructionAddress
                 = sentry_formatHexAddressUInt64(backtrace.addresses[backtraceAddressIdx]);
             const auto frameIndex = state.frameIndexLookup[instructionAddress];

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -54,7 +54,7 @@ sentry_writeProfileFile(NSData *JSONData)
     NSUInteger numberOfProfiles = [contents count];
     NSString *pathToWrite = [testProfileDirPath
         stringByAppendingPathComponent:[NSString stringWithFormat:@"profile%lld",
-                                                 (long long)numberOfProfiles]];
+                                           (long long)numberOfProfiles]];
 
     if ([fm fileExistsAtPath:pathToWrite]) {
         SENTRY_LOG_DEBUG(@"Already a profile file present; make sure to remove them right after "

--- a/Sources/Sentry/SentryANRTracker.m
+++ b/Sources/Sentry/SentryANRTracker.m
@@ -16,8 +16,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     kSentryANRTrackerStopping
 };
 
-@interface
-SentryANRTracker ()
+@interface SentryANRTracker ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -21,8 +21,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     kSentryANRTrackerStopping
 };
 
-@interface
-SentryANRTrackerV2 ()
+@interface SentryANRTrackerV2 ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -24,8 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryANRTrackingIntegration ()
+@interface SentryANRTrackingIntegration ()
 
 @property (nonatomic, strong) SentryANRTracker *tracker;
 @property (nonatomic, strong) SentryOptions *options;
@@ -102,7 +101,7 @@ SentryANRTrackingIntegration ()
     }
 
     NSString *message = [NSString stringWithFormat:@"App hanging for at least %li ms.",
-                                  (long)(self.options.appHangTimeoutInterval * 1000)];
+        (long)(self.options.appHangTimeoutInterval * 1000)];
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
     SentryException *sentryException =
         [[SentryException alloc] initWithValue:message type:SentryANRExceptionType];

--- a/Sources/Sentry/SentryANRTrackingIntegrationV2.m
+++ b/Sources/Sentry/SentryANRTrackingIntegrationV2.m
@@ -24,8 +24,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryANRTrackingIntegrationV2 ()
+@interface SentryANRTrackingIntegrationV2 ()
 
 @property (nonatomic, strong) SentryANRTrackerV2 *tracker;
 @property (nonatomic, strong) SentryOptions *options;
@@ -101,7 +100,7 @@ SentryANRTrackingIntegrationV2 ()
     }
 
     NSString *message = [NSString stringWithFormat:@"App hanging for at least %li ms.",
-                                  (long)(self.options.appHangTimeoutInterval * 1000)];
+        (long)(self.options.appHangTimeoutInterval * 1000)];
     SentryEvent *event = [[SentryEvent alloc] initWithLevel:kSentryLevelError];
     SentryException *sentryException =
         [[SentryException alloc] initWithValue:message type:SentryANRExceptionTypeV2];

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -28,8 +28,7 @@ static BOOL isActivePrewarm = NO;
  */
 static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 180.0;
 
-@interface
-SentryAppStartTracker () <SentryFramesTrackerListener>
+@interface SentryAppStartTracker () <SentryFramesTrackerListener>
 
 @property (nonatomic, strong) SentryAppState *previousAppState;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -12,8 +12,7 @@
 #    import <SentryDependencyContainer.h>
 #    import <SentryDispatchQueueWrapper.h>
 
-@interface
-SentryAppStartTrackingIntegration ()
+@interface SentryAppStartTrackingIntegration ()
 
 @property (nonatomic, strong) SentryAppStartTracker *tracker;
 

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -17,8 +17,7 @@
 #    import <UIKit/UIKit.h>
 #endif
 
-@interface
-SentryAppStateManager ()
+@interface SentryAppStateManager ()
 
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;

--- a/Sources/Sentry/SentryAsynchronousOperation.m
+++ b/Sources/Sentry/SentryAsynchronousOperation.m
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryAsynchronousOperation ()
+@interface SentryAsynchronousOperation ()
 
 @property (nonatomic, getter=isCancelled, readwrite) BOOL cancelled;
 @property (nonatomic, getter=isFinished, readwrite) BOOL finished;

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -9,8 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryAutoBreadcrumbTrackingIntegration ()
+@interface SentryAutoBreadcrumbTrackingIntegration ()
 
 @property (nonatomic, strong) SentryBreadcrumbTracker *breadcrumbTracker;
 

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -7,8 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryAutoSessionTrackingIntegration ()
+@interface SentryAutoSessionTrackingIntegration ()
 
 @property (nonatomic, strong) SentrySessionTracker *tracker;
 

--- a/Sources/Sentry/SentryBinaryImageCache.m
+++ b/Sources/Sentry/SentryBinaryImageCache.m
@@ -11,8 +11,7 @@ static void binaryImageWasRemoved(const SentryCrashBinaryImage *image);
 @implementation SentryBinaryImageInfo
 @end
 
-@interface
-SentryBinaryImageCache ()
+@interface SentryBinaryImageCache ()
 @property (nonatomic, strong) NSMutableArray<SentryBinaryImageInfo *> *cache;
 - (void)binaryImageAdded:(const SentryCrashBinaryImage *)image;
 - (void)binaryImageRemoved:(const SentryCrashBinaryImage *)image;

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -4,8 +4,7 @@
 #import "SentryNSDictionarySanitize.h"
 #import "SentrySwift.h"
 
-@interface
-SentryBreadcrumb ()
+@interface SentryBreadcrumb ()
 @property (atomic, strong) NSDictionary<NSString *, id> *_Nullable unknown;
 @end
 

--- a/Sources/Sentry/SentryBreadcrumbTracker.m
+++ b/Sources/Sentry/SentryBreadcrumbTracker.m
@@ -25,8 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const SentryBreadcrumbTrackerSwizzleSendAction
     = @"SentryBreadcrumbTrackerSwizzleSendAction";
 
-@interface
-SentryBreadcrumbTracker ()
+@interface SentryBreadcrumbTracker ()
 #if SENTRY_HAS_REACHABILITY
     <SentryReachabilityObserver>
 #endif // !TARGET_OS_WATCH

--- a/Sources/Sentry/SentryByteCountFormatter.m
+++ b/Sources/Sentry/SentryByteCountFormatter.m
@@ -21,7 +21,7 @@
     [formatter setPositiveFormat:@"#,##0"];
 
     return [NSString stringWithFormat:@"%@ %@",
-                     [formatter stringFromNumber:[NSNumber numberWithDouble:result]], units[index]];
+        [formatter stringFromNumber:[NSNumber numberWithDouble:result]], units[index]];
 }
 
 @end

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -55,8 +55,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryClient ()
+@interface SentryClient ()
 
 @property (nonatomic, strong) SentryTransportAdapter *transportAdapter;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
@@ -985,7 +984,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                               app[@"view_names"] = @[ scope.currentScreen ];
                           } else {
                               app[@"view_names"] = [SentryDependencyContainer.sharedInstance
-                                                        .application relevantViewControllersNames];
+                                      .application relevantViewControllersNames];
                           }
                       }
                   }];

--- a/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
+++ b/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
@@ -1,8 +1,7 @@
 #import "SentryConcurrentRateLimitsDictionary.h"
 #import <Foundation/Foundation.h>
 
-@interface
-SentryConcurrentRateLimitsDictionary ()
+@interface SentryConcurrentRateLimitsDictionary ()
 
 /* Key is the type and value is valid until date */
 @property (nonatomic, strong) NSMutableDictionary<NSNumber *, NSDate *> *rateLimits;

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -145,10 +145,10 @@
         if (items && items.count > 0) {
             if (items.count == 1) {
                 [resultParts addObject:[NSString stringWithFormat:@"%@ %@ '%@'", op,
-                                                 items.allValues[0], items.allKeys[0]]];
+                                           items.allValues[0], items.allKeys[0]]];
             } else {
                 [resultParts addObject:[NSString stringWithFormat:@"%@ %lu items", op,
-                                                 (unsigned long)total]];
+                                           (unsigned long)total]];
             }
         }
     };
@@ -197,7 +197,7 @@
 
     if (request.predicate) {
         [result appendFormat:@" WHERE %@",
-                [predicateDescriptor predicateDescription:request.predicate]];
+            [predicateDescriptor predicateDescription:request.predicate]];
     }
 
     if (request.sortDescriptors.count > 0) {

--- a/Sources/Sentry/SentryCoreDataTrackingIntegration.m
+++ b/Sources/Sentry/SentryCoreDataTrackingIntegration.m
@@ -8,8 +8,7 @@
 #import "SentryOptions.h"
 #import "SentryThreadInspector.h"
 
-@interface
-SentryCoreDataTrackingIntegration ()
+@interface SentryCoreDataTrackingIntegration ()
 
 @property (nonatomic, strong) SentryCoreDataTracker *tracker;
 

--- a/Sources/Sentry/SentryCrashInstallationReporter.m
+++ b/Sources/Sentry/SentryCrashInstallationReporter.m
@@ -7,8 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryCrashInstallationReporter ()
+@interface SentryCrashInstallationReporter ()
 
 @property (nonatomic, strong) SentryInAppLogic *inAppLogic;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -30,8 +30,7 @@ static SentryCrashInstallationReporter *installation = nil;
 static NSString *const DEVICE_KEY = @"device";
 static NSString *const LOCALE_KEY = @"locale";
 
-@interface
-SentryCrashIntegration ()
+@interface SentryCrashIntegration ()
 
 @property (nonatomic, weak) SentryOptions *options;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -16,8 +16,7 @@
 #import "SentryThread.h"
 #import "SentryUser.h"
 
-@interface
-SentryCrashReportConverter ()
+@interface SentryCrashReportConverter ()
 
 @property (nonatomic, strong) NSDictionary *report;
 @property (nonatomic, assign) NSInteger crashedThreadIndex;
@@ -132,7 +131,7 @@ SentryCrashReportConverter ()
             && appContext[@"app_build"]) {
             event.releaseName =
                 [NSString stringWithFormat:@"%@@%@+%@", appContext[@"app_identifier"],
-                          appContext[@"app_version"], appContext[@"app_build"]];
+                    appContext[@"app_version"], appContext[@"app_build"]];
         }
 
         if (nil == event.dist && appContext[@"app_build"]) {
@@ -369,16 +368,16 @@ SentryCrashReportConverter ()
     } else if ([exceptionType isEqualToString:@"mach"]) {
         exception = [[SentryException alloc]
             initWithValue:[NSString stringWithFormat:@"Exception %@, Code %@, Subcode %@",
-                                    self.exceptionContext[@"mach"][@"exception"],
-                                    self.exceptionContext[@"mach"][@"code"],
-                                    self.exceptionContext[@"mach"][@"subcode"]]
+                              self.exceptionContext[@"mach"][@"exception"],
+                              self.exceptionContext[@"mach"][@"code"],
+                              self.exceptionContext[@"mach"][@"subcode"]]
                      type:self.exceptionContext[@"mach"][@"exception_name"]];
     } else if ([exceptionType isEqualToString:@"signal"]) {
-        exception = [[SentryException alloc]
-            initWithValue:[NSString stringWithFormat:@"Signal %@, Code %@",
-                                    self.exceptionContext[@"signal"][@"signal"],
-                                    self.exceptionContext[@"signal"][@"code"]]
-                     type:self.exceptionContext[@"signal"][@"name"]];
+        exception =
+            [[SentryException alloc] initWithValue:[NSString stringWithFormat:@"Signal %@, Code %@",
+                                                       self.exceptionContext[@"signal"][@"signal"],
+                                                       self.exceptionContext[@"signal"][@"code"]]
+                                              type:self.exceptionContext[@"signal"][@"name"]];
     } else if ([exceptionType isEqualToString:@"user"]) {
         NSString *exceptionReason =
             [NSString stringWithFormat:@"%@", self.exceptionContext[@"reason"]];
@@ -451,9 +450,8 @@ SentryCrashReportConverter ()
         }
     }
     if (reasons.count > 0) {
-        exception.value =
-            [[[reasons array] sortedArrayUsingSelector:@selector(localizedCaseInsensitiveCompare:)]
-                componentsJoinedByString:@" > "];
+        exception.value = [[[reasons array] sortedArrayUsingSelector:@selector
+            (localizedCaseInsensitiveCompare:)] componentsJoinedByString:@" > "];
     }
 }
 

--- a/Sources/Sentry/SentryCrashReportSink.m
+++ b/Sources/Sentry/SentryCrashReportSink.m
@@ -19,8 +19,7 @@
 static const NSTimeInterval SENTRY_APP_START_CRASH_DURATION_THRESHOLD = 2.0;
 static const NSTimeInterval SENTRY_APP_START_CRASH_FLUSH_DURATION = 5.0;
 
-@interface
-SentryCrashReportSink ()
+@interface SentryCrashReportSink ()
 
 @property (nonatomic, strong) SentryInAppLogic *inAppLogic;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;

--- a/Sources/Sentry/SentryCrashStackEntryMapper.m
+++ b/Sources/Sentry/SentryCrashStackEntryMapper.m
@@ -8,8 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryCrashStackEntryMapper ()
+@interface SentryCrashStackEntryMapper ()
 
 @property (nonatomic, strong) SentryInAppLogic *inAppLogic;
 

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -132,7 +132,7 @@ NS_ASSUME_NONNULL_BEGIN
 #else
     NSOperatingSystemVersion version = [NSProcessInfo processInfo].operatingSystemVersion;
     NSString *systemVersion = [NSString stringWithFormat:@"%d.%d.%d", (int)version.majorVersion,
-                                        (int)version.minorVersion, (int)version.patchVersion];
+        (int)version.minorVersion, (int)version.patchVersion];
     [osData setValue:systemVersion forKey:@"version"];
 
 #endif

--- a/Sources/Sentry/SentryDateUtil.m
+++ b/Sources/Sentry/SentryDateUtil.m
@@ -3,8 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryDateUtil ()
+@interface SentryDateUtil ()
 
 @property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;
 

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -11,8 +11,7 @@
 #import "SentryThread.h"
 #import <Foundation/Foundation.h>
 
-@interface
-SentryDebugImageProvider ()
+@interface SentryDebugImageProvider ()
 
 @property (nonatomic, strong) id<SentryCrashBinaryImageProvider> binaryImageProvider;
 @end

--- a/Sources/Sentry/SentryDefaultRateLimits.m
+++ b/Sources/Sentry/SentryDefaultRateLimits.m
@@ -10,8 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryDefaultRateLimits ()
+@interface SentryDefaultRateLimits ()
 
 @property (nonatomic, strong) SentryConcurrentRateLimitsDictionary *rateLimits;
 @property (nonatomic, strong) SentryRetryAfterHeaderParser *retryAfterHeaderParser;

--- a/Sources/Sentry/SentryDelayedFramesTracker.m
+++ b/Sources/Sentry/SentryDelayedFramesTracker.m
@@ -10,8 +10,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryDelayedFramesTracker ()
+@interface SentryDelayedFramesTracker ()
 
 @property (nonatomic, assign) CFTimeInterval keepDelayedFramesDuration;
 @property (nonatomic, strong, readonly) SentryCurrentDateProvider *dateProvider;

--- a/Sources/Sentry/SentryDevice.mm
+++ b/Sources/Sentry/SentryDevice.mm
@@ -189,7 +189,7 @@ sentry_getOSVersion(void)
 #else
     const auto version = [[NSProcessInfo processInfo] operatingSystemVersion];
     return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion,
-                     (long)version.minorVersion, (long)version.patchVersion];
+        (long)version.minorVersion, (long)version.patchVersion];
 #endif // SENTRY_HAS_UIKIT
 }
 

--- a/Sources/Sentry/SentryDsn.m
+++ b/Sources/Sentry/SentryDsn.m
@@ -5,8 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryDsn ()
+@interface SentryDsn ()
 
 @end
 
@@ -79,7 +78,7 @@ SentryDsn ()
         [paths removeObjectAtIndex:0]; // We remove the leading /
         [paths removeLastObject]; // We remove projectId since we add it later
         path = [NSString stringWithFormat:@"/%@",
-                         [paths componentsJoinedByString:@"/"]]; // We put together the path
+            [paths componentsJoinedByString:@"/"]]; // We put together the path
     }
     NSURLComponents *components = [NSURLComponents new];
     components.scheme = url.scheme;

--- a/Sources/Sentry/SentryEnvelopeRateLimit.m
+++ b/Sources/Sentry/SentryEnvelopeRateLimit.m
@@ -7,8 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryEnvelopeRateLimit ()
+@interface SentryEnvelopeRateLimit ()
 
 @property (nonatomic, strong) id<SentryRateLimits> rateLimits;
 @property (nonatomic, weak) id<SentryEnvelopeRateLimitDelegate> delegate;

--- a/Sources/Sentry/SentryError.mm
+++ b/Sources/Sentry/SentryError.mm
@@ -31,7 +31,7 @@ SENTRY_EXTERN NSError *_Nullable NSErrorFromSentryErrorWithKernelError(
 {
     return _SentryError(error, @ {
         NSLocalizedDescriptionKey : [NSString stringWithFormat:@"%@ (%s)", description,
-                                              sentry::kernelReturnCodeDescription(kernelErrorCode)],
+            sentry::kernelReturnCodeDescription(kernelErrorCode)],
     });
 }
 

--- a/Sources/Sentry/SentryExtraContextProvider.m
+++ b/Sources/Sentry/SentryExtraContextProvider.m
@@ -12,8 +12,7 @@ NSString *const kSentryProcessInfoThermalStateFair = @"fair";
 NSString *const kSentryProcessInfoThermalStateSerious = @"serious";
 NSString *const kSentryProcessInfoThermalStateCritical = @"critical";
 
-@interface
-SentryExtraContextProvider ()
+@interface SentryExtraContextProvider ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryNSProcessInfoWrapper *processInfoWrapper;

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -57,8 +57,7 @@ _non_thread_safe_removeFileAtPath(NSString *path)
     }
 }
 
-@interface
-SentryFileManager ()
+@interface SentryFileManager ()
 
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, copy) NSString *basePath;
@@ -149,8 +148,7 @@ SentryFileManager ()
     //      need this because otherwise 10 would be sorted before 2 for example.
     // %@ = NSString
     // For example 978307200.000000-00001-3FE8C3AE-EB9C-4BEB-868C-14B8D47C33DD.json
-    return [NSString
-        stringWithFormat:@"%f-%05lu-%@.json",
+    return [NSString stringWithFormat:@"%f-%05lu-%@.json",
         [[SentryDependencyContainer.sharedInstance.dateProvider date] timeIntervalSince1970],
         (unsigned long)self.currentFileCounter++, [NSUUID UUID].UUIDString];
 }

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -28,8 +28,7 @@ typedef NSMutableArray<NSDictionary<NSString *, NSNumber *> *> SentryMutableFram
 static CFTimeInterval const SentryFrozenFrameThreshold = 0.7;
 static CFTimeInterval const SentryPreviousFrameInitialValue = -1;
 
-@interface
-SentryFramesTracker ()
+@interface SentryFramesTracker ()
 
 @property (nonatomic, assign, readonly) BOOL isStarted;
 

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -8,8 +8,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryFramesTrackingIntegration ()
+@interface SentryFramesTrackingIntegration ()
 
 @property (nonatomic, strong) SentryFramesTracker *tracker;
 

--- a/Sources/Sentry/SentryHttpDateParser.m
+++ b/Sources/Sentry/SentryHttpDateParser.m
@@ -3,8 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryHttpDateParser ()
+@interface SentryHttpDateParser ()
 
 @property (nonatomic, strong) NSDateFormatter *dateFormatter;
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -25,8 +25,7 @@
 #    import "SentryReachability.h"
 #endif // !TARGET_OS_WATCH
 
-@interface
-SentryHttpTransport ()
+@interface SentryHttpTransport ()
 #if SENTRY_HAS_REACHABILITY
     <SentryReachabilityObserver>
 #endif // !TARGET_OS_WATCH
@@ -152,7 +151,7 @@ SentryHttpTransport ()
     }
 
     NSString *key = [NSString stringWithFormat:@"%@:%@", nameForSentryDataCategory(category),
-                              nameForSentryDiscardReason(reason)];
+        nameForSentryDiscardReason(reason)];
 
     @synchronized(self.discardedEvents) {
         SentryDiscardedEvent *event = self.discardedEvents[key];

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -35,8 +35,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryHub () <SentryMetricsAPIDelegate>
+@interface SentryHub () <SentryMetricsAPIDelegate>
 
 @property (nullable, nonatomic, strong) SentryClient *client;
 @property (nullable, nonatomic, strong) SentryScope *scope;
@@ -220,7 +219,7 @@ SentryHub () <SentryMetricsAPIDelegate>
         if (client.options.diagnosticLevel == kSentryLevelDebug) {
             [SentryLog
                 logWithMessage:[NSString stringWithFormat:@"Capturing session with status: %@",
-                                         [self createSessionDebugString:session]]
+                                   [self createSessionDebugString:session]]
                       andLevel:kSentryLevelDebug];
         }
         [client captureSession:session];
@@ -682,7 +681,7 @@ SentryHub () <SentryMetricsAPIDelegate>
                 if (_client.options.diagnosticLevel == kSentryLevelDebug) {
                     [SentryLog
                         logWithMessage:[NSString stringWithFormat:@"Ending session with status: %@",
-                                                 [self createSessionDebugString:currentSession]]
+                                           [self createSessionDebugString:currentSession]]
                               andLevel:kSentryLevelDebug];
                 }
                 if (startNewSession) {

--- a/Sources/Sentry/SentryInstallation.m
+++ b/Sources/Sentry/SentryInstallation.m
@@ -6,8 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryInstallation ()
+@interface SentryInstallation ()
 @property (class, nonatomic, readonly)
     NSMutableDictionary<NSString *, NSString *> *installationStringsByCacheDirectoryPaths;
 

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -45,8 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface
-SentryMetricKitIntegration ()
+@interface SentryMetricKitIntegration ()
 
 @property (nonatomic, strong, nullable) SentryMXManager *metricKitManager;
 @property (nonatomic, strong) NSMeasurementFormatter *measurementFormatter;
@@ -100,7 +99,7 @@ SentryMetricKitIntegration ()
 {
     NSString *exceptionValue =
         [NSString stringWithFormat:@"MachException Type:%@ Code:%@ Signal:%@",
-                  diagnostic.exceptionType, diagnostic.exceptionCode, diagnostic.signal];
+            diagnostic.exceptionType, diagnostic.exceptionCode, diagnostic.signal];
 
     SentryMXExceptionParams *params = [[SentryMXExceptionParams alloc] init];
     params.handled = NO;
@@ -135,7 +134,7 @@ SentryMetricKitIntegration ()
 
     NSString *exceptionValue =
         [NSString stringWithFormat:@"MXCPUException totalCPUTime:%@ totalSampledTime:%@",
-                  totalCPUTime, totalSampledTime];
+            totalCPUTime, totalSampledTime];
 
     // Still need to figure out proper exception values and types.
     // This code is currently only there for testing with TestFlight.

--- a/Sources/Sentry/SentryMigrateSessionInit.m
+++ b/Sources/Sentry/SentryMigrateSessionInit.m
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_BEGIN
         [SentryLog
             logWithMessage:[NSString stringWithFormat:@"Could not migrate session init, because "
                                                       @"storing the updated envelope failed: %@",
-                                     error.description]
+                               error.description]
                   andLevel:kSentryLevelError];
     }
 }

--- a/Sources/Sentry/SentryMsgPackSerializer.m
+++ b/Sources/Sentry/SentryMsgPackSerializer.m
@@ -71,8 +71,7 @@
 
 @end
 
-@implementation
-NSURL (SentryStreameble)
+@implementation NSURL (SentryStreameble)
 
 - (NSInputStream *)asInputStream
 {
@@ -94,8 +93,7 @@ NSURL (SentryStreameble)
 
 @end
 
-@implementation
-NSData (SentryStreameble)
+@implementation NSData (SentryStreameble)
 
 - (NSInputStream *)asInputStream
 {

--- a/Sources/Sentry/SentryNSDataSwizzling.m
+++ b/Sources/Sentry/SentryNSDataSwizzling.m
@@ -13,8 +13,7 @@
 #import <SentryLog.h>
 #import <objc/runtime.h>
 
-@interface
-SentryNSDataSwizzling ()
+@interface SentryNSDataSwizzling ()
 
 @property (nonatomic, strong) SentryNSDataTracker *dataTracker;
 

--- a/Sources/Sentry/SentryNSDataTracker.m
+++ b/Sources/Sentry/SentryNSDataTracker.m
@@ -21,8 +21,7 @@
 
 const NSString *SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
 
-@interface
-SentryNSDataTracker ()
+@interface SentryNSDataTracker ()
 
 @property (nonatomic, assign) BOOL isEnabled;
 @property (nonatomic, strong) NSMutableSet<NSData *> *processingData;
@@ -265,7 +264,7 @@ SentryNSDataTracker ()
 - (NSString *)transactionDescriptionForFile:(NSString *)path fileSize:(NSUInteger)size
 {
     return size > 0 ? [NSString stringWithFormat:@"%@ (%@)", [path lastPathComponent],
-                                [SentryByteCountFormatter bytesCountDescription:size]]
+                          [SentryByteCountFormatter bytesCountDescription:size]]
                     : [NSString stringWithFormat:@"%@", [path lastPathComponent]];
 }
 

--- a/Sources/Sentry/SentryNSURLRequest.m
+++ b/Sources/Sentry/SentryNSURLRequest.m
@@ -113,8 +113,7 @@ newAuthHeader(NSURL *url)
 {
     NSMutableString *string = [NSMutableString stringWithString:@"Sentry "];
     [string appendFormat:@"%@,", newHeaderPart(@"sentry_version", SentryServerVersionString)];
-    [string
-        appendFormat:@"%@,",
+    [string appendFormat:@"%@,",
         newHeaderPart(@"sentry_client",
             [NSString stringWithFormat:@"%@/%@", SentryMeta.sdkName, SentryMeta.versionString])];
     [string appendFormat:@"%@", newHeaderPart(@"sentry_key", url.user)];

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -37,8 +37,7 @@
  * break on specific iOS versions to ensure it works properly when modifying this file. If they
  * could, please add UI tests and run them on older iOS versions.
  */
-@interface
-SentryNetworkTracker ()
+@interface SentryNetworkTracker ()
 
 @property (nonatomic, assign) BOOL isNetworkTrackingEnabled;
 @property (nonatomic, assign) BOOL isNetworkBreadcrumbEnabled;
@@ -190,9 +189,8 @@ SentryNetworkTracker ()
         [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable innerSpan) {
             if (innerSpan != nil) {
                 span = innerSpan;
-                netSpan =
-                    [span startChildWithOperation:SENTRY_NETWORK_REQUEST_OPERATION
-                                      description:[NSString stringWithFormat:@"%@ %@",
+                netSpan = [span startChildWithOperation:SENTRY_NETWORK_REQUEST_OPERATION
+                                            description:[NSString stringWithFormat:@"%@ %@",
                                                             sessionTask.currentRequest.HTTPMethod,
                                                             safeUrl.sanitizedUrl]];
                 netSpan.origin = SentryTraceOriginAutoHttpNSURLSession;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -175,7 +175,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         if (infoDict != nil) {
             self.releaseName =
                 [NSString stringWithFormat:@"%@@%@+%@", infoDict[@"CFBundleIdentifier"],
-                          infoDict[@"CFBundleShortVersionString"], infoDict[@"CFBundleVersion"]];
+                    infoDict[@"CFBundleShortVersionString"], infoDict[@"CFBundleVersion"]];
         }
 
         NSRegularExpression *everythingAllowedRegex =
@@ -703,7 +703,7 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
     static Class blockClass;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        blockClass = [^{} class];
+        blockClass = [^{ } class];
         while ([blockClass superclass] != NSObject.class) {
             blockClass = [blockClass superclass];
         }

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -15,8 +15,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryPerformanceTracker () <SentryTracerDelegate>
+@interface SentryPerformanceTracker () <SentryTracerDelegate>
 
 @property (nonatomic, strong) NSMutableDictionary<SentrySpanId *, id<SentrySpan>> *spans;
 @property (nonatomic, strong) NSMutableArray<id<SentrySpan>> *activeSpanStack;

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -12,8 +12,7 @@
 #    import "SentryUIViewControllerPerformanceTracker.h"
 #    import "SentryUIViewControllerSwizzling.h"
 
-@interface
-SentryPerformanceTrackingIntegration ()
+@interface SentryPerformanceTrackingIntegration ()
 
 @property (nonatomic, strong) SentryUIViewControllerSwizzling *swizzling;
 

--- a/Sources/Sentry/SentryPredicateDescriptor.m
+++ b/Sources/Sentry/SentryPredicateDescriptor.m
@@ -32,8 +32,8 @@
 
     if (expressions.count == 1) {
         return [NSString stringWithFormat:@"%@ %@",
-                         [self compoundPredicateTypeDescription:predicate.compoundPredicateType],
-                         expressions.firstObject];
+            [self compoundPredicateTypeDescription:predicate.compoundPredicateType],
+            expressions.firstObject];
     }
 
     return [expressions
@@ -76,9 +76,9 @@
     case NSConditionalExpressionType:
         if (@available(macOS 10.11, *)) {
             return [NSString stringWithFormat:@"TERNARY(%@,%@,%@)",
-                             [self predicateDescription:predicate.predicate],
-                             [self expressionDescription:predicate.trueExpression],
-                             [self expressionDescription:predicate.falseExpression]];
+                [self predicateDescription:predicate.predicate],
+                [self expressionDescription:predicate.trueExpression],
+                [self expressionDescription:predicate.falseExpression]];
         } else {
             // this is not supposed to happen, NSConditionalExpressionType was introduced in
             // macOS 10.11 but we need this version check because cocoapod lint check is failing

--- a/Sources/Sentry/SentryQueueableRequestManager.m
+++ b/Sources/Sentry/SentryQueueableRequestManager.m
@@ -4,8 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryQueueableRequestManager ()
+@interface SentryQueueableRequestManager ()
 
 @property (nonatomic, strong) NSOperationQueue *queue;
 @property (nonatomic, strong) NSURLSession *session;

--- a/Sources/Sentry/SentryRateLimitParser.m
+++ b/Sources/Sentry/SentryRateLimitParser.m
@@ -6,8 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryRateLimitParser ()
+@interface SentryRateLimitParser ()
 
 @property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;
 

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -145,8 +145,7 @@ SentryConnectivityActualCallback(
     SentryConnectivityCallback(flags);
 }
 
-@interface
-SentryReachability ()
+@interface SentryReachability ()
 
 @property SCNetworkReachabilityRef sentry_reachability_ref;
 

--- a/Sources/Sentry/SentryRequestOperation.m
+++ b/Sources/Sentry/SentryRequestOperation.m
@@ -9,8 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryRequestOperation ()
+@interface SentryRequestOperation ()
 
 @property (nonatomic, strong) NSURLSessionTask *task;
 @property (nonatomic, strong) NSURLRequest *request;

--- a/Sources/Sentry/SentryRetryAfterHeaderParser.m
+++ b/Sources/Sentry/SentryRetryAfterHeaderParser.m
@@ -5,8 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryRetryAfterHeaderParser ()
+@interface SentryRetryAfterHeaderParser ()
 
 @property (nonatomic, strong) SentryHttpDateParser *httpDateParser;
 @property (nonatomic, strong) SentryCurrentDateProvider *currentDateProvider;

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -38,8 +38,7 @@
 #    import "SentryProfiler+Private.h"
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-@interface
-SentrySDK ()
+@interface SentrySDK ()
 
 @property (class) SentryHub *currentHub;
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -17,8 +17,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryScope ()
+@interface SentryScope ()
 
 /**
  * Set global tags -> these will be sent with every event

--- a/Sources/Sentry/SentryScreenFrames.m
+++ b/Sources/Sentry/SentryScreenFrames.m
@@ -85,8 +85,8 @@
         (unsigned long)_total, (unsigned long)_slow, (unsigned long)_frozen];
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
     [result appendFormat:
-                @"\nslowFrameTimestamps: %@\nfrozenFrameTimestamps: %@\nframeRateTimestamps: %@",
-            _slowFrameTimestamps, _frozenFrameTimestamps, _frameRateTimestamps];
+            @"\nslowFrameTimestamps: %@\nfrozenFrameTimestamps: %@\nframeRateTimestamps: %@",
+        _slowFrameTimestamps, _frozenFrameTimestamps, _frameRateTimestamps];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
     return result;
 }

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -22,8 +22,7 @@ saveScreenShot(const char *path)
     [SentryDependencyContainer.sharedInstance.screenshot saveScreenShots:reportPath];
 }
 
-@interface
-SentryScreenshotIntegration ()
+@interface SentryScreenshotIntegration ()
 
 @property (nonatomic, strong) SentryOptions *options;
 

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -25,8 +25,7 @@ static SentryPackageManagerOption SENTRY_PACKAGE_INFO = SentryPackageManagerUnko
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySdkInfo ()
+@interface SentrySdkInfo ()
 
 @property (nonatomic) SentryPackageManagerOption packageManager;
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -320,10 +320,9 @@ NS_ASSUME_NONNULL_BEGIN
                                                                       error:&error];
     if (nil != error) {
         [SentryLog
-            logWithMessage:
-                [NSString
-                    stringWithFormat:@"Failed to retrieve event level from envelope item data: %@",
-                    error]
+            logWithMessage:[NSString stringWithFormat:
+                                   @"Failed to retrieve event level from envelope item data: %@",
+                               error]
                   andLevel:kSentryLevelError];
         return kSentryLevelError;
     }

--- a/Sources/Sentry/SentrySessionCrashedHandler.m
+++ b/Sources/Sentry/SentrySessionCrashedHandler.m
@@ -9,8 +9,7 @@
 #import "SentrySwift.h"
 #import "SentryWatchdogTerminationLogic.h"
 
-@interface
-SentrySessionCrashedHandler ()
+@interface SentrySessionCrashedHandler ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -39,8 +39,7 @@ static SentryTouchTracker *_touchTracker;
 
 static SentrySessionReplayIntegration *_installedInstance;
 
-@interface
-SentrySessionReplayIntegration () <SentryReachabilityObserver>
+@interface SentrySessionReplayIntegration () <SentryReachabilityObserver>
 - (void)newSceneActivate;
 @end
 
@@ -306,9 +305,9 @@ SentrySessionReplayIntegration () <SentryReachabilityObserver>
                           path:(NSString *)path
                        options:(SentryReplayOptions *)options
 {
-    NSDictionary *info = [[NSDictionary alloc]
-        initWithObjectsAndKeys:sessionId.sentryIdString, @"replayId", path.lastPathComponent,
-        @"path", @(options.onErrorSampleRate), @"errorSampleRate", nil];
+    NSDictionary *info =
+        [[NSDictionary alloc] initWithObjectsAndKeys:sessionId.sentryIdString, @"replayId",
+            path.lastPathComponent, @"path", @(options.onErrorSampleRate), @"errorSampleRate", nil];
 
     NSData *data = [SentrySerialization dataWithJSONObject:info];
 

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -15,8 +15,7 @@
 #    import <Cocoa/Cocoa.h>
 #endif
 
-@interface
-SentrySessionTracker ()
+@interface SentrySessionTracker ()
 
 @property (nonatomic, strong) SentryOptions *options;
 @property (atomic, strong) NSDate *lastInForeground;

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -33,8 +33,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySpan ()
+@interface SentrySpan ()
 @end
 
 @implementation SentrySpan {

--- a/Sources/Sentry/SentrySpanId.m
+++ b/Sources/Sentry/SentrySpanId.m
@@ -4,8 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const emptyUUIDString = @"0000000000000000";
 
-@interface
-SentrySpanId ()
+@interface SentrySpanId ()
 
 @property (nonatomic, strong) NSString *value;
 

--- a/Sources/Sentry/SentrySpotlightTransport.m
+++ b/Sources/Sentry/SentrySpotlightTransport.m
@@ -12,8 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySpotlightTransport ()
+@interface SentrySpotlightTransport ()
 
 @property (nonatomic, strong) id<SentryRequestManager> requestManager;
 @property (nonatomic, strong) SentryNSURLRequestBuilder *requestBuilder;

--- a/Sources/Sentry/SentryStacktraceBuilder.m
+++ b/Sources/Sentry/SentryStacktraceBuilder.m
@@ -12,8 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryStacktraceBuilder ()
+@interface SentryStacktraceBuilder ()
 
 @property (nonatomic, strong) SentryCrashStackEntryMapper *crashStackEntryMapper;
 

--- a/Sources/Sentry/SentryStatsdClient.m
+++ b/Sources/Sentry/SentryStatsdClient.m
@@ -7,8 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryStatsdClient ()
+@interface SentryStatsdClient ()
 
 @property (nonatomic, strong) SentryClient *client;
 

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -9,8 +9,7 @@
 #    import <UIKit/UIKit.h>
 #endif // SENTRY_HAS_UIKIT
 
-@interface
-SentrySubClassFinder ()
+@interface SentrySubClassFinder ()
 
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
@@ -92,7 +91,7 @@ SentrySubClassFinder ()
             [SentryLog
                 logWithMessage:[NSString stringWithFormat:@"The following UIViewControllers will "
                                                           @"generate automatic transactions: %@",
-                                         [classesToSwizzle componentsJoinedByString:@", "]]
+                                   [classesToSwizzle componentsJoinedByString:@", "]]
                       andLevel:kSentryLevelDebug];
         }];
     }];

--- a/Sources/Sentry/SentrySwizzle.m
+++ b/Sources/Sentry/SentrySwizzle.m
@@ -9,8 +9,7 @@
 
 typedef IMP (^SentrySwizzleImpProvider)(void);
 
-@interface
-SentrySwizzleInfo ()
+@interface SentrySwizzleInfo ()
 @property (nonatomic, copy) SentrySwizzleImpProvider impProviderBlock;
 @property (nonatomic, readwrite) SEL selector;
 @end
@@ -157,7 +156,7 @@ swizzledClassesForKey(const void *key)
                 }
             } else if (mode == SentrySwizzleModeOncePerClassAndSuperclasses) {
                 for (Class currentClass = classToSwizzle; nil != currentClass;
-                     currentClass = class_getSuperclass(currentClass)) {
+                    currentClass = class_getSuperclass(currentClass)) {
                     if ([swizzledClasses containsObject:currentClass]) {
                         return NO;
                     }

--- a/Sources/Sentry/SentrySystemEventBreadcrumbs.m
+++ b/Sources/Sentry/SentrySystemEventBreadcrumbs.m
@@ -11,8 +11,7 @@
 
 #    import <UIKit/UIKit.h>
 
-@interface
-SentrySystemEventBreadcrumbs ()
+@interface SentrySystemEventBreadcrumbs ()
 @property (nonatomic, weak) id<SentryBreadcrumbDelegate> delegate;
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryNSNotificationCenterWrapper *notificationCenterWrapper;

--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -13,8 +13,7 @@
 #import "SentryThread.h"
 #include <pthread.h>
 
-@interface
-SentryThreadInspector ()
+@interface SentryThreadInspector ()
 
 @property (nonatomic, strong) SentryStacktraceBuilder *stacktraceBuilder;
 @property (nonatomic, strong) id<SentryCrashMachineContextWrapper> machineContextWrapper;

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -24,8 +24,7 @@
 #        import "SentryLaunchProfiling.h"
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-@interface
-SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
+@interface SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
 
 @property (nonatomic, weak) SentrySpan *initialDisplaySpan;
 @property (nonatomic, weak) SentrySpan *fullDisplaySpan;
@@ -73,7 +72,7 @@ SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
         self.fullDisplaySpan =
             [tracer startChildWithOperation:SentrySpanOperationUILoadFullDisplay
                                 description:[NSString stringWithFormat:@"%@ full display",
-                                                      _controllerName]];
+                                                _controllerName]];
         self.fullDisplaySpan.origin = SentryTraceOriginManualUITimeToDisplay;
 
         // By concept TTID and TTFD spans should have the same beginning,

--- a/Sources/Sentry/SentryTraceHeader.m
+++ b/Sources/Sentry/SentryTraceHeader.m
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return _sampled != kSentrySampleDecisionUndecided
         ? [NSString stringWithFormat:@"%@-%@-%i", _traceId.sentryIdString,
-                    _spanId.sentrySpanIdString, _sampled == kSentrySampleDecisionYes ? 1 : 0]
+              _spanId.sentrySpanIdString, _sampled == kSentrySampleDecisionYes ? 1 : 0]
         : [NSString stringWithFormat:@"%@-%@", _traceId.sentryIdString, _spanId.sentrySpanIdString];
 }
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -64,8 +64,7 @@ static const NSTimeInterval SENTRY_APP_START_MEASUREMENT_DIFFERENCE = 5.0;
 
 static const NSTimeInterval SENTRY_AUTO_TRANSACTION_DEADLINE = 30.0;
 
-@interface
-SentryTracer ()
+@interface SentryTracer ()
 
 @property (nonatomic) uint64_t startSystemTime;
 @property (nonatomic) SentrySpanStatus finishStatus;
@@ -417,12 +416,11 @@ static BOOL appStartMeasurementRead;
     if (_traceContext == nil) {
         @synchronized(self) {
             if (_traceContext == nil) {
-                _traceContext = [[SentryTraceContext alloc]
-                    initWithTracer:self
-                             scope:_hub.scope
-                           options:_hub.client.options
-                               ?: SentrySDK.options]; // We should remove static classes and always
-                                                      // inject dependencies.
+                _traceContext = [[SentryTraceContext alloc] initWithTracer:self
+                                                                     scope:_hub.scope
+                                                                   options:_hub.client.options
+                        ?: SentrySDK.options]; // We should remove static classes and always
+                                               // inject dependencies.
             }
         }
     }

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -7,8 +7,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryTransportAdapter ()
+@interface SentryTransportAdapter ()
 
 @property (nonatomic, strong) NSArray<id<SentryTransport>> *transports;
 @property (nonatomic, strong) SentryOptions *options;

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -17,8 +17,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryTransportFactory ()
+@interface SentryTransportFactory ()
 
 @end
 

--- a/Sources/Sentry/SentryUIDeviceWrapper.m
+++ b/Sources/Sentry/SentryUIDeviceWrapper.m
@@ -6,8 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryUIDeviceWrapper ()
+@interface SentryUIDeviceWrapper ()
 @property (nonatomic) BOOL cleanupDeviceOrientationNotifications;
 @property (nonatomic) BOOL cleanupBatteryMonitoring;
 @property (nonatomic, copy) NSString *systemVersion;

--- a/Sources/Sentry/SentryUIEventTracker.m
+++ b/Sources/Sentry/SentryUIEventTracker.m
@@ -13,8 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const SentryUIEventTrackerSwizzleSendAction
     = @"SentryUIEventTrackerSwizzleSendAction";
 
-@interface
-SentryUIEventTracker ()
+@interface SentryUIEventTracker ()
 
 @property (nonatomic, strong) id<SentryUIEventTrackerMode> uiEventTrackerMode;
 

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -16,8 +16,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryUIEventTrackerTransactionMode ()
+@interface SentryUIEventTrackerTransactionMode ()
 
 @property (nonatomic, assign) NSTimeInterval idleTimeout;
 @property (nullable, nonatomic, strong) NSMutableArray<SentryTracer *> *activeTransactions;

--- a/Sources/Sentry/SentryUIEventTrackingIntegration.m
+++ b/Sources/Sentry/SentryUIEventTrackingIntegration.m
@@ -9,8 +9,7 @@
 #    import <SentryUIEventTracker.h>
 #    import <SentryUIEventTrackerTransactionMode.h>
 
-@interface
-SentryUIEventTrackingIntegration ()
+@interface SentryUIEventTrackingIntegration ()
 
 @property (nonatomic, strong) SentryUIEventTracker *uiEventTracker;
 

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -18,8 +18,7 @@
 #    import <UIKit/UIKit.h>
 #    import <objc/runtime.h>
 
-@interface
-SentryUIViewControllerPerformanceTracker ()
+@interface SentryUIViewControllerPerformanceTracker ()
 
 @property (nonatomic, strong) SentryPerformanceTracker *tracker;
 @property (nullable, nonatomic, weak) SentryTimeToDisplayTracker *currentTTDTracker;

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -31,12 +31,10 @@
  * see https://github.com/getsentry/sentry-cocoa/issues/3763. This category doesn't contain any
  * functions and is safe to use.
  */
-@interface
-UIApplication (SentryUIApplication) <SentryUIApplication>
+@interface UIApplication (SentryUIApplication) <SentryUIApplication>
 @end
 
-@interface
-SentryUIViewControllerSwizzling ()
+@interface SentryUIViewControllerSwizzling ()
 
 @property (nonatomic, strong) SentryInAppLogic *inAppLogic;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -4,8 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryUser ()
+@interface SentryUser ()
 @property (atomic, strong) NSDictionary<NSString *, id> *_Nullable unknown;
 @end
 

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -27,8 +27,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
     [SentryDependencyContainer.sharedInstance.viewHierarchy saveViewHierarchy:reportPath];
 }
 
-@interface
-SentryViewHierarchyIntegration ()
+@interface SentryViewHierarchyIntegration ()
 
 @property (nonatomic, strong) SentryOptions *options;
 

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -9,8 +9,7 @@
 #    import <SentryOptions.h>
 #    import <SentrySDK+Private.h>
 
-@interface
-SentryWatchdogTerminationLogic ()
+@interface SentryWatchdogTerminationLogic ()
 
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryCrashWrapper *crashAdapter;

--- a/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
+++ b/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
@@ -6,8 +6,7 @@
 #    import <SentryFileManager.h>
 #    import <SentryLog.h>
 
-@interface
-SentryWatchdogTerminationScopeObserver ()
+@interface SentryWatchdogTerminationScopeObserver ()
 
 @property (strong, nonatomic) SentryFileManager *fileManager;
 @property (strong, nonatomic) NSFileHandle *fileHandle;

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -16,8 +16,7 @@
 #import <SentryWatchdogTerminationLogic.h>
 #import <SentryWatchdogTerminationTracker.h>
 
-@interface
-SentryWatchdogTerminationTracker ()
+@interface SentryWatchdogTerminationTracker ()
 
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryWatchdogTerminationLogic *watchdogTerminationLogic;

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -18,8 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryWatchdogTerminationTrackingIntegration ()
+@interface SentryWatchdogTerminationTrackingIntegration ()
 
 @property (nonatomic, strong) SentryWatchdogTerminationTracker *tracker;
 @property (nonatomic, strong) SentryANRTracker *anrTracker;

--- a/Sources/Sentry/include/HybridPublic/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/HybridPublic/SentryBreadcrumb+Private.h
@@ -1,7 +1,6 @@
 #import "SentryBreadcrumb.h"
 
-@interface
-SentryBreadcrumb ()
+@interface SentryBreadcrumb ()
 
 /**
  * Initializes a SentryBreadcrumb from a JSON object.

--- a/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
+++ b/Sources/Sentry/include/HybridPublic/SentryOptions+HybridSDKs.h
@@ -6,8 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryOptions ()
+@interface SentryOptions ()
 
 - (_Nullable instancetype)initWithDict:(NSDictionary<NSString *, id> *)options
                       didFailWithError:(NSError *_Nullable *_Nullable)error;

--- a/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration-Hybrid.h
+++ b/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration-Hybrid.h
@@ -18,8 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface
-SentrySessionReplayIntegration ()
+@interface SentrySessionReplayIntegration ()
 
 + (id<SentryRRWebEvent>)createBreadcrumbwithTimestamp:(NSDate *)timestamp
                                              category:(NSString *)category

--- a/Sources/Sentry/include/HybridPublic/SentryUser+Private.h
+++ b/Sources/Sentry/include/HybridPublic/SentryUser+Private.h
@@ -1,7 +1,6 @@
 #import "SentryUser.h"
 
-@interface
-SentryUser ()
+@interface SentryUser ()
 
 /**
  * Initializes a SentryUser from a dictionary.

--- a/Sources/Sentry/include/SentryAttachment+Private.h
+++ b/Sources/Sentry/include/SentryAttachment+Private.h
@@ -19,8 +19,7 @@ NSString *nameForSentryAttachmentType(SentryAttachmentType attachmentType);
 
 SentryAttachmentType typeForSentryAttachmentName(NSString *name);
 
-@interface
-SentryAttachment ()
+@interface SentryAttachment ()
 SENTRY_NO_INIT
 
 /**

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -15,8 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface
-SentryClient ()
+@interface SentryClient ()
 
 @property (nonatomic, strong)
     NSMutableArray<id<SentryClientAttachmentProcessor>> *attachmentProcessors;

--- a/Sources/Sentry/include/SentryEnvelope+Private.h
+++ b/Sources/Sentry/include/SentryEnvelope+Private.h
@@ -6,8 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryReplayRecording;
 @class SentryClientReport;
 
-@interface
-SentryEnvelopeItem ()
+@interface SentryEnvelopeItem ()
 
 - (instancetype)initWithClientReport:(SentryClientReport *)clientReport;
 

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -3,8 +3,7 @@
 #import "SentryProfilingConditionals.h"
 #import <Foundation/Foundation.h>
 
-@interface
-SentryEvent ()
+@interface SentryEvent ()
 
 /**
  * This indicates whether this event is a result of a crash.

--- a/Sources/Sentry/include/SentryHttpStatusCodeRange+Private.h
+++ b/Sources/Sentry/include/SentryHttpStatusCodeRange+Private.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryHttpStatusCodeRange ()
+@interface SentryHttpStatusCodeRange ()
 
 - (BOOL)isInRange:(NSInteger)statusCode;
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -17,8 +17,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryHub ()
+@interface SentryHub ()
 
 @property (nullable, nonatomic, strong) SentrySession *session;
 

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -4,9 +4,9 @@
 #define SENTRY_LOG(_SENTRY_LOG_LEVEL, ...)                                                         \
     if ([SentryLog willLogAtLevel:_SENTRY_LOG_LEVEL]) {                                            \
         [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                        \
-                                            [[[NSString stringWithUTF8String:__FILE__]             \
-                                                lastPathComponent] stringByDeletingPathExtension], \
-                                            __LINE__, [NSString stringWithFormat:__VA_ARGS__]]     \
+                                      [[[NSString stringWithUTF8String:__FILE__]                   \
+                                          lastPathComponent] stringByDeletingPathExtension],       \
+                                      __LINE__, [NSString stringWithFormat:__VA_ARGS__]]           \
                          andLevel:_SENTRY_LOG_LEVEL];                                              \
     }
 #define SENTRY_LOG_DEBUG(...) SENTRY_LOG(kSentryLevelDebug, __VA_ARGS__)

--- a/Sources/Sentry/include/SentryMsgPackSerializer.h
+++ b/Sources/Sentry/include/SentryMsgPackSerializer.h
@@ -22,12 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface
-NSData (inputStreameble) <SentryStreamable>
+@interface NSData (inputStreameble) <SentryStreamable>
 @end
 
-@interface
-NSURL (inputStreameble) <SentryStreamable>
+@interface NSURL (inputStreameble) <SentryStreamable>
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -8,8 +8,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
 
-@interface
-SentryOptions ()
+@interface SentryOptions ()
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 @property (nonatomic, assign) BOOL enableProfiling_DEPRECATED_TEST_ONLY;
 - (BOOL)isContinuousProfilingEnabled;

--- a/Sources/Sentry/include/SentryProfilerState+ObjCpp.h
+++ b/Sources/Sentry/include/SentryProfilerState+ObjCpp.h
@@ -10,8 +10,7 @@
  * a bridging header via SentryProfilerState.h due to C++/Swift interop limitations.
  */
 
-@interface
-SentryProfilerState ()
+@interface SentryProfilerState ()
 
 - (void)appendBacktrace:(const sentry::profiling::Backtrace &)backtrace;
 

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -14,8 +14,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySDK ()
+@interface SentrySDK ()
 
 + (void)captureCrashEvent:(SentryEvent *)event;
 

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -9,8 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryScope ()
+@interface SentryScope ()
 
 @property (atomic, copy, nullable) NSString *environmentString;
 

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -5,8 +5,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 NSString *nameForSentrySessionStatus(SentrySessionStatus status);
 
-@interface
-SentrySession ()
+@interface SentrySession ()
 
 @property (nonatomic) NSUInteger errors;
 

--- a/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
@@ -6,8 +6,7 @@
 
 @class SentrySessionReplay;
 
-@interface
-SentrySessionReplayIntegration () <SentryIntegrationProtocol, SentrySessionListener,
+@interface SentrySessionReplayIntegration () <SentryIntegrationProtocol, SentrySessionListener,
     SentrySessionReplayDelegate>
 
 @property (nonatomic, strong) SentrySessionReplay *sessionReplay;

--- a/Sources/Sentry/include/SentrySpan+Private.h
+++ b/Sources/Sentry/include/SentrySpan+Private.h
@@ -2,8 +2,7 @@
 
 #import "SentryProfilingConditionals.h"
 
-@interface
-SentrySpan ()
+@interface SentrySpan ()
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 @property (copy, nonatomic) NSString *_Nullable profileSessionID;

--- a/Sources/Sentry/include/SentrySpanContext+Private.h
+++ b/Sources/Sentry/include/SentrySpanContext+Private.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySpanContext ()
+@interface SentrySpanContext ()
 
 - (instancetype)initWithOperation:(NSString *)operation
                            origin:(NSString *)origin

--- a/Sources/Sentry/include/SentryTracer+Private.h
+++ b/Sources/Sentry/include/SentryTracer+Private.h
@@ -1,7 +1,6 @@
 #import "SentryTracer.h"
 
-@interface
-SentryTracer ()
+@interface SentryTracer ()
 
 @property (nonatomic, strong) SentryHub *hub;
 

--- a/Sources/Sentry/include/SentryTransactionContext+Private.h
+++ b/Sources/Sentry/include/SentryTransactionContext+Private.h
@@ -3,8 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryTransactionContext ()
+@interface SentryTransactionContext ()
 
 - (instancetype)initWithName:(NSString *)name
                   nameSource:(SentryTransactionNameSource)source

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation+Private.h
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation+Private.h
@@ -38,8 +38,7 @@ typedef struct {
     ReportField *reportFields[0];
 } CrashHandlerData;
 
-@interface
-SentryCrashInstallation ()
+@interface SentryCrashInstallation ()
 
 /** Initializer.
  *

--- a/Sources/SentryCrash/Installations/SentryCrashInstallation.m
+++ b/Sources/SentryCrash/Installations/SentryCrashInstallation.m
@@ -54,8 +54,7 @@ crashCallback(const SentryCrashReportWriter *writer)
     }
 }
 
-@interface
-SentryCrashInstallation ()
+@interface SentryCrashInstallation ()
 
 @property (nonatomic, readwrite, assign) int nextFieldIndex;
 @property (nonatomic, readonly, assign) CrashHandlerData *crashHandlerData;
@@ -77,16 +76,15 @@ SentryCrashInstallation ()
     [NSException raise:NSInternalInconsistencyException
                 format:@"%@ does not support init. Subclasses must call "
                        @"initWithMaxReportFieldCount:requiredProperties:",
-                [self class]];
+        [self class]];
     return nil;
 }
 
 - (id)initWithRequiredProperties:(NSArray *)requiredProperties
 {
     if ((self = [super init])) {
-        self.crashHandlerDataBacking =
-            [NSMutableData dataWithLength:sizeof(*self.crashHandlerData)
-                           + sizeof(*self.crashHandlerData->reportFields) * kMaxProperties];
+        self.crashHandlerDataBacking = [NSMutableData dataWithLength:sizeof(*self.crashHandlerData)
+            + sizeof(*self.crashHandlerData->reportFields) * kMaxProperties];
         self.fields = [NSMutableDictionary dictionary];
         self.requiredProperties = requiredProperties;
     }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -163,7 +163,8 @@ CPPExceptionTerminate(void)
                 strncpy(descriptionBuff, exc.what(), sizeof(descriptionBuff));
             }
 #define CATCH_VALUE(TYPE, PRINTFTYPE)                                                              \
-    catch (TYPE value) {                                                                           \
+    catch (TYPE value)                                                                             \
+    {                                                                                              \
         snprintf(descriptionBuff, sizeof(descriptionBuff), "%" #PRINTFTYPE, value);                \
     }
             CATCH_VALUE(char, d)

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -533,7 +533,7 @@ initialize(void)
             stringWithFormat:@"%d.%d", (int)version.majorVersion, (int)version.minorVersion];
     } else {
         systemVersion = [NSString stringWithFormat:@"%d.%d.%d", (int)version.majorVersion,
-                                  (int)version.minorVersion, (int)version.patchVersion];
+            (int)version.minorVersion, (int)version.patchVersion];
     }
     g_systemData.systemVersion = cString(systemVersion);
 

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -54,8 +54,7 @@
 #pragma mark - Globals -
 // ============================================================================
 
-@interface
-SentryCrash ()
+@interface SentryCrash ()
 
 @property (nonatomic, readwrite, retain) NSString *bundleName;
 @property (nonatomic, readwrite, assign) SentryCrashMonitorType monitoringWhenUninstalled;
@@ -448,8 +447,8 @@ SYNTHESIZE_CRASH_STATE_PROPERTY(BOOL, crashedLastLaunch)
     NSMutableDictionary *crashReport =
         [SentryCrashJSONCodec decode:jsonData
                              options:SentryCrashJSONDecodeOptionIgnoreNullInArray
-                             | SentryCrashJSONDecodeOptionIgnoreNullInObject
-                             | SentryCrashJSONDecodeOptionKeepPartialObject
+            | SentryCrashJSONDecodeOptionIgnoreNullInObject
+            | SentryCrashJSONDecodeOptionKeepPartialObject
                                error:&error];
 
     if (error != nil) {

--- a/Sources/SentryCrash/Recording/SentryCrashDoctor.m
+++ b/Sources/SentryCrash/Recording/SentryCrashDoctor.m
@@ -84,7 +84,7 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
                 [string appendString:param.previousClassName];
             } else if (param.className != nil) {
                 [string appendFormat:@"%@ (%@)", param.className,
-                        param.isInstance ? @"instance" : @"class"];
+                    param.isInstance ? @"instance" : @"class"];
             } else {
                 [string appendString:@"?"];
             }
@@ -117,7 +117,7 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
         [str appendFormat:@"Param %d:  ", i + 1];
         if (param.className != nil) {
             [str appendFormat:@"%@ (%@) ", param.className,
-                 param.isInstance ? @"instance" : @"class"];
+                param.isInstance ? @"instance" : @"class"];
         }
         if (param.value != nil) {
             [str appendFormat:@"%@ ", param.value];
@@ -368,9 +368,9 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
     CPUFamily family = [self cpuFamily:report];
     NSDictionary *registers = [self basicRegistersFromThreadReport:crashedThread];
     NSArray *regNames = [NSArray arrayWithObjects:[self registerNameForFamily:family paramIndex:0],
-                                 [self registerNameForFamily:family paramIndex:1],
-                                 [self registerNameForFamily:family paramIndex:2],
-                                 [self registerNameForFamily:family paramIndex:3], nil];
+        [self registerNameForFamily:family paramIndex:1],
+        [self registerNameForFamily:family paramIndex:2],
+        [self registerNameForFamily:family paramIndex:3], nil];
     NSMutableArray *params = [NSMutableArray arrayWithCapacity:4];
     for (NSString *regName in regNames) {
         SentryCrashDoctorParam *param = [[SentryCrashDoctorParam alloc] init];
@@ -459,8 +459,8 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
         }
 
         if ([self isInvalidAddress:errorReport]) {
-            uintptr_t address = (uintptr_t)[
-                [errorReport objectForKey:@SentryCrashField_Address] unsignedLongLongValue];
+            uintptr_t address = (uintptr_t)[[errorReport objectForKey:@SentryCrashField_Address]
+                unsignedLongLongValue];
             if (address == 0) {
                 return @"Attempted to dereference null pointer.";
             }
@@ -473,7 +473,7 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
             } else {
                 return
                     [NSString stringWithFormat:@"Attempted to dereference garbage pointer at %p.",
-                              (void *)address];
+                        (void *)address];
             }
         }
 
@@ -487,11 +487,11 @@ typedef enum { CPUFamilyUnknown, CPUFamilyArm, CPUFamilyX86, CPUFamilyX86_64 } C
         if (symbols) {
             return [NSString stringWithFormat:@"No diagnosis due to exception %@:\n%@\nPlease "
                                               @"file a bug report to the SentryCrash project.",
-                             e, symbols];
+                e, symbols];
         }
         return [NSString stringWithFormat:@"No diagnosis due to exception %@\nPlease file a "
                                           @"bug report to the SentryCrash project.",
-                         e];
+            e];
     }
 }
 

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -163,7 +163,7 @@ addTextFileElement(
     char buffer[512];
     int bytesRead;
     for (bytesRead = (int)read(fd, buffer, sizeof(buffer)); bytesRead > 0;
-         bytesRead = (int)read(fd, buffer, sizeof(buffer))) {
+        bytesRead = (int)read(fd, buffer, sizeof(buffer))) {
         if (sentrycrashjson_appendStringElement(getJsonContext(writer), buffer, bytesRead)
             != SentryCrashJSON_OK) {
             SENTRY_ASYNC_SAFE_LOG_ERROR("Could not append string element");

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodec.c
@@ -1210,7 +1210,7 @@ decodeElement(const char *const name, SentryCrashJSONDecodeContext *context)
         const char *const start = context->bufferPtr;
 
         for (; context->bufferPtr < context->bufferEnd && isdigit(*context->bufferPtr);
-             context->bufferPtr++) {
+            context->bufferPtr++) {
             unlikely_if((isOverflow = accum > (ULLONG_MAX / 10))) { break; }
             accum *= 10;
             int nextDigit = (*context->bufferPtr - '0');

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashJSONCodecObjC.m
@@ -31,8 +31,7 @@
 #import "SentryCrashJSONCodec.h"
 #import "SentryCrashNSErrorUtil.h"
 
-@interface
-SentryCrashJSONCodec ()
+@interface SentryCrashJSONCodec ()
 
 #pragma mark Properties
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashObjCApple.h
@@ -479,7 +479,7 @@ CF_INLINE const void *
 __CFStrContents(CFStringRef str)
 {
     if (__CFStrIsInline(str)) {
-        return (const void *)(((uintptr_t) & (str->variants))
+        return (const void *)(((uintptr_t)&(str->variants))
             + (__CFStrHasExplicitLength(str) ? sizeof(CFIndex) : 0));
     } else { // Not inline; pointer is always word 2
         return str->variants.notInlineImmutable1.buffer;

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -47,8 +47,7 @@
 
 @end
 
-@interface
-SentryCrashReportFilterCombine ()
+@interface SentryCrashReportFilterCombine ()
 
 @property (nonatomic, readwrite, retain) NSArray *filters;
 @property (nonatomic, readwrite, retain) NSArray *keys;
@@ -192,8 +191,7 @@ SentryCrashReportFilterCombine ()
 
 @end
 
-@interface
-SentryCrashReportFilterPipeline ()
+@interface SentryCrashReportFilterPipeline ()
 
 @property (nonatomic, readwrite, retain) NSArray *filters;
 
@@ -289,8 +287,7 @@ SentryCrashReportFilterPipeline ()
 
 @end
 
-@interface
-SentryCrashReportFilterObjectForKey ()
+@interface SentryCrashReportFilterObjectForKey ()
 
 @property (nonatomic, readwrite, retain) id key;
 @property (nonatomic, readwrite, assign) BOOL allowNotFound;
@@ -344,8 +341,7 @@ SentryCrashReportFilterObjectForKey ()
 
 @end
 
-@interface
-SentryCrashReportFilterConcatenate ()
+@interface SentryCrashReportFilterConcatenate ()
 
 @property (nonatomic, readwrite, retain) NSString *separatorFmt;
 @property (nonatomic, readwrite, retain) NSArray *keys;
@@ -411,8 +407,7 @@ SentryCrashReportFilterConcatenate ()
 
 @end
 
-@interface
-SentryCrashReportFilterSubset ()
+@interface SentryCrashReportFilterSubset ()
 
 @property (nonatomic, readwrite, retain) NSArray *keyPaths;
 

--- a/Sources/SentryCrash/Reporting/Filters/Tools/SentryCrashVarArgs.h
+++ b/Sources/SentryCrash/Reporting/Filters/Tools/SentryCrashVarArgs.h
@@ -55,7 +55,7 @@ typedef void (^SentryCrashVA_Block)(id entry);
         va_list sentrycrashva_args;                                                                \
         va_start(sentrycrashva_args, FIRST_ARG_NAME);                                              \
         for (id sentrycrashva_arg = FIRST_ARG_NAME; sentrycrashva_arg != nil;                      \
-             sentrycrashva_arg = va_arg(sentrycrashva_args, id)) {                                 \
+            sentrycrashva_arg = va_arg(sentrycrashva_args, id)) {                                  \
             sentrycrashva_block(sentrycrashva_arg);                                                \
         }                                                                                          \
         va_end(sentrycrashva_args);                                                                \

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
@@ -3,8 +3,7 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
-@interface
-SentryTestObjCRuntimeWrapper ()
+@interface SentryTestObjCRuntimeWrapper ()
 
 @property (nonatomic, strong) SentryDefaultObjCRuntimeWrapper *objcRuntimeWrapper;
 

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegration+Test.h
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegration+Test.h
@@ -4,8 +4,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class SentryOptions, SentryBreadcrumbTracker, SentrySystemEventBreadcrumbs;
 
-@interface
-SentryAutoBreadcrumbTrackingIntegration (Test)
+@interface SentryAutoBreadcrumbTrackingIntegration (Test)
 
 - (void)installWithOptions:(nonnull SentryOptions *)options
          breadcrumbTracker:(SentryBreadcrumbTracker *)breadcrumbTracker

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.h
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.h
@@ -3,8 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryCoreDataTracker (Test)
+@interface SentryCoreDataTracker (Test)
 
 - (BOOL)saveManagedObjectContextWithNilError:(NSManagedObjectContext *)context
                                  originalImp:(BOOL(NS_NOESCAPE ^)(NSError **))original;

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.m
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.m
@@ -1,8 +1,7 @@
 #import "SentryCoreDataTracker+Test.h"
 #import <Foundation/Foundation.h>
 
-@implementation
-SentryCoreDataTracker (Test)
+@implementation SentryCoreDataTracker (Test)
 
 - (BOOL)saveManagedObjectContextWithNilError:(NSManagedObjectContext *)context
                                  originalImp:(BOOL(NS_NOESCAPE ^)(NSError **))original

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTracker+TestInit.h
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTracker+TestInit.h
@@ -9,8 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 SENTRY_EXTERN double slowFrameThreshold(uint64_t actualFramesPerSecond);
 SENTRY_EXTERN CFTimeInterval const SentryFrozenFrameThreshold;
 
-@interface
-SentryFramesTracker (TestInit)
+@interface SentryFramesTracker (TestInit)
 
 - (instancetype)initWithDisplayLinkWrapper:(SentryDisplayLinkWrapper *)displayLinkWrapper;
 

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationObjCTests.m
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationObjCTests.m
@@ -219,9 +219,8 @@
     if ([operation isEqualToString:SENTRY_FILE_READ_OPERATION]) {
         XCTAssertEqualObjects(ioSpan.spanDescription, filename);
     } else {
-        NSString *expectedString =
-            [NSString stringWithFormat:@"%@ (%@)", filename,
-                      [SentryByteCountFormatter bytesCountDescription:someData.length]];
+        NSString *expectedString = [NSString stringWithFormat:@"%@ (%@)", filename,
+            [SentryByteCountFormatter bytesCountDescription:someData.length]];
 
         XCTAssertEqualObjects(ioSpan.spanDescription, expectedString);
     }

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTracker+Testing.h
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTracker+Testing.h
@@ -5,8 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryPerformanceTracker (Testing) <SentryTracerDelegate>
+@interface SentryPerformanceTracker (Testing) <SentryTracerDelegate>
 
 - (void)clear;
 

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzling+Test.h
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzling+Test.h
@@ -4,8 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryUIViewControllerSwizzling (Test)
+@interface SentryUIViewControllerSwizzling (Test)
 
 - (BOOL)shouldSwizzleViewController:(Class)class;
 

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegration+TestInit.h
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegration+TestInit.h
@@ -3,8 +3,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryCrashIntegration (TestInit)
+@interface SentryCrashIntegration (TestInit)
 
 - (instancetype)initWithCrashAdapter:(SentryCrashWrapper *)crashWrapper
              andDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper;

--- a/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchy.h
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchy.h
@@ -7,8 +7,7 @@
 
 void saveViewHierarchy(const char *path);
 
-@interface
-SentryViewHierarchy (Test)
+@interface SentryViewHierarchy (Test)
 - (int)viewHierarchyFromView:(UIView *)view intoContext:(SentryCrashJSONEncodeContext *)context;
 - (BOOL)processViewHierarchy:(NSArray<UIView *> *)windows
                  addFunction:(SentryCrashJSONAddDataFunc)addJSONDataFunc

--- a/Tests/SentryTests/Networking/SentryDsnTests.m
+++ b/Tests/SentryTests/Networking/SentryDsnTests.m
@@ -34,7 +34,7 @@
                                          @"sentry_version=7,sentry_client=sentry.cocoa/"
                                          @"%@,sentry_key=username,sentry_"
                                          @"secret=password",
-                          SentryMeta.versionString];
+            SentryMeta.versionString];
 
     XCTAssertEqualObjects(request.allHTTPHeaderFields[@"X-Sentry-Auth"], authHeader);
     XCTAssertNil(error);
@@ -53,7 +53,7 @@
         [[NSString alloc] initWithFormat:@"Sentry "
                                          @"sentry_version=7,sentry_client=sentry.cocoa/"
                                          @"%@,sentry_key=username",
-                          SentryMeta.versionString];
+            SentryMeta.versionString];
 
     XCTAssertEqualObjects(request.allHTTPHeaderFields[@"X-Sentry-Auth"], authHeader);
     XCTAssertNil(error);

--- a/Tests/SentryTests/Networking/TestNSURLRequestBuilder.m
+++ b/Tests/SentryTests/Networking/TestNSURLRequestBuilder.m
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-TestNSURLRequestBuilder ()
+@interface TestNSURLRequestBuilder ()
 
 @property (nonatomic, strong) SentryNSURLRequestBuilder *builder;
 @property (nonatomic, strong) NSError *error;

--- a/Tests/SentryTests/Protocol/SentryAppState+Equality.h
+++ b/Tests/SentryTests/Protocol/SentryAppState+Equality.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryAppState (Equality)
+@interface SentryAppState (Equality)
 
 - (BOOL)isEqual:(id _Nullable)object;
 

--- a/Tests/SentryTests/Protocol/SentryAppState+Equality.m
+++ b/Tests/SentryTests/Protocol/SentryAppState+Equality.m
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@implementation
-SentryAppState (Equality)
+@implementation SentryAppState (Equality)
 
 - (BOOL)isEqual:(id _Nullable)other
 {

--- a/Tests/SentryTests/Protocol/SentryAttachment+Equality.h
+++ b/Tests/SentryTests/Protocol/SentryAttachment+Equality.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryAttachment (Equality)
+@interface SentryAttachment (Equality)
 
 - (BOOL)isEqual:(id _Nullable)other;
 

--- a/Tests/SentryTests/Protocol/SentryAttachment+Equality.m
+++ b/Tests/SentryTests/Protocol/SentryAttachment+Equality.m
@@ -1,8 +1,7 @@
 #import "SentryAttachment+Equality.h"
 #import "SentryAttachment+Private.h"
 
-@implementation
-SentryAttachment (Equality)
+@implementation SentryAttachment (Equality)
 
 - (BOOL)isEqual:(id _Nullable)other
 {

--- a/Tests/SentryTests/Protocol/SentryMessage+Equality.h
+++ b/Tests/SentryTests/Protocol/SentryMessage+Equality.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryMessage (Equality)
+@interface SentryMessage (Equality)
 
 - (BOOL)isEqual:(id _Nullable)object;
 

--- a/Tests/SentryTests/Protocol/SentryMessage+Equality.m
+++ b/Tests/SentryTests/Protocol/SentryMessage+Equality.m
@@ -1,7 +1,6 @@
 #import "SentryMessage+Equality.h"
 
-@implementation
-SentryMessage (Equality)
+@implementation SentryMessage (Equality)
 
 - (BOOL)isEqual:(id)other
 {

--- a/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.h
+++ b/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySdkInfo (Equality)
+@interface SentrySdkInfo (Equality)
 
 - (BOOL)isEqual:(id _Nullable)object;
 

--- a/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.m
+++ b/Tests/SentryTests/Protocol/SentrySdkInfo+Equality.m
@@ -1,7 +1,6 @@
 #import "SentrySdkInfo+Equality.h"
 
-@implementation
-SentrySdkInfo (Equality)
+@implementation SentrySdkInfo (Equality)
 
 - (BOOL)isEqual:(id _Nullable)object
 {

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.h
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySession (Equality)
+@interface SentrySession (Equality)
 
 - (BOOL)isEqual:(id _Nullable)object;
 

--- a/Tests/SentryTests/Protocol/SentrySession+Equality.m
+++ b/Tests/SentryTests/Protocol/SentrySession+Equality.m
@@ -1,8 +1,7 @@
 #import "SentrySession+Equality.h"
 #import "SentryUser.h"
 
-@implementation
-SentrySession (Equality)
+@implementation SentrySession (Equality)
 
 - (BOOL)isEqual:(id _Nullable)other
 {

--- a/Tests/SentryTests/SentryBinaryImageCache+Private.h
+++ b/Tests/SentryTests/SentryBinaryImageCache+Private.h
@@ -1,8 +1,7 @@
 #import "SentryBinaryImageCache.h"
 #import "SentryCrashBinaryImageCache.h"
 
-@interface
-SentryBinaryImageCache ()
+@interface SentryBinaryImageCache ()
 
 @property (nonatomic, strong) NSArray<SentryBinaryImageInfo *> *cache;
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -9,8 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryClient ()
+@interface SentryClient ()
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
                             dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue

--- a/Tests/SentryTests/SentryContinuousProfiler+Test.h
+++ b/Tests/SentryTests/SentryContinuousProfiler+Test.h
@@ -6,8 +6,7 @@
 
 @class SentryProfiler;
 
-@interface
-SentryContinuousProfiler ()
+@interface SentryContinuousProfiler ()
 
 + (void)stopTimerAndCleanup;
 + (nullable SentryProfiler *)profiler;

--- a/Tests/SentryTests/SentryCrash/Container+DeepSearch_Tests.m
+++ b/Tests/SentryTests/SentryCrash/Container+DeepSearch_Tests.m
@@ -38,11 +38,10 @@
 {
     id expected = @"Object";
     id container = [NSDictionary
-        dictionaryWithObjectsAndKeys:
-            [NSDictionary
-                dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:expected,
-                                                           @"key3", nil],
-                @"key2", nil],
+        dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:
+                                             [NSDictionary dictionaryWithObjectsAndKeys:expected,
+                                                 @"key3", nil],
+                                         @"key2", nil],
         @"key1", nil];
 
     id actual = sentry_objectForKeyPath(container, @"key1/key2/key3");
@@ -53,11 +52,10 @@
 {
     id expected = @"Object";
     id container = [NSDictionary
-        dictionaryWithObjectsAndKeys:
-            [NSDictionary
-                dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:expected,
-                                                           @"key3", nil],
-                @"key2", nil],
+        dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:
+                                             [NSDictionary dictionaryWithObjectsAndKeys:expected,
+                                                 @"key3", nil],
+                                         @"key2", nil],
         @"key1", nil];
 
     id actual = sentry_objectForKeyPath(container, @"/key1/key2/key3");
@@ -68,11 +66,10 @@
 {
     id expected = @"Object";
     id container = [NSDictionary
-        dictionaryWithObjectsAndKeys:
-            [NSDictionary
-                dictionaryWithObjectsAndKeys:[NSDictionary
+        dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:
+                                             [NSDictionary
                                                  dictionaryWithObjectsAndKeys:expected, @"3", nil],
-                @"2", nil],
+                                         @"2", nil],
         @"1", nil];
 
     id actual = sentry_objectForKeyPath(container, @"1/2/3");
@@ -84,8 +81,8 @@
     id expected = @"Object";
     id container =
         [NSArray arrayWithObjects:[NSArray arrayWithObjects:@"blah",
-                                           [NSArray arrayWithObjects:@"blah2", expected, nil], nil],
-                 nil];
+                                      [NSArray arrayWithObjects:@"blah2", expected, nil], nil],
+            nil];
 
     id actual = sentry_objectForKeyPath(container, @"0/1/1");
     XCTAssertEqualObjects(expected, actual, @"");
@@ -96,9 +93,9 @@
     id expected = @"Object";
     id container = [NSDictionary
         dictionaryWithObjectsAndKeys:[NSArray arrayWithObjects:@"blah",
-                                              [NSDictionary dictionaryWithObjectsAndKeys:expected,
-                                                            @"key3", nil],
-                                              nil],
+                                         [NSDictionary
+                                             dictionaryWithObjectsAndKeys:expected, @"key3", nil],
+                                         nil],
         @"key1", nil];
 
     id actual = sentry_objectForKeyPath(container, @"key1/1/key3");

--- a/Tests/SentryTests/SentryCrash/SentryCrash+Test.h
+++ b/Tests/SentryTests/SentryCrash/SentryCrash+Test.h
@@ -1,6 +1,5 @@
 #import "SentryCrash.h"
 
-@interface
-SentryCrash (Test)
+@interface SentryCrash (Test)
 - (NSString *)getBundleName;
 @end

--- a/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashJSONCodec_Tests.m
@@ -288,7 +288,7 @@ toString(NSData *data)
     NSString *expected = @"[{\"Blah\":true}]";
     id original = [NSArray
         arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithBool:YES],
-                                       @"Blah", nil],
+                             @"Blah", nil],
         nil];
     NSString *jsonString = toString([SentryCrashJSONCodec encode:original
                                                          options:SentryCrashJSONEncodeOptionSorted
@@ -451,9 +451,8 @@ toString(NSData *data)
 {
     NSError *error = (NSError *)self;
     NSString *expected = @"{\"One\":\"Value\",\"Three\":true,\"Two\":1000}";
-    id original =
-        [NSDictionary dictionaryWithObjectsAndKeys:@"Value", @"One", [NSNumber numberWithInt:1000],
-                      @"Two", [NSNumber numberWithBool:YES], @"Three", nil];
+    id original = [NSDictionary dictionaryWithObjectsAndKeys:@"Value", @"One",
+        [NSNumber numberWithInt:1000], @"Two", [NSNumber numberWithBool:YES], @"Three", nil];
     NSString *jsonString = toString([SentryCrashJSONCodec encode:original
                                                          options:SentryCrashJSONEncodeOptionSorted
                                                            error:&error]);
@@ -593,17 +592,16 @@ toString(NSData *data)
 - (void)testSerializeDeserializeBigDictionary
 {
     NSError *error = (NSError *)self;
-    id original = [NSDictionary
-        dictionaryWithObjectsAndKeys:@"0", @"0", @"1", @"1", @"2", @"2", @"3", @"3", @"4", @"4",
-        @"5", @"5", @"6", @"6", @"7", @"7", @"8", @"8", @"9", @"9", @"10", @"10", @"11", @"11",
-        @"12", @"12", @"13", @"13", @"14", @"14", @"15", @"15", @"16", @"16", @"17", @"17", @"18",
-        @"18", @"19", @"19", @"20", @"20", @"21", @"21", @"22", @"22", @"23", @"23", @"24", @"24",
-        @"25", @"25", @"26", @"26", @"27", @"27", @"28", @"28", @"29", @"29", @"30", @"30", @"31",
-        @"31", @"32", @"32", @"33", @"33", @"34", @"34", @"35", @"35", @"36", @"36", @"37", @"37",
-        @"38", @"38", @"39", @"39", @"40", @"40", @"41", @"41", @"42", @"42", @"43", @"43", @"44",
-        @"44", @"45", @"45", @"46", @"46", @"47", @"47", @"48", @"48", @"49", @"49", @"50", @"50",
-        @"51", @"51", @"52", @"52", @"53", @"53", @"54", @"54", @"55", @"55", @"56", @"56", @"57",
-        @"57", @"58", @"58", @"59", @"59", nil];
+    id original = [NSDictionary dictionaryWithObjectsAndKeys:@"0", @"0", @"1", @"1", @"2", @"2",
+        @"3", @"3", @"4", @"4", @"5", @"5", @"6", @"6", @"7", @"7", @"8", @"8", @"9", @"9", @"10",
+        @"10", @"11", @"11", @"12", @"12", @"13", @"13", @"14", @"14", @"15", @"15", @"16", @"16",
+        @"17", @"17", @"18", @"18", @"19", @"19", @"20", @"20", @"21", @"21", @"22", @"22", @"23",
+        @"23", @"24", @"24", @"25", @"25", @"26", @"26", @"27", @"27", @"28", @"28", @"29", @"29",
+        @"30", @"30", @"31", @"31", @"32", @"32", @"33", @"33", @"34", @"34", @"35", @"35", @"36",
+        @"36", @"37", @"37", @"38", @"38", @"39", @"39", @"40", @"40", @"41", @"41", @"42", @"42",
+        @"43", @"43", @"44", @"44", @"45", @"45", @"46", @"46", @"47", @"47", @"48", @"48", @"49",
+        @"49", @"50", @"50", @"51", @"51", @"52", @"52", @"53", @"53", @"54", @"54", @"55", @"55",
+        @"56", @"56", @"57", @"57", @"58", @"58", @"59", @"59", nil];
     NSString *jsonString = toString([SentryCrashJSONCodec encode:original
                                                          options:SentryCrashJSONEncodeOptionSorted
                                                            error:&error]);
@@ -620,18 +618,14 @@ toString(NSData *data)
     NSError *error = (NSError *)self;
     NSString *expected = @"{\"a0\":\"A0\",\"a1\":{\"b0\":{\"c0\":\"C0\",\"c1\":{\"d0\":[[],[],"
                          @"[]],\"d1\":\"D1\"}},\"b1\":\"B1\"},\"a2\":\"A2\"}";
-    id original = [NSDictionary
-        dictionaryWithObjectsAndKeys:@"A0", @"a0",
+    id original = [NSDictionary dictionaryWithObjectsAndKeys:@"A0", @"a0",
         [NSDictionary
-            dictionaryWithObjectsAndKeys:
-                [NSDictionary
-                    dictionaryWithObjectsAndKeys:@"C0", @"c0",
-                    [NSDictionary
-                        dictionaryWithObjectsAndKeys:[NSArray arrayWithObjects:[NSArray array],
-                                                              [NSArray array], [NSArray array],
-                                                              nil],
-                        @"d0", @"D1", @"d1", nil],
-                    @"c1", nil],
+            dictionaryWithObjectsAndKeys:[NSDictionary dictionaryWithObjectsAndKeys:@"C0", @"c0",
+                                             [NSDictionary dictionaryWithObjectsAndKeys:
+                                                     [NSArray arrayWithObjects:[NSArray array],
+                                                         [NSArray array], [NSArray array], nil],
+                                                 @"d0", @"D1", @"d1", nil],
+                                             @"c1", nil],
             @"b0", @"B1", @"b1", nil],
         @"a1", @"A2", @"a2", nil];
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportFilter_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportFilter_Tests.m
@@ -278,8 +278,8 @@
     NSArray *source = [NSArray arrayWithObjects:@"1", @"2", @"3", nil];
     NSArray *expected =
         [NSArray arrayWithObjects:(id _Nonnull)[@"1" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
+            (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
     id<SentryCrashReportFilter> filter = [SentryCrashReportFilterStringToData filter];
 
     [filter filterReports:source
@@ -294,8 +294,8 @@
 {
     NSArray *source =
         [NSArray arrayWithObjects:(id _Nonnull)[@"1" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
+            (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
     NSArray *expected = [NSArray arrayWithObjects:@"1", @"2", @"3", nil];
     id<SentryCrashReportFilter> filter = [SentryCrashReportFilterDataToString filter];
 
@@ -327,8 +327,8 @@
     NSArray *expected1 = [NSArray arrayWithObjects:@"1", @"2", @"3", nil];
     NSArray *expected2 =
         [NSArray arrayWithObjects:(id _Nonnull)[@"1" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
+            (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
     id<SentryCrashReportFilter> filter = [SentryCrashReportFilterCombine
         filterWithFiltersAndKeys:[SentryCrashReportFilterPassthrough filter], @"normal",
         [SentryCrashReportFilterStringToData filter], @"data", nil];
@@ -354,8 +354,8 @@
     NSArray *expected1 = [NSArray arrayWithObjects:@"1", @"2", @"3", nil];
     NSArray *expected2 =
         [NSArray arrayWithObjects:(id _Nonnull)[@"1" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
+            (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
     id<SentryCrashReportFilter> filter = [[SentryCrashReportFilterCombine alloc]
         initWithFiltersAndKeys:[SentryCrashReportFilterPassthrough filter], @"normal",
         [SentryCrashReportFilterStringToData filter], @"data", nil];
@@ -429,8 +429,8 @@
     NSArray *expected1 = [NSArray arrayWithObjects:@"1", @"2", @"3", nil];
     NSArray *expected2 =
         [NSArray arrayWithObjects:(id _Nonnull)[@"1" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
-                 (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
+            (id _Nonnull)[@"2" dataUsingEncoding:NSUTF8StringEncoding],
+            (id _Nonnull)[@"3" dataUsingEncoding:NSUTF8StringEncoding], nil];
     id<SentryCrashReportFilter> filter = [SentryCrashReportFilterCombine
         filterWithFiltersAndKeys:[NSArray
                                      arrayWithObject:[SentryCrashReportFilterPassthrough filter]],
@@ -544,8 +544,8 @@
 - (void)testConcatenate
 {
     NSArray *reports = [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:@"1",
-                                                               @"first", @"a", @"second", nil],
-                                nil];
+                                                     @"first", @"a", @"second", nil],
+        nil];
     NSString *expected = @"1,a";
     id<SentryCrashReportFilter> filter =
         [SentryCrashReportFilterConcatenate filterWithSeparatorFmt:@","
@@ -562,8 +562,8 @@
 - (void)testConcatenateInit
 {
     NSArray *reports = [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:@"1",
-                                                               @"first", @"a", @"second", nil],
-                                nil];
+                                                     @"first", @"a", @"second", nil],
+        nil];
     NSString *expected = @"1,a";
     id<SentryCrashReportFilter> filter =
         [[SentryCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@","
@@ -582,8 +582,8 @@
 {
     NSArray *reports =
         [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:@"1", @"first", @"a",
-                                                @"second", @"b", @"third", nil],
-                 nil];
+                                      @"second", @"b", @"third", nil],
+            nil];
     NSDictionary *expected =
         [NSDictionary dictionaryWithObjectsAndKeys:@"1", @"first", @"b", @"third", nil];
     id<SentryCrashReportFilter> filter =
@@ -601,8 +601,8 @@
 {
     NSArray *reports =
         [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:@"1", @"first", @"a",
-                                                @"second", @"b", @"third", nil],
-                 nil];
+                                      @"second", @"b", @"third", nil],
+            nil];
     id<SentryCrashReportFilter> filter =
         [SentryCrashReportFilterSubset filterWithKeys:@"first", @"aaa", nil];
 
@@ -617,8 +617,8 @@
 {
     NSArray *reports =
         [NSArray arrayWithObjects:[NSDictionary dictionaryWithObjectsAndKeys:@"1", @"first", @"a",
-                                                @"second", @"b", @"third", nil],
-                 nil];
+                                      @"second", @"b", @"third", nil],
+            nil];
     NSDictionary *expected =
         [NSDictionary dictionaryWithObjectsAndKeys:@"1", @"first", @"b", @"third", nil];
     id<SentryCrashReportFilter> filter =

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportStore_Tests.m
@@ -253,7 +253,7 @@
 
     XCTAssertEqualObjects([NSString stringWithUTF8String:attachmentsPath],
         [self.tempPath stringByAppendingPathComponent:
-                           @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
+                @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
 }
 
 - (void)test_AttachmentsPath_forReport
@@ -271,7 +271,7 @@
 
     XCTAssertEqualObjects([NSString stringWithUTF8String:attachmentsPath],
         [self.tempPath stringByAppendingPathComponent:
-                           @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
+                @"/ReportPath/AppName-report-00000013b0ac358d-attachments"]);
 }
 
 - (void)test_initializeIDs

--- a/Tests/SentryTests/SentryCrash/SentryCrashTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashTests.m
@@ -7,8 +7,7 @@
 
 @end
 
-@interface
-SentryCrash ()
+@interface SentryCrash ()
 
 - (NSString *)clearBundleName:(NSString *)filename;
 
@@ -36,7 +35,7 @@ SentryCrash ()
     XCTAssertEqual(files.count, 1);
     XCTAssertEqualObjects(files.firstObject,
         [self.tempPath stringByAppendingPathComponent:
-                           @"Reports/AppName-report-000000000000000c-attachments/0.png"]);
+                @"Reports/AppName-report-000000000000000c-attachments/0.png"]);
 }
 
 - (void)test_getScreenshots_TwoFiles

--- a/Tests/SentryTests/SentryCrash/SentryDebugImageProvider+TestInit.h
+++ b/Tests/SentryTests/SentryCrash/SentryDebugImageProvider+TestInit.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryDebugImageProvider (TestInit)
+@interface SentryDebugImageProvider (TestInit)
 - (instancetype)initWithBinaryImageProvider:(id<SentryCrashBinaryImageProvider>)binaryImageProvider;
 
 @end

--- a/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.h
+++ b/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.h
@@ -27,8 +27,7 @@
 
 #import <XCTest/XCTest.h>
 
-@interface
-XCTestCase (XCTestCase_SentryCrash)
+@interface XCTestCase (XCTestCase_SentryCrash)
 
 - (NSString *)createTempPath;
 

--- a/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.m
+++ b/Tests/SentryTests/SentryCrash/XCTestCase+SentryCrash.m
@@ -27,8 +27,7 @@
 
 #import "XCTestCase+SentryCrash.h"
 
-@implementation
-XCTestCase (XCTestCase_SentryCrash)
+@implementation XCTestCase (XCTestCase_SentryCrash)
 
 - (NSString *)createTempPath
 {

--- a/Tests/SentryTests/SentryKSCrashReportConverterTests.m
+++ b/Tests/SentryTests/SentryKSCrashReportConverterTests.m
@@ -446,7 +446,7 @@
 
     NSLog(@"%@",
         [NSString stringWithFormat:@"%@",
-                  [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]]);
+            [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]]);
 }
 
 - (void)testBreadcrumb:(NSString *)reportPath

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -84,7 +84,7 @@
 {
     NSDictionary *infoDict = [[NSBundle mainBundle] infoDictionary];
     return [NSString stringWithFormat:@"%@@%@+%@", infoDict[@"CFBundleIdentifier"],
-                     infoDict[@"CFBundleShortVersionString"], infoDict[@"CFBundleVersion"]];
+        infoDict[@"CFBundleShortVersionString"], infoDict[@"CFBundleVersion"]];
 }
 
 - (void)testEnvironment

--- a/Tests/SentryTests/SentrySDK+Tests.h
+++ b/Tests/SentryTests/SentrySDK+Tests.h
@@ -6,8 +6,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentrySDK ()
+@interface SentrySDK ()
 
 + (void)setCurrentHub:(nullable SentryHub *)hub;
 

--- a/Tests/SentryTests/SentryScope+Equality.h
+++ b/Tests/SentryTests/SentryScope+Equality.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryScope (Equality)
+@interface SentryScope (Equality)
 
 - (BOOL)isEqual:(id _Nullable)other;
 - (BOOL)isEqualToScope:(SentryScope *)scope;

--- a/Tests/SentryTests/SentryScope+Equality.m
+++ b/Tests/SentryTests/SentryScope+Equality.m
@@ -2,8 +2,7 @@
 #import "SentryScope+Properties.h"
 #import "SentryUser.h"
 
-@implementation
-SentryScope (Equality)
+@implementation SentryScope (Equality)
 
 - (BOOL)isEqual:(id _Nullable)other
 {

--- a/Tests/SentryTests/SentryScope+Properties.h
+++ b/Tests/SentryTests/SentryScope+Properties.h
@@ -7,8 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /** Expose the internal properties for testing. */
-@interface
-SentryScope (Properties)
+@interface SentryScope (Properties)
 
 @property (atomic, strong) SentryUser *_Nullable userObject;
 @property (nonatomic, strong) NSMutableDictionary<NSString *, NSString *> *_Nullable tagDictionary;

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -13,8 +13,7 @@
 #import <XCTest/XCTest.h>
 @import Sentry;
 
-@interface
-SentryBreadcrumbTracker ()
+@interface SentryBreadcrumbTracker ()
 
 + (NSString *)sanitizeViewControllerName:(NSString *)controller;
 

--- a/Tests/SentryTests/SentryTraceProfiler+Test.h
+++ b/Tests/SentryTests/SentryTraceProfiler+Test.h
@@ -10,8 +10,7 @@
 
 SENTRY_EXTERN NSTimer *_Nullable _sentry_threadUnsafe_traceProfileTimeoutTimer;
 
-@interface
-SentryTraceProfiler ()
+@interface SentryTraceProfiler ()
 
 #    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
 

--- a/Tests/SentryTests/SentryUIApplication+Private.h
+++ b/Tests/SentryTests/SentryUIApplication+Private.h
@@ -9,8 +9,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryUIApplication ()
+@interface SentryUIApplication ()
 
 - (NSArray<UIViewController *> *)relevantViewControllers;
 

--- a/Tests/SentryTests/State/SentryInstallation+Test.h
+++ b/Tests/SentryTests/State/SentryInstallation+Test.h
@@ -1,7 +1,6 @@
 #import "SentryInstallation.h"
 
-@interface
-SentryInstallation (Test)
+@interface SentryInstallation (Test)
 @property (class, nonatomic, readonly)
     NSMutableDictionary<NSString *, NSString *> *installationStringsByCacheDirectoryPaths;
 @end

--- a/Tests/SentryTests/TestUtils/SentryBooleanSerialization.m
+++ b/Tests/SentryTests/TestUtils/SentryBooleanSerialization.m
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     NSString *selectorString =
         [NSString stringWithFormat:@"set%@%@:", [[property substringToIndex:1] uppercaseString],
-                  [property substringFromIndex:1]];
+            [property substringFromIndex:1]];
     SEL selector = NSSelectorFromString(selectorString);
     NSAssert([serializable respondsToSelector:selector], @"Object doesn't have a property '%@'",
         property);

--- a/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
+++ b/Tests/SentryTests/TestUtils/SentryInvalidJSONString.m
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryInvalidJSONString ()
+@interface SentryInvalidJSONString ()
 
 @property (nonatomic, strong) NSString *stringHolder;
 @property (nonatomic, assign) NSUInteger lengthInvocations;

--- a/Tests/SentryTests/Transaction/SentryTracer+Test.h
+++ b/Tests/SentryTests/Transaction/SentryTracer+Test.h
@@ -2,8 +2,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface
-SentryTracer (Test)
+@interface SentryTracer (Test)
 
 + (void)resetAppStartMeasurementRead;
 


### PR DESCRIPTION
`clang-format` had updated and we need a PR to use its new format


_#skip-changelog_