### PR TITLE
impr(ci): automatically detect ci/local environments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Debug
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME ci build "iPhone 14" DebugWithoutUIKit uikit-check-build
+        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" DebugWithoutUIKit uikit-check-build
       - name: Ensure UIKit is not linked
         run: ./scripts/check-uikit-linkage.sh DebugWithoutUIKit uikit-check-build unlinked SentryWithoutUIKit
 
@@ -222,7 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Release
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME ci build "iPhone 14" ReleaseWithoutUIKit uikit-check-build
+        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" ReleaseWithoutUIKit uikit-check-build
       - name: Ensure UIKit is not linked
         run: ./scripts/check-uikit-linkage.sh ReleaseWithoutUIKit uikit-check-build unlinked SentryWithoutUIKit
 
@@ -232,7 +232,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Debug
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME ci build "iPhone 14" Debug uikit-check-build
+        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" Debug uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Debug uikit-check-build linked Sentry
 
@@ -242,6 +242,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build for Release
-        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME ci build "iPhone 14" Release uikit-check-build
+        run: ./scripts/xcode-test.sh "iOS" "latest" $GITHUB_REF_NAME build "iPhone 14" Release uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Release uikit-check-build linked Sentry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,14 +185,14 @@ jobs:
       # We split building and running tests in two steps so we know how long running the tests takes.
       - name: Build tests
         id: build_tests
-        run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME "ci" build-for-testing "${{matrix.device}}" TestCI ${{matrix.scheme}}
+        run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME build-for-testing "${{matrix.device}}" TestCI ${{matrix.scheme}}
 
       - name: Run tests
         # We call a script with the platform so the destination
         # passed to xcodebuild doesn't end up in the job name,
         # because GitHub Actions don't provide an easy way of
         # manipulating string in expressions.
-        run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME "ci" test-without-building "${{matrix.device}}" TestCI ${{matrix.scheme}}
+        run: ./scripts/xcode-test.sh ${{matrix.platform}} ${{matrix.test-destination-os}} $GITHUB_REF_NAME test-without-building "${{matrix.device}}" TestCI ${{matrix.scheme}}
 
       - name: Slowest Tests
         if: ${{ always() }}

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ GIT-REF := $(shell git rev-parse --abbrev-ref HEAD)
 
 test:
 	@echo "--> Running all tests"
-	./scripts/xcode-test.sh iOS latest $(GIT-REF) YES test Test
+	./scripts/xcode-test.sh iOS latest $(GIT-REF) test Test
 	./scripts/xcode-slowest-tests.sh
 .PHONY: test
 

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -11,12 +11,11 @@ set -euxo pipefail
 PLATFORM="${1}"
 OS=${2:-latest}
 REF_NAME="${3-HEAD}"
-IS_LOCAL_BUILD="${4:-ci}"
-COMMAND="${5:-test}"
-DEVICE=${6:-iPhone 14}
-CONFIGURATION_OVERRIDE="${7:-}"
-DERIVED_DATA_PATH="${8:-}"
-TEST_SCHEME="${9:-Sentry}"
+COMMAND="${4:-test}"
+DEVICE=${5:-iPhone 14}
+CONFIGURATION_OVERRIDE="${6:-}"
+DERIVED_DATA_PATH="${7:-}"
+TEST_SCHEME="${8:-Sentry}"
 
 case $PLATFORM in
 
@@ -56,15 +55,6 @@ else
     esac
 fi
 
-case $IS_LOCAL_BUILD in
-"ci")
-    RUBY_ENV_ARGS=""
-    ;;
-*)
-    RUBY_ENV_ARGS="rbenv exec bundle exec"
-    ;;
-esac
-
 case $COMMAND in
 "build")
     RUN_BUILD=true
@@ -87,6 +77,12 @@ case $COMMAND in
     RUN_TEST_WITHOUT_BUILDING=true
     ;;
 esac
+
+if [ "$CI" == true ]; then
+    RUBY_ENV_ARGS="rbenv exec bundle exec"
+else
+    RUBY_ENV_ARGS=""
+fi
 
 if [ $RUN_BUILD == true ]; then
     set -o pipefail && env NSUnbufferedIO=YES xcodebuild \

--- a/scripts/xcode-test.sh
+++ b/scripts/xcode-test.sh
@@ -79,9 +79,9 @@ case $COMMAND in
 esac
 
 if [ "$CI" == true ]; then
-    RUBY_ENV_ARGS="rbenv exec bundle exec"
-else
     RUBY_ENV_ARGS=""
+else
+    RUBY_ENV_ARGS="rbenv exec bundle exec"
 fi
 
 if [ $RUN_BUILD == true ]; then


### PR DESCRIPTION
I realized after making the changes in #4814 that there has to be a better way to differentiate between ci and local runs. Instead of relying on a parameter to the script, just check one of the environment variables set by github actions.

#skip-changelog