### PR TITLE
fix: Swizzling RootUIViewController if ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Linking ongoing trace to crash event (#4393)
 - Edge case for swizzleClassNameExclude (#4405): Skip creating transactions for UIViewControllers ignored for swizzling
 via the option `swizzleClassNameExclude`.
+- Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
 
 ## 8.37.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - Fix the versioning to support app release with Beta versions (#4368)
 - Linking ongoing trace to crash event (#4393)
+- Edge case for swizzleClassNameExclude (#4405): Skip creating transactions for UIViewControllers ignored for swizzling
+via the option `swizzleClassNameExclude`.
 
 ## 8.37.0-beta.1
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		62872B5F2BA1B7F300A4FA7D /* NSLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B5E2BA1B7F300A4FA7D /* NSLock.swift */; };
 		62872B632BA1B86100A4FA7D /* NSLockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62872B622BA1B86100A4FA7D /* NSLockTests.swift */; };
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
+		629428802CB3BF69002C454C /* SwizzleClassNameExclude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294287F2CB3BF4E002C454C /* SwizzleClassNameExclude.swift */; };
 		6294774C2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */; };
 		62950F1029E7FE0100A42624 /* SentryTransactionContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */; };
 		629690532AD3E060000185FA /* SentryReachabilitySwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */; };
