### PR TITLE
ci: Use large runner for one UI test job

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -87,6 +87,7 @@ jobs:
             xcode: "15.2"
             device: "iPhone 14 (16.4)"
 
+          # We only use large to investigate if UI tests are less flaky there.
           - runs-on: macos-14-large
             xcode: "15.4"
             device: "iPhone 15 (17.2)"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -87,7 +87,7 @@ jobs:
             xcode: "15.2"
             device: "iPhone 14 (16.4)"
 
-          - runs-on: macos-14
+          - runs-on: macos-14-large
             xcode: "15.4"
             device: "iPhone 15 (17.2)"
 


### PR DESCRIPTION
Use a large runner for one UI test job to check if the flakiness is less on large runners.

Follow up on https://github.com/getsentry/sentry-cocoa/pull/4774.

#skip-changelog