### PR TITLE
ref: Reduce nesting in performance tracker

### DIFF
--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -61,36 +61,36 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                  operation:operation
                                                                                     origin:origin];
 
-        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> span) {
-            BOOL bindToScope = NO;
-            if (span == nil) {
+        id<SentrySpan> span = SentrySDK.currentHub.scope.span;
+
+        BOOL bindToScope = NO;
+        if (span == nil) {
+            bindToScope = YES;
+        }
+#if SENTRY_HAS_UIKIT
+        else {
+            if ([SentryUIEventTracker isUIEventOperation:span.operation]) {
+                SENTRY_LOG_DEBUG(
+                    @"Cancelling previous UI event span %@", span.spanId.sentrySpanIdString);
+                [span finishWithStatus:kSentrySpanStatusCancelled];
                 bindToScope = YES;
             }
-#if SENTRY_HAS_UIKIT
-            else {
-                if ([SentryUIEventTracker isUIEventOperation:span.operation]) {
-                    SENTRY_LOG_DEBUG(
-                        @"Cancelling previous UI event span %@", span.spanId.sentrySpanIdString);
-                    [span finishWithStatus:kSentrySpanStatusCancelled];
-                    bindToScope = YES;
-                }
-            }
+        }
 #endif // SENTRY_HAS_UIKIT
 
-            SENTRY_LOG_DEBUG(@"Creating new transaction bound to scope: %d", bindToScope);
+        SENTRY_LOG_DEBUG(@"Creating new transaction bound to scope: %d", bindToScope);
 
-            newSpan = [SentrySDK.currentHub
-                startTransactionWithContext:context
-                                bindToScope:bindToScope
-                      customSamplingContext:@{}
-                              configuration:[SentryTracerConfiguration configurationWithBlock:^(
-                                                SentryTracerConfiguration *configuration) {
-                                  configuration.waitForChildren = YES;
-                                  configuration.finishMustBeCalled = YES;
-                              }]];
+        newSpan = [SentrySDK.currentHub
+            startTransactionWithContext:context
+                            bindToScope:bindToScope
+                  customSamplingContext:@{}
+                          configuration:[SentryTracerConfiguration configurationWithBlock:^(
+                                            SentryTracerConfiguration *configuration) {
+                              configuration.waitForChildren = YES;
+                              configuration.finishMustBeCalled = YES;
+                          }]];
 
-            [(SentryTracer *)newSpan setDelegate:self];
-        }];
+        [(SentryTracer *)newSpan setDelegate:self];
     }
 
     SentrySpanId *spanId = newSpan.spanId;


### PR DESCRIPTION
Reduce nesting in startSpanWithName by using .span instead of useSpan.

useSpan basically does the same.

https://github.com/getsentry/sentry-cocoa/blob/9854a5751cac3edac5b75aec7b68c36728269aaa/Sources/Sentry/SentryScope.m#L149-L156

This PR depends on https://github.com/getsentry/sentry-cocoa/pull/4519 cause `scope.getSpan` isn't thread-safe yet.

#skip-changelog