### PR TITLE
chore(test): use correct capitalization for function "without" "logs"

### DIFF
--- a/SentryTestUtils/SentryLogExtensions.swift
+++ b/SentryTestUtils/SentryLogExtensions.swift
@@ -12,7 +12,7 @@ extension SentryLog {
     
     /// SentryLog uses NSLog internally, which can significantly slow down code because it requires
     /// synchronization. Tests that need code to run fast should can turn off logs to avoid flakiness.
-    public static func withOutLogs<T>(_ closure: () throws -> T) rethrows -> T {
+    public static func withoutLogs<T>(_ closure: () throws -> T) rethrows -> T {
         defer { setTestDefaultLogLevel() }
         disable()
         return try closure()

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -310,7 +310,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         // This would print thousands of logs so we execute it without
         // to avoid spamming the test logs.
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             wait(for: [firstListener.anrDetectedExpectation, firstListener.anrStoppedExpectation, thirdListener.anrStoppedExpectation, thirdListener.anrDetectedExpectation], timeout: waitTimeout)
         }
 
@@ -366,7 +366,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         // This would print thousands of logs so we execute it without
         // to avoid spamming the test logs.
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
         }
     }
@@ -391,7 +391,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         // This would print thousands of logs so we execute it without
         // to avoid spamming the test logs.
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
         }
     }
@@ -515,7 +515,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         // This would print thousands of logs so we execute it without
         // to avoid spamming the test logs.
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             wait(for: [listener.anrDetectedExpectation, listener.anrStoppedExpectation], timeout: waitTimeout)
         }
     }

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -145,7 +145,7 @@ class SentryFeedbackTests: XCTestCase {
             func testCaseDescription() -> String {
                 "(config: (requiresName: \(input.config.requiresName), requiresEmail: \(input.config.requiresEmail), nameInput: \(input.config.nameInput == nil ? "nil" : "\"\(input.config.nameInput!)\""), emailInput: \(input.config.emailInput == nil ? "nil" : "\"\(input.config.emailInput!)\""), messageInput: \(input.config.messageInput == nil ? "nil" : "\"\(input.config.messageInput!)\""), includeScreenshot: \(input.config.includeScreenshot)), expectedSubmitButtonAccessibilityHint: \(input.expectedSubmitButtonAccessibilityHint)"
             }
-            SentryLog.withOutLogs {
+            SentryLog.withoutLogs {
                 switch viewModel.validate() {
                 case .success(let hint):
                     XCTAssert(input.shouldValidate)

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -799,7 +799,7 @@ class SentryHttpTransportTests: XCTestCase {
         givenCachedEvents(amount: 30)
         fixture.requestManager.responseDelay = fixture.flushTimeout + 0.2
         
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             let beforeFlush = getAbsoluteTime()
             let result = sut.flush(fixture.flushTimeout)
             let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
@@ -814,7 +814,7 @@ class SentryHttpTransportTests: XCTestCase {
     func testFlush_BlocksCallingThread_FinishesFlushingWhenSent() {
         givenCachedEvents(amount: 1)
         
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             let beforeFlush = getAbsoluteTime()
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
@@ -827,7 +827,7 @@ class SentryHttpTransportTests: XCTestCase {
     func testFlush_CalledSequentially_BlocksTwice() {
         givenCachedEvents()
         
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             let beforeFlush = getAbsoluteTime()
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
@@ -845,7 +845,7 @@ class SentryHttpTransportTests: XCTestCase {
         var blockingDurationSum: TimeInterval = 0.0
         let flushInvocations = 100
         
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             for _ in  0..<flushInvocations {
                 let beforeFlush = getAbsoluteTime()
@@ -872,7 +872,7 @@ class SentryHttpTransportTests: XCTestCase {
         var blockingDurationSum: TimeInterval = 0.0
         let flushInvocations = 100
         
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             for _ in  0..<flushInvocations {
                 let beforeFlush = getAbsoluteTime()
@@ -890,7 +890,7 @@ class SentryHttpTransportTests: XCTestCase {
     func testFlush_CallingFlushDirectlyAfterCapture_Flushes() {
         let sut = fixture.getSut(dispatchQueueWrapper: SentryDispatchQueueWrapper())
         
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             for _ in 0..<10 {
                 sut.send(envelope: fixture.eventEnvelope)
@@ -903,7 +903,7 @@ class SentryHttpTransportTests: XCTestCase {
     }
     
     func testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse() {
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             givenCachedEvents(amount: 30)
             

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -991,7 +991,7 @@ class SentrySDKTests: XCTestCase {
 class SentrySDKWithSetupTests: XCTestCase {
     
     func testAccessingHubAndOptions_NoDeadlock() {
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             
             let concurrentQueue = DispatchQueue(label: "concurrent", attributes: .concurrent)
             

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -206,7 +206,7 @@ class SentryTracerTests: XCTestCase {
     /// to a crash when spans keep finishing while finishInternal is executed because
     /// shouldIgnoreWaitForChildrenCallback could be then nil in hasUnfinishedChildSpansToWaitFor.
     func testFinish_ShouldIgnoreWaitForChildrenCallback_DoesNotCrash() throws {
-        SentryLog.withOutLogs {
+        SentryLog.withoutLogs {
             for _ in 0..<5 {
                 let sut = fixture.getSut()
                 
@@ -1108,7 +1108,7 @@ class SentryTracerTests: XCTestCase {
     }
     
     func testFinishAsync() throws {
-        try SentryLog.withOutLogs {
+        try SentryLog.withoutLogs {
             let sut = fixture.getSut()
             let child = sut.startChild(operation: fixture.transactionOperation)
             sut.finish()
@@ -1179,7 +1179,7 @@ class SentryTracerTests: XCTestCase {
     #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     
     func testAddingSpansOnDifferentThread_WhileFinishing_DoesNotCrash() throws {
-        try SentryLog.withOutLogs {
+        try SentryLog.withoutLogs {
             
             let sut = fixture.getSut(waitForChildren: false)
                 


### PR DESCRIPTION
#skip-changelog