### PR TITLE
test: 200-399 HTTP status has log level info

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -579,6 +579,62 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertEqual(breadcrumbs?.count, 0)
     }
     
+    func test_Breadcrumb_HTTP200_HasLevelInfo() throws {
+        // Arrange
+        fixture.options.enableAutoPerformanceTracing = false
+
+        let task = createDataTask()
+        task.setResponse(createResponse(code: 200))
+        let _ = spanForTask(task: task)!
+        
+        //Act
+        try setTaskState(task, state: .completed)
+        
+        //Assert
+        let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
+        let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
+        XCTAssertEqual(breadcrumbs.count, 1)
+        let breadcrumb = try XCTUnwrap(breadcrumbs.first)
+
+        XCTAssertEqual(breadcrumb.category, "http")
+        XCTAssertEqual(breadcrumb.level, .info)
+        XCTAssertEqual(breadcrumb.type, "http")
+        
+        let data = try XCTUnwrap(breadcrumb.data)
+        XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
+        XCTAssertEqual("GET", data["method"] as? String)
+        XCTAssertEqual(200, data["status_code"] as? Int)
+        XCTAssertEqual("no error", data["reason"] as? String)
+    }
+    
+    func test_Breadcrumb_HTTP399_HasLevelInfo() throws {
+        // Arrange
+        fixture.options.enableAutoPerformanceTracing = false
+
+        let task = createDataTask()
+        task.setResponse(createResponse(code: 399))
+        let _ = spanForTask(task: task)!
+        
+        //Act
+        try setTaskState(task, state: .completed)
+        
+        //Assert
+        let breadcrumbsDynamic = Dynamic(fixture.scope).breadcrumbArray as [Breadcrumb]?
+        let breadcrumbs = try XCTUnwrap(breadcrumbsDynamic)
+        XCTAssertEqual(breadcrumbs.count, 1)
+        let breadcrumb = try XCTUnwrap(breadcrumbs.first)
+
+        XCTAssertEqual(breadcrumb.category, "http")
+        XCTAssertEqual(breadcrumb.level, .info)
+        XCTAssertEqual(breadcrumb.type, "http")
+        
+        let data = try XCTUnwrap(breadcrumb.data)
+        XCTAssertEqual(SentryNetworkTrackerTests.testUrl, data["url"] as? String)
+        XCTAssertEqual("GET", data["method"] as? String)
+        XCTAssertEqual(399, data["status_code"] as? Int)
+        XCTAssertEqual("redirected", data["reason"] as? String)
+    }
+    
     func test_Breadcrumb_HTTP400_HasLevelWarning() throws {
         // Arrange
         fixture.options.enableAutoPerformanceTracing = false


### PR DESCRIPTION
Add tests to validate that 200-399 HTTP status codes return the log level info for crumbs, as pointed out in the develop docs: https://develop.sentry.dev/sdk/expected-features/#http-client-integrations.

Follow up  on GH-4779, came up in https://github.com/getsentry/team-sdks/issues/100#issuecomment-2624916929.

#skip-changelog