### PR TITLE
ref: Unify ANRTrackerDelegate

### DIFF
--- a/Sources/Sentry/SentryANRTracker.m
+++ b/Sources/Sentry/SentryANRTracker.m
@@ -143,7 +143,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     }
 
     for (id<SentryANRTrackerDelegate> target in localListeners) {
-        [target anrDetected];
+        [target anrDetectedWithType:SentryANRTypeUnknown];
     }
 }
 

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -26,7 +26,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 @property (nonatomic, strong) SentryThreadWrapper *threadWrapper;
-@property (nonatomic, strong) NSHashTable<id<SentryANRTrackerV2Delegate>> *listeners;
+@property (nonatomic, strong) NSHashTable<id<SentryANRTrackerDelegate>> *listeners;
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;
 @property (nonatomic, assign) NSTimeInterval timeoutInterval;
 
@@ -199,7 +199,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         localListeners = [self.listeners allObjects];
     }
 
-    for (id<SentryANRTrackerV2Delegate> target in localListeners) {
+    for (id<SentryANRTrackerDelegate> target in localListeners) {
         [target anrDetectedWithType:type];
     }
 }
@@ -211,12 +211,12 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         targets = [self.listeners allObjects];
     }
 
-    for (id<SentryANRTrackerV2Delegate> target in targets) {
+    for (id<SentryANRTrackerDelegate> target in targets) {
         [target anrStopped];
     }
 }
 
-- (void)addListener:(id<SentryANRTrackerV2Delegate>)listener
+- (void)addListener:(id<SentryANRTrackerDelegate>)listener
 {
     @synchronized(self.listeners) {
         [self.listeners addObject:listener];
@@ -234,7 +234,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     }
 }
 
-- (void)removeListener:(id<SentryANRTrackerV2Delegate>)listener
+- (void)removeListener:(id<SentryANRTrackerDelegate>)listener
 {
     @synchronized(self.listeners) {
         [self.listeners removeObject:listener];

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -75,7 +75,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self uninstall];
 }
 
