### PR TITLE
fix: Use the same SdkInfo for envelope header and event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Fixes
 
 - `SentrySdkInfo.packages` should be an array (#4626)
-- Use the same SdkInfo for envelope header and event 
+- Use the same SdkInfo for envelope header and event (#4629)
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - `SentrySdkInfo.packages` should be an array (#4626)
+- Use the same SdkInfo for envelope header and event 
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY (#4603)
 
+### Fixes
+
+- `SentrySdkInfo.packages` should be an array (#4626)
+
 ## 8.42.0-beta.2
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - `SentrySdkInfo.packages` should be an array (#4626)
 
+### Internal
+
+- Remove loading `integrations` names from `event.extra` (#4627)
+
 ## 8.42.0-beta.2
 
 ### Fixes

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -880,16 +880,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-    id integrations = event.extra[@"__sentry_sdk_integrations"];
-    if (!integrations) {
-        integrations = [SentrySDK.currentHub trimmedInstalledIntegrationNames];
+    NSMutableArray<NSString *> *integrations =
+        [SentrySDK.currentHub trimmedInstalledIntegrationNames];
 
 #if SENTRY_HAS_UIKIT
-        if (self.options.enablePreWarmedAppStartTracing) {
-            [integrations addObject:@"PreWarmedAppStartTracing"];
-        }
-#endif
+    if (self.options.enablePreWarmedAppStartTracing) {
+        [integrations addObject:@"PreWarmedAppStartTracing"];
     }
+#endif
 
     NSArray<NSString *> *features =
         [SentryEnabledFeaturesBuilder getEnabledFeaturesWithOptions:self.options];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -880,24 +880,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-    NSMutableArray<NSString *> *integrations =
-        [SentrySDK.currentHub trimmedInstalledIntegrationNames];
-
-#if SENTRY_HAS_UIKIT
-    if (self.options.enablePreWarmedAppStartTracing) {
-        [integrations addObject:@"PreWarmedAppStartTracing"];
-    }
-#endif
-
-    NSArray<NSString *> *features =
-        [SentryEnabledFeaturesBuilder getEnabledFeaturesWithOptions:self.options];
-
-    event.sdk = @{
-        @"name" : SentryMeta.sdkName,
-        @"version" : SentryMeta.versionString,
-        @"integrations" : integrations,
-        @"features" : features
-    };
+    event.sdk = [SentrySdkInfo serializedFromOptions:self.options];
 }
 
 - (void)setUserInfo:(NSDictionary *)userInfo withEvent:(SentryEvent *)event

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -8,7 +8,6 @@
 #import "SentryEvent.h"
 #import "SentryLog.h"
 #import "SentryMessage.h"
-#import "SentryMeta.h"
 #import "SentryMsgPackSerializer.h"
 #import "SentrySdkInfo.h"
 #import "SentrySerialization.h"
@@ -30,8 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithId:(nullable SentryId *)eventId
               traceContext:(nullable SentryTraceContext *)traceContext
 {
-    SentrySdkInfo *sdkInfo = [[SentrySdkInfo alloc] initWithName:SentryMeta.sdkName
-                                                      andVersion:SentryMeta.versionString];
+    SentrySdkInfo *sdkInfo = [SentrySdkInfo fromGlobals];
     self = [self initWithId:eventId sdkInfo:sdkInfo traceContext:traceContext];
     return self;
 }

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -101,10 +101,12 @@ NS_ASSUME_NONNULL_BEGIN
     if (self.packageManager != SentryPackageManagerUnkown) {
         NSString *format = [self getPackageName:self.packageManager];
         if (format != nil) {
-            sdk[@"packages"] = @{
-                @"name" : [NSString stringWithFormat:format, self.name],
-                @"version" : self.version
-            };
+            sdk[@"packages"] = @[
+                @{
+                    @"name" : [NSString stringWithFormat:format, self.name],
+                    @"version" : self.version
+                },
+            ];
         }
     }
 

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     SentrySdkInfo *sdkInfo = envelope.header.sdkInfo;
     if (nil != sdkInfo) {
-        [serializedData addEntriesFromDictionary:[sdkInfo serialize]];
+        [serializedData setValue:[sdkInfo serialize] forKey:@"sdk"];
     }
 
     SentryTraceContext *traceContext = envelope.header.traceContext;
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 
             SentrySdkInfo *sdkInfo = nil;
             if (nil != headerDictionary[@"sdk"]) {
-                sdkInfo = [[SentrySdkInfo alloc] initWithDict:headerDictionary];
+                sdkInfo = [[SentrySdkInfo alloc] initWithDict:headerDictionary[@"sdk"]];
             }
 
             SentryTraceContext *traceContext = nil;

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -10,6 +10,12 @@
 #    import "SentryInternalSerializable.h"
 #endif
 
+#if __has_include(<Sentry/SentryOptions.h>)
+#    import <Sentry/SentryOptions.h>
+#else
+#    import "SentryOptions.h"
+#endif
+
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
@@ -21,6 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SentrySdkInfo : NSObject <SentryInternalSerializable>
 SENTRY_NO_INIT
+
++ (instancetype)fromGlobals;
+
++ (NSDictionary<NSString *, id> *)serializedFromOptions:(SentryOptions *)options;
 
 /**
  * The name of the SDK. Examples: sentry.cocoa, sentry.cocoa.vapor, ...
@@ -34,8 +44,26 @@ SENTRY_NO_INIT
  */
 @property (nonatomic, readonly, copy) NSString *version;
 
+/**
+ * A list of names identifying enabled integrations. The list should
+ * have all enabled integrations, including default integrations. Default
+ * integrations are included because different SDK releases may contain different
+ * default integrations.
+ */
+@property (nonatomic, readonly, copy) NSArray<NSString *> *integrations;
+
+/**
+ * A list of feature names identifying enabled SDK features. This list
+ * should contain all enabled SDK features. On some SDKs, enabling a feature in the
+ * options also adds an integration. We encourage tracking such features with either
+ * integrations or features but not both to reduce the payload size.
+ */
+@property (nonatomic, readonly, copy) NSArray<NSString *> *features;
+
 - (instancetype)initWithName:(NSString *)name
-                  andVersion:(NSString *)version NS_DESIGNATED_INITIALIZER;
+                     version:(NSString *)version
+                integrations:(NSArray<NSString *> *)integrations
+                    features:(NSArray<NSString *> *)features NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithDict:(NSDictionary *)dict;
 

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -135,7 +135,7 @@ class SentryFileManagerTests: XCTestCase {
     }
     
     func testStoreInvalidEnvelope_ReturnsNil() {
-        let sdkInfoWithInvalidJSON = SentrySdkInfo(name: SentryInvalidJSONString() as String, andVersion: "8.0.0")
+        let sdkInfoWithInvalidJSON = SentrySdkInfo(name: SentryInvalidJSONString() as String, version: "8.0.0", integrations: [], features: [])
         let headerWithInvalidJSON = SentryEnvelopeHeader(id: nil, sdkInfo: sdkInfoWithInvalidJSON, traceContext: nil)
         
         let envelope = SentryEnvelope(header: headerWithInvalidJSON, items: [])

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -24,7 +24,7 @@ class SentrySerializationTests: XCTestCase {
     }
     
     func testEnvelopeWithData_InvalidEnvelopeHeaderJSON_ReturnsNil() {
-        let sdkInfoWithInvalidJSON = SentrySdkInfo(name: SentryInvalidJSONString() as String, andVersion: "8.0.0")
+        let sdkInfoWithInvalidJSON = SentrySdkInfo(name: SentryInvalidJSONString() as String, version: "8.0.0", integrations: [], features: [])
         let headerWithInvalidJSON = SentryEnvelopeHeader(id: nil, sdkInfo: sdkInfoWithInvalidJSON, traceContext: nil)
         
         let envelope = SentryEnvelope(header: headerWithInvalidJSON, items: [])
@@ -125,7 +125,7 @@ class SentrySerializationTests: XCTestCase {
     }
     
     func testEnvelopeWithData_WithSdkInfo_ReturnsSDKInfo() throws {
-        let sdkInfo = SentrySdkInfo(name: "sentry.cocoa", andVersion: "5.0.1")
+        let sdkInfo = SentrySdkInfo(name: "sentry.cocoa", version: "5.0.1", integrations: [], features: [])
         let envelopeHeader = SentryEnvelopeHeader(id: nil, sdkInfo: sdkInfo, traceContext: nil)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
         
@@ -524,7 +524,7 @@ class SentrySerializationTests: XCTestCase {
     }
     
     private func assertDefaultSdkInfoSet(deserializedEnvelope: SentryEnvelope) {
-        let sdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, andVersion: SentryMeta.versionString)
+        let sdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, version: SentryMeta.versionString, integrations: [], features: [])
         XCTAssertEqual(sdkInfo, deserializedEnvelope.header.sdkInfo)
     }
     

--- a/Tests/SentryTests/Networking/SentryNSURLRequestBuilderTests.swift
+++ b/Tests/SentryTests/Networking/SentryNSURLRequestBuilderTests.swift
@@ -66,7 +66,9 @@ class SentryNSURLRequestBuilderTests: XCTestCase {
     private func givenEnvelopeWithInvalidData() -> SentryEnvelope {
         let sdkInfoWithInvalidJSON = SentrySdkInfo(
             name: SentryInvalidJSONString() as String,
-            andVersion: "8.0.0"
+            version: "8.0.0",
+            integrations: [],
+            features: []
         )
         let headerWithInvalidJSON = SentryEnvelopeHeader(
             id: nil,

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -66,8 +66,8 @@ class SentryEnvelopeTests: XCTestCase {
         clearTestState()
     }
 
-    private let defaultSdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, andVersion: SentryMeta.versionString)
-    
+    private let defaultSdkInfo = SentrySdkInfo(name: SentryMeta.sdkName, version: SentryMeta.versionString, integrations: [], features: [])
+
     func testSentryEnvelopeFromEvent() throws {
         let event = Event()
         
@@ -147,7 +147,7 @@ class SentryEnvelopeTests: XCTestCase {
     
     func testInitSentryEnvelopeHeader_SetIdAndSdkInfo() {
         let eventId = SentryId()
-        let sdkInfo = SentrySdkInfo(name: "sdk", andVersion: "1.2.3-alpha.0")
+        let sdkInfo = SentrySdkInfo(name: "sdk", version: "1.2.3-alpha.0", integrations: [], features: [])
         
         let envelopeHeader = SentryEnvelopeHeader(id: eventId, sdkInfo: sdkInfo, traceContext: nil)
         XCTAssertEqual(eventId, envelopeHeader.eventId)

--- a/Tests/SentryTests/Protocol/SentrySdkInfoNilTests.m
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoNilTests.m
@@ -15,17 +15,49 @@
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    SentrySdkInfo *actual = [[SentrySdkInfo alloc] initWithName:nil andVersion:@""];
+    SentrySdkInfo *actual = [[SentrySdkInfo alloc] initWithName:nil
+                                                        version:@""
+                                                   integrations:@[]
+                                                       features:@[]];
 #pragma clang diagnostic pop
 
     [self assertSdkInfoIsEmtpy:actual];
 }
 
-- (void)testVersinoStringIsNil
+- (void)testVersinStringIsNil
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
-    SentrySdkInfo *actual = [[SentrySdkInfo alloc] initWithName:@"" andVersion:nil];
+    SentrySdkInfo *actual = [[SentrySdkInfo alloc] initWithName:@""
+                                                        version:nil
+                                                   integrations:@[]
+                                                       features:@[]];
+#pragma clang diagnostic pop
+
+    [self assertSdkInfoIsEmtpy:actual];
+}
+
+- (void)testIntegrationsAreNil
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    SentrySdkInfo *actual = [[SentrySdkInfo alloc] initWithName:@""
+                                                        version:@""
+                                                   integrations:nil
+                                                       features:@[]];
+#pragma clang diagnostic pop
+
+    [self assertSdkInfoIsEmtpy:actual];
+}
+
+- (void)testFeaturesAreNil
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    SentrySdkInfo *actual = [[SentrySdkInfo alloc] initWithName:@""
+                                                        version:@""
+                                                   integrations:@[]
+                                                       features:nil];
 #pragma clang diagnostic pop
 
     [self assertSdkInfoIsEmtpy:actual];
@@ -46,7 +78,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"
     SentrySdkInfo *actual =
-        [[SentrySdkInfo alloc] initWithDict:@{ @"sdk" : @ { @"name" : @20, @"version" : @0 } }];
+        [[SentrySdkInfo alloc] initWithDict:@{ @"name" : @20, @"version" : @0 }];
 #pragma clang diagnostic pop
 
     [self assertSdkInfoIsEmtpy:actual];
@@ -56,6 +88,8 @@
 {
     XCTAssertEqualObjects(@"", sdkInfo.name);
     XCTAssertEqualObjects(@"", sdkInfo.version);
+    XCTAssertEqualObjects(@[], sdkInfo.integrations);
+    XCTAssertEqualObjects(@[], sdkInfo.features);
 }
 
 @end

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -43,9 +43,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "spm:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
+            XCTAssertEqual(1, packages.count)
+            XCTAssertEqual(packages[0]["name"] as? String, "spm:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"] as? String, version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -60,9 +61,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "carthage:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
+            XCTAssertEqual(1, packages.count)
+            XCTAssertEqual(packages[0]["name"] as? String, "carthage:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"] as? String, version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }
@@ -77,9 +79,10 @@ class SentrySdkInfoTests: XCTestCase {
         if let sdkInfo = serialization["sdk"] as? [String: Any] {
             XCTAssertEqual(3, sdkInfo.count)
 
-            let packageInfo = try XCTUnwrap(sdkInfo["packages"] as? [String: Any])
-            XCTAssertEqual(packageInfo["name"] as? String, "cocoapods:getsentry/\(sdkName)")
-            XCTAssertEqual(packageInfo["version"] as? String, version)
+            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
+            XCTAssertEqual(1, packages.count)
+            XCTAssertEqual(packages[0]["name"] as? String, "cocoapods:getsentry/\(sdkName)")
+            XCTAssertEqual(packages[0]["version"] as? String, version)
         } else {
             XCTFail("Serialization of SdkInfo doesn't contain sdk")
         }

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -7,15 +7,15 @@ class SentrySdkInfoTests: XCTestCase {
     
     func testWithPatchLevelSuffix() {
         let version = "50.10.20-beta1"
-        let actual = SentrySdkInfo(name: sdkName, andVersion: version)
-        
+        let actual = SentrySdkInfo(name: sdkName, version: version, integrations: [], features: [])
+
         XCTAssertEqual(sdkName, actual.name)
         XCTAssertEqual(version, actual.version)
     }
     
     func testWithAnyVersion() {
         let version = "anyVersion"
-        let actual = SentrySdkInfo(name: sdkName, andVersion: version)
+        let actual = SentrySdkInfo(name: sdkName, version: version, integrations: [], features: [])
         
         XCTAssertEqual(sdkName, actual.name)
         XCTAssertEqual(version, actual.version)
@@ -23,94 +23,85 @@ class SentrySdkInfoTests: XCTestCase {
     
     func testSerialization() {
         let version = "5.2.0"
-        let actual = SentrySdkInfo(name: sdkName, andVersion: version).serialize()
-        
-        if let sdkInfo = actual["sdk"] as? [String: Any] {
-            XCTAssertEqual(2, sdkInfo.count)
-            XCTAssertEqual(sdkName, sdkInfo["name"] as? String)
-            XCTAssertEqual(version, sdkInfo["version"] as? String)
-        } else {
-            XCTFail("Serialization of SdkInfo doesn't contain sdk")
-        }
+        let sdkInfo = SentrySdkInfo(name: sdkName, version: version, integrations: ["a"], features: ["b"]).serialize()
+
+        XCTAssertEqual(sdkName, sdkInfo["name"] as? String)
+        XCTAssertEqual(version, sdkInfo["version"] as? String)
+        XCTAssertEqual(["a"], sdkInfo["integrations"] as? [String])
+        XCTAssertEqual(["b"], sdkInfo["features"] as? [String])
+    }
+
+    func testSerializationValidIntegrations() {
+        let sdkInfo = SentrySdkInfo(name: "", version: "", integrations: ["a", "b"], features: []).serialize()
+
+        XCTAssertEqual(["a", "b"], sdkInfo["integrations"] as? [String])
+    }
+
+    func testSerializationValidFeatures() {
+        let sdkInfo = SentrySdkInfo(name: "", version: "", integrations: [], features: ["c", "d"]).serialize()
+
+        XCTAssertEqual(["c", "d"], sdkInfo["features"] as? [String])
     }
 
     func testSPM_packageInfo() throws {
         let version = "5.2.0"
-        let actual = SentrySdkInfo(name: sdkName, andVersion: version)
+        let actual = SentrySdkInfo(name: sdkName, version: version, integrations: [], features: [])
         Dynamic(actual).packageManager = 0
         let serialization = actual.serialize()
 
-        if let sdkInfo = serialization["sdk"] as? [String: Any] {
-            XCTAssertEqual(3, sdkInfo.count)
-
-            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
-            XCTAssertEqual(1, packages.count)
-            XCTAssertEqual(packages[0]["name"] as? String, "spm:getsentry/\(sdkName)")
-            XCTAssertEqual(packages[0]["version"] as? String, version)
-        } else {
-            XCTFail("Serialization of SdkInfo doesn't contain sdk")
-        }
+        let packages = try XCTUnwrap(serialization["packages"] as? [[String: Any]])
+        XCTAssertEqual(1, packages.count)
+        XCTAssertEqual(packages[0]["name"] as? String, "spm:getsentry/\(sdkName)")
+        XCTAssertEqual(packages[0]["version"] as? String, version)
     }
 
     func testCarthage_packageInfo() throws {
         let version = "5.2.0"
-        let actual = SentrySdkInfo(name: sdkName, andVersion: version)
+        let actual = SentrySdkInfo(name: sdkName, version: version, integrations: [], features: [])
         Dynamic(actual).packageManager = 2
         let serialization = actual.serialize()
 
-        if let sdkInfo = serialization["sdk"] as? [String: Any] {
-            XCTAssertEqual(3, sdkInfo.count)
-
-            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
-            XCTAssertEqual(1, packages.count)
-            XCTAssertEqual(packages[0]["name"] as? String, "carthage:getsentry/\(sdkName)")
-            XCTAssertEqual(packages[0]["version"] as? String, version)
-        } else {
-            XCTFail("Serialization of SdkInfo doesn't contain sdk")
-        }
+        let packages = try XCTUnwrap(serialization["packages"] as? [[String: Any]])
+        XCTAssertEqual(1, packages.count)
+        XCTAssertEqual(packages[0]["name"] as? String, "carthage:getsentry/\(sdkName)")
+        XCTAssertEqual(packages[0]["version"] as? String, version)
     }
 
     func testcocoapods_packageInfo() throws {
         let version = "5.2.0"
-        let actual = SentrySdkInfo(name: sdkName, andVersion: version)
+        let actual = SentrySdkInfo(name: sdkName, version: version, integrations: [], features: [])
         Dynamic(actual).packageManager = 1
         let serialization = actual.serialize()
 
-        if let sdkInfo = serialization["sdk"] as? [String: Any] {
-            XCTAssertEqual(3, sdkInfo.count)
-
-            let packages = try XCTUnwrap(sdkInfo["packages"] as? [[String: Any]])
-            XCTAssertEqual(1, packages.count)
-            XCTAssertEqual(packages[0]["name"] as? String, "cocoapods:getsentry/\(sdkName)")
-            XCTAssertEqual(packages[0]["version"] as? String, version)
-        } else {
-            XCTFail("Serialization of SdkInfo doesn't contain sdk")
-        }
+        let packages = try XCTUnwrap(serialization["packages"] as? [[String: Any]])
+        XCTAssertEqual(1, packages.count)
+        XCTAssertEqual(packages[0]["name"] as? String, "cocoapods:getsentry/\(sdkName)")
+        XCTAssertEqual(packages[0]["version"] as? String, version)
     }
 
     func testNoPackageNames () {
-        let actual = SentrySdkInfo(name: sdkName, andVersion: "")
+        let actual = SentrySdkInfo(name: sdkName, version: "", integrations: [], features: [])
         XCTAssertNil(Dynamic(actual).getPackageName(3).asString)
     }
     
     func testInitWithDict_SdkInfo() {
         let version = "10.3.1"
-        let expected = SentrySdkInfo(name: sdkName, andVersion: version)
-        
-        let dict = ["sdk": [ "name": sdkName, "version": version]]
-        
+        let expected = SentrySdkInfo(name: sdkName, version: version, integrations: ["a", "b"], features: ["c", "d"])
+
+        let dict = [ "name": sdkName, "version": version, "integrations": ["a", "b"], "features": ["c", "d"]] as [String: Any]
+
         XCTAssertEqual(expected, SentrySdkInfo(dict: dict))
     }
     
     func testInitWithDict_AllNil() {
-        let dict = ["sdk": [ "name": nil, "version": nil] as [String: Any?]]
-        
-        assertEmptySdkInfo(actual: SentrySdkInfo(dict: dict))
+        let dict = [ "name": nil, "version": nil, "integraions": nil, "features": nil] as [String: Any?]
+
+        assertEmptySdkInfo(actual: SentrySdkInfo(dict: dict as [AnyHashable: Any]))
     }
     
     func testInitWithDict_WrongTypes() {
-        let dict = ["sdk": [ "name": 0, "version": 0]]
-        
+        let dict = [ "name": 0, "version": 0, "integrations": 0, "features": 0]
+
         assertEmptySdkInfo(actual: SentrySdkInfo(dict: dict))
     }
     
@@ -119,8 +110,17 @@ class SentrySdkInfoTests: XCTestCase {
         
         assertEmptySdkInfo(actual: SentrySdkInfo(dict: dict))
     }
-    
+
+    func testFromGlobals() throws {
+        SentrySDK.start(options: Options())
+        let actual = SentrySdkInfo.fromGlobals()
+        XCTAssertEqual(actual.name, SentryMeta.sdkName)
+        XCTAssertEqual(actual.version, SentryMeta.versionString)
+        XCTAssertTrue(actual.integrations.count > 0)
+        XCTAssertTrue(actual.features.count > 0)
+    }
+
     private func assertEmptySdkInfo(actual: SentrySdkInfo) {
-        XCTAssertEqual(SentrySdkInfo(name: "", andVersion: ""), actual)
+        XCTAssertEqual(SentrySdkInfo(name: "", version: "", integrations: [], features: []), actual)
     }
 }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

This PR unifies event body sdk info and envelope header sdk info.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This can be used for better debugging when envelope is broken.

## :green_heart: How did you test it?
unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

