### PR TITLE
fix: Masking for fast animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Session replay touch tracking race condition (#4548)
 - Session replay transformed view masking (#4529)
 - Load integration from same binary (#4541)
+- Masking for fast animations #4574
 
 
 ### Improvements

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/SRRedactSampleViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/SRRedactSampleViewController.swift
@@ -26,7 +26,19 @@ class SRRedactSampleViewController: UIViewController {
         animatedLabel.frame = CGRect(origin: .zero, size: animatedLabel.frame.size)
         view.addSubview(animatedLabel)
         animate()
-      }
+    
+    }
+    
+    func inspectViewLayer() {
+        guard let layer = view.layer.presentation() else {
+            print("### No presentation layer")
+            return
+        }
+        
+        layer.sublayers?.forEach { sublayer in
+            print("### Sublayer: \(sublayer.delegate)")
+        }
+    }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/SRRedactSampleViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/SRRedactSampleViewController.swift
@@ -7,11 +7,38 @@ class SRRedactSampleViewController: UIViewController {
     
     @IBOutlet var label: UILabel!
     
+    private let animatedLabel: UILabel = {
+        let label = UILabel()
+        label.text = "Animated"
+        label.sizeToFit()
+        return label
+    }()
+    
+    private var continueAnimating = true
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         notRedactedView.backgroundColor = .green
         notRedactedView.transform = CGAffineTransform(rotationAngle: 45 * .pi / 180.0)
         SentrySDK.replay.unmaskView(notRedactedLabel)
+        
+        animatedLabel.frame = CGRect(origin: .zero, size: animatedLabel.frame.size)
+        view.addSubview(animatedLabel)
+        animate()
       }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        continueAnimating = false
+    }
+    
+    private func animate() {
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.repeat, .autoreverse], animations: { [weak self] in
+            guard let self = self else { return }
+            self.animatedLabel.frame = CGRect(
+                origin: CGPoint(x: 0, y: self.view.frame.height),
+                size: self.animatedLabel.frame.size)
+        })
+    }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ViewControllers/SRRedactSampleViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ViewControllers/SRRedactSampleViewController.swift
@@ -29,17 +29,6 @@ class SRRedactSampleViewController: UIViewController {
     
     }
     
-    func inspectViewLayer() {
-        guard let layer = view.layer.presentation() else {
-            print("### No presentation layer")
-            return
-        }
-        
-        layer.sublayers?.forEach { sublayer in
-            print("### Sublayer: \(sublayer.delegate)")
-        }
-    }
-    
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         continueAnimating = false

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -38,9 +38,9 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     }
     
     func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback ) {
+        let redact = redactBuilder.redactRegionsFor(view: view)
         let image = renderer.render(view: view)
         
-        let redact = redactBuilder.redactRegionsFor(view: view)
         let imageSize = view.bounds.size
         dispatchQueue.dispatchAsync {
             let screenshot = UIGraphicsImageRenderer(size: imageSize, format: .init(for: .init(displayScale: 1))).image { context in

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -263,14 +263,14 @@ class UIRedactBuilder {
             }
         }
         
-        guard view.subviews.count > 0 else { return }
+        guard let subLayers = layer.sublayers, subLayers.count > 0 else { return }
         
         if view.clipsToBounds {
             /// Because the order in which we process the redacted regions is reversed, we add the end of the clip region first.
             /// The beginning will be added after all the subviews have been mapped.
             redacting.append(RedactRegion(size: layer.bounds.size, transform: newTransform, type: .clipEnd))
         }
-        for subLayer in (layer.sublayers ?? []).sorted(by: { $0.zPosition < $1.zPosition }) {
+        for subLayer in subLayers.sorted(by: { $0.zPosition < $1.zPosition }) {
             mapRedactRegion(fromLayer: subLayer, relativeTo: layer, redacting: &redacting, rootFrame: rootFrame, transform: newTransform, forceRedact: enforceRedact)
         }
         if view.clipsToBounds {


### PR DESCRIPTION
## :scroll: Description

Speeding up mask calculation 


## :green_heart: How did you test it?

Samples Only

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
