### PR TITLE
ref: Add comment why no lock required in scope

### DIFF
--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -606,6 +606,8 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 
+    // We don't need call synchronized(_spanLock) here because we get a copy of the span in the
+    // _spanLock above.
     newContext[@"trace"] = [self buildTraceContext:span];
 
     event.context = newContext;


### PR DESCRIPTION
Add a short comment to explain why we don't need to call synchronize spanLock when building the trace context in SentryScope.applyToEvent.

#skip-changelog