### PR TITLE
Allow compiling with APPLICATION_EXTENSION_API_ONLY=NO

### DIFF
--- a/Sources/Sentry/Public/SentryDebugImageProvider.h
+++ b/Sources/Sentry/Public/SentryDebugImageProvider.h
@@ -1,6 +1,8 @@
+#import "SentryDebugMeta.h"
+#import "SentryThread.h"
 #import <Foundation/Foundation.h>
 
-@class SentryDebugMeta, SentryThread, SentryFrame;
+@class SentryFrame;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -4,10 +4,12 @@
 #    import <SentryWithoutUIKit/SentryDefines.h>
 #endif
 
+#import "SentryOptions.h"
+
 @protocol SentrySpan;
 
-@class SentryOptions, SentryEvent, SentryBreadcrumb, SentryScope, SentryUser, SentryId,
-    SentryUserFeedback, SentryTransactionContext;
+@class SentryEvent, SentryBreadcrumb, SentryScope, SentryUser, SentryId, SentryUserFeedback,
+    SentryTransactionContext;
 @class SentryMetricsAPI;
 @class UIView;
 @class SentryReplayApi;

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -125,7 +125,7 @@ NS_ASSUME_NONNULL_BEGIN
         endSessionExitedWithTimestamp:[SentryDependencyContainer.sharedInstance.dateProvider date]];
     [self captureSession:lastSession];
 
-    [_sessionListener sentrySessionStarted:_session];
+    [_sessionListener sentrySessionStarted];
 }
 
 - (void)endSession
@@ -150,7 +150,7 @@ NS_ASSUME_NONNULL_BEGIN
     [currentSession endSessionExitedWithTimestamp:timestamp];
     [self captureSession:currentSession];
 
-    [_sessionListener sentrySessionEnded:currentSession];
+    [_sessionListener sentrySessionEnded];
 }
 
 - (void)storeCurrentSession:(SentrySession *)session

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -304,16 +304,16 @@ static SentryTouchTracker *_touchTracker;
                                               attributes:attributes];
 
     self.sessionReplay = [[SentrySessionReplay alloc]
-        initWithReplayOptions:replayOptions
-             replayFolderPath:docs
-           screenshotProvider:screenshotProvider
-                  replayMaker:replayMaker
-          breadcrumbConverter:breadcrumbConverter
-                 touchTracker:_touchTracker
-                 dateProvider:SentryDependencyContainer.sharedInstance.dateProvider
-                     delegate:self
-                dispatchQueue:dispatchQueue
-           displayLinkWrapper:[[SentryDisplayLinkWrapper alloc] init]];
+            initWithReplayOptions:replayOptions
+                 replayFolderPath:docs
+               screenshotProvider:screenshotProvider
+                      replayMaker:replayMaker
+              breadcrumbConverter:breadcrumbConverter
+                     touchTracker:_touchTracker
+                     dateProvider:SentryDependencyContainer.sharedInstance.dateProvider
+                         delegate:self
+             dispatchQueueGeneric:dispatchQueue
+        displayLinkWrapperGeneric:[[SentryDisplayLinkWrapper alloc] init]];
 
     [self.sessionReplay
         startWithRootView:SentryDependencyContainer.sharedInstance.application.windows.firstObject
@@ -447,7 +447,7 @@ static SentryTouchTracker *_touchTracker;
     self.sessionReplay = nil;
 }
 
