### PR TITLE
test: invert launch arg so feedback widget is injected by default

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/xcshareddata/xcschemes/iOS-ObjectiveC.xcscheme
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC.xcodeproj/xcshareddata/xcschemes/iOS-ObjectiveC.xcscheme
@@ -67,6 +67,12 @@
             ReferencedContainer = "container:iOS-ObjectiveC.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "--io.sentry.feedback.no-auto-inject-widget"
+            isEnabled = "NO">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -55,11 +55,11 @@
                 config.useShakeGesture = YES;
                 config.showFormForScreenshots = YES;
                 config.configureWidget = ^(SentryUserFeedbackWidgetConfiguration *_Nonnull widget) {
-                    if ([args containsObject:@"--io.sentry.feedback.auto-inject-widget"]) {
+                    if ([args containsObject:@"--io.sentry.feedback.no-auto-inject-widget"]) {
+                        widget.autoInject = NO;
+                    } else {
                         widget.labelText = @"Report Jank";
                         widget.layoutUIOffset = layoutOffset;
-                    } else {
-                        widget.autoInject = NO;
                     }
 
                     if ([args containsObject:@"--io.sentry.feedback.no-widget-text"]) {

--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/xcshareddata/xcschemes/iOS-Swift.xcscheme
@@ -221,8 +221,8 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--io.sentry.feedback.auto-inject-widget"
-            isEnabled = "YES">
+            argument = "--io.sentry.feedback.no-auto-inject-widget"
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -128,22 +128,24 @@ extension SentrySDKWrapper {
     var layoutOffset: UIOffset { UIOffset(horizontal: 25, vertical: 75) }
     
     func configureFeedbackWidget(config: SentryUserFeedbackWidgetConfiguration) {
-        if args.contains("--io.sentry.feedback.auto-inject-widget") {
-            if Locale.current.languageCode == "ar" { // arabic
-                config.labelText = "﷽"
-            } else if Locale.current.languageCode == "ur" { // urdu
-                config.labelText = "نستعلیق"
-            } else if Locale.current.languageCode == "he" { // hebrew
-                config.labelText = "עִבְרִית‎"
-            } else if Locale.current.languageCode == "hi" { // Hindi
-                config.labelText = "नागरि"
-            } else {
-                config.labelText = "Report Jank"
-            }
-            config.layoutUIOffset = layoutOffset
-        } else {
+        guard !args.contains("--io.sentry.feedback.no-auto-inject-widget") else {
             config.autoInject = false
+            return
         }
+        
+        if Locale.current.languageCode == "ar" { // arabic
+            config.labelText = "﷽"
+        } else if Locale.current.languageCode == "ur" { // urdu
+            config.labelText = "نستعلیق"
+        } else if Locale.current.languageCode == "he" { // hebrew
+            config.labelText = "עִבְרִית‎"
+        } else if Locale.current.languageCode == "hi" { // Hindi
+            config.labelText = "नागरि"
+        } else {
+            config.labelText = "Report Jank"
+        }
+        config.layoutUIOffset = layoutOffset
+        
         if args.contains("--io.sentry.feedback.no-widget-text") {
             config.labelText = nil
         }


### PR DESCRIPTION
Before we generate a release dogfood build of iOS-Sample, we need to change showing the feedback widget from opt-in via launch arg, to opt-out, as that was previously the only way to show it, but we can't set launch args in the dogfood build.

#skip-changelog