### PR TITLE
impr: Add more debug logs for SentryViewHierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Add more debug logs for SentryViewHierarchy (#4780)
+
 ## 8.44.0
 
 ### Fixes

--- a/Sources/Sentry/SentryViewHierarchy.m
+++ b/Sources/Sentry/SentryViewHierarchy.m
@@ -60,8 +60,12 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
 
     void (^fetchViewHierarchy)(void) = ^{ result = [self appViewHierarchy]; };
 
+    SENTRY_LOG_INFO(@"Starting to fetch the view hierarchy from the main thread.");
+
     [[SentryDependencyContainer sharedInstance].dispatchQueueWrapper
         dispatchSyncOnMainQueue:fetchViewHierarchy];
+
+    SENTRY_LOG_INFO(@"Finished fetching the view hierarchy from the main thread.");
 
     return result;
 }
@@ -93,6 +97,8 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
     __block SentryCrashJSONEncodeContext JSONContext;
     sentrycrashjson_beginEncode(&JSONContext, NO, addJSONDataFunc, userData);
 
+    SENTRY_LOG_DEBUG(@"Processing view hierarchy.");
+
     int (^serializeJson)(void) = ^int() {
         int result;
         tryJson(sentrycrashjson_beginObject(&JSONContext, NULL));
@@ -121,6 +127,8 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
 
 - (int)viewHierarchyFromView:(UIView *)view intoContext:(SentryCrashJSONEncodeContext *)context
 {
+    SENTRY_LOG_DEBUG(@"Processing view hierarchy of view: %@", view);
+
     int result = 0;
     tryJson(sentrycrashjson_beginObject(context, NULL));
     const char *viewClassName = [[SwiftDescriptor getObjectClassName:view] UTF8String];


### PR DESCRIPTION


## :scroll: Description

Add a few more logs to SentryViewHierarchy to get more insight into what the class is doing.

## :bulb: Motivation and Context

A customer claims that their app hangs once they enable ViewHierarchy. These debug logs can help to investigate such problems.

## :green_heart: How did you test it?
Unit tests still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
