### PR TITLE
Changelog for 8.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,24 @@
 ### Features
 
 - Session replay GA (#4662)
+- Show session replay options as replay tags (#4639)
 
 ### Fixes
 
 - Remove empty session replay tags (#4667)
+- - `SentrySdkInfo.packages` should be an array (#4626)
+- Use the same SdkInfo for envelope header and event (#4629)
 
+### Improvements
+
+- Improve compiler error message for missing Swift declarations due to APPLICATION_EXTENSION_API_ONLY (#4603)
+- Mask screenshots for errors (#4623)
+- Slightly speed up serializing scope (#4661)
+
+### Internal
+
+- Remove loading `integrations` names from `event.extra` (#4627)
+- Add Hybrid SDKs API to add extra SDK packages (#4637)
 
 ## 8.43.0-beta.1
 


### PR DESCRIPTION
Copy 8.43.0-beta.1 entries to the unreleased section for releasing 8.43.0.

#skip-changelog
