### PR TITLE
test: HttpTransport remove unused eventRequest

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -10,7 +10,6 @@ class SentryHttpTransportTests: XCTestCase {
     private class Fixture {
         let event: Event
         let eventEnvelope: SentryEnvelope
-        let eventRequest: SentryNSURLRequest
         let attachmentEnvelopeItem: SentryEnvelopeItem
         let eventWithAttachmentRequest: SentryNSURLRequest
         let eventWithSessionEnvelope: SentryEnvelope
@@ -53,8 +52,6 @@ class SentryHttpTransportTests: XCTestCase {
 
             event = Event()
             event.message = SentryMessage(formatted: "Some message")
-            
-            eventRequest = buildRequest(SentryEnvelope(event: event))
             
             attachmentEnvelopeItem = SentryEnvelopeItem(attachment: TestData.dataAttachment, maxAttachmentSize: 5 * 1_024 * 1_024)!
             


### PR DESCRIPTION
Remove unused SentryHttpTransportTests.fixture.eventRequest property.

This came up while investigating flaky SentryHttpTransportTests tests.

#skip-changelog