### PR TITLE
Fix: `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Use strlcpy to save session replay info path (#4740)
+- `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction ()
 
 ## 8.44.0-beta.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixed
 
 - Use strlcpy to save session replay info path (#4740)
-- `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction ()
+- `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction (#4749)
 
 ## 8.44.0-beta.1
 

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/ContentView.swift
@@ -195,7 +195,7 @@ struct ContentView: View {
                             }
                             Button(action: showTTD) {
                                 Text("Show TTD")
-                            }
+                            }.sentryReplayUnmask()
                         }
                         VStack(spacing: 16) {
                             Button(action: {

--- a/Sources/SentrySwiftUI/SentryReplayView.swift
+++ b/Sources/SentrySwiftUI/SentryReplayView.swift
@@ -19,13 +19,11 @@ struct SentryReplayView: UIViewRepresentable {
     class SentryRedactView: UIView {
     }
     
-    func makeUIView(context: Context) -> UIView {
-        let view = SentryRedactView()
-        view.isUserInteractionEnabled = false
-        return view
+    func makeUIView(context: Context) -> SentryRedactView {
+        return SentryRedactView()
     }
     
-    func updateUIView(_ uiView: UIView, context: Context) {
+    func updateUIView(_ uiView: SentryRedactView, context: Context) {
         switch maskBehavior {
             case .mask: SentryRedactViewHelper.maskSwiftUI(uiView)
             case .unmask: SentryRedactViewHelper.clipOutView(uiView)
@@ -37,7 +35,7 @@ struct SentryReplayView: UIViewRepresentable {
 struct SentryReplayModifier: ViewModifier {
     let behavior: MaskBehavior
     func body(content: Content) -> some View {
-        content.overlay(SentryReplayView(maskBehavior: behavior))
+        content.overlay(SentryReplayView(maskBehavior: behavior).disabled(true))
     }
 }
 


### PR DESCRIPTION
## :scroll: Description

Adding `sentryReplayUnmask` and `sentryReplayUnmask` to a view was preventing interaction with such view.
Solved now.

## :green_heart: How did you test it?

Sample and UITest

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x]  I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
