### PR TITLE
feat: Track usage of appHangTrackingV2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - feat: API to manually start/stop Session Replay (#4414)
 - Custom redact modifier for SwiftUI (#4362, #4392)
+- Track usage of appHangTrackingV2 (#4445)
 
 ### Removal of Experimental API
 
@@ -25,6 +26,7 @@ via the option `swizzleClassNameExclude`.
 - Serializing profile on a BG Thread (#4377) to avoid potentially slightly blocking the main thread.
 - Session Replay performance for SwiftUI (#4419)
 - Speed up getBinaryImages (#4435) for finishing transactions and capturing events
+
 ## 8.38.0
 
 - No documented changes.

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -35,6 +35,12 @@ import Foundation
         if options.swiftAsyncStacktraces {
             features.append("swiftAsyncStacktraces")
         }
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        if options.enableAppHangTrackingV2 {
+            features.append("appHangTrackingV2")
+        }
+#endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         
         return features
     }

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -25,6 +25,10 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         options.enablePreWarmedAppStartTracing = true
 #endif // canImport(UIKit)
 #endif // os(iOS) || os(tvOS)
+      
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        options.enableAppHangTrackingV2 = true
+#endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
         
@@ -42,5 +46,9 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         XCTAssert(features.contains("preWarmedAppStartTracing"))
 #endif // canImport(UIKit)
 #endif // os(iOS) || os(tvOS)
+        
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        XCTAssert(features.contains("appHangTrackingV2"))
+#endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     }
 }


### PR DESCRIPTION


## :scroll: Description

Add appHangTrackingV2 to the list of enabled features when the option enableAppHangTrackingV2 is enabled.

## :bulb: Motivation and Context

We want to know how many people use appHangTrackingV2.

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
