### PR TITLE
fix: add variable escaping in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ init:
 	which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	brew bundle
 	pre-commit install
-	clang-format --version | awk '{print $3}' > scripts/.clang-format-version
+	clang-format --version | awk '{print $$3}' > scripts/.clang-format-version
 	swiftlint version > scripts/.swiftlint-version
 	
 # installs the tools needed to test various CI tasks locally


### PR DESCRIPTION
## :scroll: Description

Fixes the variable escaping of `awk` in the Makefile

## :bulb: Motivation and Context

Running `make init` 

## :green_heart: How did you test it?

1. Run `make init` without the changes
2. File `.clang-format-version` contains `clang-format version 19.1.6`
3. Applying changes of PR
4. Run `make init` again
5. File `.clang-format-version` contains `19.1.6`

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog