### PR TITLE
ref: Make inAppExcludes internal

### DIFF
--- a/Sources/Sentry/SentryInAppLogic.m
+++ b/Sources/Sentry/SentryInAppLogic.m
@@ -4,6 +4,12 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@interface SentryInAppLogic ()
+
+@property (nonnull, readonly) NSArray<NSString *> *inAppExcludes;
+
+@end
+
 @implementation SentryInAppLogic
 
 - (instancetype)initWithInAppIncludes:(NSArray<NSString *> *)inAppIncludes

--- a/Sources/Sentry/include/SentryInAppLogic.h
+++ b/Sources/Sentry/include/SentryInAppLogic.h
@@ -32,8 +32,6 @@ SENTRY_NO_INIT
 
 @property (nonnull, readonly) NSArray<NSString *> *inAppIncludes;
 
-@property (nonnull, readonly) NSArray<NSString *> *inAppExcludes;
-
 /**
  * Initializes @c SentryInAppLogic with @c inAppIncludes and @c inAppExcludes.
  *


### PR DESCRIPTION
Make SentryInAppLogic.inAppExcludes internal as it's not used by any other class.

#skip-changelog