### PR TITLE
chore(ci): add multiple segmented ui test schemes

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -6,14 +6,13 @@ on:
 
   pull_request:
     paths:
-      - 'Sources/**'
-      - 'Tests/**'
-      - '.github/workflows/ui-tests.yml'
-      - 'fastlane/**'
-      - '.sauce/config.yml'
-      - 'scripts/ci-select-xcode.sh'
-      - 'Samples/iOS-Swift/**'
-
+      - "Sources/**"
+      - "Tests/**"
+      - ".github/workflows/ui-tests.yml"
+      - "fastlane/**"
+      - ".sauce/config.yml"
+      - "scripts/ci-select-xcode.sh"
+      - "Samples/iOS-Swift/**"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -30,18 +29,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
       - run: ./scripts/ci-select-xcode.sh
 
-      # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_${{matrix.target}} && break ; done
-        shell: sh
+        run: bundle exec fastlane ui_tests_${{matrix.target}}
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-uitest-output-${{matrix.target}}
+          name: ui-tests-${{matrix.target}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -60,93 +61,115 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
-      
-      # GitHub Actions sometimes fail to launch the UI tests. Therefore we retry
+
       - name: Run Fastlane
-        run: for i in {1..2}; do fastlane ui_tests_ios_swiftui device:"${{matrix.device}}" && break ; done
-        shell: sh
+        run: bundle exec fastlane ui_tests_ios_swiftui device:"${{matrix.device}}"
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-ios-swiftui-test-output-xcode-${{matrix.xcode}}-${{matrix.device}}
+          name: ui-tests-swift-ui-${{matrix.device}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
 
   ui-tests-swift:
-    name: UI Tests for iOS-Swift ${{matrix.device}} Simulator
-    runs-on: ${{matrix.runs-on}}
+    name: iOS-Swift '${{ matrix.test_plan }}' on ${{matrix.destination.device}}
+    runs-on: ${{matrix.destination.runs-on}}
     strategy:
       fail-fast: false
       matrix:
-        include:
+        destination:
           - runs-on: macos-13
             xcode: "15.2"
             device: "iPhone 14 (16.4)"
-
-          # We only use large to investigate if UI tests are less flaky there.
-          - runs-on: macos-14-large
+          - runs-on: macos-14-large # We only use large to investigate if UI tests are less flaky there.
             xcode: "15.4"
             device: "iPhone 15 (17.2)"
+        test_plan:
+          - "Base"
+          - "LaunchUI"
+          - "ProfilingUI"
+          - "SentryDevices"
+          - "TopViewControllerTests"
+          - "UIEventBreadcrumb"
+          - "UserFeedbackUI"
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
+      - run: ./scripts/ci-select-xcode.sh ${{matrix.destination.xcode}}
 
       - name: Create iOS 16.4 simulator
-        if: ${{ matrix.device == 'iPhone 14 (16.4)' }}
+        if: ${{ matrix.destination.device == 'iPhone 14 (16.4)' }}
         run: ./scripts/create-simulator.sh 14.3.1 16.4 "iPhone 14" true
 
       - name: Run Fastlane
-        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+        run: bundle exec fastlane ui_tests_ios_swift device:"${{matrix.destination.device}}" test_plan:"${{matrix.test_plan}}"
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: raw-ios-swift-test-output-${{matrix.xcode}}-${{matrix.device}}
+          name: ui-tests-swift-${{matrix.test_plan}}-${{matrix.destination.device}}-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
-            
+
   ui-tests-swift6:
     name: UI Tests for iOS-Swift6 Simulator
     runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
       - run: ./scripts/ci-select-xcode.sh "16.2"
+
       - name: Run Fastlane
-        run: fastlane ui_tests_ios_swift6
+        run: bundle exec fastlane ui_tests_ios_swift6
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
-        if: ${{  failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         with:
-          name: raw-ios-swift-test-output-${{matrix.xcode}}-${{matrix.device}}
+          name: ui-tests-swift6-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
-            
+
   duplication-tests:
     name: UI Tests for project with Sentry duplicated
     runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          # Runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true
       - run: ./scripts/ci-select-xcode.sh "16.2"
+
       - run: ./scripts/build-xcframework.sh gameOnly
       - name: Run Fastlane
-        run: fastlane duplication_test
+        run: bundle exec fastlane duplication_test
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
-        if: ${{  failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         with:
-          name: raw-ios-swift-test-output-${{matrix.xcode}}-${{matrix.device}}
+          name: duplication-tests-raw-test-output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**

--- a/Samples/iOS-Swift/TestPlans/Base.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/Base.xctestplan
@@ -1,0 +1,281 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "LaunchUITests",
+        "LaunchUITests\/testBreadcrumbData()",
+        "LaunchUITests\/testCaptureError()",
+        "LaunchUITests\/testCaptureException()",
+        "LaunchUITests\/testCheckSlowAndFrozenFrames()",
+        "LaunchUITests\/testCheckTotalFrames()",
+        "LaunchUITests\/testLoremIpsum()",
+        "LaunchUITests\/testNavigationTransaction()",
+        "LaunchUITests\/testShowNib()",
+        "LaunchUITests\/testShowTableView()",
+        "LaunchUITests\/testSplitView()",
+        "LaunchUITests\/testUiClickTransaction()",
+        "LaunchUITests\/testUseAfterFreeAfterUIImageNamedEmptyString()",
+        "ProfilingUITests",
+        "ProfilingUITests\/testAppLaunchesWithContinuousProfiler()",
+        "ProfilingUITests\/testAppLaunchesWithTraceProfiler()",
+        "ProfilingUITests\/testProfilingGPUInfo()",
+        "SentryDeviceTests",
+        "SentryDeviceTests\/testCPUArchitecture",
+        "SentryDeviceTests\/testDeviceModel",
+        "SentryDeviceTests\/testIsSimulator",
+        "SentryDeviceTests\/testOSBuildNumber",
+        "SentryDeviceTests\/testOSName",
+        "SentryDeviceTests\/testOSVersion",
+        "SentryDeviceTests\/testSimulatedDeviceModel",
+        "TopViewControllerTests",
+        "TopViewControllerTests\/testChildControllerLoadCount()",
+        "TopViewControllerTests\/testNavigationViewController()",
+        "TopViewControllerTests\/testPagesViewController()",
+        "TopViewControllerTests\/testSplitViewController()",
+        "TopViewControllerTests\/testTabBarViewController()",
+        "UIEventBreadcrumbTests",
+        "UIEventBreadcrumbTests\/testExtractInfoFromView()",
+        "UIEventBreadcrumbTests\/testNoBreadcrumbForTextFieldEditingChanged()",
+        "UserFeedbackUITests",
+        "UserFeedbackUITests\/testAddingAndRemovingScreenshots()",
+        "UserFeedbackUITests\/testCancelFromFormByButton()",
+        "UserFeedbackUITests\/testCancelFromFormBySwipeDown()",
+        "UserFeedbackUITests\/testNoPrefilledUserInformation()",
+        "UserFeedbackUITests\/testPrefilledUserInformation()",
+        "UserFeedbackUITests\/testSubmissionErrorThenSuccessAfterFixingIssues()",
+        "UserFeedbackUITests\/testSubmitFullyFilledCustomForm()",
+        "UserFeedbackUITests\/testSubmitFullyFilledForm()",
+        "UserFeedbackUITests\/testSubmitOnlyWithOptionalFieldsFilled()",
+        "UserFeedbackUITests\/testSubmitWithNoFieldsFilledAllRequired()",
+        "UserFeedbackUITests\/testSubmitWithNoFieldsFilledDefault()",
+        "UserFeedbackUITests\/testSubmitWithNoFieldsFilledEmailAndMessageRequired()",
+        "UserFeedbackUITests\/testSubmitWithOnlyRequiredFieldsFilled()",
+        "UserFeedbackUITests\/testUIElementsWithCustomizations()",
+        "UserFeedbackUITests\/testUIElementsWithDefaults()"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/TestPlans/LaunchUI.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/LaunchUI.xctestplan
@@ -1,0 +1,243 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "LaunchUITests\/testBreadcrumbData()",
+        "LaunchUITests\/testCaptureError()",
+        "LaunchUITests\/testCaptureException()",
+        "LaunchUITests\/testCheckSlowAndFrozenFrames()",
+        "LaunchUITests\/testCheckTotalFrames()",
+        "LaunchUITests\/testLoremIpsum()",
+        "LaunchUITests\/testNavigationTransaction()",
+        "LaunchUITests\/testShowNib()",
+        "LaunchUITests\/testShowTableView()",
+        "LaunchUITests\/testSplitView()",
+        "LaunchUITests\/testUiClickTransaction()",
+        "LaunchUITests\/testUseAfterFreeAfterUIImageNamedEmptyString()"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/TestPlans/ProfilingUI.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/ProfilingUI.xctestplan
@@ -1,0 +1,235 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "ProfilingUITests\/testAppLaunchesWithContinuousProfiler()",
+        "ProfilingUITests\/testAppLaunchesWithTraceProfiler()",
+        "ProfilingUITests\/testProfilingGPUInfo()"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/TestPlans/SentryDevices.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/SentryDevices.xctestplan
@@ -1,0 +1,239 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "SentryDeviceTests\/testCPUArchitecture",
+        "SentryDeviceTests\/testDeviceModel",
+        "SentryDeviceTests\/testIsSimulator",
+        "SentryDeviceTests\/testOSBuildNumber",
+        "SentryDeviceTests\/testOSName",
+        "SentryDeviceTests\/testOSVersion",
+        "SentryDeviceTests\/testSimulatedDeviceModel"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/TestPlans/TopViewControllerTests.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/TopViewControllerTests.xctestplan
@@ -1,0 +1,237 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "TopViewControllerTests\/testChildControllerLoadCount()",
+        "TopViewControllerTests\/testNavigationViewController()",
+        "TopViewControllerTests\/testPagesViewController()",
+        "TopViewControllerTests\/testSplitViewController()",
+        "TopViewControllerTests\/testTabBarViewController()"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/TestPlans/UIEventBreadcrumb.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/UIEventBreadcrumb.xctestplan
@@ -1,0 +1,234 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "UIEventBreadcrumbTests\/testExtractInfoFromView()",
+        "UIEventBreadcrumbTests\/testNoBreadcrumbForTextFieldEditingChanged()"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/TestPlans/UserFeedbackUI.xctestplan
+++ b/Samples/iOS-Swift/TestPlans/UserFeedbackUI.xctestplan
@@ -1,0 +1,247 @@
+{
+  "configurations" : [
+    {
+      "id" : "7C735E20-AC3E-4566-91D1-63D5EF65CB48",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "commandLineArgumentEntries" : [
+      {
+        "argument" : "--io.sentry.disable-everything",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-time-to-full-display-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-performance-v2",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-view-hierarchy",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-attach-screenshot",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.base64-attachment-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.disable-http-transport",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-file-io-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.dont-use-sentry-user",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-name",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.require-email",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-animations",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-icon",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.no-widget-text",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.all-defaults",
+        "enabled" : false
+      },
+      {
+        "argument" : "--skip-sentry-init",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-spotlight",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-session-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-metrickit-integration",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-session-replay",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.enableContinuousProfiling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.wipe-data",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.slow-load-method",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-watchdog-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--profile-app-launches",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-crash-handler",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-swizzling",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-core-data-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-network-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-uiviewcontroller-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-automatic-breadcrumbs",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-anr-tracking",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-auto-performance-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--disable-ui-tracing",
+        "enabled" : false
+      },
+      {
+        "argument" : "--io.sentry.feedback.auto-inject-widget"
+      }
+    ],
+    "environmentVariableEntries" : [
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSampleRate",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.tracesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.profilesSamplerValue",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sdk-environment",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.dsn",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.username",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.email",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.sessionTrackingIntervalMillis",
+        "value" : ""
+      },
+      {
+        "enabled" : false,
+        "key" : "--io.sentry.user.name",
+        "value" : ""
+      }
+    ],
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:iOS-Swift.xcodeproj",
+      "identifier" : "637AFDA5243B02760034958B",
+      "name" : "iOS-Swift"
+    }
+  },
+  "testTargets" : [
+    {
+      "selectedTests" : [
+        "UserFeedbackUITests\/testAddingAndRemovingScreenshots()",
+        "UserFeedbackUITests\/testCancelFromFormByButton()",
+        "UserFeedbackUITests\/testCancelFromFormBySwipeDown()",
+        "UserFeedbackUITests\/testNoPrefilledUserInformation()",
+        "UserFeedbackUITests\/testPrefilledUserInformation()",
+        "UserFeedbackUITests\/testSubmissionErrorThenSuccessAfterFixingIssues()",
+        "UserFeedbackUITests\/testSubmitFullyFilledCustomForm()",
+        "UserFeedbackUITests\/testSubmitFullyFilledForm()",
+        "UserFeedbackUITests\/testSubmitOnlyWithOptionalFieldsFilled()",
+        "UserFeedbackUITests\/testSubmitWithNoFieldsFilledAllRequired()",
+        "UserFeedbackUITests\/testSubmitWithNoFieldsFilledDefault()",
+        "UserFeedbackUITests\/testSubmitWithNoFieldsFilledEmailAndMessageRequired()",
+        "UserFeedbackUITests\/testSubmitWithOnlyRequiredFieldsFilled()",
+        "UserFeedbackUITests\/testUIElementsWithCustomizations()",
+        "UserFeedbackUITests\/testUIElementsWithDefaults()"
+      ],
+      "target" : {
+        "containerPath" : "container:iOS-Swift.xcodeproj",
+        "identifier" : "7B64386726A6C544000D0F65",
+        "name" : "iOS-Swift-UITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -299,6 +299,13 @@
 		8E8C57AE25EF16E6001CEEFA /* TraceTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraceTestViewController.swift; sourceTree = "<group>"; };
 		924857552C89A85F00774AC3 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		B70038842BB33E7700065A38 /* ReplaceContentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReplaceContentViewController.swift; sourceTree = "<group>"; };
+		D4D025222D5CA24300B4DFAA /* LaunchUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = LaunchUI.xctestplan; sourceTree = "<group>"; };
+		D4F9ECF42D5A4D7800F0E3D3 /* Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Base.xctestplan; sourceTree = "<group>"; };
+		D4F9ECF52D5A4D7800F0E3D3 /* ProfilingUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = ProfilingUI.xctestplan; sourceTree = "<group>"; };
+		D4F9ECF62D5A4D7800F0E3D3 /* SentryDevices.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = SentryDevices.xctestplan; sourceTree = "<group>"; };
+		D4F9ECF72D5A4D7800F0E3D3 /* TopViewControllerTests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TopViewControllerTests.xctestplan; sourceTree = "<group>"; };
+		D4F9ECF82D5A4D7800F0E3D3 /* UIEventBreadcrumb.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UIEventBreadcrumb.xctestplan; sourceTree = "<group>"; };
+		D4F9ECF92D5A4D7800F0E3D3 /* UserFeedbackUI.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = UserFeedbackUI.xctestplan; sourceTree = "<group>"; };
 		D80D021229EE93630084393D /* ErrorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorsViewController.swift; sourceTree = "<group>"; };
 		D80D021929EE936F0084393D /* ExtraViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtraViewController.swift; sourceTree = "<group>"; };
 		D8269A39274C095E00BD5BD5 /* iOS13-Swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "iOS13-Swift.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -446,6 +453,7 @@
 			isa = PBXGroup;
 			children = (
 				62C97DB92CC69B0200DDA204 /* SampleAssets.xcassets */,
+				D4F9ECFA2D5A4D7800F0E3D3 /* TestPlans */,
 				84BA72A62C93698E0045B828 /* Shared */,
 				848A2576286E3490008A8858 /* PerformanceBenchmarks */,
 				637AFDA8243B02760034958B /* iOS-Swift */,
@@ -551,6 +559,20 @@
 			);
 			name = Shared;
 			path = ../Shared;
+			sourceTree = "<group>";
+		};
+		D4F9ECFA2D5A4D7800F0E3D3 /* TestPlans */ = {
+			isa = PBXGroup;
+			children = (
+				D4F9ECF42D5A4D7800F0E3D3 /* Base.xctestplan */,
+				D4D025222D5CA24300B4DFAA /* LaunchUI.xctestplan */,
+				D4F9ECF52D5A4D7800F0E3D3 /* ProfilingUI.xctestplan */,
+				D4F9ECF62D5A4D7800F0E3D3 /* SentryDevices.xctestplan */,
+				D4F9ECF72D5A4D7800F0E3D3 /* TopViewControllerTests.xctestplan */,
+				D4F9ECF82D5A4D7800F0E3D3 /* UIEventBreadcrumb.xctestplan */,
+				D4F9ECF92D5A4D7800F0E3D3 /* UserFeedbackUI.xctestplan */,
+			);
+			path = TestPlans;
 			sourceTree = "<group>";
 		};
 		D8269A3A274C095E00BD5BD5 /* iOS13-Swift */ = {

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1400"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,30 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:TestPlans/Base.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/UIEventBreadcrumb.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/UserFeedbackUI.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/ProfilingUI.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/TopViewControllerTests.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/SentryDevices.xctestplan">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:TestPlans/LaunchUI.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -220,11 +220,12 @@ platform :ios do
     )
   end
 
-  lane :ui_tests_ios_swiftui do
+  lane :ui_tests_ios_swiftui do |options|
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-SwiftUI",
-      configuration: configuration
+      configuration: configuration,
+      testplan: options[:test_plan]
     )
   end
   
@@ -232,15 +233,17 @@ platform :ios do
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-Swift6",
-      configuration: configuration
+      configuration: configuration,
+      testplan: options[:test_plan]
     )
   end
 
-  lane :ui_tests_ios_objc do
+  lane :ui_tests_ios_objc do |options|
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "iOS-ObjectiveC",
-      configuration: configuration
+      configuration: configuration,
+      testplan: options[:test_plan]
     )
   end
 
@@ -250,15 +253,17 @@ platform :ios do
       scheme: "iOS-Swift",
       device: options[:device],
       address_sanitizer: options[:address_sanitizer],
-      configuration: configuration
+      configuration: configuration,
+      testplan: options[:test_plan]
     )
   end
 
-  lane :ui_tests_tvos_swift do
+  lane :ui_tests_tvos_swift do |options|
     run_tests(
       workspace: "Sentry.xcworkspace",
       scheme: "tvOS-Swift",
-      configuration: configuration
+      configuration: configuration,
+      testplan: options[:test_plan]
     )
   end
   


### PR DESCRIPTION
- Splits ui tests into multiple schemes to run more isolated tests.
- I added the jobs in addition to existing tests, so we can compare the stability.
- Migrates the schemes to use test plans for more control
- I added a test plan `Base.xctestplan` where all new tests are added automatically (basically a catch-all), configured as `skippedTests`.
- For each segment I created an additional test plan which does **not** add new tests automatically, configured as `selectedTests`.


Todo:
- [ ] Reduce build-time using build once for testing, use for multiple tests

#skip-changelog