### PR TITLE
ref: Make `SentrySDK.replay.start()` thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ via the option `swizzleClassNameExclude`.
 - Speed up getBinaryImages (#4435) for finishing transactions and capturing events
 - Align SDK dispatch queue names (#4442) to start with `io.sentry`
 - Use UInts in envelope deserialization (#4441)
+- Make `SentrySDK.replay.start()` thread safe ()
 
 ## 8.38.0
 

--- a/Sources/Sentry/SentryReplayApi.m
+++ b/Sources/Sentry/SentryReplayApi.m
@@ -39,20 +39,25 @@
 
 - (void)start
 {
-    SentrySessionReplayIntegration *replayIntegration
+    // Start could be misused and called multiple times, causing it to
+    // be initialized more than once before being installed.
+    // Synchronizing it will prevent this problem.
+    @synchronized (self) {
+        SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
-            getInstalledIntegration:SentrySessionReplayIntegration.class];
-
-    if (replayIntegration == nil) {
-        SentryOptions *currentOptions = SentrySDK.currentHub.client.options;
-        replayIntegration =
+                                             getInstalledIntegration:SentrySessionReplayIntegration.class];
+        
+        if (replayIntegration == nil) {
+            SentryOptions *currentOptions = SentrySDK.currentHub.client.options;
+            replayIntegration =
             [[SentrySessionReplayIntegration alloc] initForManualUse:currentOptions];
-
-        [SentrySDK.currentHub addInstalledIntegration:replayIntegration
-                                                 name:NSStringFromClass(SentrySessionReplay.class)];
+            
+            [SentrySDK.currentHub addInstalledIntegration:replayIntegration
+                                                     name:NSStringFromClass(SentrySessionReplay.class)];
+        }
+        
+        [replayIntegration start];
     }
-
-    [replayIntegration start];
 }
 
 - (void)stop


### PR DESCRIPTION
## :scroll: Description

Making `SentrySDK.replay.start()` thread safe to avoid multiple initialization

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
