### PR TITLE
impr: Add uptime to SDK log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Improvements
 
 - Add `sample_rand` to baggage (#4751)
+- Add uptime to log messages (#4781)
 
 ## Fixes
 

--- a/Tests/SentryTests/Helper/SentryLog.swift
+++ b/Tests/SentryTests/Helper/SentryLog.swift
@@ -21,4 +21,10 @@ extension Sentry.SentryLog {
         SentryLogOutput()
         #endif
     }
+    
+    static func setCurrentDateProvider(_ dateProvider: SentryCurrentDateProvider) {
+        #if SENTRY_TEST || SENTRY_TEST_CI
+        SentryLog.setDateProvider(dateProvider)
+        #endif
+    }
 }


### PR DESCRIPTION


## :scroll: Description

Add the system uptime to the SDK log messages to know precisely when the logger logs. This can help when investigating issues by reading the SDK log messages.

## :bulb: Motivation and Context

For investigating the raw logs of flaky tests this can be highly useful to understand exactly where a test might have hanged.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
