### PR TITLE
impr: Slightly speed up SentryInAppLogic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Speed up HTTP tracking for multiple requests in parallel (#4366)
+- Slightly speed up SentryInAppLogic (#4370)
 
 ## 8.37.0-beta.1
 

--- a/Sources/Sentry/SentryInAppLogic.m
+++ b/Sources/Sentry/SentryInAppLogic.m
@@ -66,7 +66,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     return [SentryInAppLogic
         isImageNameLastPathComponentInApp:imageName.lastPathComponent.lowercaseString
-                             inAppInclude:inAppInclude];
+                             inAppInclude:inAppInclude.lowercaseString];
 }
 
 + (BOOL)isImageNameLastPathComponentInApp:(NSString *)imageNameLastPathComponent

--- a/Sources/Sentry/SentryInAppLogic.m
+++ b/Sources/Sentry/SentryInAppLogic.m
@@ -1,4 +1,5 @@
 #import "SentryInAppLogic.h"
+#import "SentryLog.h"
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
@@ -10,8 +11,19 @@ NS_ASSUME_NONNULL_BEGIN
                         inAppExcludes:(NSArray<NSString *> *)inAppExcludes
 {
     if (self = [super init]) {
-        _inAppIncludes = inAppIncludes;
-        _inAppExcludes = inAppExcludes;
+        NSMutableArray<NSString *> *includes =
+            [[NSMutableArray alloc] initWithCapacity:inAppIncludes.count];
+        for (NSString *include in inAppIncludes) {
+            [includes addObject:include.lowercaseString];
+        }
+        _inAppIncludes = includes;
+
+        NSMutableArray<NSString *> *excludes =
+            [[NSMutableArray alloc] initWithCapacity:inAppExcludes.count];
+        for (NSString *exclude in inAppExcludes) {
+            [excludes addObject:exclude.lowercaseString];
+        }
+        _inAppExcludes = excludes;
     }
 
     return self;
@@ -23,13 +35,17 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
+    NSString *imageNameLastPathComponent = imageName.lastPathComponent.lowercaseString;
+
     for (NSString *inAppInclude in self.inAppIncludes) {
-        if ([SentryInAppLogic isImageNameInApp:imageName inAppInclude:inAppInclude])
+        if ([SentryInAppLogic isImageNameLastPathComponentInApp:imageNameLastPathComponent
+                                                   inAppInclude:inAppInclude])
+
             return YES;
     }
 
-    for (NSString *inAppExlude in self.inAppExcludes) {
-        if ([imageName.lastPathComponent.lowercaseString hasPrefix:inAppExlude.lowercaseString])
+    for (NSString *inAppExclude in self.inAppExcludes) {
+        if ([imageNameLastPathComponent hasPrefix:inAppExclude])
             return NO;
     }
 
@@ -48,7 +64,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (BOOL)isImageNameInApp:(NSString *)imageName inAppInclude:(NSString *)inAppInclude
 {
-    return [imageName.lastPathComponent.lowercaseString hasPrefix:inAppInclude.lowercaseString];
+    return [SentryInAppLogic
+        isImageNameLastPathComponentInApp:imageName.lastPathComponent.lowercaseString
+                             inAppInclude:inAppInclude];
+}
+
++ (BOOL)isImageNameLastPathComponentInApp:(NSString *)imageNameLastPathComponent
+                             inAppInclude:(NSString *)inAppInclude
+{
+    return [imageNameLastPathComponent hasPrefix:inAppInclude];
 }
 
 @end


### PR DESCRIPTION


## :scroll: Description

Slightly speed up the SentryInAppLogic by avoiding calls to lastPathComponent and lowercaseString in loops. Both properties require some extra work, such as iterating over the contents of the string. This is noticeable for larger apps with many images and inAppIncludes and inAppExcludes. For small apps, this doesn't make a difference.

## :bulb: Motivation and Context

This came up while investigating the Sentry Cocoa SDK potentially slowing down a specific UIViewController of a customer.

## :green_heart: How did you test it?

Unit tests still pass, and by running a performance test locally, which doesn't work in CI, so I'm not adding it.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
