### PR TITLE
internal(replay): Add IgnoreWrapper class for hybrid SDKs

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -358,11 +358,18 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer addRedactClasses:classes];
 }
 
-+ (void)setIgnoreWrapperClass:(Class _Nonnull)ignoreClass
++ (void)setIgnoreContainerClass:(Class _Nonnull)containerClass
 {
     [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
-        setIgnoreWrapperClass:ignoreClass];
+        setIgnoreContainerClass:containerClass];
 }
+
++ (void)setRedactContainerClass:(Class _Nonnull)containerClass
+{
+    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
+        setRedactContainerClass:containerClass];
+}
+
 #endif
 
 @end

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -357,6 +357,12 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 {
     [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer addRedactClasses:classes];
 }
+
++ (void)setIgnoreWrapperClass:(Class _Nonnull)ignoreClass
+{
+    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
+        setIgnoreWrapperClass:ignoreClass];
+}
 #endif
 
 @end

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -182,7 +182,8 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 + (NSString *__nullable)getReplayId;
 + (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes;
 + (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes;
-+ (void)setIgnoreWrapperClass:(Class _Nonnull)ignoreClass;
++ (void)setIgnoreContainerClass:(Class _Nonnull)containerClass;
++ (void)setRedactContainerClass:(Class _Nonnull)containerClass;
 
 #endif
 + (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans;

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -182,6 +182,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 + (NSString *__nullable)getReplayId;
 + (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes;
 + (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes;
++ (void)setIgnoreWrapperClass:(Class _Nonnull)ignoreClass;
 
 #endif
 + (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans;

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -95,7 +95,12 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     func addRedactClasses(classes: [AnyClass]) {
         redactBuilder.addRedactClasses(classes)
     }
-    
+
+    @objc(setIgnoreWrapperClass:)
+    func setIgnoreWrapperClass(wrapperClass: AnyClass) {
+        redactBuilder.setIgnoreWrapperClass(wrapperClass)
+    }
+
 #if TEST || TESTCI
     func getRedactBuild() -> UIRedactBuilder {
         redactBuilder

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -97,12 +97,12 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     }
 
     @objc(setIgnoreContainerClass:)
-    func setIgnoreContainerClass(containerClass: AnyClass) {
+    func setIgnoreContainerClass(_ containerClass: AnyClass) {
         redactBuilder.setIgnoreContainerClass(containerClass)
     }
 
     @objc(setRedactContainerClass:)
-    func setRedactContainerClass(containerClass: AnyClass) {
+    func setRedactContainerClass(_ containerClass: AnyClass) {
         redactBuilder.setRedactContainerClass(containerClass)
     }
 

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -96,9 +96,14 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
         redactBuilder.addRedactClasses(classes)
     }
 
-    @objc(setIgnoreWrapperClass:)
-    func setIgnoreWrapperClass(wrapperClass: AnyClass) {
-        redactBuilder.setIgnoreWrapperClass(wrapperClass)
+    @objc(setIgnoreContainerClass:)
+    func setIgnoreContainerClass(containerClass: AnyClass) {
+        redactBuilder.setIgnoreContainerClass(containerClass)
+    }
+
+    @objc(setRedactContainerClass:)
+    func setRedactContainerClass(containerClass: AnyClass) {
+        redactBuilder.setRedactContainerClass(containerClass)
     }
 
 #if TEST || TESTCI

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -206,11 +206,7 @@ class UIRedactBuilder {
     }
 
     private func shouldIgnoreParentContainer(_ view: UIView) -> Bool {
-        if isRedactContainerClass(type(of: view)) {
-            return false
-        }
-
-        guard let parent = view.superview  else { return false }
+        guard !isRedactContainerClass(type(of: view)), let parent = view.superview else { return false }
         return isIgnoreContainerClass(type(of: parent))
     }
 

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -210,26 +210,17 @@ class UIRedactBuilder {
             return false
         }
 
-        if let parent = view.superview {
-            return isIgnoreContainerClass(type(of: parent))
-        }
-
-        return false
+        guard let parent = view.superview  else { return false }
+        return isIgnoreContainerClass(type(of: parent))
     }
 
     private func isIgnoreContainerClass(_ containerClass: AnyClass) -> Bool {
-        if ignoreContainerClassIdentifier == nil {
-            return false
-        }
-
+        guard ignoreContainerClassIdentifier != nil  else { return false }
         return ObjectIdentifier(containerClass) == ignoreContainerClassIdentifier
     }
 
     private func isRedactContainerClass(_ containerClass: AnyClass) -> Bool {
-        if redactContainerClassIdentifier == nil {
-            return false
-        }
-
+        guard redactContainerClassIdentifier != nil  else { return false }
         return ObjectIdentifier(containerClass) == redactContainerClassIdentifier
     }
 

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -190,10 +190,10 @@ class UIRedactBuilder {
     
     private func shouldIgnore(view: UIView) -> Bool {
 
-        return  SentryRedactViewHelper.shouldUnmask(view) || containsIgnoreClass(type(of: view)) || isParentUnmaskWrapper(view)
+        return  SentryRedactViewHelper.shouldUnmask(view) || containsIgnoreClass(type(of: view)) || isParentIgnoreWrapper(view)
     }
 
-    private func isParentUnmaskWrapper(_ view: UIView) -> Bool {
+    private func isParentIgnoreWrapper(_ view: UIView) -> Bool {
         let parent = view.superview
         if let parent = parent {
             return isIgnoreWrapperClass(type(of: parent))

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -1,3 +1,4 @@
+@testable import Sentry
 import SentryTestUtils
 import XCTest
 
@@ -367,6 +368,26 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         SentrySDK.start(options: options)
 
         PrivateSentrySDKOnly.addReplayRedactClasses([UILabel.self])
+    }
+
+    func testAddIgnoreWrapper() throws {
+        class IgnoreWrapper: UIView {}
+
+        SentrySDK.start {
+            $0.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1)
+            $0.setIntegrations([SentrySessionReplayIntegration.self])
+        }
+
+        PrivateSentrySDKOnly.setIgnoreWrapperClass(IgnoreWrapper.self)
+
+        let replayIntegration = try getReplayIntegration()
+
+        let redactBuilder = replayIntegration.viewPhotographer.getRedactBuild()
+        XCTAssertTrue(redactBuilder.isIgnoreWrapperClassTestOnly(IgnoreWrapper.self))
+    }
+
+    private func getReplayIntegration() throws -> SentrySessionReplayIntegration {
+        return try XCTUnwrap(SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
     }
 
     let VALID_REPLAY_ID = "0eac7ab503354dd5819b03e263627a29"

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -370,23 +370,39 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         PrivateSentrySDKOnly.addReplayRedactClasses([UILabel.self])
     }
 
-    func testAddIgnoreWrapper() throws {
-        class IgnoreWrapper: UIView {}
+    func testAddIgnoreContainer() throws {
+        class IgnoreContainer: UIView {}
 
         SentrySDK.start {
             $0.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1)
             $0.setIntegrations([SentrySessionReplayIntegration.self])
         }
 
-        PrivateSentrySDKOnly.setIgnoreWrapperClass(IgnoreWrapper.self)
+        PrivateSentrySDKOnly.setIgnoreContainerClass(IgnoreContainer.self)
 
-        let replayIntegration = try getReplayIntegration()
+        let replayIntegration = try getFirstIntegrationAsReplay()
 
         let redactBuilder = replayIntegration.viewPhotographer.getRedactBuild()
-        XCTAssertTrue(redactBuilder.isIgnoreWrapperClassTestOnly(IgnoreWrapper.self))
+        XCTAssertTrue(redactBuilder.isIgnoreContainerClassTestOnly(IgnoreContainer.self))
     }
 
-    private func getReplayIntegration() throws -> SentrySessionReplayIntegration {
+    func testAddRedactContainer() throws {
+        class RedactContainer: UIView {}
+
+        SentrySDK.start {
+            $0.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1)
+            $0.setIntegrations([SentrySessionReplayIntegration.self])
+        }
+
+        PrivateSentrySDKOnly.setRedactContainerClass(RedactContainer.self)
+
+        let replayIntegration = try getFirstIntegrationAsReplay()
+
+        let redactBuilder = replayIntegration.viewPhotographer.getRedactBuild()
+        XCTAssertTrue(redactBuilder.isRedactContainerClassTestOnly(RedactContainer.self))
+    }
+
+    private func getFirstIntegrationAsReplay() throws -> SentrySessionReplayIntegration {
         return try XCTUnwrap(SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
     }
 

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -201,38 +201,110 @@ class UIRedactBuilderTests: XCTestCase {
         XCTAssertEqual(result.count, 1)
     }
 
-    func testIgnoreWrappedChildView() {
-        class IgnoreWrapper: UIView {}
+    func testIgnoreContainerChildView() {
+        class IgnoreContainer: UIView {}
         class AnotherLabel: UILabel {}
 
         let sut = getSut()
-        sut.setIgnoreWrapperClass(IgnoreWrapper.self)
+        sut.setIgnoreContainerClass(IgnoreContainer.self)
 
-        let ignoreWrapper = IgnoreWrapper(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let ignoreContainer = IgnoreContainer(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
         let wrappedLabel = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
-        ignoreWrapper.addSubview(wrappedLabel)
-        rootView.addSubview(ignoreWrapper)
+        ignoreContainer.addSubview(wrappedLabel)
+        rootView.addSubview(ignoreContainer)
 
         let result = sut.redactRegionsFor(view: rootView)
         XCTAssertEqual(result.count, 0)
     }
 
-    func testIgnoreWrappedDirectChildView() {
-        class IgnoreWrapper: UIView {}
+    func testIgnoreContainerDirectChildView() {
+        class IgnoreContainer: UIView {}
         class AnotherLabel: UILabel {}
 
         let sut = getSut()
-        sut.setIgnoreWrapperClass(IgnoreWrapper.self)
+        sut.setIgnoreContainerClass(IgnoreContainer.self)
 
-        let ignoreWrapper = IgnoreWrapper(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let ignoreContainer = IgnoreContainer(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
         let wrappedLabel = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
         let redactedLabel = AnotherLabel(frame: CGRect(x: 10, y: 10, width: 10, height: 10))
         wrappedLabel.addSubview(redactedLabel)
-        ignoreWrapper.addSubview(wrappedLabel)
-        rootView.addSubview(ignoreWrapper)
+        ignoreContainer.addSubview(wrappedLabel)
+        rootView.addSubview(ignoreContainer)
 
         let result = sut.redactRegionsFor(view: rootView)
         XCTAssertEqual(result.count, 1)
+    }
+
+    func testRedactIgnoreContainerAsChildOfMaskedView() {
+        class IgnoreContainer: UIView {}
+
+        let sut = getSut()
+        sut.setIgnoreContainerClass(IgnoreContainer.self)
+
+        let redactedLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let ignoreContainer = IgnoreContainer(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        let redactedChildLabel = UILabel(frame: CGRect(x: 10, y: 10, width: 10, height: 10))
+        ignoreContainer.addSubview(redactedChildLabel)
+        redactedLabel.addSubview(ignoreContainer)
+        rootView.addSubview(redactedLabel)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testRedactChildrenOfRedactContainer() {
+        class RedactContainer: UIView {}
+        class AnotherView: UIView {}
+
+        let sut = getSut()
+        sut.setRedactContainerClass(RedactContainer.self)
+
+        let redactContainer = RedactContainer(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let redactedView = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        let redactedView2 = AnotherView(frame: CGRect(x: 10, y: 10, width: 10, height: 10))
+        redactedView.addSubview(redactedView2)
+        redactContainer.addSubview(redactedView)
+        rootView.addSubview(redactContainer)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testRedactChildrenOfRedactedView() {
+        class AnotherView: UIView {}
+
+        let sut = getSut()
+
+        let redactedLabel = UILabel(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let redactedView = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        redactedLabel.addSubview(redactedView)
+        rootView.addSubview(redactedLabel)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.count, 2)
+    }
+
+    func testRedactContainerHasPriorityOverIgnoreContainer() {
+        class IgnoreContainer: UIView {}
+        class RedactContainer: UIView {}
+        class AnotherView: UIView {}
+
+        let sut = getSut()
+        sut.setRedactContainerClass(RedactContainer.self)
+
+        let ignoreContainer = IgnoreContainer(frame: CGRect(x: 0, y: 0, width: 80, height: 80))
+        let redactContainer = RedactContainer(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let redactedView = AnotherView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        let ignoreContainer2 = IgnoreContainer(frame: CGRect(x: 10, y: 10, width: 10, height: 10))
+        let redactedView2 = AnotherView(frame: CGRect(x: 15, y: 15, width: 5, height: 5))
+        ignoreContainer2.addSubview(redactedView2)
+        redactedView.addSubview(ignoreContainer2)
+        redactContainer.addSubview(redactedView)
+        ignoreContainer.addSubview(redactContainer)
+        rootView.addSubview(ignoreContainer)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.count, 4)
     }
 
     func testIgnoreView() {

--- a/Tests/SentryTests/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/UIRedactBuilderTests.swift
@@ -200,7 +200,41 @@ class UIRedactBuilderTests: XCTestCase {
         let result = sut.redactRegionsFor(view: rootView)
         XCTAssertEqual(result.count, 1)
     }
-    
+
+    func testIgnoreWrappedChildView() {
+        class IgnoreWrapper: UIView {}
+        class AnotherLabel: UILabel {}
+
+        let sut = getSut()
+        sut.setIgnoreWrapperClass(IgnoreWrapper.self)
+
+        let ignoreWrapper = IgnoreWrapper(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let wrappedLabel = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        ignoreWrapper.addSubview(wrappedLabel)
+        rootView.addSubview(ignoreWrapper)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.count, 0)
+    }
+
+    func testIgnoreWrappedDirectChildView() {
+        class IgnoreWrapper: UIView {}
+        class AnotherLabel: UILabel {}
+
+        let sut = getSut()
+        sut.setIgnoreWrapperClass(IgnoreWrapper.self)
+
+        let ignoreWrapper = IgnoreWrapper(frame: CGRect(x: 0, y: 0, width: 60, height: 60))
+        let wrappedLabel = AnotherLabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        let redactedLabel = AnotherLabel(frame: CGRect(x: 10, y: 10, width: 10, height: 10))
+        wrappedLabel.addSubview(redactedLabel)
+        ignoreWrapper.addSubview(wrappedLabel)
+        rootView.addSubview(ignoreWrapper)
+
+        let result = sut.redactRegionsFor(view: rootView)
+        XCTAssertEqual(result.count, 1)
+    }
+
     func testIgnoreView() {
         class AnotherLabel: UILabel {
         }


### PR DESCRIPTION
## :scroll: Description

This PR adds `IgnoreWrapper` functionality to Replay Redaction logic.

Why is this needed? In RN JS we don't have access to the native view instances directly. So we create a native wrapper class which we can use from JS.

- https://github.com/getsentry/sentry-react-native/pull/4224

## :green_heart: How did you test it?
rn sample app, unit and integration tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog 