### PR TITLE
test: Fix ANRTrackerTests.clearDirectlyAfterStart

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -189,7 +189,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: 0.0)
     }
     
-    func testClearDirectlyAfterStart() {
+    func testClearDirectlyAfterStart_FinishesThread() {
         anrDetectedExpectation.isInverted = true
         
         let invocations = 10
@@ -201,8 +201,9 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: 1)
         
         XCTAssertEqual(0, fixture.threadWrapper.threads.count)
-        XCTAssertEqual(1, fixture.threadWrapper.threadStartedInvocations.count)
-        XCTAssertEqual(1, fixture.threadWrapper.threadFinishedInvocations.count)
+        // As it can take a while until a new thread is started, the thread tracker may start
+        // and finish multiple times. Most importantly, the code covers every start with one finish.
+        XCTAssertEqual(fixture.threadWrapper.threadStartedInvocations.count, fixture.threadWrapper.threadFinishedInvocations.count, "The number of started and finished threads should be equal, otherwise the ANR tracker could run.")
     }
     
     func anrDetected(type: Sentry.SentryANRType) {

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -403,9 +403,10 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: self.waitTimeout)
         
-        XCTAssertEqual(0, threadWrapper.threads.count)
-        XCTAssertEqual(1, threadWrapper.threadStartedInvocations.count)
-        XCTAssertEqual(1, threadWrapper.threadFinishedInvocations.count)
+        XCTAssertEqual(0, threadWrapper.threads.count)        
+        // As it can take a while until a new thread is started, the thread tracker may start
+        // and finish multiple times. Most importantly, the code covers every start with one finish.
+        XCTAssertEqual(threadWrapper.threadStartedInvocations.count, threadWrapper.threadFinishedInvocations.count, "The number of started and finished threads should be equal, otherwise the ANR tracker could run.")
     }
     
     func testNoFrameDelayData_FullyBlocking_NotReported() throws {


### PR DESCRIPTION
The tests testClearDirectlyAfterStart,
testClearDirectlyAfterStart_FullyBlocking_NotReported sometimes failed with the started and finished invocations being greater than 1. This is fixed now by asserting the number of starts matches the number of finish invocations.

#skip-changelog