### PR TITLE
fix(envelope): SentrySdkInfo.packages should be an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY (#4603)
 
+### Fixes
+
+- `SentrySdkInfo.packages` should be an array (#4626)
+
 ## 8.42.0-beta.2
 
 ### Fixes

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -101,10 +101,12 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.packageManager != SentryPackageManagerUnkown) {
         NSString *format = [self getPackageName:self.packageManager];
         if (format != nil) {
-            sdk[@"packages"] = @{
-                @"name" : [NSString stringWithFormat:format, self.name],
-                @"version" : self.version
-            };
+            sdk[@"packages"] = @[
+                @{
+                    @"name" : [NSString stringWithFormat:format, self.name],
+                    @"version" : self.version
+                },
+            ];
         }
     }
 

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -43,9 +43,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "spm:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
+            XCTAssertEqual(1, packages.count)
+            XCTAssertEqual(packages[0]["name"] as? String, "spm:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"] as? String, version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -60,9 +61,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "carthage:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
+            XCTAssertEqual(1, packages.count)
+            XCTAssertEqual(packages[0]["name"] as? String, "carthage:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"] as? String, version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -77,9 +79,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "cocoapods:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
+            XCTAssertEqual(1, packages.count)
+            XCTAssertEqual(packages[0]["name"] as? String, "cocoapods:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"] as? String, version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

This PR fixes sdk packages which by the develop docs should be an array but was dict in cocoa.

https://develop.sentry.dev/sdk/data-model/event-payloads/sdk/

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

