### PR TITLE
ref: Delete unused SentryBeforeEmitMetricCallback

### DIFF
--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -139,16 +139,6 @@ typedef NSNumber *_Nullable (^SentryTracesSamplerCallback)(
 typedef void (^SentrySpanCallback)(id<SentrySpan> _Nullable span);
 
 /**
- * A callback block which gets called right before a metric is about to be emitted.
-
- * @param key  The key of the metric.
- * @param tags A dictionary of key-value pairs associated with the metric.
- * @return BOOL YES if the metric should be emitted, NO otherwise.
- */
-typedef BOOL (^SentryBeforeEmitMetricCallback)(
-    NSString *_Nonnull key, NSDictionary<NSString *, NSString *> *_Nonnull tags);
-
-/**
  * Log level.
  */
 typedef NS_ENUM(NSInteger, SentryLogLevel) {

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -48,8 +48,10 @@ static SentryTouchTracker *_touchTracker;
     SentryNSNotificationCenterWrapper *_notificationCenter;
     SentryOnDemandReplay *_resumeReplayMaker;
     id<SentryRateLimits> _rateLimits;
-   // We need to use this variable to identify whether rate limiting was ever activated for session replay in this session, instead of always looking for the rate status in `SentryRateLimits`
-   // This is the easiest way to ensure segment 0 will always reach the server, because session replay absolutely needs segment 0 to make replay work.
+    // We need to use this variable to identify whether rate limiting was ever activated for session
+    // replay in this session, instead of always looking for the rate status in `SentryRateLimits`
+    // This is the easiest way to ensure segment 0 will always reach the server, because session
+    // replay absolutely needs segment 0 to make replay work.
     BOOL _rateLimited;
 }
 


### PR DESCRIPTION
We missed this bit in #4406.

This is based on https://github.com/getsentry/sentry-cocoa/pull/4515.

#skip-changelog
