### PR TITLE
ci: Fix failing macOS-SwiftUI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
   build-sample:
     name: Sample ${{ matrix.scheme }}
-    runs-on: macos-14
+    runs-on: ${{ matrix.runs-on }}
     strategy:
       fail-fast: false
       matrix:
@@ -58,14 +58,17 @@ jobs:
         include:
           - scheme: macOS-Swift
             xcode: 15.4
+            runs-on: macos-14
           - scheme: iOS13-Swift
             xcode: 15.4
+            runs-on: macos-14
           - scheme: watchOS-Swift WatchKit App
             xcode: 15.4
+            runs-on: macos-14
           # Only compiles on Xcode 16.0
           - scheme: macOS-SwiftUI
             xcode: 16.0
-
+            runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh ${{ matrix.xcode }}


### PR DESCRIPTION
Use macos-15 for Xcode 16, cause Xcode 16 is not available on macos-14.

#skip-changelog