### PR TITLE
feat: Show session replay options as replay tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY (#4603)
 
+### Features
+
+- Show session replay options as replay tags ()
+
 ### Fixes
 
 - `SentrySdkInfo.packages` should be an array (#4626)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Features
 
-- Show session replay options as replay tags ()
+- Show session replay options as replay tags (#4639)
 
 ### Fixes
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -814,6 +814,7 @@
 		D82915632C85EF0C00A6CDD4 /* SentryViewPhotographerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82915622C85EF0C00A6CDD4 /* SentryViewPhotographerTests.swift */; };
 		D8292D7D2A39A027009872F7 /* UrlSanitizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8292D7C2A39A027009872F7 /* UrlSanitizedTests.swift */; };
 		D82DD1CD2BEEB1A0001AB556 /* SentrySRDefaultBreadcrumbConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82DD1CC2BEEB1A0001AB556 /* SentrySRDefaultBreadcrumbConverterTests.swift */; };
+		D833D57C2D10784800961E7A /* SentryRRWebOptionsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D833D57B2D10783D00961E7A /* SentryRRWebOptionsEvent.swift */; };
 		D8370B6A273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m in Sources */ = {isa = PBXBuildFile; fileRef = D8370B68273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m */; };
 		D8370B6C273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h in Headers */ = {isa = PBXBuildFile; fileRef = D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */; };
 		D83D079B2B7F9D1C00CC9674 /* SentryMsgPackSerializer.h in Headers */ = {isa = PBXBuildFile; fileRef = D83D07992B7F9D1C00CC9674 /* SentryMsgPackSerializer.h */; };
@@ -1895,6 +1896,7 @@
 		D8292D7A2A38AF04009872F7 /* HTTPHeaderSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderSanitizer.swift; sourceTree = "<group>"; };
 		D8292D7C2A39A027009872F7 /* UrlSanitizedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlSanitizedTests.swift; sourceTree = "<group>"; };
 		D82DD1CC2BEEB1A0001AB556 /* SentrySRDefaultBreadcrumbConverterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySRDefaultBreadcrumbConverterTests.swift; sourceTree = "<group>"; };
+		D833D57B2D10783D00961E7A /* SentryRRWebOptionsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRRWebOptionsEvent.swift; sourceTree = "<group>"; };
 		D8370B68273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryNSURLSessionTaskSearch.m; sourceTree = "<group>"; };
 		D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryNSURLSessionTaskSearch.h; path = include/SentryNSURLSessionTaskSearch.h; sourceTree = "<group>"; };
 		D83D07992B7F9D1C00CC9674 /* SentryMsgPackSerializer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryMsgPackSerializer.h; path = include/SentryMsgPackSerializer.h; sourceTree = "<group>"; };
@@ -3685,6 +3687,7 @@
 				D8739D132BEE5049007D2F66 /* SentryRRWebSpanEvent.swift */,
 				D81988C82BEC19200020E36C /* SentryRRWebBreadcrumbEvent.swift */,
 				D8BC28CB2BFF78220054DA4D /* SentryRRWebTouchEvent.swift */,
+				D833D57B2D10783D00961E7A /* SentryRRWebOptionsEvent.swift */,
 			);
 			path = RRWeb;
 			sourceTree = "<group>";
@@ -4691,6 +4694,7 @@
 				8EC3AE7A25CA23B600E7591A /* SentrySpan.m in Sources */,
 				6360850E1ED2AFE100E8599E /* SentryBreadcrumb.m in Sources */,
 				D82859432C3E753C009A28AA /* SentrySessionReplaySyncC.c in Sources */,
+				D833D57C2D10784800961E7A /* SentryRRWebOptionsEvent.swift in Sources */,
 				84A8891D28DBD28900C51DFD /* SentryDevice.mm in Sources */,
 				7B56D73324616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m in Sources */,
 				8ECC674825C23A20000E2BF6 /* SentryTransaction.m in Sources */,

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
@@ -10,6 +10,7 @@ import Foundation
                         "errorSampleRate": options.onErrorSampleRate,
                         "maskAllText": options.maskAllText,
                         "maskAllImages": options.maskAllImages,
