### PR TITLE
chore(ci): add release version to workflow title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release ${{ github.event.inputs.version }}
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Adds the input version to the worklfow title so we can identify it in the GitHub UI:

https://github.com/getsentry/sentry-cocoa/actions/workflows/release.yml

#skip-changelog