### PR TITLE
ref: Remove not required Foundation.h imports

### DIFF
--- a/Sources/Sentry/Profiling/SentryProfilerDefines.h
+++ b/Sources/Sentry/Profiling/SentryProfilerDefines.h
@@ -3,7 +3,6 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryDefines.h"
-#    import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSUInteger, SentryProfilerMode) {
     SentryProfilerModeTrace,

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization+Test.h
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization+Test.h
@@ -6,7 +6,6 @@
 
 #        import "SentryDefines.h"
 #        import "SentryProfiler+Private.h"
-#        import <Foundation/Foundation.h>
 
 @class SentryDebugMeta;
 @class SentryHub;

--- a/Sources/Sentry/Public/SentryReplayApi.h
+++ b/Sources/Sentry/Public/SentryReplayApi.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #if __has_include(<Sentry/SentryDefines.h>)
 #    import <Sentry/SentryDefines.h>
 #else

--- a/Sources/Sentry/SentryAppStartMeasurement.m
+++ b/Sources/Sentry/SentryAppStartMeasurement.m
@@ -4,7 +4,6 @@
 
 #    import "SentryDateUtils.h"
 #    import "SentryLog.h"
-#    import <Foundation/Foundation.h>
 
 @implementation SentryAppStartTypeToString
 + (NSString *)convert:(SentryAppStartType)type

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -8,7 +8,6 @@
 #    import "SentryFramesTracker.h"
 #    import "SentryLog.h"
 #    import "SentrySysctl.h"
-#    import <Foundation/Foundation.h>
 #    import <PrivateSentrySDKOnly.h>
 #    import <SentryAppState.h>
 #    import <SentryDependencyContainer.h>

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -5,7 +5,6 @@
 #    import "SentryAppStartTracker.h"
 #    import "SentryLog.h"
 #    import "SentryOptions.h"
-#    import <Foundation/Foundation.h>
 #    import <PrivateSentrySDKOnly.h>
 #    import <SentryAppStateManager.h>
 #    import <SentryCrashWrapper.h>

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -1,7 +1,6 @@
 #import "SentryCrashSysCtl.h"
 #import "SentryDependencyContainer.h"
 #import "SentrySysctl.h"
-#import <Foundation/Foundation.h>
 #import <SentryAppState.h>
 #import <SentryAppStateManager.h>
 #import <SentryCrashWrapper.h>

--- a/Sources/Sentry/SentryAttachment.m
+++ b/Sources/Sentry/SentryAttachment.m
@@ -1,5 +1,4 @@
 #import "SentryAttachment+Private.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -2,7 +2,6 @@
 #import "SentryCrashWrapper.h"
 #import "SentryLog.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 #import <SentryDependencyContainer.h>
 #import <SentryOptions+Private.h>
 

--- a/Sources/Sentry/SentryBuildAppStartSpans.m
+++ b/Sources/Sentry/SentryBuildAppStartSpans.m
@@ -4,7 +4,6 @@
 #import "SentrySpanId.h"
 #import "SentrySwift.h"
 #import "SentryTracer.h"
-#import <Foundation/Foundation.h>
 #import <SentryBuildAppStartSpans.h>
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryClientReport.m
+++ b/Sources/Sentry/SentryClientReport.m
@@ -1,7 +1,6 @@
 #import "SentryClientReport.h"
 #import "SentryDependencyContainer.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 #import <SentryDiscardedEvent.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
+++ b/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
@@ -1,5 +1,4 @@
 #import "SentryConcurrentRateLimitsDictionary.h"
-#import <Foundation/Foundation.h>
 
 @interface SentryConcurrentRateLimitsDictionary ()
 

--- a/Sources/Sentry/SentryCrashScopeObserver.m
+++ b/Sources/Sentry/SentryCrashScopeObserver.m
@@ -1,5 +1,4 @@
 #import "SentryLevelMapper.h"
-#import <Foundation/Foundation.h>
 #import <SentryBreadcrumb.h>
 #import <SentryCrashJSONCodec.h>
 #import <SentryCrashJSONCodecObjC.h>

--- a/Sources/Sentry/SentryCrashStackEntryMapper.m
+++ b/Sources/Sentry/SentryCrashStackEntryMapper.m
@@ -4,7 +4,6 @@
 #import "SentryFormatter.h"
 #import "SentryFrame.h"
 #import "SentryInAppLogic.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -6,7 +6,6 @@
 #import "SentryCrashMonitor_System.h"
 #import "SentryScope.h"
 #import "SentryUIDeviceWrapper.h"