+                        "quality": String(describing: options.quality),
                         "maskedViewClasses": options.maskedViewClasses.map(String.init(describing: )).joined(separator: ", "),
                         "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: )).joined(separator: ", ")
                     ]

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
@@ -1,0 +1,18 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+@objc class SentryRRWebOptionsEvent: SentryRRWebCustomEvent {
+    
+    init(timestamp: Date, options: SentryReplayOptions) {
+        super.init(timestamp: timestamp, tag: "options", payload:
+                    [
+                        "sessionSampleRate": options.sessionSampleRate,
+                        "errorSampleRate": options.onErrorSampleRate,
+                        "maskAllText": options.maskAllText,
+                        "maskAllImates": options.maskAllImages,
+                        "maskedViewClasses": options.maskedViewClasses.map(String.init(describing: )),
+                        "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: ))
+                    ]
+        )
+    }
+}

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
@@ -9,9 +9,9 @@ import Foundation
                         "sessionSampleRate": options.sessionSampleRate,
                         "errorSampleRate": options.onErrorSampleRate,
                         "maskAllText": options.maskAllText,
-                        "maskAllImates": options.maskAllImages,
-                        "maskedViewClasses": options.maskedViewClasses.map(String.init(describing: )),
-                        "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: ))
+                        "maskAllImages": options.maskAllImages,
+                        "maskedViewClasses": options.maskedViewClasses.map(String.init(describing: )).joined(separator: ", "),
+                        "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: )).joined(separator: ", ")
                     ]
         )
     }

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -258,7 +258,11 @@ class SentrySessionReplay: NSObject {
             events.append(contentsOf: touchTracker.replayEvents(from: videoSegmentStart ?? video.start, until: video.end))
             touchTracker.flushFinishedEvents()
         }
-
+        
+        if segment == 0 {
+            events.append(SentryRRWebOptionsEvent(timestamp: video.start, options: self.replayOptions))
+        }
+        
         let recording = SentryReplayRecording(segmentId: segment, video: video, extraEvents: events)
                 
         delegate?.sessionReplayNewSegment(replayEvent: replayEvent, replayRecording: recording, videoUrl: video.path)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -427,14 +427,16 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertEqual(options["maskAllImages"] as? Bool, true)
         XCTAssertEqual(options["maskedViewClasses"] as? String, "")
         XCTAssertEqual(options["unmaskedViewClasses"] as? String, "")
+        XCTAssertEqual(options["quality"] as? String, "medium")
     }
     
     func testOptionsInTheEventAllChanged() throws {
         let fixture = Fixture()
         
         let replayOptions = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 0, maskAllText: false, maskAllImages: false)
-        replayOptions.maskedViewClasses = [UIView.self, UISwitch.self]
+        replayOptions.maskedViewClasses = [UIView.self]
         replayOptions.unmaskedViewClasses = [UITextField.self, UITextView.self]
+        replayOptions.quality = .high
         
         let sut = fixture.getSut(options: replayOptions)
         sut.start(rootView: fixture.rootView, fullSession: true)
@@ -453,16 +455,15 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertEqual(options["errorSampleRate"] as? Float, 0)
         XCTAssertEqual(options["maskAllText"] as? Bool, false)
         XCTAssertEqual(options["maskAllImages"] as? Bool, false)
-        XCTAssertEqual(options["maskedViewClasses"] as? String, "UIView, UISwitch")
+        XCTAssertEqual(options["maskedViewClasses"] as? String, "UIView")
         XCTAssertEqual(options["unmaskedViewClasses"] as? String, "UITextField, UITextView")
+        XCTAssertEqual(options["quality"] as? String, "high")
     }
     
     func testOptionsNotInSegmentsOtherThanZero() throws {
         let fixture = Fixture()
         
-        let replayOptions = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 0, maskAllText: false, maskAllImages: false)
-        replayOptions.maskedViewClasses = [UIView.self, UISwitch.self]
-        replayOptions.unmaskedViewClasses = [UITextField.self, UITextView.self]
+        let replayOptions = SentryReplayOptions(sessionSampleRate: 1, onErrorSampleRate: 1)
         
         let sut = fixture.getSut(options: replayOptions)
         sut.start(rootView: fixture.rootView, fullSession: true)


### PR DESCRIPTION
## :scroll: Description

Send the options used for session replay in the replay tag event.

![image](https://github.com/user-attachments/assets/5b9f9ac6-287b-405e-a646-4d15e0a3191f)

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
