### PR TITLE
Add getDebugImagesForImageAddressesFromCache method in the HybridSDKs header

### DIFF
--- a/Sources/Sentry/include/HybridPublic/SentryDebugImageProvider+HybridSDKs.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDebugImageProvider+HybridSDKs.h
@@ -24,6 +24,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSArray<SentryDebugMeta *> *)getDebugImagesFromCacheForThreads:(NSArray<SentryThread *> *)threads
     NS_SWIFT_NAME(getDebugImagesFromCacheForThreads(threads:));
 
+/**
+ * Returns a list of debug images that are being referenced in the given image addresses.
+ * This function uses the @c SentryBinaryImageCache which is significantly faster than @c
+ * SentryCrashDefaultBinaryImageProvider for retrieving binary image information.
+ */
+- (NSArray<SentryDebugMeta *> *)getDebugImagesForImageAddressesFromCache:
+    (NSSet<NSString *> *)imageAddresses
+    NS_SWIFT_NAME(getDebugImagesForImageAddressesFromCache(imageAddresses:));
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
@@ -272,6 +272,42 @@ class SentryDebugImageProviderTests: XCTestCase {
         
         XCTAssertEqual(actual.count, 0)
     }
+    
+    func testGetDebugImagesForImageAddressesFromCache() throws {
+        let sut = fixture.getSut(images: fixture.getTestImages())
+        
+        let imageAddress = "0x00000001410b1a00"
+        
+        let actual = sut.getDebugImagesForImageAddressesFromCache(imageAddresses: [imageAddress])
+        
+        XCTAssertEqual(actual.count, 1)
+        let image = try XCTUnwrap(actual.first)
+        
+        XCTAssertEqual(image.debugID, "84BAEBDA-AD1A-33F4-B35D-8A45F5DAF322")
+        XCTAssertEqual(image.type, SentryDebugImageType)
+        XCTAssertEqual(image.imageVmAddress, "0x0000daf262294000")
+        XCTAssertEqual(image.imageAddress, "0x00000001410b1a00")
+        XCTAssertEqual(image.imageSize, 1_352_256)
+        XCTAssertEqual(image.codeFile, "UIKit")
+    }
+    
+    func testGetDebugImagesForImageAddressesFromCache_GarbageImageAddress() throws {
+        let sut = fixture.getSut(images: fixture.getTestImages())
+        
+        let imageAddress = "garbage"
+        
+        let actual = sut.getDebugImagesForImageAddressesFromCache(imageAddresses: [imageAddress])
+
+        XCTAssertEqual(actual.count, 0)
+    }
+    
+    func testGetDebugImagesForImageAddressesFromCache_EmptyArray() throws {
+        let sut = fixture.getSut(images: fixture.getTestImages())
+        
+        let actual = sut.getDebugImagesForImageAddressesFromCache(imageAddresses: [])
+        
+        XCTAssertEqual(actual.count, 0)
+    }
         
     private static func createSentryCrashBinaryImage(
         address: UInt64 = 0,


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->
Add getDebugImagesForImageAddressesFromCache method in the HybridSDKs header.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See discussion in https://github.com/getsentry/sentry-react-native/issues/4169#issuecomment-2425962458

## :green_heart: How did you test it?
CI

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog
