### PR TITLE
chore: Removing unused argument

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -303,7 +303,7 @@ class SentrySessionReplay: NSObject {
 
         let screenName = delegate?.currentScreenNameForSessionReplay()
         
-        screenshotProvider.image(view: rootView, options: replayOptions) { [weak self] screenshot in
+        screenshotProvider.image(view: rootView) { [weak self] screenshot in
             self?.newImage(image: screenshot, forScreen: screenName)
         }
     }

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -37,7 +37,7 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
         self.redactBuilder = UIRedactBuilder(options: redactOptions)
     }
     
-    func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback ) {
+    func image(view: UIView, onComplete: @escaping ScreenshotCallback ) {
         let redact = redactBuilder.redactRegionsFor(view: view)
         let image = renderer.render(view: view)
         

--- a/Sources/Swift/Tools/SentryViewScreenshotProvider.swift
+++ b/Sources/Swift/Tools/SentryViewScreenshotProvider.swift
@@ -7,7 +7,7 @@ typealias ScreenshotCallback = (UIImage) -> Void
 
 @objc
 protocol SentryViewScreenshotProvider: NSObjectProtocol {
-    func image(view: UIView, options: SentryRedactOptions, onComplete: @escaping ScreenshotCallback)
+    func image(view: UIView, onComplete: @escaping ScreenshotCallback)
 }
 #endif
 #endif

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -7,10 +7,10 @@ import XCTest
 class SentrySessionReplayTests: XCTestCase {
     
     private class ScreenshotProvider: NSObject, SentryViewScreenshotProvider {
-        var lastImageCall: (view: UIView, options: SentryRedactOptions)?
-        func image(view: UIView, options: Sentry.SentryRedactOptions, onComplete: @escaping Sentry.ScreenshotCallback) {
+        var lastImageCall: UIView?
+        func image(view: UIView, onComplete: @escaping Sentry.ScreenshotCallback) {
             onComplete(UIImage.add)
-            lastImageCall = (view, options)
+            lastImageCall = view
         }
     }
      

--- a/Tests/SentryTests/SentryViewPhotographerTests.swift
+++ b/Tests/SentryTests/SentryViewPhotographerTests.swift
@@ -19,7 +19,7 @@ class SentryViewPhotographerTests: XCTestCase {
         return SentryViewPhotographer(renderer: TestViewRenderer(), redactOptions: RedactOptions())
     }
     
-    private func prepare(views: [UIView], options: any SentryRedactOptions = RedactOptions()) -> UIImage? {
+    private func prepare(views: [UIView]) -> UIImage? {
         let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
         rootView.backgroundColor = .white
         views.forEach(rootView.addSubview(_:))
@@ -28,7 +28,7 @@ class SentryViewPhotographerTests: XCTestCase {
         let expect = expectation(description: "Image rendered")
         var result: UIImage?
              
-        sut.image(view: rootView, options: options) { image in
+        sut.image(view: rootView) { image in
             result = image
             expect.fulfill()
         }


### PR DESCRIPTION
SentryViewPhotographer had an unused argument for  SentryViewPhotographer.image()


_#skip-changelog_