### PR TITLE
ci: upgrade testflight workflow macos image

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   upload_to_testflight:
     name: Build and Upload iOS-Swift to Testflight
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 15.2


### PR DESCRIPTION
I got the TestFlight emails for the iOS-Swift sample app, which contained:

> ITMS-90725: SDK version issue - This app was built with the iOS 17.2 SDK. Starting April 24, 2025, all iOS and iPadOS apps must be built with the iOS 18 SDK or later, included in Xcode 16 or later, in order to be uploaded to App Store Connect or submitted for distribution.

We use [`macos-13`](https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks) which only supports up to iOS 17.2. Upgrading to [`macos-14`](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-sdks) satisfies the requirement to support 18.

#skip-changelog