### PR TITLE
ref: Stops session replay if rate limiting is activated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - Improve frames tracker performance (#4469)
 - Log a warning when dropping envelopes due to rate-limiting (#4463)
 - Expose `SentrySessionReplayIntegration-Hybrid.h` as `private` (#4486)
-- Stops session replay if rate limiting is activated ()
+- Stops session replay if rate limiting is activated (#4496)
 
 ## 8.39.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Improve frames tracker performance (#4469)
 - Log a warning when dropping envelopes due to rate-limiting (#4463)
 - Expose `SentrySessionReplayIntegration-Hybrid.h` as `private` (#4486)
+- Stops session replay if rate limiting is activated ()
 
 ## 8.39.0
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -99,10 +99,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
                     fileManager:(SentryFileManager *)fileManager
          deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
 {
-    NSArray<id<SentryTransport>> *transports = [SentryTransportFactory
-             initTransports:options
-          sentryFileManager:fileManager
-        currentDateProvider:SentryDependencyContainer.sharedInstance.dateProvider];
+    NSArray<id<SentryTransport>> *transports =
+        [SentryTransportFactory initTransports:options
+                             sentryFileManager:fileManager
+                                    rateLimits:SentryDependencyContainer.sharedInstance.rateLimits];
 
     SentryTransportAdapter *transportAdapter =
         [[SentryTransportAdapter alloc] initWithTransports:transports options:options];

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -135,7 +135,7 @@ SentryConnectivityActualCallback(
 {
     SENTRY_LOG_DEBUG(
         @"SentryConnectivityCallback called with target: %@; flags: %u", target, flags);
-#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
+#    if defined(TEST) || defined(TESTCI) | wai | defined(DEBUG)
     if (sentry_reachability_ignore_actual_callback) {
         SENTRY_LOG_DEBUG(@"Ignoring actual callback.");
         return;

--- a/Sources/Sentry/SentryReachability.m
+++ b/Sources/Sentry/SentryReachability.m
@@ -135,7 +135,7 @@ SentryConnectivityActualCallback(
 {
     SENTRY_LOG_DEBUG(
         @"SentryConnectivityCallback called with target: %@; flags: %u", target, flags);
-#    if defined(TEST) || defined(TESTCI) | wai | defined(DEBUG)
+#    if defined(TEST) || defined(TESTCI) || defined(DEBUG)
     if (sentry_reachability_ignore_actual_callback) {
         SENTRY_LOG_DEBUG(@"Ignoring actual callback.");
         return;

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -48,6 +48,8 @@ static SentryTouchTracker *_touchTracker;
     SentryNSNotificationCenterWrapper *_notificationCenter;
     SentryOnDemandReplay *_resumeReplayMaker;
     id<SentryRateLimits> _rateLimits;
+   // We need to use this variable to identify whether rate limiting was ever activated for session replay in this session, instead of always looking for the rate status in `SentryRateLimits`
+   // This is the easiest way to ensure segment 0 will always reach the server, because session replay absolutely needs segment 0 to make replay work.
     BOOL _rateLimited;
 }
 

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
                                sentryFileManager:(SentryFileManager *)sentryFileManager
-                             currentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider
+                                      rateLimits:(id<SentryRateLimits>)rateLimits
 {
     NSURLSession *session;
 
@@ -41,17 +41,6 @@ NS_ASSUME_NONNULL_BEGIN
 
     id<SentryRequestManager> requestManager =
         [[SentryQueueableRequestManager alloc] initWithSession:session];
-
-    SentryHttpDateParser *httpDateParser = [[SentryHttpDateParser alloc] init];
-    SentryRetryAfterHeaderParser *retryAfterHeaderParser =
-        [[SentryRetryAfterHeaderParser alloc] initWithHttpDateParser:httpDateParser
-                                                 currentDateProvider:currentDateProvider];
-    SentryRateLimitParser *rateLimitParser =
-        [[SentryRateLimitParser alloc] initWithCurrentDateProvider:currentDateProvider];
-    id<SentryRateLimits> rateLimits =
-        [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser
-                                                     andRateLimitParser:rateLimitParser
-                                                    currentDateProvider:currentDateProvider];
 
     SentryEnvelopeRateLimit *envelopeRateLimit =
         [[SentryEnvelopeRateLimit alloc] initWithRateLimits:rateLimits];

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -20,6 +20,7 @@
 @class SentryThreadInspector;
 @protocol SentryRandom;
 @protocol SentryCurrentDateProvider;
+@protocol SentryRateLimits;
 
 #if SENTRY_HAS_METRIC_KIT
 @class SentryMXManager;
@@ -71,6 +72,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryExtraContextProvider *extraContextProvider;
 @property (nonatomic, strong) SentrySysctl *sysctlWrapper;
 @property (nonatomic, strong) SentryThreadInspector *threadInspector;
+@property (nonatomic, strong) id<SentryRateLimits> rateLimits;
 
 #if SENTRY_UIKIT_AVAILABLE
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -4,6 +4,7 @@
 
 @class SentryOptions, SentryFileManager;
 @protocol SentryCurrentDateProvider;
+@protocol SentryRateLimits;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -12,7 +13,7 @@ NS_SWIFT_NAME(TransportInitializer)
 
 + (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
                                sentryFileManager:(SentryFileManager *)sentryFileManager
-                             currentDateProvider:(id<SentryCurrentDateProvider>)currentDateProvider;
+                                      rateLimits:(id<SentryRateLimits>)rateLimits;
 
 @end
 

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -18,7 +18,7 @@ class SentryTransportInitializerTests: XCTestCase {
     func testDefault() throws {
         let options = try Options(dict: ["dsn": SentryTransportInitializerTests.dsnAsString])
     
-        let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager, currentDateProvider: TestCurrentDateProvider())
+        let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager, rateLimits: SentryDependencyContainer.sharedInstance().rateLimits)
         XCTAssertEqual(result.count, 1)
         
         let firstTransport = result.first


### PR DESCRIPTION
## :scroll: Description

Stop session replay if the app is being rate limited.

## :bulb: Motivation and Context

https://github.com/getsentry/team-replay/issues/496

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
