### PR TITLE
ref: Replace OOM wording with watchdog termination

### DIFF
--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -151,7 +151,7 @@
 {
     // The app is terminating so it is fine to do this on the main thread.
     // Furthermore, so users can manually post UIApplicationWillTerminateNotification and then call
-    // exit(0), to avoid getting false OOM when using exit(0), see GH-1252.
+    // exit(0), to avoid getting false watchdog terminations when using exit(0), see GH-1252.
     [self updateAppState:^(SentryAppState *appState) { appState.wasTerminated = YES; }];
 }
 

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -179,7 +179,7 @@ sentry_finishAndSaveTransaction(void)
         // there and the AutoSessionTrackingIntegration can work properly.
         //
         // This is a pragmatic and not the most optimal place for this logic.
-        [self.crashedSessionHandler endCurrentSessionAsCrashedWhenCrashOrOOM];
+        [self.crashedSessionHandler endCurrentSessionAsCrashedWhenCrashOrWatchdogTermination];
 
         // We only need to send all reports on the first initialization of SentryCrash. If
         // SenryCrash was deactivated there are no new reports to send. Furthermore, the

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -60,8 +60,8 @@ static SentryOptions *_Nullable startOption;
 static NSObject *startOptionsLock;
 
 /**
- * @brief We need to keep track of the number of times @c +[startWith...] is called, because our OOM
- * reporting breaks if it's called more than once.
+ * @brief We need to keep track of the number of times @c +[startWith...] is called, because our
+ * watchdog termination reporting breaks if it's called more than once.
  * @discussion This doesn't just protect from multiple sequential calls to start the SDK, so we
  * can't simply @c dispatch_once the logic inside the start method; there is also a valid workflow
  * where a consumer could start the SDK, then call @c +[close] and then start again, and we want to

--- a/Sources/Sentry/SentrySessionCrashedHandler.m
+++ b/Sources/Sentry/SentrySessionCrashedHandler.m
@@ -36,7 +36,7 @@
     return self;
 }
 
-- (void)endCurrentSessionAsCrashedWhenCrashOrOOM
+- (void)endCurrentSessionAsCrashedWhenCrashOrWatchdogTermination
 {
     if (self.crashWrapper.crashedLastLaunch
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -72,7 +72,7 @@
     }
 
     // Restarting the app in development is a termination we can't catch and would falsely
-    // report OOMs.
+    // report watchdog termiations.
     if (previousAppState.isDebugging) {
         return NO;
     }

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -80,7 +80,8 @@
             event.exceptions = @[ exception ];
 
             // We don't need to update the releaseName of the event to the previous app state as we
-            // assume it's not an OOM when the releaseName changed between app starts.
+            // assume it's not a watchdog termination when the releaseName changed between app
+            // starts.
             [SentrySDK captureCrashEvent:event];
         }
     }];

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -17,11 +17,11 @@
 
 /**
  * We're storing serialized breadcrumbs to disk in JSON, and when we're reading them back (in
- * the case of OOM), we end up with the serialized breadcrumbs again. Instead of turning those
- * dictionaries into proper SentryBreadcrumb instances which then need to be serialized again in
- * SentryEvent, we use this serializedBreadcrumbs property to set the pre-serialized
- * breadcrumbs. It saves a LOT of work - especially turning an NSDictionary into a SentryBreadcrumb
- * is silly when we're just going to do the opposite right after.
+ * the case of watchdog termination), we end up with the serialized breadcrumbs again. Instead of
+ * turning those dictionaries into proper SentryBreadcrumb instances which then need to be
+ * serialized again in SentryEvent, we use this serializedBreadcrumbs property to set the
+ * pre-serialized breadcrumbs. It saves a LOT of work - especially turning an NSDictionary into a
+ * SentryBreadcrumb is silly when we're just going to do the opposite right after.
  */
 @property (nonatomic, strong) NSArray *serializedBreadcrumbs;
 

--- a/Sources/Sentry/include/SentrySessionCrashedHandler.h
+++ b/Sources/Sentry/include/SentrySessionCrashedHandler.h
@@ -22,6 +22,6 @@
  * location and the current session is deleted. Checkout SentryHub where most of the session logic
  * is implemented for more details about sessions.
  */
-- (void)endCurrentSessionAsCrashedWhenCrashOrOOM;
+- (void)endCurrentSessionAsCrashedWhenCrashOrWatchdogTermination;
 
 @end

--- a/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
@@ -14,9 +14,10 @@ static NSString *const SentryWatchdogTerminationExceptionValue
 static NSString *const SentryWatchdogTerminationMechanismType = @"watchdog_termination";
 
 /**
- * Detect OOMs based on heuristics described in a blog post:
- * https://engineering.fb.com/2015/08/24/ios/reducing-fooms-in-the-facebook-ios-app/ If a OOM is
- * detected, the SDK sends it as crash event. Only works for iOS, tvOS and macCatalyst.
+ * Detect watchdog terminations based on heuristics described in a blog post:
+ * https://engineering.fb.com/2015/08/24/ios/reducing-fooms-in-the-facebook-ios-app/ If a watchdog
+ * termination is detected, the SDK sends it as crash event. Only works for iOS, tvOS and
+ * macCatalyst.
  */
 @interface SentryWatchdogTerminationTracker : NSObject
 SENTRY_NO_INIT


### PR DESCRIPTION
Replace OOM with watchdog termination wording. We previously called the watchdog termination tracking OOM tracking, but as it turned out OOMs are just a part of watchdog terminations. There can be other reasons for watchdog terminations than OOMs.

#skip-changelog