### PR TITLE
chore(ci): add retry-mechanism for UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -34,14 +34,67 @@ jobs:
 
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_${{matrix.target}} && break ; done
-        shell: sh
+        id: run-fastlane
+        run: fastlane ui_tests_${{matrix.target}}
+        continue-on-error: true
+      
+      - name: Recovery - Check if the test runner never began executing
+        id: check-if-test-should-be-retried
+        if: ${{ steps.run-fastlane.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const logsDir = path.join('~/Library/Logs/scan');
+            if (!fs.existsSync(logsDir)) {
+              throw new Error('No logs directory found');
+            }
+            const logs = fs.readdirSync(logsDir);
+            const lastLog = logs[logs.length - 1];
+            if (!lastLog) {
+              throw new Error('No logs found');
+            }
+            const lastLogPath = path.join(logsDir, lastLog);
+            const lastLogContent = fs.readFileSync(lastLogPath, 'utf8');
+            const retryReasonRegexs = [
+              /Test\srunner\snever\sbegan\sexecuting\stests\safter\slaunching/
+            ]
+            const retryReason = retryReasonRegexs.find(regex => lastLogContent.match(regex));
+            if (retryReason) {
+              core.setOutput('RETRY_TEST', 'true');
+            }
+      
+      - name: Recovery - Run Fastlane again
+        id: run-fastlane-retry-1
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+
+      - name: Capture Spindump on Failure
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: |
+          echo "Detecting xctest process..."
+          XCTEST_PID=$(pgrep -f xctest || echo "")
+          if [[ -n "$XCTEST_PID" ]]; then
+            echo "Capturing spindump for xctest PID: $XCTEST_PID"
+            sudo spindump $XCTEST_PID -file spindump.txt
+          else
+            echo "No xctest process found. Capturing system-wide spindump."
+            sudo spindump -file spindump.txt
+          fi
+
+      - name: Upload Spindump (if available)
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-tests-${{matrix.xcode}}-${{matrix.device}}-spindump
+          path: spindump.txt
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-uitest-output-${{matrix.target}}
+          name: ui-tests-${{matrix.xcode}}-${{matrix.device}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -57,21 +110,72 @@ jobs:
           - runs-on: macos-13
             xcode: "14.3"
             device: "iPhone 8 (16.1)"
-
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
       
       # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swiftui device:"${{matrix.device}}" && break ; done
-        shell: sh
+        run: fastlane ui_tests_ios_swiftui device:"${{matrix.device}}"
+        continue-on-error: true
+
+      - name: Recovery - Check if the test runner never began executing
+        id: check-if-test-should-be-retried
+        if: ${{ steps.run-fastlane.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const logsDir = path.join('~/Library/Logs/scan');
+            if (!fs.existsSync(logsDir)) {
+              throw new Error('No logs directory found');
+            }
+            const logs = fs.readdirSync(logsDir);
+            const lastLog = logs[logs.length - 1];
+            if (!lastLog) {
+              throw new Error('No logs found');
+            }
+            const lastLogPath = path.join(logsDir, lastLog);
+            const lastLogContent = fs.readFileSync(lastLogPath, 'utf8');
+            const retryReasonRegexs = [
+              /Test\srunner\snever\sbegan\sexecuting\stests\safter\slaunching/
+            ]
+            const retryReason = retryReasonRegexs.find(regex => lastLogContent.match(regex));
+            if (retryReason) {
+              core.setOutput('RETRY_TEST', 'true');
+            } 
+
+      - name: Recovery - Run Fastlane again
+        id: run-fastlane-retry-1
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+
+      - name: Capture Spindump on Failure
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: |
+          echo "Detecting xctest process..."
+          XCTEST_PID=$(pgrep -f xctest || echo "")
+          if [[ -n "$XCTEST_PID" ]]; then
+            echo "Capturing spindump for xctest PID: $XCTEST_PID"
+            sudo spindump $XCTEST_PID -file spindump.txt
+          else
+            echo "No xctest process found. Capturing system-wide spindump."
+            sudo spindump -file spindump.txt
+          fi
+
+      - name: Upload Spindump (if available)
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-tests-swift-ui-${{matrix.xcode}}-${{matrix.device}}-spindump
+          path: spindump.txt
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-ios-swiftui-test-output-xcode-${{matrix.xcode}}-${{matrix.device}}
+          name: ui-tests-swift-ui-${{matrix.xcode}}-${{matrix.device}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -90,7 +194,6 @@ jobs:
           - runs-on: macos-14
             xcode: "15.4"
             device: "iPhone 15 (17.2)"
-
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
@@ -101,16 +204,69 @@ jobs:
 
       - name: Run Fastlane
         run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+        continue-on-error: true
+
+      - name: Recovery - Check if the test runner never began executing
+        id: check-if-test-should-be-retried
+        if: ${{ steps.run-fastlane.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const logsDir = path.join('~/Library/Logs/scan');
+            if (!fs.existsSync(logsDir)) {
+              throw new Error('No logs directory found');
+            }
+            const logs = fs.readdirSync(logsDir);
+            const lastLog = logs[logs.length - 1];
+            if (!lastLog) {
+              throw new Error('No logs found');
+            }
+            const lastLogPath = path.join(logsDir, lastLog);
+            const lastLogContent = fs.readFileSync(lastLogPath, 'utf8');
+            const retryReasonRegexs = [
+              /Test\srunner\snever\sbegan\sexecuting\stests\safter\slaunching/
+            ]
+            const retryReason = retryReasonRegexs.find(regex => lastLogContent.match(regex));
+            if (retryReason) {
+              core.setOutput('RETRY_TEST', 'true');
+            } 
+
+      - name: Recovery - Run Fastlane again
+        id: run-fastlane-retry-1
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+
+      - name: Capture Spindump on Failure
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: |
+          echo "Detecting xctest process..."
+          XCTEST_PID=$(pgrep -f xctest || echo "")
+          if [[ -n "$XCTEST_PID" ]]; then
+            echo "Capturing spindump for xctest PID: $XCTEST_PID"
+            sudo spindump $XCTEST_PID -file spindump.txt
+          else
+            echo "No xctest process found. Capturing system-wide spindump."
+            sudo spindump -file spindump.txt
+          fi
+
+      - name: Upload Spindump (if available)
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-tests-swift-${{matrix.xcode}}-${{matrix.device}}-spindump
+          path: spindump.txt
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-ios-swift-test-output-${{matrix.xcode}}-${{matrix.device}}
+          name: ui-tests-swift-${{matrix.xcode}}-${{matrix.device}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
-            
+   
   ui-tests-swift6:
     name: UI Tests for iOS-Swift6 Simulator
     runs-on: macos-15
@@ -120,12 +276,65 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh "16.2"
       - name: Run Fastlane
         run: fastlane ui_tests_ios_swift6
+        continue-on-error: true
+
+      - name: Recovery - Check if the test runner never began executing
+        id: check-if-test-should-be-retried
+        if: ${{ steps.run-fastlane.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const logsDir = path.join('~/Library/Logs/scan');
+            if (!fs.existsSync(logsDir)) {
+              throw new Error('No logs directory found');
+            }
+            const logs = fs.readdirSync(logsDir);
+            const lastLog = logs[logs.length - 1];
+            if (!lastLog) {
+              throw new Error('No logs found');
+            }
+            const lastLogPath = path.join(logsDir, lastLog);
+            const lastLogContent = fs.readFileSync(lastLogPath, 'utf8');
+            const retryReasonRegexs = [
+              /Test\srunner\snever\sbegan\sexecuting\stests\safter\slaunching/
+            ]
+            const retryReason = retryReasonRegexs.find(regex => lastLogContent.match(regex));
+            if (retryReason) {
+              core.setOutput('RETRY_TEST', 'true');
+            } 
+
+      - name: Recovery - Run Fastlane again
+        id: run-fastlane-retry-1
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+
+      - name: Capture Spindump on Failure
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: |
+          echo "Detecting xctest process..."
+          XCTEST_PID=$(pgrep -f xctest || echo "")
+          if [[ -n "$XCTEST_PID" ]]; then
+            echo "Capturing spindump for xctest PID: $XCTEST_PID"
+            sudo spindump $XCTEST_PID -file spindump.txt
+          else
+            echo "No xctest process found. Capturing system-wide spindump."
+            sudo spindump -file spindump.txt
+          fi
+
+      - name: Upload Spindump (if available)
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-tests-swift6-${{matrix.xcode}}-${{matrix.device}}-spindump
+          path: spindump.txt
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-ios-swift-test-output-${{matrix.xcode}}-${{matrix.device}}
+          name: ui-tests-swift6-${{matrix.xcode}}-${{matrix.device}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -140,12 +349,65 @@ jobs:
       - run: ./scripts/build-xcframework.sh gameOnly
       - name: Run Fastlane
         run: fastlane duplication_test
+        continue-on-error: true
+
+      - name: Recovery - Check if the test runner never began executing
+        id: check-if-test-should-be-retried
+        if: ${{ steps.run-fastlane.outcome == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            
+            const logsDir = path.join('~/Library/Logs/scan');
+            if (!fs.existsSync(logsDir)) {
+              throw new Error('No logs directory found');
+            }
+            const logs = fs.readdirSync(logsDir);
+            const lastLog = logs[logs.length - 1];
+            if (!lastLog) {
+              throw new Error('No logs found');
+            }
+            const lastLogPath = path.join(logsDir, lastLog);
+            const lastLogContent = fs.readFileSync(lastLogPath, 'utf8');
+            const retryReasonRegexs = [
+              /Test\srunner\snever\sbegan\sexecuting\stests\safter\slaunching/
+            ]
+            const retryReason = retryReasonRegexs.find(regex => lastLogContent.match(regex));
+            if (retryReason) {
+              core.setOutput('RETRY_TEST', 'true');
+            } 
+
+      - name: Recovery - Run Fastlane again
+        id: run-fastlane-retry-1
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: fastlane duplication_test
+
+      - name: Capture Spindump on Failure
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        run: |
+          echo "Detecting xctest process..."
+          XCTEST_PID=$(pgrep -f xctest || echo "")
+          if [[ -n "$XCTEST_PID" ]]; then
+            echo "Capturing spindump for xctest PID: $XCTEST_PID"
+            sudo spindump $XCTEST_PID -file spindump.txt
+          else
+            echo "No xctest process found. Capturing system-wide spindump."
+            sudo spindump -file spindump.txt
+          fi
+
+      - name: Upload Spindump (if available)
+        if: ${{ steps.check-if-test-should-be-retried.outputs.RETRY_TEST == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: duplication-test-spindump
+          path: spindump.txt
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-ios-swift-test-output-${{matrix.xcode}}-${{matrix.device}}
+          name: duplication-test-raw-ios-swift-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**


### PR DESCRIPTION
## :scroll: Description

- Adds a retry mechanism for error "Test runner never began executing tests after launching"
- Uploads a spindump on failure

## :bulb: Motivation and Context

Should ignore flakiness of CI.

## :green_heart: How did you test it?

- Ran CI until it failed and retried

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps

#skip-changelog