### PR TITLE
ci: Rollback xlarge runner for UI test

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -88,8 +88,7 @@ jobs:
             xcode: "15.2"
             device: "iPhone 14 (16.4)"
 
-          # We only use large to investigate if UI tests are less flaky there.
-          - runs-on: macos-14-large
+          - runs-on: macos-14
             xcode: "15.4"
             device: "iPhone 15 (17.2)"
 


### PR DESCRIPTION
Our CI stats clearly show that there isn't any benefit for stability when using xlarge runners. In fact, the flakiness rate there is the highest. See [Discover](https://sentry.sentry.io/discover/results/?dataset=transactions&display=bar&field=title&field=failure_rate%28%29&name=Cocoa&project=5899451&query=branch%3Amain%20repo%3Agetsentry%2Fsentry-cocoa%20%22ui%20tests%22&queryDataset=transaction-like&sort=-title&statsPeriod=7d&yAxis=failure_rate%28%29).

![CleanShot 2025-02-20 at 19 19 07@2x](https://github.com/user-attachments/assets/9a17ddd8-b265-4084-bffe-3322ba4f56fe)



Rollback of GH-4799