### PR TITLE
fix: Keep PropagationContext when cloning scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Keep PropagationContext when cloning scope (#4518)
+
 ## 8.40.1
 
 ### Fixes

--- a/Sources/Sentry/SentryPropagationContext.h
+++ b/Sources/Sentry/SentryPropagationContext.h
@@ -8,8 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryPropagationContext : NSObject
 
-@property (nonatomic, strong) SentryId *traceId;
-@property (nonatomic, strong) SentrySpanId *spanId;
+@property (nonatomic, strong, readonly) SentryId *traceId;
+@property (nonatomic, strong, readonly) SentrySpanId *spanId;
 @property (nonatomic, readonly) SentryTraceHeader *traceHeader;
 
 - (NSDictionary<NSString *, NSString *> *)traceContextForEvent;

--- a/Sources/Sentry/SentryPropagationContext.m
+++ b/Sources/Sentry/SentryPropagationContext.m
@@ -8,8 +8,8 @@
 - (instancetype)init
 {
     if (self = [super init]) {
-        self.traceId = [[SentryId alloc] init];
-        self.spanId = [[SentrySpanId alloc] init];
+        _traceId = [[SentryId alloc] init];
+        _spanId = [[SentrySpanId alloc] init];
     }
     return self;
 }

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
         [_fingerprintArray addObjectsFromArray:[scope fingerprints]];
         [_attachmentArray addObjectsFromArray:[scope attachments]];
 
-        self.propagationContext = [[SentryPropagationContext alloc] init];
+        self.propagationContext = scope.propagationContext;
         self.maxBreadcrumbs = scope.maxBreadcrumbs;
         self.userObject = scope.userObject.copy;
         self.distString = scope.distString;

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -127,6 +127,8 @@ class SentryScopeSwiftTests: XCTestCase {
 
         let cloned = Scope(scope: scope)
         XCTAssertEqual(try XCTUnwrap(cloned.serialize() as? [String: AnyHashable]), snapshot)
+        XCTAssertEqual(scope.propagationContext.spanId, cloned.propagationContext.spanId)
+        XCTAssertEqual(scope.propagationContext.traceId, cloned.propagationContext.traceId)
 
         let (event1, event2) = (Event(), Event())
         (event1.timestamp, event2.timestamp) = (fixture.date, fixture.date)


### PR DESCRIPTION


## :scroll: Description

When cloning the scope with initWithScope, the SDK wrongly created a new propagation context instead of cloning it. This is fixe now.

## :bulb: Motivation and Context

I found this bug in https://github.com/getsentry/sentry-cocoa/pull/4504. This aligns with the behavior from Java: https://github.com/getsentry/sentry-java/blob/e039872d80a9a352d10e642ff630a3d905ff89d0/sentry/src/main/java/io/sentry/Scope.java#L154

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
