### PR TITLE
internal: Measure app hang duration

### DIFF
--- a/Sources/Sentry/SentryANRTrackerV1.m
+++ b/Sources/Sentry/SentryANRTrackerV1.m
@@ -155,8 +155,13 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         targets = [self.listeners allObjects];
     }
 
+    // We don't measure the duration of app hangs for the V1 to minimize the scope, and we will
+    // replace V1 with V2 anyway.
+    NSString *errorMessage = [NSString
+        stringWithFormat:@"App hanging for at least %li ms.", (long)(self.timeoutInterval * 1000)];
+
     for (id<SentryANRTrackerDelegate> target in targets) {
-        [target anrStopped];
+        [target anrStoppedWithErrorMessage:errorMessage];
     }
 }
 

--- a/Sources/Sentry/SentryANRTrackerV1.m
+++ b/Sources/Sentry/SentryANRTrackerV1.m
@@ -156,6 +156,8 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     }
 
     for (id<SentryANRTrackerDelegate> target in targets) {
+        // We intentionally don't measure the ANR duration, because V2 will replace V1, so it's not
+        // worth the effort.
         [target anrStoppedWithResult:nil];
     }
 }

--- a/Sources/Sentry/SentryANRTrackerV1.m
+++ b/Sources/Sentry/SentryANRTrackerV1.m
@@ -155,13 +155,8 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         targets = [self.listeners allObjects];
     }
 
-    // We don't measure the duration of app hangs for the V1 to minimize the scope, and we will
-    // replace V1 with V2 anyway.
-    NSString *errorMessage = [NSString
-        stringWithFormat:@"App hanging for at least %li ms.", (long)(self.timeoutInterval * 1000)];
-
     for (id<SentryANRTrackerDelegate> target in targets) {
-        [target anrStoppedWithErrorMessage:errorMessage];
+        [target anrStoppedWithResult:nil];
     }
 }
 

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -228,13 +228,11 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         targets = [self.listeners allObjects];
     }
 
-    // We round to 0.1 seconds accuracy because we can't precicely measure the app hand duration.
-    NSString *errorMessage =
-        [NSString stringWithFormat:@"App hanging between %.1f and %.1f seconds.",
-            hangDurationMinimum, hangDurationMaximum];
-
+    SentryANRStoppedResult *result =
+        [[SentryANRStoppedResult alloc] initWithMinDuration:hangDurationMinimum
+                                                maxDuration:hangDurationMaximum];
     for (id<SentryANRTrackerDelegate> target in targets) {
-        [target anrStoppedWithErrorMessage:errorMessage];
+        [target anrStoppedWithResult:result];
     }
 }
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
     [SentrySDK captureEvent:event];
 }
 
-- (void)anrStopped
+- (void)anrStoppedWithErrorMessage:(NSString *)errorMessage
 {
     // We dont report when an ANR ends.
 }

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -134,7 +134,7 @@ NS_ASSUME_NONNULL_BEGIN
     [SentrySDK captureEvent:event];
 }
 
-- (void)anrStoppedWithErrorMessage:(NSString *)errorMessage
+- (void)anrStoppedWithResult:(SentryANRStoppedResult *_Nullable)result
 {
     // We dont report when an ANR ends.
 }

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
         updateAppState:^(SentryAppState *appState) { appState.isANROngoing = YES; }];
 }
 
-- (void)anrStoppedWithErrorMessage:(NSString *)errorMessage
+- (void)anrStoppedWithResult:(SentryANRStoppedResult *_Nullable)result
 {
     [self.appStateManager
         updateAppState:^(SentryAppState *appState) { appState.isANROngoing = NO; }];

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
         updateAppState:^(SentryAppState *appState) { appState.isANROngoing = YES; }];
 }
 
