### PR TITLE
ci: Remove benchmarking schedule

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -1,7 +1,5 @@
 name: Benchmarking
 on:
-  schedule:
-    - cron: '0 0 * * *' # every night at midnight UTC
   push:
     branches:
       - main


### PR DESCRIPTION
Remove running the benchmarks at midnight because nobody looks at the data.

#skip-changelog