### PR TITLE
Chore: Update size difference benchmark

### DIFF
--- a/Tests/Perf/metrics-test.yml
+++ b/Tests/Perf/metrics-test.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 200 KiB
-  diffMax: 900 KiB
+  diffMax: 800 KiB

--- a/Tests/Perf/metrics-test.yml
+++ b/Tests/Perf/metrics-test.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 200 KiB
-  diffMax: 700 KiB
+  diffMax: 900 KiB


### PR DESCRIPTION
## :scroll: Description

CI is failing because the SDK size has increased.

_#skip-changelog_