### PR TITLE
feat: Add in_foreground AppContext to crash events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add in_foreground app context to transactions (#4561)
+- Add in_foreground app context to crash events ((#4584)
 - Promote the option `performanceV2` from experimental to stable (#4564)
 
 ### Fixes


### PR DESCRIPTION




## :scroll: Description

The SDK now adds the in_foreground AppContext to crash events by retrieving this information from the application_stats of the crash report.

## :bulb: Motivation and Context

Fixes GH-4563

## :green_heart: How did you test it?
Unit tests and simulator.

[Before](https://sentry-sdks.sentry.io/issues/6044162827/events/a1727e5be46c4bc8ab789af800942ee3/?project=5428557)
![CleanShot 2024-11-29 at 09 00 03@2x](https://github.com/user-attachments/assets/5586ae62-723d-4a2d-b94e-444147fe01d5)

[Now](https://sentry-sdks.sentry.io/issues/4911583360/events/5a33347b088447de9cc03bf71cc3174b/?project=5428557)
![CleanShot 2024-11-29 at 09 00 31@2x](https://github.com/user-attachments/assets/2f1fa91c-bb62-40ee-8a1d-96fb8ee8e0de)


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
