### PR TITLE
fix: Session Redact wrong clipping order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `SentrySdkInfo.packages` should be an array (#4626)
 - Use the same SdkInfo for envelope header and event (#4629)
 - Fixes Session replay screenshot provider crash (#4649)
+- Session Redact wrong clipping order ()
 
 ### Internal
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - `SentrySdkInfo.packages` should be an array (#4626)
 - Use the same SdkInfo for envelope header and event (#4629)
 - Fixes Session replay screenshot provider crash (#4649)
-- Session Redact wrong clipping order ()
+- Session Redact wrong clipping order (#4651)
 
 ### Internal
 

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -66,7 +66,6 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
             let imageRect = CGRect(origin: .zero, size: size)
             context.cgContext.addRect(CGRect(origin: CGPoint.zero, size: size))
             context.cgContext.clip(using: .evenOdd)
-            UIColor.blue.setStroke()
             
             context.cgContext.interpolationQuality = .none
             image.draw(at: .zero)

--- a/Sources/Swift/Tools/SentryViewPhotographer.swift
+++ b/Sources/Swift/Tools/SentryViewPhotographer.swift
@@ -78,10 +78,9 @@ class SentryViewPhotographer: NSObject, SentryViewScreenshotProvider {
                 
                 defer { latestRegion = region }
                 
-                guard latestRegion?.canReplace(as: region) != true && imageRect.intersects(path.boundingBoxOfPath) else { continue }
-                
                 switch region.type {
                 case .redact, .redactSwiftUI:
+                    guard latestRegion?.canReplace(as: region) != true && imageRect.intersects(path.boundingBoxOfPath) else { continue }
                     (region.color ?? UIImageHelper.averageColor(of: context.currentImage, at: rect.applying(region.transform))).setFill()
                     context.cgContext.addPath(path)
                     context.cgContext.fillPath()

--- a/Sources/Swift/Tools/UIRedactBuilder.swift
+++ b/Sources/Swift/Tools/UIRedactBuilder.swift
@@ -264,8 +264,8 @@ class UIRedactBuilder {
         }
         
         guard let subLayers = layer.sublayers, subLayers.count > 0 else { return }
-        
-        if view.clipsToBounds {
+        let clipToBounds = view.clipsToBounds
+        if clipToBounds {
             /// Because the order in which we process the redacted regions is reversed, we add the end of the clip region first.
             /// The beginning will be added after all the subviews have been mapped.
             redacting.append(RedactRegion(size: layer.bounds.size, transform: newTransform, type: .clipEnd))
@@ -273,7 +273,7 @@ class UIRedactBuilder {
         for subLayer in subLayers.sorted(by: { $0.zPosition < $1.zPosition }) {
             mapRedactRegion(fromLayer: subLayer, relativeTo: layer, redacting: &redacting, rootFrame: rootFrame, transform: newTransform, forceRedact: enforceRedact)
         }
-        if view.clipsToBounds {
+        if clipToBounds {
             redacting.append(RedactRegion(size: layer.bounds.size, transform: newTransform, type: .clipBegin))
         }
     }

--- a/Tests/SentryTests/SentryViewPhotographerTests.swift
+++ b/Tests/SentryTests/SentryViewPhotographerTests.swift
@@ -268,6 +268,32 @@ class SentryViewPhotographerTests: XCTestCase {
         ])
     }
     
+    func testLabelRedactedStackedHierarchy() throws {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
+        label.text = "Test"
+        
+        let bottomView = UIView(frame: CGRect(x: 5, y: 5, width: 40, height: 40))
+        bottomView.clipsToBounds = true
+        bottomView.backgroundColor = .white
+        
+        let middleView = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+        middleView.clipsToBounds = true
+        middleView.backgroundColor = .white
+        
+        let topView = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
+        topView.clipsToBounds = true
+        topView.backgroundColor = .white
+                
+        bottomView.addSubview(middleView)
+        middleView.addSubview(topView)
+        topView.addSubview(label)
+        
+        let image = try XCTUnwrap(prepare(views: [bottomView]))
+        let pixel = color(at: CGPoint(x: 10, y: 10), in: image)
+        
+        assertColor(pixel, .black)
+    }
+    
     private func assertColor(_ color: UIColor, in image: UIImage, at points: [CGPoint]) {
         points.forEach {
             let pixel = self.color(at: $0, in: image)


### PR DESCRIPTION
## :scroll: Description

Fix an error where SR clipping happens in the wrong order.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
