### PR TITLE
fix: Make Scope.span fully thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Make `Scope.span` fully thread safe (#4519)
+
 ## 8.40.1
 
 ### Fixes

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -59,6 +59,8 @@ NS_ASSUME_NONNULL_BEGIN
     NSObject *_spanLock;
 }
 
+@synthesize span = _span;
+
 #pragma mark Initializer
 
 - (instancetype)initWithMaxBreadcrumbs:(NSInteger)maxBreadcrumbs
@@ -146,12 +148,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (nullable id<SentrySpan>)span
+{
+    @synchronized(_spanLock) {
+        return _span;
+    }
+}
+
 - (void)useSpan:(SentrySpanCallback)callback
 {
-    id<SentrySpan> localSpan = nil;
-    @synchronized(_spanLock) {
-        localSpan = _span;
-    }
+    id<SentrySpan> localSpan = [self span];
     callback(localSpan);
 }
 


### PR DESCRIPTION


## :scroll: Description

Setting the span on the scope and useSpan were thread safe, but not setSpan. This is fixed now.

## :bulb: Motivation and Context

This came up while investigating #4513.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
