### PR TITLE
fix: Finish TTFD when binding transaction to scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Make `Scope.span` fully thread safe (#4519)
-- Finish TTFD on new UIViewControllers when not calling reportFullyDisplayed (#4526).
+- Finish TTFD when not calling reportFullyDisplayed before binding a new transaction to the scope (#4526).
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Fixes
 
 - Make `Scope.span` fully thread safe (#4519)
+- Finish TTFD on new UIViewControllers when not calling reportFullyDisplayed (#4526).
+
 ### Features
 
 - Transactions for crashes (#4504): Finish the transaction bound to the scope when the app crashes. This __experimental__ feature is disabled by default. You can enable it via the option `enablePersistingTracesWhenCrashing`.

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -78,7 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
         }
 #endif // SENTRY_HAS_UIKIT
 
-        SENTRY_LOG_DEBUG(@"Creating new transaction bound to scope: %d", bindToScope);
+        SENTRY_LOG_DEBUG(
+            @"Starting new transaction for %@ with bindToScope: %d", name, bindToScope);
 
         newSpan = [SentrySDK.currentHub
             startTransactionWithContext:context

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -146,7 +146,8 @@
     if (self.fullDisplaySpan.isFinished == NO) {
         SENTRY_LOG_WARN(
             @"You didn't call SentrySDK.reportFullyDisplayed(). Finishing full display span with "
-            @"status deadline exceeded.");
+            @"status: %@.",
+            nameForSentrySpanStatus(kSentrySpanStatusDeadlineExceeded));
 
         [self.fullDisplaySpan finishWithStatus:kSentrySpanStatusDeadlineExceeded];
     }

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -149,7 +149,6 @@
             @"status deadline exceeded.");
 
         [self.fullDisplaySpan finishWithStatus:kSentrySpanStatusDeadlineExceeded];
-        return;
     }
 }
 

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -144,10 +144,9 @@
     }
 
     if (self.fullDisplaySpan.isFinished == NO) {
-        SENTRY_LOG_WARN(
-            @"You didn't call SentrySDK.reportFullyDisplayed(). Finishing full display span with "
-            @"status: %@.",
-            nameForSentrySpanStatus(kSentrySpanStatusDeadlineExceeded));
+        SENTRY_LOG_WARN(@"You didn't call SentrySDK.reportFullyDisplayed() for UIViewController: "
+                        @"%@. Finishing full display span with status: %@.",
+            _controllerName, nameForSentrySpanStatus(kSentrySpanStatusDeadlineExceeded));
 
         [self.fullDisplaySpan finishWithStatus:kSentrySpanStatusDeadlineExceeded];
     }

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -137,6 +137,22 @@
     [_dispatchQueueWrapper dispatchAsyncOnMainQueue:^{ self->_fullyDisplayedReported = YES; }];
 }
 
+- (void)finishSpansIfNotFinished
+{
+    if (self.initialDisplaySpan.isFinished == NO) {
+        [self.initialDisplaySpan finish];
+    }
+
+    if (self.fullDisplaySpan.isFinished == NO) {
+        SENTRY_LOG_WARN(
+            @"You didn't call SentrySDK.reportFullyDisplayed(). Finishing full display span with "
+            @"status deadline exceeded.");
+
+        [self.fullDisplaySpan finishWithStatus:kSentrySpanStatusDeadlineExceeded];
+        return;
+    }
+}
+
 - (void)framesTrackerHasNewFrame:(NSDate *)newFrameDate
 {
     // The purpose of TTID and TTFD is to measure how long

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -118,8 +118,9 @@
 
         // The tracker must create a new transaction and bind it to the scope when there is no
         // active span. If the user didn't call reportFullyDisplayed, the previous UIViewController
-        // transaction is still bound to the scope, and we need to finish and remove it from the
-        // scope so that we can bind this new UIViewController transaction to the scope.
+        // transaction is still bound to the scope because it waits for its children to finish,
+        // including the TTFD span. Therefore, we need to finish the TTFD span so the tracer can
+        // finish and remove itself from the scope.
         if (self.tracker.activeSpanId == nil) {
             [self.currentTTDTracker finishSpansIfNotFinished];
         }

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -163,8 +163,10 @@
         objc_setAssociatedObject(controller, &SENTRY_UI_PERFORMANCE_TRACKER_TTD_TRACKER, ttdTracker,
             OBJC_ASSOCIATION_ASSIGN);
 
+        [self.currentTTDTracker finishSpansIfNotFinished];
         self.currentTTDTracker = ttdTracker;
     } else {
+        [self.currentTTDTracker finishSpansIfNotFinished];
         self.currentTTDTracker = nil;
     }
 }

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -120,7 +120,8 @@
         // active span. If the user didn't call reportFullyDisplayed, the previous UIViewController
         // transaction is still bound to the scope because it waits for its children to finish,
         // including the TTFD span. Therefore, we need to finish the TTFD span so the tracer can
-        // finish and remove itself from the scope.
+        // finish and remove itself from the scope. We don't need to finish the transaction because
+        // we already finished it in viewControllerViewDidAppear.
         if (self.tracker.activeSpanId == nil) {
             [self.currentTTDTracker finishSpansIfNotFinished];
         }

--- a/Sources/Sentry/include/SentryTimeToDisplayTracker.h
+++ b/Sources/Sentry/include/SentryTimeToDisplayTracker.h
@@ -35,6 +35,8 @@ SENTRY_NO_INIT
 
 - (void)reportFullyDisplayed;
 
+- (void)finishSpansIfNotFinished;
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## :scroll: Description

Finish the TTFD span before creating a new transaction and binding it to the scope in SentryUIViewControllerPerformanceTracker when the user doesn't call reportFullyDisplayed.

## :bulb: Motivation and Context

Fixes GH-4513

## :green_heart: How did you test it?
Unit tests and simulator.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
