### PR TITLE
feat: Deserialize SentryBreadcrumb

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		626E2D4C2BEA0C37005596FE /* SentryEnabledFeaturesBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E2D4B2BEA0C37005596FE /* SentryEnabledFeaturesBuilderTests.swift */; };
 		6271ADF32BA06D9B0098D2E9 /* SentryInternalSerializable.h in Headers */ = {isa = PBXBuildFile; fileRef = 6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6273513F2CBD14970021D100 /* SentryDebugImageProvider+HybridSDKs.h in Headers */ = {isa = PBXBuildFile; fileRef = 6273513E2CBD14970021D100 /* SentryDebugImageProvider+HybridSDKs.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		627C77892D50B6840055E966 /* SentryBreadcrumbCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627C77882D50B6840055E966 /* SentryBreadcrumbCodable.swift */; };
 		627E7589299F6FE40085504D /* SentryInternalDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 627E7588299F6FE40085504D /* SentryInternalDefines.h */; };
 		628094742D39584C00B3F18B /* SentryUserCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628094732D39584700B3F18B /* SentryUserCodable.swift */; };
 		6281C5722D3E4F12009D0978 /* DecodeArbitraryData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6281C5712D3E4F06009D0978 /* DecodeArbitraryData.swift */; };
@@ -1152,6 +1153,7 @@
 		626E2D4B2BEA0C37005596FE /* SentryEnabledFeaturesBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryEnabledFeaturesBuilderTests.swift; sourceTree = "<group>"; };
 		6271ADF22BA06D9B0098D2E9 /* SentryInternalSerializable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalSerializable.h; path = include/SentryInternalSerializable.h; sourceTree = "<group>"; };
 		6273513E2CBD14970021D100 /* SentryDebugImageProvider+HybridSDKs.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryDebugImageProvider+HybridSDKs.h"; path = "include/HybridPublic/SentryDebugImageProvider+HybridSDKs.h"; sourceTree = "<group>"; };
+		627C77882D50B6840055E966 /* SentryBreadcrumbCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbCodable.swift; sourceTree = "<group>"; };
 		627E7588299F6FE40085504D /* SentryInternalDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalDefines.h; path = include/SentryInternalDefines.h; sourceTree = "<group>"; };
 		628094732D39584700B3F18B /* SentryUserCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUserCodable.swift; sourceTree = "<group>"; };
 		6281C5712D3E4F06009D0978 /* DecodeArbitraryData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodeArbitraryData.swift; sourceTree = "<group>"; };
@@ -1924,9 +1926,9 @@
 		A8AFFCD32907E0CA00967CD7 /* SentryRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRequestTests.swift; sourceTree = "<group>"; };
 		A8F17B2D2901765900990B25 /* SentryRequest.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryRequest.m; sourceTree = "<group>"; };
 		A8F17B332902870300990B25 /* SentryHttpStatusCodeRange.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryHttpStatusCodeRange.m; sourceTree = "<group>"; };
-		D42E48562D48DF1600D251BC /* SentryBuildAppStartSpansTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBuildAppStartSpansTests.swift; sourceTree = "<group>"; };
 		D41909922D48FFF6002B83D0 /* SentryNSDictionarySanitize+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryNSDictionarySanitize+Tests.h"; sourceTree = "<group>"; };
 		D41909942D490006002B83D0 /* SentryNSDictionarySanitize+Tests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "SentryNSDictionarySanitize+Tests.m"; sourceTree = "<group>"; };
+		D42E48562D48DF1600D251BC /* SentryBuildAppStartSpansTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBuildAppStartSpansTests.swift; sourceTree = "<group>"; };
 		D42E48582D48FC8F00D251BC /* SentryNSDictionarySanitizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSDictionarySanitizeTests.swift; sourceTree = "<group>"; };
 		D48724DA2D352591005DE483 /* SentryTraceOrigin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTraceOrigin.swift; sourceTree = "<group>"; };
 		D48724DC2D354934005DE483 /* SentrySpanOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySpanOperation.swift; sourceTree = "<group>"; };
@@ -2215,6 +2217,7 @@
 				620467AB2D3FFD1C0025F06C /* SentryNSErrorCodable.swift */,
 				620078712D38F00D0022CB67 /* SentryGeoCodable.swift */,
 				628094732D39584700B3F18B /* SentryUserCodable.swift */,
+				627C77882D50B6840055E966 /* SentryBreadcrumbCodable.swift */,
 				620078732D38F0DF0022CB67 /* SentryCodable.swift */,
 			);
 			path = Codable;
@@ -4904,6 +4907,7 @@
 				63FE717320DA4C1100CDBAE8 /* SentryCrashC.c in Sources */,
 				6293F5752D422A95002BC3BD /* SentryStacktraceCodable.swift in Sources */,
 				63FE712120DA4C1000CDBAE8 /* SentryCrashSymbolicator.c in Sources */,
