### PR TITLE
test: Crash on deallocated object

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/project.pbxproj
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		6250B97C2CB69C96009512D6 /* NoARCCrash.m in Sources */ = {isa = PBXBuildFile; fileRef = 6250B97B2CB69C96009512D6 /* NoARCCrash.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		630853492440C46E00DDE4CE /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6308533B2440C45500DDE4CE /* Sentry.framework */; };
 		6308534A2440C46E00DDE4CE /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6308533B2440C45500DDE4CE /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		637AFDCB243B036B0034958B /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 637AFDCA243B036B0034958B /* AppDelegate.m */; };
@@ -95,6 +96,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		6250B9752CB69C86009512D6 /* NoARCCrash.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NoARCCrash.h; sourceTree = "<group>"; };
+		6250B97B2CB69C96009512D6 /* NoARCCrash.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NoARCCrash.m; sourceTree = "<group>"; };
 		630853352440C45500DDE4CE /* Sentry.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Sentry.xcodeproj; path = ../../Sentry.xcodeproj; sourceTree = "<group>"; };
 		634C7EC724406A4900AFDE9F /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		637AFDC6243B036B0034958B /* iOS-ObjectiveC.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS-ObjectiveC.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -186,6 +189,8 @@
 				637AFDD0243B036B0034958B /* ViewController.m */,
 				7B8A5C9C2715B5CF008ACD3B /* InitializerViewController.h */,
 				7B8A5C9D2715B5DE008ACD3B /* InitializerViewController.m */,
+				6250B9752CB69C86009512D6 /* NoARCCrash.h */,
+				6250B97B2CB69C96009512D6 /* NoARCCrash.m */,
 				637AFDD2243B036B0034958B /* Main.storyboard */,
 				637AFDD5243B036D0034958B /* Assets.xcassets */,
 				7B3427F925876DDB00056519 /* Tongariro.jpg */,
@@ -415,6 +420,7 @@
 				637AFDCB243B036B0034958B /* AppDelegate.m in Sources */,
 				84BA72AB2C9369A40045B828 /* GitInjections.swift in Sources */,
 				637AFDDC243B036D0034958B /* main.m in Sources */,
+				6250B97C2CB69C96009512D6 /* NoARCCrash.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/Base.lproj/Main.storyboard
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -24,7 +24,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="AVC-4r-eVc">
-                                <rect key="frame" x="8" y="120.5" width="398" height="240"/>
+                                <rect key="frame" x="8" y="120.5" width="398" height="270"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rUC-at-hwU">
                                         <rect key="frame" x="0.0" y="0.0" width="398" height="30"/>
@@ -77,8 +77,15 @@
                                             <action selector="crash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6xT-zA-EZI"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7cg-k4-wJ5" userLabel="oomCrash">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eUX-Yi-7fo">
                                         <rect key="frame" x="0.0" y="210" width="398" height="30"/>
+                                        <state key="normal" title="sigsevCrash"/>
+                                        <connections>
+                                            <action selector="sigsevCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Z0n-Rw-Tpu"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7cg-k4-wJ5" userLabel="oomCrash">
+                                        <rect key="frame" x="0.0" y="240" width="398" height="30"/>
                                         <state key="normal" title="OOM Crash"/>
                                         <connections>
                                             <action selector="oomCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="6Eb-uS-ljp"/>

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/NoARCCrash.h
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/NoARCCrash.h
@@ -1,0 +1,6 @@
+/**
+ * We need to this into an extra file so we can disable ARC with the -fno-objc-arc Compiler flag.
+ * Otherwise, we can't call [NSObject release].
+ *
+ */
+void callMessageOnDeallocatedObject(void);

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/NoARCCrash.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/NoARCCrash.m
@@ -1,0 +1,10 @@
+#import "NoARCCrash.h"
+#import <Foundation/Foundation.h>
+
+void
+callMessageOnDeallocatedObject(void)
+{
+    NSObject *obj = [[NSObject alloc] init];
+    [obj release]; // Manually releasing in MRC, making `obj` a dangling pointer
+    [obj description]; // Sending a message to a deallocated object causes a SIGSEGV
+}

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -1,4 +1,5 @@
 #import "ViewController.h"
