### PR TITLE
refactor(tests): Change example binary message errors to silent version

### DIFF
--- a/Tests/Resources/fatal-error-binary-images-iphone.json
+++ b/Tests/Resources/fatal-error-binary-images-iphone.json
@@ -3354,7 +3354,7 @@
             "major_version": 1300,
             "minor_version": 0,
             "revision_version": 46,
-            "crash_info_message": "iOS_Swift/ViewController.swift:53: Fatal error: Hello fatal\n"
+            "crash_info_message": "iOS_Swift/ViewController.swift:53: FatalX error: Hello fatal\n"
         },
         {
             "image_addr": 6855647232,

--- a/Tests/Resources/fatal-error-binary-images-message2.json
+++ b/Tests/Resources/fatal-error-binary-images-message2.json
@@ -126,7 +126,7 @@
             "major_version": 1300,
             "minor_version": 0,
             "revision_version": 46,
-            "crash_info_message2": "iOS_Swift/ViewController.swift:53: Fatal error: Hello fatal\n"
+            "crash_info_message2": "iOS_Swift/ViewController.swift:53: FatalX error: Hello fatal\n"
         },
         {
             "image_addr": 4541874176,

--- a/Tests/Resources/fatal-error-binary-images-simulator.json
+++ b/Tests/Resources/fatal-error-binary-images-simulator.json
@@ -126,7 +126,7 @@
             "major_version": 1300,
             "minor_version": 0,
             "revision_version": 46,
-            "crash_info_message": "iOS_Swift/ViewController.swift:53: Fatal error: Hello fatal\n"
+            "crash_info_message": "iOS_Swift/ViewController.swift:53: FatalX error: Hello fatal\n"
         },
         {
             "image_addr": 4541874176,

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -169,7 +169,7 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         
         assertSpans(1, "file.read") {
             let data = try? NSData(contentsOfFile: jsonFile, options: .uncached)
-            XCTAssertEqual(data?.count, 341_431)
+            XCTAssertEqual(data?.count, 341_432)
         }
     }
     
@@ -191,7 +191,7 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
 
             let size = try? fixture.fileURL.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
             
-            XCTAssertEqual(size, 341_431)
+            XCTAssertEqual(size, 341_432)
         }
     }
     

--- a/Tests/SentryTests/SentryKSCrashReportConverterTests.m
+++ b/Tests/SentryTests/SentryKSCrashReportConverterTests.m
@@ -306,7 +306,7 @@
 - (void)testFatalErrorBinaryiPhone
 {
     [self testFatalErrorBinary:@"Resources/fatal-error-binary-images-iphone"
-                 expectedValue:@"iOS_Swift/ViewController.swift:53: Fatal error: Hello fatal\n"];
+                 expectedValue:@"iOS_Swift/ViewController.swift:53: FatalX error: Hello fatal\n"];
 }
 
 - (void)testFatalErrorBinaryMac
@@ -318,13 +318,13 @@
 - (void)testFatalErrorBinarySimulator
 {
     [self testFatalErrorBinary:@"Resources/fatal-error-binary-images-simulator"
-                 expectedValue:@"iOS_Swift/ViewController.swift:53: Fatal error: Hello fatal\n"];
+                 expectedValue:@"iOS_Swift/ViewController.swift:53: FatalX error: Hello fatal\n"];
 }
 
 - (void)testFatalErrorBinaryMessage2
 {
     [self testFatalErrorBinary:@"Resources/fatal-error-binary-images-message2"
-                 expectedValue:@"iOS_Swift/ViewController.swift:53: Fatal error: Hello fatal\n"];
+                 expectedValue:@"iOS_Swift/ViewController.swift:53: FatalX error: Hello fatal\n"];
 }
 
 - (void)testFatalErrorBinary:(NSString *)reportPath expectedValue:(NSString *)expectedValue


### PR DESCRIPTION
## :scroll: Description

Change the example errors `fatal error: Hello fatal\n` to `fatalX error: Hello fatal\n` to stop xcbeautify from parsing it as fatal error messages.

## :bulb: Motivation and Context

`xcbeautify` uses a regex to capture fatal errors in the log:

https://github.com/cpisciotta/xcbeautify/blob/87008cd2c78f7cd8735e573fa93912d4ac67f9e3/Sources/XcbeautifyLib/CaptureGroups.swift#L1543

This regex also picks up the crash converter examples:

https://github.com/getsentry/sentry-cocoa/blob/9f579537c70270d5a228bbb3bf7275161911d5eb/Tests/SentryTests/SentryKSCrashReportConverterTests.m#L309

This leads to a lot of false-positive errors logged as GitHub Action annotations:

https://github.com/getsentry/sentry-cocoa/actions/runs/12884509686

Changing the keyword `fatal` to something else, silents the logging, without changing the test case itself.

## :green_heart: How did you test it?

Need to check if CI passes

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog