### PR TITLE
fix: Use UInts in envelope deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ via the option `swizzleClassNameExclude`.
 - Swizzling RootUIViewController if ignored by `swizzleClassNameExclude` (#4407)
 - Data race in SentrySwizzleInfo.originalCalled (#4434)
 
+
 ### Improvements
 
 - Serializing profile on a BG Thread (#4377) to avoid potentially slightly blocking the main thread.
 - Session Replay performance for SwiftUI (#4419)
 - Speed up getBinaryImages (#4435) for finishing transactions and capturing events
+- Use UInts in envelope deserialization (#4441)
 
 ## 8.38.0-beta.1
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -82,9 +82,9 @@ NS_ASSUME_NONNULL_BEGIN
 {
     SentryEnvelopeHeader *envelopeHeader = nil;
     const unsigned char *bytes = [data bytes];
-    int envelopeHeaderIndex = 0;
+    NSUInteger envelopeHeaderIndex = 0;
 
-    for (int i = 0; i < data.length; ++i) {
+    for (NSUInteger i = 0; i < data.length; ++i) {
         if (bytes[i] == '\n') {
             envelopeHeaderIndex = i;
             // Envelope header end
@@ -142,12 +142,12 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     // Parse items
-    NSInteger itemHeaderStart = envelopeHeaderIndex + 1;
+    NSUInteger itemHeaderStart = envelopeHeaderIndex + 1;
 
     NSMutableArray<SentryEnvelopeItem *> *items = [NSMutableArray new];
     NSUInteger endOfEnvelope = data.length - 1;
 
-    for (NSInteger i = itemHeaderStart; i <= endOfEnvelope; ++i) {
+    for (NSUInteger i = itemHeaderStart; i <= endOfEnvelope; ++i) {
         if (bytes[i] == '\n' || i == endOfEnvelope) {
 
             NSData *itemHeaderData =


### PR DESCRIPTION


## :scroll: Description

Use unsigned integers for the indexes for accessing envelope data to eliminate the risk of negative indices.

## :bulb: Motivation and Context

Brought up as a nitpick by one of our customers, and it makes sense.

## :green_heart: How did you test it?
CI still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
