### PR TITLE
impr: Add date encoding strategy

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 		620379DD2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m in Sources */ = {isa = PBXBuildFile; fileRef = 620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */; };
 		620467AC2D3FFD230025F06C /* SentryNSErrorCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620467AB2D3FFD1C0025F06C /* SentryNSErrorCodable.swift */; };
 		6205B4A42CE73AA100744684 /* TestDebugImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = D85790282976A69F00C6AC1F /* TestDebugImageProvider.swift */; };
+		6205CF262D549D8A001E6049 /* SentryDateCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6205CF252D549D8A001E6049 /* SentryDateCodableTests.swift */; };
 		621AE74B2C626C230012E730 /* SentryANRTrackerV2.h in Headers */ = {isa = PBXBuildFile; fileRef = 621AE74A2C626C230012E730 /* SentryANRTrackerV2.h */; };
 		621AE74D2C626C510012E730 /* SentryANRTrackerV2.m in Sources */ = {isa = PBXBuildFile; fileRef = 621AE74C2C626C510012E730 /* SentryANRTrackerV2.m */; };
 		621C88482CAD23B9000EABCB /* SentryCaptureTransactionWithProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 621C88472CAD23B9000EABCB /* SentryCaptureTransactionWithProfile.h */; };
@@ -1140,6 +1141,7 @@
 		620379DA2AFE1415005AC0C1 /* SentryBuildAppStartSpans.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryBuildAppStartSpans.h; path = include/SentryBuildAppStartSpans.h; sourceTree = "<group>"; };
 		620379DC2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBuildAppStartSpans.m; sourceTree = "<group>"; };
 		620467AB2D3FFD1C0025F06C /* SentryNSErrorCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSErrorCodable.swift; sourceTree = "<group>"; };
+		6205CF252D549D8A001E6049 /* SentryDateCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDateCodableTests.swift; sourceTree = "<group>"; };
 		621AE74A2C626C230012E730 /* SentryANRTrackerV2.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryANRTrackerV2.h; path = include/SentryANRTrackerV2.h; sourceTree = "<group>"; };
 		621AE74C2C626C510012E730 /* SentryANRTrackerV2.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryANRTrackerV2.m; sourceTree = "<group>"; };
 		621AE74E2C626CF70012E730 /* SentryANRTrackerV2Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryANRTrackerV2Tests.swift; sourceTree = "<group>"; };
@@ -2247,6 +2249,7 @@
 				623FD9052D3FA9BA00803EDA /* NSNumberDecodableWrapperTests.swift */,
 				6281C5732D3E50D8009D0978 /* ArbitraryDataTests.swift */,
 				620078772D3906BF0022CB67 /* SentryCodableTests.swift */,
+				6205CF252D549D8A001E6049 /* SentryDateCodableTests.swift */,
 			);
 			path = Codable;
 			sourceTree = "<group>";
@@ -5299,6 +5302,7 @@
 				6281C5742D3E50DF009D0978 /* ArbitraryDataTests.swift in Sources */,
 				7BE0DC2F272ABAF6004FA8B7 /* SentryAutoBreadcrumbTrackingIntegrationTests.swift in Sources */,
 				7B869EBE249B964D004F4FDB /* SentryThreadEquality.swift in Sources */,
+				6205CF262D549D8A001E6049 /* SentryDateCodableTests.swift in Sources */,
 				7BC6EBF8255C05060059822A /* TestData.swift in Sources */,
 				7B88F30224BC5C6D00ADF90A /* SentrySdkInfoTests.swift in Sources */,
 				7BC8523B2458849E005A70F0 /* SentryDataCategoryMapperTests.swift in Sources */,

