### PR TITLE
test: Switch testCorruptEnvelope to a unit test

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
@@ -92,20 +92,6 @@ class LaunchUITests: BaseUITest {
         XCTAssertTrue(0.5 > frozenFramesPercentage, "Too many frozen frames.")
     }
     
-    func testCorruptEnvelope() {
-        // This is to prevent https://github.com/getsentry/sentry-cocoa/issues/4280
-        // Tapping "Corrupt Envelope" will try to capture an envelope but it closes the app
-        // in the middle of the process. For 8.33.0 this would generate a corrupted envelope.
-        // 8.35.0+ reverts to writing envelopes atomically, so that in this scenario no envelope is written, as is expected.
-        // By opening the app again we can check whether the SDK can handle such scenario.
-        app.buttons["Corrupt Envelope"].tap()
-        app.tabBars.firstMatch.waitForNonExistence("The app did not closed")
-        
-        app.launch()
-        app.waitForExistence("App did not open again")
-        XCTAssertEqual(app.state, .runningForeground)
-    }
-    
     func testCheckTotalFrames() {
         app.buttons["Extra"].tap()
         

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -747,13 +747,13 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="40A-vG-dFA">
-                                <rect key="frame" x="0.0" y="134" width="320" height="268"/>
+                                <rect key="frame" x="0.0" y="134" width="320" height="246.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="fn9-mQ-2PY">
-                                        <rect key="frame" x="0.0" y="0.0" width="320" height="140"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="320" height="118.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Q2k-6Y-RnD">
-                                                <rect key="frame" x="0.0" y="0.0" width="160" height="140"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="160" height="118.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NFC-V3-lgW">
                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
@@ -764,7 +764,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Llv-Yz-cwF">
-                                                        <rect key="frame" x="0.0" y="28" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="30" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Capture NSException"/>
                                                         <connections>
@@ -772,7 +772,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJ4-gS-64G" userLabel="fatalError">
-                                                        <rect key="frame" x="0.0" y="56" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="60.5" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Throw FatalError"/>
                                                         <connections>
@@ -780,25 +780,17 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NYx-6R-0bb">
-                                                        <rect key="frame" x="0.0" y="84" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="90.5" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="OOM crash"/>
                                                         <connections>
                                                             <action selector="oomCrash:" destination="QmU-DD-itF" eventType="touchUpInside" id="U4n-XL-dJf"/>
                                                         </connections>
                                                     </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rJk-dh-q7U">
-                                                        <rect key="frame" x="0.0" y="112" width="160" height="28"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                        <state key="normal" title="Corrupt Envelope"/>
-                                                        <connections>
-                                                            <action selector="corruptEnvelope:" destination="QmU-DD-itF" eventType="touchUpInside" id="5hY-Uf-cey"/>
-                                                        </connections>
-                                                    </button>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="2CV-VI-MDY">
-                                                <rect key="frame" x="160" y="0.0" width="160" height="140"/>
+                                                <rect key="frame" x="160" y="0.0" width="160" height="118.5"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zbo-2T-1Zm">
                                                         <rect key="frame" x="0.0" y="0.0" width="160" height="28"/>
@@ -810,7 +802,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="s6w-E3-5yE" userLabel="DiskWriteException">
-                                                        <rect key="frame" x="0.0" y="35" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="28" width="160" height="28"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="DiskWriteException"/>
                                                         <connections>
@@ -818,7 +810,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NNd-Ec-zXw">
-                                                        <rect key="frame" x="0.0" y="70.5" width="160" height="28"/>
+                                                        <rect key="frame" x="0.0" y="56" width="160" height="28"/>
                                                         <accessibility key="accessibilityConfiguration" label="crashTheApp"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                         <state key="normal" title="Crash the app"/>
@@ -827,7 +819,7 @@
                                                         </connections>
                                                     </button>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wJs-Av-cg2">
-                                                        <rect key="frame" x="0.0" y="105.5" width="160" height="34.5"/>
+                                                        <rect key="frame" x="0.0" y="84" width="160" height="34.5"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="plain" title="Use-after-free"/>
                                                         <connections>
@@ -839,7 +831,7 @@
                                         </subviews>
                                     </stackView>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="1zm-ho-TCr">
-                                        <rect key="frame" x="0.0" y="140" width="320" height="128"/>
+                                        <rect key="frame" x="0.0" y="118.5" width="320" height="128"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="128" id="lc6-97-p3W"/>
                                         </constraints>

--- a/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ErrorsViewController.swift
@@ -84,20 +84,4 @@ class ErrorsViewController: UIViewController {
             }
         }
     }