-#import <Foundation/Foundation.h>
 #import <SentryCrashCachedData.h>
 #import <SentryCrashDebug.h>
 #import <SentryCrashMonitor_System.h>

--- a/Sources/Sentry/SentryDataCategoryMapper.m
+++ b/Sources/Sentry/SentryDataCategoryMapper.m
@@ -1,7 +1,6 @@
 #import "SentryDataCategoryMapper.h"
 #import "SentryDataCategory.h"
 #import "SentryEnvelopeItemType.h"
-#import <Foundation/Foundation.h>
 
 // While these data categories names might look similar to the envelope item types, they are not
 // identical, and have slight differences. Just open them side by side and you'll see the

--- a/Sources/Sentry/SentryDefaultRateLimits.m
+++ b/Sources/Sentry/SentryDefaultRateLimits.m
@@ -6,7 +6,6 @@
 #import "SentryRateLimitParser.h"
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -1,6 +1,5 @@
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryThreadWrapper.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryEnvelopeRateLimit.m
+++ b/Sources/Sentry/SentryEnvelopeRateLimit.m
@@ -3,7 +3,6 @@
 #import "SentryEnvelope.h"
 #import "SentryEnvelopeItemHeader.h"
 #import "SentryRateLimits.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryFrameRemover.m
+++ b/Sources/Sentry/SentryFrameRemover.m
@@ -1,6 +1,5 @@
 #import "SentryFrameRemover.h"
 #import "SentryFrame.h"
-#import <Foundation/Foundation.h>
 
 @implementation SentryFrameRemover
 

--- a/Sources/Sentry/SentryGeo.m
+++ b/Sources/Sentry/SentryGeo.m
@@ -1,7 +1,5 @@
 #import "SentryGeo.h"
 
-#import <Foundation/Foundation.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryGeo

--- a/Sources/Sentry/SentryHttpDateParser.m
+++ b/Sources/Sentry/SentryHttpDateParser.m
@@ -1,5 +1,4 @@
 #import "SentryHttpDateParser.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryInAppLogic.m
+++ b/Sources/Sentry/SentryInAppLogic.m
@@ -1,6 +1,5 @@
 #import "SentryInAppLogic.h"
 #import "SentryLog.h"
-#import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentryMessage.m
+++ b/Sources/Sentry/SentryMessage.m
@@ -1,5 +1,4 @@
 #import "SentryMessage.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryNSURLRequestBuilder.m
+++ b/Sources/Sentry/SentryNSURLRequestBuilder.m
@@ -3,7 +3,6 @@
 #import "SentryLog.h"
 #import "SentryNSURLRequest.h"
 #import "SentrySerialization.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryRateLimitParser.m
+++ b/Sources/Sentry/SentryRateLimitParser.m
@@ -2,7 +2,6 @@
 #import "SentryDataCategoryMapper.h"
 #import "SentryDateUtil.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryRetryAfterHeaderParser.m
+++ b/Sources/Sentry/SentryRetryAfterHeaderParser.m
@@ -1,7 +1,6 @@
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentryHttpDateParser.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -7,7 +7,6 @@
 #import "SentrySDK+Private.h"
 #import "SentrySdkPackage.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -3,7 +3,6 @@
 #import "SentryEvent.h"
 #import "SentryOptions.h"
 #import "SentryUserFeedback.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -13,7 +13,6 @@
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentrySpotlightTransport.h"
 #import "SentryTransport.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryUserFeedback.m
+++ b/Sources/Sentry/SentryUserFeedback.m
@@ -1,6 +1,5 @@
 #import "SentryUserFeedback.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 @implementation SentryUserFeedback
 

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -2,7 +2,6 @@
 
 #if SENTRY_HAS_UIKIT
 
-#    import <Foundation/Foundation.h>
 #    import <SentryAppState.h>
 #    import <SentryAppStateManager.h>
 #    import <SentryCrashWrapper.h>

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -1,7 +1,6 @@
 #import "SentryDateUtils.h"
 #import "SentryEvent+Private.h"
 #import "SentryFileManager.h"
-#import <Foundation/Foundation.h>
 #import <SentryAppState.h>
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>

