### PR TITLE
test(critical): Shutdown all simulators before tests, wait for sim boot

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -82,10 +82,16 @@ jobs:
         with:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
+
+      - run: xcrun simctl shutdown all
       - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9 # pin@v3
         with:
+          erase_before_boot: true
+          wait_for_boot: true
+          shutdown_after_job: true
           model: ${{matrix.device}}
           os_version: ${{matrix.os-version}}
+
       - name: Run Maestro Flows
         run: |
           xcrun simctl install booted ${{env.APP_PATH}}


### PR DESCRIPTION
This PR tries to improve Critical Tests for iOS 17.

---

wait_for_boot is by default false.

erase_before_boot and shutdown_after_job are true by default, I added them just for clarity.
