### PR TITLE
fix: SentryCrashExceptionApplication implementation missing for non-macOS target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use strlcpy to save session replay info path (#4740)
 - `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction (#4749)
+- missing `SentryCrashExceptionApplication` implementation for non-macOS target ()
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Use strlcpy to save session replay info path (#4740)
 - `sentryReplayUnmask` and `sentryReplayUnmask` preventing interaction (#4749)
-- missing `SentryCrashExceptionApplication` implementation for non-macOS target ()
+- Missing `SentryCrashExceptionApplication` implementation for non-macOS target (#4759)
 
 ### Improvements
 

--- a/Sources/Sentry/Public/SentryCrashExceptionApplication.h
+++ b/Sources/Sentry/Public/SentryCrashExceptionApplication.h
@@ -9,8 +9,7 @@
 #if TARGET_OS_OSX
 #    import <AppKit/NSApplication.h>
 @interface SentryCrashExceptionApplication : NSApplication
-#else
-@interface SentryCrashExceptionApplication : NSObject
+@end
 #endif
 
-@end
+

--- a/Sources/Sentry/Public/SentryCrashExceptionApplication.h
+++ b/Sources/Sentry/Public/SentryCrashExceptionApplication.h
@@ -11,5 +11,3 @@
 @interface SentryCrashExceptionApplication : NSApplication
 @end
 #endif
-
-


### PR DESCRIPTION
## :scroll: Description

Removed the interface for `SentryCrashExceptionApplication` when not on macOS

## :bulb: Motivation and Context

closes #4758 

## :green_heart: How did you test it?

CI

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
