### PR TITLE
Fix: Check if clipPath is empty before removing last element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 - `SentrySdkInfo.packages` should be an array (#4626)
 - Use the same SdkInfo for envelope header and event (#4629)
+- Fixes Session replay screenshot provider crash (#4649)
 
 ### Internal
 

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -82,7 +82,9 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
                                             clipPaths: clipPaths,
                                             clipOutPath: clipOutPath)
                     case .clipEnd:
-                        clipPaths.removeLast()
+                        if !clipPaths.isEmpty {
+                            clipPaths.removeLast()
+                        }
                         self.updateClipping(for: context.cgContext,
                                             clipPaths: clipPaths,
                                             clipOutPath: clipOutPath)


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

I've noticed the following crash while testing https://github.com/getsentry/sentry-react-native/pull/4328 [after upgrading to 8.42.0](https://github.com/getsentry/sentry-react-native/pull/4387) [that included the `clipPaths.removeLast()` addition](https://github.com/getsentry/sentry-cocoa/commit/114f2350b1969a0f22e2cd9b99bf8e5f99a2bb13#diff-7065ad52e9de8e634171ef82eeb8098030f9de3779b5c0afa7a006fc42847f56R85).

```
Thread 6::  Dispatch queue: io.sentry.default
...
4   libswiftCore.dylib            	       0x1930e5614 RangeReplaceableCollection<>.removeLast() + 548
5   sentryreactnativesample.debug.dylib	       0x10a1d968c closure #1 in closure #1 in SentryViewPhotographer.image(view:options:onComplete:) + 2672 (SentryViewPhotographer.swift:85)
```

## :green_heart: How did you test it?

Manual testing with the React Native Sample app [and local code changes](https://github.com/getsentry/sentry-react-native/blob/main/CONTRIBUTING.md#develop-with-sentry-cocoa):
1. Open the RN sample app from https://github.com/getsentry/sentry-react-native/pull/4328
2. Open the feedback form
3. Verified no crash

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
