### PR TITLE
impr: Log message when setUser before starting SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Log message when setting user before starting the SDK (#4882)
+
 ## 8.45.0
 
 ### Features

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -289,6 +289,8 @@ SENTRY_NO_INIT
 /**
  * Set user to the current Scope of the current Hub.
  * @param user The user to set to the current Scope.
+ *
+ * @note You must start the SDK before calling this method, otherwise it doesn't set the user.
  */
 + (void)setUser:(nullable SentryUser *)user;
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -446,7 +446,7 @@ static NSDate *_Nullable startTimestamp = nil;
         // the SDK, and it confuses them. Ideally, we would do something to store the user and set
         // it once we start the SDK, but this is a breaking change, so we live with the workaround
         // for now.
-        SENTRY_LOG_FATAL(@"The SDK s disabled, so setUser doesn't work. Please ensure to start "
+        SENTRY_LOG_FATAL(@"The SDK is disabled, so setUser doesn't work. Please ensure to start "
                          @"the SDK before setting the user.");
     }
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -440,6 +440,16 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)setUser:(SentryUser *_Nullable)user
 {
+    if (![SentrySDK isEnabled]) {
+        // We must log with level fatal because only fatal messages get logged even when the SDK
+        // isn't started. We've seen multiple times that users try to set the user before starting
+        // the SDK, and it confuses them. Ideally, we would do something to store the user and set
+        // it once we start the SDK, but this is a breaking change, so we live with the workaround
+        // for now.
+        SENTRY_LOG_FATAL(@"The SDK s disabled, so setUser doesn't work. Please ensure to start "
+                         @"the SDK before setting the user.");
+    }
+
     [SentrySDK.currentHub setUser:user];
 }
 

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -420,6 +420,49 @@ class SentrySDKTests: XCTestCase {
         XCTAssertEqual(event?.user, user)
     }
     
+    func testSetUserBeforeStartingSDK_LogsFatalMessage() throws {
+        // Arrange
+        let oldOutput = SentryLog.getLogOutput()
+        
+        defer {
+            SentryLog.setLogOutput(oldOutput)
+        }
+        
+        let logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+        
+        // Act
+        SentrySDK.setUser(nil)
+    
+        // Assert
+        let actualLogMessage = try XCTUnwrap(logOutput.loggedMessages.first)
+        let expectedLogMessage = "The SDK is disabled, so setUser doesn't work. Please ensure to start the SDK before setting the user."
+        
+        XCTAssertTrue(actualLogMessage.contains(expectedLogMessage), "Expected log message to contain '\(expectedLogMessage)', but got '\(actualLogMessage)'")
+    }
+    
+    func testSetUserAFterStartingSDK_DoesNotLogFatalMessage() {
+        // Arrange
+        let oldOutput = SentryLog.getLogOutput()
+        
+        defer {
+            SentryLog.setLogOutput(oldOutput)
+        }
+        
+        let logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+        
+        givenSdkWithHub()
+        
+        let user = TestData.user
+        
+        // Act
+        SentrySDK.setUser(user)
+        
+        //Assert
+        XCTAssertEqual(0, logOutput.loggedMessages.count, "Expected no log messages, but got \(logOutput.loggedMessages.count)")
+    }
+    
     func testStartTransaction() throws {
         givenSdkWithHub()
         


### PR DESCRIPTION

## :scroll: Description

The SDK now logs a message when you call setUser before starting the SDK.

Docs PR: https://github.com/getsentry/sentry-docs/pull/12798.

## :bulb: Motivation and Context

Came up here: GH-4878

## :green_heart: How did you test it?
Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
