### PR TITLE
ref: Remove redundant log prefix in swizzling

### DIFF
--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -99,9 +99,8 @@
         // twice. We could also use objc_getClassList to lookup sub classes of UIViewController, but
         // the lookup can take around 60ms, which is not acceptable.
         if (![self swizzleRootViewControllerFromUIApplication:app]) {
-            SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: Failed to find root UIViewController "
-                             @"from UIApplicationDelegate. Trying to use "
-                             @"UISceneWillConnectNotification notification.");
+            SENTRY_LOG_DEBUG(@"Failed to find root UIViewController from UIApplicationDelegate. "
+                             @"Trying to use UISceneWillConnectNotification notification.");
 
             if (@available(iOS 13.0, tvOS 13.0, *)) {
                 [NSNotificationCenter.defaultCenter
@@ -110,9 +109,9 @@
                            name:UISceneWillConnectNotification
                          object:nil];
             } else {
-                SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: iOS version older then 13. There is "
-                                 @"no UISceneWillConnectNotification notification. Could not find "
-                                 @"a rootViewController");
+                SENTRY_LOG_DEBUG(
+                    @"iOS version older then 13. There is no UISceneWillConnectNotification "
+                    @"notification. Could not find a rootViewController");
             }
         }
     }
@@ -124,15 +123,14 @@
 - (id<SentryUIApplication>)findApp
 {
     if (![UIApplication respondsToSelector:@selector(sharedApplication)]) {
-        SENTRY_LOG_DEBUG(
-            @"UIViewControllerSwizzling: UIApplication doesn't respond to sharedApplication.");
+        SENTRY_LOG_DEBUG(@"UIApplication doesn't respond to sharedApplication.");
         return nil;
     }
 
     UIApplication *app = [UIApplication performSelector:@selector(sharedApplication)];
 
     if (app == nil) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: UIApplication.sharedApplication is nil.");
+        SENTRY_LOG_DEBUG(@"UIApplication.sharedApplication is nil.");
         return nil;
     }
 
@@ -142,18 +140,17 @@
 - (void)swizzleUIViewControllersOfClassesInImageOf:(Class)class
 {
     if (class == NULL) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: class is NULL. Skipping swizzling of classes "
-                         @"in same image.");
+        SENTRY_LOG_DEBUG(@"Class is NULL. Skipping swizzling of classes in same image.");
         return;
     }
 
-    SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: Class to get the image name: %@", class);
+    SENTRY_LOG_DEBUG(@"Class to get the image name: %@", class);
 
     const char *imageNameAsCharArray = [self.objcRuntimeWrapper class_getImageName:class];
 
     if (imageNameAsCharArray == NULL) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: Wasn't able to get image name of the class: "
-                         @"%@. Skipping swizzling of classes in same image.",
+        SENTRY_LOG_DEBUG(@"Wasn't able to get image name of the class: %@. Skipping swizzling of "
+                         @"classes in same image.",
             class);
         return;
     }
@@ -162,9 +159,8 @@
                                              encoding:NSUTF8StringEncoding];
 
     if (imageName == nil || imageName.length == 0) {
-        SENTRY_LOG_DEBUG(
-            @"UIViewControllerSwizzling: Wasn't able to get the app image name of the app "
-            @"delegate class: %@. Skipping swizzling of classes in same image.",
+        SENTRY_LOG_DEBUG(@"Wasn't able to get the app image name of the app delegate class: %@. "
+                         @"Skipping swizzling of classes in same image.",
             class);
         return;
     }
@@ -175,14 +171,12 @@
 - (void)swizzleUIViewControllersOfImage:(NSString *)imageName
 {
     if ([imageName containsString:@"UIKitCore"]) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: Skipping UIKitCore.");
+        SENTRY_LOG_DEBUG(@"Skipping UIKitCore.");
         return;
     }
 
     if ([self.imagesActedOnSubclassesOfUIViewControllers containsObject:imageName]) {
-        SENTRY_LOG_DEBUG(
-            @"UIViewControllerSwizzling: Already swizzled UIViewControllers in image: %@.",
-            imageName);
+        SENTRY_LOG_DEBUG(@"Already swizzled UIViewControllers in image: %@.", imageName);
         return;
     }
 
@@ -225,15 +219,15 @@
         // The object of a UISceneWillConnectNotification should be a NSWindowScene
         if (![notification.object respondsToSelector:@selector(windows)]) {
             SENTRY_LOG_DEBUG(
-                @"UIViewControllerSwizzling: Failed to find root UIViewController from "
-                @"UISceneWillConnectNotification. Notification object has no windows property");
+                @"Failed to find root UIViewController from UISceneWillConnectNotification. "
+                @"Notification object has no windows property");
             return;
         }
 
         id windows = [notification.object performSelector:@selector(windows)];
         if (![windows isKindOfClass:[NSArray class]]) {
-            SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: Failed to find root UIViewController "
-                             @"from UISceneWillConnectNotification. Windows is not an array");
+            SENTRY_LOG_DEBUG(@"Failed to find root UIViewController from "
+                             @"UISceneWillConnectNotification. Windows is not an array");
             return;
         }
 