--- a/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration-Hybrid.h
+++ b/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration-Hybrid.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #if __has_include(<Sentry/SentryDefines.h>)
 #    import <Sentry/SentryDefines.h>
 #else

--- a/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration.h
+++ b/Sources/Sentry/include/HybridPublic/SentrySessionReplayIntegration.h
@@ -10,8 +10,6 @@
 #    import "SentryDefines.h"
 #endif
 
-#import <Foundation/Foundation.h>
-
 NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 

--- a/Sources/Sentry/include/NSMutableDictionary+Sentry.h
+++ b/Sources/Sentry/include/NSMutableDictionary+Sentry.h
@@ -1,4 +1,3 @@
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/SentryANRTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryANRTrackingIntegration.h
@@ -1,7 +1,6 @@
 #import "SentryANRTrackerV1.h"
 #import "SentryBaseIntegration.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryAppStartTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAppStartTrackingIntegration.h
@@ -4,7 +4,6 @@
 
 #    import "SentryBaseIntegration.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryAttachment+Private.h
+++ b/Sources/Sentry/include/SentryAttachment+Private.h
@@ -1,6 +1,5 @@
 #import "SentryAttachment.h"
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoSessionTrackingIntegration.h
@@ -1,6 +1,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryCaptureTransactionWithProfile.h
+++ b/Sources/Sentry/include/SentryCaptureTransactionWithProfile.h
@@ -3,7 +3,6 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryDefines.h"
-#    import <Foundation/Foundation.h>
 
 @class SentryEnvelope;
 @class SentryEnvelopeItem;

--- a/Sources/Sentry/include/SentryConcurrentRateLimitsDictionary.h
+++ b/Sources/Sentry/include/SentryConcurrentRateLimitsDictionary.h
@@ -1,5 +1,4 @@
 #import "SentryDataCategory.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryCoreDataSwizzling.h
+++ b/Sources/Sentry/include/SentryCoreDataSwizzling.h
@@ -1,7 +1,6 @@
 
 #import "SentryDefines.h"
 #import <CoreData/CoreData.h>
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryCrashInstallationReporter.h
+++ b/Sources/Sentry/include/SentryCrashInstallationReporter.h
@@ -1,7 +1,6 @@
 #import "SentryCrash.h"
 #import "SentryCrashInstallation.h"
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryCrashWrapper;
 @class SentryDispatchQueueWrapper;

--- a/Sources/Sentry/include/SentryCrashIntegration.h
+++ b/Sources/Sentry/include/SentryCrashIntegration.h
@@ -1,6 +1,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryCrashReportSink.h
+++ b/Sources/Sentry/include/SentryCrashReportSink.h
@@ -1,6 +1,5 @@
 #import "SentryCrash.h"
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryCrashWrapper;
 @class SentryDispatchQueueWrapper;

--- a/Sources/Sentry/include/SentryCrashStackEntryMapper.h
+++ b/Sources/Sentry/include/SentryCrashStackEntryMapper.h
@@ -1,7 +1,6 @@
 #import "SentryCrashDynamicLinker.h"
 #import "SentryCrashStackCursor.h"
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryFrame;
 @class SentryInAppLogic;

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentryInternalCDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryDataCategoryMapper.h
+++ b/Sources/Sentry/include/SentryDataCategoryMapper.h
@@ -1,5 +1,4 @@
 #import "SentryDataCategory.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryDateUtils.h
+++ b/Sources/Sentry/include/SentryDateUtils.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryDefaultRateLimits.h
+++ b/Sources/Sentry/include/SentryDefaultRateLimits.h
@@ -1,5 +1,4 @@
 #import "SentryRateLimits.h"
-#import <Foundation/Foundation.h>
 
 @class SentryRetryAfterHeaderParser;
 @class SentryRateLimitParser;

--- a/Sources/Sentry/include/SentryDiscardReasonMapper.h
+++ b/Sources/Sentry/include/SentryDiscardReasonMapper.h
@@ -1,5 +1,4 @@
 #import "SentryDiscardReason.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryEnvelopeRateLimit.h
+++ b/Sources/Sentry/include/SentryEnvelopeRateLimit.h
@@ -1,5 +1,4 @@
 #import "SentryRateLimits.h"
-#import <Foundation/Foundation.h>
 
 @protocol SentryEnvelopeRateLimitDelegate;
 

