### PR TITLE
fix: Data race in SentrySwizzleInfo.originalCalled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ via the option `swizzleClassNameExclude`.
 - Add TTID/TTFD spans when loadView gets skipped (#4415)
 - Finish TTID correctly when viewWillAppear is skipped (#4417)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
+- Data race in SentrySwizzleInfo.originalCalled ()
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ via the option `swizzleClassNameExclude`.
 - Add TTID/TTFD spans when loadView gets skipped (#4415)
 - Finish TTID correctly when viewWillAppear is skipped (#4417)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
-- Data race in SentrySwizzleInfo.originalCalled ()
+- Data race in SentrySwizzleInfo.originalCalled (#4434)
 
 ### Improvements
 

--- a/Sources/Sentry/SentrySwizzle.m
+++ b/Sources/Sentry/SentrySwizzle.m
@@ -24,7 +24,7 @@ typedef IMP (^SentrySwizzleImpProvider)(void);
         return NULL;
     }
 
-#if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#if defined(TEST) || defined(TESTCI)
     @synchronized(self) {
         self.originalCalled = YES;
     }

--- a/Sources/Sentry/include/HybridPublic/SentrySwizzle.h
+++ b/Sources/Sentry/include/HybridPublic/SentrySwizzle.h
@@ -159,7 +159,7 @@ typedef void (*SentrySwizzleOriginalIMP)(void /* id, SEL, ... */);
  */
 @property (nonatomic, readonly) SEL selector;
 
-#if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#if defined(TEST) || defined(TESTCI)
 /**
  * A flag to check whether the original implementation was called.
  */
@@ -367,7 +367,7 @@ typedef NS_ENUM(NSUInteger, SentrySwizzleMode) {
 // and remove it later.
 #define _SentrySWArguments(arguments...) DEL, ##arguments
 
-#if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#if defined(TEST) || defined(TESTCI)
 #    define _SentrySWReplacement(code...)                                                          \
         @try {                                                                                     \
             code                                                                                   \


### PR DESCRIPTION
## :scroll: Description

We have a Swizzling test that was also enabled for debug, which will cause thread sanitizer to complain about data race (which probably won't happen).

## :bulb: Motivation and Context

Close #4432 

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
