### PR TITLE
fix: Add directory Pods and *.xcarchive to ignored paths in format-clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ format: format-clang format-swift format-markdown format-json
 # Format ObjC, ObjC++, C, and C++
 format-clang:
 	@find . -type f \( -name "*.h" -or -name "*.hpp" -or -name "*.c" -or -name "*.cpp" -or -name "*.m" -or -name "*.mm" \) -and \
-		! \( -path "**.build/*" -or -path "**Build/*" -or -path "**/Carthage/Checkouts/*"  -or -path "**/libs/**" \) \
+		! \( -path "**.build/*" -or -path "**Build/*" -or -path "**/Carthage/Checkouts/*"  -or -path "**/libs/**" -or -path "**/Pods/**" -or -path "**/*.xcarchive/*" \) \
 		| xargs clang-format -i -style=file
 
 # Format Swift


### PR DESCRIPTION
The format-clang script picked up files in a local `Pods` folder, including `Carthage/.../*.xcarchive` directories. Both are ignored, so we should also ignore them in the Makefile.

Fixes this error:
```
Check development environment tooling versions...........................Passed
check for case conflicts.................................................Passed
check for merge conflicts................................................Passed
check for broken symlinks............................(no files to check)Skipped
check xml............................................(no files to check)Skipped
check yaml...........................................(no files to check)Skipped
detect private key.......................................................Passed
fix end of files.........................................................Passed
don't commit to branch...................................................Passed
Validate GitHub Actions..............................(no files to check)Skipped
Validate GitHub Workflows............................(no files to check)Skipped
shellcheck...........................................(no files to check)Skipped
Format ObjC, ObjC++, C, and C++..........................................Failed
- hook id: format-clang
- exit code: 2

No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
No such file or directory
make: *** [format-clang] Error 1

Format Swift.............................................................Passed
Run Linters..............................................................Passed
```

#skip-changelog