### PR TITLE
Use strlcpy to save session replay info path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Use strlcpy to save session replay info path ()
+
 ## 8.44.0-beta.1
 
 ### Fixes

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -360,8 +360,8 @@ static SentryTouchTracker *_touchTracker;
     }
     [data writeToFile:infoPath atomically:YES];
 
-    sentrySessionReplaySync_start([[path stringByAppendingPathComponent:@"crashInfo"]
-        cStringUsingEncoding:NSUTF8StringEncoding]);
+    NSString* crashInfoPath = [path stringByAppendingPathComponent:@"crashInfo"];
+    sentrySessionReplaySync_start([crashInfoPath cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 - (void)moveCurrentReplay


### PR DESCRIPTION
## :scroll: Description

Use safer strlcpy and add room for null-terminator when saving sr path for info file.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
