### PR TITLE
docs: apply formatting to markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 - Fix missing `sample_rate` in baggage (#4751)
 - Serializing SentryGeo with `nil` values (#4724)
 
-### Internal 
+### Internal
 
 - Deserializing SentryEvents with Decodable (#4724)
 - Remove internal unknown dict for Breadcrumbs (#4803) This potentially only impacts hybrid SDKs.
@@ -159,7 +159,7 @@
 ### Fixes
 
 - Session replay touch tracking race condition (#4548)
-- Use `options.reportAccessibilityIdentifier` for Breadcrumbs and UIEvents (#4569) 
+- Use `options.reportAccessibilityIdentifier` for Breadcrumbs and UIEvents (#4569)
 - Session replay transformed view masking (#4529)
 - Load integration from same binary (#4541)
 - Masking for fast animations #4574
@@ -193,7 +193,7 @@
 ### Fixes
 
 - Session replay touch tracking race condition (#4548)
-- Use `options.reportAccessibilityIdentifier` for Breadcrumbs and UIEvents (#4569) 
+- Use `options.reportAccessibilityIdentifier` for Breadcrumbs and UIEvents (#4569)
 - Session replay transformed view masking (#4529)
 - Load integration from same binary (#4541)
 - Masking for fast animations #4574
@@ -208,7 +208,7 @@
 
 ### Features
 
-- Transactions for crashes (#4504): Finish the transaction bound to the scope when the app crashes. This __experimental__ feature is disabled by default. You can enable it via the option `enablePersistingTracesWhenCrashing`.
+- Transactions for crashes (#4504): Finish the transaction bound to the scope when the app crashes. This **experimental** feature is disabled by default. You can enable it via the option `enablePersistingTracesWhenCrashing`.
 
 ### Fixes
 
@@ -223,7 +223,7 @@
 
 ### Features
 
-- Transactions for crashes (#4504): Finish the transaction bound to the scope when the app crashes. This __experimental__ feature is disabled by default. You can enable it via the option `enablePersistingTracesWhenCrashing`.
+- Transactions for crashes (#4504): Finish the transaction bound to the scope when the app crashes. This **experimental** feature is disabled by default. You can enable it via the option `enablePersistingTracesWhenCrashing`.
 
 ### Fixes
 
@@ -501,7 +501,7 @@ This bug caused unhandled/crash events to have the unhandled property and mach i
 - Don’t force cast to `NSComparisonPredicate` in TERNARY operator (#4232)
 - Fix accessing UI API on bg thread in enrichScope (#4245)
 - EXC_BAD_ACCESS in SentryMetricProfiler (#4242)
-- Missing '#include <sys/_types/_ucontext64.h>' (#4244)
+- Missing `#include <sys/_types/_ucontext64.h>` (#4244)
 - Rare flush timeout when called in tight loop (#4257)
 
 ### Improvements
@@ -601,10 +601,10 @@ This bug caused unhandled/crash events to have the unhandled property and mach i
 - Add C++ exception support for `__cxa_rethrow` (#3996)
 - Add beforeCaptureScreenshot callback (#4016)
 - Disable SIGTERM reporting by default (#4025). We added support
-for SIGTERM reporting in the last release and enabled it by default.
-For some users, SIGTERM events were verbose and not actionable.
-Therefore, we disable it per default in this release. If you'd like
-to receive SIGTERM events, set the option `enableSigtermReporting = true`.
+  for SIGTERM reporting in the last release and enabled it by default.
+  For some users, SIGTERM events were verbose and not actionable.
+  Therefore, we disable it per default in this release. If you'd like
+  to receive SIGTERM events, set the option `enableSigtermReporting = true`.
 
 ### Improvements
 
@@ -713,7 +713,7 @@ The following two features, disabled by default, were mistakenly added to the re
 ### Features
 
 - Add Metrics API (#3791, #3799): Read our [docs](https://docs.sentry.io/platforms/apple/metrics/) to learn
-more about how to use the Metrics API.
+  more about how to use the Metrics API.
 - Pre-main profiling data is now attached to the app start transaction (#3736)
 - Release framework without UIKit/AppKit (#3793)
 - Add the option swizzleClassNameExcludes (#3813)
@@ -760,14 +760,15 @@ more about how to use the Metrics API.
 - Checksum error when resolving the SDK via SPM (#3760)
 
 ## 8.22.0
+
 **Warning:** this version is not working with SPM
 
 ### Improvements
 
-- __SPM uses a prebuilt XCFramework and remove SentryPrivate (#3623)__:
-We now provide a prebuilt XCFramework for SPM, which speeds up your build and allows us to write
-more code in Swift. To make this happen, we had to remove the SentryPrivate target for SPM and
-CocoaPods, which you shouldn't have included directly.
+- **SPM uses a prebuilt XCFramework and remove SentryPrivate (#3623)**:
+  We now provide a prebuilt XCFramework for SPM, which speeds up your build and allows us to write
+  more code in Swift. To make this happen, we had to remove the SentryPrivate target for SPM and
+  CocoaPods, which you shouldn't have included directly.
 
 ### Fixes
 
@@ -779,7 +780,7 @@ CocoaPods, which you shouldn't have included directly.
 ### Features
 
 - Add support for Sentry [Spotlight](https://spotlightjs.com/) (#3642), which is basically Sentry
-for development. Read our [blog post](https://blog.sentry.io/sentry-for-development/) to find out more.
+  for development. Read our [blog post](https://blog.sentry.io/sentry-for-development/) to find out more.
 - Add field `SentrySDK.detectedStartUpCrash` (#3644)
 - Automatically profile app launches (#3529)
 - Use CocoaPods resource_bundles for PrivacyInfo (#3651)
@@ -795,8 +796,8 @@ for development. Read our [blog post](https://blog.sentry.io/sentry-for-developm
 - Finish TTID span when transaction finishes (#3610)
 - Don't take screenshot and view hierarchy for app hanging (#3620)
 - Remove `free_storage` and `storage_size` from the device context (#3627), because Apple forbids sending
-information retrieved via `NSFileSystemFreeSize` and `NSFileSystemSize` off a device; see
-[Apple docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc).
+  information retrieved via `NSFileSystemFreeSize` and `NSFileSystemSize` off a device; see
+  [Apple docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc).
 - Make SentryFramesTracker available for HybridSDKs ([#3683](https://github.com/getsentry/sentry-cocoa/pull/3683))
 - Make SentrySwizzle available for HybridSDKs ([#3684](https://github.com/getsentry/sentry-cocoa/pull/3684))
 - Move headers reference out of "extern C" (#3690)
@@ -806,7 +807,7 @@ information retrieved via `NSFileSystemFreeSize` and `NSFileSystemSize` off a de
 ### Features
 
 - Add support for Sentry [Spotlight](https://spotlightjs.com/) (#3642), which is basically Sentry
-for development. Read our [blog post](https://blog.sentry.io/sentry-for-development/) to find out more.
+  for development. Read our [blog post](https://blog.sentry.io/sentry-for-development/) to find out more.
 - Add field `SentrySDK.detectedStartUpCrash` (#3644)
 - Automatically profile app launches (#3529)
 - Use CocoaPods resource_bundles for PrivacyInfo (#3651)
@@ -822,8 +823,8 @@ for development. Read our [blog post](https://blog.sentry.io/sentry-for-developm
 - Finish TTID span when transaction finishes (#3610)
 - Don't take screenshot and view hierarchy for app hanging (#3620)
 - Remove `free_storage` and `storage_size` from the device context (#3627), because Apple forbids sending
-information retrieved via `NSFileSystemFreeSize` and `NSFileSystemSize` off a device; see
-[Apple docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc).
+  information retrieved via `NSFileSystemFreeSize` and `NSFileSystemSize` off a device; see
+  [Apple docs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api?language=objc).
 
 ## 8.20.0
 
@@ -966,8 +967,8 @@ The XCFramework attached to GitHub releases is now built with Xcode 15.
 ### Features
 
 - Sentry can now be used without linking UIKit; this is helpful for using the SDK in certain app extension contexts (#3175)
-**Note:** this is an experimental feature not yet available for with SPM.
-**Warning:** this breaks some SPM integrations. Use 8.14.1 if you integrate using SPM.
+  **Note:** this is an experimental feature not yet available for with SPM.
+  **Warning:** this breaks some SPM integrations. Use 8.14.1 if you integrate using SPM.
 
 - GA of MetricKit integration (#3340)
 
@@ -975,7 +976,6 @@ Once enabled, this feature subscribes to [MetricKit's](https://developer.apple.c
 The MetricKit integration subscribes to [MXHangDiagnostic](https://developer.apple.com/documentation/metrickit/mxhangdiagnostic),
 [MXDiskWriteExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxdiskwriteexceptiondiagnostic),
 and [MXCPUExceptionDiagnostic](https://developer.apple.com/documentation/metrickit/mxcpuexceptiondiagnostic).
-
 
 ## 8.13.1
 
@@ -1097,7 +1097,7 @@ This change considerably speeds up retrieving stacktraces, which the SDK uses fo
 ### Breaking change
 
 - Renamed `enableTimeToFullDisplay` to `enableTimeToFullDisplayTracing` (#3106)
-    - This is an experimental feature and may change at any time without a major revision.
+  - This is an experimental feature and may change at any time without a major revision.
 
 ## 8.9.0-beta.1
 
@@ -1105,7 +1105,6 @@ This change considerably speeds up retrieving stacktraces, which the SDK uses fo
 
 - Symbolicate locally only when debug is enabled (#3079)
 - Sanitize HTTP info from breadcrumbs, spans and events (#3094)
-
 
 ## 8.8.0
 
@@ -1172,10 +1171,10 @@ SentrySDK.capture(error: LoginError.wrongUser("12345678"))
 
 For the Swift error above Sentry displays:
 
-| sentry-cocoa SDK | Title | Description |
-| ----------- | ----------- | ----------- |
-| Since 8.7.0 | `LoginError` | `wrongUser(id: "12345678") (Code: 1)` |
-| Before 8.7.0 | `LoginError` | `Code: 1` |
+| sentry-cocoa SDK | Title        | Description                           |
+| ---------------- | ------------ | ------------------------------------- |
+| Since 8.7.0      | `LoginError` | `wrongUser(id: "12345678") (Code: 1)` |
+| Before 8.7.0     | `LoginError` | `Code: 1`                             |
 
 [Customized error descriptions](https://docs.sentry.io/platforms/apple/usage/#customizing-error-descriptions) have precedence over this feature.
 This change has no impact on grouping of the issues in Sentry.
@@ -1266,6 +1265,7 @@ The `stitchAsyncCode` experimental option has been removed from `SentryOptions` 
 ## 8.3.0
 
 ### Important Note
+
 This release can cause crashes when Profiling is enabled (#2779). Please update to `8.3.1`.
 
 ### Fixes
@@ -1366,29 +1366,29 @@ We renamed the default branch from `master` to `main`. We are going to keep the 
 - Make `SpanProtocol.data` non nullable (#2409)
 - Mark `- [SpanProtocol setExtraValue:forKey:]` as deprecated (#2413)
 - Make SpanContext immutable (#2408)
-    - Remove tags from SpanContext
-    - Remove context property from SentrySpan
+  - Remove tags from SpanContext
+  - Remove context property from SentrySpan
 - Bump minimum supported OS versions to macOS 10.13, iOS 11, tvOS 11, and watchOS 4 (#2414)
 - Make public APIs Swift friendly
-    - Rename `SentrySDK.addBreadcrumb(crumb:)` to `SentrySDK.addBreadcrumb(_ crumb:)` (#2416)
-    - Rename `SentryScope.add(_ crumb:)` to `SentryScope.addBreadcrumb(_ crumb:)` (#2416)
-    - Rename `SentryScope.add(_ attachment:)` to `SentryScope.addAttachment(_ attachment:)` (#2416)
-    - Rename `Client` to `SentryClient` (#2403)
+  - Rename `SentrySDK.addBreadcrumb(crumb:)` to `SentrySDK.addBreadcrumb(_ crumb:)` (#2416)
+  - Rename `SentryScope.add(_ crumb:)` to `SentryScope.addBreadcrumb(_ crumb:)` (#2416)
+  - Rename `SentryScope.add(_ attachment:)` to `SentryScope.addAttachment(_ attachment:)` (#2416)
+  - Rename `Client` to `SentryClient` (#2403)
 - Remove public APIs
-    - Remove `SentryScope.apply(to:)` (#2416)
-    - Remove `SentryScope.apply(to:maxBreadcrumb:)` (#2416)
-    - Remove `- [SentryOptions initWithDict:didFailWithError:]` (#2404)
-    - Remove `- [SentryOptions sdkInfo]` (#2404)
-    - Make SentrySession and SentrySDKInfo internal (#2451)
+  - Remove `SentryScope.apply(to:)` (#2416)
+  - Remove `SentryScope.apply(to:maxBreadcrumb:)` (#2416)
+  - Remove `- [SentryOptions initWithDict:didFailWithError:]` (#2404)
+  - Remove `- [SentryOptions sdkInfo]` (#2404)
+  - Make SentrySession and SentrySDKInfo internal (#2451)
 - Marks App hang's event stacktrace snapshot as true (#2441)
 - Enable user interaction tracing by default (#2442)
 - Remove default attachment content type (#2443)
 - Rename APM tracking feature flags to tracing (#2450)
-    - Rename `SentryOptions.enableAutoPerformanceTracking` to `enableAutoPerformanceTracing`
-    - Rename `SentryOptions.enableUIViewControllerTracking` to `enableUIViewControllerTracing`
-    - Rename `SentryOptions.enablePreWarmedAppStartTracking` to `enablePreWarmedAppStartTracing`
-    - Rename `SentryOptions.enableFileIOTracking` to `enableFileIOTracing`
-    - Rename `SentryOptions.enableCoreDataTracking` to `enableCoreDataTracing`
+  - Rename `SentryOptions.enableAutoPerformanceTracking` to `enableAutoPerformanceTracing`
+  - Rename `SentryOptions.enableUIViewControllerTracking` to `enableUIViewControllerTracing`
+  - Rename `SentryOptions.enablePreWarmedAppStartTracking` to `enablePreWarmedAppStartTracing`
+  - Rename `SentryOptions.enableFileIOTracking` to `enableFileIOTracing`
+  - Rename `SentryOptions.enableCoreDataTracking` to `enableCoreDataTracing`
 - SentrySDK.close calls flush, which is a blocking call (#2453)
 - Bump minimum Xcode version to 13 (#2483)
 - Rename `SentryOptions.enableOutOfMemoryTracking` to `SentryOptions.enableWatchdogTerminationTracking` (#2499)
@@ -2347,7 +2347,7 @@ Breaking changes:
 
 Features and fixes:
 
-- fix: Make public isEqual _Nullable #751
+- fix: Make public isEqual \_Nullable #751
 - feat: Use error domain and code for event message #750
 - feat: Remove SDK frames when attaching stacktrace #739
 - fix: captureException crates a event type=error #746

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,11 @@ We welcome suggested improvements and bug fixes for `sentry-cocoa`, in the form 
 For feedback in PRs, we use the [LOGAF scale](https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale) to specify how important a comment is. You only need one approval from a maintainer to be able to merge. For some PRs, asking specific or multiple people for review might be adequate.
 
 Our different types of reviews:
-  
-  1. **LGTM without any comments.** You can merge immediately.
-  2. **LGTM with low and medium comments.** The reviewer trusts you to resolve these comments yourself, and you don't need to wait for another approval. 
-  3. **Only comments.** You must address all the comments and need another review until you merge.
-  4. **Request changes.** Only use if something critical is in the PR that absolutely must be addressed. We usually use `h` comments for that. When someone requests changes, the same person must approve the changes to allow merging. Use this sparingly.
+
+1. **LGTM without any comments.** You can merge immediately.
+2. **LGTM with low and medium comments.** The reviewer trusts you to resolve these comments yourself, and you don't need to wait for another approval.
+3. **Only comments.** You must address all the comments and need another review until you merge.
+4. **Request changes.** Only use if something critical is in the PR that absolutely must be addressed. We usually use `h` comments for that. When someone requests changes, the same person must approve the changes to allow merging. Use this sparingly.
 
 ## Setting up an Environment
 
@@ -34,13 +34,11 @@ make run-test-server
 
 Test guidelines:
 
-* We write our tests in Swift. When touching a test file written in Objective-C consider converting it to Swift and then add your tests.
-* Make use of the fixture pattern for test setup code. For examples, checkout [SentryClientTest](/Tests/SentryTests/SentryClientTest.swift) or [SentryHttpTransportTests](/Tests/SentryTests/SentryHttpTransportTests.swift).
-* Use [TestData](/Tests/SentryTests/Protocol/TestData.swift) when possible to avoid setting up data classes with test values.
-* Name the variable of the class you are testing `sut`, which stands for [system under test](https://en.wikipedia.org/wiki/System_under_test).
-* When calling `SentrySDK.start` in a test, specify only the minimum integrations required to minimize side effects for tests and reduce flakiness.
-
-
+- We write our tests in Swift. When touching a test file written in Objective-C consider converting it to Swift and then add your tests.
+- Make use of the fixture pattern for test setup code. For examples, checkout [SentryClientTest](/Tests/SentryTests/SentryClientTest.swift) or [SentryHttpTransportTests](/Tests/SentryTests/SentryHttpTransportTests.swift).
+- Use [TestData](/Tests/SentryTests/Protocol/TestData.swift) when possible to avoid setting up data classes with test values.
+- Name the variable of the class you are testing `sut`, which stands for [system under test](https://en.wikipedia.org/wiki/System_under_test).
+- When calling `SentrySDK.start` in a test, specify only the minimum integrations required to minimize side effects for tests and reduce flakiness.
 
 Test can either be ran inside from Xcode or via
 
@@ -58,7 +56,7 @@ or by right-clicking it in the Tests Navigator (⌘6):
 
 ![Disabling test cases via the Xcode Tests navigator](./develop-docs/disabling_tests_xcode_tests_navigator.png)
 
-Then create a GH issue with the [flaky test issue template](https://github.com/getsentry/sentry-cocoa/issues/new?assignees=&labels=Platform%3A+Cocoa%2CType%3A+Flaky+Test&template=flaky-test.yml). 
+Then create a GH issue with the [flaky test issue template](https://github.com/getsentry/sentry-cocoa/issues/new?assignees=&labels=Platform%3A+Cocoa%2CType%3A+Flaky+Test&template=flaky-test.yml).
 
 Disabling the test in the scheme has the advantage that the test report will state "X tests passed, Y tests failed, Z tests skipped", as well as maintaining a centralized list of skipped tests (look in Sentry.xcscheme) and they will be grayed out when viewing in the Xcode Tests Navigator (⌘6):
 
@@ -81,7 +79,7 @@ It can be that it uses a different clang-format version, than you local computer
 
 **More information:**
 We always use the latest version of clang-format in homebrew in [our GH actions](https://github.com/getsentry/sentry-cocoa/blob/bdaf35331fa9dc67fc318e4a25b92cdc9b0c0ed7/.github/workflows/format-code.yml#L19-L20) for formatting the code.
-As we use homebrew for setting up the development environment,  homebrew only contains formulas for clang-format 8, 11, or the latest, and we want to use the latest clang-format version; we accept that we don't pin clang-format to a specific version. Using the GH action images clang-format version doesn't work, as it can be different than the one from homebrew.
+As we use homebrew for setting up the development environment, homebrew only contains formulas for clang-format 8, 11, or the latest, and we want to use the latest clang-format version; we accept that we don't pin clang-format to a specific version. Using the GH action images clang-format version doesn't work, as it can be different than the one from homebrew.
 This means if homebrew updates the [formula](https://formulae.brew.sh/formula/) for the default clang-format version so does our GH actions job. If the GH actions job suddenly starts to format code differently than your local make format, please compare your clang-format version with the GH actions jobs version.
 
 ## Linting
@@ -100,17 +98,17 @@ Please use `Sentry.xcworkspace` as the entry point when opening the project in X
 
 To make a header public follow these steps:
 
-* Move it into the folder [Public](/Sources/Sentry/Public). Both [CocoaPods](Sentry.podspec) and [Swift Package Manager](Package.swift) make all headers in this folder public.
-* Add it to the Umbrella Header [Sentry.h](/Sources/Sentry/Public/Sentry.h).
-* Set the target membership to public.
+- Move it into the folder [Public](/Sources/Sentry/Public). Both [CocoaPods](Sentry.podspec) and [Swift Package Manager](Package.swift) make all headers in this folder public.
+- Add it to the Umbrella Header [Sentry.h](/Sources/Sentry/Public/Sentry.h).
+- Set the target membership to public.
 
 ## Configuring certificates and provisioning profiles locally
 
 You can run samples in a real device without changing certificates and provisioning profiles if you are a Sentry employee with access to Sentry profiles repository and 1Password account.
 
-* Configure your environment to use SSH to access GitHub. Follow [this instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
-* You will need `Cocoa codesigning match encryption password` from your Sentry 1Password account.
-* run `fastlane match_local`
+- Configure your environment to use SSH to access GitHub. Follow [this instructions](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+- You will need `Cocoa codesigning match encryption password` from your Sentry 1Password account.
+- run `fastlane match_local`
 
 This will setup certificates and provisioning profiles into your machine, but in order to be able to run a sample in a real device you need to register that device with Sentry AppConnect account, add the device to the provisioning profile you want to use, download the profile again and open it with Xcode.
 
@@ -129,5 +127,5 @@ We frequently release a beta version of our SDK and dogfood it with internal app
 
 When contributing to the codebase, please make note of the following:
 
-* Non-trivial PRs will not be accepted without tests (see above).
-* Please do not bump version numbers yourself.
+- Non-trivial PRs will not be accepted without tests (see above).
+- Please do not bump version numbers yourself.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ _Bad software is everywhere, and we're tired of it. Sentry is on a mission to he
 [![SwiftPM compatible](https://img.shields.io/badge/spm-compatible-brightgreen.svg?style=flat)](https://swift.org/package-manager)
 ![platforms](https://img.shields.io/cocoapods/p/Sentry.svg?style=flat)
 [![Swift Package Index](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fgetsentry%2Fsentry-cocoa%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/getsentry/sentry-cocoa)
-[![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)  
+[![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)
 
 This SDK is written in Objective-C but also provides a nice Swift interface.
 
@@ -34,7 +34,7 @@ We renamed the default branch from `master` to `main`.
 
 # Initialization
 
-*Remember to call this as early in your application life cycle as possible*
+_Remember to call this as early in your application life cycle as possible_
 Ideally in `applicationDidFinishLaunching` in `AppDelegate`
 
 ```swift
@@ -45,7 +45,7 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.debug = true // Helpful to see what's going on
-}    
+}
 ```
 
 ```objc
@@ -76,9 +76,9 @@ For more information checkout the [docs](https://docs.sentry.io/platforms/apple)
 
 # Resources
 
-* [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/apple/)
-* [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-cocoa.svg)](https://github.com/getsentry/sentry-cocoa/discussions)
-* [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)  
-* [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
-* [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-sentry-green.svg)](https://github.com/getsentry/.github/blob/master/CODE_OF_CONDUCT.md)
-* [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
+- [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/apple/)
+- [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-cocoa.svg)](https://github.com/getsentry/sentry-cocoa/discussions)
+- [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)
+- [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
+- [![Code of Conduct](https://img.shields.io/badge/code%20of%20conduct-sentry-green.svg)](https://github.com/getsentry/.github/blob/master/CODE_OF_CONDUCT.md)
+- [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)

--- a/Samples/README.md
+++ b/Samples/README.md
@@ -6,9 +6,10 @@ Most subdirectories contain an xcodeproj per platform/version, with one or more 
 
 ## Automatically created Sentry tags
 
-To help pinpoint where to look to debug an issue we see on our Sentry dashboard for the `sentry-sdks` project for events coming from our sample apps, each sample app injects some information from the build environment automatically. 
+To help pinpoint where to look to debug an issue we see on our Sentry dashboard for the `sentry-sdks` project for events coming from our sample apps, each sample app injects some information from the build environment automatically.
+
 - The Git commit hash, branch name and working index status at build time into its Info.plist, which is then accessed on app launch and injected into the initial scope during options configuration in the call to `SentrySDK.startWithOptions`. These then show up as tags in the event detail named `git-branch-name` and `git-commit-hash`. Some apps weren't instrumented yet:
-    - tvOS-SBSwift and iOS15-SwiftUI, as those use plist generation from build settings, and that doesn't work with the current strategy implemented with the scripts
-    - visionOS-Swift because I was unable to build and test it
+  - tvOS-SBSwift and iOS15-SwiftUI, as those use plist generation from build settings, and that doesn't work with the current strategy implemented with the scripts
+  - visionOS-Swift because I was unable to build and test it
 - `SentryUser.username` is automatically set to the `SIMULATOR_HOST_HOME` if it is defined, which is usually the value of `whoami` on a developer's work machine. This can be overridden in the scheme with the environment variable key `--io.sentry.user.username` if you need something more specific for your tests.
 - `SentryUser.email` is hardcoded to `"tony@example.comn"` but can be overridden using the environment variable `--io.sentry.user.email` in the scheme.

--- a/Tests/README.md
+++ b/Tests/README.md
@@ -4,5 +4,5 @@ For test guidelines please checkout the [Contributing Guidelines](../CONTRIBUTIN
 
 # Integration tests
 
-* [SessionGeneratorTests](./SentryTests/Integrations/SentrySessionGeneratorTests.swift) generates session data to validate release health.
-* [External integration tests](../.github/workflows/integration-tests.yml) integrate the Sentry SDK via CocoaPods into some open source apps and run their tests.
+- [SessionGeneratorTests](./SentryTests/Integrations/SentrySessionGeneratorTests.swift) generates session data to validate release health.
+- [External integration tests](../.github/workflows/integration-tests.yml) integrate the Sentry SDK via CocoaPods into some open source apps and run their tests.

--- a/develop-docs/DECISIONS.md
+++ b/develop-docs/DECISIONS.md
@@ -19,7 +19,7 @@ Contributors: @marandaneto, @brustolin and @philipphofmann
 
 We decided not to use the `NSRange` type for the `failedRequestStatusCodes` property of the `SentryNetworkTracker` class because it's not compatible with the specification, which requires the type to be a range of `from` -> `to` integers. The `NSRange` type is a range of `location` -> `length` integers. We decided to use a custom type instead of `NSRange` to avoid confusion. The custom type is called `SentryHttpStatusCodeRange`.
 
-## Manually installing iOS 12 simulators  <a name="ios-12-simulators"></a>
+## Manually installing iOS 12 simulators <a name="ios-12-simulators"></a>
 
 Date: October 21st 2022
 Contributors: @philipphofmann
@@ -44,10 +44,9 @@ Contributors: @brustolin
 A Sentry SDK started to be [written in Swift once,](https://github.com/getsentry/raven-swift) but due to ABI not being stable at that time, it got dropped. Since then Swift 5.0 landed and we got ABI stability. We’ve considered adding Swift to our sentry.cocoa SDK since then, but because of some of the trade offs, we’ve postponed that decision.
 This changed with our goal to better support SwiftUI. It’s growing in popularity and we need to write code in Swift in order to support it.
 SwiftUI support will be available through an additional library, but to support it, we need to be able to demangle Swift class names in Sentry SDK, which can be done by using Swift API.
-Since we support SPM, and SPM doesn't support multi-language projects, we need to create two different targets, one with Swift and another with Objective-C code. Because of that, our swift code needs to be public, so we're creating a second module called SentryPrivate, where all swift code will be, and we need an extra cocoapod library. 
+Since we support SPM, and SPM doesn't support multi-language projects, we need to create two different targets, one with Swift and another with Objective-C code. Because of that, our swift code needs to be public, so we're creating a second module called SentryPrivate, where all swift code will be, and we need an extra cocoapod library.
 With this approach, classes from SentryPrivate will not be available when users import Sentry.
 We don't mind breaking changes in SentryPrivate, because this is not meant to be use by the user, we going to point this out in the docs.
-
 
 ## Writing breadcrumbs to disk in the main thread
 
@@ -86,7 +85,7 @@ With 8.0.0, we rename the default branch from `master` to `main`. We will keep t
 Date: January 18th, 2023
 Contributors: @brustolin and @philipphofmann
 
-We release experimental SentrySwiftUI cocoa package with the version 8.0.0 because all podspecs file in a repo need to have the same version. 
+We release experimental SentrySwiftUI cocoa package with the version 8.0.0 because all podspecs file in a repo need to have the same version.
 
 ## Tracking package managers
 
@@ -113,17 +112,17 @@ on specific iOS versions. If we have functionality that risks breaking on older 
 For the swizzling of UIViewControllers and NSURLSession, we have UI tests running on iOS 12. Therefore, dropping running unit
 tests on iOS 12 simulators is acceptable. This decision reverts [manually installing iOS 12 simulators](#ios-12-simulators).
 
-Related to [GH-2862](https://github.com/getsentry/sentry-cocoa/issues/2862) and 
+Related to [GH-2862](https://github.com/getsentry/sentry-cocoa/issues/2862) and
 
 ## Remove integration tests from CI <a name="remove-integration-tests-from-ci"></a>
 
 Date: April 17th 2023
 Contributors: @brustolin @philipphofmann
 
-Both Alamofire and Home Assistance integration tests are no longer reliable as they keep failing and causing more problems than adding value. 
-These tests used to work for a while, and we know that the Sentry SDK was not breaking these projects. 
-Therefore, we have decided to remove the tests and add some key files to our list of risk files. 
-This way, if these files are changed, we will be reminded to test the changes with other projects. 
+Both Alamofire and Home Assistance integration tests are no longer reliable as they keep failing and causing more problems than adding value.
+These tests used to work for a while, and we know that the Sentry SDK was not breaking these projects.
+Therefore, we have decided to remove the tests and add some key files to our list of risk files.
+This way, if these files are changed, we will be reminded to test the changes with other projects.
 Additionally, two new 'make' commands(test-alamofire, test-homekit) are being added to the project to assist in testing the Sentry SDK in third-party projects.
 
 Related to [GH-2916](https://github.com/getsentry/sentry-cocoa/pull/2916)
@@ -140,7 +139,6 @@ thread because scheduling the init synchronously on the main thread could lead t
 Related links:
 
 - https://github.com/getsentry/sentry-cocoa/pull/3291
-
 
 ## Dependency Injection Strategy
 
@@ -176,18 +174,17 @@ As of February 20, 2024, we have severe problems with the UI tests on SauceLabs:
 08:43:59 WRN unable to report result to insights error="internal server error" action=parsingXML jobID=92e4f31ed2e0464caa069ac36fed4a1a
 ```
 
-2. The test runs for iOS 17 keep hanging forever and frequently time out. 
+2. The test runs for iOS 17 keep hanging forever and frequently time out.
 3. Until February 19, 2024 we had a retry mechanism for running SauceLabs UI tests because they
-frequently failed to tun.
+   frequently failed to tun.
 
 Working with such an unreliable tool in CI is a killer for developer productivity. When looking at
-our UI test suite, we currently have one UI test that should run on an actual device:  . This test
+our UI test suite, we currently have one UI test that should run on an actual device: . This test
 validates the data from our screen frames logic, and validating that it works correctly on an iPhone
 Pro with 120 fps makes sense. Apart from that, running all the UI tests on different simulators in
 CI should be enough to surface most of our bugs. Fighting against SauceLabs and not relying on it is
 worse than running UI tests on simulators and accepting the fact that they might not capture 100% of
 bugs and regressions.
-
 
 Another major reason why we chose SauceLabs in the past was the support of running UI tests on older
 iOS versions, which are not supported on GH action simulators. This was vital when we dealt with
@@ -195,7 +192,6 @@ severe bugs when swizzling UIViewControllers. We don’t face that challenge any
 solution is stable, and we don’t receive any bugs anymore. The lowest supported simulator version on
 GH actions is currently iOS 13. Given the low market share of iOS 12, it’s acceptable to not run our
 UI tests on iOS 12 and lower even though we support them.
-
 
 All that said, we should replace running UI tests in SauceLabs with running them on different iOS
 versions with GH actions.
@@ -207,23 +203,24 @@ It’s worth noting that we want to keep running benchmark tests on SauceLabs as
 Date: March 4th 2024
 Contributors: @brustolin, @philipphofmann, @kahest
 
-With the necessity of using Swift, we introduced a secondary framework that was a Sentry dependency. 
-That means we could not write a public API in Swift or access the core classes from Swift code. 
+With the necessity of using Swift, we introduced a secondary framework that was a Sentry dependency.
+That means we could not write a public API in Swift or access the core classes from Swift code.
 Another problem is that some users were experiencing issues when compiling the framework in CI.
 
-Swift is the present and has a long future ahead of it for Apple development. It's less verbose, 
+Swift is the present and has a long future ahead of it for Apple development. It's less verbose,
 requires fewer files, and is more powerful when it comes to language features.
 
-Because of all of this, we decided that we want Swift for the core framework. The only obstacle 
-is that SPM doesn't support two languages for the same target. To solve this, we exposed 
-Sentry as a pre-built binary for SPM. This adds the benefit of Sentry not being 
+Because of all of this, we decided that we want Swift for the core framework. The only obstacle
+is that SPM doesn't support two languages for the same target. To solve this, we exposed
+Sentry as a pre-built binary for SPM. This adds the benefit of Sentry not being
 compiled with the project, which speeds up build time.
 
-Another challenge we face with this decision is where to host the pre-compiled framework. 
+Another challenge we face with this decision is where to host the pre-compiled framework.
 We choose to use git release assets. To understand CI changes needed to publish the framework
-please refer to this [PR](https://github.com/getsentry/sentry-cocoa/pull/3623). 
+please refer to this [PR](https://github.com/getsentry/sentry-cocoa/pull/3623).
 
 When coding with Swift be aware of two things:
+
 1. If you want to use swift code in an Objc file: `#import "SentrySwift.h"`
 2. If you want to use Objc code from Swift, first add the desired header file to `SentryInternal.h`, then, in your Swift file, `@_implementationOnly import _SentryPrivate` (the underscore makes auto-complete ignore it since we dont want users importing this module).
 
@@ -250,7 +247,8 @@ Comments:
 3. @armcknight: I think the best bet to get the actual work done that is needed is to go with option B, vs all the refactors that would be needed to use Codable to go with A. Then, protocol APIs could be migrated from ObjC to Swift as-needed and converted to Codable.
 4. @philipphofmann: I think Option B/ manually deserializing is the way to go for now. I actually tried it and it seemed a bit wrong. I evaluated the other options and with all your input, I agree with doing it manually. We do it once and then all good. Thanks everyone.
 
-### Background 
+### Background
+
 To report fatal app hangs and measure how long an app hangs lasts ([GH Epic](https://github.com/getsentry/sentry-cocoa/issues/4261)), we need to serialize events to disk, deserialize, modify, and send them to Sentry. As of January 14, 2025, the Cocoa SDK doesn’t support deserializing events. As the fatal app hangs must go through beforeSend, we can’t simply modify the serialized JSON stored on disk. Instead, we must deserialize the event JSON and initialize a SentryEvent so that it can go through beforeSend.
 
 As of January 14, 2025, all the serialization is custom-made with the [SentrySerializable](https://github.com/getsentry/sentry-cocoa/blob/main/Sources/Sentry/Public/SentrySerializable.h) protocol:
@@ -260,7 +258,7 @@ As of January 14, 2025, all the serialization is custom-made with the [SentrySer
 
 - (NSDictionary<NSString *, id> *)serialize;
 
-@end 
+@end
 ```
 
 The SDK manually creates a JSON-like dict:
@@ -326,7 +324,7 @@ All that said, I suggest converting all public protocol classes to Swift and swi
 
 ### Option B: Add Deserialize in Swift
 
-We could implement all deserializing code in Swift without requiring a major version. The implementation would be the counterpart of ObjC serialize implementations, but written in Swift. 
+We could implement all deserializing code in Swift without requiring a major version. The implementation would be the counterpart of ObjC serialize implementations, but written in Swift.
 
 #### Pros
 
@@ -338,7 +336,7 @@ We could implement all deserializing code in Swift without requiring a major ver
 
 1. Potentially slightly higher maintenance effort, which is negligible as we hardly change the protocol classes.
 
-*Sample for implementation of Codable:*
+_Sample for implementation of Codable:_
 
 ```swift
 @_implementationOnly import _SentryPrivate

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -10,6 +10,7 @@ To use Swift in the project take a look at [Swift Usage](Swift-Usage.md) documen
 
 This repository follows the [codesiging.guide](https://codesigning.guide/) in combination with [fastlane match](https://docs.fastlane.tools/actions/match/).
 Therefore the sample apps use manual code signing, see [fastlane docs](https://docs.fastlane.tools/codesigning/xcode-project/):
+
 > In most cases, fastlane will work out of the box with Xcode 9 and up if you selected manual code signing and choose a provisioning profile name for each of your targets.
 
 ### Creating new App Identifiers
@@ -46,15 +47,15 @@ The profiler doesn't work with TSAN attached, so tests that run the profiler wil
 
 ### Further Reading
 
-* [ThreadSanitizerSuppressions](https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions)
-* [Running Tests with Clang's AddressSanitizer](https://pspdfkit.com/blog/2016/test-with-asan/)
-* [Diagnosing Memory, Thread, and Crash Issues Early](https://developer.apple.com/documentation/xcode/diagnosing-memory-thread-and-crash-issues-early)
-* [Stackoverflow: ThreadSanitizer suppression file with Xcode](https://stackoverflow.com/questions/38251409/how-can-i-suppress-thread-sanitizer-warnings-in-xcode-from-an-external-library)
+- [ThreadSanitizerSuppressions](https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions)
+- [Running Tests with Clang's AddressSanitizer](https://pspdfkit.com/blog/2016/test-with-asan/)
+- [Diagnosing Memory, Thread, and Crash Issues Early](https://developer.apple.com/documentation/xcode/diagnosing-memory-thread-and-crash-issues-early)
+- [Stackoverflow: ThreadSanitizer suppression file with Xcode](https://stackoverflow.com/questions/38251409/how-can-i-suppress-thread-sanitizer-warnings-in-xcode-from-an-external-library)
 
 ## Test Logs
 
 The [`SentryTestLogConfig`](https://github.com/getsentry/sentry-cocoa/blob/3a6ab6ec167d2532c024322a0a0019431275d1c1/Tests/SentryTests/TestUtils/SentryTestLogConfig.m) sets the log level to debug in `load`, so we understand what's going on during out tests.
-The  [`clearTestState`](https://github.com/getsentry/sentry-cocoa/blob/3a6ab6ec167d2532c024322a0a0019431275d1c1/SentryTestUtils/ClearTestState.swift#L25) method does the same, in case a test changes the log level.
+The [`clearTestState`](https://github.com/getsentry/sentry-cocoa/blob/3a6ab6ec167d2532c024322a0a0019431275d1c1/SentryTestUtils/ClearTestState.swift#L25) method does the same, in case a test changes the log level.
 
 ## UI Tests
 
@@ -80,8 +81,8 @@ Once daily and for every PR via [Github action](../.github/workflows/benchmarkin
 #### Test Plan
 
 - Run the procedure 20 times, then assert that the 90th percentile remains under 5% so we can be alerted via CI if it spikes.
-    - Sauce Labs allows relaxing the timeout for a suite of tests and for a `XCTestCase` subclass' collection of test case methods, but each test case in the suite must run in less than 15 minutes. 20 trials takes too long, so we split it up into multiple test cases, each running a subset of the trials. 
-    - This is done by dynamically generating test case methods in `SentrySDKPerformanceBenchmarkTests`, which is necessarily written in Objective-C since this is not possible to do in Swift tests. By doing this dynamically, we can easily fine tune how we split up the work to account for changes in the test duration or in constraints on how things run in Sauce Labs etc.
+  - Sauce Labs allows relaxing the timeout for a suite of tests and for a `XCTestCase` subclass' collection of test case methods, but each test case in the suite must run in less than 15 minutes. 20 trials takes too long, so we split it up into multiple test cases, each running a subset of the trials.
+  - This is done by dynamically generating test case methods in `SentrySDKPerformanceBenchmarkTests`, which is necessarily written in Objective-C since this is not possible to do in Swift tests. By doing this dynamically, we can easily fine tune how we split up the work to account for changes in the test duration or in constraints on how things run in Sauce Labs etc.
 
 ## Upload iOS-Swift's dSYMs with Xcode Run Script
 
@@ -101,11 +102,12 @@ You can use the `generate-classes.sh` to generate ViewControllers and other clas
 Some customers would like to not link UIKit for various reasons. Either they simply may not want to use our UIKit functionality, or they actually cannot link to it in certain circumstances, like a File Provider app extension.
 
 There are two build configurations they can use for this: `DebugWithoutUIKit` and `ReleaseWithoutUIKit`, that are essentially the same as `Debug` and `Release` with the following differences:
+
 - They set `CLANG_MODULES_AUTOLINK` to `NO`. This avoids a load command being automatically inserted for any UIKit API that make their way into the type system during compilation of SDK sources.
 - `GCC_PREPROCESSOR_DEFINITIONS` has an additional setting `SENTRY_NO_UIKIT=1`. This is now part of the definition of `SENTRY_HAS_UIKIT` in `SentryDefines.h` that is used to conditionally compile out any code that would otherwise use UIKit API and cause UIKit to be automatically linked as described above. There is another macro `SENTRY_UIKIT_AVAILABLE` defined as `SENTRY_HAS_UIKIT` used to be, meaning simply that compilation is targeting a platform where UIKit is available to be used. This is used in headers we deliver in the framework bundle to compile out declarations that rely on UIKit, and their corresponding implementations are switched over `SENTRY_HAS_UIKIT` to either provide the logic for configurations that link UIKit, or to provide a stub delivering a default value (`nil`, `0.0`, `NO` etc) and a warning log for publicly facing things like SentryOptions, or debug log for internal things like SentryDependencyContainer.
 
 There are two jobs in `.github/workflows/build.yml` that will build each of the new configs and use `otool -L` to ensure that UIKit does not appear as a load command in the build products.
- 
+
 This feature is experimental and is currently not compatible with SPM.
 
 ## Logging
@@ -114,28 +116,28 @@ We have a set of macros for logging at various levels defined in SentryLog.h. Th
 
 ## Profiling
 
-The profiler runs on a dedicated thread, and on a predefined interval will enumerate all other threads and gather the backtrace on each non-idle thread. 
+The profiler runs on a dedicated thread, and on a predefined interval will enumerate all other threads and gather the backtrace on each non-idle thread.
 
 The information is stored in deduplicated frame and stack indexed lookups for memory and transmission efficiency. These are maintained in `SentryProfilerState`.
 
-If enabled and sampled in (controlled by `SentryOptions.profilesSampleRate` or `SentryOptions.profilesSampler`), the profiler will start along with a trace, and the profile information is sliced to the start and end of each transaction and sent with them an envelope attachments. 
+If enabled and sampled in (controlled by `SentryOptions.profilesSampleRate` or `SentryOptions.profilesSampler`), the profiler will start along with a trace, and the profile information is sliced to the start and end of each transaction and sent with them an envelope attachments.
 
 The profiler will automatically time out if it is not stopped within 30 seconds, and also stops automatically if the app is sent to the background.
 
-There's only ever one profiler instance running at a time, but instances that have timed out will be kept in memory until all traces that ran concurrently with it have finished and serialized to envelopes. The associations between profiler instances and traces are maintained in `SentryProfiledTracerConcurrency`. 
+There's only ever one profiler instance running at a time, but instances that have timed out will be kept in memory until all traces that ran concurrently with it have finished and serialized to envelopes. The associations between profiler instances and traces are maintained in `SentryProfiledTracerConcurrency`.
 
 App launches can be automatically profiled if configured with `SentryOptions.enableAppLaunchProfiling`. If enabled, when `SentrySDK.startWithOptions` is called, `SentryLaunchProfiling.configureLaunchProfiling` will get a sample rate for traces and profiles with their respective options, and store those rates in a file to be read on the next launch. On each launch, `SentryLaunchProfiling.startLaunchProfile` checks for the presence of that file is used to decide whether to start an app launch profiled trace, and afterwards retrieves those rates to initialize a `SentryTransactionContext` and `SentryTracerConfiguration`, and provides them to a new `SentryTracer` instance, which is what actually starts the profiler. There is no hub at this time; also in the call to `SentrySDK.startWithOptions`, any current profiled launch trace is attempted to be finished, and the hub that exists by that time is provided to the `SentryTracer` instance via `SentryLaunchProfiling.stopAndTransmitLaunchProfile` so that when it needs to transmit the transaction envelope, the infrastructure is in place to do so.
 
-In testing and debug environments, when a profile payload is serialized for transmission, the dictionary will also be written to a file in NSCachesDirectory that can be retrieved by a sample app. This helps with UI tests that want to verify the contents of a profile after some app interaction. See `iOS-Swift.ProfilingViewController.viewLastProfile`  and `iOS-Swift-UITests.ProfilingUITests`.
+In testing and debug environments, when a profile payload is serialized for transmission, the dictionary will also be written to a file in NSCachesDirectory that can be retrieved by a sample app. This helps with UI tests that want to verify the contents of a profile after some app interaction. See `iOS-Swift.ProfilingViewController.viewLastProfile` and `iOS-Swift-UITests.ProfilingUITests`.
 
-## Swift and Objective-C Interoperability**
+## Swift and Objective-C Interoperability
 
 When making an Objective-C class public for Swift SDK code, do the following:
 
-* Add it to SentryPrivate.h
-* Remove existing imports from any test bridging headers.
-* Add the import `@_implementationOnly import _SentryPrivate` to your Swift class that wants to use
-the Objective-C class.
+- Add it to SentryPrivate.h
+- Remove existing imports from any test bridging headers.
+- Add the import `@_implementationOnly import _SentryPrivate` to your Swift class that wants to use
+  the Objective-C class.
 
 ## Public Protocols
 
@@ -152,14 +154,9 @@ are automatically visible to Swift without imports. Our umbrella header is defin
 Accessing private Objective-C classes doesn't
 work out of the box. One approach to making this work is to define a private module that contains
 all the private ObjC headers. To define such a module, we added a module.modulemap file to our
-project with the name _SentryPrivate. We added the prefix `_` because Xcode autocomplete seems to
-ignore such modules. This modulemap file points to a header called `SentryPrivate.h`, which include
- all private ObjC headers that should be available for Swift. When importing the generated
- _SentryPrivate module we have to use `@_implementationOnly import _SentryPrivate`.
- [@_implementationOnly](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly)
- will most likely be superseded by [access level imports](https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md)
- in a future Swift version. Not using `@_implementationOnly` leads to errors when including the
- prebuilt XCFramwork into projects, such as:
+project with the name _SentryPrivate. We added the prefix `_`because Xcode autocomplete seems to ignore such modules. This modulemap file points to a header called`SentryPrivate.h`, which include all private ObjC headers that should be available for Swift. When importing the generated _SentryPrivate module we have to use `@\_implementationOnly import \_SentryPrivate`.
+[@_implementationOnly](https://github.com/apple/swift/blob/main/docs/ReferenceGuides/UnderscoredAttributes.md#_implementationonly) will most likely be superseded by [access level imports](https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md) in a future Swift version. Not using `@\_implementationOnly` leads to errors when including the
+prebuilt XCFramwork into projects, such as:
 
 ```sh
 Sentry.swiftmodule/arm64-apple-ios.private.swiftinterface:10:8: error: no such module '_SentryPrivate'
@@ -167,10 +164,10 @@ Sentry.swiftmodule/arm64-apple-ios.private.swiftinterface:10:8: error: no such m
 import _SentryPrivate
 ```
 
-Adding Objective-C classes to the _SentryPrivate module also exposes them to test classes written in
+Adding Objective-C classes to the \_SentryPrivate module also exposes them to test classes written in
 Swift. When making an Objective-C class public to SDK Swift code, we must remove it from test
 bridging headers because this can lead to compiler errors. The SentryTests only find the
-_SentryPrivate module when adding setting `HEADER_SEARCH_PATHS = $(SRCROOT)/Sources/Sentry/include/**`
+\_SentryPrivate module when adding setting `HEADER_SEARCH_PATHS = $(SRCROOT)/Sources/Sentry/include/**`
 which we must not set for SwiftUI, because this uses its own implementation of SentryInternal.h.
 Setting the `HEADER_SEARCH_PATHS` for SwiftUI breaks the build.
 
@@ -178,7 +175,7 @@ See also [decision to remove SentryPrivate](./DECISIONS.md#removing-sentryprivat
 
 Useful resources:
 
-* [Module Map Syntax](https://clang.llvm.org/docs/Modules.html#module-map-file)
-* Sample GH Repo for [mixed Swift ObjC Framework](https://github.com/danieleggert/mixed-swift-objc-framework)
-* [Swift Forum Discussion](https://forums.swift.org/t/mixing-swift-and-objective-c-in-a-framework-and-private-headers/27787/6)
-* [Apple Docs: Importing Objective-C into Swift](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift#Import-Code-Within-a-Framework-Target)
+- [Module Map Syntax](https://clang.llvm.org/docs/Modules.html#module-map-file)
+- Sample GH Repo for [mixed Swift ObjC Framework](https://github.com/danieleggert/mixed-swift-objc-framework)
+- [Swift Forum Discussion](https://forums.swift.org/t/mixing-swift-and-objective-c-in-a-framework-and-private-headers/27787/6)
+- [Apple Docs: Importing Objective-C into Swift](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift#Import-Code-Within-a-Framework-Target)

--- a/develop-docs/Swift-Usage.md
+++ b/develop-docs/Swift-Usage.md
@@ -8,16 +8,16 @@ When working with Swift, it's important to keep the following restrictions in mi
 
 1. All Swift code will be bundled within the `SentryPrivate` library, which `Sentry` depends on.
 2. User-facing APIs cannot be written in Swift because their components will be accessed through imports from "SentryPrivate."
-3. `SentryPrivate` does not have access to `Sentry` classes to avoid cyclic references. As a result, any code written in Objective-C is not accessible from the  Swift layer.
-    - However, it is possible to create Dependency Injection (DI) APIs in Swift, allowing `Sentry` to inject its objects for use within `SentryPrivate`.
+3. `SentryPrivate` does not have access to `Sentry` classes to avoid cyclic references. As a result, any code written in Objective-C is not accessible from the Swift layer.
+   - However, it is possible to create Dependency Injection (DI) APIs in Swift, allowing `Sentry` to inject its objects for use within `SentryPrivate`.
 4. `SentryPrivate` public APIs (code consumed by `Sentry`) cannot utilize certain Objective-C incompatible features, including:
-    - Generics
-    - Non-@objc protocols and protocol extensions
-    - Top-level functions and properties
-    - Global variables
-    - Structs
-    - Swift-only enums
-    - Swift-only optionals
-    - Swift-only tuples
+   - Generics
+   - Non-@objc protocols and protocol extensions
+   - Top-level functions and properties
+   - Global variables
+   - Structs
+   - Swift-only enums
+   - Swift-only optionals
+   - Swift-only tuples
 
 By keeping these considerations in mind, you can effectively work with Swift code within the project, ensuring compatibility with the `Sentry` framework and adhering to the necessary restrictions imposed by the language differences.


### PR DESCRIPTION
Formatted Markdown documents using prettier to remove unused whitespaces and apply best-practices for character escaping (i.e. `\_` instead of `_` because it is used to format text in `_text_`)

#skip-changelog