### PR TITLE
refactor: Replace calls useSpan with callback to direct span accessor

### DIFF
--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -158,7 +158,9 @@ NS_SWIFT_NAME(Scope)
  * Mutates the current transaction atomically.
  * @param callback the SentrySpanCallback.
  */
-- (void)useSpan:(SentrySpanCallback)callback;
+- (void)useSpan:(SentrySpanCallback)callback DEPRECATED_MSG_ATTRIBUTE("use `span` instead");
+
+- (id<SentrySpan> _Nullable)span;
 
 @end
 

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -36,12 +36,11 @@
                             error:(NSError **)error
                       originalImp:(NSArray *(NS_NOESCAPE ^)(NSFetchRequest *, NSError **))original
 {
-    __block id<SentrySpan> fetchSpan;
-    [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-        fetchSpan = [span startChildWithOperation:SentrySpanOperation.coredataFetchOperation
-                                      description:[self descriptionFromRequest:request]];
-        fetchSpan.origin = SentryTraceOrigin.autoDBCoreData;
-    }];
+    id<SentrySpan> span = [SentrySDK.currentHub.scope span];
+    __block id<SentrySpan> fetchSpan =
+        [span startChildWithOperation:SentrySpanOperation.coredataFetchOperation
+                          description:[self descriptionFromRequest:request]];
+    fetchSpan.origin = SentryTraceOrigin.autoDBCoreData;
 
     if (fetchSpan) {
         SENTRY_LOG_DEBUG(@"SentryCoreDataTracker automatically started a new span with "
@@ -75,12 +74,11 @@
         __block NSDictionary<NSString *, NSDictionary *> *operations =
             [self groupEntitiesOperations:context];
 
-        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-            saveSpan = [span startChildWithOperation:SentrySpanOperation.coredataSaveOperation
-                                         description:[self descriptionForOperations:operations
-                                                                          inContext:context]];
-            saveSpan.origin = SentryTraceOrigin.autoDBCoreData;
-        }];
+        id<SentrySpan> _Nullable span = [SentrySDK.currentHub.scope span];
+        saveSpan = [span startChildWithOperation:SentrySpanOperation.coredataSaveOperation
+                                     description:[self descriptionForOperations:operations
+                                                                      inContext:context]];
+        saveSpan.origin = SentryTraceOrigin.autoDBCoreData;
 
         if (saveSpan) {
             SENTRY_LOG_DEBUG(@"SentryCoreDataTracker automatically started a new span with "

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -193,13 +193,12 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
         return nil;
     }
 
-    __block id<SentrySpan> ioSpan;
     NSString *spanDescription = [self transactionDescriptionForFile:path fileSize:size];
-    [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-        // Keep the logic inside the `useSpan` block to a minimum, as we have noticed memory issues
-        // See: https://github.com/getsentry/sentry-cocoa/issues/4887
-        ioSpan = [span startChildWithOperation:operation description:spanDescription];
-    }];
+    id<SentrySpan> span = [SentrySDK.currentHub.scope span];
+    __block id<SentrySpan> ioSpan =
+        [span startChildWithOperation:operation
+                          description:[self transactionDescriptionForFile:path fileSize:size]];
+    ioSpan.origin = origin;
 
     if (ioSpan == nil) {
         SENTRY_LOG_DEBUG(@"No transaction bound to scope. Won't track file IO operation.");

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -183,28 +183,27 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
             return;
         }
 
-        [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable innerSpan) {
-            if (innerSpan != nil) {
-                span = innerSpan;
-                netSpan = [span startChildWithOperation:SentrySpanOperation.networkRequestOperation
-                                            description:[NSString stringWithFormat:@"%@ %@",
-                                                            sessionTask.currentRequest.HTTPMethod,
-                                                            safeUrl.sanitizedUrl]];
-                netSpan.origin = SentryTraceOrigin.autoHttpNSURLSession;
+        id<SentrySpan> _Nullable innerSpan = [SentrySDK.currentHub.scope span];
+        if (innerSpan != nil) {
+            span = innerSpan;
+            netSpan = [span startChildWithOperation:SentrySpanOperation.networkRequestOperation
+                                        description:[NSString stringWithFormat:@"%@ %@",
+                                                        sessionTask.currentRequest.HTTPMethod,
+                                                        safeUrl.sanitizedUrl]];
+            netSpan.origin = SentryTraceOrigin.autoHttpNSURLSession;
 
-                [netSpan setDataValue:sessionTask.currentRequest.HTTPMethod
-                               forKey:@"http.request.method"];
-                [netSpan setDataValue:safeUrl.sanitizedUrl forKey:@"url"];
-                [netSpan setDataValue:@"fetch" forKey:@"type"];
+            [netSpan setDataValue:sessionTask.currentRequest.HTTPMethod
+                           forKey:@"http.request.method"];
+            [netSpan setDataValue:safeUrl.sanitizedUrl forKey:@"url"];
+            [netSpan setDataValue:@"fetch" forKey:@"type"];
 
-                if (safeUrl.queryItems && safeUrl.queryItems.count > 0) {
-                    [netSpan setDataValue:safeUrl.query forKey:@"http.query"];
-                }
-                if (safeUrl.fragment != nil) {
-                    [netSpan setDataValue:safeUrl.fragment forKey:@"http.fragment"];
-                }
+            if (safeUrl.queryItems && safeUrl.queryItems.count > 0) {
+                [netSpan setDataValue:safeUrl.query forKey:@"http.query"];
             }
-        }];
+            if (safeUrl.fragment != nil) {
+                [netSpan setDataValue:safeUrl.fragment forKey:@"http.fragment"];
+            }
+        }
 
         // We only create a span if there is a transaction in the scope,
         // otherwise we have nothing else to do here.

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -635,11 +635,10 @@ static BOOL appStartMeasurementRead;
     }
 
     if (shouldCleanUp) {
-        [_hub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-            if (span == self) {
-                [self->_hub.scope setSpan:nil];
-            }
-        }];
+        id<SentrySpan> _Nullable span = [_hub.scope span];
+        if (span == self) {
+            [self->_hub.scope setSpan:nil];
+        }
     }
 
     if (self.configuration.finishMustBeCalled && !self.wasFinishCalled) {

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -67,30 +67,28 @@ NS_ASSUME_NONNULL_BEGIN
                                              operation:operation
                                                 origin:SentryTraceOrigin.autoUiEventTracker];
 
