### PR TITLE
internal(hybrid): Add Replay Mask options to dict init

### DIFF
--- a/Brewfile.lock.json
+++ b/Brewfile.lock.json
@@ -2,40 +2,40 @@
   "entries": {
     "brew": {
       "clang-format": {
-        "version": "19.1.1",
+        "version": "19.1.3",
         "bottle": {
           "rebuild": 0,
           "root_url": "https://ghcr.io/v2/homebrew/core",
           "files": {
             "arm64_sequoia": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:7b5f8c066c04e831f51f2abf16312084e3fa098b0ff76abc6480967a2860bd24",
-              "sha256": "7b5f8c066c04e831f51f2abf16312084e3fa098b0ff76abc6480967a2860bd24"
+              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:9df6e7a73647777ea7d721611ff214cb6dfb0035270f7c075706c10126127fe7",
+              "sha256": "9df6e7a73647777ea7d721611ff214cb6dfb0035270f7c075706c10126127fe7"
             },
             "arm64_sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:e7ba64f5fba3cf0ceadaa3c520a2208642ce1169bffac8db1e9b56569195148e",
-              "sha256": "e7ba64f5fba3cf0ceadaa3c520a2208642ce1169bffac8db1e9b56569195148e"
+              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:51c70ed59125cdc84a9e69c71519e0389302fa79ec69237daad87d56f880fef7",
+              "sha256": "51c70ed59125cdc84a9e69c71519e0389302fa79ec69237daad87d56f880fef7"
             },
             "arm64_ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:ce317db950e3d268110f2bc62c5f1aa07cbb50dafd2603e168e363718a9d9e21",
-              "sha256": "ce317db950e3d268110f2bc62c5f1aa07cbb50dafd2603e168e363718a9d9e21"
+              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:221b6502def9c8349e7b55503a925b7afad79e75edeaad2039d449156e31fe00",
+              "sha256": "221b6502def9c8349e7b55503a925b7afad79e75edeaad2039d449156e31fe00"
             },
             "sonoma": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:43bcbde28012da49f5679bec7ba8d2c341771cee9909bddde1ec2e29e1fd8320",
-              "sha256": "43bcbde28012da49f5679bec7ba8d2c341771cee9909bddde1ec2e29e1fd8320"
+              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:387d602bb80b80d5e46d091bb620080d5734022b0512b42be0a0368416e40ff5",
+              "sha256": "387d602bb80b80d5e46d091bb620080d5734022b0512b42be0a0368416e40ff5"
             },
             "ventura": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:80ac7aac07528efb14db1928d1268db16033dcbaf73a0fa5c1d08817d3bf3ab4",
-              "sha256": "80ac7aac07528efb14db1928d1268db16033dcbaf73a0fa5c1d08817d3bf3ab4"
+              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:8609c73a51e4a27538fec7cf473da6a8808a273291c04df0f15959c134104048",
+              "sha256": "8609c73a51e4a27538fec7cf473da6a8808a273291c04df0f15959c134104048"
             },
             "x86_64_linux": {
               "cellar": ":any_skip_relocation",
-              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:f8318eea6c50bf91462397af31ee5c20413dfb1a6625aa8b73d524f4b7396180",
-              "sha256": "f8318eea6c50bf91462397af31ee5c20413dfb1a6625aa8b73d524f4b7396180"
+              "url": "https://ghcr.io/v2/homebrew/core/clang-format/blobs/sha256:b1f7cdba80030cd264f64d22fc3d5e0865c7167a0b2462a64bfe82d155e821c2",
+              "sha256": "b1f7cdba80030cd264f64d22fc3d5e0865c7167a0b2462a64bfe82d155e821c2"
             }
           }
         }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -152,5 +152,11 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
         let maskAllText = (dictionary["maskAllText"] as? NSNumber)?.boolValue ?? true
         let maskAllImages = (dictionary["maskAllImages"] as? NSNumber)?.boolValue ?? true
         self.init(sessionSampleRate: sessionSampleRate, onErrorSampleRate: onErrorSampleRate, maskAllText: maskAllText, maskAllImages: maskAllImages)
+        self.maskedViewClasses = ((dictionary["maskedViewClasses"] as? NSArray) ?? []).compactMap({ element in
+            NSClassFromString((element as? String) ?? "")
+        })
+        self.unmaskedViewClasses = ((dictionary["unmaskedViewClasses"] as? NSArray) ?? []).compactMap({ element in
+            NSClassFromString((element as? String) ?? "")
+        })
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
@@ -27,5 +27,155 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.replayBitRate, 60_000)
         XCTAssertEqual(options.sizeScale, 1.0)
     }
