### PR TITLE
fix: Masking text with transparent text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - Expose `SentrySessionReplayIntegration-Hybrid.h` as `private` (#4486)
 - Add `maskedViewClasses` and `unmaskedViewClasses` to SentryReplayOptions init via dict (#4492)
 
+### Fixes
+
+- Masking text with transparent text color
+
 ## 8.39.0
 
 ### Removal of Experimental API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 ### Fixes
 
-- Masking text with transparent text color
+- Masking text with transparent text color (#4499)
 
 ## 8.39.0
 

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -261,7 +261,7 @@ class UIRedactBuilder {
     }
 
     private func color(for view: UIView) -> UIColor? {
-        return (view as? UILabel)?.textColor
+        return (view as? UILabel)?.textColor.withAlphaComponent(1)
     }
     
     /**

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -51,6 +51,16 @@ class UIRedactBuilderTests: XCTestCase {
         XCTAssertEqual(result.first?.transform, CGAffineTransform(a: 1, b: 0, c: 0, d: 1, tx: 20, ty: 20))
     }
     
+    func testDontUseLabelTransparentColor() {
+        let sut = getSut()
+        let label = UILabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        label.textColor = .purple.withAlphaComponent(0.5)
+        rootView.addSubview(label)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.first?.color, .purple)
+    }
+    
     func testDontRedactALabelOptionDisabled() {
         let sut = getSut(RedactOptions(maskAllText: false))
         let label = UILabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))


### PR DESCRIPTION
## :scroll: Description

Labels with transparent text color get a transparent rectangle masking over. Removed the alpha component of the text color to use in the masking.

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
