### PR TITLE
test: Increase timeout for ANRV1 tests

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -9,7 +9,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
     private var fixture: Fixture!
     private var anrDetectedExpectation: XCTestExpectation!
     private var anrStoppedExpectation: XCTestExpectation!
-    private let waitTimeout: TimeInterval = 1.0
+    private let waitTimeout: TimeInterval = 2.0
     
     private class Fixture {
         let timeoutInterval: TimeInterval = 5


### PR DESCRIPTION
Increase the timeout for ANRTrackerV1 tests from 1.0 to 2.0, cause they timed out here https://github.com/getsentry/sentry-cocoa/actions/runs/12886410167/job/35926973742.

2.0 is still OK. If they still are flaky we need to disable them.

#skip-changelog