### PR TITLE
misc(tests): Remove Crash Recovery test from non-critical UI Tests

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/LaunchUITests.swift
@@ -2,23 +2,6 @@ import XCTest
 
 class LaunchUITests: BaseUITest {
 
-    func testCrashRecovery() throws {
-        //We will be removing this test from iOS 12 because it fails during CI, which looks like a bug that we cannot reproduce.
-        //If we introduce a bug in the crash report process we will catch it with tests for iOS 13 or above.
-        //For some reason is not possible to use @available(iOS 13, *) in the test function.
-        if #available(iOS 13, *) {
-            app.buttons["crashTheApp"].tap()
-            if app.buttons["crashTheApp"].exists {
-                XCTFail("App did not crashed")
-            }
-
-            app.launch()
-            waitForExistenceOfMainScreen()
-        } else {
-            throw XCTSkip("Only run on iOS 13 or later.")
-        }
-    }
-
     func testBreadcrumbData() {
         app.buttons["Extra"].tap()
 


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Removes duplicate crash recovery ui test.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
After https://github.com/getsentry/sentry-cocoa/pull/4421 this test is duplicate of the crash recovery from critical ui tests.

## :green_heart: How did you test it?
ci

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
#skip-changelog 