### PR TITLE
feat: Session replay masking preview for SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Features
 
 - Add `showMaskPreview` to `SentrySDK.replay` api to debug replay masking (#4761)
+- Session replay masking preview for SwiftUI (#4737)
 
 ## 8.44.0-beta.1
 

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
@@ -238,16 +238,10 @@ struct ContentView: View {
 
                     Text(TTDInfo)
                         .accessibilityIdentifier("TTDInfo")
-                    
-                    TextField("DAE", text: $dae)
-                        .background(Color.red)
-                    TextField("Ola", text: $dae).sentryReplayUnmask()
                 }
             }
         }
     }
-    
-    @State var dae: String = ""
 }
 
 struct SecondView: View {

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
@@ -137,7 +137,7 @@ struct ContentView: View {
 
         return DataBag.shared.info["lastSpan"] as? Span
     }
-    
+ 
     var body: some View {
         return SentryTracedView("Content View Body", waitForFullDisplay: true) {
             NavigationView {
@@ -235,13 +235,19 @@ struct ContentView: View {
                         .background(Color.white)
                     }
                     SecondView()
-                    
+
                     Text(TTDInfo)
                         .accessibilityIdentifier("TTDInfo")
+                    
+                    TextField("DAE", text: $dae)
+                        .background(Color.red)
+                    TextField("Ola", text: $dae).sentryReplayUnmask()
                 }
             }
         }
     }
+    
+    @State var dae: String = ""
 }
 
 struct SecondView: View {
@@ -255,5 +261,6 @@ struct SecondView: View {
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         ContentView()
+            .sentryReplayPreviewMask(opacity: 0.3)
     }
 }

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -874,6 +874,9 @@
 		D867063F27C3BC2400048851 /* SentryCoreDataTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = D867063C27C3BC2400048851 /* SentryCoreDataTracker.h */; };
 		D86B6835294348A400B8B1FC /* SentryAttachment+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = D86B6834294348A400B8B1FC /* SentryAttachment+Private.h */; };
 		D86F419827C8FEFA00490520 /* SentryCoreDataTrackerExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86F419727C8FEFA00490520 /* SentryCoreDataTrackerExtension.swift */; };
+		D8709AC42D3E9C63006C491E /* SentryReplayMaskPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709AC32D3E9C5C006C491E /* SentryReplayMaskPreview.swift */; };
+		D8709ACB2D3F848E006C491E /* SentryReplayMaskPreviewUIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709ACA2D3F8480006C491E /* SentryReplayMaskPreviewUIView.swift */; };
+		D8709ACD2D3F84CF006C491E /* PreviewRedactOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8709ACC2D3F84C9006C491E /* PreviewRedactOptions.swift */; };
 		D8739CF32BECF70F007D2F66 /* SentryLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8739CF22BECF70F007D2F66 /* SentryLevel.swift */; };
 		D8739CF92BECFFB5007D2F66 /* SentryTransactionNameSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8739CF82BECFFB5007D2F66 /* SentryTransactionNameSource.swift */; };
 		D8739D142BEE5049007D2F66 /* SentryRRWebSpanEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8739D132BEE5049007D2F66 /* SentryRRWebSpanEvent.swift */; };
@@ -1985,6 +1988,9 @@
 		D86B6820293F39E000B8B1FC /* TestSentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSentryViewHierarchy.h; sourceTree = "<group>"; };
 		D86B6834294348A400B8B1FC /* SentryAttachment+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryAttachment+Private.h"; path = "include/SentryAttachment+Private.h"; sourceTree = "<group>"; };
 		D86F419727C8FEFA00490520 /* SentryCoreDataTrackerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCoreDataTrackerExtension.swift; sourceTree = "<group>"; };
+		D8709AC32D3E9C5C006C491E /* SentryReplayMaskPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReplayMaskPreview.swift; sourceTree = "<group>"; };
+		D8709ACA2D3F8480006C491E /* SentryReplayMaskPreviewUIView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReplayMaskPreviewUIView.swift; sourceTree = "<group>"; };
+		D8709ACC2D3F84C9006C491E /* PreviewRedactOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewRedactOptions.swift; sourceTree = "<group>"; };
 		D8739CF22BECF70F007D2F66 /* SentryLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLevel.swift; sourceTree = "<group>"; };
 		D8739CF82BECFFB5007D2F66 /* SentryTransactionNameSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTransactionNameSource.swift; sourceTree = "<group>"; };
 		D8739D132BEE5049007D2F66 /* SentryRRWebSpanEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRRWebSpanEvent.swift; sourceTree = "<group>"; };
@@ -3779,6 +3785,7 @@
 			isa = PBXGroup;
 			children = (
 				D8199DB429376ECC0074249E /* SentryInternal */,
