### PR TITLE
ref(iOS-Swift): reorganize SDK configuration

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -70,8 +70,16 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
+            argument = "--io.sentry.disable-everything"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--disable-file-io-tracing"
             isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--io.sentry.feedback.use-sentry-user"
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--io.sentry.feedback.require-name"

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -114,10 +114,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--disable-metrics"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "--disable-metrickit-integration"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -78,10 +78,6 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--io.sentry.feedback.use-sentry-user"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "--io.sentry.feedback.require-name"
             isEnabled = "NO">
          </CommandLineArgument>

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -1,268 +1,16 @@
 import Sentry
 import UIKit
 
-//swiftlint:disable type_body_length
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
     private var randomDistributionTimer: Timer?
-    
     var window: UIWindow?
 
-    static let defaultDSN = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
-
-    //swiftlint:disable function_body_length cyclomatic_complexity
-    func startSentry() {
-        let args = ProcessInfo.processInfo.arguments
-        let env = ProcessInfo.processInfo.environment
-        
-        // For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
-        var dsn: String?
-        do {
-            if let dsn = env["--io.sentry.dsn"] {
-                try DSNStorage.shared.saveDSN(dsn: dsn)
-            }
-            dsn = try DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
-        } catch {
-            print("[iOS-Swift] Error encountered while reading stored DSN: \(error)")
-        }
-        
-        SentrySDK.start(configureOptions: { options in
-            options.dsn = dsn
-            options.beforeSend = { event in
-                return event
-            }
-            options.beforeSendSpan = { span in
-                return span
-            }
-            options.beforeCaptureScreenshot = { _ in
-                return true
-            }
-            options.beforeCaptureViewHierarchy = { _ in
-                return true
-            }
-            options.debug = true
-            
-            if #available(iOS 16.0, *), !args.contains("--disable-session-replay") {
-                options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
-                options.experimental.sessionReplay.quality = .high
-            }
-            
-            if #available(iOS 15.0, *), !args.contains("--disable-metrickit-integration") {
-                options.enableMetricKit = true
-                options.enableMetricKitRawPayload = true
-            }
-            
-            var tracesSampleRate: NSNumber = 1
-            if let tracesSampleRateOverride = env["--io.sentry.tracesSampleRate"] {
-               tracesSampleRate = NSNumber(value: (tracesSampleRateOverride as NSString).integerValue)
-            }
-            options.tracesSampleRate = tracesSampleRate
-            
-            if let tracesSamplerValue = env["--io.sentry.tracesSamplerValue"] {
-                options.tracesSampler = { _ in
-                    return NSNumber(value: (tracesSamplerValue as NSString).integerValue)
-                }
-            }
-            
-            var profilesSampleRate: NSNumber? = 1
-            if args.contains("--io.sentry.enableContinuousProfiling") {
-                profilesSampleRate = nil
-            } else if let profilesSampleRateOverride = env["--io.sentry.profilesSampleRate"] {
-               profilesSampleRate = NSNumber(value: (profilesSampleRateOverride as NSString).integerValue)
-            }
-            options.profilesSampleRate = profilesSampleRate
-            
-            if let profilesSamplerValue = env["--io.sentry.profilesSamplerValue"] {
-                options.profilesSampler = { _ in
-                    return NSNumber(value: (profilesSamplerValue as NSString).integerValue)
-                }
-            }
-
-            options.enableAppLaunchProfiling = args.contains("--profile-app-launches")
-
-            options.enableAutoSessionTracking = !args.contains("--disable-automatic-session-tracking")
-            if let sessionTrackingIntervalMillis = env["--io.sentry.sessionTrackingIntervalMillis"] {
-                options.sessionTrackingIntervalMillis = UInt((sessionTrackingIntervalMillis as NSString).integerValue)
-            }
-            options.attachScreenshot = true
-            options.attachViewHierarchy = true
-       
-#if targetEnvironment(simulator)
-            options.enableSpotlight = !args.contains("--disable-spotlight")
-#else
-            options.enableWatchdogTerminationTracking = false // The UI tests generate false OOMs
-#endif
-            options.enableTimeToFullDisplayTracing = true
-            options.enablePerformanceV2 = true
-            
-            options.add(inAppInclude: "iOS_External")
-
-            let isBenchmarking = args.contains("--io.sentry.test.benchmarking")
-
-            // the benchmark test starts and stops a custom transaction using a UIButton, and automatic user interaction tracing stops the transaction that begins with that button press after the idle timeout elapses, stopping the profiler (only one profiler runs regardless of the number of concurrent transactions)
-            options.enableUserInteractionTracing = !isBenchmarking && !args.contains("--disable-ui-tracing")
-            options.enableAutoPerformanceTracing = !isBenchmarking && !args.contains("--disable-auto-performance-tracing")
-            options.enablePreWarmedAppStartTracing = !isBenchmarking
-
-            options.enableFileIOTracing = !args.contains("--disable-file-io-tracing")
-            options.enableAutoBreadcrumbTracking = !args.contains("--disable-automatic-breadcrumbs")
-            options.enableUIViewControllerTracing = !args.contains("--disable-uiviewcontroller-tracing")
-            options.enableNetworkTracking = !args.contains("--disable-network-tracking")
-            options.enableCoreDataTracing = !args.contains("--disable-core-data-tracing")
-            options.enableNetworkBreadcrumbs = !args.contains("--disable-network-breadcrumbs")
-            options.enableSwizzling = !args.contains("--disable-swizzling")
-            options.enableCrashHandler = !args.contains("--disable-crash-handler")
-            options.enableTracing = !args.contains("--disable-tracing")
-            options.enablePersistingTracesWhenCrashing = true
-
-            // because we run CPU for 15 seconds at full throttle, we trigger ANR issues being sent. disable such during benchmarks.
-            options.enableAppHangTracking = !isBenchmarking && !args.contains("--disable-anr-tracking")
-            options.enableWatchdogTerminationTracking = !isBenchmarking && !args.contains("--disable-watchdog-tracking")
-            options.appHangTimeoutInterval = 2
-            options.enableCaptureFailedRequests = true
-            let httpStatusCodeRange = HttpStatusCodeRange(min: 400, max: 599)
-            options.failedRequestStatusCodes = [ httpStatusCodeRange ]
-            options.beforeBreadcrumb = { breadcrumb in
-                //Raising notifications when a new breadcrumb is created in order to use this information
-                //to validate whether proper breadcrumb are being created in the right places.
-                NotificationCenter.default.post(name: .init("io.sentry.newbreadcrumb"), object: breadcrumb)
-                return breadcrumb
-            }
-            
-            options.initialScope = { scope in
-                if let environmentOverride = env["--io.sentry.sdk-environment"] {
-                    scope.setEnvironment(environmentOverride)
-                } else if isBenchmarking {
-                    scope.setEnvironment("benchmarking")
-                } else {
-        #if targetEnvironment(simulator)
-                    scope.setEnvironment("simulator")
-        #else
-                    scope.setEnvironment("device")
-        #endif // targetEnvironment(simulator)
-                }
-                
-                scope.setTag(value: "swift", key: "language")
-                
-                scope.injectGitInformation()
-                                               
-                let user = User(userId: "1")
-                user.email = env["--io.sentry.user.email"] ?? "tony@example.com"
-                // first check if the username has been overridden in the scheme for testing purposes; then try to use the system username so each person gets an automatic way to easily filter things on the dashboard; then fall back on a hardcoded value if none of these are present
-                let username = env["--io.sentry.user.username"] ?? (env["SIMULATOR_HOST_HOME"] as? NSString)?
-                    .lastPathComponent ?? "cocoa developer"
-                user.username = username
-                scope.setUser(user)
-
-                if let path = Bundle.main.path(forResource: "Tongariro", ofType: "jpg") {
-                    scope.addAttachment(Attachment(path: path, filename: "Tongariro.jpg", contentType: "image/jpeg"))
-                }
-                if let data = "hello".data(using: .utf8) {
-                    scope.addAttachment(Attachment(data: data, filename: "log.txt"))
-                }
-                return scope
-            }
-            
-            options.configureUserFeedback = { config in
-                let layoutOffset = UIOffset(horizontal: 25, vertical: 75)
-                guard !args.contains("--io.sentry.feedback.all-defaults") else {
-                    config.configureWidget = { widget in   
-                        widget.layoutUIOffset = layoutOffset
-                    }
-                    return
-                }
-                config.animations = !args.contains("--io.sentry.feedback.no-animations")
-                config.useShakeGesture = true
-                config.showFormForScreenshots = true
-                config.configureWidget = { widget in
-                    if args.contains("--io.sentry.feedback.auto-inject-widget") {
-                        if Locale.current.languageCode == "ar" { // arabic
-                            widget.labelText = "﷽"
-                        } else if Locale.current.languageCode == "ur" { // urdu
-                            widget.labelText = "نستعلیق"
-                        } else if Locale.current.languageCode == "he" { // hebrew
-                            widget.labelText = "עִבְרִית‎"
-                        } else if Locale.current.languageCode == "hi" { // Hindi
-                            widget.labelText = "नागरि"
-                        } else {
-                            widget.labelText = "Report Jank"
-                        }
-                        widget.widgetAccessibilityLabel = "io.sentry.iOS-Swift.button.report-jank"
-                        widget.layoutUIOffset = layoutOffset
-                    } else {
-                        widget.autoInject = false
-                    }
-                    if args.contains("--io.sentry.feedback.no-widget-text") {
-                        widget.labelText = nil
-                    }
-                    if args.contains("--io.sentry.feedback.no-widget-icon") {
-                        widget.showIcon = false
-                    }
-                }
-                config.configureForm = { uiForm in
-                    uiForm.formTitle = "Jank Report"
-                    uiForm.isEmailRequired = args.contains("--io.sentry.feedback.require-email")
-                    uiForm.isNameRequired = args.contains("--io.sentry.feedback.require-name")
-                    uiForm.submitButtonLabel = "Report that jank"
-                    uiForm.addScreenshotButtonLabel = "Show us the jank"
-                    uiForm.removeScreenshotButtonLabel = "Oof too nsfl"
-                    uiForm.cancelButtonLabel = "What, me worry?"
-                    uiForm.messagePlaceholder = "Describe the nature of the jank. Its essence, if you will."
-                    uiForm.namePlaceholder = "Yo name"
-                    uiForm.emailPlaceholder = "Yo email"
-                    uiForm.messageLabel = "Thy complaint"
-                    uiForm.emailLabel = "Thine email"
-                    uiForm.nameLabel = "Thy name"
-                }
-                config.configureTheme = { theme in
-                    let fontFamily: String
-                    if Locale.current.languageCode == "ar" { // arabic; ar_EG
-                        fontFamily = "Damascus"
-                    } else if Locale.current.languageCode == "ur" { // urdu; ur_PK
-                        fontFamily = "NotoNastaliq"
-                    } else if Locale.current.languageCode == "he" { // hebrew; he_IL
-                        fontFamily = "Arial Hebrew"
-                    } else if Locale.current.languageCode == "hi" { // Hindi; hi_IN
-                        fontFamily = "DevanagariSangamMN"
-                    } else {
-                        fontFamily = "ChalkboardSE-Regular"
-                    }
-                    theme.fontFamily = fontFamily
-                    theme.outlineStyle = .init(outlineColor: .purple)
-                    theme.foreground = .purple
-                    theme.background = .init(red: 0.95, green: 0.9, blue: 0.95, alpha: 1)
-                    theme.submitBackground = .orange
-                    theme.submitForeground = .purple
-                    theme.buttonBackground = .purple
-                    theme.buttonForeground = .white
-                }
-                config.onSubmitSuccess = { info in
-                    let name = info["name"] ?? "$shakespearean_insult_name"
-                    let alert = UIAlertController(title: "Thanks?", message: "We have enough jank of our own, we really didn't need yours too, \(name).", preferredStyle: .alert)
-                    alert.addAction(.init(title: "Deal with it 🕶️", style: .default))
-                    self.window?.rootViewController?.present(alert, animated: true)
-                }
-                config.onSubmitError = { error in
-                    let alert = UIAlertController(title: "D'oh", message: "You tried to report jank, and encountered more jank. The jank has you now: \(error).", preferredStyle: .alert)
-                    alert.addAction(.init(title: "Derp", style: .default))
-                    self.window?.rootViewController?.present(alert, animated: true)
-                }
-            }
-        })
-    }
-    //swiftlint:enable function_body_length cyclomatic_complexity
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
-        print("[iOS-Swift] [debug] launch arguments: \(ProcessInfo.processInfo.arguments)")
-        print("[iOS-Swift] [debug] environment: \(ProcessInfo.processInfo.environment)")
-        
-        if ProcessInfo.processInfo.arguments.contains("--io.sentry.wipe-data") {
+        if args.contains("--io.sentry.wipe-data") {
             removeAppData()
         }
-        if !ProcessInfo.processInfo.arguments.contains("--skip-sentry-init") {
+        if !args.contains("--skip-sentry-init") {
             startSentry()
         }
         
@@ -313,4 +61,315 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
-//swiftlint:enable type_body_length
+// MARK: SDK Configuration
+extension AppDelegate {
+    func startSentry() {
+        SentrySDK.start(configureOptions: configureSentryOptions(options:))
+    }
+    
+    func configureSentryOptions(options: Options) {
+        options.dsn = dsn
+        options.beforeSend = { $0 }
+        options.beforeSendSpan = { $0 }
+        options.beforeCaptureScreenshot = { _ in true }
+        options.beforeCaptureViewHierarchy = { _ in true }
+        options.debug = true
+        
+        if #available(iOS 16.0, *), enableSessionReplay {
+            options.experimental.sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
+            options.experimental.sessionReplay.quality = .high
+        }
+        
+        if #available(iOS 15.0, *), enableMetricKit {
+            options.enableMetricKit = true
+            options.enableMetricKitRawPayload = true
+        }
+        
+        options.tracesSampleRate = tracesSampleRate
+        options.tracesSampler = tracesSampler
+        options.profilesSampleRate = profilesSampleRate
+        options.profilesSampler = profilesSampler
+        options.enableAppLaunchProfiling = enableAppLaunchProfiling
+
+        options.enableAutoSessionTracking = enableSessionTracking
+        if let sessionTrackingIntervalMillis = env["--io.sentry.sessionTrackingIntervalMillis"] {
+            options.sessionTrackingIntervalMillis = UInt((sessionTrackingIntervalMillis as NSString).integerValue)
+        }
+        
+        options.add(inAppInclude: "iOS_External")
+
+        options.enableUserInteractionTracing = enableUITracing
+        options.enableAppHangTracking = enableANRTracking
+        options.enableWatchdogTerminationTracking = enableWatchdogTracking
+        options.enableAutoPerformanceTracing = enablePerformanceTracing
+        options.enablePreWarmedAppStartTracing = enablePrewarmedAppStartTracing
+        options.enableFileIOTracing = enableFileIOTracing
+        options.enableAutoBreadcrumbTracking = enableBreadcrumbs
+        options.enableUIViewControllerTracing = enableUIVCTracing
+        options.enableNetworkTracking = enableNetworkTracing
+        options.enableCoreDataTracing = enableCoreDataTracing
+        options.enableNetworkBreadcrumbs = enableNetworkBreadcrumbs
+        options.enableSwizzling = enableSwizzling
+        options.enableCrashHandler = enableCrashHandling
+        options.enableTracing = enableTracing
+        options.enablePersistingTracesWhenCrashing = true
+        options.attachScreenshot = true
+        options.attachViewHierarchy = true
+        options.enableTimeToFullDisplayTracing = true
+        options.enablePerformanceV2 = true
+        options.failedRequestStatusCodes = [ HttpStatusCodeRange(min: 400, max: 599) ]
+        
+        options.beforeBreadcrumb = { breadcrumb in
+            //Raising notifications when a new breadcrumb is created in order to use this information
+            //to validate whether proper breadcrumb are being created in the right places.
+            NotificationCenter.default.post(name: .init("io.sentry.newbreadcrumb"), object: breadcrumb)
+            return breadcrumb
+        }
+        
+        options.initialScope = configureInitialScope(scope:)
+        options.configureUserFeedback = configureFeedback(config:)
+    }
+    
+    func configureInitialScope(scope: Scope) -> Scope {
+        if let environmentOverride = self.env["--io.sentry.sdk-environment"] {
+            scope.setEnvironment(environmentOverride)
+        } else if isBenchmarking {
+            scope.setEnvironment("benchmarking")
+        } else {
+#if targetEnvironment(simulator)
+            scope.setEnvironment("simulator")
+#else
+            scope.setEnvironment("device")
+#endif // targetEnvironment(simulator)
+        }
+        
+        scope.setTag(value: "swift", key: "language")
+        
+        scope.injectGitInformation()
+        
+        let user = User(userId: "1")
+        user.email = self.env["--io.sentry.user.email"] ?? "tony@example.com"
+        // first check if the username has been overridden in the scheme for testing purposes; then try to use the system username so each person gets an automatic way to easily filter things on the dashboard; then fall back on a hardcoded value if none of these are present
+        let username = self.env["--io.sentry.user.username"] ?? (self.env["SIMULATOR_HOST_HOME"] as? NSString)?
+            .lastPathComponent ?? "cocoadev"
+        user.username = username
+        user.name = self.env["--io.sentry.user.name"] ?? "cocoa developer"
+        scope.setUser(user)
+        
+        if let path = Bundle.main.path(forResource: "Tongariro", ofType: "jpg") {
+            scope.addAttachment(Attachment(path: path, filename: "Tongariro.jpg", contentType: "image/jpeg"))
+        }
+        if let data = "hello".data(using: .utf8) {
+            scope.addAttachment(Attachment(data: data, filename: "log.txt"))
+        }
+        return scope
+    }
+}
+
+// MARK: User feedback configuration
+extension AppDelegate {
+    var layoutOffset: UIOffset { UIOffset(horizontal: 25, vertical: 75) }
+    
+    func configureFeedbackWidget(config: SentryUserFeedbackWidgetConfiguration) {
+        if args.contains("--io.sentry.feedback.auto-inject-widget") {
+            if Locale.current.languageCode == "ar" { // arabic
+                config.labelText = "﷽"
+            } else if Locale.current.languageCode == "ur" { // urdu
+                config.labelText = "نستعلیق"
+            } else if Locale.current.languageCode == "he" { // hebrew
+                config.labelText = "עִבְרִית‎"
+            } else if Locale.current.languageCode == "hi" { // Hindi
+                config.labelText = "नागरि"
+            } else {
+                config.labelText = "Report Jank"
+            }
+            config.widgetAccessibilityLabel = "io.sentry.iOS-Swift.button.report-jank"
+            config.layoutUIOffset = layoutOffset
+        } else {
+            config.autoInject = false
+        }
+        if args.contains("--io.sentry.feedback.no-widget-text") {
+            config.labelText = nil
+        }
+        if args.contains("--io.sentry.feedback.no-widget-icon") {
+            config.showIcon = false
+        }
+    }
+    
+    func configureFeedbackForm(config: SentryUserFeedbackFormConfiguration) {
+        config.formTitle = "Jank Report"
+        config.isEmailRequired = args.contains("--io.sentry.feedback.require-email")
+        config.isNameRequired = args.contains("--io.sentry.feedback.require-name")
+        config.submitButtonLabel = "Report that jank"
+        config.addScreenshotButtonLabel = "Show us the jank"
+        config.removeScreenshotButtonLabel = "Oof too nsfl"
+        config.cancelButtonLabel = "What, me worry?"
+        config.messagePlaceholder = "Describe the nature of the jank. Its essence, if you will."
+        config.namePlaceholder = "Yo name"
+        config.emailPlaceholder = "Yo email"
+        config.messageLabel = "Thy complaint"
+        config.emailLabel = "Thine email"
+        config.nameLabel = "Thy name"
+    }
+    
+    func configureFeedbackTheme(config: SentryUserFeedbackThemeConfiguration) {
+        let fontFamily: String
+        if Locale.current.languageCode == "ar" { // arabic; ar_EG
+            fontFamily = "Damascus"
+        } else if Locale.current.languageCode == "ur" { // urdu; ur_PK
+            fontFamily = "NotoNastaliq"
+        } else if Locale.current.languageCode == "he" { // hebrew; he_IL
+            fontFamily = "Arial Hebrew"
+        } else if Locale.current.languageCode == "hi" { // Hindi; hi_IN
+            fontFamily = "DevanagariSangamMN"
+        } else {
+            fontFamily = "ChalkboardSE-Regular"
+        }
+        config.fontFamily = fontFamily
+        config.outlineStyle = .init(outlineColor: .purple)
+        config.foreground = .purple
+        config.background = .init(red: 0.95, green: 0.9, blue: 0.95, alpha: 1)
+        config.submitBackground = .orange
+        config.submitForeground = .purple
+        config.buttonBackground = .purple
+        config.buttonForeground = .white
+    }
+    
+    func configureFeedback(config: SentryUserFeedbackConfiguration) {
+        guard !args.contains("--io.sentry.feedback.all-defaults") else {
+            config.configureWidget = { widget in
+                widget.layoutUIOffset = self.layoutOffset
+            }
+            return
+        }
+        
+        config.useSentryUser = args.contains("--io.sentry.feedback.use-sentry-user")
+        config.animations = !args.contains("--io.sentry.feedback.no-animations")
+        config.useShakeGesture = true
+        config.showFormForScreenshots = true
+        config.configureWidget = configureFeedbackWidget(config:)
+        config.configureForm = configureFeedbackForm(config:)
+        config.configureTheme = configureFeedbackTheme(config:)
+        config.onSubmitSuccess = { info in
+            let name = info["name"] ?? "$shakespearean_insult_name"
+            let alert = UIAlertController(title: "Thanks?", message: "We have enough jank of our own, we really didn't need yours too, \(name).", preferredStyle: .alert)
+            alert.addAction(.init(title: "Deal with it 🕶️", style: .default))
+            self.window?.rootViewController?.present(alert, animated: true)
+        }
+        config.onSubmitError = { error in
+            let alert = UIAlertController(title: "D'oh", message: "You tried to report jank, and encountered more jank. The jank has you now: \(error).", preferredStyle: .alert)
+            alert.addAction(.init(title: "Derp", style: .default))
+            self.window?.rootViewController?.present(alert, animated: true)
+        }
+    }
+}
+
+// MARK: Convenience access to SDK configuration via launch arg / environment variable
+extension AppDelegate {
+    static let defaultDSN = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
+    
+    var args: [String] {
+        let args = ProcessInfo.processInfo.arguments
+        print("[iOS-Swift] [debug] launch arguments: \(args)")
+        return args
+    }
+    
+    var env: [String: String] {
+        let env = ProcessInfo.processInfo.environment
+        print("[iOS-Swift] [debug] environment: \(env)")
+        return env
+    }
+    
+    /// For testing purposes, we want to be able to change the DSN and store it to disk. In a real app, you shouldn't need this behavior.
+    var dsn: String? {
+        do {
+            if let dsn = env["--io.sentry.dsn"] {
+                try DSNStorage.shared.saveDSN(dsn: dsn)
+            }
+            return try DSNStorage.shared.getDSN() ?? AppDelegate.defaultDSN
+        } catch {
+            print("[iOS-Swift] Error encountered while reading stored DSN: \(error)")
+        }
+        return nil
+    }
+    
+    /// Whether or not profiling benchmarks are being run; this requires disabling certain other features for proper functionality.
+    var isBenchmarking: Bool { args.contains("--io.sentry.test.benchmarking") }
+    var isUITest: Bool { env["--io.sentry.sdk-environment"] == "ui-tests" }
+    
+    func checkDisabled(with arg: String) -> Bool {
+        args.contains("--disable-everything") || args.contains(arg)
+    }
+    
+    // MARK: features that care about simulator vs device, ui tests and profiling benchmarks
+    var enableSpotlight: Bool {
+#if targetEnvironment(simulator)
+        !checkDisabled(with: "--disable-spotlight")
+#else
+        false
+#endif // targetEnvironment(simulator)
+    }
+    
+    /// - note: the benchmark test starts and stops a custom transaction using a UIButton, and automatic user interaction tracing stops the transaction that begins with that button press after the idle timeout elapses, stopping the profiler (only one profiler runs regardless of the number of concurrent transactions)
+    var enableUITracing: Bool { !isBenchmarking && !checkDisabled(with: "--disable-ui-tracing") }
+    var enablePrewarmedAppStartTracing: Bool { !isBenchmarking }
+    var enablePerformanceTracing: Bool { !isBenchmarking && !checkDisabled(with: "--disable-auto-performance-tracing") }
+    var enableTracing: Bool { !isBenchmarking && !checkDisabled(with: "--disable-tracing") }
+    /// - note: UI tests generate false OOMs
+    var enableWatchdogTracking: Bool { !isUITest && !isBenchmarking && !checkDisabled(with: "--disable-watchdog-tracking") }
+    /// - note: disable during benchmarks because we run CPU for 15 seconds at full throttle which can trigger ANRs
+    var enableANRTracking: Bool { !isBenchmarking && !checkDisabled(with: "--disable-anr-tracking") }
+    
+    // MARK: Other features
+    
+    var enableSessionReplay: Bool { !checkDisabled(with: "--disable-session-replay") }
+    var enableMetricKit: Bool { !checkDisabled(with: "--disable-metrickit-integration") }
+    var enableSessionTracking: Bool { !checkDisabled(with: "--disable-automatic-session-tracking") }
+    var enableFileIOTracing: Bool { !checkDisabled(with: "--disable-file-io-tracing") }
+    var enableBreadcrumbs: Bool { !checkDisabled(with: "--disable-automatic-breadcrumbs") }
+    var enableUIVCTracing: Bool { !checkDisabled(with: "--disable-uiviewcontroller-tracing") }
+    var enableNetworkTracing: Bool { !checkDisabled(with: "--disable-network-tracking") }
+    var enableCoreDataTracing: Bool { !checkDisabled(with: "--disable-core-data-tracing") }
+    var enableNetworkBreadcrumbs: Bool { !checkDisabled(with: "--disable-network-breadcrumbs") }
+    var enableSwizzling: Bool { !checkDisabled(with: "--disable-swizzling") }
+    var enableCrashHandling: Bool { !checkDisabled(with: "--disable-crash-handler") }
+    
+    var tracesSampleRate: NSNumber {
+        guard let tracesSampleRateOverride = env["--io.sentry.tracesSampleRate"] else {
+            return 1
+        }
+        return NSNumber(value: (tracesSampleRateOverride as NSString).integerValue)
+    }
+    
+    var tracesSampler: ((SamplingContext) -> NSNumber?)? {
+        guard let tracesSamplerValue = env["--io.sentry.tracesSamplerValue"] else {
+            return nil
+        }
+        
+        return { _ in
+            return NSNumber(value: (tracesSamplerValue as NSString).integerValue)
+        }
+    }
+    
+    var profilesSampleRate: NSNumber? {
+        if args.contains("--io.sentry.enableContinuousProfiling") {
+            return nil
+        } else if let profilesSampleRateOverride = env["--io.sentry.profilesSampleRate"] {
+            return NSNumber(value: (profilesSampleRateOverride as NSString).integerValue)
+        } else {
+            return 1
+        }
+    }
+    
+    var profilesSampler: ((SamplingContext) -> NSNumber?)? {
+        guard let profilesSamplerValue = env["--io.sentry.profilesSamplerValue"] else {
+            return nil
+        }
+        
+        return { _ in
+            return NSNumber(value: (profilesSamplerValue as NSString).integerValue)
+        }
+    }
+    
+    var enableAppLaunchProfiling: Bool { args.contains("--profile-app-launches") }
+}


### PR DESCRIPTION
- remove the need for most of the swiftlint toggles we had for type/function length and cyclomatic complexity
- remove a few things that just set the option to the default value
- fix some cases where the same setting was set twice
- add a launch argument to easily disable everything
- organize things with `// MARK:`: 
<img width="489" alt="image" src="https://github.com/user-attachments/assets/ce876eb9-30d8-4ce3-8c04-51eec5464086" />

Food for thought: this points towards a potential enhancement to be able to configure the SDK using a plist. Wonder if customers have ever asked for it? I'm just looking at the long list of options in code and the scheme and thinking we could move that checking logic into the SDK itself.

#skip-changelog