### PR TITLE
impr: Stop canceling timer for manual transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - Speed up HTTP tracking for multiple requests in parallel (#4366)
 - Slightly speed up SentryInAppLogic (#4370)
+- Stop canceling timer for manual transactions (#4380)
 
 ## 8.37.0-beta.1
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -307,6 +307,10 @@ static BOOL appStartMeasurementRead;
 
 - (void)cancelDeadlineTimer
 {
+    if (self.deadlineTimer == nil) {
+        return;
+    }
+
     // If the main thread is busy the tracer could be deallocated in between.
     __weak SentryTracer *weakSelf = self;
 

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -349,6 +349,18 @@ class SentryTracerTests: XCTestCase {
 
         fixture.timerFactory.fire()
     }
+    
+    func testDeadlineTimerForManualTransaction_NoWorkQueuedOnMainQueue() {
+        let sut = fixture.getSut(waitForChildren: false, idleTimeout: 0.0)
+        
+        let invocationsBeforeFinish = fixture.dispatchQueue.blockOnMainInvocations.count
+        
+        sut.finish()
+        
+        let invocationsAfterFinish = fixture.dispatchQueue.blockOnMainInvocations.count
+        
+        XCTAssertEqual(invocationsBeforeFinish, invocationsAfterFinish)
+    }
 
     func testFramesofSpans_SetsDebugMeta() {
         let sut = fixture.getSut()


### PR DESCRIPTION


## :scroll: Description

Avoid canceling the deadline timer on the main thread when there is no deadline timer when finishing a transaction.

## :bulb: Motivation and Context

This same up while investigating https://github.com/getsentry/sentry-cocoa/issues/3977.

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
