### PR TITLE
fix: Missing UIViewController traces with Xcode 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Keep PropagationContext when cloning scope (#4518)
+- UIViewController with Xcode 16 in debug (#4523). The Xcode 16 build setting [ENABLE_DEBUG_DYLIB](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support), which is turned on by default only in debug, could lead to missing UIViewController traces. 
 
 ## 8.40.1
 

--- a/Sources/Sentry/SentryBinaryImageCache.m
+++ b/Sources/Sentry/SentryBinaryImageCache.m
@@ -141,16 +141,18 @@ static void binaryImageWasRemoved(const SentryCrashBinaryImage *image);
     return -1; // Address not found
 }
 
-- (nullable NSString *)pathForInAppInclude:(NSString *)inAppInclude
+- (NSSet<NSString *> *)imagePathsForInAppInclude:(NSString *)inAppInclude
 {
+    NSMutableSet<NSString *> *imagePaths = [NSMutableSet new];
+
     @synchronized(self) {
         for (SentryBinaryImageInfo *info in _cache) {
             if ([SentryInAppLogic isImageNameInApp:info.name inAppInclude:inAppInclude]) {
-                return info.name;
+                [imagePaths addObject:info.name];
             }
         }
     }
-    return nil;
+    return imagePaths;
 }
 
 @end

--- a/Sources/Sentry/SentrySubClassFinder.m
+++ b/Sources/Sentry/SentrySubClassFinder.m
@@ -49,6 +49,8 @@
             copyClassNamesForImage:[imageName cStringUsingEncoding:NSUTF8StringEncoding]
                             amount:&count];
 
+        SENTRY_LOG_DEBUG(@"Found %u number of classes in image: %@.", count, imageName);
+
         // Storing the actual classes in an NSArray would call initializer of the class, which we
         // must avoid as we are on a background thread here and dealing with UIViewControllers,
         // which assume they are running on the main thread. Therefore, we store the class name
@@ -87,9 +89,9 @@
                 block(NSClassFromString(className));
             }
 
-            SENTRY_LOG_DEBUG(
-                @"The following UIViewControllers will generate automatic transactions: %@",
-                [classesToSwizzle componentsJoinedByString:@", "]);
+            SENTRY_LOG_DEBUG(@"The following UIViewControllers for image: %@ will generate "
+                             @"automatic transactions: %@",
+                imageName, [classesToSwizzle componentsJoinedByString:@", "]);
         }];
     }];
 }

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -79,12 +79,17 @@
 - (void)start
 {
     for (NSString *inAppInclude in self.inAppLogic.inAppIncludes) {
-        NSString *pathToImage = [self.binaryImageCache pathForInAppInclude:inAppInclude];
-        if (pathToImage != nil) {
-            [self swizzleUIViewControllersOfImage:pathToImage];
+        NSSet<NSString *> *imagePathsToInAppInclude =
+            [self.binaryImageCache imagePathsForInAppInclude:inAppInclude];
+
+        if (imagePathsToInAppInclude.count > 0) {
+            for (NSString *imagePath in imagePathsToInAppInclude) {
+                [self swizzleUIViewControllersOfImage:imagePath];
+            }
         } else {
-            SENTRY_LOG_WARN(@"Failed to find the binary image for inAppInclude <%@> and, therefore "
-                            @"can't instrument UIViewControllers in that binary",
+            SENTRY_LOG_WARN(
+                @"Failed to find the binary image(s) for inAppInclude <%@> and, therefore "
+                @"can't instrument UIViewControllers in these binaries.",
                 inAppInclude);
         }
     }

--- a/Sources/Sentry/include/HybridPublic/SentryBinaryImageCache.h
+++ b/Sources/Sentry/include/HybridPublic/SentryBinaryImageCache.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable SentryBinaryImageInfo *)imageByAddress:(const uint64_t)address;
 
-- (nullable NSString *)pathForInAppInclude:(NSString *)inAppInclude;
+- (NSSet<NSString *> *)imagePathsForInAppInclude:(NSString *)inAppInclude;
 
 + (NSString *_Nullable)convertUUID:(const unsigned char *const)value;
 


### PR DESCRIPTION


## :scroll: Description

Xcode 16 introduces a new flag ENABLE_DEBUG_DYLIB. If this flag is enabled, debug builds of app and app extension targets on supported platforms and SDKs will be built with the main binary code in a separate “NAME.debug.dylib”. Our swizzling logic for UIViewControllers sometimes skipped swizzling the UIViewControllers in that debug.dylib binary. This is fixed now, by swizzling all matching inAppInclude binary images that the binary image cache returns and not only the first one.

## :bulb: Motivation and Context

A customer reported this problem.

## :green_heart: How did you test it?
Unit tests and sample app with Xcode 16.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
