### PR TITLE
test: Surface IO errors in OnDemandReplayTests

### DIFF
--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -6,25 +6,29 @@ import XCTest
 #if os(iOS) || os(tvOS)
 class SentryOnDemandReplayTests: XCTestCase {
     
-    let dateProvider = TestCurrentDateProvider()
-    var outputPath: URL = {
-        let temp = FileManager.default.temporaryDirectory.appendingPathComponent("replayTest")
-        try? FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
-        return temp
-    }()
+    private let dateProvider = TestCurrentDateProvider()
+    private var outputPath = FileManager.default.temporaryDirectory.appendingPathComponent("replayTest")
+    
+    override func setUpWithError() throws {
+        try removeDirectoryIfExists(at: outputPath)
+        try FileManager.default.createDirectory(at: outputPath, withIntermediateDirectories: true)
+    }
     
     override func tearDownWithError() throws {
-        let files = try FileManager.default.contentsOfDirectory(atPath: outputPath.path)
-        for file in files {
-            try? FileManager.default.removeItem(at: outputPath.appendingPathComponent(file))
+        try removeDirectoryIfExists(at: outputPath)
+    }
+    
+    private func removeDirectoryIfExists(at path: URL) throws {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: path.path) {
+            try fileManager.removeItem(at: path)
         }
     }
     
-    func getSut(trueDispatchQueueWrapper: Bool = false) -> SentryOnDemandReplay {
-        let sut = SentryOnDemandReplay(outputPath: outputPath.path,
-                                       workingQueue: trueDispatchQueueWrapper ? SentryDispatchQueueWrapper() : TestSentryDispatchQueueWrapper(),
-                                       dateProvider: dateProvider)
-        return sut
+    private func getSut(trueDispatchQueueWrapper: Bool = false) -> SentryOnDemandReplay {
+        return SentryOnDemandReplay(outputPath: outputPath.path,
+                                    workingQueue: trueDispatchQueueWrapper ? SentryDispatchQueueWrapper() : TestSentryDispatchQueueWrapper(),
+                                    dateProvider: dateProvider)
     }
     
     func testAddFrame() {


### PR DESCRIPTION
Potential errors when creating the output path were swallowed by the tests. This is fixed now by bubbling up potential errors. Furthermore, the setUp test method now ensures that the output directory is empty.

This could potentially fix the SentryOnDemandReplayTests or at least surface the underlying errors. These tests failed on the main branch:
* https://github.com/getsentry/sentry-cocoa/actions/runs/13036796645/job/36369304427
* https://github.com/getsentry/sentry-cocoa/actions/runs/13028885214/job/36343606049
* https://github.com/getsentry/sentry-cocoa/actions/runs/13006112174/job/36273341122

#skip-changelog