### PR TITLE
ref(transport): Log a warning when dropping envelopes due to rate-limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Log a warning when dropping envelopes due to rate-limiting (#4463)
+
 ## 8.39.0-beta.1
 
 ### Removal of Experimental API

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -124,7 +124,7 @@
     envelope = [self.envelopeRateLimit removeRateLimitedItems:envelope];
 
     if (envelope.items.count == 0) {
-        SENTRY_LOG_DEBUG(@"RateLimit is active for all envelope items.");
+        SENTRY_LOG_WARN(@"RateLimit is active for all envelope items.");
         return;
     }
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -232,6 +232,7 @@
 - (void)envelopeItemDropped:(SentryEnvelopeItem *)envelopeItem
                withCategory:(SentryDataCategory)dataCategory;
 {
+    SENTRY_LOG_WARN(@"Envelope item dropped due to exceeding rate limit. Category: %@", nameForSentryDataCategory(dataCategory));
     [self recordLostEvent:dataCategory reason:kSentryDiscardReasonRateLimitBackoff];
     [self recordLostSpans:envelopeItem reason:kSentryDiscardReasonRateLimitBackoff];
 }


### PR DESCRIPTION
## :scroll: Description

- Raise the level of an existing log statement which indicated that **all** envelope items were rate-limited, to `SENTRY_LOG_WARN`.
- Introduce a new log statement which will log a warning **each time** an envelope item has been dropped due to an exceeding rate-limit.
- ~Update `clang-formatter` to `19.1.2`~ (will be addressed in a separate PR)
  - When trying to commit I've got following error:
    - _`clang-format version mismatch, expected: 19.1.1, but found: 19.1.2. Please run `make init` to update your local dev tools. This may actually upgrade to a newer version than what is currently recorded in the lockfile; if that happens, please commit the update to the lockfile as well.`_
    - Tried to resolve via `make init`, but then followed _`This may actually upgrade to a newer version than what is currently recorded in the lockfile; if that happens, please commit the update to the lockfile as well.`_
  - It looks like `pre-commit`, `python` and `mobile-dev-inc/tap/maestro` got updated as well, but since those weren't crucial for the commit, I didn't stage/commit those changes. 


## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes #4456 

## :green_heart: How did you test it?

- Ran `SentryHttpTransportTests`

See below:

| Running all tests in `SentryHttpTransportTests` |
| ------------- |
| <img width="800" alt="SentryHttpTransportTests" src="https://github.com/user-attachments/assets/212fd916-e39b-43fe-8c2c-8c5db2011028"> |


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [ ] I added tests to verify the changes.
- [x] **No new PII added** or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or **entry added to the changelog**.
- [x] **No breaking change** for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- Let me know if the new log message is specific/descriptive enough, or feel free to suggest an alternative. Thanks!
