### PR TITLE
chore(ci): refactor xcode-test from positional to named arguments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,8 +102,8 @@ jobs:
           run-id: ${{ env.FRAMEWORK_RUN_ID }}
 
       - name: Check XCFramework
-        #We dont compile the framework during releases to not change the artefact SHA value
-        #instead we use the one archive as an artefact
+        # We dont compile the framework during releases to not change the artefact SHA value
+        # instead we use the one archive as an artefact
         if: startsWith(github.ref, 'refs/heads/release/')
         run: |
           ls -R Carthage

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,17 +7,17 @@ on:
 
   pull_request:
     paths:
-      - 'Sources/**'
-      - 'test-server/**'
-      - 'Samples/**'
-      - '.github/workflows/build.yml'
-      - 'fastlane/**'
-      - 'scripts/ci-select-xcode.sh'
+      - "Sources/**"
+      - "test-server/**"
+      - "Samples/**"
+      - ".github/workflows/build.yml"
+      - "fastlane/**"
+      - "scripts/ci-select-xcode.sh"
       - Sentry.xcworkspace/**
       - Sentry.xcodeproj/**
       - Gemfile.lock
-      - 'Package.swift'
-      - 'scripts/build-xcframework.sh'
+      - "Package.swift"
+      - "scripts/build-xcframework.sh"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -85,14 +85,14 @@ jobs:
 
   build-xcframework:
     name: Build XCFramework
-    # The macos-13 uses an Intel processor and doesn't compile the XCFramework for visionOS. 
+    # The macos-13 uses an Intel processor and doesn't compile the XCFramework for visionOS.
     # The large image compiles on arm64 and successfully creates the XCFramework for visionOS.
     runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 15.2
       - run: echo "FRAMEWORK_RUN_ID=$(./scripts/xcframework-generated-run.sh)" >> $GITHUB_ENV
-      
+
       - uses: actions/download-artifact@v4
         if: startsWith(github.ref, 'refs/heads/release/')
         with:
@@ -100,18 +100,18 @@ jobs:
           path: Carthage/
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ env.FRAMEWORK_RUN_ID }}
-      
+
       - name: Check XCFramework
-       #We dont compile the framework during releases to not change the artefact SHA value
-       #instead we use the one archive as an artefact
-        if: startsWith(github.ref, 'refs/heads/release/') 
+        #We dont compile the framework during releases to not change the artefact SHA value
+        #instead we use the one archive as an artefact
+        if: startsWith(github.ref, 'refs/heads/release/')
         run: |
           ls -R Carthage
           if [ ! -f Carthage/Sentry.xcframework.zip ]; then
             echo "XCFramework is not available"
             exit 1
           fi
-      
+
       - name: Build xcframework
         if: startsWith(github.ref, 'refs/heads/release/') == false
         run: make build-xcframework
@@ -212,7 +212,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Debug
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" DebugWithoutUIKit uikit-check-build
+        run: |
+          ./scripts/xcode-test.sh \
+            --platform iOS \
+            --os latest \
+            --ref ${{ github.ref }} \
+            --command build \
+            --device "iPhone 14" \
+            --configuration DebugWithoutUIKit \
+            --scheme uikit-check-build
       - name: Ensure UIKit is not linked
         run: ./scripts/check-uikit-linkage.sh DebugWithoutUIKit uikit-check-build unlinked SentryWithoutUIKit
 
@@ -222,7 +230,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Release
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" ReleaseWithoutUIKit uikit-check-build
+        run: |
+          ./scripts/xcode-test.sh \
+            --platform iOS \
+            --os latest \
+            --ref ${{ github.ref }} \
+            --command build \
+            --device "iPhone 14" \
+            --configuration ReleaseWithoutUIKit \
+            --scheme uikit-check-build
       - name: Ensure UIKit is not linked
         run: ./scripts/check-uikit-linkage.sh ReleaseWithoutUIKit uikit-check-build unlinked SentryWithoutUIKit
 
@@ -232,7 +248,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Debug
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" Debug uikit-check-build
+        run: |
+          ./scripts/xcode-test.sh \
+            --platform iOS \
+            --os latest \
+            --ref ${{ github.ref }} \
+            --command build \
+            --device "iPhone 14" \
+            --configuration Debug \
+            --scheme uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Debug uikit-check-build linked Sentry
 
@@ -242,6 +266,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Release
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" Release uikit-check-build
+        run: |
+          ./scripts/xcode-test.sh \
+            --platform iOS \
+            --os latest \
+            --ref ${{ github.ref }} \
+            --command build \
+            --device "iPhone 14" \
+            --configuration Release \
+            --scheme uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Release uikit-check-build linked Sentry

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -220,7 +220,7 @@ jobs:
             --command build \
             --device "iPhone 14" \
             --configuration DebugWithoutUIKit \
-            --scheme uikit-check-build
+            --derived-data uikit-check-build
       - name: Ensure UIKit is not linked
         run: ./scripts/check-uikit-linkage.sh DebugWithoutUIKit uikit-check-build unlinked SentryWithoutUIKit
 
@@ -238,7 +238,7 @@ jobs:
             --command build \
             --device "iPhone 14" \
             --configuration ReleaseWithoutUIKit \
-            --scheme uikit-check-build
+            --derived-data uikit-check-build
       - name: Ensure UIKit is not linked
         run: ./scripts/check-uikit-linkage.sh ReleaseWithoutUIKit uikit-check-build unlinked SentryWithoutUIKit
 
@@ -256,7 +256,7 @@ jobs:
             --command build \
             --device "iPhone 14" \
             --configuration Debug \
-            --scheme uikit-check-build
+            --derived-data uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Debug uikit-check-build linked Sentry
 
@@ -274,6 +274,6 @@ jobs:
             --command build \
             --device "iPhone 14" \
             --configuration Release \
-            --scheme uikit-check-build
+            --derived-data uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Release uikit-check-build linked Sentry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
             test-destination-os: "16.4"
             device: "iPhone 14"
             scheme: "Sentry"
-            
+
           # iOS 17
           - runs-on: macos-14
             platform: "iOS"
@@ -93,7 +93,7 @@ jobs:
             test-destination-os: "17.2"
             device: "iPhone 15"
             scheme: "Sentry"
-            
+
           # iOS 18
           - runs-on: macos-15
             platform: "iOS"
@@ -101,7 +101,7 @@ jobs:
             test-destination-os: "18.2"
             device: "iPhone 16"
             scheme: "Sentry"
-            
+
           # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.
           # We are running tests on macOS 14 and later, as there were OS-internal changes introduced in succeeding versions.
@@ -112,14 +112,14 @@ jobs:
             xcode: "15.4"
             test-destination-os: "latest"
             scheme: "Sentry"
-            
+
           # macOS 15
           - runs-on: macos-15
             platform: "macOS"
             xcode: "16.2"
             test-destination-os: "latest"
             scheme: "Sentry"
-            
+
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
           # In addition we are running tests on macOS 14, as there were OS-internal changes introduced in succeeding versions.
@@ -128,7 +128,7 @@ jobs:
             xcode: "15.4"
             test-destination-os: "latest"
             scheme: "Sentry"
-            
+
           - runs-on: macos-15
             platform: "Catalyst"
             xcode: "16.2"
@@ -145,8 +145,8 @@ jobs:
             xcode: "15.4"
             test-destination-os: "17.5"
             scheme: "Sentry"
-            
-        # iOS 17
+
+          # iOS 17
           - runs-on: macos-14
             platform: "iOS"
             xcode: "15.4"
@@ -185,14 +185,30 @@ jobs:
       # We split building and running tests in two steps so we know how long running the tests takes.
       - name: Build tests
         id: build_tests
-        run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME build-for-testing "${{matrix.device}}" TestCI ${{matrix.scheme}}
+        run: |
+          ./scripts/xcode-test.sh \
+            --platform ${{matrix.platform}} \
+            --os ${{matrix.test-destination-os}} \
+            --ref ${{ github.ref_name }} \
+            --command build-for-testing \
+            --device "${{matrix.device}}" \
+            --configuration TestCI \
+            --scheme ${{matrix.scheme}}
 
       - name: Run tests
         # We call a script with the platform so the destination
         # passed to xcodebuild doesn't end up in the job name,
         # because GitHub Actions don't provide an easy way of
         # manipulating string in expressions.
-        run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME test-without-building "${{matrix.device}}" TestCI ${{matrix.scheme}}
+        run: |
+          ./scripts/xcode-test.sh \
+            --platform ${{matrix.platform}} \
+            --os ${{matrix.test-destination-os}} \
+            --ref ${{ github.ref_name }} \
+            --command test-without-building \
+            --device "${{matrix.device}}" \
+            --configuration TestCI \
+            --scheme ${{matrix.scheme}}
 
       - name: Slowest Tests
         if: ${{ always() }}
@@ -255,7 +271,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 20
     needs: [build-test-server]
-    
+
     # There are several ways this test can flake. Sometimes threaded tests will just hang and the job will time out, other times waiting on expectations will take much longer than in a non-TSAN run and the test case will fail. We're making this nonfailable and will grep the logs to extract any actual thread sanitizer warnings to push to the PR, and ignore everything else.
     continue-on-error: true
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GIT-REF := $(shell git rev-parse --abbrev-ref HEAD)
 
 test:
 	@echo "--> Running all tests"
-	./scripts/xcode-test.sh iOS latest $(GIT-REF) test Test
+	./scripts/xcode-test.sh --platform iOS --os latest --ref $(GIT-REF) --command test --configuration Test
 	./scripts/xcode-slowest-tests.sh
 .PHONY: test
 

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -8,14 +8,70 @@ set -euxo pipefail
 # To fix this, we specify a readable platform in the matrix and then call
 # this script to map the platform to the destination.
 
-PLATFORM="${1}"
-OS=${2:-latest}
-REF_NAME="${3-HEAD}"
-COMMAND="${4:-test}"
-DEVICE=${5:-iPhone 14}
-CONFIGURATION_OVERRIDE="${6:-}"
-DERIVED_DATA_PATH="${7:-}"
-TEST_SCHEME="${8:-Sentry}"
+# Parse named arguments
+PLATFORM=""
+OS="latest"
+REF_NAME="HEAD"
+COMMAND="test"
+DEVICE="iPhone 14"
+CONFIGURATION_OVERRIDE=""
+DERIVED_DATA_PATH=""
+TEST_SCHEME="Sentry"
+
+usage() {
+    echo "Usage: $0"
+    echo "  -p|--platform <platform>        Platform (macOS/Catalyst/iOS/tvOS)"
+    echo "  -o|--os <os>                    OS version (default: latest)"
+    echo "  -r|--ref <ref>                  Reference name (default: HEAD)"
+    echo "  -c|--command <command>          Command (build/build-for-testing/test-without-building/test)"
+    echo "  -d|--device <device>            Device name (default: iPhone 14)"
+    echo "  -C|--configuration <config>     Configuration override"
+    echo "  -D|--derived-data <path>        Derived data path"
+    echo "  -s|--scheme <scheme>            Test scheme (default: Sentry)"
+    exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p|--platform)
+            PLATFORM="$2"
+            shift 2
+            ;;
+        -o|--os)
+            OS="$2"
+            shift 2
+            ;;
+        -r|--ref-name)
+            REF_NAME="$2"
+            shift 2
+            ;;
+        -c|--command)
+            COMMAND="$2"
+            shift 2
+            ;;
+        -d|--device)
+            DEVICE="$2"
+            shift 2
+            ;;
+        -C|--configuration)
+            CONFIGURATION_OVERRIDE="$2"
+            shift 2
+            ;;
+        -D|--derived-data)
+            DERIVED_DATA_PATH="$2"
+            shift 2
+            ;;
+        -s|--scheme)
+            TEST_SCHEME="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
 
 case $PLATFORM in
 

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -42,7 +42,7 @@ while [[ $# -gt 0 ]]; do
             OS="$2"
             shift 2
             ;;
-        -r|--ref-name)
+        -r|--ref)
             REF_NAME="$2"
             shift 2
             ;;


### PR DESCRIPTION
Changes the `scripts/xcode-test.sh` to use named arguments instead of positional.

This should improve usability of the script, and reduce accidental usage errors when changing the script.

Furthermore it surfaced that the 7th argument `${{ matrix.scheme }}` is actually used as the `DERIVED_DATA` path, instead of the 8th argument

https://github.com/getsentry/sentry-cocoa/blob/bdd896e6bef9469b6d43891fed3df6d6bd019cb9/.github/workflows/test.yml#L188

https://github.com/getsentry/sentry-cocoa/blob/bdd896e6bef9469b6d43891fed3df6d6bd019cb9/scripts/xcode-test.sh#L11-L18

#skip-changelog