-    __block SentryTracer *transaction;
-    [SentrySDK.currentHub.scope useSpan:^(id<SentrySpan> _Nullable span) {
-        BOOL ongoingScreenLoadTransaction
-            = span != nil && [span.operation isEqualToString:SentrySpanOperation.uiLoad];
-        BOOL ongoingManualTransaction = span != nil
-            && ![span.operation isEqualToString:SentrySpanOperation.uiLoad]
-            && ![span.operation containsString:SentrySpanOperation.uiAction];
+    id<SentrySpan> span = [SentrySDK.currentHub.scope span];
+    BOOL ongoingScreenLoadTransaction
+        = span != nil && [span.operation isEqualToString:SentrySpanOperation.uiLoad];
+    BOOL ongoingManualTransaction = span != nil
+        && ![span.operation isEqualToString:SentrySpanOperation.uiLoad]
+        && ![span.operation containsString:SentrySpanOperation.uiAction];
 
-        BOOL bindToScope = !ongoingScreenLoadTransaction && !ongoingManualTransaction;
+    BOOL bindToScope = !ongoingScreenLoadTransaction && !ongoingManualTransaction;
 
-        transaction = [SentrySDK.currentHub
-            startTransactionWithContext:context
-                            bindToScope:bindToScope
-                  customSamplingContext:@{}
-                          configuration:[SentryTracerConfiguration configurationWithBlock:^(
-                                            SentryTracerConfiguration *config) {
-                              config.idleTimeout = self.idleTimeout;
-                              config.waitForChildren = YES;
-                          }]];
+    __block SentryTracer *transaction = [SentrySDK.currentHub
+        startTransactionWithContext:context
+                        bindToScope:bindToScope
+              customSamplingContext:@{}
+                      configuration:[SentryTracerConfiguration configurationWithBlock:^(
+                                        SentryTracerConfiguration *config) {
+                          config.idleTimeout = self.idleTimeout;
+                          config.waitForChildren = YES;
+                      }]];
 
-        SENTRY_LOG_DEBUG(@"Automatically started a new transaction with name: "
-                         @"%@, bindToScope: %@",
-            action, bindToScope ? @"YES" : @"NO");
-    }];
+    SENTRY_LOG_DEBUG(@"Automatically started a new transaction with name: "
+                     @"%@, bindToScope: %@",
+        action, bindToScope ? @"YES" : @"NO");
 
     if (accessibilityIdentifier) {
         [transaction setTagValue:accessibilityIdentifier forKey:@"accessibilityIdentifier"];

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -271,7 +271,8 @@ class SentryScopeSwiftTests: XCTestCase {
         
         XCTAssertEqual(event.environment, actual?.environment)
     }
-    
+
+    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of useSpan")
     func testUseSpan() {
         fixture.scope.span = fixture.transaction
         fixture.scope.useSpan { (span) in
@@ -279,6 +280,7 @@ class SentryScopeSwiftTests: XCTestCase {
         }
     }
     
+    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of useSpan")
     func testUseSpanLock_DoesNotBlock_WithBlockingCallback() {
         let scope = fixture.scope
         scope.span = fixture.transaction
@@ -311,6 +313,7 @@ class SentryScopeSwiftTests: XCTestCase {
         wait(for: [expect], timeout: 0.1)
     }
     
+    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of useSpan")
     func testUseSpanLock_IsReentrant() {
         let expect = expectation(description: "finish on time")
         let scope = fixture.scope
@@ -324,6 +327,7 @@ class SentryScopeSwiftTests: XCTestCase {
         wait(for: [expect], timeout: 0.1)
     }
     
+    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of useSpan")
     func testSpan_FromMultipleThreads() {
         let scope = fixture.scope
         
@@ -358,6 +362,7 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertNil(serialized["breadcrumbs"])
     }
     
+    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of useSpan")
     func testUseSpanForClear() {
         fixture.scope.span = fixture.transaction
         fixture.scope.useSpan { (_) in


### PR DESCRIPTION
## :scroll: Description

Removes the callback-based access to the span in scope with a direct accessor

## :bulb: Motivation and Context

We have noticed issues in #4887 relevant to the `useSpan` method. @philipphofmann mentioned before that `NSBlock` has caused issues in the past. The current implementation of `useSpan` really doesn't do anything other than accessing the `span` then calling the callback, therefore inlining the method into uses could reduce the usage of `NSBlock`.
