### PR TITLE
ref: use a json file to define the large unit test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.configure-matrix.outputs.matrix }}
+      matrix: ${{ fromJson(needs.configure-matrix.outputs.matrix) }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,7 @@ jobs:
        uses: actions/checkout@v3
      - name: Configure test matrix
        id: configure-test-matrix
-       run: echo "matrix=$(jq -c . < ./unit-test-matrix.json)" >> $GITHUB_OUTPUT
+       run: echo "matrix=$(jq -c . < ./.github/workflows/unit-test-matrix.json)" >> $GITHUB_OUTPUT
      
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}} ${{matrix.scheme}}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - "SentryTestUtils/**"
       - "test-server/**"
       - ".github/workflows/test.yml"
+      - ".github/workflows/unit-test-matrix.json"
       - "fastlane/**"
       - "scripts/tests-with-thread-sanitizer.sh"
       - "scripts/ci-select-xcode.sh"
@@ -65,101 +66,28 @@ jobs:
           path: |
             raw-test-output.log
 
+  configure-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.configure-test-matrix.outputs.matrix }}
+    steps:
+     - name: Checkout repository
+       uses: actions/checkout@v3
+     - name: Configure test matrix
+       id: configure-test-matrix
+       run: echo "matrix=$(jq -c . < ./unit-test-matrix.json)" >> $GITHUB_OUTPUT
+     
   unit-tests:
     name: Unit ${{matrix.platform}} - Xcode ${{matrix.xcode}} - OS ${{matrix.test-destination-os}} ${{matrix.scheme}}
     runs-on: ${{matrix.runs-on}}
     timeout-minutes: 20
-    needs: build-test-server
+    needs:
+      - build-test-server
+      - configure-matrix
 
     strategy:
       fail-fast: false
-      matrix:
-        # Can't run tests on watchOS because XCTest is not available
-        include:
-          # We are running tests on iOS 17 and later, as there were OS-internal changes introduced in succeeding versions.
-
-          # iOS 16
-          - runs-on: macos-13
-            platform: "iOS"
-            xcode: "14.3"
-            test-destination-os: "16.4"
-            device: "iPhone 14"
-            scheme: "Sentry"
-            
-          # iOS 17
-          - runs-on: macos-14
-            platform: "iOS"
-            xcode: "15.4"
-            test-destination-os: "17.2"
-            device: "iPhone 15"
-            scheme: "Sentry"
-            
-          # iOS 18
-          - runs-on: macos-15
-            platform: "iOS"
-            xcode: "16.2"
-            test-destination-os: "18.2"
-            device: "iPhone 16"
-            scheme: "Sentry"
-            
-          # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
-          # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.
-          # We are running tests on macOS 14 and later, as there were OS-internal changes introduced in succeeding versions.
-
-          # macOS 14
-          - runs-on: macos-14
-            platform: "macOS"
-            xcode: "15.4"
-            test-destination-os: "latest"
-            scheme: "Sentry"
-            
-          # macOS 15
-          - runs-on: macos-15
-            platform: "macOS"
-            xcode: "16.2"
-            test-destination-os: "latest"
-            scheme: "Sentry"
-            
-          # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
-          # on an older iOS or macOS version is low.
-          # In addition we are running tests on macOS 14, as there were OS-internal changes introduced in succeeding versions.
-          - runs-on: macos-14
-            platform: "Catalyst"
-            xcode: "15.4"
-            test-destination-os: "latest"
-            scheme: "Sentry"
-            
-          - runs-on: macos-15
-            platform: "Catalyst"
-            xcode: "16.2"
-            test-destination-os: "latest"
-            scheme: "Sentry"
-
-          # We don't run the unit tests on tvOS 16 cause we run them on all on GH actions available iOS versions.
-          # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, tvOS 15 or tvOS 16 is minimal.
-          # We are running tests on tvOS 17 and latest, as there were OS-internal changes introduced in succeeding versions.
-
-          # tvOS 17
-          - runs-on: macos-14
-            platform: "tvOS"
-            xcode: "15.4"
-            test-destination-os: "17.5"
-            scheme: "Sentry"
-            
-        # iOS 17
-          - runs-on: macos-14
-            platform: "iOS"
-            xcode: "15.4"
-            test-destination-os: "17.2"
-            device: "iPhone 15"
-            scheme: "SentrySwiftUI"
-
-          # tvOS 18
-          - runs-on: macos-15
-            platform: "tvOS"
-            xcode: "16.2"
-            test-destination-os: "18.1"
-            scheme: "Sentry"
+      matrix: ${{ fromJson(needs.configure-matrix.outputs.matrix }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -45,7 +45,7 @@ jobs:
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
-
+            
   # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:
     name: UI Tests for SwiftUI on ${{matrix.device}} Simulator

--- a/.github/workflows/unit-test-matrix.json
+++ b/.github/workflows/unit-test-matrix.json
@@ -8,5 +8,5 @@
   { "scheme": "Sentry", "platform": "Catalyst", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "latest" },
   { "scheme": "Sentry", "platform": "Catalyst", "runs-on": "macos-14", "xcode": "16.2", "test-destination-os": "latest" },
   { "scheme": "Sentry", "platform": "tvOS", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "17.5", "device": "iPhone 15" },
-  { "scheme": "Sentry", "platform": "tvOS", "runs-on": "macos-14", "xcode": "16.2", "test-destination-os": "18.1", "device": "iPhone 15" },
+  { "scheme": "Sentry", "platform": "tvOS", "runs-on": "macos-14", "xcode": "16.2", "test-destination-os": "18.1", "device": "iPhone 15" }
 ]}

--- a/.github/workflows/unit-test-matrix.json
+++ b/.github/workflows/unit-test-matrix.json
@@ -1,0 +1,12 @@
+{ "include": [
+  { "scheme": "SentrySwiftUI", "platform": "iOS", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "17.2", "device": "iPhone 15" },
+  { "scheme": "Sentry", "platform": "iOS", "runs-on": "macos-13", "xcode": "14.3", "test-destination-os": "16.4", "device": "iPhone 14" },
+  { "scheme": "Sentry", "platform": "iOS", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "17.2", "device": "iPhone 15" },
+  { "scheme": "Sentry", "platform": "iOS", "runs-on": "macos-15", "xcode": "16.2", "test-destination-os": "18.2", "device": "iPhone 16" },
+  { "scheme": "Sentry", "platform": "macOS", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "latest" },
+  { "scheme": "Sentry", "platform": "macOS", "runs-on": "macos-14", "xcode": "16.2", "test-destination-os": "latest" },
+  { "scheme": "Sentry", "platform": "Catalyst", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "latest" },
+  { "scheme": "Sentry", "platform": "Catalyst", "runs-on": "macos-14", "xcode": "16.2", "test-destination-os": "latest" },
+  { "scheme": "Sentry", "platform": "tvOS", "runs-on": "macos-14", "xcode": "15.4", "test-destination-os": "17.5", "device": "iPhone 15" },
+  { "scheme": "Sentry", "platform": "tvOS", "runs-on": "macos-14", "xcode": "16.2", "test-destination-os": "18.1", "device": "iPhone 15" },
+]}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -228,7 +228,7 @@ platform :ios do
     )
   end
   
-    lane :ui_tests_ios_swift6 do |options|
+  lane :ui_tests_ios_swift6 do |options|
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift6",


### PR DESCRIPTION
I got tired of scrolling past a huge test matrix definition 🙃 

#skip-changelog