### PR TITLE
fix: Finish TTID when viewWillAppear is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Edge case for swizzleClassNameExclude (#4405): Skip creating transactions for UIViewControllers ignored for swizzling
 via the option `swizzleClassNameExclude`.
 - Add TTID/TTFD spans when loadView gets skipped (#4415)
+- Finish TTID correctly when viewWillAppear is skipped (#4417)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
 
 ## 8.38.0-beta.1


### PR DESCRIPTION



## :scroll: Description

According to the Apple docs, viewWillAppear should be called before the UIViewController is added to the view hierarchy. There are some edge cases, though, when this doesn't happen, and we saw customers' transactions also proofing this. Therefore, we must also report the initial display here, as the customers' transactions had spans for viewWillLayoutSubViews.

## :bulb: Motivation and Context

Fixes GH-4383

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