@@ -1113,6 +1114,7 @@
 		62872B5E2BA1B7F300A4FA7D /* NSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLock.swift; sourceTree = "<group>"; };
 		62872B622BA1B86100A4FA7D /* NSLockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLockTests.swift; sourceTree = "<group>"; };
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
+		6294287F2CB3BF4E002C454C /* SwizzleClassNameExclude.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzleClassNameExclude.swift; sourceTree = "<group>"; };
 		6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryANRTrackerV2Delegate.swift; sourceTree = "<group>"; };
 		62950F0F29E7FE0100A42624 /* SentryTransactionContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionContextTests.swift; sourceTree = "<group>"; };
 		629690522AD3E060000185FA /* SentryReachabilitySwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReachabilitySwiftTests.swift; sourceTree = "<group>"; };
@@ -3838,6 +3840,7 @@
 		D8739CF72BECFF92007D2F66 /* Performance */ = {
 			isa = PBXGroup;
 			children = (
+				6294287F2CB3BF4E002C454C /* SwizzleClassNameExclude.swift */,
 				D8739CF82BECFFB5007D2F66 /* SentryTransactionNameSource.swift */,
 			);
 			path = Performance;
@@ -4744,6 +4747,7 @@
 				7B2A70DD27D6083D008B0D15 /* SentryThreadWrapper.m in Sources */,
 				62E146D02BAAE47600ED34FD /* LocalMetricsAggregator.swift in Sources */,
 				D8ACE3C72762187200F5A213 /* SentryNSDataSwizzling.m in Sources */,
+				629428802CB3BF69002C454C /* SwizzleClassNameExclude.swift in Sources */,
 				638DC9A11EBC6B6400A66E41 /* SentryRequestOperation.m in Sources */,
 				63AA767A1EB8D20500D153DE /* SentryLogC.m in Sources */,
 				6344DDBA1EC3115C00D9160D /* SentryCrashReportConverter.m in Sources */,

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -446,17 +446,17 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableSwizzling;
 
 /**
- * An array of class names to ignore for swizzling.
+ * A set of class names to ignore for swizzling.
  *
  * @discussion The SDK checks if a class name of a class to swizzle contains a class name of this
  * array. For example, if you add MyUIViewController to this list, the SDK excludes the following
  * classes from swizzling: YourApp.MyUIViewController, YourApp.MyUIViewControllerA,
  * MyApp.MyUIViewController.
- * We can't use an @c NSArray<Class>  here because we use this as a workaround for which users have
+ * We can't use an @c NSSet<Class>  here because we use this as a workaround for which users have
  * to pass in class names that aren't available on specific iOS versions. By using @c
- * NSArray<NSString *>, users can specify unavailable class names.
+ * NSSet<NSString *>, users can specify unavailable class names.
  *
- * @note Default is an empty array.
+ * @note Default is an empty set.
  */
 @property (nonatomic, strong) NSSet<NSString *> *swizzleClassNameExcludes;
 

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -2,6 +2,7 @@
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryLog.h"
 #import "SentryObjCRuntimeWrapper.h"
+#import "SentrySwift.h"
 #import <objc/runtime.h>
 #import <string.h>
 
@@ -61,13 +62,9 @@
         for (int i = 0; i < count; i++) {
             NSString *className = [NSString stringWithUTF8String:classes[i]];
 
-            BOOL shouldExcludeClassFromSwizzling = NO;
-            for (NSString *swizzleClassNameExclude in self.swizzleClassNameExcludes) {
-                if ([className containsString:swizzleClassNameExclude]) {
-                    shouldExcludeClassFromSwizzling = YES;
-                    break;
-                }
-            }
+            BOOL shouldExcludeClassFromSwizzling = [SentrySwizzleClassNameExclude
+                shouldExcludeClassWithClassName:className
+                       swizzleClassNameExcludes:self.swizzleClassNameExcludes];
 
             // It is vital to avoid calling NSClassFromString for the excluded classes because we
             // had crashes for specific classes when calling NSClassFromString, such as

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -68,6 +68,18 @@
         return;
     }
 
+    SentryOptions *options = [SentrySDK options];
+
+    if ([SentrySwizzleClassNameExclude
+            shouldExcludeClassWithClassName:NSStringFromClass([controller class])
+                   swizzleClassNameExcludes:options.swizzleClassNameExcludes]) {
+        SENTRY_LOG_DEBUG(@"Won't track view controller because it's excluded with the option "
+                         @"swizzleClassNameExcludes: %@",
+            controller);
+        callbackToOrigin();
+        return;
+    }
+
     [self limitOverride:@"loadView"
                   target:controller
         callbackToOrigin:callbackToOrigin

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -36,6 +36,7 @@
 
 @interface SentryUIViewControllerSwizzling ()
 
+@property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryInAppLogic *inAppLogic;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
@@ -56,6 +57,7 @@
                binaryImageCache:(SentryBinaryImageCache *)binaryImageCache
 {
     if (self = [super init]) {
+        self.options = options;
         self.inAppLogic = [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
                                                             inAppExcludes:options.inAppExcludes];
         self.dispatchQueue = dispatchQueue;
@@ -341,6 +343,15 @@
  */
 - (BOOL)shouldSwizzleViewController:(Class)class
 {
+    NSString *className = NSStringFromClass(class);
+
+    BOOL shouldExcludeClassFromSwizzling = [SentrySwizzleClassNameExclude
+        shouldExcludeClassWithClassName:className
+               swizzleClassNameExcludes:self.options.swizzleClassNameExcludes];
+    if (shouldExcludeClassFromSwizzling) {
+        return NO;
+    }
+
     return [self.inAppLogic isClassInApp:class];
 }
 

--- a/Sources/Swift/Integrations/Performance/SwizzleClassNameExclude.swift
+++ b/Sources/Swift/Integrations/Performance/SwizzleClassNameExclude.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+@objcMembers
+class SentrySwizzleClassNameExclude: NSObject {
+    static func shouldExcludeClass(className: String, swizzleClassNameExcludes: Set<String>) -> Bool {
+        for exclude in swizzleClassNameExcludes {
+            if className.contains(exclude) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -13,14 +13,13 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         let subClassFinder: TestSubClassFinder
         let processInfoWrapper = SentryNSProcessInfoWrapper()
         let binaryImageCache: SentryBinaryImageCache
+        var options: Options
         
         init() {
             subClassFinder = TestSubClassFinder(dispatchQueue: dispatchQueue, objcRuntimeWrapper: objcRuntimeWrapper, swizzleClassNameExcludes: [])
             binaryImageCache = SentryDependencyContainer.sharedInstance().binaryImageCache
-        }
-         
-        var options: Options {
-            let options = Options.noIntegrations()
+            
+            options = Options.noIntegrations()
             
             let imageName = String(
                 cString: class_getImageName(SentryUIViewControllerSwizzlingTests.self)!,
@@ -31,8 +30,6 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
                 cString: class_getImageName(ExternalUIViewController.self)!,
                 encoding: .utf8)! as NSString
             options.add(inAppInclude: externalImageName.lastPathComponent)
-            
-            return options
         }
         
         var sut: SentryUIViewControllerSwizzling {
@@ -96,6 +93,18 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
     func testShouldNotSwizzle_UIViewController() {
         let result = fixture.sut.shouldSwizzleViewController(UIViewController.self)
         XCTAssertFalse(result)
+    }
+    
+    func testShouldNotSwizzle_UIViewControllerExcludedFromSwizzling() {
+        fixture.options.swizzleClassNameExcludes = ["TestViewController"]
+        
+        XCTAssertFalse(fixture.sut.shouldSwizzleViewController(TestViewController.self))
+    }
+    
+    func testShouldSwizzle_UIViewControllerNotExcludedFromSwizzling() {
+        fixture.options.swizzleClassNameExcludes = ["TestViewController1"]
+        
+        XCTAssertTrue(fixture.sut.shouldSwizzleViewController(TestViewController.self))
     }
     
     func testUIViewController_loadView_noTransactionBoundToScope() {


### PR DESCRIPTION



## :scroll: Description

The SDK didn't exclude the RootViewController from swizzling when ignored by the option swizzleClassNameExclude. This is fixed now.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/4405.

## :bulb: Motivation and Context

Fixes GH-4385

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
