### PR TITLE
fix: Remove empty session replay tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - Session replay GA (#4662)
 
+### Fixes
+
+- Remove empty session replay tags (#4667)
+
+
 ## 8.43.0-beta.1
 
 ### Improvements

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebOptionsEvent.swift
@@ -4,16 +4,22 @@ import Foundation
 @objc class SentryRRWebOptionsEvent: SentryRRWebCustomEvent {
     
     init(timestamp: Date, options: SentryReplayOptions) {
-        super.init(timestamp: timestamp, tag: "options", payload:
-                    [
-                        "sessionSampleRate": options.sessionSampleRate,
-                        "errorSampleRate": options.onErrorSampleRate,
-                        "maskAllText": options.maskAllText,
-                        "maskAllImages": options.maskAllImages,
-                        "quality": String(describing: options.quality),
-                        "maskedViewClasses": options.maskedViewClasses.map(String.init(describing: )).joined(separator: ", "),
-                        "unmaskedViewClasses": options.unmaskedViewClasses.map(String.init(describing: )).joined(separator: ", ")
-                    ]
-        )
+        var payload: [String: Any] = [
+            "sessionSampleRate": options.sessionSampleRate,
+            "errorSampleRate": options.onErrorSampleRate,
+            "maskAllText": options.maskAllText,
+            "maskAllImages": options.maskAllImages,
+            "quality": String(describing: options.quality)
+        ]
+        
+        if !options.maskedViewClasses.isEmpty {
+            payload["maskedViewClasses"] = options.maskedViewClasses.map(String.init(describing:)).joined(separator: ", ")
+        }
+        
+        if !options.unmaskedViewClasses.isEmpty {
+            payload["unmaskedViewClasses"] = options.unmaskedViewClasses.map(String.init(describing:)).joined(separator: ", ")
+        }
+        
+        super.init(timestamp: timestamp, tag: "options", payload: payload)
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -425,8 +425,8 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertEqual(options["errorSampleRate"] as? Float, 1)
         XCTAssertEqual(options["maskAllText"] as? Bool, true)
         XCTAssertEqual(options["maskAllImages"] as? Bool, true)
-        XCTAssertEqual(options["maskedViewClasses"] as? String, "")
-        XCTAssertEqual(options["unmaskedViewClasses"] as? String, "")
+        XCTAssertNil(options["maskedViewClasses"])
+        XCTAssertNil(options["unmaskedViewClasses"])
         XCTAssertEqual(options["quality"] as? String, "medium")
     }
     


### PR DESCRIPTION


## :scroll: Description

Don't add maskedViewClasses and unmaskedViewClasses when being empty.

## :bulb: Motivation and Context

Slightly improves the situation for https://github.com/getsentry/sentry-cocoa/issues/4666.

## :green_heart: How did you test it?

Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