+				627C77892D50B6840055E966 /* SentryBreadcrumbCodable.swift in Sources */,
 				63FE70D720DA4C1000CDBAE8 /* SentryCrashMonitor_MachException.c in Sources */,
 				7B96572226830D2400C66E25 /* SentryScopeSyncC.c in Sources */,
 				0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */,

--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -40,6 +40,12 @@ NS_SWIFT_NAME(Breadcrumb)
 @property (nonatomic, copy, nullable) NSString *message;
 
 /**
+ * Origin of the breadcrumb that is used to identify source of the breadcrumb
+ * For example hybrid SDKs can identify native breadcrumbs from JS or Flutter
+ */
+@property (nonatomic, copy, nullable) NSString *origin;
+
+/**
  * Arbitrary additional data that will be sent with the breadcrumb
  */
 @property (nonatomic, strong, nullable) NSDictionary<NSString *, id> *data;

--- a/Sources/Sentry/SentryLevelHelper.m
+++ b/Sources/Sentry/SentryLevelHelper.m
@@ -6,4 +6,9 @@
 {
     return breadcrumb.level;
 }
+
++ (void)setBreadcrumbLevel:(SentryBreadcrumb *)breadcrumb level:(NSUInteger)level
+{
+    breadcrumb.level = level;
+}
 @end

--- a/Sources/Sentry/include/HybridPublic/SentryBreadcrumb+Private.h
+++ b/Sources/Sentry/include/HybridPublic/SentryBreadcrumb+Private.h
@@ -4,13 +4,9 @@
 #    import "SentryBreadcrumb.h"
 #endif
 
-@interface SentryBreadcrumb ()
+NS_ASSUME_NONNULL_BEGIN
 
-/**
- * Origin of the breadcrumb that is used to identify source of the breadcrumb
- * For example hybrid SDKs can identify native breadcrumbs from JS or Flutter
- */
-@property (nonatomic, copy, nullable) NSString *origin;
+@interface SentryBreadcrumb ()
 
 /**
  * Initializes a SentryBreadcrumb from a JSON object.
@@ -19,3 +15,5 @@
  */
 - (instancetype _Nonnull)initWithDictionary:(NSDictionary *_Nonnull)dictionary;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryLevelHelper.h
+++ b/Sources/Sentry/include/SentryLevelHelper.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface SentryLevelBridge : NSObject
 + (NSUInteger)breadcrumbLevel:(SentryBreadcrumb *)breadcrumb;
++ (void)setBreadcrumbLevel:(SentryBreadcrumb *)breadcrumb level:(NSUInteger)level;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
@@ -1,0 +1,39 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+extension Breadcrumb: Decodable {
+    
+    private enum CodingKeys: String, CodingKey {
+        case level
+        case category
+        case timestamp
+        case type
+        case message
+        case data
+        case origin
+    }
+    
+    required convenience public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.init()
+        
+        let rawLevel = try container.decode(String.self, forKey: .level)
+        let level = SentryLevelHelper.levelForName(rawLevel)
+        SentryLevelBridge.setBreadcrumbLevel(self, level: level.rawValue)
+        
+        self.category = try container.decode(String.self, forKey: .category)
+        self.timestamp = try container.decodeIfPresent(Date.self, forKey: .timestamp)
+        self.type = try container.decodeIfPresent(String.self, forKey: .type)
+        self.message = try container.decodeIfPresent(String.self, forKey: .message)
+        self.origin = try container.decodeIfPresent(String.self, forKey: .origin)
+        
+        self.data = decodeArbitraryData {
+            try container.decodeIfPresent([String: ArbitraryData].self, forKey: .data)
+        }
+        
+        // We leave out unknown on purpose, because it's complicated to decode.
+        // We either are going to add unkown for all classes or remove it for
+        // breadcrumbs.
+    }
+}

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -156,7 +156,9 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(crumb.message, decoded.message)
         
         let crumbData = try XCTUnwrap(crumb.data as? NSDictionary)
-        XCTAssertTrue((crumbData.isEqual(to: decoded.data as NSDictionary?)))
+        let decodedData = try XCTUnwrap(decoded.data as? NSDictionary)
+
+        XCTAssertEqual(crumbData, decodedData)
         XCTAssertEqual(crumb.origin, decoded.origin)
         
         // We don't decode unknown on purpose, because it's complicated to decode with


### PR DESCRIPTION
Add Decodable/Deserializing of SentryBreadcrumb.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/4724.

According to @denrase he added unknown in https://github.com/getsentry/sentry-cocoa/pull/2820 because we have this pattern also in Java and Dart. We don't have this pattern anywhere else in Cocoa. So, IMO we should either remove it for SentryBreadcrumb or also add it for all other classes. This decision shouldn't block this PR at the moment. I added an item to #4724, so we don't forget about it.

#skip-changelog
