### PR TITLE
Reference LOGAF Scale from develop docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,7 @@ We welcome suggested improvements and bug fixes for `sentry-cocoa`, in the form 
 
 ## PR reviews
 
-For feedback in PRs, we use the [LOGAF scale](https://blog.danlew.net/2020/04/15/the-logaf-scale/) to specify how important a comment is:
-
-* `l`: low - nitpick. You may address this comment, but you don't have to.
-* `m`: medium - normal comment. Worth addressing and fixing.
-* `h`: high - Very important. We must not merge this PR without addressing this issue.
-
-You only need one approval from a maintainer to be able to merge. For some PRs, asking specific or multiple people for review might be adequate.
+For feedback in PRs, we use the [LOGAF scale](https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale) to specify how important a comment is. You only need one approval from a maintainer to be able to merge. For some PRs, asking specific or multiple people for review might be adequate.
 
 Our different types of reviews:
   


### PR DESCRIPTION
Link to the Sentry develop docs for explaining the LOGAF scale.

#skip-changelog
