### PR TITLE
chore: moves unreleased changes to correct section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+- Add `showMaskPreview` to `SentrySDK.replay` api to debug replay masking (#4761)
+- Session replay masking preview for SwiftUI (#4737)
 - HTTP Breadcrumb level based on response status code (#4779) 4xx is warning, 5xx is error.
 
 ### Improvements
@@ -18,7 +20,6 @@
 ### Internal
 
 - Remove internal unknown dict for Breadcrumbs (#4803) This potentially only impacts hybrid SDKs.
-
 
 ## 8.44.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,6 @@
 
 ### Features
 
-- Add `showMaskPreview` to `SentrySDK.replay` api to debug replay masking (#4761)
-- Session replay masking preview for SwiftUI (#4737)
 - SwiftUI time for initial display and time for full display (#4596)
 - Add protocol for custom screenName for UIViewControllers (#4646)
 - Allow hybrid SDK to set replay options tags information (#4710)


### PR DESCRIPTION
Moves changes to the changelog introduced in #4761 to the correct section

#skip-changelog