### PR TITLE
ci: Remove deprecated macos-12 image

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,13 +76,6 @@ jobs:
       matrix:
         # Can't run tests on watchOS because XCTest is not available
         include:
-          # iOS 15
-          - runs-on: macos-12
-            platform: "iOS"
-            xcode: "13.4.1"
-            test-destination-os: "latest"
-            device: "iPhone 8"
-
           # iOS 16
           - runs-on: macos-13
             platform: "iOS"
@@ -96,12 +89,6 @@ jobs:
             xcode: "15.4"
             test-destination-os: "17.2"
             device: "iPhone 15"
-
-          # macOS 12
-          - runs-on: macos-12
-            platform: "macOS"
-            xcode: "13.4.1"
-            test-destination-os: "latest"
 
           # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.
@@ -119,12 +106,6 @@ jobs:
             platform: "Catalyst"
             xcode: "15.4"
             test-destination-os: "latest"
-
-          # tvOS 15
-          - runs-on: macos-12
-            platform: "tvOS"
-            xcode: "13.4.1"
-            test-destination-os: "16.1"
 
           # We don't run the unit tests on tvOS 16 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, tvOS 15 or tvOS 16 is minimal.

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -49,11 +49,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-12
-            xcode: "13.4.1"
-            device: "iPhone 8"
-            os-version: "15.5"
-            create-simulator: true
           - runs-on: macos-13
             xcode: "14.3.1"
             device: "iPhone 14"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -54,10 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-12
-            xcode: "13.4.1"
-            device: "iPhone 8 (15.2)"
-
           - runs-on: macos-13
             xcode: "14.3"
             device: "iPhone 8 (16.1)"
@@ -87,10 +83,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-12
-            xcode: "13.4.1"
-            device: "iPhone 8 (15.5)"
-
           - runs-on: macos-13
             xcode: "15.2"
             device: "iPhone 14 (16.4)"

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 # For available Xcode versions see:
-# - https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md
 # - https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
 # - https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md
 


### PR DESCRIPTION
macos-12 runners will be fully unsupported by December 3rd, 2024, and are already deprecated. We have to remove them.

GH actions issue: https://github.com/actions/runner-images/issues/10721

#skip-changelog