-- (void)anrStopped
+- (void)anrStoppedWithErrorMessage:(NSString *)errorMessage
 {
     [self.appStateManager
         updateAppState:^(SentryAppState *appState) { appState.isANROngoing = NO; }];

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -4,5 +4,6 @@ import Foundation
 @objc
 protocol SentryANRTrackerDelegate {
     func anrDetected(type: SentryANRType)
-    func anrStopped()
+    
+    func anrStopped(errorMessage: String)
 }

--- a/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -5,5 +5,17 @@ import Foundation
 protocol SentryANRTrackerDelegate {
     func anrDetected(type: SentryANRType)
     
-    func anrStopped(errorMessage: String)
+    func anrStopped(result: SentryANRStoppedResult?)
+}
+
+@objcMembers
+class SentryANRStoppedResult: NSObject {
+    
+    let minDuration: TimeInterval
+    let maxDuration: TimeInterval
+    
+    init(minDuration: TimeInterval, maxDuration: TimeInterval) {
+        self.minDuration = minDuration
+        self.maxDuration = maxDuration
+    }
 }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -10,7 +10,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
     private var anrDetectedExpectation: XCTestExpectation!
     private var anrStoppedExpectation: XCTestExpectation!
     private let waitTimeout: TimeInterval = 2.0
-    private var lastANRStoppedErrorMessage: String?
+    private var lastANRStoppedResult: SentryANRStoppedResult?
     
     private class Fixture {
         let timeoutInterval: TimeInterval = 5
@@ -111,7 +111,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: waitTimeout)
         XCTAssertEqual(expectedANRStoppedInvocations, fixture.dispatchQueue.dispatchAsyncInvocations.count)
         
-        XCTAssertEqual("App hanging for at least 5000 ms.", lastANRStoppedErrorMessage)
+        XCTAssertNil(lastANRStoppedResult)
     }
     
     func testAppSuspended_NoANR() {
@@ -216,8 +216,8 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         anrDetectedExpectation.fulfill()
     }
     
