### PR TITLE
ref: Mask screenshots for errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY (#4603)
+- Mask screenshots for errors ()
 
 ## 8.42.0-beta.2
 

--- a/Sources/Sentry/SentryScreenshot.m
+++ b/Sources/Sentry/SentryScreenshot.m
@@ -50,8 +50,6 @@
 
 - (NSArray<NSData *> *)appScreenshots
 {
-//    [SentryViewPhotographer alloc] ini
-    
     NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:windows.count];
 
@@ -64,23 +62,16 @@
             continue;
         }
 
-        //photographer imageWithView:window options:<#(id<SentryRedactOptions> _Nonnull)#> onComplete:<#^(UIImage * _Nonnull)onComplete#>
+        UIImage * img = [photographer imageWithView:window];
         
-        UIGraphicsBeginImageContext(size);
-
-        if ([window drawViewHierarchyInRect:window.bounds afterScreenUpdates:false]) {
-            UIImage *img = UIGraphicsGetImageFromCurrentImageContext();
-            // this shouldn't happen now that we discard windows with either 0 height or 0 width,
-            // but still, we shouldn't send any images with either one.
-            if (LIKELY(img.size.width > 0 && img.size.height > 0)) {
-                NSData *bytes = UIImagePNGRepresentation(img);
-                if (bytes && bytes.length > 0) {
-                    [result addObject:bytes];
-                }
+        // this shouldn't happen now that we discard windows with either 0 height or 0 width,
+        // but still, we shouldn't send any images with either one.
+        if (LIKELY(img.size.width > 0 && img.size.height > 0)) {
+            NSData *bytes = UIImagePNGRepresentation(img);
+            if (bytes && bytes.length > 0) {
+                [result addObject:bytes];
             }
         }
-
-        UIGraphicsEndImageContext();
     }
     return result;
 }

--- a/Sources/Sentry/SentryScreenshot.m
+++ b/Sources/Sentry/SentryScreenshot.m
@@ -7,8 +7,18 @@
 #    import "SentryDispatchQueueWrapper.h"
 #    import "SentryUIApplication.h"
 #    import <UIKit/UIKit.h>
+#    import "SentrySwift.h"
 
