### PR TITLE
feat: Add in_foreground AppContext to transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add in_foreground app context to transactions (#4561)
+
 ### Improvements
 
 - impr: Speed up getBinaryImages V2 (#4539). Follow up on (#4435)

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -915,6 +915,18 @@ class SentryClientTest: XCTestCase {
         let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
         XCTAssertEqual(inForeground, true)
     }
+    
+    func testCaptureTransaction_WithAppStateInForegroudWhenAppIsInForeground() throws {
+        let app = TestSentryUIApplication()
+        app.applicationState = .active
+        SentryDependencyContainer.sharedInstance().application = app
+        
+        let event = fixture.transaction
+        fixture.getSut().capture(event: event)
+        let actual = try lastSentEvent()
+        let inForeground = actual.context?["app"]?["in_foreground"] as? Bool
+        XCTAssertEqual(inForeground, true)
+    }
 
     func testCaptureExceptionWithAppStateInForegroudWhenAppIsInBackground() throws {
         let app = TestSentryUIApplication()


### PR DESCRIPTION


## :scroll: Description

The SDK already attaches the in_foreground to events, but it didn't for transactions. This is fixed now.

## :bulb: Motivation and Context

Fixes GH-4559

## :green_heart: How did you test it?

Unit tests and [sample transaction](https://sentry-sdks.sentry.io/performance/trace/b97b7d50de1d4126bfba889ea767bfd5/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&field=replayId&id=18214&name=&node=txn-565b14d5c32c4901926d4c9948249f2a&project=5428557&query=&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=1h&timestamp=1732193473&topEvents=5&yAxis=count%28%29)

![CleanShot 2024-11-21 at 13 54 04@2x](https://github.com/user-attachments/assets/bf488317-3446-4930-92d0-192cb2bf1bd3)


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
