### PR TITLE
ci: Use macos-15 for Xcode 16

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   build-sample:
     name: Build SwiftUITestSample Sample
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh "16.0"
@@ -45,6 +45,7 @@ jobs:
 
       # https://github.com/facebook/react-native/blob/24e7f7d25629a7af6d877a0b79fed2faaab96437/.github/actions/maestro-ios/action.yml#L57
       MAESTRO_DRIVER_STARTUP_TIMEOUT: 1500000 # 25 min, CI can be slow at times
+
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -113,7 +113,7 @@ jobs:
             
   ui-tests-swift6:
     name: UI Tests for iOS-Swift6 Simulator
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Xcode 16 is only available on macos-15 and not anymore on macos-14; see https://github.com/actions/runner-images/issues/10703

This fixes random can't find Xcode 16 errors, such as https://github.com/getsentry/sentry-cocoa/actions/runs/11792762676/job/32846958857
```
Run ./scripts/ci-select-xcode.sh "16.0"
xcode-select: error: invalid developer directory '/Applications/Xcode_16.0.app/Contents/Developer'
Error: Process completed with exit code 1.
```

#skip-changelog