### PR TITLE
impr: Speed up SentryNetworkTracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Speed up HTTP tracking for multiple requests in parallel
+
 ## 8.37.0-beta.1
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Speed up HTTP tracking for multiple requests in parallel
+- Speed up HTTP tracking for multiple requests in parallel (#4366)
 
 ## 8.37.0-beta.1
 

--- a/Sources/Resources/ThreadSanitizer.sup
+++ b/Sources/Resources/ThreadSanitizer.sup
@@ -3,7 +3,6 @@
 
 # Races to fix
 race:returnResponse
-race:enableNetworkTracking
 race:enableNetworkBreadcrumbs
 race:disable
 race:URLSessionDataTaskMock


### PR DESCRIPTION
## :scroll: Description

Speed up SentryNetworkTracker for multiple HTTP requests in parallel by removing unnecessary locks.

@brustolin, you added these locks in the past. Can you recall if there was a good reason for that, except a race condition? I just want to double-check, that we don't break anything.

## :bulb: Motivation and Context

This surfaced while investigating a potential slow down for a specific UIViewController when enabling the Sentry Cocoa SDK.

## :green_heart: How did you test it?

Running unit performance tests locally. Sadly, they don't work in CI, so adding them to the repository adds no value.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
