### PR TITLE
impr: Slightly speed up serializing scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY (#4603)
 - Mask screenshots for errors (#4623)
+- Slightly speed up serializing scope (#4661)
 
 ### Features
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -466,7 +466,7 @@ NS_ASSUME_NONNULL_BEGIN
 
     NSDictionary *traceContext = nil;
     id<SentrySpan> span = nil;
-    
+
     if (self.span != nil) {
         @synchronized(_spanLock) {
             span = self.span;

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -465,9 +465,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     NSDictionary *traceContext = nil;
-    @synchronized(_spanLock) {
-        traceContext = [self buildTraceContext:_span];
+    id<SentrySpan> span = nil;
+    
+    if (self.span != nil) {
+        @synchronized(_spanLock) {
+            span = self.span;
+        }
     }
+    traceContext = [self buildTraceContext:span];
     serializedData[@"traceContext"] = traceContext;
 
     NSDictionary *context = [self context];
@@ -606,8 +611,6 @@ NS_ASSUME_NONNULL_BEGIN
         }
     }
 
-    // We don't need call synchronized(_spanLock) here because we get a copy of the span in the
-    // _spanLock above.
     newContext[@"trace"] = [self buildTraceContext:span];
 
     event.context = newContext;
@@ -619,9 +622,6 @@ NS_ASSUME_NONNULL_BEGIN
     [self.observers addObject:observer];
 }
 
-/**
- * Make sure to call this inside @c  synchronized(_spanLock) caus this method isn't thread safe.
- */
 - (NSDictionary *)buildTraceContext:(nullable id<SentrySpan>)span
 {
     if (span != nil) {


### PR DESCRIPTION


## :scroll: Description

Use a double checked lock for getting the span when building the trace context.

## :bulb: Motivation and Context

@armcknight found this.

## :green_heart: How did you test it?
Unit tests still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
