### PR TITLE
ci: Increase allowed binary size

### DIFF
--- a/Tests/Perf/metrics-test.yml
+++ b/Tests/Perf/metrics-test.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 200 KiB
-  diffMax: 800 KiB
+  diffMax: 850 KiB


### PR DESCRIPTION
Fix CI by allowing bit of increase for the binary size. At some point, we need to split up the SDK into multiple modules or come up with other strategies to decrease the binary size.