-@implementation SentryScreenshot
+@implementation SentryScreenshot {
+    SentryViewPhotographer * photographer;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        photographer = [[SentryViewPhotographer alloc] initWithRedactOptions:[[SentryRedactDefaultOptions alloc] init]];
+    }
+    return self;
+}
 
 - (NSArray<NSData *> *)appScreenshotsFromMainThread
 {
@@ -40,8 +50,9 @@
 
 - (NSArray<NSData *> *)appScreenshots
 {
+//    [SentryViewPhotographer alloc] ini
+    
     NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
-
     NSMutableArray *result = [NSMutableArray arrayWithCapacity:windows.count];
 
     for (UIWindow *window in windows) {
@@ -53,6 +64,8 @@
             continue;
         }
 
+        //photographer imageWithView:window options:<#(id<SentryRedactOptions> _Nonnull)#> onComplete:<#^(UIImage * _Nonnull)onComplete#>
+        
         UIGraphicsBeginImageContext(size);
 
         if ([window drawViewHierarchyInRect:window.bounds afterScreenUpdates:false]) {

--- a/Sources/Swift/Protocol/SentryRedactOptions.swift
+++ b/Sources/Swift/Protocol/SentryRedactOptions.swift
@@ -7,3 +7,11 @@ protocol SentryRedactOptions {
     var maskedViewClasses: [AnyClass] { get }
     var unmaskedViewClasses: [AnyClass] { get }
 }
+
+@objcMembers
+final class SentryRedactDefaultOptions: NSObject, SentryRedactOptions {
+    var maskAllText: Bool = true
+    var maskAllImages: Bool = true
+    var maskedViewClasses: [AnyClass] = []
+    var unmaskedViewClasses: [AnyClass] = []
+}

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -37,60 +37,72 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
         self.redactBuilder = UIRedactBuilder(options: redactOptions)
     }
     
-    func image(view: UIView, onComplete: @escaping ScreenshotCallback ) {
+    func image(view: UIView, onComplete: @escaping ScreenshotCallback) {
         let redact = redactBuilder.redactRegionsFor(view: view)
         let image = renderer.render(view: view)
         
-        let imageSize = view.bounds.size
         dispatchQueue.dispatchAsync {
-            let screenshot = UIGraphicsImageRenderer(size: imageSize, format: .init(for: .init(displayScale: 1))).image { context in
-                
-                let clipOutPath = CGMutablePath(rect: CGRect(origin: .zero, size: imageSize), transform: nil)
-                var clipPaths = [CGPath]()
-                
-                let imageRect = CGRect(origin: .zero, size: imageSize)
-                context.cgContext.addRect(CGRect(origin: CGPoint.zero, size: imageSize))
-                context.cgContext.clip(using: .evenOdd)
-                UIColor.blue.setStroke()
-                
-                context.cgContext.interpolationQuality = .none
-                image.draw(at: .zero)
-                
-                var latestRegion: RedactRegion?
-                for region in redact {
-                    let rect = CGRect(origin: CGPoint.zero, size: region.size)
-                    var transform = region.transform
-                    let path = CGPath(rect: rect, transform: &transform)
-                    
-                    defer { latestRegion = region }
-                    
-                    guard latestRegion?.canReplace(as: region) != true && imageRect.intersects(path.boundingBoxOfPath) else { continue }
-                          
-                    switch region.type {
-                    case .redact, .redactSwiftUI:
-                        (region.color ?? UIImageHelper.averageColor(of: context.currentImage, at: rect.applying(region.transform))).setFill()
-                        context.cgContext.addPath(path)
-                        context.cgContext.fillPath()
-                    case .clipOut:
-                        clipOutPath.addPath(path)
-                        self.updateClipping(for: context.cgContext,
-                                            clipPaths: clipPaths,
-                                            clipOutPath: clipOutPath)
-                    case .clipBegin:
-                        clipPaths.append(path)
-                        self.updateClipping(for: context.cgContext,
-                                            clipPaths: clipPaths,
-                                            clipOutPath: clipOutPath)
-                    case .clipEnd:
-                        clipPaths.removeLast()
-                        self.updateClipping(for: context.cgContext,
-                                            clipPaths: clipPaths,
-                                            clipOutPath: clipOutPath)
-                    }
-                }
-            }
+            let screenshot = self.maskScreenshot(screenshot: image, from: view, masking: redact)
             onComplete(screenshot)
         }
+    }
+    
+    func image(view: UIView) -> UIImage {
+        let redact = redactBuilder.redactRegionsFor(view: view)
+        let image = renderer.render(view: view)
+        
+        return self.maskScreenshot(screenshot: image, from: view, masking: redact)
+    }
+    
+    private func maskScreenshot(screenshot image: UIImage, from view: UIView, masking: [RedactRegion]) -> UIImage {
+        let imageSize = view.bounds.size
+        let screenshot = UIGraphicsImageRenderer(size: imageSize, format: .init(for: .init(displayScale: 1))).image { context in
+            
+            let clipOutPath = CGMutablePath(rect: CGRect(origin: .zero, size: imageSize), transform: nil)
+            var clipPaths = [CGPath]()
+            
+            let imageRect = CGRect(origin: .zero, size: imageSize)
+            context.cgContext.addRect(CGRect(origin: CGPoint.zero, size: imageSize))
+            context.cgContext.clip(using: .evenOdd)
+            UIColor.blue.setStroke()
+            
+            context.cgContext.interpolationQuality = .none
+            image.draw(at: .zero)
+            
+            var latestRegion: RedactRegion?
+            for region in masking {
+                let rect = CGRect(origin: CGPoint.zero, size: region.size)
+                var transform = region.transform
+                let path = CGPath(rect: rect, transform: &transform)
+                
+                defer { latestRegion = region }
+                
+                guard latestRegion?.canReplace(as: region) != true && imageRect.intersects(path.boundingBoxOfPath) else { continue }
+                
+                switch region.type {
+                case .redact, .redactSwiftUI:
+                    (region.color ?? UIImageHelper.averageColor(of: context.currentImage, at: rect.applying(region.transform))).setFill()
+                    context.cgContext.addPath(path)
+                    context.cgContext.fillPath()
+                case .clipOut:
+                    clipOutPath.addPath(path)
+                    self.updateClipping(for: context.cgContext,
+                                        clipPaths: clipPaths,
+                                        clipOutPath: clipOutPath)
+                case .clipBegin:
+                    clipPaths.append(path)
+                    self.updateClipping(for: context.cgContext,
+                                        clipPaths: clipPaths,
+                                        clipOutPath: clipOutPath)
+                case .clipEnd:
+                    clipPaths.removeLast()
+                    self.updateClipping(for: context.cgContext,
+                                        clipPaths: clipPaths,
+                                        clipOutPath: clipOutPath)
+                }
+            }
+        }
+        return screenshot
     }
     
     private func updateClipping(for context: CGContext, clipPaths: [CGPath], clipOutPath: CGPath) {


### PR DESCRIPTION
## :scroll: Description

Using api created for SR to mask a error screenshot

## :bulb: Motivation and Context

Closes #3802 

## :green_heart: How did you test it?

Samples

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
