### PR TITLE
fix: move assignment of file IO span origin outside of block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Log message when setting user before starting the SDK (#4882)
 - Add experimental flag to disable swizzling of `NSData` individually (#4859)
 
+### Fixes
+
+- fix: move assignment of file IO span origin outside of block (#4888)
+
 ## 8.45.0
 
 ### Features

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -198,7 +198,6 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
         ioSpan = [span startChildWithOperation:operation
                                    description:[self transactionDescriptionForFile:path
                                                                           fileSize:size]];
-        ioSpan.origin = origin;
     }];
 
     if (ioSpan == nil) {
@@ -209,6 +208,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
     SENTRY_LOG_DEBUG(@"Automatically started a new span with description: %@, operation: %@",
         ioSpan.description, operation);
 
+    ioSpan.origin = origin;
     [ioSpan setDataValue:path forKey:SentrySpanDataKey.filePath];
 
     [self mainThreadExtraInfo:ioSpan];

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -194,10 +194,9 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
     }
 
     __block id<SentrySpan> ioSpan;
+    NSString *spanDescription = [self transactionDescriptionForFile:path fileSize:size];
     [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-        ioSpan = [span startChildWithOperation:operation
-                                   description:[self transactionDescriptionForFile:path
-                                                                          fileSize:size]];
+        ioSpan = [span startChildWithOperation:operation description:spanDescription];
     }];
 
     if (ioSpan == nil) {

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -196,6 +196,8 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
     __block id<SentrySpan> ioSpan;
     NSString *spanDescription = [self transactionDescriptionForFile:path fileSize:size];
     [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
+        // Keep the logic inside the `useSpan` block to a minimum, as we have noticed memory issues
+        // See: https://github.com/getsentry/sentry-cocoa/issues/4887
         ioSpan = [span startChildWithOperation:operation description:spanDescription];
     }];
 


### PR DESCRIPTION
## :scroll: Description

Moves the assignment of the `ioSpan` in the `NSBlock` to the outside, as it might affect memory management. 

Note: This might also not be relevant anymore as the access to Bridged-from-Swift type `SentryTraceOrigin` is not in the block anymore.

## :bulb: Motivation and Context

See #4887 

## :green_heart: How did you test it?

Effect can not be tested reliably. Method `spanForPath` is already covered by tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
