### PR TITLE
chore: Run benchmark workflow if build script changed

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -126,7 +126,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Build Framework
-        run: make build-xcframework
+        run: ./scripts/build-xcframework.sh reduced
         
       - name: Archive build log if failed
         uses: actions/upload-artifact@v4

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -16,6 +16,7 @@ on:
       - '.sauce/benchmarking-config.yml'
       - 'fastlane/**'
       - 'scripts/ci-select-xcode.sh'
+      - 'scripts/build-xcframework.sh'
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -126,7 +126,7 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
       - name: Build Framework
-        run: ./scripts/build-xcframework.sh reduced
+        run: ./scripts/build-xcframework.sh iOSOnly
         
       - name: Archive build log if failed
         uses: actions/upload-artifact@v4

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -2,7 +2,9 @@
 
 set -eou pipefail
 
-if [ "$1" = "reduced" ]; then
+args="${1:-}"
+
+if [ "$args" = "reduced" ]; then
     sdks=( iphoneos iphonesimulator )
 else
     sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
@@ -85,7 +87,7 @@ generate_xcframework() {
         OTHER_LDFLAGS="-Wl,-make_mergeable"
     fi
 
-    if [ "$1" != "reduced" ]; then
+    if [ "$args" != "reduced" ]; then
         #Create framework for mac catalyst
         xcodebuild \
             -project Sentry.xcodeproj/ \
@@ -120,7 +122,7 @@ generate_xcframework() {
 
 generate_xcframework "Sentry" "-Dynamic"
 
-if [ "$1" != "reduced" ]; then
+if [ "$args" != "reduced" ]; then
     generate_xcframework "Sentry" "" staticlib
 
     generate_xcframework "SentrySwiftUI"

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -2,7 +2,11 @@
 
 set -eou pipefail
 
-sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
+if [ "$1" = "reduced" ]; then
+    sdks=( iphoneos iphonesimulator )
+else
+    sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
+fi
 
 rm -rf Carthage/
 mkdir Carthage
@@ -81,31 +85,33 @@ generate_xcframework() {
         OTHER_LDFLAGS="-Wl,-make_mergeable"
     fi
 
-    #Create framework for mac catalyst
-    xcodebuild \
-        -project Sentry.xcodeproj/ \
-        -scheme "$scheme" \
-        -configuration "$resolved_configuration" \
-        -sdk iphoneos \
-        -destination 'platform=macOS,variant=Mac Catalyst' \
-        -derivedDataPath ./Carthage/DerivedData \
-        CODE_SIGNING_REQUIRED=NO \
-        CODE_SIGN_IDENTITY= \
-        CARTHAGE=YES \
-        MACH_O_TYPE="$MACH_O_TYPE" \
-        SUPPORTS_MACCATALYST=YES \
-        ENABLE_CODE_COVERAGE=NO \
-        GCC_GENERATE_DEBUGGING_SYMBOLS="$GCC_GENERATE_DEBUGGING_SYMBOLS" \
-        OTHER_LDFLAGS="$OTHER_LDFLAGS"
+    if [ "$1" != "reduced" ]; then
+        #Create framework for mac catalyst
+        xcodebuild \
+            -project Sentry.xcodeproj/ \
+            -scheme "$scheme" \
+            -configuration "$resolved_configuration" \
+            -sdk iphoneos \
+            -destination 'platform=macOS,variant=Mac Catalyst' \
+            -derivedDataPath ./Carthage/DerivedData \
+            CODE_SIGNING_REQUIRED=NO \
+            CODE_SIGN_IDENTITY= \
+            CARTHAGE=YES \
+            MACH_O_TYPE="$MACH_O_TYPE" \
+            SUPPORTS_MACCATALYST=YES \
+            ENABLE_CODE_COVERAGE=NO \
+            GCC_GENERATE_DEBUGGING_SYMBOLS="$GCC_GENERATE_DEBUGGING_SYMBOLS" \
+            OTHER_LDFLAGS="$OTHER_LDFLAGS"
 
-    if [ "$MACH_O_TYPE" = "staticlib" ]; then
-        local infoPlist="Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${scheme}.framework/Resources/Info.plist"
-        plutil -replace "MinimumOSVersion" -string "100.0" "$infoPlist"
-    fi
-    
-    createxcframework+="-framework Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${resolved_product_name}.framework "
-    if [ -d "Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${resolved_product_name}.framework.dSYM" ]; then
-        createxcframework+="-debug-symbols $(pwd -P)/Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${resolved_product_name}.framework.dSYM "
+        if [ "$MACH_O_TYPE" = "staticlib" ]; then
+            local infoPlist="Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${scheme}.framework/Resources/Info.plist"
+            plutil -replace "MinimumOSVersion" -string "100.0" "$infoPlist"
+        fi
+        
+        createxcframework+="-framework Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${resolved_product_name}.framework "
+        if [ -d "Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${resolved_product_name}.framework.dSYM" ]; then
+            createxcframework+="-debug-symbols $(pwd -P)/Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${resolved_product_name}.framework.dSYM "
+        fi
     fi
     
     createxcframework+="-output Carthage/${scheme}${suffix}.xcframework"
@@ -114,8 +120,10 @@ generate_xcframework() {
 
 generate_xcframework "Sentry" "-Dynamic"
 
-generate_xcframework "Sentry" "" staticlib
+if [ "$1" != "reduced" ]; then
+    generate_xcframework "Sentry" "" staticlib
 
-generate_xcframework "SentrySwiftUI"
+    generate_xcframework "SentrySwiftUI"
 
-generate_xcframework "Sentry" "-WithoutUIKitOrAppKit" mh_dylib WithoutUIKit
+    generate_xcframework "Sentry" "-WithoutUIKitOrAppKit" mh_dylib WithoutUIKit
+fi

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -4,7 +4,7 @@ set -eou pipefail
 
 args="${1:-}"
 
-if [ "$args" = "reduced" ]; then
+if [ "$args" = "iOSOnly" ]; then
     sdks=( iphoneos iphonesimulator )
 else
     sdks=( iphoneos iphonesimulator macosx appletvos appletvsimulator watchos watchsimulator xros xrsimulator )
@@ -87,7 +87,7 @@ generate_xcframework() {
         OTHER_LDFLAGS="-Wl,-make_mergeable"
     fi
 
-    if [ "$args" != "reduced" ]; then
+    if [ "$args" != "iOSOnly" ]; then
         #Create framework for mac catalyst
         xcodebuild \
             -project Sentry.xcodeproj/ \
@@ -122,7 +122,7 @@ generate_xcframework() {
 
 generate_xcframework "Sentry" "-Dynamic"
 
-if [ "$args" != "reduced" ]; then
+if [ "$args" != "iOSOnly" ]; then
     generate_xcframework "Sentry" "" staticlib
 
     generate_xcframework "SentrySwiftUI"


### PR DESCRIPTION
We broke main CI because of this.

Any change in the build script should also run benchmark workflow.

And I small improvement in performance

|before|after|
|-|-|
|![Screenshot 2024-10-03 at 17 26 25](https://github.com/user-attachments/assets/25d05365-feef-4b87-8d3c-75eff0c41cf2)|![Screenshot 2024-10-03 at 17 24 46](https://github.com/user-attachments/assets/ac5cf3d7-4d30-4cc6-86f7-0cb7e68e85c4)|




_#skip-changelog_