### PR TITLE
fix(envelope): SentrySdkInfo.packages should be array

### DIFF
--- a/Sources/Swift/Protocol/SentrySdkInfo.swift
+++ b/Sources/Swift/Protocol/SentrySdkInfo.swift
@@ -67,25 +67,18 @@ class SentrySdkInfo: NSObject, SentrySerializable {
     }
 
     func serialize() -> [String: Any] {
-        if let sdkPackageName = SentrySdkInfo.getPackageName(packageManager, name) {
-            return [
-                "sdk": [
-                    "name": name,
-                    "version": version,
-                    "packages": [
-                        "name": sdkPackageName,
-                        "version": version
-                    ]
-                ]
-            ] as [String: Any]
-        } else {
-            return [
-                "sdk": [
-                    "name": name,
-                    "version": version
-                ]
-            ]
+        var packages: [[String: String]] = []
+        if let packageName = SentrySdkInfo.getPackageName(packageManager, name) {
+            packages = [["name": packageName, "version": version]]
         }
+
+        return [
+            "sdk": [
+                "name": name,
+                "version": version,
+                "packages": packages
+            ]
+        ] as [String: Any]
     }
 
 #if TEST

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -27,9 +27,10 @@ class SentrySdkInfoTests: XCTestCase {
         let actual = SentrySdkInfo(name: sdkName, version: version).serialize()
         
         if let sdkInfo = actual["sdk"] as? [String: Any] {
-            XCTAssertEqual(2, sdkInfo.count)
+            XCTAssertEqual(3, sdkInfo.count)
             XCTAssertEqual(sdkName, sdkInfo["name"] as? String)
             XCTAssertEqual(version, sdkInfo["version"] as? String)
+            XCTAssertEqual([], sdkInfo["packages"] as? [[String: String]])
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -44,9 +45,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "spm:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: String]])
+            XCTAssertEqual(packages.count, 1)
+            XCTAssertEqual(packages[0]["name"], "spm:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"], version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -60,9 +62,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "carthage:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: String]])
+            XCTAssertEqual(packages.count, 1)
+            XCTAssertEqual(packages[0]["name"], "carthage:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"], version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -76,9 +79,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "cocoapods:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: String]])
+            XCTAssertEqual(packages.count, 1)
+            XCTAssertEqual(packages[0]["name"], "cocoapods:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"], version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

- Based on https://github.com/getsentry/sentry-cocoa/pull/4622
- Definition on SDK info from develop docs https://develop.sentry.dev/sdk/data-model/event-payloads/sdk/

## :green_heart: How did you test it?
tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
