### PR TITLE
chore: Bumping Xcode and SauceLab CLI for benchmarking

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: macos-13
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh 15.2
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -104,7 +104,7 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh
+      - run: ./scripts/ci-select-xcode.sh 15.2
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -126,6 +126,15 @@ jobs:
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Build Framework
         run: make build-xcframework
+        
+      - name: Archive build log if failed
+        uses: actions/upload-artifact@v4
+        if: ${{  failure() || cancelled() }}
+        with:
+          name: raw-build-output-build-xcframework
+          path: |
+            build-xcframework.log
+
       - name: Build test app with sentry
         run: bundle exec fastlane build_perf_test_app_sentry
         env:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -100,7 +100,7 @@ jobs:
 
   app-metrics:
     name: Collect app metrics
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - name: Git checkout
         uses: actions/checkout@v4

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: DerivedData-Xcode
-      - run: npm install -g saucectl@0.173.2
+      - run: npm install -g saucectl@0.186.0
       - name: Run Benchmarks in SauceLab
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
Our benchmarking workflows still uses Xcode 14 that does not work with mergeable-libraries.


_#skip-changelog_