### PR TITLE
test(critical): Remove iOS 17

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -55,14 +55,6 @@ jobs:
             os-version: "16.4"
             create-simulator: true
 
-          - runs-on: macos-14-xlarge
-            # on macos-14 the iOS 17.5 simulator was unstable
-            # crashing and failing all UI tests
-            # iOS 15.5, 16.4 and 18.1 worked on the base runners
-            xcode: "15.4"
-            device: "iPhone 15"
-            os-version: "17.5"
-
           - runs-on: macos-15
             xcode: "16"
             device: "iPhone 16"

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -74,7 +74,6 @@ jobs:
         with:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
-
       - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9 # pin@v3
         with:
           model: ${{matrix.device}}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -82,10 +82,16 @@ jobs:
         with:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
+
+      - run: xcrun simctl shutdown all
       - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9 # pin@v3
         with:
+          erase_before_boot: true
+          wait_for_boot: true
+          shutdown_after_job: true
           model: ${{matrix.device}}
           os_version: ${{matrix.os-version}}
+
       - name: Run Maestro Flows
         run: |
           xcrun simctl install booted ${{env.APP_PATH}}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -55,6 +55,8 @@ jobs:
             os-version: "16.4"
             create-simulator: true
 
+          # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests 
+
           - runs-on: macos-15
             xcode: "16"
             device: "iPhone 16"

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -75,15 +75,10 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
-      - run: xcrun simctl shutdown all
       - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9 # pin@v3
         with:
-          erase_before_boot: true
-          wait_for_boot: true
-          shutdown_after_job: true
           model: ${{matrix.device}}
           os_version: ${{matrix.os-version}}
-
       - name: Run Maestro Flows
         run: |
           xcrun simctl install booted ${{env.APP_PATH}}


### PR DESCRIPTION
It's flaky, as the only test from iOS 16, 17 and 18, the 17 keeps failing on XCUIServer not found.

#skip-changelog 