### PR TITLE
fix: Add TTID/TTFD spans when loadView skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Edge case for swizzleClassNameExclude (#4405): Skip creating transactions for UIViewControllers ignored for swizzling
 via the option `swizzleClassNameExclude`.
+- Add TTID/TTFD spans when loadView gets skipped (#4415)
 
 ## 8.38.0-beta.1
 

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/SplitViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/SplitViewController.swift
@@ -66,7 +66,6 @@ class SecondarySplitViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        SentrySDK.reportFullyDisplayed()
         
         if let topvc = TopViewControllerInspector.shared {
             topvc.bringToFront()

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -102,6 +102,7 @@
                    block:^{
                        SENTRY_LOG_DEBUG(@"Tracking viewDidLoad");
                        [self createTransaction:controller];
+                       [self createTimeToDisplay:controller];
                        [self measurePerformance:@"viewDidLoad"
                                          target:controller
                                callbackToOrigin:callbackToOrigin];

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -622,6 +622,34 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         XCTAssertEqual("viewDidLoad", secondChild.spanDescription)
     }
     
+    func test_OnlyViewDidLoadTTFDEnabled_CreatesTTIDAndTTFDSpans() throws {
+        let sut = fixture.getSut()
+        sut.enableWaitForFullDisplay = true
+        let tracker = fixture.tracker
+
+        var tracer: SentryTracer!
+
+        sut.viewControllerViewDidLoad(TestViewController()) {
+            tracer = self.getStack(tracker).first as? SentryTracer
+        }
+
+        let children: [Span]? = Dynamic(tracer).children as [Span]?
+
+        XCTAssertEqual(children?.count, 3)
+        
+        let child1 = try XCTUnwrap(children?.first)
+        XCTAssertEqual("ui.load.initial_display", child1.operation)
+        XCTAssertEqual("TestViewController initial display", child1.spanDescription)
+        
+        let child2 = try XCTUnwrap(children?[1])
+        XCTAssertEqual("ui.load.full_display", child2.operation)
+        XCTAssertEqual("TestViewController full display", child2.spanDescription)
+        
+        let child3 = try XCTUnwrap(children?[2])
+        XCTAssertEqual("ui.load", child3.operation)
+        XCTAssertEqual("viewDidLoad", child3.spanDescription)
+    }
+    
     func test_BothLoadViewAndViewDidLoad_CreatesOneTTIDSpan() throws {
         let sut = fixture.getSut()
         let tracker = fixture.tracker

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -576,7 +576,6 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
 
         sut.enableWaitForFullDisplay = true
 
-        //The first view controller creates a transaction
         sut.viewControllerLoadView(firstController) {
             tracer = self.getStack(tracker).first as? SentryTracer
         }
@@ -594,12 +593,63 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
 
         sut.enableWaitForFullDisplay = false
 
-        //The first view controller creates a transaction
         sut.viewControllerLoadView(firstController) {
             tracer = self.getStack(tracker).first as? SentryTracer
         }
 
         XCTAssertEqual(tracer?.children.count, 2)
+    }
+    
+    func test_OnlyViewDidLoad_CreatesTTIDSpan() throws {
+        let sut = fixture.getSut()
+        let tracker = fixture.tracker
+
+        var tracer: SentryTracer!
+
+        sut.viewControllerViewDidLoad(TestViewController()) {
+            tracer = self.getStack(tracker).first as? SentryTracer
+        }
+
+        let children: [Span]? = Dynamic(tracer).children as [Span]?
+
+        XCTAssertEqual(children?.count, 2)
+        
+        let firstChild = try XCTUnwrap(children?.first)
+        XCTAssertEqual("ui.load.initial_display", firstChild.operation)
+        XCTAssertEqual("TestViewController initial display", firstChild.spanDescription)
+        let secondChild = try XCTUnwrap(children?[1])
+        XCTAssertEqual("ui.load", secondChild.operation)
+        XCTAssertEqual("viewDidLoad", secondChild.spanDescription)
+    }
+    
+    func test_OnlyLoadViewAndViewDidLoad_CreatesOneTTIDSpan() throws {
+        let sut = fixture.getSut()
+        let tracker = fixture.tracker
+        let controller = TestViewController()
+        var tracer: SentryTracer!
+        
+        sut.viewControllerLoadView(controller) {
+            tracer = self.getStack(tracker).first as? SentryTracer
+        }
+
+        sut.viewControllerViewDidLoad(controller) {
+            // Empty on purpose
+        }
+
+        let children: [Span]? = Dynamic(tracer).children as [Span]?
+
+        XCTAssertEqual(children?.count, 3)
+        
+        let child1 = try XCTUnwrap(children?.first)
+        XCTAssertEqual("ui.load.initial_display", child1.operation)
+        
+        let child2 = try XCTUnwrap(children?[1])
+        XCTAssertEqual("ui.load", child2.operation)
+        XCTAssertEqual("loadView", child2.spanDescription)
+        
+        let child3 = try XCTUnwrap(children?[2])
+        XCTAssertEqual("ui.load", child3.operation)
+        XCTAssertEqual("viewDidLoad", child3.spanDescription)
     }
 
     func test_captureAllAutomaticSpans() {
@@ -643,12 +693,13 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
 
         let children: [Span]? = Dynamic(tracer).children as [Span]?
 
-        //First Controller viewDidLoad
-        //Second Controller root span
-        //Second Controller viewDidLoad
-        //Third Controller root span
-        //Third Controller viewDidLoad
-        XCTAssertEqual(children?.count, 5)
+        // First Controller initial_display
+        // First Controller viewDidLoad
+        // Second Controller root span
+        // Second Controller viewDidLoad
+        // Third Controller root span
+        // Third Controller viewDidLoad
+        XCTAssertEqual(children?.count, 6)
     }
 
     private func assertSpanDuration(span: Span?, expectedDuration: TimeInterval) throws {

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -622,7 +622,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         XCTAssertEqual("viewDidLoad", secondChild.spanDescription)
     }
     
-    func test_OnlyLoadViewAndViewDidLoad_CreatesOneTTIDSpan() throws {
+    func test_BothLoadViewAndViewDidLoad_CreatesOneTTIDSpan() throws {
         let sut = fixture.getSut()
         let tracker = fixture.tracker
         let controller = TestViewController()


### PR DESCRIPTION




## :scroll: Description

The SDK creates a transaction when only viewDidLoad gets called for a UIViewController but doesn't create TTID/TTFD spans, leading to transactions missing TTID/TTFD data. Now, the SDK also creates TTID/TTFD spans when only viewDidLoad gets called and loadView gets skipped.

## :bulb: Motivation and Context

Fixes GH-4396

## :green_heart: How did you test it?

Unit tests and with a simulator.

| Before | Now |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/663a60ef-0df1-47ef-aa60-433dfdd7180a) [Sentry Event](https://sentry-sdks.sentry.io/performance/trace/05f1d934b0974f2aa263c0692a665247/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&field=replayId&id=18214&name=&node=txn-17530c9ea6f641dba80e4f771a6298e3&project=5428557&query=&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=1h&timestamp=1727954439&topEvents=5&yAxis=count%28%29) | ![CleanShot 2024-10-08 at 16 45 06@2x](https://github.com/user-attachments/assets/5fb2450b-e09f-4717-a45a-e06f7f195e38) [Sentry Event](https://sentry-sdks.sentry.io/performance/trace/409bf6d454c249b3944af41b2e5266fd/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&field=replayId&id=18214&name=&node=txn-fff61993388345e684c79a542374d30c&project=5428557&query=user.display%3Aphilipp%40sentry.io&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=1h&timestamp=1728398177&topEvents=5&yAxis=count%28%29) | 


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
