### PR TITLE
chore: update to Xcode 16.2 in workflows

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -81,7 +81,7 @@ jobs:
 
   run-ui-tests-with-sauce:
     name: Run benchmarks on Sauce Labs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     needs: build-benchmark-test-target
     strategy:
       fail-fast: false

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -81,7 +81,7 @@ jobs:
 
   run-ui-tests-with-sauce:
     name: Run benchmarks on Sauce Labs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build-benchmark-test-target
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,9 @@ jobs:
           - scheme: watchOS-Swift WatchKit App
             xcode: 15.4
             runs-on: macos-14
-          # Only compiles on Xcode 16.0
+          # Only compiles on Xcode 16+
           - scheme: macOS-SwiftUI
-            xcode: 16.0
+            xcode: 16.2
             runs-on: macos-15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,8 +95,8 @@ jobs:
           # iOS 18
           - runs-on: macos-15
             platform: "iOS"
-            xcode: "16.1"
-            test-destination-os: "18.1"
+            xcode: "16.2"
+            test-destination-os: "18.2"
             device: "iPhone 16"
 
           # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
@@ -112,7 +112,7 @@ jobs:
           # macOS 15
           - runs-on: macos-15
             platform: "macOS"
-            xcode: "16.1"
+            xcode: "16.2"
             test-destination-os: "latest"
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
@@ -125,7 +125,7 @@ jobs:
 
           - runs-on: macos-15
             platform: "Catalyst"
-            xcode: "16.1"
+            xcode: "16.2"
             test-destination-os: "latest"
 
           # We don't run the unit tests on tvOS 16 cause we run them on all on GH actions available iOS versions.
@@ -141,7 +141,7 @@ jobs:
           # tvOS 18
           - runs-on: macos-15
             platform: "tvOS"
-            xcode: "16.1"
+            xcode: "16.2"
             test-destination-os: "18.1"
 
     steps:

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh "16.0"
+      - run: ./scripts/ci-select-xcode.sh "16.2"
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -59,9 +59,9 @@ jobs:
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           - runs-on: macos-15
-            xcode: "16"
+            xcode: "16.2"
             device: "iPhone 16"
-            os-version: "18.0"
+            os-version: "18.2"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh "16.0"
+      - run: ./scripts/ci-select-xcode.sh "16.2"
       - name: Run Fastlane
         run: fastlane ui_tests_ios_swift6
 
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh "16.0"
+      - run: ./scripts/ci-select-xcode.sh "16.2"
       - run: ./scripts/build-xcframework.sh gameOnly
       - name: Run Fastlane
         run: fastlane duplication_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Internal
+
+- Update to Xcode 16.2 in workflows (#4673)
+
 ## 8.43.0
 
 > [!WARNING]


### PR DESCRIPTION
## :scroll: Description

Changes workflows to use Xcode 16.2 when using the macOS 15 GitHub Actions runner image.

## :bulb: Motivation and Context

https://github.blog/changelog/2025-01-02-actions-xcode-16-2-will-replace-xcode-16-0-in-macos-14-images/

## :green_heart: How did you test it?

Created the PR and waited for checks to pass.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

_none_