### PR TITLE
chore(ci): add direct branch cloning for fastlane match

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,7 +83,9 @@ platform :ios do
     sync_code_signing(
       type: "appstore",
       readonly: true,
-      app_identifier: ["io.sentry.sample.iOS-Swift",  "io.sentry.sample.iOS-Swift.Clip"]
+      app_identifier: ["io.sentry.sample.iOS-Swift",  "io.sentry.sample.iOS-Swift.Clip"],
+      git_branch: "master",
+      clone_branch_directly: true
     )
 
     build_app(
@@ -107,7 +109,9 @@ platform :ios do
     sync_code_signing(
       type: "development",
       readonly: true,
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"]
+      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"],
+      git_branch: "master",
+      clone_branch_directly: true
     )
 
     build_app(
@@ -129,7 +133,9 @@ platform :ios do
     sync_code_signing(
       type: "development",
       readonly: true,
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Swift-UITests.xctrunner"]
+      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Swift-UITests.xctrunner"],
+      git_branch: "master",
+      clone_branch_directly: true
     )
 
     # don't use gym here because it always appends a "build" command which fails, since this is a test target not configured for running
@@ -147,7 +153,9 @@ platform :ios do
     sync_code_signing(
       type: "development",
       readonly: true,
-      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Benchmarking.xctrunner"]
+      app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Benchmarking.xctrunner"],
+      git_branch: "master",
+      clone_branch_directly: true
     )
 
     build_app(
@@ -258,7 +266,9 @@ platform :ios do
     sync_code_signing(
       type: "development",
       readonly: true,
-      app_identifier: ["io.sentry.cocoa.perf-test-app-plain"]
+      app_identifier: ["io.sentry.cocoa.perf-test-app-plain"],
+      git_branch: "master",
+      clone_branch_directly: true
     )
 
     build_app(
@@ -283,7 +293,9 @@ platform :ios do
     sync_code_signing(
       type: "development",
       readonly: true,
-      app_identifier: ["io.sentry.cocoa.perf-test-app-sentry"]
+      app_identifier: ["io.sentry.cocoa.perf-test-app-sentry"],
+      git_branch: "master",
+      clone_branch_directly: true
     )
 
     build_app(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -84,6 +84,9 @@ platform :ios do
       type: "appstore",
       readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift",  "io.sentry.sample.iOS-Swift.Clip"],
+      
+      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
+      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
       git_branch: "master",
       clone_branch_directly: true
     )
@@ -110,6 +113,9 @@ platform :ios do
       type: "development",
       readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"],
+      
+      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
+      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
       git_branch: "master",
       clone_branch_directly: true
     )
@@ -134,6 +140,9 @@ platform :ios do
       type: "development",
       readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Swift-UITests.xctrunner"],
+      
+      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
+      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
       git_branch: "master",
       clone_branch_directly: true
     )
@@ -154,6 +163,10 @@ platform :ios do
       type: "development",
       readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Benchmarking.xctrunner"],
+      
+      
+      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
+      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
       git_branch: "master",
       clone_branch_directly: true
     )
@@ -267,6 +280,9 @@ platform :ios do
       type: "development",
       readonly: true,
       app_identifier: ["io.sentry.cocoa.perf-test-app-plain"],
+      
+      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
+      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
       git_branch: "master",
       clone_branch_directly: true
     )
@@ -294,6 +310,9 @@ platform :ios do
       type: "development",
       readonly: true,
       app_identifier: ["io.sentry.cocoa.perf-test-app-sentry"],
+      
+      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
+      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
       git_branch: "master",
       clone_branch_directly: true
     )


### PR DESCRIPTION
## :scroll: Description

Changes `sync_code_signing` in fastlane lanes to use direct branch cloning.

## :bulb: Motivation and Context

Workflow runs were occasionally failing due to the following error:

```
Cloning remote git repo...
If cloning the repo takes too long, you can use the `clone_branch_directly` option in match.
Checking out branch master...
fatal: a branch named 'master' already exists
```

Example: https://github.com/getsentry/sentry-cocoa/actions/runs/12154028573/job/33893118719?pr=4593#step:5:96

By directly defining the branch to clone, the branch checkout step should be skipped instead.

## :green_heart: How did you test it?

Created this PR to run workflows on CI.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog