### PR TITLE
ref: Remove unused getAllThreads method

### DIFF
--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.c
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.c
@@ -202,15 +202,6 @@ sentrycrashccd_unfreeze(void)
     }
 }
 
-SentryCrashThread *
-sentrycrashccd_getAllThreads(int *threadCount)
-{
-    if (threadCount != NULL) {
-        *threadCount = g_allThreadsCount;
-    }
-    return g_allMachThreads;
-}
-
 const char *
 sentrycrashccd_getThreadName(SentryCrashThread thread)
     SENTRY_DISABLE_THREAD_SANITIZER("Known data race to fix")

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.h
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.h
@@ -35,8 +35,6 @@ bool sentrycrashccd_hasThreadStarted(void);
 void sentrycrashccd_freeze(void);
 void sentrycrashccd_unfreeze(void);
 
-SentryCrashThread *sentrycrashccd_getAllThreads(int *threadCount);
-
 const char *sentrycrashccd_getThreadName(SentryCrashThread thread);
 
 const char *sentrycrashccd_getQueueName(SentryCrashThread thread);


### PR DESCRIPTION
Remove unused sentrycrashccd_getAllThreads.

#skip-changelog