-- (void)anrDetected
+- (void)anrDetectedWithType:(enum SentryANRType)type
 {
     if (self.reportAppHangs == NO) {
         SENTRY_LOG_DEBUG(@"AppHangTracking paused. Ignoring reported app hang.")

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -102,7 +102,7 @@ NS_ASSUME_NONNULL_BEGIN
     [self.anrTracker removeListener:self];
 }
 
-- (void)anrDetected
+- (void)anrDetectedWithType:(enum SentryANRType)type
 {
     [self.appStateManager
         updateAppState:^(SentryAppState *appState) { appState.isANROngoing = YES; }];

--- a/Sources/Sentry/include/SentryANRTracker.h
+++ b/Sources/Sentry/include/SentryANRTracker.h
@@ -1,7 +1,10 @@
 #import "SentryDefines.h"
 #import "SentrySwift.h"
 
-@class SentryOptions, SentryCrashWrapper, SentryDispatchQueueWrapper, SentryThreadWrapper;
+@class SentryOptions;
+@class SentryCrashWrapper;
+@class SentryDispatchQueueWrapper;
+@class SentryThreadWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryANRTracker.h
+++ b/Sources/Sentry/include/SentryANRTracker.h
@@ -5,8 +5,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol SentryANRTrackerDelegate;
-
 /**
  * This class detects ANRs with a dedicated watchdog thread. The thread schedules a simple block to
  * run on the main thread, sleeps for the configured timeout interval, and checks if the main thread

--- a/Sources/Sentry/include/SentryANRTracker.h
+++ b/Sources/Sentry/include/SentryANRTracker.h
@@ -1,4 +1,5 @@
 #import "SentryDefines.h"
+#import "SentrySwift.h"
 
 @class SentryOptions, SentryCrashWrapper, SentryDispatchQueueWrapper, SentryThreadWrapper;
 
@@ -33,17 +34,6 @@ SENTRY_NO_INIT
 
 // Function used for tests
 - (void)clear;
-
-@end
-
-/**
- * The ``SentryANRTracker`` calls the methods from background threads.
- */
-@protocol SentryANRTrackerDelegate <NSObject>
-
-- (void)anrDetected;
-
-- (void)anrStopped;
 
 @end
 

--- a/Sources/Sentry/include/SentryANRTrackerV2.h
+++ b/Sources/Sentry/include/SentryANRTrackerV2.h
@@ -29,9 +29,9 @@ SENTRY_NO_INIT
                           threadWrapper:(SentryThreadWrapper *)threadWrapper
                           framesTracker:(SentryFramesTracker *)framesTracker;
 
-- (void)addListener:(id<SentryANRTrackerV2Delegate>)listener;
+- (void)addListener:(id<SentryANRTrackerDelegate>)listener;
 
-- (void)removeListener:(id<SentryANRTrackerV2Delegate>)listener;
+- (void)removeListener:(id<SentryANRTrackerDelegate>)listener;
 
 // Function used for tests
 - (void)clear;

--- a/Sources/Sentry/include/SentryANRTrackingIntegrationV2.h
+++ b/Sources/Sentry/include/SentryANRTrackingIntegrationV2.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 static NSString *const SentryANRExceptionTypeV2 = @"App Hanging";
 
 @interface SentryANRTrackingIntegrationV2
-    : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerV2Delegate>
+    : SentryBaseIntegration <SentryIntegrationProtocol, SentryANRTrackerDelegate>
 
 - (void)pauseAppHangTracking;
 - (void)resumeAppHangTracking;

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -1,7 +1,8 @@
 import Foundation
 
+/// The  methods are called from a  background thread.
 @objc
-protocol SentryANRTrackerV2Delegate {
+protocol SentryANRTrackerDelegate {
     func anrDetected(type: SentryANRType)
     func anrStopped()
 }
@@ -10,4 +11,5 @@ protocol SentryANRTrackerV2Delegate {
 enum SentryANRType: Int {
     case fullyBlocking
     case nonFullyBlocking
+    case unknown
 }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerTests.swift
@@ -205,7 +205,7 @@ class SentryANRTrackerTests: XCTestCase, SentryANRTrackerDelegate {
         XCTAssertEqual(1, fixture.threadWrapper.threadFinishedInvocations.count)
     }
     
-    func anrDetected() {
+    func anrDetected(type: Sentry.SentryANRType) {
         anrDetectedExpectation.fulfill()
     }
     
@@ -231,7 +231,7 @@ class SentryANRTrackerTestDelegate: NSObject, SentryANRTrackerDelegate {
         anrStoppedExpectation.fulfill()
     }
     
-    func anrDetected() {
+    func anrDetected(type: Sentry.SentryANRType) {
         anrDetectedExpectation.fulfill()
     }
 }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -453,7 +453,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
     
 }
 
-class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerV2Delegate {
+class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerDelegate {
     
     let anrDetectedExpectation = XCTestExpectation(description: "Test Delegate ANR Detection")
     let anrStoppedExpectation  = XCTestExpectation(description: "Test Delegate ANR Stopped")

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -1,3 +1,4 @@
+@testable import Sentry
 import SentryTestUtils
 import XCTest
 
@@ -68,7 +69,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker()
         setUpThreadInspector()
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.unknown)
         
         try assertEventWithScopeCaptured { event, _, _ in
             XCTAssertNotNil(event)
@@ -106,7 +107,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         setUpThreadInspector()
         sut.pauseAppHangTracking()
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.unknown)
         
         assertNoEventCaptured()
     }
@@ -117,7 +118,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         sut.pauseAppHangTracking()
         sut.resumeAppHangTracking()
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.unknown)
         
         try assertEventWithScopeCaptured { event, _, _ in
             XCTAssertNotNil(event)
@@ -135,10 +136,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         
         testConcurrentModifications(asyncWorkItems: 100, writeLoopCount: 10, writeWork: {_ in
             self.sut.pauseAppHangTracking()
-            Dynamic(self.sut).anrDetected()
+            Dynamic(self.sut).anrDetectedWithType(SentryANRType.unknown)
         }, readWork: {
             self.sut.resumeAppHangTracking()
-            Dynamic(self.sut).anrDetected()
+            Dynamic(self.sut).anrDetectedWithType(SentryANRType.unknown)
         })
     }
     
@@ -146,7 +147,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker()
         setUpThreadInspector(addThreads: false)
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.unknown)
         
         assertNoEventCaptured()
     }
@@ -161,7 +162,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         setUpThreadInspector()
         SentryDependencyContainer.sharedInstance().application = BackgroundSentryUIApplication()
 
-        Dynamic(sut).anrsDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.unknown)
 
         assertNoEventCaptured()
     }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationsIntegrationTests.swift
@@ -1,5 +1,6 @@
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
+@testable import Sentry
 import SentryTestUtils
 import XCTest
 
@@ -72,7 +73,7 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         let sut = givenIntegration()
         sut.install(with: Options())
         
-        Dynamic(sut).anrDetected()
+        Dynamic(sut).anrDetectedWithType(SentryANRType.unknown)
 
         let appState = try XCTUnwrap(fixture.fileManager.readAppState())
         

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -746,11 +746,11 @@ class SentrySDKTests: XCTestCase {
         let anrTrackingIntegration = SentrySDK.currentHub().getInstalledIntegration(SentryANRTrackingIntegration.self)
         
         SentrySDK.pauseAppHangTracking()
-        Dynamic(anrTrackingIntegration).anrDetected()
+        Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
         XCTAssertEqual(0, client.captureEventWithScopeInvocations.count)
         
         SentrySDK.resumeAppHangTracking()
-        Dynamic(anrTrackingIntegration).anrDetected()
+        Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
         
         if SentryDependencyContainer.sharedInstance().crashWrapper.isBeingTraced() {
             XCTAssertEqual(0, client.captureEventWithScopeInvocations.count)


### PR DESCRIPTION
Merge SentryANRTrackerDelegate and SentryANRTrackerDelegateV2 into one implementation to reduce complexity.

This is the first step in making swapping between the ANRTrackerV1 and ANRTrackerV2 easier. 

#skip-changelog