### PR TITLE
feat: add threshold to always log fatal logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add protocol for custom screenName for UIViewControllers (#4646)
+- Add threshold to always log fatal logs (#4707)
 
 ## 8.43.1-beta.0
 

--- a/Sources/Swift/Tools/SentryLog.swift
+++ b/Sources/Swift/Tools/SentryLog.swift
@@ -8,7 +8,7 @@ class SentryLog: NSObject {
     static private(set) var diagnosticLevel = SentryLevel.error
 
     /**
-     * The log level that will always be logged, regardless of the current configuration
+     * Threshold log level to always log, regardless of the current configuration
      */
     static let alwaysLevel = SentryLevel.fatal
     private static var logOutput = SentryLogOutput()

--- a/Sources/Swift/Tools/SentryLog.swift
+++ b/Sources/Swift/Tools/SentryLog.swift
@@ -6,6 +6,11 @@ class SentryLog: NSObject {
     
     static private(set) var isDebug = true
     static private(set) var diagnosticLevel = SentryLevel.error
+
+    /**
+     * The log level that will always be logged, regardless of the current configuration
+     */
+    static let alwaysLevel = SentryLevel.fatal
     private static var logOutput = SentryLogOutput()
     private static var logConfigureLock = NSLock()
 
@@ -30,7 +35,13 @@ class SentryLog: NSObject {
      */
     @objc
     static func willLog(atLevel level: SentryLevel) -> Bool {
-        return isDebug && level != .none && level.rawValue >= diagnosticLevel.rawValue
+        if level == .none {
+            return false
+        }
+        if level.rawValue >= alwaysLevel.rawValue {
+            return true
+        }
+        return isDebug && level.rawValue >= diagnosticLevel.rawValue
     }
  
     #if TEST || TESTCI

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -37,19 +37,23 @@ class SentryLogTests: XCTestCase {
         SentryLog.log(message: "0", andLevel: SentryLevel.error)
     }
     
-    func testConfigureWithoutDebug_PrintsNothing() {
+    func testConfigureWithoutDebug_PrintsOnlyAlwaysThreshold() {
+        // -- Arrange --
         let logOutput = TestLogOutput()
         SentryLog.setLogOutput(logOutput)
-        
+
+        // -- Act --
         SentryLog.configure(false, diagnosticLevel: SentryLevel.none)
-        SentryLog.log(message: "0", andLevel: SentryLevel.fatal)
-        SentryLog.log(message: "0", andLevel: SentryLevel.error)
-        SentryLog.log(message: "0", andLevel: SentryLevel.warning)
-        SentryLog.log(message: "0", andLevel: SentryLevel.info)
-        SentryLog.log(message: "0", andLevel: SentryLevel.debug)
-        SentryLog.log(message: "0", andLevel: SentryLevel.none)
-        
-        XCTAssertEqual(0, logOutput.loggedMessages.count)
+        SentryLog.log(message: "fatal", andLevel: SentryLevel.fatal)
+        SentryLog.log(message: "error", andLevel: SentryLevel.error)
+        SentryLog.log(message: "warning", andLevel: SentryLevel.warning)
+        SentryLog.log(message: "info", andLevel: SentryLevel.info)
+        SentryLog.log(message: "debug", andLevel: SentryLevel.debug)
+        SentryLog.log(message: "none", andLevel: SentryLevel.none)
+
+        // -- Assert --
+        XCTAssertEqual(1, logOutput.loggedMessages.count)
+        XCTAssertEqual("[Sentry] [fatal] fatal", logOutput.loggedMessages.first)
     }
     
     func testLevelNone_PrintsEverythingExceptNone() {


### PR DESCRIPTION
## :scroll: Description

Introduces a new constant in `SentryLog` to configure a log level that will always be logged.

## :bulb: Motivation and Context

Closes #4467

## :green_heart: How did you test it?

I added a statement `SENTRY_LOG_FATAL(@"test")` in the SDK install code and checked if it gets printed.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

_none_