### PR TITLE
ci: Run critical UI tests on iOS 18

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -54,11 +54,13 @@ jobs:
             device: "iPhone 8"
             os-version: "15.5"
             create-simulator: true
+
           - runs-on: macos-13
             xcode: "14.3.1"
             device: "iPhone 14"
             os-version: "16.4"
             create-simulator: true
+
           - runs-on: macos-14-xlarge
             # on macos-14 the iOS 17.5 simulator was unstable
             # crashing and failing all UI tests
@@ -66,10 +68,11 @@ jobs:
             xcode: "15.4"
             device: "iPhone 15"
             os-version: "17.5"
+
           - runs-on: macos-15
             xcode: "16"
             device: "iPhone 16"
-            os-version: "18.1"
+            os-version: "18.0"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
iOS 18.1 is still in beta. Let's use 18.0 instead.

#skip-changelog