### PR TITLE
feat: Promote performanceV2 to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add in_foreground app context to transactions (#4561)
+- Promote the option `performanceV2` from experimental to stable (#4564)
 
 ### Improvements
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -270,13 +270,11 @@ NS_SWIFT_NAME(Options)
 @property (nonatomic, assign) BOOL enableAutoPerformanceTracing;
 
 /**
- * @warning This is an experimental feature and may still have bugs.
- *
- * Sentry works on reworking the whole performance offering with the code Mobile Starfish, which
- * aims to provide better insights into the performance of mobile apps and highlight clear actions
- * to improve app performance to developers. This feature flag enables experimental features that
- * impact the v1 performance offering and would require a major version update. Sentry aims to
- * include most features in the next major by default.
+ * We're working to update our Performance product offering in order to be able to provide better
+ * insights and highlight specific actions you can take to improve your mobile app's overall
+ * performance. The performanceV2 option changes the following behavior: The app start duration will
+ * now finish when the first frame is drawn instead of when the OS posts the
+ * UIWindowDidBecomeVisibleNotification. This change will be the default in the next major version.
  */
 @property (nonatomic, assign) BOOL enablePerformanceV2;
 


### PR DESCRIPTION


## :scroll: Description

Make the performanceV2 flag stable, as it's been experimental long enough, and we didn't hear any negative feedback from customers using it.

Docs PR: https://github.com/getsentry/sentry-docs/pull/11913.

## :bulb: Motivation and Context

Customers frequently want to use the feature and it only confuses them when it's experimental.

## :green_heart: How did you test it?
It's well tested with unit tests and we didn't hear any negative feedback.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
