### PR TITLE
impr: Align SDK dispatch queue names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ via the option `swizzleClassNameExclude`.
 - Serializing profile on a BG Thread (#4377) to avoid potentially slightly blocking the main thread.
 - Session Replay performance for SwiftUI (#4419)
 - Speed up getBinaryImages (#4435) for finishing transactions and capturing events
+- Align SDK dispatch queue names (#4442) to start with `io.sentry`
 
 ## 8.38.0-beta.1
 

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
     // iOS 9 we need to manually add the autoreleasepool.
     dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    self = [self initWithName:"sentry-default" attributes:attributes];
+    self = [self initWithName:"io.sentry.default" attributes:attributes];
     return self;
 }
 

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -29,7 +29,7 @@
     dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_HIGH, 0);
     SentryDispatchQueueWrapper *dispatchQueue =
-        [[SentryDispatchQueueWrapper alloc] initWithName:"sentry-ui-view-controller-swizzling"
+        [[SentryDispatchQueueWrapper alloc] initWithName:"io.sentry.ui-view-controller-swizzling"
                                               attributes:attributes];
 
     SentrySubClassFinder *subClassFinder = [[SentrySubClassFinder alloc]

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -59,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_LOW, 0);
     SentryDispatchQueueWrapper *dispatchQueueWrapper =
-        [[SentryDispatchQueueWrapper alloc] initWithName:"sentry-http-transport"
+        [[SentryDispatchQueueWrapper alloc] initWithName:"io.sentry.http-transport"
                                               attributes:attributes];
 
     SentryNSURLRequestBuilder *requestBuilder = [[SentryNSURLRequestBuilder alloc] init];

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -53,7 +53,7 @@ NS_ASSUME_NONNULL_BEGIN
     dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, DISPATCH_QUEUE_PRIORITY_HIGH, 0);
     SentryDispatchQueueWrapper *dispatchQueueWrapper =
-        [[SentryDispatchQueueWrapper alloc] initWithName:"sentry-out-of-memory-tracker"
+        [[SentryDispatchQueueWrapper alloc] initWithName:"io.sentry.watchdog-termination-tracker"
                                               attributes:attributes];
 
     SentryFileManager *fileManager = [[[SentrySDK currentHub] getClient] fileManager];


### PR DESCRIPTION


## :scroll: Description

All dispatch queues now start with the prefix `io.sentry`.

## :bulb: Motivation and Context

Came up in https://github.com/getsentry/sentry-cocoa/pull/4439#discussion_r1801008595.

## :green_heart: How did you test it?
CI still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
