### PR TITLE
Fix: Time-of-check time-of-use filesystem race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Build visionOS project with static Sentry SDK (#4462)
+- Time-of-check time-of-use filesystem race condition (#4473)
 
 ### Improvements
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -236,7 +236,6 @@ sentrycrashfu_readEntireFile(const char *const path, char **data, int *length, i
     int fd = -1;
     int bytesToRead = maxLength;
 
-    struct stat st;
 
     fd = open(path, O_RDONLY);
     if (fd < 0) {
@@ -244,6 +243,7 @@ sentrycrashfu_readEntireFile(const char *const path, char **data, int *length, i
         goto done;
     }
 
+    struct stat st;
     if (fstat(fd, &st) < 0) {
         SENTRY_ASYNC_SAFE_LOG_ERROR("Could not fstat %s: %s", path, strerror(errno));
         goto done;

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -237,14 +237,15 @@ sentrycrashfu_readEntireFile(const char *const path, char **data, int *length, i
     int bytesToRead = maxLength;
 
     struct stat st;
-    if (stat(path, &st) < 0) {
-        SENTRY_ASYNC_SAFE_LOG_ERROR("Could not stat %s: %s", path, strerror(errno));
-        goto done;
-    }
 
     fd = open(path, O_RDONLY);
     if (fd < 0) {
         SENTRY_ASYNC_SAFE_LOG_ERROR("Could not open %s: %s", path, strerror(errno));
+        goto done;
+    }
+
+    if (fstat(fd, &st) < 0) {
+        SENTRY_ASYNC_SAFE_LOG_ERROR("Could not fstat %s: %s", path, strerror(errno));
         goto done;
     }
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashFileUtils.c
@@ -236,7 +236,6 @@ sentrycrashfu_readEntireFile(const char *const path, char **data, int *length, i
     int fd = -1;
     int bytesToRead = maxLength;
 
-
     fd = open(path, O_RDONLY);
     if (fd < 0) {
         SENTRY_ASYNC_SAFE_LOG_ERROR("Could not open %s: %s", path, strerror(errno));


### PR DESCRIPTION
Fixes [https://github.com/getsentry/sentry-cocoa/security/code-scanning/6](https://github.com/getsentry/sentry-cocoa/security/code-scanning/6)

To fix the TOCTOU race condition, we should avoid using `stat` and `open` separately. Instead, we can use the `open` function with the `O_RDONLY` flag to open the file directly and then use `fstat` to get the file status. This ensures that the file we are operating on is the same file we checked, as both operations are performed on the file descriptor.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
