### PR TITLE
test(sim): Use custom scripts to manage simulators

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -53,9 +53,9 @@ jobs:
             xcode: "14.3.1"
             device: "iPhone 14"
             os-version: "16.4"
-            create-simulator: true
+            force-sim-runtime: true
 
-          # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests 
+          # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           - runs-on: macos-15
             xcode: "16"
@@ -65,8 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Create ${{matrix.device}} (${{matrix.os-version}}) Simulator using Xcode ${{matrix.xcode}}
-        if: ${{matrix.create-simulator}}
-        run: ./scripts/create-simulator.sh "${{matrix.xcode}}" "${{matrix.os-version}}" "${{matrix.device}}"
+        run: ./scripts/create-simulator.sh "${{matrix.xcode}}" "${{matrix.os-version}}" "${{matrix.device}}" "${{matrix.force-sim-runtime}}"
       - name: Install Maestro
         run: brew tap mobile-dev-inc/tap && brew install mobile-dev-inc/tap/maestro@1.38
       - name: Install iDB Companion
@@ -76,15 +75,16 @@ jobs:
         with:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
-      - uses: futureware-tech/simulator-action@bfa03d93ec9de6dacb0c5553bbf8da8afc6c2ee9 # pin@v3
-        with:
-          model: ${{matrix.device}}
-          os_version: ${{matrix.os-version}}
+
       - name: Run Maestro Flows
         run: |
           xcrun simctl install booted ${{env.APP_PATH}}
 
           maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}
+
+      - name: Delete Simulator
+        if: always()
+        run: ./scripts/delete-simulator.sh
 
       - name: Store Maestro Logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Create iOS 16.4 simulator
         if: ${{ matrix.device == 'iPhone 14 (16.4)' }}
-        run: ./scripts/create-simulator.sh 14.3.1 16.4 "iPhone 14"
+        run: ./scripts/create-simulator.sh 14.3.1 16.4 "iPhone 14" true
 
       - name: Run Fastlane
         run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"

--- a/scripts/create-simulator.sh
+++ b/scripts/create-simulator.sh
@@ -6,9 +6,28 @@ set -euo pipefail
 XCODE_VERSION="${1}"
 SIM_RUNTIME="${2}"
 DEVICE_TYPE="${3}" # A valid available device type. Find these by running "xcrun simctl list devicetypes".
+FORCE_SIM_RUNTIME="${4}"
 
 SIM_RUNTIME_WITH_DASH="${SIM_RUNTIME//./-}"
+SIM_NAME="Sentry ${DEVICE_TYPE} (${SIM_RUNTIME})"
 
-sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
-sudo ln -s "/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime" "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS ${SIM_RUNTIME}.simruntime"
-xcrun simctl create custom-test-device "${DEVICE_TYPE}" "com.apple.CoreSimulator.SimRuntime.iOS-${SIM_RUNTIME_WITH_DASH}"
+if [ "${FORCE_SIM_RUNTIME}" == "true" ]; then
+  sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+  sudo ln -s \
+    "/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime" \
+    "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS ${SIM_RUNTIME}.simruntime"
+fi
+
+uuid=$(xcrun simctl create \
+  "${SIM_NAME}" \
+  "${DEVICE_TYPE}" \
+  "com.apple.CoreSimulator.SimRuntime.iOS-${SIM_RUNTIME_WITH_DASH}")
+echo "Created simulator ${SIM_NAME} with UUID ${uuid}"
+
+xcrun simctl boot "${uuid}"
+xcrun simctl bootstatus "${uuid}"
+echo "Booted simulator ${SIM_NAME} with UUID ${uuid}"
+
+if [ -n "${GITHUB_ENV}" ]; then
+  echo "SENTRY_SIMULATOR_UUID=${uuid}" >> "${GITHUB_ENV}"
+fi

--- a/scripts/delete-simulator.sh
+++ b/scripts/delete-simulator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# SENTRY_SIMULATOR_UUID is set by create-simulator.sh
+if [ -z "${SENTRY_SIMULATOR_UUID}" ]; then
+  echo "No simulator UUID provided"
+  exit 0
+fi
+
+uuid="${SENTRY_SIMULATOR_UUID}"
+
+xcrun simctl shutdown "${uuid}"
+echo "Shutdown simulator with UUID ${uuid}"
+
+xcrun simctl delete "${uuid}"
+echo "Deleted simulator with UUID ${uuid}"


### PR DESCRIPTION
This PR replaces custom github action with bash scripts booting and deleting simulators. 

#skip-changelog 