--- a/Sources/Sentry/include/SentryExtraPackages.h
+++ b/Sources/Sentry/include/SentryExtraPackages.h
@@ -4,8 +4,6 @@
 #    import "SentryDefines.h"
 #endif
 
-#import <Foundation/Foundation.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryExtraPackages : NSObject

--- a/Sources/Sentry/include/SentryFileIOTracker.h
+++ b/Sources/Sentry/include/SentryFileIOTracker.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryFramesTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryFramesTrackingIntegration.h
@@ -4,7 +4,6 @@
 
 #    import "SentryBaseIntegration.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryHttpTransport.h
+++ b/Sources/Sentry/include/SentryHttpTransport.h
@@ -4,7 +4,6 @@
 #import "SentryRateLimits.h"
 #import "SentryRequestManager.h"
 #import "SentryTransport.h"
-#import <Foundation/Foundation.h>
 
 @class SentryDispatchQueueWrapper;
 @class SentryNSURLRequestBuilder;

--- a/Sources/Sentry/include/SentryInAppLogic.h
+++ b/Sources/Sentry/include/SentryInAppLogic.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryMetricKitIntegration.h
+++ b/Sources/Sentry/include/SentryMetricKitIntegration.h
@@ -5,7 +5,6 @@
 #    import "SentryBaseIntegration.h"
 #    import "SentryEvent.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryMetricProfiler.h
+++ b/Sources/Sentry/include/SentryMetricProfiler.h
@@ -4,7 +4,6 @@
 
 #    import "SentryDefines.h"
 #    import "SentryProfilerDefines.h"
-#    import <Foundation/Foundation.h>
 
 @class SentryTransaction;
 

--- a/Sources/Sentry/include/SentryNSDataSwizzling.h
+++ b/Sources/Sentry/include/SentryNSDataSwizzling.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentryFileIOTracker.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryNSFileManagerSwizzling.h
+++ b/Sources/Sentry/include/SentryNSFileManagerSwizzling.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentryFileIOTracker.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryPerformanceTracker.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentrySpanStatus.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryPerformanceTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryPerformanceTrackingIntegration.h
@@ -4,7 +4,6 @@
 
 #    import "SentryBaseIntegration.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryProfiler+Private.h
+++ b/Sources/Sentry/include/SentryProfiler+Private.h
@@ -4,7 +4,6 @@
 
 #    import "SentryDefines.h"
 #    import "SentryProfilerDefines.h"
-#    import <Foundation/Foundation.h>
 
 @class SentryEnvelopeItem;
 @class SentryHub;

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -3,7 +3,6 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
 #    import "SentryDefines.h"
-#    import <Foundation/Foundation.h>
 
 @class SentryEnvelope;
 @class SentryEnvelopeItem;

--- a/Sources/Sentry/include/SentryQueueableRequestManager.h
+++ b/Sources/Sentry/include/SentryQueueableRequestManager.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryDefines.h"
 #import "SentryRequestManager.h"
 

--- a/Sources/Sentry/include/SentryRateLimits.h
+++ b/Sources/Sentry/include/SentryRateLimits.h
@@ -1,5 +1,4 @@
 #import "SentryDataCategory.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryReachability.h
+++ b/Sources/Sentry/include/SentryReachability.h
@@ -25,7 +25,6 @@
 //
 
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 #if SENTRY_HAS_REACHABILITY
 #    import <SystemConfiguration/SystemConfiguration.h>

--- a/Sources/Sentry/include/SentryRequestOperation.h
+++ b/Sources/Sentry/include/SentryRequestOperation.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryAsynchronousOperation.h"
 #import "SentryQueueableRequestManager.h"
 

