### PR TITLE
chore: Fix check tooling versions

### DIFF
--- a/scripts/check-tooling-versions.sh
+++ b/scripts/check-tooling-versions.sh
@@ -6,7 +6,7 @@ LOCAL_CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
 LOCAL_SWIFTLINT_VERSION=$(swiftlint version)
 RESOLUTION_MESSAGE="Please run \`make init\` to update your local dev tools. This may actually upgrade to a newer version than what is currently recorded in the lockfile; if that happens, please commit the update to the lockfile as well."
 
-if [ "${LOCAL_CLANG_FORMAT_VERSION}" == "${BREW_CLANG_FORMAT_VERSION}" ]; then
+if [ "${LOCAL_CLANG_FORMAT_VERSION}" != "${BREW_CLANG_FORMAT_VERSION}" ]; then
     echo "clang-format version mismatch, expected: ${BREW_CLANG_FORMAT_VERSION}, but found: ${LOCAL_CLANG_FORMAT_VERSION}. ${RESOLUTION_MESSAGE}"
     exit 1
 fi


### PR DESCRIPTION
Comparing the clang versions should be != and not ==.

I got this funky error message. This PR fixes this.
```
clang-format version mismatch, expected: 19.1.1, but found: 19.1.1. Please run `make init` to update your local dev tools.
This may actually upgrade to a newer version than what is currently recorded in the lockfile; if that happens, please
commit the update to the lockfile as well.
```

#skip-changelog