### PR TITLE
internal: Add abnormal mechanism to SentrySession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@
 
 - Deserializing SentryEvents with Decodable (#4724)
 - Remove internal unknown dict for Breadcrumbs (#4803) This potentially only impacts hybrid SDKs.
-- Add abnormal mechanism to SentrySession (#4842)
 
 ## 8.44.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 - Deserializing SentryEvents with Decodable (#4724)
 - Remove internal unknown dict for Breadcrumbs (#4803) This potentially only impacts hybrid SDKs.
+- Add abnormal mechanism to SentrySession (#4842)
 
 ## 8.44.0
 

--- a/Sources/Sentry/SentrySession.m
+++ b/Sources/Sentry/SentrySession.m
@@ -132,6 +132,11 @@ nameForSentrySessionStatus(SentrySessionStatus status)
         if ([duration isKindOfClass:[NSNumber class]]) {
             _duration = duration;
         }
+
+        id abnormalMechanism = [jsonObject valueForKey:@"abnormal_mechanism"];
+        if ([abnormalMechanism isKindOfClass:[NSString class]]) {
+            _abnormalMechanism = abnormalMechanism;
+        }
     }
 
     return self;
@@ -238,6 +243,10 @@ nameForSentrySessionStatus(SentrySessionStatus status)
 
         [serializedData setValue:_distinctId forKey:@"did"];
 
+        if (_abnormalMechanism != nil) {
+            serializedData[@"abnormal_mechanism"] = _abnormalMechanism;
+        }
+
         return serializedData;
     }
 }
@@ -258,6 +267,7 @@ nameForSentrySessionStatus(SentrySessionStatus status)
         copy->_releaseName = _releaseName;
         copy.environment = self.environment;
         copy.user = self.user;
+        copy->_abnormalMechanism = _abnormalMechanism;
         copy->_init = _init;
     }
 

--- a/Sources/Sentry/include/SentrySession.h
+++ b/Sources/Sentry/include/SentrySession.h
@@ -49,6 +49,11 @@ SENTRY_NO_INIT
 @property (nonatomic, copy) NSString *_Nullable environment;
 @property (nonatomic, copy) SentryUser *_Nullable user;
 
+/**
+ * The reason for session to become abnormal, for example an app hang.
+ */
+@property (nonatomic, copy) NSString *_Nullable abnormalMechanism;
+
 - (NSDictionary<NSString *, id> *)serialize;
 
 @end


### PR DESCRIPTION

## :scroll: Description

Add abnormal mechanism to SentrySession, which is required for reporting fatal app hangs, and the app hangs rate. This PR only adds the property, which will only be used in a follow up PR via the ANRIntegration. Currently, the property is unused.

#skip-changelog

## :bulb: Motivation and Context

Required for https://github.com/getsentry/sentry-cocoa/issues/3319.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
