### PR TITLE
Chore: Persist SR Screenshot provider and breadcrumbs converter

### DIFF
--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -271,8 +271,9 @@ static SentryTouchTracker *_touchTracker;
              fullSession:(BOOL)shouldReplayFullSession
 {
     [self startWithOptions:replayOptions
-        screenshotProvider:_currentScreenshotProvider ?: _viewPhotographer
-       breadcrumbConverter:_currentBreadcrumbConverter ?: [[SentrySRDefaultBreadcrumbConverter alloc] init]
+         screenshotProvider:_currentScreenshotProvider ?: _viewPhotographer
+        breadcrumbConverter:_currentBreadcrumbConverter
+            ?: [[SentrySRDefaultBreadcrumbConverter alloc] init]
                 fullSession:shouldReplayFullSession];
 }
 

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -48,6 +48,8 @@ static SentryTouchTracker *_touchTracker;
     SentryNSNotificationCenterWrapper *_notificationCenter;
     SentryOnDemandReplay *_resumeReplayMaker;
     id<SentryRateLimits> _rateLimits;
+    id<SentryViewScreenshotProvider> _currentScreenshotProvider;
+    id<SentryReplayBreadcrumbConverter> _currentBreadcrumbConverter;
     // We need to use this variable to identify whether rate limiting was ever activated for session
     // replay in this session, instead of always looking for the rate status in `SentryRateLimits`
     // This is the easiest way to ensure segment 0 will always reach the server, because session
@@ -269,8 +271,8 @@ static SentryTouchTracker *_touchTracker;
              fullSession:(BOOL)shouldReplayFullSession
 {
     [self startWithOptions:replayOptions
-         screenshotProvider:_viewPhotographer
-        breadcrumbConverter:[[SentrySRDefaultBreadcrumbConverter alloc] init]
+        screenshotProvider:_currentScreenshotProvider ?: _viewPhotographer
+       breadcrumbConverter:_currentBreadcrumbConverter ?: [[SentrySRDefaultBreadcrumbConverter alloc] init]
                 fullSession:shouldReplayFullSession];
 }
 
@@ -474,10 +476,12 @@ static SentryTouchTracker *_touchTracker;
          screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider
 {
     if (breadcrumbConverter) {
+        _currentBreadcrumbConverter = breadcrumbConverter;
         self.sessionReplay.breadcrumbConverter = breadcrumbConverter;
     }
 
     if (screenshotProvider) {
+        _currentScreenshotProvider = screenshotProvider;
         self.sessionReplay.screenshotProvider = screenshotProvider;
     }
 }

--- a/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration-Hybrid.h
+++ b/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration-Hybrid.h
@@ -22,11 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentrySessionReplayIntegration ()
 
-- (void)startWithOptions:(SentryReplayOptions *)replayOptions
-      screenshotProvider:(id<SentryViewScreenshotProvider>)screenshotProvider
-     breadcrumbConverter:(id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
-             fullSession:(BOOL)shouldReplayFullSession;
-
 + (id<SentryRRWebEvent>)createBreadcrumbwithTimestamp:(NSDate *)timestamp
                                              category:(NSString *)category
                                               message:(nullable NSString *)message

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -502,7 +502,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     }
     
     func testPersistScreenshotProviderAndBreadcrumbConverter() throws {
-        class CustomImageProvider:NSObject, SentryViewScreenshotProvider {
+        class CustomImageProvider: NSObject, SentryViewScreenshotProvider {
             func image(view: UIView, onComplete: @escaping Sentry.ScreenshotCallback) {
                 onComplete(UIImage())
             }


### PR DESCRIPTION
This is a fix for hybrid SDK, where the screenshot provider and the breadcrumb converter was reverting to the default after starting a new app session, usually when the app stays too long in the background.

_#skip-changelog_