--- a/Sources/Swift/Protocol/Codable/DecodeArbitraryData.swift
+++ b/Sources/Swift/Protocol/Codable/DecodeArbitraryData.swift
@@ -30,16 +30,16 @@ enum ArbitraryData: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
-        if let dateValue = try? container.decode(Date.self) {
-            self = .date(dateValue)
-        } else if let stringValue = try? container.decode(String.self) {
-            self = .string(stringValue)
-        } else if let intValue = try? container.decode(Int.self) {
+        if let intValue = try? container.decode(Int.self) {
             self = .int(intValue)
         } else if let numberValue = try? container.decode(Double.self) {
             self = .number(numberValue)
         } else if let boolValue = try? container.decode(Bool.self) {
             self = .boolean(boolValue)
+        } else if let dateValue = try? container.decode(Date.self) {
+            self = .date(dateValue)
+        } else if let stringValue = try? container.decode(String.self) {
+            self = .string(stringValue)
         } else if let objectValue = try? container.decode([String: ArbitraryData].self) {
             self = .dict(objectValue)
         } else if let arrayValue = try? container.decode([ArbitraryData].self) {

--- a/Sources/Swift/Protocol/Codable/SentryCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryCodable.swift
@@ -8,8 +8,30 @@ func decodeFromJSONData<T: Decodable>(jsonData: Data) -> T? {
     
     do {
         let decoder = JSONDecoder()
-        let formatter = sentryGetIso8601FormatterWithMillisecondPrecision()
-        decoder.dateDecodingStrategy = .formatted(formatter)
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            
+            // We prefer a Double/TimeInterval because it allows nano second precision.
+            // The ISO8601 formatter only supports millisecond precision.
+            if let timeIntervalSince1970 = try? container.decode(Double.self) {
+                return Date(timeIntervalSince1970: timeIntervalSince1970)
+            }
+            
+            if let dateString = try? container.decode(String.self) {
+                let formatter = sentryGetIso8601FormatterWithMillisecondPrecision()
+                guard let date = formatter.date(from: dateString) else {
+                    throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format. The following string doesn't represent a valid ISO 8601 date string: '\(dateString)'")
+                }
+                
+                return date
+            }
+            
+            throw DecodingError.typeMismatch(Date.self, DecodingError.Context(
+                codingPath: decoder.codingPath,
+                debugDescription: "Invalid date format. The Date must either be a Double/TimeInterval representing the timeIntervalSince1970 or it can be a ISO 8601 formatted String."
+            ))
+
+        }
         return try decoder.decode(T.self, from: jsonData)
     } catch {
         SentryLog.error("Could not decode object of type \(T.self) from JSON data due to error: \(error)")

--- a/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
@@ -41,8 +41,8 @@ extension SentryEventDecodable: Decodable {
         let eventIdAsString = try container.decode(String.self, forKey: .eventId)
         self.eventId = SentryId(uuidString: eventIdAsString)
         self.message = try container.decodeIfPresent(SentryMessage.self, forKey: .message)
-        self.timestamp = try self.decodeTimeIntervalSince1970(from: container, forKey: .timestamp)
-        self.startTimestamp = try self.decodeTimeIntervalSince1970(from: container, forKey: .startTimestamp)
+        self.timestamp = try container.decode(Date.self, forKey: .timestamp)
+        self.startTimestamp = try container.decodeIfPresent(Date.self, forKey: .startTimestamp)
 
         if let rawLevel = try container.decodeIfPresent(String.self, forKey: .level) {
             let level = SentryLevelHelper.levelForName(rawLevel)
@@ -93,15 +93,5 @@ extension SentryEventDecodable: Decodable {
         
         self.breadcrumbs = try container.decodeIfPresent([Breadcrumb].self, forKey: .breadcrumbs)
         self.request = try container.decodeIfPresent(SentryRequest.self, forKey: .request)
-    }
-    
-    private func decodeTimeIntervalSince1970(
-        from container: KeyedDecodingContainer<SentryEventDecodable.CodingKeys>,
-        forKey key: CodingKeys
-    ) throws -> Date? {
-        if let timestampAsTimeIntervalSince1970 = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: key)?.value {
-            return Date(timeIntervalSince1970: timestampAsTimeIntervalSince1970.doubleValue)
-        }
-        return nil
     }
 }

--- a/Tests/SentryTests/Protocol/Codable/SentryDateCodableTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/SentryDateCodableTests.swift
@@ -1,0 +1,59 @@
+@testable import Sentry
+import SentryTestUtils
+import XCTest
+
+final class SentryDateCodableTests: XCTestCase {
+
+    func testDecodeDate_WithTimeIntervalSince1970() throws {
+        //Arrange
+        let timestamp = 0.012345678
+        let date = Date(timeIntervalSince1970: timestamp)
+        
+        let json = "{\"date\": \(timestamp)}".data(using: .utf8)!
+        // Act
+        let actual = try XCTUnwrap(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
+        
+        // Assert
+        XCTAssertEqual(date.timeIntervalSince1970, actual.date.timeIntervalSince1970, accuracy: 0.000000001)
+    }
+    
+    func testDecodeDate_WithTimeISO8601Format() throws {
+        //Arrange
+        let timestamp = 0.012345678
+        let date = Date(timeIntervalSince1970: timestamp)
+        let isoString = sentry_toIso8601String(date)
+        
+        // The ISO8601 date format only supports milliseconds precision.
+        // Therefore, we convert the ISO date string back to the date.
+        let expectedDate = sentry_fromIso8601String(isoString)
+        
+        let json = "{\"date\": \"\(isoString)\"}".data(using: .utf8)!
+        
+        // Act
+        let actual = try XCTUnwrap(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
+        
+        // Assert
+        XCTAssertEqual(expectedDate.timeIntervalSince1970, actual.date.timeIntervalSince1970, accuracy: 0.001)
+    }
+    
+    func testDecodeDate_WithWrongDateFormat() throws {
+        //Arrange
+        let json = "{\"date\": \"hello\"}".data(using: .utf8)!
+        
+        // Act & Assert
+        XCTAssertNil(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
+    }
+    
+    func testDecodeDate_WithBool() throws {
+        //Arrange
+        let json = "{\"date\": true}".data(using: .utf8)!
+        
+        // Act & Assert
+        XCTAssertNil(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
+    }
+
+}
+
+private struct SentryDateTestDecodable: Decodable {
+    let date: Date
+}

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -109,6 +109,7 @@ class SentryEventTests: XCTestCase {
 
     func testDecode_WithAllProperties() throws {
         // Arrange
+        SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
         let event = TestData.event
         // Start timestamp is only serialized if event type is transaction
         event.type = "transaction"
@@ -238,6 +239,7 @@ class SentryEventTests: XCTestCase {
 
     func testDecode_WithAllPropertiesNil() throws {
         // Arrange
+        SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
         let event = Event()
         let actual = event.serialize()
         let data = try XCTUnwrap(SentrySerialization.data(withJSONObject: actual))

--- a/Tests/SentryTests/Protocol/SentryEventTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEventTests.swift
@@ -109,7 +109,6 @@ class SentryEventTests: XCTestCase {
 
     func testDecode_WithAllProperties() throws {
         // Arrange
-        SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
         let event = TestData.event
         // Start timestamp is only serialized if event type is transaction
         event.type = "transaction"
@@ -130,8 +129,8 @@ class SentryEventTests: XCTestCase {
         XCTAssertEqual(eventMessage.message, decodedMessage.message)
         XCTAssertEqual(eventMessage.params, decodedMessage.params)
         
-        XCTAssertEqual(event.timestamp, decoded.timestamp)
-        XCTAssertEqual(event.startTimestamp, decoded.startTimestamp)
+        XCTAssertEqual(event.timestamp?.timeIntervalSince1970, decoded.timestamp?.timeIntervalSince1970)
+        XCTAssertEqual(event.startTimestamp?.timeIntervalSince1970, decoded.startTimestamp?.timeIntervalSince1970)
         XCTAssertEqual(event.level, decoded.level)
         
         XCTAssertEqual(event.platform, decoded.platform)
@@ -239,7 +238,6 @@ class SentryEventTests: XCTestCase {
 
     func testDecode_WithAllPropertiesNil() throws {
         // Arrange
-        SentryDependencyContainer.sharedInstance().dateProvider = TestCurrentDateProvider()
         let event = Event()
         let actual = event.serialize()
         let data = try XCTUnwrap(SentrySerialization.data(withJSONObject: actual))
@@ -251,7 +249,7 @@ class SentryEventTests: XCTestCase {
         XCTAssertEqual(event.eventId, decoded.eventId)
         XCTAssertNil(decoded.message)
         XCTAssertNil(decoded.error)
-        XCTAssertEqual(event.timestamp, decoded.timestamp)
+        XCTAssertEqual(event.timestamp?.timeIntervalSince1970, decoded.timestamp?.timeIntervalSince1970)
         XCTAssertNil(decoded.startTimestamp)
         XCTAssertEqual(.none, decoded.level)
         XCTAssertEqual(event.platform, decoded.platform)


### PR DESCRIPTION
Add a custom date encoding strategy, which supports time intervals since 1970 and ISO 8601 formatted strings.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/4724.

#skip-changelog