### PR TITLE
ref: Data categories and envelope item types info

### DIFF
--- a/Sources/Sentry/SentryDataCategoryMapper.m
+++ b/Sources/Sentry/SentryDataCategoryMapper.m
@@ -3,6 +3,9 @@
 #import "SentryEnvelopeItemType.h"
 #import <Foundation/Foundation.h>
 
+// While these data categories names might look similar to the envelope item types, they are not
+// identical, and have slight differences. Just open them side by side and you'll see the
+// differences.
 NSString *const kSentryDataCategoryNameAll = @"";
 NSString *const kSentryDataCategoryNameDefault = @"default";
 NSString *const kSentryDataCategoryNameError = @"error";

--- a/Sources/Sentry/include/HybridPublic/SentryEnvelopeItemType.h
+++ b/Sources/Sentry/include/HybridPublic/SentryEnvelopeItemType.h
@@ -1,5 +1,8 @@
 // each item type must have a data category name mapped to it; see SentryDataCategoryMapper
 
+// While these envelope item types might look similar to the data categories, they are not
+// identical, and have slight differences. Just open them side by side and you'll see the
+// differences.
 static NSString *const SentryEnvelopeItemTypeEvent = @"event";
 static NSString *const SentryEnvelopeItemTypeSession = @"session";
 static NSString *const SentryEnvelopeItemTypeUserFeedback = @"user_report";


### PR DESCRIPTION
Add a comment that data categories and envelope item types look similar but have slight differences.

#skip-changelog