-    
+
+    func testInitFromDictOnErrorSampleRateAsDouble() {
+        let options = SentryReplayOptions(dictionary: [
+            "errorSampleRate": 0.44
+        ])
+
+        XCTAssertEqual(options.onErrorSampleRate, 0.44)
+    }
+
+    func testInitFromDictOnErrorSampleRateMissing() {
+        let options = SentryReplayOptions(dictionary: [:])
+
+        XCTAssertEqual(options.onErrorSampleRate, 0)
+    }
+
+    func testInitFromDictOnErrorSampleRateAsString() {
+        let options = SentryReplayOptions(dictionary: [
+            "onErrorSampleRate": "0.44"
+        ])
+
+        XCTAssertEqual(options.onErrorSampleRate, 0)
+    }
+
+    func testInitFromDictSessionSampleRateAsDouble() {
+        let options = SentryReplayOptions(dictionary: [
+            "sessionSampleRate": 0.44
+        ])
+
+        XCTAssertEqual(options.sessionSampleRate, 0.44)
+    }
+
+    func testInitFromDictSessionSampleRateMissing() {
+        let options = SentryReplayOptions(dictionary: [:])
+
+        XCTAssertEqual(options.sessionSampleRate, 0)
+    }
+
+    func testInitFromDictSessionSampleRateAsString() {
+        let options = SentryReplayOptions(dictionary: [
+            "sessionSampleRate": "0.44"
+        ])
+
+        XCTAssertEqual(options.sessionSampleRate, 0)
+    }
+
+    func testInitFromDictMaskedViewClasses() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskedViewClasses": ["UILabel"]
+        ])
+
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses[0]), ObjectIdentifier(UILabel.self))
+    }
+
+    func testInitFromDictMaskedViewClassesAsString() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskedViewClasses": "UILabel"
+        ])
+
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+    }
+
+    func testInitFromDictMaskedViewClassesWithNumber() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskedViewClasses": [123]
+        ])
+
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+    }
+
+    func testInitFromDictUnmaskedViewClasses() {
+        let options = SentryReplayOptions(dictionary: [
+            "unmaskedViewClasses": ["UILabel"]
+        ])
+
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        XCTAssertEqual(ObjectIdentifier(options.unmaskedViewClasses.first as AnyClass), ObjectIdentifier(UILabel.self))
+    }
+
+    func testInitFromDictUnmaskedViewClassesAsString() {
+        let options = SentryReplayOptions(dictionary: [
+            "unmaskedViewClasses": "invalid_value"
+        ])
+
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+    }
+
+    func testInitFromDictUnmaskedViewClassesWithInvalidValues() {
+        let options = SentryReplayOptions(dictionary: [
+            "unmaskedViewClasses": [123, "not.class"]
+        ])
+
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+    }
+
+    func testInitFromDictMaskAllTextWithBool() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskAllText": true
+        ])
+        XCTAssertTrue(options.maskAllText)
+
+        let options2 = SentryReplayOptions(dictionary: [
+            "maskAllText": false
+        ])
+        XCTAssertFalse(options2.maskAllText)
+    }
+
+    func testInitFromDictMaskAllTextWithString() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskAllText": "invalid_value"
+        ])
+        XCTAssertTrue(options.maskAllText)
+    }
+
+    func testInitFromDictMaskAllImagesWithBool() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskAllImages": true
+        ])
+        XCTAssertTrue(options.maskAllImages)
+
+        let options2 = SentryReplayOptions(dictionary: [
+            "maskAllImages": false
+        ])
+        XCTAssertFalse(options2.maskAllImages)
+    }
+
+    func testInitFromDictMaskAllImagesWithString() {
+        let options = SentryReplayOptions(dictionary: [
+            "maskAllImages": "invalid_value"
+        ])
+        XCTAssertTrue(options.maskAllImages)
+    }
+
+    func testInitFromDictWithMultipleOptions() {
+        let options = SentryReplayOptions(dictionary: [
+            "sessionSampleRate": 0.5,
+            "errorSampleRate": 0.8,
+            "maskAllText": false,
+            "maskedViewClasses": ["UIView", "not.a.class", 123],
+            "unmaskedViewClasses": ["UILabel", "invalid", true]
+        ])
+
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses.first), ObjectIdentifier(UIView.self))
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        XCTAssertEqual(options.unmaskedViewClasses.first, UILabel.self)
+    }
 }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

This PR add mask class and unmask class to replay options for hybrid SDKs.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

RN uses Sentry init with dict, at the moment it's not possible to set these options thru the dict.

## :green_heart: How did you test it?
ci, unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
