### PR TITLE
refactor(tests): Change database file name in CoreData tests to unique names

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -6,13 +6,19 @@ import XCTest
 class SentryCoreDataTrackerTests: XCTestCase {
     
     private class Fixture {
-        let coreDataStack = TestCoreDataStack()
+        let coreDataStack: TestCoreDataStack
         lazy var context: TestNSManagedObjectContext = {
             coreDataStack.managedObjectContext
         }()
         let threadInspector = TestThreadInspector.instance
         let imageProvider = TestDebugImageProvider()
-        
+
+        init(testName: String) {
+            coreDataStack = TestCoreDataStack(
+                databaseFilename: "db-\(testName.hashValue).sqlite"
+            )
+        }
+
         func getSut() -> SentryCoreDataTracker {
             imageProvider.debugImages = [TestData.debugImage]
             SentryDependencyContainer.sharedInstance().debugImageProvider = imageProvider
@@ -35,13 +41,17 @@ class SentryCoreDataTrackerTests: XCTestCase {
             entityDescription.name = "SecondTestEntity"
             return SecondTestEntity(entity: entityDescription, insertInto: context)
         }
+
+        var databaseFilename: String {
+            coreDataStack.databaseFilename
+        }
     }
     
     private var fixture: Fixture!
     
     override func setUp() {
         super.setUp()
-        fixture = Fixture()
+        fixture = Fixture(testName: self.name)
     }
     
     override func tearDown() {
@@ -51,14 +61,23 @@ class SentryCoreDataTrackerTests: XCTestCase {
     
     func testFetchRequest() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
-        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity'")
+        try assertRequest(
+            fetch,
+            expectedDescription: "SELECT 'TestEntity'",
+            databaseFilename: fixture.databaseFilename
+        )
     }
 
     func testFetchRequestBackgroundThread() {
         let expect = expectation(description: "Operation in background thread")
         DispatchQueue.global(qos: .default).async {
             let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
-            try? self.assertRequest(fetch, expectedDescription: "SELECT 'TestEntity'", mainThread: false)
+            try? self.assertRequest(
+                fetch,
+                expectedDescription: "SELECT 'TestEntity'",
+                mainThread: false,
+                databaseFilename: self.fixture.databaseFilename
+            )
             expect.fulfill()
         }
 
@@ -68,44 +87,48 @@ class SentryCoreDataTrackerTests: XCTestCase {
     func test_FetchRequest_WithPredicate() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         fetch.predicate = NSPredicate(format: "field1 = %@ and field2 = %@", argumentArray: ["First Argument", 2])
-        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' WHERE field1 == %@ AND field2 == %@")
+        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' WHERE field1 == %@ AND field2 == %@", databaseFilename: fixture.databaseFilename)
     }
     
     func test_FetchRequest_WithSortAscending() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         fetch.sortDescriptors = [NSSortDescriptor(key: "field1", ascending: true)]
-        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' SORT BY field1")
+        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' SORT BY field1", databaseFilename: fixture.databaseFilename)
     }
     
     func test_FetchRequest_WithSortDescending() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         fetch.sortDescriptors = [NSSortDescriptor(key: "field1", ascending: false)]
-        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' SORT BY field1 DESCENDING")
+        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' SORT BY field1 DESCENDING", databaseFilename: fixture.databaseFilename)
     }
     
     func test_FetchRequest_WithSortTwoFields() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         fetch.sortDescriptors = [NSSortDescriptor(key: "field1", ascending: false), NSSortDescriptor(key: "field2", ascending: true)]
-        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' SORT BY field1 DESCENDING, field2")
+        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' SORT BY field1 DESCENDING, field2", databaseFilename: fixture.databaseFilename)
     }
     
     func test_FetchRequest_WithPredicateAndSort() throws {
         let fetch = NSFetchRequest<TestEntity>(entityName: "TestEntity")
         fetch.predicate = NSPredicate(format: "field1 = %@", argumentArray: ["First Argument"])
         fetch.sortDescriptors = [NSSortDescriptor(key: "field1", ascending: false)]
-        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' WHERE field1 == %@ SORT BY field1 DESCENDING")
+        try assertRequest(fetch, expectedDescription: "SELECT 'TestEntity' WHERE field1 == %@ SORT BY field1 DESCENDING", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_1Insert_1Entity() throws {
         fixture.context.inserted = [fixture.testEntity()]
-        try assertSave("INSERTED 1 'TestEntity'")
+        try assertSave("INSERTED 1 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
 
     func testSaveBackgroundThread() {
         let expect = expectation(description: "Operation in background thread")
         DispatchQueue.global(qos: .default).async {
             self.fixture.context.inserted = [self.fixture.testEntity()]
-            try? self.assertSave("INSERTED 1 'TestEntity'", mainThread: false)
+            try? self.assertSave(
+                "INSERTED 1 'TestEntity'",
+                mainThread: false,
+                databaseFilename: self.fixture.databaseFilename
+            )
             expect.fulfill()
         }
 
@@ -114,56 +137,56 @@ class SentryCoreDataTrackerTests: XCTestCase {
     
     func test_Save_2Insert_1Entity() throws {
         fixture.context.inserted = [fixture.testEntity(), fixture.testEntity()]
-        try assertSave("INSERTED 2 'TestEntity'")
+        try assertSave("INSERTED 2 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_2Insert_2Entity() throws {
         fixture.context.inserted = [fixture.testEntity(), fixture.secondTestEntity()]
-        try assertSave("INSERTED 2 items")
+        try assertSave("INSERTED 2 items", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_1Update_1Entity() throws {
         fixture.context.updated = [fixture.testEntity()]
-        try assertSave("UPDATED 1 'TestEntity'")
+        try assertSave("UPDATED 1 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_2Update_1Entity() throws {
         fixture.context.updated = [fixture.testEntity(), fixture.testEntity()]
-        try assertSave("UPDATED 2 'TestEntity'")
+        try assertSave("UPDATED 2 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_2Update_2Entity() throws {
         fixture.context.updated = [fixture.testEntity(), fixture.secondTestEntity()]
-        try assertSave("UPDATED 2 items")
+        try assertSave("UPDATED 2 items", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_1Delete_1Entity() throws {
         fixture.context.deleted = [fixture.testEntity()]
-        try assertSave("DELETED 1 'TestEntity'")
+        try assertSave("DELETED 1 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_2Delete_1Entity() throws {
         fixture.context.deleted = [fixture.testEntity(), fixture.testEntity()]
-        try assertSave("DELETED 2 'TestEntity'")
+        try assertSave("DELETED 2 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_2Delete_2Entity() throws {
         fixture.context.deleted = [fixture.testEntity(), fixture.secondTestEntity()]
-        try assertSave("DELETED 2 items")
+        try assertSave("DELETED 2 items", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_Insert_Update_Delete_1Entity() throws {
         fixture.context.inserted = [fixture.testEntity()]
         fixture.context.updated = [fixture.testEntity()]
         fixture.context.deleted = [fixture.testEntity()]
-        try assertSave("INSERTED 1 'TestEntity', UPDATED 1 'TestEntity', DELETED 1 'TestEntity'")
+        try assertSave("INSERTED 1 'TestEntity', UPDATED 1 'TestEntity', DELETED 1 'TestEntity'", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Save_Insert_Update_Delete_2Entity() throws {
         fixture.context.inserted = [fixture.testEntity(), fixture.secondTestEntity()]
         fixture.context.updated = [fixture.testEntity(), fixture.secondTestEntity()]
         fixture.context.deleted = [fixture.testEntity(), fixture.secondTestEntity()]
-        try assertSave("INSERTED 2 items, UPDATED 2 items, DELETED 2 items")
+        try assertSave("INSERTED 2 items, UPDATED 2 items, DELETED 2 items", databaseFilename: fixture.databaseFilename)
     }
     
     func test_Operation_InData() throws {
@@ -291,14 +314,14 @@ class SentryCoreDataTrackerTests: XCTestCase {
 
 private extension SentryCoreDataTrackerTests {
 
-    func assertSave(_ expectedDescription: String, mainThread: Bool = true) throws {
+    func assertSave(_ expectedDescription: String, mainThread: Bool = true, databaseFilename: String, file: StaticString = #file, line: UInt = #line) throws {
         let sut = fixture.getSut()
         
         let transaction = try startTransaction()
         
         XCTAssertNoThrow(try sut.managedObjectContext(fixture.context) { _ in
             return true
-        })
+        }, file: file, line: line)
 
         let dbSpan = try XCTUnwrap(transaction.children.first)
         
@@ -306,11 +329,14 @@ private extension SentryCoreDataTrackerTests {
             dbSpan: dbSpan,
             expectedOperation: SentrySpanOperation.coredataSaveOperation,
             expectedDescription: expectedDescription,
-            mainThread: mainThread
+            mainThread: mainThread,
+            databaseFilename: databaseFilename,
+            file: file,
+            line: line
         )
     }
     
-    func assertRequest(_ fetch: NSFetchRequest<TestEntity>, expectedDescription: String, mainThread: Bool = true) throws {
+    func assertRequest(_ fetch: NSFetchRequest<TestEntity>, expectedDescription: String, mainThread: Bool = true, databaseFilename: String, file: StaticString = #file, line: UInt = #line) throws {
         let transaction = try startTransaction()
         let sut = fixture.getSut()
         
@@ -322,36 +348,39 @@ private extension SentryCoreDataTrackerTests {
             return [someEntity]
         }
 
-        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.count, 1, file: file, line: line)
 
-        let dbSpan = try XCTUnwrap(transaction.children.first)
-        XCTAssertEqual(dbSpan.data["read_count"] as? Int, 1)
+        let dbSpan = try XCTUnwrap(transaction.children.first, file: file, line: line)
+        XCTAssertEqual(dbSpan.data["read_count"] as? Int, 1, file: file, line: line)
 
         assertDataAndFrames(
             dbSpan: dbSpan,
             expectedOperation: SentrySpanOperation.coredataFetchOperation,
             expectedDescription: expectedDescription,
-            mainThread: mainThread
+            mainThread: mainThread,
+            databaseFilename: databaseFilename,
+            file: file,
+            line: line
         )
     }
 
-    func assertDataAndFrames(dbSpan: Span, expectedOperation: String, expectedDescription: String, mainThread: Bool) {
-        XCTAssertEqual(dbSpan.operation, expectedOperation)
-        XCTAssertEqual(dbSpan.origin, "auto.db.core_data")
-        XCTAssertEqual(dbSpan.spanDescription, expectedDescription)
-        XCTAssertEqual(dbSpan.data["blocked_main_thread"] as? Bool ?? false, mainThread)
-        XCTAssertEqual(try XCTUnwrap(dbSpan.data["db.system"] as? String), "SQLite")
-        XCTAssert(try XCTUnwrap(dbSpan.data["db.name"] as? NSString).contains(TestCoreDataStack.databaseFilename))
+    func assertDataAndFrames(dbSpan: Span, expectedOperation: String, expectedDescription: String, mainThread: Bool, databaseFilename: String, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(dbSpan.operation, expectedOperation, file: file, line: line)
+        XCTAssertEqual(dbSpan.origin, "auto.db.core_data", file: file, line: line)
+        XCTAssertEqual(dbSpan.spanDescription, expectedDescription, file: file, line: line)
+        XCTAssertEqual(dbSpan.data["blocked_main_thread"] as? Bool ?? false, mainThread, file: file, line: line)
+        XCTAssertEqual(try XCTUnwrap(dbSpan.data["db.system"] as? String), "SQLite", file: file, line: line)
+        XCTAssert(try XCTUnwrap(dbSpan.data["db.name"] as? NSString).contains(databaseFilename), file: file, line: line)
 
         if mainThread {
             guard let frames = (dbSpan as? SentrySpan)?.frames else {
-                XCTFail("File IO Span in the main thread has no frames")
+                XCTFail("File IO Span in the main thread has no frames", file: file, line: line)
                 return
             }
-            XCTAssertEqual(frames.first, TestData.mainFrame)
-            XCTAssertEqual(frames.last, TestData.testFrame)
+            XCTAssertEqual(frames.first, TestData.mainFrame, file: file, line: line)
+            XCTAssertEqual(frames.last, TestData.testFrame, file: file, line: line)
         } else {
-            XCTAssertNil((dbSpan as? SentrySpan)?.frames)
+            XCTAssertNil((dbSpan as? SentrySpan)?.frames, file: file, line: line)
         }
     }
     

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -7,9 +7,10 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
     private class Fixture {
         let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         let options: Options
-        let coreDataStack = TestCoreDataStack()
-        
-        init() {
+        let coreDataStack: TestCoreDataStack
+
+        init(testName: String) {
+            coreDataStack = TestCoreDataStack(databaseFilename: "db-\(testName.hashValue).sqlite")
             options = Options()
             options.enableCoreDataTracing = true
             options.tracesSampleRate = 1
@@ -25,7 +26,7 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
     
     override func setUp() {
         super.setUp()
-        fixture = Fixture()
+        fixture = Fixture(testName: self.name)
     }
     
     override func tearDown() {
@@ -108,12 +109,12 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(transaction.children.count, 0)
     }
     
-    private func assert_DontInstall(_ confOptions: ((Options) -> Void)) {
+    private func assert_DontInstall(_ confOptions: ((Options) -> Void), file: StaticString = #file, line: UInt = #line) {
         let sut = fixture.getSut()
         confOptions(fixture.options)
-        XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.coreDataTracker)
+        XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.coreDataTracker, file: file, line: line)
         sut.install(with: fixture.options)
-        XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.coreDataTracker)
+        XCTAssertNil(SentryCoreDataSwizzling.sharedInstance.coreDataTracker, file: file, line: line)
     }
     
     private func startTransaction() throws -> SentryTracer {

--- a/Tests/SentryTests/Integrations/Performance/CoreData/TestCoreDataStack.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/TestCoreDataStack.swift
@@ -22,7 +22,9 @@ public class SecondTestEntity: NSManagedObject {
 }
 
 class TestCoreDataStack {
-    
+
+    let databaseFilename: String
+
     lazy var managedObjectModel: NSManagedObjectModel = {
         let model = NSManagedObjectModel()
         
@@ -57,32 +59,34 @@ class TestCoreDataStack {
         return model
     }()
 
-    static let databaseFilename = "SingleViewCoreData.sqlite"
-
     lazy var persistentStoreCoordinator: NSPersistentStoreCoordinator? = {
         guard let tempDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else { return nil }
-        
+
         if !FileManager.default.fileExists(atPath: tempDir.path) {
             try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true, attributes: nil)
         }
-            
+
         let coordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
-        let url = tempDir.appendingPathComponent(TestCoreDataStack.databaseFilename)
-        
+        let url = tempDir.appendingPathComponent(databaseFilename)
+
         let _ = try? coordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: url, options: nil)
-        
+
         return coordinator
     }()
-    
+
     lazy var managedObjectContext: TestNSManagedObjectContext = {
         var managedObjectContext = TestNSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         managedObjectContext.persistentStoreCoordinator = self.persistentStoreCoordinator
         return managedObjectContext
     }()
-    
+
+    init(databaseFilename: String) {
+        self.databaseFilename = databaseFilename
+    }
+
     func reset() {
         guard let tempDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first else { return }
-        let url = tempDir.appendingPathComponent(TestCoreDataStack.databaseFilename)
+        let url = tempDir.appendingPathComponent(databaseFilename)
         try? FileManager.default.removeItem(at: url)
     }
     


### PR DESCRIPTION
## :scroll: Description

Uses unique CoreData database names in unit tests

## :bulb: Motivation and Context

The current test outputs are quite noisy, mostly due to xcrun noticing issues with the test databases. See [this workflow run](https://github.com/getsentry/sentry-cocoa/actions/runs/12883706329) as an example:

- Unit iOS - Xcode 16.2 - OS 18.2 Sentry: CoreData#L1
  ```
  (1) I/O error for database at /Users/runner/Library/Developer/CoreSimulator/Devices/2123042C-07F7-46F2-8016-FEC3B637C16C/data/Library/Caches/SingleViewCoreData.sqlite. SQLite error code:1, 'cannot rollback - no transaction is active
  ```
- Unit iOS - Xcode 16.2 - OS 18.2 Sentry: CoreData#L1
  ```
  Encountered exception I/O error for database at /Users/runner/Library/Developer/CoreSimulator/Devices/2123042C-07F7-46F2-8016-FEC3B637C16C/data/Library/Caches/SingleViewCoreData.sqlite. SQLite error code:1, 'cannot rollback - no transaction is active' with userInfo
  ```

...and many more.

I believe the issue to be caused by background management of CoreData, which is abruptly terminated when the test case finishes and cleanup is triggered.

This PR applies the following changes:

- Use the test name (`self.name` in `setUp`) to create a unique hash used as the database name
- Add `file: StaticString = #file, line: UInt = #line` to assert methods to propagate `XCTAssert...` assertions to the test methods.
 
## :green_heart: How did you test it?

- Run `SentryCoreDataTrackingIntegrationTests` locally without changes, check output for "Encountered exception I/O error" (tests will pass)
- Apply changes
- Run tests again, tests still pass, less errors in output
- 
## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog