### PR TITLE
fix: Make SentryDebugImageProvider internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 via the option `swizzleClassNameExclude`.
 - Add TTID/TTFD spans when loadView gets skipped (#4415)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
+- Make SentryDebugImageProvider internal (#4425), cause it's reserved for Hybrid SDKs only. If you require `SentryDebugImageProvide` to be public, [please open](https://github.com/getsentry/sentry-cocoa/issues/new) an issue explaining why you need the API.
 
 ### Improvements
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 		7BA0C0482805600A003E0326 /* SentryTransportAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA0C0472805600A003E0326 /* SentryTransportAdapter.m */; };
 		7BA0C04C28056556003E0326 /* SentryTransportAdapterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA0C04B28056556003E0326 /* SentryTransportAdapterTests.swift */; };
 		7BA235632600B61200E12865 /* SentryInternalNotificationNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */; };
-		7BA61CAB247BA98100C130A8 /* SentryDebugImageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA61CAA247BA98100C130A8 /* SentryDebugImageProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7BA61CAB247BA98100C130A8 /* SentryDebugImageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA61CAA247BA98100C130A8 /* SentryDebugImageProvider.h */; };
 		7BA61CAD247BAA0B00C130A8 /* SentryDebugImageProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BA61CAC247BAA0B00C130A8 /* SentryDebugImageProvider.m */; };
 		7BA61CAF247BBF3C00C130A8 /* SentryDebugImageProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA61CAE247BBF3C00C130A8 /* SentryDebugImageProviderTests.swift */; };
 		7BA61CB4247BC3EB00C130A8 /* SentryCrashBinaryImageProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BA61CB3247BC3EB00C130A8 /* SentryCrashBinaryImageProvider.h */; };
@@ -1482,7 +1482,7 @@
 		7BA0C04B28056556003E0326 /* SentryTransportAdapterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransportAdapterTests.swift; sourceTree = "<group>"; };
 		7BA1C51E2716DDB3005D75A4 /* Invocations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Invocations.swift; sourceTree = "<group>"; };
 		7BA235622600B61200E12865 /* SentryInternalNotificationNames.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalNotificationNames.h; path = include/SentryInternalNotificationNames.h; sourceTree = "<group>"; };
-		7BA61CAA247BA98100C130A8 /* SentryDebugImageProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDebugImageProvider.h; path = Public/SentryDebugImageProvider.h; sourceTree = "<group>"; };
+		7BA61CAA247BA98100C130A8 /* SentryDebugImageProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDebugImageProvider.h; path = include/HybridPublic/SentryDebugImageProvider.h; sourceTree = "<group>"; };
 		7BA61CAC247BAA0B00C130A8 /* SentryDebugImageProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDebugImageProvider.m; sourceTree = "<group>"; };
 		7BA61CAE247BBF3C00C130A8 /* SentryDebugImageProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDebugImageProviderTests.swift; sourceTree = "<group>"; };
 		7BA61CB3247BC3EB00C130A8 /* SentryCrashBinaryImageProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashBinaryImageProvider.h; path = include/SentryCrashBinaryImageProvider.h; sourceTree = "<group>"; };

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -4,6 +4,7 @@
 
 #    import "SentryClient+Private.h"
 #    import "SentryDateUtils.h"
+#    import "SentryDebugImageProvider.h"
 #    import "SentryDependencyContainer.h"
 #    import "SentryDevice.h"
 #    import "SentryEnvelope.h"

--- a/Sources/Sentry/Public/Sentry.h
+++ b/Sources/Sentry/Public/Sentry.h
@@ -12,7 +12,6 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #    import <Sentry/SentryBreadcrumb.h>
 #    import <Sentry/SentryClient.h>
 #    import <Sentry/SentryCrashExceptionApplication.h>
-#    import <Sentry/SentryDebugImageProvider.h>
 #    import <Sentry/SentryDebugMeta.h>
 #    import <Sentry/SentryDefines.h>
 #    import <Sentry/SentryDsn.h>

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -65,16 +65,9 @@
 
 - (NSArray<SentryDebugMeta *> *)getDebugImagesForFrames:(NSArray<SentryFrame *> *)frames
 {
-    // maintains previous behavior for the same method call by also trying to gather crash info
-    return [self getDebugImagesForFrames:frames isCrash:YES];
-}
-
-- (NSArray<SentryDebugMeta *> *)getDebugImagesForFrames:(NSArray<SentryFrame *> *)frames
-                                                isCrash:(BOOL)isCrash
-{
     NSMutableSet<NSString *> *imageAddresses = [[NSMutableSet alloc] init];
     [self extractDebugImageAddressFromFrames:frames intoSet:imageAddresses];
-    return [self getDebugImagesForAddresses:imageAddresses isCrash:isCrash];
+    return [self getDebugImagesForAddresses:imageAddresses isCrash:NO];
 }
 
 - (NSArray<SentryDebugMeta *> *)getDebugImagesForThreads:(NSArray<SentryThread *> *)threads

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -717,8 +717,7 @@ static BOOL appStartMeasurementRead;
     if (framesOfAllSpans.count > 0) {
         SentryDebugImageProvider *debugImageProvider
             = SentryDependencyContainer.sharedInstance.debugImageProvider;
-        transaction.debugMeta = [debugImageProvider getDebugImagesForFrames:framesOfAllSpans
-                                                                    isCrash:NO];
+        transaction.debugMeta = [debugImageProvider getDebugImagesForFrames:framesOfAllSpans];
     }
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/HybridPublic/SentryDebugImageProvider.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDebugImageProvider.h
@@ -6,7 +6,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Reserved for hybrid SDKs that the debug image list for symbolication.
- * @todo This class should be renamed to @c SentryDebugImage in a future version.
  */
 @interface SentryDebugImageProvider : NSObject
 
@@ -36,23 +35,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Returns a list of debug images that are being referenced by the given frames.
  * @param frames A list of stack frames.
- * @warning This assumes a crash has occurred and attempts to read the crash information from each
- * image's data segment, which may not be present or be invalid if a crash has not actually
- * occurred. To avoid this, use the new @c -[getDebugImagesForFrames:isCrash:] instead.
- * @deprecated Use @c -[getDebugImagesForFrames:isCrash:] instead.
  */
-- (NSArray<SentryDebugMeta *> *)getDebugImagesForFrames:(NSArray<SentryFrame *> *)frames
-    DEPRECATED_MSG_ATTRIBUTE("Use -[getDebugImagesForFrames:isCrash:] instead.");
-
-/**
- * Returns a list of debug images that are being referenced by the given frames.
- * @param frames A list of stack frames.
- * @param isCrash @c YES if we're collecting binary images for a crash report, @c NO if we're
- * gathering them for other backtrace information, like a performance transaction. If this is for a
- * crash, each image's data section crash info is also included.
- */
-- (NSArray<SentryDebugMeta *> *)getDebugImagesForFrames:(NSArray<SentryFrame *> *)frames
-                                                isCrash:(BOOL)isCrash;
+- (NSArray<SentryDebugMeta *> *)getDebugImagesForFrames:(NSArray<SentryFrame *> *)frames;
 
 /**
  * Returns the current list of debug images. Be aware that the @c SentryDebugMeta is actually


### PR DESCRIPTION




## :scroll: Description

Move SentryDebugImageProvider.h to HybridPublic, as it's not supposed to be public. Strictly speaking, this is a breaking change, but nobody should have to use this API except the hybrid SDKs. We can always make it public again if we get complaints. Furthermore, remove a method not used by the SDK or hybrid SDKs.

## :bulb: Motivation and Context

It will make it easier to speed up `getDebugImagesForFrames` by using the `SentryBinaryImageCache` for GH-4399, because the `SentryBinaryImageCache` can't retrieve crash info.

Fixes GH-3056

## :green_heart: How did you test it?
CI.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
