### PR TITLE
ci: push iOS-Swift builds to testflight for release processes

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - release/**
 
     paths:
       - 'Sources/**'


### PR DESCRIPTION
It occurred to me that it might be nice to have a build of iOS-Swift to play with as part of the release process.

#skip-changelog