--- a/Sources/Sentry/include/SentrySampleDecision+Private.h
+++ b/Sources/Sentry/include/SentrySampleDecision+Private.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentrySampleDecision.h"
 
 /**

--- a/Sources/Sentry/include/SentrySamplerDecision.h
+++ b/Sources/Sentry/include/SentrySamplerDecision.h
@@ -1,5 +1,4 @@
 #import "SentrySampleDecision.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySampling.h
+++ b/Sources/Sentry/include/SentrySampling.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentryProfilingConditionals.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryScreenshotIntegration.h
+++ b/Sources/Sentry/include/SentryScreenshotIntegration.h
@@ -6,7 +6,6 @@
 #    import "SentryClient+Private.h"
 #    import "SentryScreenshot.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySdkPackage.h
+++ b/Sources/Sentry/include/SentrySdkPackage.h
@@ -4,8 +4,6 @@
 #    import "SentryDefines.h"
 #endif
 
-#import <Foundation/Foundation.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentrySdkPackage : NSObject

--- a/Sources/Sentry/include/SentrySession+Private.h
+++ b/Sources/Sentry/include/SentrySession+Private.h
@@ -1,5 +1,4 @@
 #import "SentrySession.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySessionCrashedHandler.h
+++ b/Sources/Sentry/include/SentrySessionCrashedHandler.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryCrashWrapper;
 @class SentryDispatchQueueWrapper;

--- a/Sources/Sentry/include/SentrySessionTracker.h
+++ b/Sources/Sentry/include/SentrySessionTracker.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 @class SentryCurrentDateProvider;
 @class SentryEvent;

--- a/Sources/Sentry/include/SentrySubClassFinder.h
+++ b/Sources/Sentry/include/SentrySubClassFinder.h
@@ -1,6 +1,5 @@
 #import "SentryDefines.h"
 #import "SentryObjCRuntimeWrapper.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySwiftAsyncIntegration.h
+++ b/Sources/Sentry/include/SentrySwiftAsyncIntegration.h
@@ -1,6 +1,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentrySwift.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
+++ b/Sources/Sentry/include/SentrySystemEventBreadcrumbs.h
@@ -1,5 +1,4 @@
 #import "SentryFileManager.h"
-#import <Foundation/Foundation.h>
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/include/SentrySystemWrapper.h
+++ b/Sources/Sentry/include/SentrySystemWrapper.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -3,7 +3,6 @@
 #import "SentrySpan.h"
 #import "SentrySpanProtocol.h"
 #import "SentryTracerConfiguration.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -1,6 +1,5 @@
 #import "SentryDataCategory.h"
 #import "SentryDiscardReason.h"
-#import <Foundation/Foundation.h>
 
 @class SentryEnvelope;
 

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -1,5 +1,3 @@
-#import <Foundation/Foundation.h>
-
 #import "SentryTransport.h"
 
 @class SentryFileManager;

--- a/Sources/Sentry/include/SentryViewHierarchyIntegration.h
+++ b/Sources/Sentry/include/SentryViewHierarchyIntegration.h
@@ -5,7 +5,6 @@
 #    import "SentryBaseIntegration.h"
 #    import "SentryClient+Private.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
@@ -3,7 +3,6 @@
 #if SENTRY_HAS_UIKIT
 #    import "SentryBaseIntegration.h"
 #    import "SentrySwift.h"
-#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -39,7 +39,6 @@
 #import "SentryDefines.h"
 
 #import <CommonCrypto/CommonDigest.h>
-#import <Foundation/Foundation.h>
 #include <mach-o/dyld.h>
 #include <mach/mach.h>
 

--- a/Tests/SentryTests/Helper/SentryLogTestHelper.m
+++ b/Tests/SentryTests/Helper/SentryLogTestHelper.m
@@ -1,5 +1,4 @@
 #import "SentryLogTestHelper.h"
-#import <Foundation/Foundation.h>
 #import <XCTest/XCTest.h>
 
 NSString *

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
@@ -1,6 +1,5 @@
 #import "SentryTestObjCRuntimeWrapper.h"
 #import "SentryDefaultObjCRuntimeWrapper.h"
-#import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 
 @interface SentryTestObjCRuntimeWrapper ()

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.h
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.h
@@ -1,5 +1,4 @@
 #import "SentryCoreDataTracker.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.m
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTracker+Test.m
@@ -1,5 +1,4 @@
 #import "SentryCoreDataTracker+Test.h"
-#import <Foundation/Foundation.h>
 
 @implementation SentryCoreDataTracker (Test)
 

--- a/Tests/SentryTests/SentryTraceProfiler+Test.h
+++ b/Tests/SentryTests/SentryTraceProfiler+Test.h
@@ -4,7 +4,6 @@
 
 #    import "SentryDefines.h"
 #    import "SentryTraceProfiler.h"
-#    import <Foundation/Foundation.h>
 
 @class SentryProfiler;
 


### PR DESCRIPTION
Remove plenty of not required imports of Foundation.h.

Why?
![CleanShot 2025-02-05 at 19 54 25@2x](https://github.com/user-attachments/assets/5b0e3011-e82f-471c-9163-2affd20108fd)

#skip-changelog