### PR TITLE
Fix: Session replay opacity animation masking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - UIViewController with Xcode 16 in debug (#4523). The Xcode 16 build setting [ENABLE_DEBUG_DYLIB](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support), which is turned on by default only in debug, could lead to missing UIViewController traces.
 - Concurrency crash with Swift 6 (#4512)
 - Make `Scope.span` fully thread safe (#4519)
+- Session replay opacity animation masking ()
 
 ## 8.40.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 - UIViewController with Xcode 16 in debug (#4523). The Xcode 16 build setting [ENABLE_DEBUG_DYLIB](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support), which is turned on by default only in debug, could lead to missing UIViewController traces.
 - Concurrency crash with Swift 6 (#4512)
 - Make `Scope.span` fully thread safe (#4519)
-- Session replay opacity animation masking (#4532)
 - Finish TTFD when not calling reportFullyDisplayed before binding a new transaction to the scope (#4526).
+- Session replay opacity animation masking (#4532)
 
 ## 8.40.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - UIViewController with Xcode 16 in debug (#4523). The Xcode 16 build setting [ENABLE_DEBUG_DYLIB](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support), which is turned on by default only in debug, could lead to missing UIViewController traces.
 - Concurrency crash with Swift 6 (#4512)
 - Make `Scope.span` fully thread safe (#4519)
-- Session replay opacity animation masking ()
+- Session replay opacity animation masking (#4532)
 
 ## 8.40.1
 

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.debug = true
             
             if #available(iOS 16.0, *), !args.contains("--disable-session-replay") {
-                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
+                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
                 options.experimental.sessionReplay.quality = .high
             }
             

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -43,7 +43,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             options.debug = true
             
             if #available(iOS 16.0, *), !args.contains("--disable-session-replay") {
-                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
+                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
                 options.experimental.sessionReplay.quality = .high
             }
             

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -238,9 +238,8 @@ class UIRedactBuilder {
     }
     
     private func mapRedactRegion(fromView view: UIView, relativeTo parentLayer: CALayer?, redacting: inout [RedactRegion], rootFrame: CGRect, forceRedact: Bool = false) {
-        guard !redactClassesIdentifiers.isEmpty && !view.isHidden && view.alpha != 0 else { return }
-        
         let layer = view.layer.presentation() ?? view.layer
+        guard !redactClassesIdentifiers.isEmpty && !layer.isHidden && layer.opacity != 0 else { return }
         
         let newTransform = getTranform(from: layer, withParent: parentLayer)
         
@@ -308,7 +307,8 @@ class UIRedactBuilder {
      Indicates whether the view is opaque and will block other view behind it
      */
     private func isOpaque(_ view: UIView) -> Bool {
-        return SentryRedactViewHelper.shouldClipOut(view) || (view.alpha == 1 && view.backgroundColor != nil && (view.backgroundColor?.cgColor.alpha ?? 0) == 1)
+        let layer = view.layer.presentation() ?? view.layer
+        return SentryRedactViewHelper.shouldClipOut(view) || (layer.opacity == 1 && view.backgroundColor != nil && (view.backgroundColor?.cgColor.alpha ?? 0) == 1)
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

Animated opacity was not being properly masked

## :green_heart: How did you test it?

Sample and Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I reviewed the submitted code.
- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
