### PR TITLE
chore(ci): add beautified logging to build-xcframework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ analyze:
 # For more info check out: https://github.com/Carthage/Carthage/releases/tag/0.38.0
 build-xcframework:
 	@echo "--> Carthage: creating Sentry xcframework"
-	./scripts/build-xcframework.sh > build-xcframework.log
+	./scripts/build-xcframework.sh | tee build-xcframework.log
 # use ditto here to avoid clobbering symlinks which exist in macOS frameworks
 	ditto -c -k -X --rsrc --keepParent Carthage/Sentry.xcframework Carthage/Sentry.xcframework.zip
 	ditto -c -k -X --rsrc --keepParent Carthage/Sentry-Dynamic.xcframework Carthage/Sentry-Dynamic.xcframework.zip

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -46,7 +46,7 @@ generate_xcframework() {
                 OTHER_LDFLAGS="-Wl,-make_mergeable"
             fi
 
-            xcodebuild archive \
+            set -o pipefail && NSUnbufferedIO=YES xcodebuild archive \
                 -project Sentry.xcodeproj/ \
                 -scheme "$scheme" \
                 -configuration "$resolved_configuration" \
@@ -59,7 +59,7 @@ generate_xcframework() {
                 MACH_O_TYPE="$MACH_O_TYPE" \
                 ENABLE_CODE_COVERAGE=NO \
                 GCC_GENERATE_DEBUGGING_SYMBOLS="$GCC_GENERATE_DEBUGGING_SYMBOLS" \
-                OTHER_LDFLAGS="$OTHER_LDFLAGS"
+                OTHER_LDFLAGS="$OTHER_LDFLAGS" 2>&1 | xcbeautify --preserve-unbeautified
                  
             createxcframework+="-framework Carthage/archive/${scheme}${suffix}/${sdk}.xcarchive/Products/Library/Frameworks/${resolved_product_name}.framework "
 
@@ -91,7 +91,7 @@ generate_xcframework() {
 
     if [ "$args" != "iOSOnly" ]; then
         #Create framework for mac catalyst
-        xcodebuild \
+        set -o pipefail && NSUnbufferedIO=YES xcodebuild \
             -project Sentry.xcodeproj/ \
             -scheme "$scheme" \
             -configuration "$resolved_configuration" \
@@ -105,7 +105,7 @@ generate_xcframework() {
             SUPPORTS_MACCATALYST=YES \
             ENABLE_CODE_COVERAGE=NO \
             GCC_GENERATE_DEBUGGING_SYMBOLS="$GCC_GENERATE_DEBUGGING_SYMBOLS" \
-            OTHER_LDFLAGS="$OTHER_LDFLAGS"
+            OTHER_LDFLAGS="$OTHER_LDFLAGS" 2>&1 | xcbeautify --preserve-unbeautified
 
         if [ "$MACH_O_TYPE" = "staticlib" ]; then
             local infoPlist="Carthage/DerivedData/Build/Products/$resolved_configuration-maccatalyst/${scheme}.framework/Resources/Info.plist"


### PR DESCRIPTION
## :scroll: Description

Adds log beautifying for xcodebuild used in the build-xcframework.sh

## :bulb: Motivation and Context

The current CI workflow does not output any logs making it hard to debug when it fails.
It does upload the log on failure, but only the raw xcodebuild.
With this PR the xcodebuild output is beautified, while still being written to the disk.

I added the option `--preserve-unbeautified` to include lines which are not supported by xcbeautify.

## :green_heart: How did you test it?

Used it in #4605 to find archive issues.

https://github.com/getsentry/sentry-cocoa/actions/runs/12764139525/job/35575694591?pr=4605

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog