### PR TITLE
chore: Removing experimental flag from SentryReplayAPI

### DIFF
--- a/Sources/Sentry/Public/SentryReplayApi.h
+++ b/Sources/Sentry/Public/SentryReplayApi.h
@@ -16,43 +16,31 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Marks this view to be masked during replays.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 - (void)maskView:(UIView *)view NS_SWIFT_NAME(maskView(_:));
 
 /**
  * Marks this view to not be masked during redact step of session replay.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 - (void)unmaskView:(UIView *)view NS_SWIFT_NAME(unmaskView(_:));
 
 /**
  * Pauses the replay.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 - (void)pause;
 
 /**
  * Resumes the ongoing replay.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 - (void)resume;
 
 /**
  * Start recording a session replay if not started.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 - (void)start;
 
 /**
  * Stop the current session replay recording.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 - (void)stop;
 


### PR DESCRIPTION
We already GA sentry replay and there is an API with experimental flags in it.

_#skip-changelog_