### PR TITLE
impr: More info when hub can't start session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Use strlcpy to save session replay info path (#4740)
 - `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction (#4749)
 
+### Improvements
+
+- More detailed log message when can't start session in SentryHub (#4752)
+
 ## 8.44.0-beta.1
 
 ### Fixes

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -90,10 +90,13 @@ NS_ASSUME_NONNULL_BEGIN
     SentrySession *lastSession = nil;
     SentryScope *scope = self.scope;
     SentryOptions *options = [_client options];
-    if (options == nil || options.releaseName == nil) {
-        [SentryLog
-            logWithMessage:[NSString stringWithFormat:@"No option or release to start a session."]
-                  andLevel:kSentryLevelError];
+    if (options == nil) {
+        SENTRY_LOG_ERROR(@"Options of the client are nil. Not starting a session.");
+        return;
+    }
+    if (options.releaseName == nil) {
+        SENTRY_LOG_ERROR(
+            @"Release name of the options of the client is nil. Not starting a session.");
         return;
     }
 

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -752,6 +752,19 @@ class SentryHubTests: XCTestCase {
         assertNoEventsSent()
     }
     
+    func testCaptureCrashEvent_ClientHasNoReleaseName() {
+        sut = fixture.getSut()
+        let options = fixture.options
+        options.releaseName = nil
+        let client = SentryClient(options: options)
+        sut.bindClient(client)
+        
+        givenCrashedSession()
+        sut.captureCrash(fixture.event)
+        
+        assertNoEventsSent()
+    }
+    
     func testCaptureEnvelope_WithEventWithError() throws {
         sut.startSession()
         


### PR DESCRIPTION


## :scroll: Description

Improve the log message in the hub when it can't start a session when the client doesn't have any options or the options don't have a release name.

## :bulb: Motivation and Context

The log message `No option or release to start a session.` came up in a Zendesk issue. It would be great to know if the options or the release are nil.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