+#import "NoARCCrash.h"
 
 @import Sentry;
 
@@ -121,6 +122,11 @@
 - (IBAction)crash:(id)sender
 {
     [SentrySDK crash];
+}
+
+- (IBAction)sigsevCrash:(id)sender
+{
+    callMessageOnDeallocatedObject();
 }
 
 - (IBAction)oomCrash:(id)sender

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -83,11 +83,6 @@
 		621D9F2F2B9B0320003D94DE /* SentryCurrentDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621D9F2E2B9B0320003D94DE /* SentryCurrentDateProvider.swift */; };
 		621F61F12BEA073A005E654F /* SentryEnabledFeaturesBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621F61F02BEA073A005E654F /* SentryEnabledFeaturesBuilder.swift */; };
 		6221BBCA2CAA932100C627CA /* SentryANRType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6221BBC92CAA932100C627CA /* SentryANRType.swift */; };
-		62262B862BA1C46D004DA3DD /* SentryStatsdClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 62262B852BA1C46D004DA3DD /* SentryStatsdClient.h */; };
-		62262B882BA1C490004DA3DD /* SentryStatsdClient.m in Sources */ = {isa = PBXBuildFile; fileRef = 62262B872BA1C490004DA3DD /* SentryStatsdClient.m */; };
-		62262B8B2BA1C4C1004DA3DD /* EncodeMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */; };
-		62262B8D2BA1C4DB004DA3DD /* Metric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B8C2BA1C4DB004DA3DD /* Metric.swift */; };
-		62262B912BA1C520004DA3DD /* CounterMetric.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62262B902BA1C520004DA3DD /* CounterMetric.swift */; };
 		6229416A2BB2F123004765D1 /* SentryNSDataUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 622941692BB2F123004765D1 /* SentryNSDataUtilsTests.swift */; };
 		622C08D829E546F4002571D4 /* SentryTraceOrigins.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D729E546F4002571D4 /* SentryTraceOrigins.h */; };
 		622C08DB29E554B9002571D4 /* SentrySpanContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */; };
@@ -1077,12 +1072,6 @@
 		621D9F2E2B9B0320003D94DE /* SentryCurrentDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCurrentDateProvider.swift; sourceTree = "<group>"; };
 		621F61F02BEA073A005E654F /* SentryEnabledFeaturesBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnabledFeaturesBuilder.swift; sourceTree = "<group>"; };
 		6221BBC92CAA932100C627CA /* SentryANRType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryANRType.swift; sourceTree = "<group>"; };
-		62262B852BA1C46D004DA3DD /* SentryStatsdClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryStatsdClient.h; path = include/SentryStatsdClient.h; sourceTree = "<group>"; };
-		62262B872BA1C490004DA3DD /* SentryStatsdClient.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryStatsdClient.m; sourceTree = "<group>"; };
-		62262B8A2BA1C4C1004DA3DD /* EncodeMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeMetrics.swift; sourceTree = "<group>"; };
-		62262B8C2BA1C4DB004DA3DD /* Metric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Metric.swift; sourceTree = "<group>"; };
-		62262B902BA1C520004DA3DD /* CounterMetric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CounterMetric.swift; sourceTree = "<group>"; };
-		62262B952BA1C564004DA3DD /* EncodeMetricTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EncodeMetricTests.swift; sourceTree = "<group>"; };
 		622941692BB2F123004765D1 /* SentryNSDataUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSDataUtilsTests.swift; sourceTree = "<group>"; };
 		622C08D729E546F4002571D4 /* SentryTraceOrigins.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTraceOrigins.h; path = include/SentryTraceOrigins.h; sourceTree = "<group>"; };
 		622C08D929E554B9002571D4 /* SentrySpanContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySpanContext+Private.h"; path = "include/SentrySpanContext+Private.h"; sourceTree = "<group>"; };


### PR DESCRIPTION
Add a method to cause a sigsev crash by calling a method on a deallocated object.

A customer reported that our SDK doesn't capture a sigsev crash where the topmost frames are `_objc_msSend_uncached` and `lookUpImpOrForward`, which is usually a sign for corrupted memory. Our SDK though successfully reports the sigsev crash added with this PR.

#skip-changelog