### PR TITLE
test: Disable sigterm reporting for iOS-Swift sample

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -34,7 +34,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.beforeSendSpan = { span in
                 return span
             }
-            options.enableSigtermReporting = true
             options.beforeCaptureScreenshot = { _ in
                 return true
             }


### PR DESCRIPTION
When the debugger terminates an application, we receive a sigterm event in Sentry. That's way too much noise, and we can disable it.

#skip-changelog