### PR TITLE
impr: Track usage of persistingTracesWhenCrashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Track adoption of `enablePersistingTracesWhenCrashing` (#4587)
+
 ## 8.42.0-beta.1
 
 ### Features

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -42,6 +42,10 @@ import Foundation
         }
 #endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         
+        if options.enablePersistingTracesWhenCrashing {
+            features.append("persistingTracesWhenCrashing")
+        }
+        
         return features
     }
 }

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -50,5 +50,16 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         XCTAssert(features.contains("appHangTrackingV2"))
 #endif //os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        
+    }
+    
+    func testEnablePersistingTracesWhenCrashing() {
+        let options = Options()
+        
+        options.enablePersistingTracesWhenCrashing = true
+        
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+        
+        XCTAssert(features.contains("persistingTracesWhenCrashing"))
     }
 }


### PR DESCRIPTION


## :scroll: Description

Add enablePersistingTracesWhenCrashing to the list of enabled features when the option enablePersistingTracesWhenCrashing is enabled.

## :bulb: Motivation and Context

We want to know how many people use enablePersistingTracesWhenCrashing. Follow up on #4504.

## :green_heart: How did you test it?
Unit test.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
