### PR TITLE
Fix DSN init in ios13 sample app

### DIFF
--- a/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
@@ -8,13 +8,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func startSentry() {
         // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
-        let dsn: String? = nil
+        var storedDsn: String? = nil
         do {
-            let dsn = try DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
-            try DSNStorage.shared.saveDSN(dsn: dsn)
+            storedDsn = try DSNStorage.shared.getDSN()
+            try DSNStorage.shared.saveDSN(dsn: storedDsn ?? Self.defaultDSN)
         } catch {
             print("[iOS-Swift] Failed to read/write DSN: \(error)")
         }
+        
+        let dsn = storedDsn ?? Self.defaultDSN
         
         SentrySDK.start { options in
             options.dsn = dsn

--- a/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS13-Swift/AppDelegate.swift
@@ -8,7 +8,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func startSentry() {
         // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
-        var storedDsn: String? = nil
+        var storedDsn: String?
         do {
             storedDsn = try DSNStorage.shared.getDSN()
             try DSNStorage.shared.saveDSN(dsn: storedDsn ?? Self.defaultDSN)


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

<!--- Describe your changes in detail -->

Fixes an issue where DSN was not set correctly in one of the sample apps.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Looks like this was introduced with #4320.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
