### PR TITLE
chore: Enable test_case_accessibility in SwiftLint

### DIFF
--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,5 +1,8 @@
 parent_config: ../.swiftlint.yml
 
+enabled_rules:
+  - test_case_accessibility
+
 disabled_rules:
   - force_cast
   - force_try

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
 final class SentryAppLaunchProfilingSwiftTests: XCTestCase {
-    var fixture: SentryProfileTestFixture!
+    private var fixture: SentryProfileTestFixture!
     
     override func setUp() {
         super.setUp()

--- a/Tests/SentryProfilerTests/SentryNSProcessInfoWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentryNSProcessInfoWrapperTests.swift
@@ -1,10 +1,10 @@
 import XCTest
 
 class SentryNSProcessInfoWrapperTests: XCTestCase {
-    struct Fixture {
+    private struct Fixture {
         lazy var processInfoWrapper = SentryNSProcessInfoWrapper()
     }
-    lazy var fixture = Fixture()
+    lazy private var fixture = Fixture()
 
     func testProcessorCount() {
         XCTAssert((0...UInt.max).contains(fixture.processInfoWrapper.processorCount))

--- a/Tests/SentryProfilerTests/SentryNSTimerFactoryTest.swift
+++ b/Tests/SentryProfilerTests/SentryNSTimerFactoryTest.swift
@@ -1,10 +1,11 @@
 import XCTest
 
 class SentryNSTimerFactoryTests: XCTestCase {
-    struct Fixture {
+    
+    private struct Fixture {
         lazy var timerFactory = SentryNSTimerFactory()
     }
-    lazy var fixture = Fixture()
+    private lazy var fixture = Fixture()
 
     func testNonrepeatingTimer() {
         let exp = expectation(description: "timer fires exactly once")

--- a/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
+++ b/Tests/SentryProfilerTests/SentrySystemWrapperTests.swift
@@ -1,10 +1,10 @@
 import XCTest
 
 class SentrySystemWrapperTests: XCTestCase {
-    struct Fixture {
+    private struct Fixture {
         lazy var systemWrapper = SentrySystemWrapper()
     }
-    lazy var fixture = Fixture()
+    lazy private var fixture = Fixture()
 
     func testCPUUsageReportsData() throws {
         XCTAssertNoThrow({

--- a/Tests/SentryTests/Helper/SentryAppStateTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateTests.swift
@@ -85,7 +85,7 @@ class SentryAppStateTests: XCTestCase {
         XCTAssertEqual(expectedDate, sut.systemBootTimestamp)
     }
     
-    func withValue(setValue: (inout [String: Any]) -> Void) {
+    private func withValue(setValue: (inout [String: Any]) -> Void) {
         let expected = TestData.appState
         var serialized = expected.serialize()
         setValue(&serialized)

--- a/Tests/SentryTests/Helper/SentryByteCountFormatterTests.swift
+++ b/Tests/SentryTests/Helper/SentryByteCountFormatterTests.swift
@@ -18,7 +18,7 @@ class SentryByteCountFormatterTests: XCTestCase {
         assertDescription(baseValue: 1_024 * 1_024 * 1_024, unitName: "GB")
     }
     
-    func assertDescription(baseValue: UInt, unitName: String) {
+    private func assertDescription(baseValue: UInt, unitName: String) {
         XCTAssertEqual("1 \(unitName)", SentryByteCountFormatter.bytesCountDescription(baseValue))
         XCTAssertEqual("512 \(unitName)", SentryByteCountFormatter.bytesCountDescription(baseValue * 512))
         XCTAssertEqual("1,023 \(unitName)", SentryByteCountFormatter.bytesCountDescription(baseValue * 1_024 - 1))

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -3,9 +3,9 @@ import SentryTestUtils
 import XCTest
 
 class SentryLogTests: XCTestCase {
-    var oldDebug: Bool!
-    var oldLevel: SentryLevel!
-    var oldOutput: SentryLogOutput!
+    private var oldDebug: Bool!
+    private var oldLevel: SentryLevel!
+    private var oldOutput: SentryLogOutput!
 
     override func setUp() {
         super.setUp()

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -539,7 +539,7 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertEqual(sdkInfo, deserializedEnvelope.header.sdkInfo)
     }
     
-    func assertTraceState(firstTrace: TraceContext, secondTrace: TraceContext) {
+    private func assertTraceState(firstTrace: TraceContext, secondTrace: TraceContext) {
         XCTAssertEqual(firstTrace.traceId, secondTrace.traceId)
         XCTAssertEqual(firstTrace.publicKey, secondTrace.publicKey)
         XCTAssertEqual(firstTrace.releaseName, secondTrace.releaseName)

--- a/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentrySwizzleWrapperTests.swift
@@ -26,7 +26,7 @@ class SentrySwizzleWrapperTests: XCTestCase {
     private var sut: SentrySwizzleWrapper!
     
     @objc
-    func someMethod() {
+    private func someMethod() {
         // Empty on purpose
     }
     

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -49,7 +49,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         clearTestState()
     }
     
-    func start() {
+    private func start() {
         sut.add(listener: self)
     }
     
@@ -205,6 +205,9 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         XCTAssertEqual(1, fixture.threadWrapper.threadFinishedInvocations.count)
     }
     
+    // swiftlint:disable test_case_accessibility
+    // Protocl implementation can't be private
+    
     func anrDetected(type: Sentry.SentryANRType) {
         anrDetectedExpectation.fulfill()
     }
@@ -212,6 +215,8 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
     func anrStopped() {
         anrStoppedExpectation.fulfill()
     }
+    
+    // swiftlint:enable file_length
     
     private func advanceTime(bySeconds: TimeInterval) {
         fixture.currentDate.setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentrySystemEventBreadcrumbsTest.swift
@@ -39,7 +39,7 @@ class SentrySystemEventBreadcrumbsTest: XCTestCase {
     private lazy var fixture = Fixture()
     private var sut: SentrySystemEventBreadcrumbs!
     
-    internal class MyUIDevice: UIDevice {
+    private class MyUIDevice: UIDevice {
         private var _batteryLevel: Float
         private var _batteryState: UIDevice.BatteryState
         private var _orientation: UIDeviceOrientation

--- a/Tests/SentryTests/Integrations/NotificationCenterTestCase.swift
+++ b/Tests/SentryTests/Integrations/NotificationCenterTestCase.swift
@@ -8,18 +8,21 @@ import UIKit
 class NotificationCenterTestCase: XCTestCase {
 
     #if os(tvOS) || os(iOS) 
-    let willEnterForegroundNotification = UIApplication.willEnterForegroundNotification
-    let didBecomeActiveNotification = UIApplication.didBecomeActiveNotification
-    let willResignActiveNotification = UIApplication.willResignActiveNotification
-    let didEnterBackgroundNotification = UIApplication.didEnterBackgroundNotification
-    let willTerminateNotification = UIApplication.willTerminateNotification
-    let didFinishLaunchingNotification = UIApplication.didFinishLaunchingNotification
+    private let willEnterForegroundNotification = UIApplication.willEnterForegroundNotification
+    private let didBecomeActiveNotification = UIApplication.didBecomeActiveNotification
+    private let willResignActiveNotification = UIApplication.willResignActiveNotification
+    private let didEnterBackgroundNotification = UIApplication.didEnterBackgroundNotification
+    private let willTerminateNotification = UIApplication.willTerminateNotification
+    private let didFinishLaunchingNotification = UIApplication.didFinishLaunchingNotification
     #elseif os(macOS)
-    let didBecomeActiveNotification = NSApplication.didBecomeActiveNotification
-    let willResignActiveNotification = NSApplication.willResignActiveNotification
-    let willTerminateNotification = NSApplication.willTerminateNotification
-    let didFinishLaunchingNotification = NSApplication.didFinishLaunchingNotification
+    private let didBecomeActiveNotification = NSApplication.didBecomeActiveNotification
+    private let willResignActiveNotification = NSApplication.willResignActiveNotification
+    private let willTerminateNotification = NSApplication.willTerminateNotification
+    private let didFinishLaunchingNotification = NSApplication.didFinishLaunchingNotification
     #endif
+    
+    // swiftlint:disable test_case_accessibility
+    // This is a base test class, so it's methods can't be private
     
     func goToForeground() {
         willEnterForeground()
@@ -85,6 +88,8 @@ class NotificationCenterTestCase: XCTestCase {
     func localeDidChange() {
         post(name: NSLocale.currentLocaleDidChangeNotification)
     }
+    
+    // swiftlint:enable test_case_accessibility
     
     private func post(name: Notification.Name) {
         NotificationCenter.default.post(Notification(name: name))

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -30,7 +30,7 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
     }
     
     private var fixture: Fixture!
-    var deleteFileDirectory = false
+    private var deleteFileDirectory = false
     
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -195,7 +195,7 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         }
     }
     
-    func getBigFilePath() -> String? {
+    private func getBigFilePath() -> String? {
         let bundle = Bundle(for: type(of: self))
         
         return bundle.path(forResource: "Resources/fatal-error-binary-images-message2", ofType: "json")

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -130,7 +130,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         wait(for: [expect], timeout: 5)
     }
     
-    func flaky_testWhenTaskCancelledOrSuspended_OnlyOneBreadcrumb() {
+    private func flaky_testWhenTaskCancelledOrSuspended_OnlyOneBreadcrumb() {
         startSDK()
         
         let expect = expectation(description: "Callback Expectation")

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -975,12 +975,12 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(fixture.hub.capturedEventsWithScopes.first)
     }
 
-    func setTaskState(_ task: URLSessionTaskMock, state: URLSessionTask.State) throws {
+    private func setTaskState(_ task: URLSessionTaskMock, state: URLSessionTask.State) throws {
         fixture.getSut().urlSessionTask(try XCTUnwrap(task as? URLSessionTask), setState: state)
         task.state = state
     }
 
-    func assertStatus(status: SentrySpanStatus, state: URLSessionTask.State, response: URLResponse, configSut: ((SentryNetworkTracker) -> Void)? = nil) {
+    private func assertStatus(status: SentrySpanStatus, state: URLSessionTask.State, response: URLResponse, configSut: ((SentryNetworkTracker) -> Void)? = nil) {
         let sut = fixture.getSut()
         configSut?(sut)
 
@@ -1066,7 +1066,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(duration, expectedDuration)
     }
 
-    func createDataTask(method: String = "GET", modifyRequest: ((URLRequest) -> (URLRequest))? = nil) -> URLSessionDataTaskMock {
+    private func createDataTask(method: String = "GET", modifyRequest: ((URLRequest) -> (URLRequest))? = nil) -> URLSessionDataTaskMock {
         var request = URLRequest(url: SentryNetworkTrackerTests.fullUrl)
         request.httpMethod = method
         request.httpBody = fixture.nsUrlRequest.httpBody
@@ -1080,19 +1080,19 @@ class SentryNetworkTrackerTests: XCTestCase {
         return URLSessionDataTaskMock(request: request)
     }
 
-    func createDownloadTask(method: String = "GET") -> URLSessionDownloadTaskMock {
+    private func createDownloadTask(method: String = "GET") -> URLSessionDownloadTaskMock {
         var request = URLRequest(url: SentryNetworkTrackerTests.fullUrl)
         request.httpMethod = method
         return URLSessionDownloadTaskMock(request: request)
     }
 
-    func createUploadTask(method: String = "GET") -> URLSessionUploadTaskMock {
+    private func createUploadTask(method: String = "GET") -> URLSessionUploadTaskMock {
         var request = URLRequest(url: SentryNetworkTrackerTests.fullUrl)
         request.httpMethod = method
         return URLSessionUploadTaskMock(request: request)
     }
 
-    func createStreamTask(method: String = "GET") -> URLSessionStreamTaskMock {
+    private func createStreamTask(method: String = "GET") -> URLSessionStreamTaskMock {
         var request = URLRequest(url: SentryNetworkTrackerTests.fullUrl)
         request.httpMethod = method
         return URLSessionStreamTaskMock(request: request)

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -484,7 +484,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0)
     }
 
-    func assertMeasurement(tracer: SentryTracer, name: String, duration: TimeInterval) {
+    private func assertMeasurement(tracer: SentryTracer, name: String, duration: TimeInterval) {
         XCTAssertEqual(tracer.measurements[name]?.value, NSNumber(value: duration))
         XCTAssertEqual(tracer.measurements[name]?.unit?.unit, "millisecond")
     }

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -10,19 +10,19 @@ class TestViewController: UIViewController {
 
 class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
 
-    let loadView = "loadView"
-    let viewWillLoad = "viewWillLoad"
-    let viewDidLoad = "viewDidLoad"
-    let viewWillAppear = "viewWillAppear"
-    let viewDidAppear = "viewDidAppear"
-    let viewWillDisappear = "viewWillDisappear"
-    let viewWillLayoutSubviews = "viewWillLayoutSubviews"
-    let viewDidLayoutSubviews = "viewDidLayoutSubviews"
-    let layoutSubviews = "layoutSubViews"
-    let spanName = "spanName"
-    let spanOperation = "spanOperation"
-    let origin = "auto.ui.view_controller"
-    let frameDuration = 0.0016
+    private let loadView = "loadView"
+    private let viewWillLoad = "viewWillLoad"
+    private let viewDidLoad = "viewDidLoad"
+    private let viewWillAppear = "viewWillAppear"
+    private let viewDidAppear = "viewDidAppear"
+    private let viewWillDisappear = "viewWillDisappear"
+    private let viewWillLayoutSubviews = "viewWillLayoutSubviews"
+    private let viewDidLayoutSubviews = "viewDidLayoutSubviews"
+    private let layoutSubviews = "layoutSubViews"
+    private let spanName = "spanName"
+    private let spanOperation = "spanOperation"
+    private let origin = "auto.ui.view_controller"
+    private let frameDuration = 0.0016
     
     private class Fixture {
         

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -8,10 +8,10 @@ class MyTestIntegration: SentryBaseIntegration {
 }
 
 class SentryBaseIntegrationTests: XCTestCase {
-    var logOutput: TestLogOutput!
-    var oldDebug: Bool!
-    var oldLevel: SentryLevel!
-    var oldOutput: SentryLogOutput!
+    private var logOutput: TestLogOutput!
+    private var oldDebug: Bool!
+    private var oldLevel: SentryLevel!
+    private var oldOutput: SentryLogOutput!
 
     override func setUp() {
         super.setUp()

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashReportTests.swift
@@ -205,30 +205,30 @@ class SentryCrashReportTests: XCTestCase {
     
     // We parse JSON so it's fine to disable identifier_name
     // swiftlint:disable identifier_name
-    struct CrashReport: Decodable {
+    private struct CrashReport: Decodable {
         let user: CrashReportUserInfo?
         let sentry_sdk_scope: CrashReportUserInfo?
         let crash: Crash
     }
     
-    struct Crash: Decodable, Equatable {
+    private struct Crash: Decodable, Equatable {
         let error: ErrorContext
     }
     
-    struct ErrorContext: Decodable, Equatable {
+    private struct ErrorContext: Decodable, Equatable {
         let type: String?
         let reason: String?
         let nsexception: NSException?
         let mach: Mach?
     }
     
-    struct NSException: Decodable, Equatable {
+    private struct NSException: Decodable, Equatable {
         let name: String?
         let userInfo: String?
         let reason: String?
     }
     
-    struct Mach: Decodable, Equatable {
+    private struct Mach: Decodable, Equatable {
         let exception: Int?
         let exception_name: String?
         let code: Int?
@@ -236,7 +236,7 @@ class SentryCrashReportTests: XCTestCase {
         let subcode: Int?
     }
 
-    struct CrashReportUserInfo: Decodable, Equatable {
+    private struct CrashReportUserInfo: Decodable, Equatable {
         let user: CrashReportUser?
         let dist: String?
         let context: [String: [String: String]]?
@@ -249,7 +249,7 @@ class SentryCrashReportTests: XCTestCase {
         let breadcrumbs: [CrashReportCrumb]?
     }
     
-    struct CrashReportUser: Decodable, Equatable {
+    private struct CrashReportUser: Decodable, Equatable {
         let id: String
         let email: String
         let username: String
@@ -257,7 +257,7 @@ class SentryCrashReportTests: XCTestCase {
         let data: [String: [String: String]]
     }
 
-    struct CrashReportCrumb: Decodable, Equatable {
+    private struct CrashReportCrumb: Decodable, Equatable {
         let category: String
         let data: [String: [String: String]]
         let level: String

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -6,8 +6,8 @@ import XCTest
 #if os(iOS) || os(tvOS)
 class SentryOnDemandReplayTests: XCTestCase {
     
-    let dateProvider = TestCurrentDateProvider()
-    var outputPath: URL = {
+    private let dateProvider = TestCurrentDateProvider()
+    private var outputPath: URL = {
         let temp = FileManager.default.temporaryDirectory.appendingPathComponent("replayTest")
         try? FileManager.default.createDirectory(at: temp, withIntermediateDirectories: true)
         return temp
@@ -20,7 +20,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         }
     }
     
-    func getSut(trueDispatchQueueWrapper: Bool = false) -> SentryOnDemandReplay {
+    private func getSut(trueDispatchQueueWrapper: Bool = false) -> SentryOnDemandReplay {
         let sut = SentryOnDemandReplay(outputPath: outputPath.path,
                                        workingQueue: trueDispatchQueueWrapper ? SentryDispatchQueueWrapper() : TestSentryDispatchQueueWrapper(),
                                        dateProvider: dateProvider)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -539,7 +539,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertEqual(sessionReplay.replayTags?["someOption"] as? String, "someValue")
     }
     
-    func createLastSessionReplay(writeSessionInfo: Bool = true, errorSampleRate: Double = 1) throws {
+    private func createLastSessionReplay(writeSessionInfo: Bool = true, errorSampleRate: Double = 1) throws {
         let replayFolder = replayFolder()
         let jsonPath = replayFolder + "/replay.current"
         var sessionFolder = UUID().uuidString
@@ -567,7 +567,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         }
     }
     
-    func replayFolder() -> String {
+    private func replayFolder() -> String {
         let options = Options()
         options.dsn = "https://user@test.com/test"
         options.cacheDirectoryPath = FileManager.default.temporaryDirectory.path

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -536,7 +536,7 @@ class SentrySessionReplayTests: XCTestCase {
         XCTAssertEqual(fixture.displayLink.invalidateInvocations.count, 1)
     }
 
-    func assertFullSession(_ sessionReplay: SentrySessionReplay, expected: Bool) {
+    private func assertFullSession(_ sessionReplay: SentrySessionReplay, expected: Bool) {
         XCTAssertEqual(sessionReplay.isFullSession, expected)
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryTouchTrackerTests.swift
@@ -52,7 +52,7 @@ class SentryTouchTrackerTests: XCTestCase {
         }
     }
     
-    var dateprovider = TestCurrentDateProvider()
+    private var dateprovider = TestCurrentDateProvider()
     
     override func setUp() {
         super.setUp()
@@ -66,7 +66,7 @@ class SentryTouchTrackerTests: XCTestCase {
     
     private var referenceDate = Date(timeIntervalSinceReferenceDate: 0)
     
-    func getSut(dispatchQueue: SentryDispatchQueueWrapper = TestSentryDispatchQueueWrapper()) -> SentryTouchTracker {
+    private func getSut(dispatchQueue: SentryDispatchQueueWrapper = TestSentryDispatchQueueWrapper()) -> SentryTouchTracker {
         return SentryTouchTracker(dateProvider: dateprovider, scale: 1, dispatchQueue: dispatchQueue)
     }
     

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -28,11 +28,11 @@ class SentryUIEventTrackerTests: XCTestCase {
     private var fixture: Fixture!
     private var sut: SentryUIEventTracker!
     
-    let operation = "ui.action"
-    let operationClick = "ui.action.click"
-    let action = "SomeAction:"
-    let expectedAction = "SomeAction"
-    let accessibilityIdentifier = "accessibilityIdentifier"
+    private let operation = "ui.action"
+    private let operationClick = "ui.action.click"
+    private let action = "SomeAction:"
+    private let expectedAction = "SomeAction"
+    private let accessibilityIdentifier = "accessibilityIdentifier"
     
     override func setUp() {
         super.setUp()
@@ -261,7 +261,7 @@ class SentryUIEventTrackerTests: XCTestCase {
         XCTAssertFalse(SentryUIEventTracker.isUIEventOperation("unknown"))
     }
         
-    func callExecuteAction(action: String, target: Any?, sender: Any?, event: UIEvent?) {
+    private func callExecuteAction(action: String, target: Any?, sender: Any?, event: UIEvent?) {
         fixture.swizzleWrapper.execute(action: action, target: target, sender: sender, event: event)
     }
     

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackingIntegrationTests.swift
@@ -79,7 +79,7 @@ class SentryUIEventTrackerIntegrationTests: XCTestCase {
         XCTAssertFalse(SentrySwizzleWrapper.hasItems())
     }
     
-    func assertNoInstallation(_ integration: SentryUIEventTrackingIntegration) {
+    private func assertNoInstallation(_ integration: SentryUIEventTrackingIntegration) {
         XCTAssertNil(Dynamic(integration).uiEventTracker as SentryUIEventTracker?)
     }
     

--- a/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryEnvelopeRateLimitTests.swift
@@ -78,7 +78,7 @@ class SentryEnvelopeRateLimitTests: XCTestCase {
         XCTAssertEqual(SentryEnvelopeItemTypeEvent, try XCTUnwrap(actual.items.first).header.type)
     }
     
-    func getEnvelope() -> SentryEnvelope {
+    private func getEnvelope() -> SentryEnvelope {
         var envelopeItems = [SentryEnvelopeItem]()
         for _ in 0...2 {
             let event = Event()

--- a/Tests/SentryTests/Networking/RateLimits/SentryRetryAfterHeaderParserTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryRetryAfterHeaderParserTests.swift
@@ -46,7 +46,7 @@ class SentryRetryAfterHeaderParserTests: XCTestCase {
         testWith(header: httpDateAsString, expected: expected)
     }
     
-    func testWith(header: String?, expected: Date?) {
+    private func testWith(header: String?, expected: Date?) {
         let actual = sut.parse(header)
         XCTAssertEqual(expected, actual)
     }

--- a/Tests/SentryTests/Networking/SentryHttpDateParserTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpDateParserTests.swift
@@ -36,7 +36,7 @@ class SentryHttpDateParserTests: XCTestCase {
         group.waitWithTimeout()
     }
     
-    func startWorkItemTest(i: Int, queue: DispatchQueue, group: DispatchGroup) {
+    private func startWorkItemTest(i: Int, queue: DispatchQueue, group: DispatchGroup) {
         group.enter()
         queue.async {
             let expected = self.currentDateProvider.date().addingTimeInterval(TimeInterval(i))

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -142,11 +142,11 @@ class SentryHttpTransportTests: XCTestCase {
         }
     }
 
-    class func dsn() throws -> SentryDsn {
+    private class func dsn() throws -> SentryDsn {
         try TestConstants.dsn(username: "SentryHttpTransportTests")
     }
 
-    class func buildRequest(_ envelope: SentryEnvelope) -> SentryNSURLRequest {
+    private class func buildRequest(_ envelope: SentryEnvelope) -> SentryNSURLRequest {
         let envelopeData = try! XCTUnwrap(SentrySerialization.data(with: envelope))
         return try! SentryNSURLRequest(envelopeRequestWith: dsn(), andData: envelopeData)
     }
@@ -1021,7 +1021,7 @@ class SentryHttpTransportTests: XCTestCase {
         }
     }
 
-    func givenFirstRateLimitGetsActiveWithSecondResponse() {
+    private func givenFirstRateLimitGetsActiveWithSecondResponse() {
         var i = -1
         fixture.requestManager.returnResponse { () -> HTTPURLResponse? in
             i += 1

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -71,7 +71,7 @@ class SentryTransportFactoryTests: XCTestCase {
         })
     }
 
-    func rateLimiting() -> RateLimits {
+    private func rateLimiting() -> RateLimits {
         let dateProvider = TestCurrentDateProvider()
         let retryAfterHeaderParser = RetryAfterHeaderParser(httpDateParser: HttpDateParser(), currentDateProvider: dateProvider)
         let rateLimitParser = RateLimitParser(currentDateProvider: dateProvider)

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -449,7 +449,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         return try XCTUnwrap(SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
     }
 
-    let VALID_REPLAY_ID = "0eac7ab503354dd5819b03e263627a29"
+    private let VALID_REPLAY_ID = "0eac7ab503354dd5819b03e263627a29"
 
     private class TestSentrySessionReplayIntegration: SentrySessionReplayIntegration {
         static var captureReplayCalledTimes = 0
@@ -469,7 +469,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     }
     #endif
     
-    func getUnhandledExceptionEnvelope() -> SentryEnvelope {
+    private func getUnhandledExceptionEnvelope() -> SentryEnvelope {
         let event = Event()
         event.message = SentryMessage(formatted: "Test Event with unhandled exception")
         event.level = .error

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -99,7 +99,7 @@ class SentryBreadcrumbTests: XCTestCase {
         testIsNotEqual { breadcrumb in breadcrumb.setValue(nil, forKey: "unknown") }
     }
     
-    func testIsNotEqual(block: (Breadcrumb) -> Void ) {
+    private func testIsNotEqual(block: (Breadcrumb) -> Void ) {
         let breadcrumb = Fixture().breadcrumb
         block(breadcrumb)
         XCTAssertNotEqual(fixture.breadcrumb, breadcrumb)

--- a/Tests/SentryTests/Protocol/SentryGeoTests.swift
+++ b/Tests/SentryTests/Protocol/SentryGeoTests.swift
@@ -42,7 +42,7 @@ class SentryGeoTests: XCTestCase {
         try testIsNotEqual { geo in geo.region = "" }
     }
     
-    func testIsNotEqual(block: (Geo) -> Void) throws {
+    private func testIsNotEqual(block: (Geo) -> Void) throws {
         let geo = try XCTUnwrap(TestData.geo.copy() as? Geo)
         block(geo)
         XCTAssertNotEqual(TestData.geo, geo)

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -5,7 +5,7 @@ class SentrySdkInfoTests: XCTestCase {
     
     private let sdkName = "sentry.cocoa"
 
-    func cleanUp() {
+    private func cleanUp() {
         SentrySdkPackage.resetPackageManager()
         SentryExtraPackages.clear()
     }

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -105,7 +105,7 @@ class SentryUserTests: XCTestCase {
         try testIsNotEqual { user in user.data?.removeAll() }
     }
     
-    func testIsNotEqual(block: (User) -> Void ) throws {
+    private func testIsNotEqual(block: (User) -> Void ) throws {
         let user = try XCTUnwrap(TestData.user.copy() as? User)
         block(user)
         XCTAssertNotEqual(TestData.user, user)

--- a/Tests/SentryTests/Recording/SentryCrashCTests.swift
+++ b/Tests/SentryTests/Recording/SentryCrashCTests.swift
@@ -237,7 +237,7 @@ class SentryCrashCTests: XCTestCase {
 
     // MARK: - Helper
 
-    func readFirstReportFromDisk(reportsDir: URL) throws -> NSDictionary {
+    private func readFirstReportFromDisk(reportsDir: URL) throws -> NSDictionary {
         let reportUrls = try FileManager.default.contentsOfDirectory(atPath: reportsDir.path)
         XCTAssertEqual(reportUrls.count, 1)
         XCTAssertTrue(reportUrls[0].hasPrefix("SentryCrashCTests-report-"))

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -2,7 +2,7 @@ import SentryTestUtils
 import XCTest
 
 class SentryBinaryImageCacheTests: XCTestCase {
-    var sut: SentryBinaryImageCache {
+    private var sut: SentryBinaryImageCache {
         SentryDependencyContainer.sharedInstance().binaryImageCache
     }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationTests.swift
@@ -11,7 +11,7 @@ class SentryCrashTestInstallation: SentryCrashInstallation {
 
 class SentryCrashInstallationTests: XCTestCase {
 
-    var notificationCenter: TestNSNotificationCenterWrapper!
+    private var notificationCenter: TestNSNotificationCenterWrapper!
 
     override func tearDown() {
         super.tearDown()

--- a/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
@@ -114,7 +114,7 @@ class SentryCrashStackEntryMapperTests: XCTestCase {
         return result
     }
 
-    func createCrashBinaryImage(_ address: UInt) -> SentryCrashBinaryImage {
+    private func createCrashBinaryImage(_ address: UInt) -> SentryCrashBinaryImage {
         let name = "Expected Name at \(address)"
         let nameCString = name.withCString { strdup($0) }
 

--- a/Tests/SentryTests/SentryCrash/SentryCrashUUIDConversionTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashUUIDConversionTests.swift
@@ -28,7 +28,7 @@ class SentryCrashUUIDConversionTests: XCTestCase {
         )
     }
     
-    func testWith(expected: String, uuidAsCharArray: [UInt8]) {
+    private func testWith(expected: String, uuidAsCharArray: [UInt8]) {
         var dst: [Int8] = Array(repeating: Int8.random(in: 0..<50), count: 37)
         sentrycrashdl_convertBinaryImageUUID(uuidAsCharArray, &dst)
         

--- a/Tests/SentryTests/SentryCrash/SentryInAppLogicTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryInAppLogicTests.swift
@@ -176,7 +176,7 @@ class SentryInAppLogicTests: XCTestCase {
         testWithImages(images: images, inAppIncludes: ["watchOS-Swift WatchKit Extension"])
     }
     
-    func testWithImages(images: Images, inAppIncludes: [String], inAppExcludes: [String] = []) {
+    private func testWithImages(images: Images, inAppIncludes: [String], inAppExcludes: [String] = []) {
         let sut = fixture.getSut(inAppIncludes: inAppIncludes, inAppExcludes: inAppExcludes)
         XCTAssertTrue(sut.is(inApp: images.bundleExecutable))
         images.privateFrameworks.forEach {
@@ -190,7 +190,7 @@ class SentryInAppLogicTests: XCTestCase {
         }
     }
     
-    struct Images {
+    private struct Images {
         let bundleExecutable: String
         /**
          Private frameworks embedded in the application bundle. These frameworks are embedded, but are part of the app and should me marked as inApp.

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -139,13 +139,13 @@ class SentryStacktraceBuilderTests: XCTestCase {
     }
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func firstFrame() async -> Int {
+    private func firstFrame() async -> Int {
         print("\(Date()) [Sentry] [TEST] first async frame about to await...")
         return await innerFrame1()
     }
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func innerFrame1() async -> Int {
+    private func innerFrame1() async -> Int {
         print("\(Date()) [Sentry] [TEST] second async frame about to await on task...")
         await Task { @MainActor in
             print("\(Date()) [Sentry] [TEST] executing task inside second async frame...")
@@ -154,7 +154,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
     }
 
     @available(macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0, *)
-    func innerFrame2() async -> Int {
+    private func innerFrame2() async -> Int {
         let needed = ["firstFrame", "innerFrame1", "innerFrame2"]
         let actual = fixture.sut.buildStacktraceForCurrentThreadAsyncUnsafe()!
         let filteredFrames = actual.frames

--- a/Tests/SentryTests/SentryPredicateDescriptorTests.swift
+++ b/Tests/SentryTests/SentryPredicateDescriptorTests.swift
@@ -145,11 +145,11 @@ class SentryPredicateDescriptorTests: XCTestCase {
     }
     
     @objc
-    func compareFunction(_ item1: AnyObject, _ item2: AnyObject) -> Bool {
+    private func compareFunction(_ item1: AnyObject, _ item2: AnyObject) -> Bool {
         return item1 === item2
     }
     
-    func assertPredicate(predicate: NSPredicate, expectedResult: String ) {
+    private func assertPredicate(predicate: NSPredicate, expectedResult: String ) {
         let sut = fixture.getSut()
         XCTAssertEqual(sut.predicateDescription(predicate), expectedResult)
     }

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -3,6 +3,8 @@ import Foundation
 import SentryTestUtils
 import XCTest
 
+// swiftlint:disable test_case_accessibility
+// This is a base test class, so we can't keep all methods private.
 class SentrySDKIntegrationTestsBase: XCTestCase {
     
     var currentDate = TestCurrentDateProvider()
@@ -107,7 +109,9 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         callback(capture?.event, capture?.scope)
     }
     
-    func advanceTime(bySeconds: TimeInterval) {
+    private func advanceTime(bySeconds: TimeInterval) {
         currentDate.setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))
     }
 }
+
+// swiftlint:enable test_case_accessibility

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -769,7 +769,7 @@ class SentryScopeSwiftTests: XCTestCase {
         })
     }
     
-    class TestScopeObserver: NSObject, SentryScopeObserver {
+    private class TestScopeObserver: NSObject, SentryScopeObserver {
         var tags: [String: String]?
         func setTags(_ tags: [String: String]?) {
             self.tags = tags

--- a/Tests/SentryTests/SentryScreenShotTests.swift
+++ b/Tests/SentryTests/SentryScreenShotTests.swift
@@ -106,7 +106,7 @@ class SentryScreenShotTests: XCTestCase {
         XCTAssertEqual(0, data.count, "No screenshot should be taken, cause the image has zero height.")
     }
     
-    class TestSentryUIApplication: SentryUIApplication {
+    private class TestSentryUIApplication: SentryUIApplication {
         private var _windows: [UIWindow]?
         
         override var windows: [UIWindow]? {
@@ -119,7 +119,7 @@ class SentryScreenShotTests: XCTestCase {
         }
     }
 
-    class TestWindow: UIWindow {
+    private class TestWindow: UIWindow {
         var onDrawHierarchy: (() -> Void)?
         
         override func drawHierarchy(in rect: CGRect, afterScreenUpdates afterUpdates: Bool) -> Bool {

--- a/Tests/SentryTests/SentrySessionTests.swift
+++ b/Tests/SentryTests/SentrySessionTests.swift
@@ -97,7 +97,7 @@ class SentrySessionTestsSwift: XCTestCase {
         withValue { $0["status"] = "20" }
     }
     
-    func withValue(setValue: (inout [String: Any]) -> Void) {
+    private func withValue(setValue: (inout [String: Any]) -> Void) {
         let expected = SentrySession(releaseName: "release", distinctId: "some-id")
         var serialized = expected.serialize()
         setValue(&serialized)

--- a/Tests/SentryTests/SentryViewHierarchyTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyTests.swift
@@ -220,7 +220,7 @@ class SentryViewHierarchyTests: XCTestCase {
         XCTAssertTrue(fixture.uiApplication.calledOnMainThread, "appViewHierarchy is not using the main thread to get UI windows")
     }
 
-    class TestSentryUIApplication: SentryUIApplication {
+    private class TestSentryUIApplication: SentryUIApplication {
         private var _windows: [UIWindow]?
         private var _calledOnMainThread = true
 

--- a/Tests/SentryTests/SentryViewPhotographerTests.swift
+++ b/Tests/SentryTests/SentryViewPhotographerTests.swift
@@ -15,7 +15,7 @@ class SentryViewPhotographerTests: XCTestCase {
         }
     }
     
-    func sut() -> SentryViewPhotographer {
+    private func sut() -> SentryViewPhotographer {
         return SentryViewPhotographer(renderer: TestViewRenderer(), redactOptions: RedactOptions())
     }
     

--- a/Tests/SentryTests/State/SentryInstallationTests.swift
+++ b/Tests/SentryTests/State/SentryInstallationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class SentryInstallationTests: XCTestCase {
     
     // FileManager().temporaryDirectory already has a trailing slash
-    let basePath = "\(FileManager().temporaryDirectory)\(UUID().uuidString)"
+    private let basePath = "\(FileManager().temporaryDirectory)\(UUID().uuidString)"
     
     override func setUpWithError() throws {
         try super.setUpWithError()

--- a/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
+++ b/Tests/SentryTests/Swift/Extensions/NSLockTests.swift
@@ -46,7 +46,7 @@ final class NSLockTests: XCTestCase {
         wait(for: [expectation], timeout: 0.1)
     }
 
-    enum NSLockError: Error {
+    private enum NSLockError: Error {
         case runtimeError(String)
     }
 }

--- a/Tests/SentryTests/Transaction/SentrySpanContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanContextTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 
 class SentrySpanContextTests: XCTestCase {
-    let someOperation = "Some Operation"
+    private let someOperation = "Some Operation"
     
     func testInit() {
         let spanContext = SpanContext(operation: someOperation)

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -735,7 +735,7 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(sut.data["frames.delay"])
     }
     
-    func givenFramesTracker() -> (TestDisplayLinkWrapper, SentryFramesTracker) {
+    private func givenFramesTracker() -> (TestDisplayLinkWrapper, SentryFramesTracker) {
         let displayLinkWrapper = TestDisplayLinkWrapper(dateProvider: self.fixture.currentDateProvider)
         let framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: self.fixture.currentDateProvider, dispatchQueueWrapper: TestSentryDispatchQueueWrapper(), notificationCenter: TestNSNotificationCenterWrapper(), keepDelayedFramesDuration: 10)
         framesTracker.start()

--- a/Tests/SentryTests/Transaction/SentryTraceStateTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTraceStateTests.swift
@@ -153,7 +153,7 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertEqual(baggage.replayId, fixture.replayId)
     }
         
-    func assertTraceState(traceContext: TraceContext) {
+    private func assertTraceState(traceContext: TraceContext) {
         XCTAssertEqual(traceContext.traceId, fixture.traceId)
         XCTAssertEqual(traceContext.publicKey, fixture.publicKey)
         XCTAssertEqual(traceContext.releaseName, fixture.releaseName)

--- a/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
@@ -4,15 +4,15 @@ import XCTest
 
 class SentryTransactionContextTests: XCTestCase {
     
-    let operation = "ui.load"
-    let transactionName = "Screen Load"
-    let origin = "auto.ui.swift_ui"
-    let traceID = SentryId()
-    let spanID = SpanId()
-    let parentSpanID = SpanId()
-    let nameSource = SentryTransactionNameSource.route
-    let sampled = SentrySampleDecision.yes
-    let parentSampled = SentrySampleDecision.no
+    private let operation = "ui.load"
+    private let transactionName = "Screen Load"
+    private let origin = "auto.ui.swift_ui"
+    private let traceID = SentryId()
+    private let spanID = SpanId()
+    private let parentSpanID = SpanId()
+    private let nameSource = SentryTransactionNameSource.route
+    private let sampled = SentrySampleDecision.yes
+    private let parentSampled = SentrySampleDecision.no
     
     func testPublicInit_WithOperation() {
         let context = TransactionContext(operation: operation)


### PR DESCRIPTION
Having things with the least amount of accessibility is better for
encapsulation.

Came up in https://github.com/getsentry/sentry-cocoa/pull/4771.

#skip-changelog