-    func anrStopped(errorMessage: String) {
-        lastANRStoppedErrorMessage = errorMessage
+    func anrStopped(result: Sentry.SentryANRStoppedResult?) {
+        lastANRStoppedResult = result
         anrStoppedExpectation.fulfill()
     }
     
@@ -237,7 +237,7 @@ class SentryANRTrackerTestDelegate: NSObject, SentryANRTrackerDelegate {
         anrStoppedExpectation.isInverted = true
     }
     
-    func anrStopped(errorMessage: String) {
+    func anrStopped(result: Sentry.SentryANRStoppedResult?) {
         anrStoppedExpectation.fulfill()
     }
     

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -4,12 +4,13 @@ import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
-    
+
     private var sut: SentryANRTracker!
     private var fixture: Fixture!
     private var anrDetectedExpectation: XCTestExpectation!
     private var anrStoppedExpectation: XCTestExpectation!
     private let waitTimeout: TimeInterval = 2.0
+    private var lastANRStoppedErrorMessage: String?
     
     private class Fixture {
         let timeoutInterval: TimeInterval = 5
@@ -109,6 +110,8 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         
         wait(for: [anrDetectedExpectation, anrStoppedExpectation], timeout: waitTimeout)
         XCTAssertEqual(expectedANRStoppedInvocations, fixture.dispatchQueue.dispatchAsyncInvocations.count)
+        
+        XCTAssertEqual("App hanging for at least 5000 ms.", lastANRStoppedErrorMessage)
     }
     
     func testAppSuspended_NoANR() {
@@ -213,7 +216,8 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         anrDetectedExpectation.fulfill()
     }
     
-    func anrStopped() {
+    func anrStopped(errorMessage: String) {
+        lastANRStoppedErrorMessage = errorMessage
         anrStoppedExpectation.fulfill()
     }
     
@@ -233,7 +237,7 @@ class SentryANRTrackerTestDelegate: NSObject, SentryANRTrackerDelegate {
         anrStoppedExpectation.isInverted = true
     }
     
-    func anrStopped() {
+    func anrStopped(errorMessage: String) {
         anrStoppedExpectation.fulfill()
     }
     

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -67,13 +67,13 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
         
-        let actual = try XCTUnwrap(listener.anrsStoppedResults.last)
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(2.0, actual.minDuration)
         XCTAssertGreaterThanOrEqual(4.0, actual.maxDuration)
         XCTAssertEqual(0.8, actual.maxDuration - actual.minDuration, accuracy: 0.01)
     }
     
-    func testFullyBlockingAppHangWithLargeTimeoutInterval_ReportsCorrectErrorMessage() throws {
+    func testFullyBlockingAppHangWithLargeTimeoutInterval_ReportsCorrectResult() throws {
         timeoutInterval = 5.0
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
@@ -98,13 +98,13 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
         
-        let actual = try XCTUnwrap(listener.anrsStoppedResults.last)
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(5.0, actual.minDuration)
         XCTAssertGreaterThanOrEqual(8.0, actual.maxDuration)
         XCTAssertEqual(2.0, actual.maxDuration - actual.minDuration, accuracy: 0.01)
     }
     
-    func testFullyBlockingAppHangWithSmallTimeoutInterval_ReportsCorrectErrorMessage() throws {
+    func testFullyBlockingAppHangWithSmallTimeoutInterval_ReportsCorrectResult() throws {
         timeoutInterval = 0.5
         let (sut, currentDate, displayLinkWrapper, _, _, _) = try getSut()
         defer { sut.clear() }
@@ -129,7 +129,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
 
-        let actual = try XCTUnwrap(listener.anrsStoppedResults.last)
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(timeoutInterval, actual.minDuration)
         XCTAssertGreaterThanOrEqual(2.0, actual.maxDuration)
         XCTAssertEqual(0.2, actual.maxDuration - actual.minDuration, accuracy: 0.01)
@@ -157,7 +157,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
         
-        let actual = try XCTUnwrap(listener.anrsStoppedResults.last)
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(2.0, actual.minDuration)
         XCTAssertGreaterThanOrEqual(4.0, actual.maxDuration)
         XCTAssertEqual(0.8, actual.maxDuration - actual.minDuration, accuracy: 0.01)
@@ -234,7 +234,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         wait(for: [listener.anrStoppedExpectation], timeout: waitTimeout)
 
-        let actual = try XCTUnwrap(listener.anrsStoppedResults.last)
+        let actual = try XCTUnwrap(listener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(4.0, actual.minDuration)
         XCTAssertGreaterThanOrEqual(6.0, actual.maxDuration)
         XCTAssertEqual(0.8, actual.maxDuration - actual.minDuration, accuracy: 0.01)
@@ -314,17 +314,17 @@ class SentryANRTrackerV2Tests: XCTestCase {
             wait(for: [firstListener.anrDetectedExpectation, firstListener.anrStoppedExpectation, thirdListener.anrStoppedExpectation, thirdListener.anrDetectedExpectation], timeout: waitTimeout)
         }
 
-        let firstActual = try XCTUnwrap(firstListener.anrsStoppedResults.last)
+        let firstActual = try XCTUnwrap(firstListener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(2.0, firstActual.minDuration)
         XCTAssertGreaterThanOrEqual(5.0, firstActual.maxDuration)
         XCTAssertEqual(0.8, firstActual.maxDuration - firstActual.minDuration, accuracy: 0.01)
 
-        let secondActual = try XCTUnwrap(secondListener.anrsStoppedResults.last)
+        let secondActual = try XCTUnwrap(secondListener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(2.0, secondActual.minDuration)
         XCTAssertGreaterThanOrEqual(5.0, secondActual.maxDuration)
         XCTAssertEqual(0.8, secondActual.maxDuration - secondActual.minDuration, accuracy: 0.01)
 
-        let thirdActual = try XCTUnwrap(thirdListener.anrsStoppedResults.last)
+        let thirdActual = try XCTUnwrap(thirdListener.anrStoppedResults.last)
         XCTAssertLessThanOrEqual(2.0, thirdActual.minDuration)
         XCTAssertGreaterThanOrEqual(5.0, thirdActual.maxDuration)
         XCTAssertEqual(0.8, thirdActual.maxDuration - thirdActual.minDuration, accuracy: 0.01)
@@ -555,7 +555,7 @@ class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerDelegate {
     let anrDetectedExpectation = XCTestExpectation(description: "Test Delegate ANR Detection")
     let anrStoppedExpectation  = XCTestExpectation(description: "Test Delegate ANR Stopped")
     let anrsDetected = Invocations<Sentry.SentryANRType>()
-    let anrsStoppedResults = Invocations<SentryANRStoppedResult>()
+    let anrStoppedResults = Invocations<SentryANRStoppedResult>()
     
     init(shouldANRBeDetected: Bool = true, shouldStoppedBeCalled: Bool = true) {
         if !shouldANRBeDetected {
@@ -576,7 +576,7 @@ class SentryANRTrackerV2TestDelegate: NSObject, SentryANRTrackerDelegate {
             return
         }
         
-        anrsStoppedResults.record(nonNilResult)
+        anrStoppedResults.record(nonNilResult)
         
         anrStoppedExpectation.fulfill()
     }


### PR DESCRIPTION
Measure the app hang duration for ANRTrackerV2 and report it via the delegate.anrStopped, so we can set the app hang duration in the ANRTrackingIntegration in a future PR.

Required for https://github.com/getsentry/sentry-cocoa/issues/2216.

#skip-changelog