### PR TITLE
fix: add type-safety for screenshots result array

### DIFF
--- a/Sources/Sentry/SentryScreenshot.m
+++ b/Sources/Sentry/SentryScreenshot.m
@@ -21,11 +21,23 @@
     return self;
 }
 
-- (NSArray<NSData *> *)appScreenshotsFromMainThread
+- (NSArray<UIImage *> *)appScreenshotsFromMainThread
 {
-    __block NSArray *result;
+    __block NSArray<UIImage *> *result;
 
     void (^takeScreenShot)(void) = ^{ result = [self appScreenshots]; };
+
+    [[SentryDependencyContainer sharedInstance].dispatchQueueWrapper
+        dispatchSyncOnMainQueue:takeScreenShot];
+
+    return result;
+}
+
+- (NSArray<NSData *> *)appScreenshotDatasFromMainThread
+{
+    __block NSArray<NSData *> *result;
+
+    void (^takeScreenShot)(void) = ^{ result = [self appScreenshotsData]; };
 
     [[SentryDependencyContainer sharedInstance].dispatchQueueWrapper
         dispatchSyncOnMainQueue:takeScreenShot];

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -85,8 +85,8 @@ saveScreenShot(const char *path)
         return attachments;
     }
 
-    NSArray *screenshot =
-        [SentryDependencyContainer.sharedInstance.screenshot appScreenshotsFromMainThread];
+    NSArray<NSData *> *screenshot =
+        [SentryDependencyContainer.sharedInstance.screenshot appScreenshotDatasFromMainThread];
 
     NSMutableArray *result =
         [NSMutableArray arrayWithCapacity:attachments.count + screenshot.count];

--- a/Sources/Sentry/include/SentryScreenshot.h
+++ b/Sources/Sentry/include/SentryScreenshot.h
@@ -12,7 +12,13 @@ NS_ASSUME_NONNULL_BEGIN
  * Get a screenshot of every open window in the app.
  * @return An array of @c NSData instances containing PNG images.
  */
-- (NSArray<NSData *> *)appScreenshotsFromMainThread;
+- (NSArray<NSData *> *)appScreenshotDatasFromMainThread;
+
+/**
+ * Get a screenshot of every open window in the app.
+ * @return An array of @c UIImage instances.
+ */
+- (NSArray<UIImage *> *)appScreenshotsFromMainThread;
 
 /**
  * Save the current app screen shots in the given directory.

--- a/Tests/SentryTests/Integrations/Screenshot/TestSentryScreenShot.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/TestSentryScreenShot.swift
@@ -3,6 +3,7 @@
 class TestSentryScreenshot: SentryScreenshot {
     
     var result: [Data] = []
+    var images: [UIImage] = []
     var processScreenshotsCallback: (() -> Void)?
         
     override func appScreenshotsData() -> [Data] {
@@ -10,8 +11,8 @@ class TestSentryScreenshot: SentryScreenshot {
         return result
     }
  
-    override func appScreenshotsFromMainThread() -> [Data] {
-        return result
+    override func appScreenshotsFromMainThread() -> [UIImage] {
+        return images
     }
 }
 

--- a/Tests/SentryTests/SentryScreenShotTests.swift
+++ b/Tests/SentryTests/SentryScreenShotTests.swift
@@ -26,6 +26,7 @@ class SentryScreenShotTests: XCTestCase {
     }
     
     func test_IsMainThread() {
+        // -- Arrange --
         let testWindow = TestWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         var isMainThread = false
         
@@ -35,15 +36,16 @@ class SentryScreenShotTests: XCTestCase {
         
         fixture.uiApplication.windows = [testWindow]
         
-        let queue = DispatchQueue(label: "TestQueue")
-        
+        // -- Act --
         let expect = expectation(description: "Screenshot")
+        let queue = DispatchQueue(label: "TestQueue")
         let _ = queue.async {
             self.fixture.sut.appScreenshotsFromMainThread()
             expect.fulfill()
         }
-                
         wait(for: [expect], timeout: 1)
+
+        // -- Assert --
         XCTAssertTrue(isMainThread)
     }
     


### PR DESCRIPTION
The screenshots array had wrong typing causing crashes due to type casting