### PR TITLE
Feat: Add native SDK information in the replay option event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Add native SDK information in the replay option event ()
+
 ## 8.43.0-beta.1
 
 ### Improvements

--- a/Sources/Sentry/SentryMeta.m
+++ b/Sources/Sentry/SentryMeta.m
@@ -2,11 +2,20 @@
 
 @implementation SentryMeta
 
+
+const NSString * const sentryVersionString = @"8.43.0-beta.1";
+const NSString * const sentrySdkName = @"sentry.cocoa";
+
 // Don't remove the static keyword. If you do the compiler adds the constant name to the global
 // symbol table and it might clash with other constants. When keeping the static keyword the
 // compiler replaces all occurrences with the value.
-static NSString *versionString = @"8.43.0-beta.1";
-static NSString *sdkName = @"sentry.cocoa";
+static NSString *versionString;
+static NSString *sdkName;
+
++ (void)initialize {
+    versionString = sentryVersionString.copy;
+    sdkName = sentrySdkName.copy;
+}
 
 + (NSString *)versionString
 {
@@ -27,5 +36,14 @@ static NSString *sdkName = @"sentry.cocoa";
 {
     sdkName = value;
 }
+
++ (NSString*)nativeSdkName {
+    return sentrySdkName.copy;
+}
+
++ (NSString*)nativeVersionString {
+    return sentryVersionString.copy;
+}
+
 
 @end

--- a/Sources/Sentry/include/SentryMeta.h
+++ b/Sources/Sentry/include/SentryMeta.h
@@ -14,6 +14,21 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, class, copy) NSString *sdkName;
 
+/**
+ * Return a version string e.g: 1.2.3 (3)
+ * This always report the version of Sentry.cocoa,
+ * `versionString` can be changed by hybrid SDKs.
+ * We can use this property to get which version of Sentry cocoa
+ * the hybrid SDK is using.
+ */
+@property (nonatomic, class, readonly) NSString *nativeVersionString;
+
+/**
+ * Returns "sentry.cocoa"
+ * `sdkName` can be changed by hybrid SDKs.
+ */
+@property (nonatomic, class, readonly) NSString *nativeSdkName;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -16,3 +16,4 @@
 #import "SentryRandom.h"
 #import "SentrySdkInfo.h"
 #import "SentrySession.h"
+#import "SentryMeta.h"

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
@@ -12,7 +12,9 @@ import Foundation
                         "maskAllImages": options.maskAllImages,
                         "quality": String(describing: options.quality),
                         "maskedViewClasses": options.maskedViewClasses.map(String.init(describing: )).joined(separator: ", "),
-                        "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: )).joined(separator: ", ")
+                        "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: )).joined(separator: ", "),
+                        "nativeSdkName": SentryMeta.nativeSdkName,
+                        "nativeSdkVersion": SentryMeta.nativeVersionString,
                     ]
         )
     }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -428,6 +428,8 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertEqual(options["maskedViewClasses"] as? String, "")
         XCTAssertEqual(options["unmaskedViewClasses"] as? String, "")
         XCTAssertEqual(options["quality"] as? String, "medium")
+        XCTAssertEqual(options["nativeSdkName"] as? String, SentryMeta.nativeSdkName)
+        XCTAssertEqual(options["nativeSdkVersion"] as? String, SentryMeta.nativeVersionString)
     }
     
     func testOptionsInTheEventAllChanged() throws {


### PR DESCRIPTION
## :scroll: Description

Added cocoa name and version in the session replay options event for easy investigation.

## :green_heart: How did you test it?

Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