+				D8709AC92D3F83A6006C491E /* Preview */,
 				D8199DB529376ECC0074249E /* SentrySwiftUI.h */,
 				D88D25E92B8E0BAC0073C3D5 /* module.modulemap */,
 				D8199DB629376ECC0074249E /* SentryTracedView.swift */,
@@ -3874,6 +3881,16 @@
 				D859696D27BECDA20036A46E /* SentryCoreDataTracker.m */,
 			);
 			name = CoreData;
+			sourceTree = "<group>";
+		};
+		D8709AC92D3F83A6006C491E /* Preview */ = {
+			isa = PBXGroup;
+			children = (
+				D8709ACA2D3F8480006C491E /* SentryReplayMaskPreviewUIView.swift */,
+				D8709AC32D3E9C5C006C491E /* SentryReplayMaskPreview.swift */,
+				D8709ACC2D3F84C9006C491E /* PreviewRedactOptions.swift */,
+			);
+			path = Preview;
 			sourceTree = "<group>";
 		};
 		D8739CF62BECFF86007D2F66 /* Log */ = {
@@ -5323,7 +5340,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D8709AC42D3E9C63006C491E /* SentryReplayMaskPreview.swift in Sources */,
 				D8199DC129376EEC0074249E /* SentryTracedView.swift in Sources */,
+				D8709ACD2D3F84CF006C491E /* PreviewRedactOptions.swift in Sources */,
+				D8709ACB2D3F848E006C491E /* SentryReplayMaskPreviewUIView.swift in Sources */,
 				D48E8B9D2D3E82AC0032E35E /* SentrySpanOperation.swift in Sources */,
 				D8199DBF29376EE20074249E /* SentryInternal.m in Sources */,
 				D48E8B8B2D3E79610032E35E /* SentryTraceOrigin.swift in Sources */,

--- a/SentrySwiftUI.podspec
+++ b/SentrySwiftUI.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.watchos.framework = 'WatchKit'
 
   s.source_files = "Sources/SentrySwiftUI/**/*.{swift,h,m}"
-  s.dependency 'Sentry', "8.44.0-beta.1"
+  s.dependency 'Sentry/HybridSDK', "8.44.0-beta.1"
 end

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -320,16 +320,13 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [[SentryBreadcrumb alloc] initWithDictionary:dictionary];
 }
 
