### PR TITLE
ref: Remove unused tracer arg for TracerDelegate

### DIFF
--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -221,7 +221,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (nullable id<SentrySpan>)activeSpanForTracer:(SentryTracer *)tracer
+- (nullable id<SentrySpan>)getActiveSpan
 {
     @synchronized(self.activeSpanStack) {
         return [self.activeSpanStack lastObject];

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -328,7 +328,7 @@ static BOOL appStartMeasurementRead;
 
     if (self.delegate) {
         @synchronized(_children) {
-            span = [self.delegate activeSpanForTracer:self];
+            span = [self.delegate getActiveSpan];
             if (span == nil || ![_children containsObject:span]) {
                 span = self;
             }

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -23,10 +23,10 @@ static const NSTimeInterval SENTRY_AUTO_TRANSACTION_MAX_DURATION = 500.0;
 @protocol SentryTracerDelegate
 
 /**
- * Return the active span of given tracer.
+ * Return the active span.
  * This function is used to determine which span will be used to create a new child.
  */
-- (nullable id<SentrySpan>)activeSpanForTracer:(SentryTracer *)tracer;
+- (nullable id<SentrySpan>)getActiveSpan;
 
 /**
  * Report that the tracer has finished.


### PR DESCRIPTION
Remove passing tracer to the tracer delegate activeSpan because it's not used.

#skip-changelog