### PR TITLE
fix: Remove internal unknown dict for Breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 
 - Fix missing `sample_rate` in baggage (#4751)
 
+### Internal
+
+- Remove internal unknown dict for Breadcrumbs (#4803) This potentially only impacts hybrid SDKs.
+
+
 ## 8.44.0
 
 ### Fixes

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -5,16 +5,11 @@
 #import "SentryNSDictionarySanitize.h"
 #import "SentrySwift.h"
 
-@interface SentryBreadcrumb ()
-@property (atomic, strong) NSDictionary<NSString *, id> *_Nullable unknown;
-@end
-
 @implementation SentryBreadcrumb
 
 - (instancetype)initWithDictionary:(NSDictionary *)dictionary
 {
     if (self = [super init]) {
-        NSMutableDictionary *unknown = [NSMutableDictionary dictionary];
         for (id key in dictionary) {
             id value = [dictionary valueForKey:key];
             if (value == nil) {
@@ -37,12 +32,7 @@
                 self.message = value;
             } else if ([key isEqualToString:@"data"] && isDictionary) {
                 self.data = value;
-            } else {
-                unknown[key] = value;
             }
-        }
-        if (unknown.count > 0) {
-            self.unknown = [unknown copy];
         }
     }
     return self;
@@ -75,12 +65,6 @@
     [serializedData setValue:self.origin forKey:@"origin"];
     [serializedData setValue:self.message forKey:@"message"];
     [serializedData setValue:sentry_sanitize(self.data) forKey:@"data"];
-    NSDictionary<NSString *, id> *unknown = self.unknown;
-    if (unknown != nil) {
-        for (id key in unknown) {
-            [serializedData setValue:unknown[key] forKey:key];
-        }
-    }
     return serializedData;
 }
 
@@ -116,9 +100,6 @@
         return NO;
     if (self.data != breadcrumb.data && ![self.data isEqualToDictionary:breadcrumb.data])
         return NO;
-    if (self.unknown != breadcrumb.unknown
-        && ![self.unknown isEqualToDictionary:breadcrumb.unknown])
-        return NO;
     return YES;
 }
 
@@ -132,7 +113,6 @@
     hash = hash * 23 + [self.origin hash];
     hash = hash * 23 + [self.message hash];
     hash = hash * 23 + [self.data hash];
-    hash = hash * 23 + [self.unknown hash];
     return hash;
 }
 

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -22,7 +22,6 @@ class SentryBreadcrumbTests: XCTestCase {
             breadcrumb.origin = origin
             breadcrumb.message = message
             breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
-            breadcrumb.setValue(["foo": "bar"], forKey: "unknown")
         }
         
         var dateAs8601String: String {
@@ -40,8 +39,7 @@ class SentryBreadcrumbTests: XCTestCase {
             "type": fixture.type,
             "origin": fixture.origin,
             "message": fixture.message,
-            "data": ["foo": "bar"],
-            "foo": "bar" // Unknown
+            "data": ["foo": "bar"]
         ]
         let breadcrumb = PrivateSentrySDKOnly.breadcrumb(with: dict)
         
@@ -52,7 +50,6 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(breadcrumb.origin, fixture.origin)
         XCTAssertEqual(breadcrumb.message, fixture.message)
         XCTAssertEqual(breadcrumb.data as? [String: String], ["foo": "bar"])
-        XCTAssertEqual(breadcrumb.value(forKey: "unknown") as? NSDictionary, ["foo": "bar"])
     }
     
     func testHash() {
@@ -96,7 +93,6 @@ class SentryBreadcrumbTests: XCTestCase {
         testIsNotEqual { breadcrumb in breadcrumb.origin = "" }
         testIsNotEqual { breadcrumb in breadcrumb.message = "" }
         testIsNotEqual { breadcrumb in breadcrumb.data?.removeAll() }
-        testIsNotEqual { breadcrumb in breadcrumb.setValue(nil, forKey: "unknown") }
     }
     
     private func testIsNotEqual(block: (Breadcrumb) -> Void ) {
@@ -117,7 +113,6 @@ class SentryBreadcrumbTests: XCTestCase {
         crumb.origin = ""
         crumb.message = ""
         crumb.data = nil
-        crumb.setValue(nil, forKey: "unknown")
         
         XCTAssertEqual("info", actual["level"] as? String)
         XCTAssertEqual(fixture.dateAs8601String, actual["timestamp"] as? String)
@@ -126,7 +121,6 @@ class SentryBreadcrumbTests: XCTestCase {
         XCTAssertEqual(fixture.origin, actual["origin"] as? String)
         XCTAssertEqual(fixture.message, actual["message"] as? String)
         XCTAssertEqual(["some": ["data": "data", "date": fixture.dateAs8601String]], actual["data"] as? Dictionary)
-        XCTAssertEqual("bar", actual["foo"] as? String)
     }
     
     func testDescription() {


### PR DESCRIPTION


## :scroll: Description

Remove unknown dict when initializing the crumbs with a dict added in #2820. The Java SDK, for example, implements this pattern to keep unknown JSON properties when deserializing and serializing classes. This allows more flexibility when a hybrid SDK or the native SDK serializes an event to disk, and the Java SDK deserializes this event. With the unknown dict, the Java SDK doesn't need to implement all the properties other SDKs have. We only have this for crumbs on the Cocoa SDK, and it doesn't make sense only to keep it for one class. Instead, we removed it to simplify the code because we would need to implement some complex deserialization logic with Swift Decodable for deserializing events. We can always reconsider this approach, but then we would need to add the unknown property concept for all serializable/decodable classes.

## :bulb: Motivation and Context

Came up in https://github.com/getsentry/sentry-cocoa/pull/4785

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
