### PR TITLE
Fix: Dont create transaction for unused ViewControllers

### DIFF
--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -96,6 +96,7 @@ static const NSTimeInterval SENTRY_AUTO_TRANSACTION_DEADLINE = 30.0;
     dispatch_block_t _idleTimeoutBlock;
     NSMutableArray<id<SentrySpan>> *_children;
     BOOL _startTimeChanged;
+    BOOL _timeout;
     NSObject *_idleTimeoutLock;
 
 #if SENTRY_HAS_UIKIT
@@ -148,6 +149,8 @@ static BOOL appStartMeasurementRead;
     self.wasFinishCalled = NO;
     _measurements = [[NSMutableDictionary alloc] init];
     self.finishStatus = kSentrySpanStatusUndefined;
+    self.finishMustBeCalled = NO;
+    _timeout = YES;
 
     if (_configuration.timerFactory == nil) {
         _configuration.timerFactory = [[SentryNSTimerFactory alloc] init];
@@ -289,6 +292,8 @@ static BOOL appStartMeasurementRead;
 - (void)deadlineTimerFired
 {
     SENTRY_LOG_DEBUG(@"Sentry tracer deadline fired");
+    _timeout = YES;
+
     @synchronized(self) {
         // This try to minimize a race condition with a proper call to `finishInternal`.
         if (self.isFinished) {
@@ -303,7 +308,8 @@ static BOOL appStartMeasurementRead;
         }
     }
 
-    [self finishWithStatus:kSentrySpanStatusDeadlineExceeded];
+    _finishStatus = kSentrySpanStatusDeadlineExceeded;
+    [self finishInternal];
 }
 
 - (void)cancelDeadlineTimer
@@ -580,6 +586,12 @@ static BOOL appStartMeasurementRead;
             [self->_hub.scope setSpan:nil];
         }
     }];
+
+    if (self.finishMustBeCalled && !self.wasFinishCalled) {
+        SENTRY_LOG_DEBUG(
+            @"Not capturing transaction because finish was not called before timing out.");
+        return;
+    }
 
     @synchronized(_children) {
         if (_configuration.idleTimeout > 0.0 && _children.count == 0) {

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -125,6 +125,12 @@
         SENTRY_LOG_DEBUG(@"Started span with id %@ to track view controller %@.",
             spanId.sentrySpanIdString, name);
 
+        id<SentrySpan> vcSpan = [self.tracker getSpan:spanId];
+        if ([vcSpan isKindOfClass:SentryTracer.class]) {
+            SentryTracer *vcTracer = (SentryTracer *)vcSpan;
+            vcTracer.finishMustBeCalled = YES;
+        }
+
         // Use the target itself to store the spanId to avoid using a global mapper.
         objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_SPAN_ID, spanId,
             OBJC_ASSOCIATION_RETAIN_NONATOMIC);

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -44,6 +44,13 @@ static const NSTimeInterval SENTRY_AUTO_TRANSACTION_MAX_DURATION = 500.0;
 @property (nullable, nonatomic, copy) BOOL (^shouldIgnoreWaitForChildrenCallback)(id<SentrySpan>);
 
 /**
+ * This flag indicates whether the trace should be captured when the timeout triggers.
+ * If Yes, this tracer will be discarced in case the timeout triggers.
+ * Default @c NO
+ */
+@property (nonatomic) BOOL finishMustBeCalled;
+
+/**
  * All the spans that where created with this tracer but rootSpan.
  */
 @property (nonatomic, readonly) NSArray<id<SentrySpan>> *children;

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -136,6 +136,7 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
         XCTAssertEqual(tracer.transactionContext.nameSource, .component)
         XCTAssertEqual(tracer.transactionContext.origin, origin)
         XCTAssertFalse(tracer.isFinished)
+        XCTAssertTrue(tracer.finishMustBeCalled)
 
         sut.viewControllerViewDidLoad(viewController) {
             if let blockSpan = self.getStack(tracker).last {

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -1292,6 +1292,15 @@ class SentryTracerTests: XCTestCase {
     }
 #endif
     
+    func testFinishShouldBeCalled_Timeout_NotCaptured() {
+        fixture.dispatchQueue.blockBeforeMainBlock = { true }
+        
+        let sut = fixture.getSut()
+        sut.finishMustBeCalled = true
+        fixture.timerFactory.fire()
+        assertTransactionNotCaptured(sut)
+    }
+    
     @available(*, deprecated)
     func testSetExtra_ForwardsToSetData() {
         let sut = fixture.getSut()


### PR DESCRIPTION
## :scroll: Description

Its possible to create a view controller but never add it to the view hierarchy.
This will create a transaction with data that is not helpful

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
