### PR TITLE
docs: add breaking changes warning for session replay options to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+> [!WARNING]
+> This release contains breaking changes, as the options for Session Replay have been moved from `options.experimental.sessionReplay` to `options.sessionReplay`.
+
 - Session replay GA (#4662)
 - Show session replay options as replay tags (#4639)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 8.43.0
 
 > [!WARNING]
-> This release contains breaking changes, as the options for Session Replay have been moved from `options.experimental.sessionReplay` to `options.sessionReplay`.
+> This release contains a breaking change for the previously experimental session replay options. We moved the options from Session from `options.experimental.sessionReplay` to `options.sessionReplay`.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## 8.43.0
 
-### Features
-
 > [!WARNING]
 > This release contains breaking changes, as the options for Session Replay have been moved from `options.experimental.sessionReplay` to `options.sessionReplay`.
+
+### Features
 
 - Session replay GA (#4662)
 - Show session replay options as replay tags (#4639)


### PR DESCRIPTION
## :scroll: Description

With the GA of Session Replay we introduced a breaking change in the Sentry options by moving the session replay options from `experimental` to the root config. This adds a warning to the changelog.

## :bulb: Motivation and Context

We accepted the breaking change, as it also indicates to SDK users, that the feature is now in GA.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

- [ ] Manually add the note to the GitHub release v8.34.0