### PR TITLE
Fix: Thread running at User-initiated quality-of-service for Session replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ via the option `swizzleClassNameExclude`.
 - Finish TTID correctly when viewWillAppear is skipped (#4417)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
 - Data race in SentrySwizzleInfo.originalCalled (#4434)
+- Thread running at User-initiated quality-of-service for session replay ()
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ via the option `swizzleClassNameExclude`.
 - Finish TTID correctly when viewWillAppear is skipped (#4417)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
 - Data race in SentrySwizzleInfo.originalCalled (#4434)
-- Thread running at User-initiated quality-of-service for session replay (#4439)
+- Thread running at user-initiated quality-of-service for session replay (#4439)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ via the option `swizzleClassNameExclude`.
 - Finish TTID correctly when viewWillAppear is skipped (#4417)
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
 - Data race in SentrySwizzleInfo.originalCalled (#4434)
-- Thread running at User-initiated quality-of-service for session replay ()
+- Thread running at User-initiated quality-of-service for session replay (#4439)
 
 ### Improvements
 

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -281,10 +281,12 @@ static SentryTouchTracker *_touchTracker;
         = (NSInteger)(shouldReplayFullSession ? replayOptions.sessionSegmentDuration + 1
                                               : replayOptions.errorReplayDuration + 1);
 
-    
-    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(                                                                               DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_LOW, 0);
-    SentryDispatchQueueWrapper* dispatchQueue = [[SentryDispatchQueueWrapper alloc] initWithName:"Sentry Session Replay" attributes:attributes];
-    
+    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_LOW, 0);
+    SentryDispatchQueueWrapper *dispatchQueue =
+        [[SentryDispatchQueueWrapper alloc] initWithName:"Sentry Session Replay"
+                                              attributes:attributes];
+
     self.sessionReplay = [[SentrySessionReplay alloc]
         initWithReplayOptions:replayOptions
              replayFolderPath:docs

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -284,7 +284,7 @@ static SentryTouchTracker *_touchTracker;
     dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_LOW, 0);
     SentryDispatchQueueWrapper *dispatchQueue =
-        [[SentryDispatchQueueWrapper alloc] initWithName:"Sentry Session Replay"
+        [[SentryDispatchQueueWrapper alloc] initWithName:"io.sentry.session-replay"
                                               attributes:attributes];
 
     self.sessionReplay = [[SentrySessionReplay alloc]

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -281,6 +281,10 @@ static SentryTouchTracker *_touchTracker;
         = (NSInteger)(shouldReplayFullSession ? replayOptions.sessionSegmentDuration + 1
                                               : replayOptions.errorReplayDuration + 1);
 
+    
+    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(                                                                               DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_LOW, 0);
+    SentryDispatchQueueWrapper* dispatchQueue = [[SentryDispatchQueueWrapper alloc] initWithName:"Sentry Session Replay" attributes:attributes];
+    
     self.sessionReplay = [[SentrySessionReplay alloc]
         initWithReplayOptions:replayOptions
              replayFolderPath:docs
@@ -290,7 +294,7 @@ static SentryTouchTracker *_touchTracker;
                  touchTracker:_touchTracker
                  dateProvider:SentryDependencyContainer.sharedInstance.dateProvider
                      delegate:self
-                dispatchQueue:[[SentryDispatchQueueWrapper alloc] init]
+                dispatchQueue:dispatchQueue
            displayLinkWrapper:[[SentryDisplayLinkWrapper alloc] init]];
 
     [self.sessionReplay

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -225,7 +225,7 @@ class SentrySessionReplay: NSObject {
         //Creating a video is heavy and blocks the thread
         //Since this function is always called in the main thread
         //we dispatch it to a background thread.
-        dispatchQueue.queue.async(qos: .utility) {
+        dispatchQueue.dispatchAsync {
             do {
                 let videos = try self.replayMaker.createVideoWith(beginning: startedAt, end: self.dateProvider.date())
                 for video in videos {

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -225,7 +225,7 @@ class SentrySessionReplay: NSObject {
         //Creating a video is heavy and blocks the thread
         //Since this function is always called in the main thread
         //we dispatch it to a background thread.
-        dispatchQueue.dispatchAsync {
+        dispatchQueue.queue.async(qos: .utility) {
             do {
                 let videos = try self.replayMaker.createVideoWith(beginning: startedAt, end: self.dateProvider.date())
                 for video in videos {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -66,7 +66,7 @@ class SentrySessionReplayTests: XCTestCase {
         var lastReplayId: SentryId?
         var currentScreen: String?
         
-        func getSut(options: SentryReplayOptions = .init(sessionSampleRate: 0, onErrorSampleRate: 0) ) -> SentrySessionReplay {
+        func getSut(options: SentryReplayOptions = .init(sessionSampleRate: 0, onErrorSampleRate: 0), dispatchQueue: SentryDispatchQueueWrapper = TestSentryDispatchQueueWrapper() ) -> SentrySessionReplay {
             return SentrySessionReplay(replayOptions: options,
                                        replayFolderPath: cacheFolder,
                                        screenshotProvider: screenshotProvider,
@@ -75,7 +75,7 @@ class SentrySessionReplayTests: XCTestCase {
                                        touchTracker: SentryTouchTracker(dateProvider: dateProvider, scale: 0),
                                        dateProvider: dateProvider,
                                        delegate: self,
-                                       dispatchQueue: TestSentryDispatchQueueWrapper(),
+                                       dispatchQueue: dispatchQueue,
                                        displayLinkWrapper: displayLink)
         }
         

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -150,26 +150,7 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertNotNil(fixture.lastReplayRecording)
         assertFullSession(sut, expected: true)
     }
-    
-    func testMakeReplayQueueQos() {
-        let fixture = Fixture()
-        
-        let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))
-        sut.start(rootView: fixture.rootView, fullSession: true)
-        
-        let expect = expectation(description: "create video called")
-        fixture.replayMaker.createVideoCallBack = { _ in
-            let current = qos_class_self()
-            XCTAssertEqual(current, QOS_CLASS_UTILITY)
-            expect.fulfill()
-        }
-        
-        fixture.dateProvider.advance(by: 5)
-        Dynamic(sut).newFrame(nil)
-                
-        wait(for: [expect], timeout: 1)
-    }
-    
+   
     func testReplayScreenNames() throws {
         let fixture = Fixture()
         let sut = fixture.getSut(options: SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1))


### PR DESCRIPTION
## :scroll: Description

AVFoundation video maker runs on a lower QoS than user-initiated processes, and the thread sanitizer complains about waiting for it on a higher-level thread. We are changing the QoS of our call to create video.

## :bulb: Motivation and Context

Reported in here: https://github.com/getsentry/sentry/discussions/74322#discussioncomment-10934816

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x]  No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