-    
-    @IBAction func corruptEnvelope(_ sender: UIButton) {
-        class TestSentryEnvelopeItem: SentryEnvelopeItem {
-            override var header: SentryEnvelopeItemHeader {
-                SentryEnvelopeItemHeader(type: "test", length: 50)
-            }
-            
-            override var data: Data {
-                defer { exit(0) }
-                return Data(repeating: 1, count: 100_000_000)
-            }
-        }
-        
-        let envelope = SentryEnvelope(id: SentryId(uuid: UUID()), singleItem: TestSentryEnvelopeItem())
-        SentrySDK.capture(envelope)
-    }
 }

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -298,20 +298,6 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertEqual(payloadAsString.data(using: .utf8), item.data)
     }
     
-    /// This is to prevent https://github.com/getsentry/sentry-cocoa/issues/4280
-    /// With 8.33.0, writing an envelope could fail in the middle of the process, which the envelope
-    /// payload below simulates. The JSON stems from writing an envelope to disk with vast data
-    /// that leads to an OOM termination on v 8.33.0.
-    /// Running this test on v 8.33.0 leads to a crash.
-    func testEnvelopeWithDataCorruptEnvelope() throws {
-        let itemData = """
-                       {"event_id":"1990b5bc31904b7395fd07feb72daf1c","sdk":{"name":"sentry.cocoa","version":"8.33.0"}}
-                       {"type":"test","length":50}
-                       """.data(using: .utf8)!
-        
-        XCTAssertNil(SentrySerialization.envelope(with: itemData))
-    }
-    
     func testEnvelopeWithData_CorruptHeader_ReturnsNil() throws {
         var itemData = Data()
         itemData.append(contentsOf: [0xFF, 0xFF, 0xFF]) // Invalid UTF-8 bytes

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -298,6 +298,20 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertEqual(payloadAsString.data(using: .utf8), item.data)
     }
     
+    /// This is to prevent https://github.com/getsentry/sentry-cocoa/issues/4280
+    /// With 8.33.0, writing an envelope could fail in the middle of the process, which the envelope
+    /// payload below simulates. The JSON stems from writing an envelope to disk with vast data
+    /// that leads to an OOM termination on v 8.33.0.
+    /// Running this test on v 8.33.0 leads to a crash.
+    func testEnvelopeWithDataCorruptEnvelope() throws {
+        let itemData = """
+                       {"event_id":"1990b5bc31904b7395fd07feb72daf1c","sdk":{"name":"sentry.cocoa","version":"8.33.0"}}
+                       {"type":"test","length":50}
+                       """.data(using: .utf8)!
+        
+        XCTAssertNil(SentrySerialization.envelope(with: itemData))
+    }
+    
     func testEnvelopeWithData_CorruptHeader_ReturnsNil() throws {
         var itemData = Data()
         itemData.append(contentsOf: [0xFF, 0xFF, 0xFF]) // Invalid UTF-8 bytes

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -357,6 +357,27 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(envelope.header.eventId, fixture.client.storedEnvelopeInvocations.first?.header.eventId)
     }
     
+    /// This is to prevent https://github.com/getsentry/sentry-cocoa/issues/4280
+    /// With 8.33.0, writing an envelope could fail in the middle of the process, which the envelope
+    /// payload below simulates. The JSON stems from writing an envelope to disk with vast data
+    /// that leads to an OOM termination on v 8.33.0.
+    /// Running this test on v 8.33.0 leads to a crash.
+    func testStartSDK_WithCorruptedEnvelope() throws {
+        
+        let fileManager = try SentryFileManager(options: fixture.options)
+        
+        let corruptedEnvelopeData = """
+                       {"event_id":"1990b5bc31904b7395fd07feb72daf1c","sdk":{"name":"sentry.cocoa","version":"8.33.0"}}
+                       {"type":"test","length":50}
+                       """.data(using: .utf8)!
+        
+        try corruptedEnvelopeData.write(to: URL(fileURLWithPath: "\(fileManager.envelopesPath)/corrupted-envelope.json"))
+        
+        SentrySDK.start(options: fixture.options)
+        
+        fileManager.deleteAllEnvelopes()
+    }
+    
     func testStoreEnvelope_WhenNoClient_NoCrash() {
         SentrySDK.store(SentryEnvelope(event: TestData.event))
         


### PR DESCRIPTION
Change the testCorruptEnvelope to a unit test instead of using a UITest. Tapping the corruptEnvelope button after v 8.33.0 doesn't even create an envelope because the writing of the envelope is atomic. The app terminates without writing an envelope. As the UITest was flaky, we instead switched to a unit test validating the underlying problem of deserializing a corrupted envelope. Furthermore, we have to ensure that the corrupted envelopes don't crash when deserializing them because we have no guarantee that our users don't modify the envelope files.

#skip-changelog