-- (void)sentrySessionEnded:(SentrySession *)session
+- (void)sentrySessionEnded
 {
     [self pause];
     [_notificationCenter removeObserver:self
@@ -459,7 +459,7 @@ static SentryTouchTracker *_touchTracker;
     _sessionReplay = nil;
 }
 
-- (void)sentrySessionStarted:(SentrySession *)session
+- (void)sentrySessionStarted
 {
     _rateLimited = NO;
     [self startSession];

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -3,11 +3,11 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryDefines.h"
+#    import "SentryHub.h"
 #    import <Foundation/Foundation.h>
 
 @class SentryEnvelope;
 @class SentryEnvelopeItem;
-@class SentryHub;
 @class SentryId;
 @class SentryScreenFrames;
 @class SentryTransaction;

--- a/Sources/Swift/Helper/Log/SentryLevel.swift
+++ b/Sources/Swift/Helper/Log/SentryLevel.swift
@@ -37,12 +37,12 @@ extension SentryLevel: CustomStringConvertible {
 }
 
 @objcMembers
-class SentryLevelHelper: NSObject {
-    static func nameForLevel(_  level: SentryLevel) -> String {
+public class SentryLevelHelper: NSObject {
+    public static func nameForLevel(_  level: SentryLevel) -> String {
         return level.description
     }
     
-    static func levelForName(_ name: String) -> SentryLevel {
+    public static func levelForName(_ name: String) -> SentryLevel {
         .fromName(name)
     }
 

--- a/Sources/Swift/Helper/SentryBaggageSerialization.swift
+++ b/Sources/Swift/Helper/SentryBaggageSerialization.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 @objcMembers
-class SentryBaggageSerialization: NSObject {
+public class SentryBaggageSerialization: NSObject {
     
     private static let SENTRY_BAGGAGE_MAX_SIZE = 8_192
     
-    static func encodeDictionary(_ dictionary: [String: String]) -> String {
+    public static func encodeDictionary(_ dictionary: [String: String]) -> String {
         var items: [String] = []
         items.reserveCapacity(dictionary.count)
         
@@ -29,7 +29,7 @@ class SentryBaggageSerialization: NSObject {
         return items.sorted().joined(separator: ",")
     }
     
-    static func decode(_ baggage: String) -> [String: String] {
+    public static func decode(_ baggage: String) -> [String: String] {
         guard !baggage.isEmpty else {
             return [:]
         }

--- a/Sources/Swift/Helper/SentryCurrentDateProvider.swift
+++ b/Sources/Swift/Helper/SentryCurrentDateProvider.swift
@@ -6,7 +6,7 @@ import Foundation
  * Mocking the previous private class from `SentryTestUtils` stopped working in Xcode 16.
 */
 @objc
-protocol SentryCurrentDateProvider {
+public protocol SentryCurrentDateProvider {
     func date() -> Date
     func timezoneOffset() -> Int
     func systemTime() -> UInt64
@@ -14,20 +14,20 @@ protocol SentryCurrentDateProvider {
 }
 
 @objcMembers
-class SentryDefaultCurrentDateProvider: NSObject, SentryCurrentDateProvider {
-    func date() -> Date {
+public class SentryDefaultCurrentDateProvider: NSObject, SentryCurrentDateProvider {
+    public func date() -> Date {
         return Date()
     }
     
-    func timezoneOffset() -> Int {
+    public func timezoneOffset() -> Int {
         return TimeZone.current.secondsFromGMT()
     }
     
-    func systemTime() -> UInt64 {
+    public func systemTime() -> UInt64 {
         getAbsoluteTime()
     }
     
-    func systemUptime() -> TimeInterval {
+    public func systemUptime() -> TimeInterval {
         ProcessInfo.processInfo.systemUptime
     }
 }

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-@objcMembers class SentryEnabledFeaturesBuilder: NSObject {
+@objcMembers
+public class SentryEnabledFeaturesBuilder: NSObject {
     
-    static func getEnabledFeatures(options: Options) -> [String] {
+    public static func getEnabledFeatures(options: Options) -> [String] {
         
         var features: [String] = []
         

--- a/Sources/Swift/Helper/SentryFileContents.swift
+++ b/Sources/Swift/Helper/SentryFileContents.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 @objcMembers
-class SentryFileContents: NSObject {
+public class SentryFileContents: NSObject {
     
-    let path: String
-    let contents: Data
+    public let path: String
+    public let contents: Data
     
-    init(path: String, contents: Data) {
+    public init(path: String, contents: Data) {
         self.path = path
         self.contents = contents
     }

--- a/Sources/Swift/Integrations/ANR/SentryANRTracker.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTracker.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc
-protocol SentryANRTracker {
+public protocol SentryANRTracker {
     @objc(addListener:)
     func add(listener: SentryANRTrackerDelegate)
     @objc(removeListener:)

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The  methods are called from a  background thread.
 @objc
-protocol SentryANRTrackerDelegate {
+public protocol SentryANRTrackerDelegate {
     func anrDetected(type: SentryANRType)
     func anrStopped()
 }

--- a/Sources/Swift/Integrations/ANR/SentryANRType.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRType.swift
@@ -1,12 +1,12 @@
 @objc
-enum SentryANRType: Int {
+public enum SentryANRType: Int {
     case fullyBlocking
     case nonFullyBlocking
     case unknown
 }
 
 @objc
-class SentryAppHangTypeMapper: NSObject {
+public class SentryAppHangTypeMapper: NSObject {
 
     private enum ExceptionType: String {
         case fullyBlocking = "App Hanging Fully Blocked"
@@ -15,7 +15,7 @@ class SentryAppHangTypeMapper: NSObject {
     }
 
     @objc
-    static func getExceptionType(anrType: SentryANRType) -> String {
+    public static func getExceptionType(anrType: SentryANRType) -> String {
         switch anrType {
         case .fullyBlocking:
             return ExceptionType.fullyBlocking.rawValue
@@ -27,7 +27,7 @@ class SentryAppHangTypeMapper: NSObject {
     }
 
     @objc
-    static func isExceptionTypeAppHang(exceptionType: String) -> Bool {
+    public static func isExceptionTypeAppHang(exceptionType: String) -> Bool {
         return ExceptionType(rawValue: exceptionType) != nil
     }
 }

--- a/Sources/Swift/Integrations/FramesTracking/SentryFramesDelayResult.swift
+++ b/Sources/Swift/Integrations/FramesTracking/SentryFramesDelayResult.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 @objcMembers
-class SentryFramesDelayResult: NSObject {
+public class SentryFramesDelayResult: NSObject {
     /// The frames delay for the passed time period. If frame delay can't be calculated this is -1.
-    let delayDuration: CFTimeInterval
-    let framesContributingToDelayCount: UInt
+    public let delayDuration: CFTimeInterval
+    public let framesContributingToDelayCount: UInt
 
-    init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt) {
+    public init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt) {
         self.delayDuration = delayDuration
         self.framesContributingToDelayCount = framesContributingToDelayCount
     }

--- a/Sources/Swift/Integrations/Performance/SwizzleClassNameExclude.swift
+++ b/Sources/Swift/Integrations/Performance/SwizzleClassNameExclude.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 @objcMembers
-class SentrySwizzleClassNameExclude: NSObject {
-    static func shouldExcludeClass(className: String, swizzleClassNameExcludes: Set<String>) -> Bool {
+public class SentrySwizzleClassNameExclude: NSObject {
+    public static func shouldExcludeClass(className: String, swizzleClassNameExcludes: Set<String>) -> Bool {
         for exclude in swizzleClassNameExcludes {
             if className.contains(exclude) {
                 SentryLog.debug("Excluding class \(className) from swizzling cause it matches the exclude pattern: \(exclude).")

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebBreadcrumbEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebBreadcrumbEvent.swift
@@ -1,8 +1,8 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-class SentryRRWebBreadcrumbEvent: SentryRRWebCustomEvent {
-    init(timestamp: Date, category: String, message: String? = nil, level: SentryLevel = .none, data: [String: Any]? = nil) {
+public class SentryRRWebBreadcrumbEvent: SentryRRWebCustomEvent {
+    public init(timestamp: Date, category: String, message: String? = nil, level: SentryLevel = .none, data: [String: Any]? = nil) {
         
         var payload: [String: Any] = ["type": "default", "category": category, "level": level.description, "timestamp": timestamp.timeIntervalSince1970 ]
 

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebCustomEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebCustomEvent.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objcMembers
-class SentryRRWebCustomEvent: SentryRRWebEvent {
+public class SentryRRWebCustomEvent: SentryRRWebEvent {
     let tag: String
     
     init(timestamp: Date, tag: String, payload: [String: Any]) {

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebEvent.swift
@@ -10,11 +10,11 @@ enum SentryRRWebEventType: Int {
 }
 
 @objc(SentryRRWebEvent)
-protocol SentryRRWebEventProtocol: SentrySerializable {
+public protocol SentryRRWebEventProtocol: SentrySerializable {
 }
 
 @objcMembers
-class SentryRRWebEvent: NSObject, SentryRRWebEventProtocol {
+public class SentryRRWebEvent: NSObject, SentryRRWebEventProtocol {
     let type: SentryRRWebEventType
     let timestamp: Date
     let data: [String: Any]?
@@ -25,7 +25,7 @@ class SentryRRWebEvent: NSObject, SentryRRWebEventProtocol {
         self.data = data
     }
     
-    func serialize() -> [String: Any] {
+    public func serialize() -> [String: Any] {
         var result: [String: Any] = [
             "type": type.rawValue,
             "timestamp": SentryDateUtil.millisecondsSince1970(timestamp)

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebSpanEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebSpanEvent.swift
@@ -1,9 +1,10 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-@objc class SentryRRWebSpanEvent: SentryRRWebCustomEvent {
+@objc
+public class SentryRRWebSpanEvent: SentryRRWebCustomEvent {
     
-    init(timestamp: Date, endTimestamp: Date, operation: String, description: String, data: [String: Any]) {
+    public init(timestamp: Date, endTimestamp: Date, operation: String, description: String, data: [String: Any]) {
         super.init(timestamp: timestamp, tag: "performanceSpan", payload:
                     [
                         "op": operation,

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -20,7 +20,7 @@ enum SentryOnDemandReplayError: Error {
 }
 
 @objcMembers
-class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
+public class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         
     private let _outputPath: String
     private var _totalFrames = 0
@@ -35,10 +35,10 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         set { _frames = newValue }
     }
     #endif // TEST || TESTCI || DEBUG
-    var videoScale: Float = 1
-    var bitRate = 20_000
+    public var videoScale: Float = 1
+    public var bitRate = 20_000
     var frameRate = 1
-    var cacheMaxSize = UInt.max
+    public var cacheMaxSize = UInt.max
         
     init(outputPath: String, workingQueue: SentryDispatchQueueWrapper, dateProvider: SentryCurrentDateProvider) {
         self._outputPath = outputPath
@@ -62,19 +62,19 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         }
     }
     
-    convenience init(outputPath: String) {
+    public convenience init(outputPath: String) {
         self.init(outputPath: outputPath,
                   workingQueue: SentryDispatchQueueWrapper(name: "io.sentry.onDemandReplay", attributes: nil),
                   dateProvider: SentryDefaultCurrentDateProvider())
     }
     
-    convenience init(withContentFrom outputPath: String) {
+    public convenience init(withContentFrom outputPath: String) {
         self.init(withContentFrom: outputPath,
                   workingQueue: SentryDispatchQueueWrapper(name: "io.sentry.onDemandReplay", attributes: nil),
                   dateProvider: SentryDefaultCurrentDateProvider())
     }
     
-    func addFrameAsync(image: UIImage, forScreen: String?) {
+    public func addFrameAsync(image: UIImage, forScreen: String?) {
         workingQueue.dispatchAsync({
             self.addFrame(image: image, forScreen: forScreen)
         })
@@ -110,7 +110,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         return UIGraphicsGetImageFromCurrentImageContext()
     }
     
-    func releaseFramesUntil(_ date: Date) {
+    public func releaseFramesUntil(_ date: Date) {
         workingQueue.dispatchAsync ({
             while let first = self._frames.first, first.time < date {
                 self._frames.removeFirst()
@@ -119,11 +119,11 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         })
     }
         
-    var oldestFrameDate: Date? {
+    public var oldestFrameDate: Date? {
         return _frames.first?.time
     }
     
-    func createVideoWith(beginning: Date, end: Date) throws -> [SentryVideoInfo] {
+    public func createVideoWith(beginning: Date, end: Date) throws -> [SentryVideoInfo] {
         let videoFrames = filterFrames(beginning: beginning, end: end)
         var frameCount = 0
         

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @objcMembers
-class SentryReplayEvent: Event {
+public class SentryReplayEvent: Event {
     
     // Start time of the replay segment
     let replayStartTimestamp: Date
@@ -14,7 +14,7 @@ class SentryReplayEvent: Event {
      * Number of the segment in the replay.
      * This is an incremental number
      */
-    let segmentId: Int
+    public let segmentId: Int
  
     /**
      * This will be used to store the name of the screens
@@ -22,7 +22,7 @@ class SentryReplayEvent: Event {
      */
     var urls: [String]?
     
-    init(eventId: SentryId, replayStartTimestamp: Date, replayType: SentryReplayType, segmentId: Int) {
+    public init(eventId: SentryId, replayStartTimestamp: Date, replayType: SentryReplayType, segmentId: Int) {
         self.replayStartTimestamp = replayStartTimestamp
         self.replayType = replayType
         self.segmentId = segmentId
@@ -36,7 +36,7 @@ class SentryReplayEvent: Event {
         fatalError("init() has not been implemented")
     }
     
-    override func serialize() -> [String: Any] {
+    public override func serialize() -> [String: Any] {
         var result = super.serialize()
         result["urls"] = urls
         result["replay_start_timestamp"] = replayStartTimestamp.timeIntervalSince1970

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -109,14 +109,14 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * Defines the quality of the session replay.
      * Higher bit rates better quality, but also bigger files to transfer.
      */
-    var replayBitRate: Int {
+    public var replayBitRate: Int {
         quality.rawValue * 20_000 + 20_000
     }
 
     /**
      * The scale related to the window size at which the replay will be created
      */
-    var sizeScale: Float {
+    public var sizeScale: Float {
         quality == .low ? 0.8 : 1.0
     }
 
@@ -134,12 +134,12 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     /**
      * The maximum duration of replays for error events.
      */
-    let errorReplayDuration = TimeInterval(30)
+    public let errorReplayDuration = TimeInterval(30)
 
     /**
      * The maximum duration of the segment of a session replay.
      */
-    let sessionSegmentDuration = TimeInterval(5)
+    public let sessionSegmentDuration = TimeInterval(5)
 
     /**
      * The maximum duration of a replay session.

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayRecording.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayRecording.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @objcMembers
-class SentryReplayRecording: NSObject {
+public class SentryReplayRecording: NSObject {
     
     static let SentryReplayEncoding = "h264"
     static let SentryReplayContainer = "mp4"
@@ -14,7 +14,7 @@ class SentryReplayRecording: NSObject {
     let height: Int
     let width: Int
     
-    convenience init(segmentId: Int, video: SentryVideoInfo, extraEvents: [any SentryRRWebEventProtocol]) {
+    public convenience init(segmentId: Int, video: SentryVideoInfo, extraEvents: [any SentryRRWebEventProtocol]) {
         self.init(segmentId: segmentId, size: video.fileSize, start: video.start, duration: video.duration, frameCount: video.frameCount, frameRate: video.frameRate, height: video.height, width: video.width, extraEvents: extraEvents)
     }
     
@@ -28,11 +28,11 @@ class SentryReplayRecording: NSObject {
         self.events = [meta, video] + (extraEvents ?? [])
     }
 
-    func headerForReplayRecording() -> [String: Any] {
+    public func headerForReplayRecording() -> [String: Any] {
         return ["segment_id": segmentId]
     }
 
-    func serialize() -> [[String: Any]] {
+    public func serialize() -> [[String: Any]] {
         return events.map { $0.serialize() }
     }
 }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayType.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayType.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc
-enum SentryReplayType: Int {
+public enum SentryReplayType: Int {
     case session
     case buffer
 }

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
@@ -3,7 +3,7 @@ import Foundation
 import UIKit
 
 @objc
-protocol SentryReplayVideoMaker: NSObjectProtocol {
+public protocol SentryReplayVideoMaker: NSObjectProtocol {
     func addFrameAsync(image: UIImage, forScreen: String?) 
     func releaseFramesUntil(_ date: Date)
     func createVideoWith(beginning: Date, end: Date) throws -> [SentryVideoInfo]

--- a/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 @objc
-protocol SentryReplayBreadcrumbConverter: NSObjectProtocol {
+public protocol SentryReplayBreadcrumbConverter: NSObjectProtocol {
     func convert(from breadcrumb: Breadcrumb) -> SentryRRWebEventProtocol?
 }
 
 @objcMembers
-class SentrySRDefaultBreadcrumbConverter: NSObject, SentryReplayBreadcrumbConverter {
+public class SentrySRDefaultBreadcrumbConverter: NSObject, SentryReplayBreadcrumbConverter {
     
     private let supportedNetworkData = Set<String>([
         "status_code",
@@ -22,7 +22,7 @@ class SentrySRDefaultBreadcrumbConverter: NSObject, SentryReplayBreadcrumbConver
      * Any deviation in the information will cause the breadcrumb or the information itself to be discarded
      * in order to avoid unknown behavior in the front-end.
      */
-    func convert(from breadcrumb: Breadcrumb) -> SentryRRWebEventProtocol? {
+    public func convert(from breadcrumb: Breadcrumb) -> SentryRRWebEventProtocol? {
         guard let timestamp = breadcrumb.timestamp else { return nil }
         if breadcrumb.category == "http" {
             return networkSpan(breadcrumb)

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -9,7 +9,7 @@ enum SessionReplayError: Error {
 }
 
 @objc
-protocol SentrySessionReplayDelegate: NSObjectProtocol {
+public protocol SentrySessionReplayDelegate: NSObjectProtocol {
     func sessionReplayShouldCaptureReplayForError() -> Bool
     func sessionReplayNewSegment(replayEvent: SentryReplayEvent, replayRecording: SentryReplayRecording, videoUrl: URL)
     func sessionReplayStarted(replayId: SentryId)
@@ -17,10 +17,11 @@ protocol SentrySessionReplayDelegate: NSObjectProtocol {
     func currentScreenNameForSessionReplay() -> String?
 }
 
+// swiftlint:disable type_body_length
 @objcMembers
-class SentrySessionReplay: NSObject {
-    private(set) var isFullSession = false
-    private(set) var sessionReplayId: SentryId?
+public class SentrySessionReplay: NSObject {
+    public private(set) var isFullSession = false
+    public private(set) var sessionReplayId: SentryId?
 
     private var urlToCache: URL?
     private var rootView: UIView?
@@ -46,8 +47,8 @@ class SentrySessionReplay: NSObject {
         displayLink.isRunning()
     }
     
-    var screenshotProvider: SentryViewScreenshotProvider
-    var breadcrumbConverter: SentryReplayBreadcrumbConverter
+    public var screenshotProvider: SentryViewScreenshotProvider
+    public var breadcrumbConverter: SentryReplayBreadcrumbConverter
     
     init(replayOptions: SentryReplayOptions,
          replayFolderPath: URL,
@@ -72,9 +73,33 @@ class SentrySessionReplay: NSObject {
         self.touchTracker = touchTracker
     }
     
+    // swiftlint:disable force_cast
+    public convenience init(replayOptions: SentryReplayOptions,
+                            replayFolderPath: URL,
+                            screenshotProvider: SentryViewScreenshotProvider,
+                            replayMaker: SentryReplayVideoMaker,
+                            breadcrumbConverter: SentryReplayBreadcrumbConverter,
+                            touchTracker: SentryTouchTracker?,
+                            dateProvider: SentryCurrentDateProvider,
+                            delegate: SentrySessionReplayDelegate,
+                            dispatchQueueGeneric: Any,
+                            displayLinkWrapperGeneric: Any) {
+        self.init(replayOptions: replayOptions,
+                  replayFolderPath: replayFolderPath,
+                  screenshotProvider: screenshotProvider,
+                  replayMaker: replayMaker,
+                  breadcrumbConverter: breadcrumbConverter,
+                  touchTracker: touchTracker,
+                  dateProvider: dateProvider,
+                  delegate: delegate,
+                  dispatchQueue: dispatchQueueGeneric as! SentryDispatchQueueWrapper,
+                  displayLinkWrapper: displayLinkWrapperGeneric as! SentryDisplayLinkWrapper)
+    }
+    // swiftlint:enable force_cast
+    
     deinit { displayLink.invalidate() }
 
-    func start(rootView: UIView, fullSession: Bool) {
+    public func start(rootView: UIView, fullSession: Bool) {
         guard !isRunning else { return }
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
         self.rootView = rootView
@@ -96,7 +121,7 @@ class SentrySessionReplay: NSObject {
         delegate?.sessionReplayStarted(replayId: sessionReplayId)
     }
 
-    func pauseSessionMode() {
+    public func pauseSessionMode() {
         lock.lock()
         defer { lock.unlock() }
         
@@ -104,7 +129,7 @@ class SentrySessionReplay: NSObject {
         self.videoSegmentStart = nil
     }
     
-    func pause() {
+    public func pause() {
         lock.lock()
         defer { lock.unlock() }
         
@@ -115,7 +140,7 @@ class SentrySessionReplay: NSObject {
         isSessionPaused = false
     }
 
-    func resume() {
+    public func resume() {
         lock.lock()
         defer { lock.unlock() }
         
@@ -131,7 +156,7 @@ class SentrySessionReplay: NSObject {
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
     }
   
-    func captureReplayFor(event: Event) {
+    public func captureReplayFor(event: Event) {
         guard isRunning else { return }
 
         if isFullSession {
@@ -146,7 +171,7 @@ class SentrySessionReplay: NSObject {
     }
 
     @discardableResult
-    func captureReplay() -> Bool {
+    public func captureReplay() -> Bool {
         guard isRunning else { return false }
         guard !isFullSession else { return true }
 
@@ -315,5 +340,6 @@ class SentrySessionReplay: NSObject {
         }
     }
 }
+// swiftlint:enable type_body_length
 
 #endif

--- a/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 @objcMembers
-class SentryTouchTracker: NSObject {
+public class SentryTouchTracker: NSObject {
     
     private struct TouchEvent {
         let x: CGFloat
@@ -46,14 +46,14 @@ class SentryTouchTracker: NSObject {
         self.dispatchQueue = dispatchQueue
     }
     
-    convenience init(dateProvider: SentryCurrentDateProvider, scale: Float) {
+    public convenience init(dateProvider: SentryCurrentDateProvider, scale: Float) {
         // SentryTouchTracker has it own dispatch queue instead of using the one
         // from Dependency container to avoid the bottleneck of sharing the same
         // queue with the rest of the SDK.
         self.init(dateProvider: dateProvider, scale: scale, dispatchQueue: SentryDispatchQueueWrapper())
     }
     
-    func trackTouchFrom(event: UIEvent) {
+    public func trackTouchFrom(event: UIEvent) {
         guard let touches = event.allTouches else { return }
         let timestamp = event.timestamp
         

--- a/Sources/Swift/Integrations/SessionReplay/SentryVideoInfo.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryVideoInfo.swift
@@ -1,20 +1,20 @@
 import Foundation
 
 @objcMembers
-class SentryVideoInfo: NSObject {
+public class SentryVideoInfo: NSObject {
     
-    let path: URL
-    let height: Int
-    let width: Int
-    let duration: TimeInterval
-    let frameCount: Int
-    let frameRate: Int
-    let start: Date
-    let end: Date
-    let fileSize: Int
-    let screens: [String]
+    public let path: URL
+    public let height: Int
+    public let width: Int
+    public let duration: TimeInterval
+    public let frameCount: Int
+    public let frameRate: Int
+    public let start: Date
+    public let end: Date
+    public let fileSize: Int
+    public let screens: [String]
     
-    init(path: URL, height: Int, width: Int, duration: TimeInterval, frameCount: Int, frameRate: Int, start: Date, end: Date, fileSize: Int, screens: [String]) {
+    public init(path: URL, height: Int, width: Int, duration: TimeInterval, frameCount: Int, frameRate: Int, start: Date, end: Date, fileSize: Int, screens: [String]) {
         self.height = height
         self.width = width
         self.duration = duration

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -9,7 +9,7 @@ import UIKit
  */
 @available(iOS 13.0, *)
 @objcMembers
-class SentryUserFeedbackIntegrationDriver: NSObject {
+public class SentryUserFeedbackIntegrationDriver: NSObject {
     let configuration: SentryUserFeedbackConfiguration
     private var window: SentryUserFeedbackWidget.Window?
     

--- a/Sources/Swift/MetricKit/SentryMXCallStackTree.swift
+++ b/Sources/Swift/MetricKit/SentryMXCallStackTree.swift
@@ -5,47 +5,47 @@ import Foundation
  * JSON specification of MXCallStackTree can be found here https://developer.apple.com/documentation/metrickit/mxcallstacktree/3552293-jsonrepresentation
  */
 @objcMembers
-class SentryMXCallStackTree: NSObject, Codable {
+public class SentryMXCallStackTree: NSObject, Codable {
     
-    let callStacks: [SentryMXCallStack]
-    let callStackPerThread: Bool
+    public let callStacks: [SentryMXCallStack]
+    public let callStackPerThread: Bool
     
-    init(callStacks: [SentryMXCallStack], callStackPerThread: Bool) {
+    public init(callStacks: [SentryMXCallStack], callStackPerThread: Bool) {
         self.callStacks = callStacks
         self.callStackPerThread = callStackPerThread
     }
     
-    static func from(data: Data) throws -> SentryMXCallStackTree {
+    public static func from(data: Data) throws -> SentryMXCallStackTree {
         return try JSONDecoder().decode(SentryMXCallStackTree.self, from: data)
     }
 }
 
 @objcMembers
-class SentryMXCallStack: NSObject, Codable {
-    var threadAttributed: Bool?
-    var callStackRootFrames: [SentryMXFrame]
+public class SentryMXCallStack: NSObject, Codable {
+    public var threadAttributed: Bool?
+    public var callStackRootFrames: [SentryMXFrame]
     
-    var flattenedRootFrames: [SentryMXFrame] {
+    public var flattenedRootFrames: [SentryMXFrame] {
         return callStackRootFrames.flatMap { [$0] + $0.frames }
     }
 
-    init(threadAttributed: Bool, rootFrames: [SentryMXFrame]) {
+    public init(threadAttributed: Bool, rootFrames: [SentryMXFrame]) {
         self.threadAttributed = threadAttributed
         self.callStackRootFrames = rootFrames
     }
 }
 
 @objcMembers
-class SentryMXFrame: NSObject, Codable {
-    var binaryUUID: UUID
-    var offsetIntoBinaryTextSegment: Int
-    var binaryName: String?
-    var address: UInt64
-    var subFrames: [SentryMXFrame]?
+public class SentryMXFrame: NSObject, Codable {
+    public var binaryUUID: UUID
+    public var offsetIntoBinaryTextSegment: Int
+    public var binaryName: String?
+    public var address: UInt64
+    public var subFrames: [SentryMXFrame]?
     
-    var sampleCount: Int?
+    public var sampleCount: Int?
     
-    init(binaryUUID: UUID, offsetIntoBinaryTextSegment: Int, sampleCount: Int? = nil, binaryName: String? = nil, address: UInt64, subFrames: [SentryMXFrame]?) {
+    public init(binaryUUID: UUID, offsetIntoBinaryTextSegment: Int, sampleCount: Int? = nil, binaryName: String? = nil, address: UInt64, subFrames: [SentryMXFrame]?) {
         self.binaryUUID = binaryUUID
         self.offsetIntoBinaryTextSegment = offsetIntoBinaryTextSegment
         self.sampleCount = sampleCount
@@ -54,11 +54,11 @@ class SentryMXFrame: NSObject, Codable {
         self.subFrames = subFrames
     }
     
-    var frames: [SentryMXFrame] {
+    public var frames: [SentryMXFrame] {
         return (subFrames?.flatMap { [$0] + $0.frames } ?? [])
     }
     
-    var framesIncludingSelf: [SentryMXFrame] {
+    public var framesIncludingSelf: [SentryMXFrame] {
         return [self] + frames
     }
 }

--- a/Sources/Swift/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/MetricKit/SentryMXManager.swift
@@ -12,7 +12,7 @@ import MetricKit
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@objc protocol SentryMXManagerDelegate {
+@objc public protocol SentryMXManagerDelegate {
     
     func didReceiveCrashDiagnostic(_ diagnostic: MXCrashDiagnostic, callStackTree: SentryMXCallStackTree, timeStampBegin: Date, timeStampEnd: Date)
     
@@ -26,7 +26,7 @@ import MetricKit
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
 @available(tvOS, unavailable)
 @available(watchOS, unavailable)
-@objcMembers class SentryMXManager: NSObject, MXMetricManagerSubscriber {
+@objcMembers public class SentryMXManager: NSObject, MXMetricManagerSubscriber {
     
     let disableCrashDiagnostics: Bool
     
@@ -34,19 +34,19 @@ import MetricKit
         self.disableCrashDiagnostics = disableCrashDiagnostics
     }
 
-    weak var delegate: SentryMXManagerDelegate?
+    public weak var delegate: SentryMXManagerDelegate?
     
-    func receiveReports() {
+    public func receiveReports() {
         let shared = MXMetricManager.shared
         shared.add(self)
     }
     
-    func pauseReports() {
+    public func pauseReports() {
         let shared = MXMetricManager.shared
         shared.remove(self)
     }
     
-    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+    public func didReceive(_ payloads: [MXDiagnosticPayload]) {
         func actOn(callStackTree: MXCallStackTree, action: (SentryMXCallStackTree) -> Void) {
             guard let callStackTree = try? SentryMXCallStackTree.from(data: callStackTree.jsonRepresentation()) else {
                 return

--- a/Sources/Swift/Protocol/SentryRedactOptions.swift
+++ b/Sources/Swift/Protocol/SentryRedactOptions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objc
-protocol SentryRedactOptions {
+public protocol SentryRedactOptions {
     var maskAllText: Bool { get }
     var maskAllImages: Bool { get }
     var maskedViewClasses: [AnyClass] { get }

--- a/Sources/Swift/Protocol/SentrySessionListener.swift
+++ b/Sources/Swift/Protocol/SentrySessionListener.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @objc
-protocol SentrySessionListener: NSObjectProtocol {
-    func sentrySessionEnded(_ session: SentrySession)
-    func sentrySessionStarted(_ session: SentrySession)
+public protocol SentrySessionListener: NSObjectProtocol {
+    func sentrySessionEnded()
+    func sentrySessionStarted()
 }

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -7,7 +7,7 @@ public class SentryExperimentalOptions: NSObject {
     public var sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 0)
     #endif
 
-    func validateOptions(_ options: [String: Any]?) {
+    public func validateOptions(_ options: [String: Any]?) {
         #if canImport(UIKit)
         if let sessionReplayOptions = options?["sessionReplay"] as? [String: Any] {
             sessionReplay = SentryReplayOptions(dictionary: sessionReplayOptions)

--- a/Sources/Swift/SwiftDescriptor.swift
+++ b/Sources/Swift/SwiftDescriptor.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 @objc
-class SwiftDescriptor: NSObject {
+public class SwiftDescriptor: NSObject {
     
     @objc
-    static func getObjectClassName(_ object: AnyObject) -> String { 
+    public static func getObjectClassName(_ object: AnyObject) -> String { 
         return String(describing: type(of: object))
     }
     
     @objc
-    static func getSwiftErrorDescription(_ error: Error) -> String? {
+    public static func getSwiftErrorDescription(_ error: Error) -> String? {
         return String(describing: error)
     }
 }

--- a/Sources/Swift/Tools/HTTPHeaderSanitizer.swift
+++ b/Sources/Swift/Tools/HTTPHeaderSanitizer.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 @objcMembers
-class HTTPHeaderSanitizer: NSObject {
-    static func sanitizeHeaders(_ headers: [String: String]) -> [String: String] {
+public class HTTPHeaderSanitizer: NSObject {
+    public static func sanitizeHeaders(_ headers: [String: String]) -> [String: String] {
         let _securityHeaders = Set([
             "X-FORWARDED-FOR", "AUTHORIZATION", "COOKIE", "SET-COOKIE", "X-API-KEY", "X-REAL-IP",
             "REMOTE-ADDR", "FORWARDED", "PROXY-AUTHORIZATION", "X-CSRF-TOKEN", "X-CSRFTOKEN",

--- a/Sources/Swift/Tools/SentryLog.swift
+++ b/Sources/Swift/Tools/SentryLog.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @objc
-class SentryLog: NSObject {
+public class SentryLog: NSObject {
     
     static private(set) var isDebug = true
     static private(set) var diagnosticLevel = SentryLevel.error
@@ -10,7 +10,7 @@ class SentryLog: NSObject {
     private static var logConfigureLock = NSLock()
 
     @objc
-    static func configure(_ isDebug: Bool, diagnosticLevel: SentryLevel) {
+    public static func configure(_ isDebug: Bool, diagnosticLevel: SentryLevel) {
         logConfigureLock.synchronized {
             self.isDebug = isDebug
             self.diagnosticLevel = diagnosticLevel
@@ -19,7 +19,7 @@ class SentryLog: NSObject {
     }
     
     @objc
-    static func log(message: String, andLevel level: SentryLevel) {
+    public static func log(message: String, andLevel level: SentryLevel) {
         guard willLog(atLevel: level) else { return }
         logOutput.log("[Sentry] [\(level)] \(message)")
     }
@@ -29,7 +29,7 @@ class SentryLog: NSObject {
      * @c NO if not.
      */
     @objc
-    static func willLog(atLevel level: SentryLevel) -> Bool {
+    public static func willLog(atLevel level: SentryLevel) -> Bool {
         return isDebug && level != .none && level.rawValue >= diagnosticLevel.rawValue
     }
  

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -20,7 +20,7 @@ class DefaultViewRenderer: ViewRenderer {
 }
 
 @objcMembers
-class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
+public class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     private let redactBuilder: UIRedactBuilder
     private let dispatchQueue = SentryDispatchQueueWrapper()
 
@@ -32,12 +32,12 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
         super.init()
     }
     
-    init(redactOptions: SentryRedactOptions) {
+    public init(redactOptions: SentryRedactOptions) {
         self.renderer = DefaultViewRenderer()
         self.redactBuilder = UIRedactBuilder(options: redactOptions)
     }
     
-    func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback ) {
+    public func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback ) {
         let redact = redactBuilder.redactRegionsFor(view: view)
         let image = renderer.render(view: view)
         
@@ -105,22 +105,22 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
     }
     
     @objc(addIgnoreClasses:)
-    func addIgnoreClasses(classes: [AnyClass]) {
+    public func addIgnoreClasses(classes: [AnyClass]) {
         redactBuilder.addIgnoreClasses(classes)
     }
 
     @objc(addRedactClasses:)
-    func addRedactClasses(classes: [AnyClass]) {
+    public func addRedactClasses(classes: [AnyClass]) {
         redactBuilder.addRedactClasses(classes)
     }
 
     @objc(setIgnoreContainerClass:)
-    func setIgnoreContainerClass(_ containerClass: AnyClass) {
+    public func setIgnoreContainerClass(_ containerClass: AnyClass) {
         redactBuilder.setIgnoreContainerClass(containerClass)
     }
 
     @objc(setRedactContainerClass:)
-    func setRedactContainerClass(_ containerClass: AnyClass) {
+    public func setRedactContainerClass(_ containerClass: AnyClass) {
         redactBuilder.setRedactContainerClass(containerClass)
     }
 

--- a/Sources/Swift/Tools/SentryViewScreenshotProvider.swift
+++ b/Sources/Swift/Tools/SentryViewScreenshotProvider.swift
@@ -3,10 +3,10 @@
 import Foundation
 import UIKit
 
-typealias ScreenshotCallback = (UIImage) -> Void
+public typealias ScreenshotCallback = (UIImage) -> Void
 
 @objc
-protocol SentryViewScreenshotProvider: NSObjectProtocol {
+public protocol SentryViewScreenshotProvider: NSObjectProtocol {
     func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback)
 }
 #endif

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -323,7 +323,7 @@ public class SentryRedactViewHelper: NSObject {
     
     override private init() {}
     
-    static func maskView(_ view: UIView) {
+    public static func maskView(_ view: UIView) {
         objc_setAssociatedObject(view, &associatedRedactObjectHandle, true, .OBJC_ASSOCIATION_ASSIGN)
     }
     
@@ -335,7 +335,7 @@ public class SentryRedactViewHelper: NSObject {
         (objc_getAssociatedObject(view, &associatedIgnoreObjectHandle) as? NSNumber)?.boolValue ?? false
     }
     
-    static func unmaskView(_ view: UIView) {
+    public static func unmaskView(_ view: UIView) {
         objc_setAssociatedObject(view, &associatedIgnoreObjectHandle, true, .OBJC_ASSOCIATION_ASSIGN)
     }
     

--- a/Sources/Swift/Tools/URLSessionTaskHelper.swift
+++ b/Sources/Swift/Tools/URLSessionTaskHelper.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 @objcMembers
-class URLSessionTaskHelper: NSObject {
+public class URLSessionTaskHelper: NSObject {
 
-    static func getGraphQLOperationName(from task: URLSessionTask?) -> String? {
+    public static func getGraphQLOperationName(from task: URLSessionTask?) -> String? {
         guard let task = task else { return nil }
         guard task.originalRequest?.value(forHTTPHeaderField: "Content-Type") == "application/json" else { return nil }
         guard let requestBody = task.originalRequest?.httpBody else { return nil }

--- a/Sources/Swift/Tools/UrlSanitized.swift
+++ b/Sources/Swift/Tools/UrlSanitized.swift
@@ -1,15 +1,15 @@
 import Foundation
 
 @objcMembers
-class UrlSanitized: NSObject {
+public class UrlSanitized: NSObject {
     static let SENSITIVE_DATA_SUBSTITUTE = "[Filtered]"
     private var components: URLComponents?
 
-    var query: String? { components?.query }
-    var queryItems: [URLQueryItem]? { components?.queryItems }
-    var fragment: String? { components?.fragment }
+    public var query: String? { components?.query }
+    public var queryItems: [URLQueryItem]? { components?.queryItems }
+    public var fragment: String? { components?.fragment }
 
-    init(URL url: URL) {
+    public init(URL url: URL) {
         components = URLComponents(url: url, resolvingAgainstBaseURL: false)
 
         if components?.user != nil {
@@ -21,7 +21,7 @@ class UrlSanitized: NSObject {
         }
     }
 
-    var sanitizedUrl: String? {
+    public var sanitizedUrl: String? {
         guard var result = self.components?.string else { return nil }
         if let end = result.firstIndex(of: "?") ?? result.firstIndex(of: "#") {
             result = String(result[result.startIndex..<end])


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->
⚠️ **Exposes internal methods** to allow compiling with `APPLICATION_EXTENSION_API_ONLY=NO`.

I was expecting that setting `APPLICATION_EXTENSION_API_ONLY=NO` would cause no issues since [it is supposed to be less restricting allowing the usage of forbidden extension API](https://github.com/getsentry/sentry-react-native/issues/3908#issuecomment-2438136419). 
In reality as soon as you enable `Allow app extension API only` the generated header will contain both public and internal classes ([reference](https://stackoverflow.com/questions/42319892/checking-allow-app-extension-api-only-in-ios-framework-project-exposes-interna), [reference 2](https://forums.developer.apple.com/forums/thread/72768)). This means that disabling the flag hides many of the internal declarations that the project needs to compile.

This PR exposes those classes allowing for the project to compile with `APPLICATION_EXTENSION_API_ONLY` both set to `YES` and `NO`.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/getsentry/sentry-cocoa/issues/4426 and https://github.com/getsentry/sentry-react-native/issues/3908

## :green_heart: How did you test it?
1. Compile and run `iOS-Swift` project on the `main` branch
2. Select the `Sentry` target and set `APPLICATION_EXTENSION_API_ONLY` to `NO`
3. Notice that compilation fails with random errors ❌ 
4. Switch to this branch
5. Compile and run `iOS-Swift` project with `APPLICATION_EXTENSION_API_ONLY` both set to `YES` and `NO` ✅ 

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

If this is is a viable solution:
- fix failing tests
- clean up the code
- document the changes
- add CI checks compiling the project with `APPLICATION_EXTENSION_API_ONLY` both set to `YES` and `NO`