@@ -244,9 +238,9 @@
                 [self
                     swizzleRootViewControllerAndDescendant:((UIWindow *)window).rootViewController];
             } else {
-                SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: Failed to find root "
-                                 @"UIViewController from UISceneWillConnectNotification. Window is "
-                                 @"not a UIWindow class or the rootViewController is nil");
+                SENTRY_LOG_DEBUG(
+                    @"Failed to find root UIViewController from UISceneWillConnectNotification. "
+                    @"Window is not a UIWindow class or the rootViewController is nil");
             }
         }
     }
@@ -255,29 +249,28 @@
 - (BOOL)swizzleRootViewControllerFromUIApplication:(id<SentryUIApplication>)app
 {
     if (app.delegate == nil) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: App delegate is nil. Skipping "
-                         @"swizzleRootViewControllerFromAppDelegate.");
+        SENTRY_LOG_DEBUG(
+            @"App delegate is nil. Skipping swizzleRootViewControllerFromAppDelegate.");
         return NO;
     }
 
     // Check if delegate responds to window, which it doesn't have to.
     if (![app.delegate respondsToSelector:@selector(window)]) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: UIApplicationDelegate.window is nil. "
-                         @"Skipping swizzleRootViewControllerFromAppDelegate.");
+        SENTRY_LOG_DEBUG(@"UIApplicationDelegate.window is nil. Skipping "
+                         @"swizzleRootViewControllerFromAppDelegate.");
         return NO;
     }
 
     if (app.delegate.window == nil) {
-        SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling: UIApplicationDelegate.window is nil. "
-                         @"Skipping swizzleRootViewControllerFromAppDelegate.");
+        SENTRY_LOG_DEBUG(@"UIApplicationDelegate.window is nil. Skipping "
+                         @"swizzleRootViewControllerFromAppDelegate.");
         return NO;
     }
 
     UIViewController *rootViewController = app.delegate.window.rootViewController;
     if (rootViewController == nil) {
-        SENTRY_LOG_DEBUG(
-            @"UIViewControllerSwizzling: UIApplicationDelegate.window.rootViewController is nil. "
-            @"Skipping swizzleRootViewControllerFromAppDelegate.");
+        SENTRY_LOG_DEBUG(@"UIApplicationDelegate.window.rootViewController is nil. Skipping "
+                         @"swizzleRootViewControllerFromAppDelegate.");
         return NO;
     }
 
@@ -294,7 +287,7 @@
     for (UIViewController *viewController in allViewControllers) {
         Class viewControllerClass = [viewController class];
         if (viewControllerClass != nil) {
-            SENTRY_LOG_DEBUG(@"UIViewControllerSwizzling Calling swizzleRootViewController.");
+            SENTRY_LOG_DEBUG(@"Calling swizzleRootViewController.");
             [self swizzleViewControllerSubClass:viewControllerClass];
 
             // We can't get the image name with the app delegate class for some apps. Therefore, we


### PR DESCRIPTION
The log messages contain the class name, so there is no need to prefix all the log messages with it.

#skip-changelog