### PR TITLE
fix: Linking ongoing trace to crash event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Fixes
 
 - Fix the versioning to support app release with Beta versions (#4368)
+- Linking ongoing trace to crash event (#4393)
 
 ## 8.37.0-beta.1
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -2,7 +2,7 @@
 #import "SentryAttachment+Private.h"
 #import "SentryBreadcrumb.h"
 #import "SentryEnvelopeItemType.h"
-#import "SentryEvent.h"
+#import "SentryEvent+Private.h"
 #import "SentryGlobalEventProcessor.h"
 #import "SentryLevelMapper.h"
 #import "SentryLog.h"
@@ -562,6 +562,13 @@ NS_ASSUME_NONNULL_BEGIN
     NSMutableDictionary *newContext = [self context].mutableCopy;
     if (event.context != nil) {
         [SentryDictionary mergeEntriesFromDictionary:event.context intoDictionary:newContext];
+    }
+
+    // Don't add the trace context of a current trace to a crash event because crash events are from
+    // a previous run.
+    if (event.isCrashEvent) {
+        event.context = newContext;
+        return event;
     }
 
     if (self.span != nil) {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -225,6 +225,17 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(trace?["span_id"] as? String, fixture.transaction.spanId.sentrySpanIdString)
     }
     
+    func testApplyToEvent_ScopeWithSpan_NotAppliedToCrashEvent() {
+        let scope = fixture.scope
+        scope.span = fixture.transaction
+        let event = fixture.event
+        event.isCrashEvent = true
+        
+        let actual = scope.applyTo(event: event, maxBreadcrumbs: 10)
+        XCTAssertNil(fixture.event.context?["trace"])
+        XCTAssertNil(actual?.transaction)
+    }
+    
     func testApplyToEvent_EventWithDist() {
         let event = fixture.event
         event.dist = "myDist"


### PR DESCRIPTION




## :scroll: Description

Fix linking a crash event to an ongoing trace by skipping setting the trace context in Scope.applyToEvent for crash events.

## :bulb: Motivation and Context

Fixes GH-4375

## :green_heart: How did you test it?

I could reproduce the problem in the SwiftUI sample app with the following code in the SwiftUIApp.swift file:
```Swift
init() {
    SentrySDK.start { options in
        options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
        options.debug = true
        options.tracesSampleRate = 1.0
        options.enableAutoPerformanceTracing = false
        options.initialScope = { scope in
            let user = User()
            user.email = "philipp@sentry.io"
            scope.setUser(user)
            return scope
        }
    }
    
    let t = SentrySDK.startTransaction(name: "after-crash", operation: "crash", bindToScope: true)
    let child = t.startChild(operation: "hello")

    DispatchQueue.global().asyncAfter(deadline: .now() + 1.0) {
        child.finish()
        t.finish()
    }
}
```

[Event](https://sentry-sdks.sentry.io/issues/5941344876/events/250c82341b454a7c8e8267caaed134f5/?fov=1%2C1027.30712890625&node=span-ec5bf228e4e944d9&node=txn-050440229c9940c292a76299708e3d79&project=5428557) in Sentry before the fix:
![CleanShot 2024-10-03 at 10 32 34@2x](https://github.com/user-attachments/assets/29997234-ed29-48ea-96aa-514506f1dbcc)

[Event](https://sentry-sdks.sentry.io/issues/5941344876/events/a9b8068100bd49638a1db787e6782aea/?project=5428557) in Sentry after the fix: 

![CleanShot 2024-10-03 at 10 35 45@2x](https://github.com/user-attachments/assets/ea44fb9f-e6e3-437b-998b-c5d559936502)



## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