-#if SENTRY_HAS_UIKIT
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 + (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options
 {
     return [[SentryMaskingPreviewView alloc] initWithRedactOptions:options];
 }
 
-#endif
-
-#if SENTRY_TARGET_REPLAY_SUPPORTED
 + (nullable SentrySessionReplayIntegration *)getReplayIntegration
 {
 

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -320,6 +320,14 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [[SentryBreadcrumb alloc] initWithDictionary:dictionary];
 }
 
+#if SENTRY_UIKIT_AVAILABLE
+
++ (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options {
+    return [[SentryMaskingPreviewView alloc] initWithRedactOptions:options];
+}
+
+#endif
+
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 + (nullable SentrySessionReplayIntegration *)getReplayIntegration
 {

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -320,7 +320,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [[SentryBreadcrumb alloc] initWithDictionary:dictionary];
 }
 
-#if SENTRY_UIKIT_AVAILABLE
+#if SENTRY_HAS_UIKIT
 
 + (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options
 {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -203,6 +203,9 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)startWithOptions:(SentryOptions *)options
 {
+    // We save the options before checking for Xcode preview because
+    // we will use this options in the preview
+    startOption = options;
     if ([SentryDependencyContainer.sharedInstance.processInfoWrapper
                 .environment[SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY] isEqualToString:@"1"]) {
         // Using NSLog because SentryLog was not initialized yet.
@@ -210,7 +213,6 @@ static NSDate *_Nullable startTimestamp = nil;
         return;
     }
 
-    startOption = options;
     [SentryLog configure:options.debug diagnosticLevel:options.diagnosticLevel];
 
     // We accept the tradeoff that the SDK might not be fully initialized directly after

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -51,7 +51,7 @@ static SentryTouchTracker *_touchTracker;
     id<SentryRateLimits> _rateLimits;
     id<SentryViewScreenshotProvider> _currentScreenshotProvider;
     id<SentryReplayBreadcrumbConverter> _currentBreadcrumbConverter;
-    SentryMaskingPreviewView *previewView;
+    SentryMaskingPreviewView *_previewView;
     // We need to use this variable to identify whether rate limiting was ever activated for session
     // replay in this session, instead of always looking for the rate status in `SentryRateLimits`
     // This is the easiest way to ensure segment 0 will always reach the server, because session
@@ -629,19 +629,19 @@ static SentryTouchTracker *_touchTracker;
         return;
     }
 
-    if (previewView == nil) {
-        previewView = [[SentryMaskingPreviewView alloc] initWithRedactOptions:_replayOptions];
+    if (_previewView == nil) {
+        _previewView = [[SentryMaskingPreviewView alloc] initWithRedactOptions:_replayOptions];
     }
 
-    previewView.opacity = opacity;
-    [previewView setFrame:window.bounds];
-    [window addSubview:previewView];
+    _previewView.opacity = opacity;
+    [_previewView setFrame:window.bounds];
+    [window addSubview:_previewView];
 }
 
 - (void)hideMaskPreview
 {
-    [previewView removeFromSuperview];
-    previewView = nil;
+    [_previewView removeFromSuperview];
+    _previewView = nil;
 }
 
 #    pragma mark - SentryReachabilityObserver

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -184,7 +184,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if SENTRY_HAS_UIKIT
+#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 /**
  * Return an instance of SentryRedactOptions with given option
@@ -192,10 +192,6 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * `SentryRedactOptions` class.
  */
 + (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options;
-
-#endif
-
-#if SENTRY_TARGET_REPLAY_SUPPORTED
 
 /**
  * Configure session replay with different breadcrumb converter

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -19,9 +19,11 @@
 @class SentryEnvelope;
 @class SentryId;
 @class SentrySessionReplayIntegration;
+@class UIView;
 
 @protocol SentryReplayBreadcrumbConverter;
 @protocol SentryViewScreenshotProvider;
+@protocol SentryRedactOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -179,6 +181,11 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * Allow Hybrids SDKs to set the current Screen.
  */
 + (void)setCurrentScreen:(NSString *)screenName;
+
+/**
+ * Return an instance of SentryRedactOptions with given option
+ */
++ (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options;
 
 #endif // SENTRY_UIKIT_AVAILABLE
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -184,7 +184,6 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 #endif // SENTRY_UIKIT_AVAILABLE
 
-
 #if SENTRY_HAS_UIKIT
 
 /**

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -182,6 +182,11 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (void)setCurrentScreen:(NSString *)screenName;
 
+#endif // SENTRY_UIKIT_AVAILABLE
+
+
+#if SENTRY_HAS_UIKIT
+
 /**
  * Return an instance of SentryRedactOptions with given option
  * To be used from SentrySwiftUI, which cannot access the private
@@ -189,7 +194,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options;
 
-#endif // SENTRY_UIKIT_AVAILABLE
+#endif
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -184,6 +184,8 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 /**
  * Return an instance of SentryRedactOptions with given option
+ * To be used from SentrySwiftUI, which cannot access the private
+ * `SentryRedactOptions` class.
  */
 + (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options;
 

--- a/Sources/SentrySwiftUI/Preview/PreviewRedactOptions.swift
+++ b/Sources/SentrySwiftUI/Preview/PreviewRedactOptions.swift
@@ -1,0 +1,18 @@
+#if canImport(SwiftUI) && canImport(UIKit) && os(iOS) || os(tvOS)
+import Sentry
+
+public class PreviewRedactOptions: SentryRedactOptions {
+    public let maskAllText: Bool
+    public let maskAllImages: Bool
+    public let maskedViewClasses: [AnyClass]
+    public let unmaskedViewClasses: [AnyClass]
+    
+    public init(maskAllText: Bool = true, maskAllImages: Bool = true, maskedViewClasses: [AnyClass] = [], unmaskedViewClasses: [AnyClass] = []) {
+        self.maskAllText = maskAllText
+        self.maskAllImages = maskAllImages
+        self.maskedViewClasses = maskedViewClasses
+        self.unmaskedViewClasses = unmaskedViewClasses
+    }
+}
+
+#endif

--- a/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreview.swift
+++ b/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreview.swift
@@ -34,7 +34,7 @@ struct SentryReplayPreviewView: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: SentryReplayMaskPreviewUIView, context: Context) {
-        uiView.opacity = opacity
+        uiView.opacity = CGFloat(opacity)
     }
 }
 

--- a/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreview.swift
+++ b/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreview.swift
@@ -1,0 +1,41 @@
+#if canImport(SwiftUI) && canImport(UIKit) && os(iOS) || os(tvOS)
+import Sentry
+import SwiftUI
+import UIKit
+
+#if CARTHAGE || SWIFT_PACKAGE
+@_implementationOnly import SentryInternal
+#endif
+
+@available(iOS 13, macOS 10.15, tvOS 13, *)
+struct SentryReplayMaskPreview: ViewModifier {
+    let redactOptions: SentryRedactOptions
+    let opacity: Float
+    func body(content: Content) -> some View {
+        content.overlay(SentryReplayPreviewView(redactOptions: redactOptions, opacity: opacity).disabled(true))
+    }
+}
+
+@available(iOS 13, macOS 10.15, tvOS 13, *)
+public extension View {
+    func sentryReplayPreviewMask(redactOptions: SentryRedactOptions? = nil, opacity: Float = 1) -> some View {
+        let options = redactOptions ?? SentrySDK.options?.sessionReplay ?? PreviewRedactOptions()
+        return modifier(SentryReplayMaskPreview(redactOptions: options, opacity: opacity))
+    }
+}
+
+@available(iOS 13, macOS 10.15, tvOS 13, *)
+struct SentryReplayPreviewView: UIViewRepresentable {
+    let redactOptions: SentryRedactOptions
+    let opacity: Float
+    
+    func makeUIView(context: Context) -> SentryReplayMaskPreviewUIView {
+        return SentryReplayMaskPreviewUIView(redactOptions: redactOptions)
+    }
+    
+    func updateUIView(_ uiView: SentryReplayMaskPreviewUIView, context: Context) {
+        uiView.opacity = opacity
+    }
+}
+
+#endif

--- a/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreviewUIView.swift
+++ b/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreviewUIView.swift
@@ -1,0 +1,84 @@
+#if canImport(SwiftUI) && canImport(UIKit) && os(iOS) || os(tvOS)
+import Sentry
+import UIKit
+
+#if CARTHAGE || SWIFT_PACKAGE
+@_implementationOnly import SentryInternal
+#endif
+
+class PreviewImageView: UIImageView {
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        return nil
+    }
+}
+
+class SentryReplayMaskPreviewUIView: UIView {
+    private let photographer: SentryViewPhotographer
+    private var displayLink: CADisplayLink?
+    private var imageView = PreviewImageView()
+    
+    var opacity: Float {
+        get { return Float(imageView.alpha) }
+        set { imageView.alpha = CGFloat(newValue)}
+    }
+    
+    init(redactOptions: SentryRedactOptions) {
+        self.photographer = SentryViewPhotographer(renderer: PreviewRederer(), redactOptions: redactOptions)
+        super.init(frame: .zero)
+        self.isUserInteractionEnabled = false
+        imageView.isUserInteractionEnabled = false
+        imageView.sentryReplayUnmask()
+    }
+    
+    deinit {
+        displayLink?.invalidate()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func didMoveToSuperview() {
+        if ProcessInfo.processInfo.environment[SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY] == "1" {
+            displayLink = CADisplayLink(target: self, selector: #selector(update))
+            displayLink?.add(to: .main, forMode: .common)
+        } else {
+            print("[SENTRY] [WARNING] SentryReplayMaskPreview is not meant to be used in your app, only with SwiftUI Previews.")
+        }
+    }
+    
+    @objc
+    private func update() {
+        guard let window = self.window else { return }
+        self.photographer.image(view: window) { image in
+            DispatchQueue.main.async {
+                self.showImage(image: image)
+            }
+        }
+    }
+    
+    private func showImage(image: UIImage) {
+        guard let window = super.window else { return }
+        if imageView.superview != window {
+            window.addSubview(imageView)
+        }
+        imageView.image = image
+        imageView.frame = window.bounds
+    }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        return nil
+    }
+}
+
+class PreviewRederer: ViewRenderer {
+    func render(view: UIView) -> UIImage {
+        return UIGraphicsImageRenderer(size: view.frame.size, format: .init(for: .init(displayScale: 1))).image { _ in
+            // Creates a transparent image of the view size that will be used to drawn the redact regions.
+            // Transparent background is the default, so no additional drawing is required.
+            // Left blank on purpose
+        }
+    }
+}
+
+#endif

--- a/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreviewUIView.swift
+++ b/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreviewUIView.swift
@@ -3,82 +3,35 @@ import Sentry
 import UIKit
 
 #if CARTHAGE || SWIFT_PACKAGE
+import Sentry._Hybrid
 @_implementationOnly import SentryInternal
 #endif
 
-class PreviewImageView: UIImageView {
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        return nil
-    }
-}
-
 class SentryReplayMaskPreviewUIView: UIView {
-    private let photographer: SentryViewPhotographer
-    private var displayLink: CADisplayLink?
-    private var imageView = PreviewImageView()
     
-    var opacity: Float {
-        get { return Float(imageView.alpha) }
-        set { imageView.alpha = CGFloat(newValue)}
+    private let maskingOverlay: UIView
+    
+    var opacity: CGFloat {
+        get { maskingOverlay.alpha }
+        set { maskingOverlay.alpha = newValue }
     }
     
     init(redactOptions: SentryRedactOptions) {
-        self.photographer = SentryViewPhotographer(renderer: PreviewRederer(), redactOptions: redactOptions)
+        maskingOverlay = PrivateSentrySDKOnly.sessionReplayMaskingOverlay(redactOptions)
         super.init(frame: .zero)
-        self.isUserInteractionEnabled = false
-        imageView.isUserInteractionEnabled = false
-        imageView.sentryReplayUnmask()
-    }
-    
-    deinit {
-        displayLink?.invalidate()
     }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
     
-    override func didMoveToSuperview() {
-        if ProcessInfo.processInfo.environment[SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY] == "1" {
-            displayLink = CADisplayLink(target: self, selector: #selector(update))
-            displayLink?.add(to: .main, forMode: .common)
-        } else {
-            print("[SENTRY] [WARNING] SentryReplayMaskPreview is not meant to be used in your app, only with SwiftUI Previews.")
-        }
-    }
-    
-    @objc
-    private func update() {
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
         guard let window = self.window else { return }
-        self.photographer.image(view: window) { image in
-            DispatchQueue.main.async {
-                self.showImage(image: image)
-            }
-        }
-    }
-    
-    private func showImage(image: UIImage) {
-        guard let window = super.window else { return }
-        if imageView.superview != window {
-            window.addSubview(imageView)
-        }
-        imageView.image = image
-        imageView.frame = window.bounds
-    }
-    
-    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        return nil
+        maskingOverlay.frame = window.bounds
+        window.addSubview(maskingOverlay)
     }
 }
 
-class PreviewRederer: ViewRenderer {
-    func render(view: UIView) -> UIImage {
-        return UIGraphicsImageRenderer(size: view.frame.size, format: .init(for: .init(displayScale: 1))).image { _ in
-            // Creates a transparent image of the view size that will be used to drawn the redact regions.
-            // Transparent background is the default, so no additional drawing is required.
-            // Left blank on purpose
-        }
-    }
-}
 
 #endif

--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -24,6 +24,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSString *const SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY;
+
 typedef NS_ENUM(NSInteger, SentryTransactionNameSource);
 
 @class SentrySpanId;

--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -6,7 +6,6 @@
  */
 
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 #if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/Sentry.h>

--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -6,6 +6,7 @@
  */
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/Sentry.h>

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -195,10 +195,7 @@ class SentrySDKTests: XCTestCase {
     }
     
     func testDontStartInsideXcodePreview() {
-        let testProcessInfoWrapper = TestSentryNSProcessInfoWrapper()
-        testProcessInfoWrapper.overrides.environment = ["XCODE_RUNNING_FOR_PREVIEWS": "1"]
-        
-        SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
+        startprocessInfoWrapperForPreview()
         
         SentrySDK.start { options in
             options.debug = true
@@ -558,6 +555,13 @@ class SentrySDKTests: XCTestCase {
     }
     
     func testGlobalOptions() {
+        SentrySDK.start(options: fixture.options)
+        XCTAssertEqual(SentrySDK.options, fixture.options)
+    }
+    
+    func testGlobalOptionsForPreview() {
+        startprocessInfoWrapperForPreview()
+        
         SentrySDK.start(options: fixture.options)
         XCTAssertEqual(SentrySDK.options, fixture.options)
     }
@@ -973,6 +977,12 @@ class SentrySDKTests: XCTestCase {
     
     private func advanceTime(bySeconds: TimeInterval) {
         fixture.currentDate.setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))
+    }
+    
+    private func startprocessInfoWrapperForPreview() {
+        let testProcessInfoWrapper = TestSentryNSProcessInfoWrapper()
+        testProcessInfoWrapper.overrides.environment = ["XCODE_RUNNING_FOR_PREVIEWS": "1"]
+        SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

Allows the user to preview how its app session replay will be masked during development.

![image](https://github.com/user-attachments/assets/94d83c5c-7d69-44fe-9b12-21f860bdcf22)


## :bulb: Motivation and Context

closes #4633 

## :green_heart: How did you test it?

Sample

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
