### PR TITLE
impr: Add SentryHub to all log messages in the Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Use strlcpy to save session replay info path (#4740)
 - `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction (#4749)
 
+### Improvments
+
+- Add SentryHub to all log messages in the Hub (#4753)
+
 ## 8.44.0-beta.1
 
 ### Fixes

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -203,10 +203,8 @@ NS_ASSUME_NONNULL_BEGIN
         SentryClient *client = _client;
 
         if (client.options.diagnosticLevel == kSentryLevelDebug) {
-            [SentryLog
-                logWithMessage:[NSString stringWithFormat:@"Capturing session with status: %@",
-                                   [self createSessionDebugString:session]]
-                      andLevel:kSentryLevelDebug];
+            SENTRY_LOG_DEBUG(
+                @"Capturing session with status: %@", [self createSessionDebugString:session]);
         }
         [client captureSession:session];
     }
@@ -688,10 +686,8 @@ NS_ASSUME_NONNULL_BEGIN
                     endSessionCrashedWithTimestamp:[SentryDependencyContainer.sharedInstance
                                                            .dateProvider date]];
                 if (_client.options.diagnosticLevel == kSentryLevelDebug) {
-                    [SentryLog
-                        logWithMessage:[NSString stringWithFormat:@"Ending session with status: %@",
-                                           [self createSessionDebugString:currentSession]]
-                              andLevel:kSentryLevelDebug];
+                    SENTRY_LOG_DEBUG(@"Ending session with status: %@",
+                        [self createSessionDebugString:currentSession]);
                 }
                 if (startNewSession) {
                     // Setting _session to nil so startSession doesn't capture it again


### PR DESCRIPTION


## :scroll: Description

The SentryHub was using SentryLog, which has the major downside of not adding the classname of SentryHub to the log message. This is fixed now.

## :bulb: Motivation and Context

Came up while fixing https://github.com/getsentry/sentry-cocoa/pull/4752.

## :green_heart: How did you test it?
Unit tests still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
