### PR TITLE
chore: Improving a flaky test.

### DIFF
--- a/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
@@ -308,7 +308,7 @@ class SentryTouchTrackerTests: XCTestCase {
         let readExp = expectation(description: "read")
         
         DispatchQueue.global().async {
-            for i in 0..<50_000 {
+            for i in 0..<1_000 {
                 let event = MockUIEvent(timestamp: Double(i))
                 let touch = MockUITouch(phase: .ended, location: CGPoint(x: 100, y: 100))
                 event.addTouch(touch)
@@ -318,14 +318,14 @@ class SentryTouchTrackerTests: XCTestCase {
         }
         
         DispatchQueue.global().async {
-            for _ in 0..<50_000 {
+            for _ in 0..<1_000 {
                 sut.flushFinishedEvents()
             }
             removeExp.fulfill()
         }
         
         DispatchQueue.global().async {
-            for _ in 0..<50_000 {
+            for _ in 0..<1_000 {
                 _ = sut.replayEvents(from: self.referenceDate, until: self.referenceDate.addingTimeInterval(10_000.0))
             }
             readExp.fulfill()


### PR DESCRIPTION
`SentryTouchTrackerTests.testLock` is super flaky because it runs 3 long loops in parallel that use locks. For our CI with no much CPU power, this can’t finish in under a second.

I’m reducing the number of iterations. In all my tests, the reduced amount was already enough to detect the error.

_#skip-changelog_