### PR TITLE
fix: Resolve static assertion failure of const in std::vector

### DIFF
--- a/Sources/Sentry/SentryThreadInspector.m
+++ b/Sources/Sentry/SentryThreadInspector.m
@@ -12,6 +12,10 @@
 #import "SentryThread.h"
 #include <pthread.h>
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 @interface SentryThreadInspector ()
 
 @property (nonatomic, strong) SentryStacktraceBuilder *stacktraceBuilder;

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -44,7 +44,7 @@ namespace profiling {
             ThreadHandle::NativeHandle handle;
             ThreadMetadata metadata;
         };
-        std::vector<const ThreadHandleMetadataPair> threadMetadataCache_;
+        std::vector<ThreadHandleMetadataPair> threadMetadataCache_;
     };
 
 } // namespace profiling

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_CPPException.cpp
@@ -40,6 +40,10 @@
 #include <string.h>
 #include <typeinfo>
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 #define STACKTRACE_BUFFER_LENGTH 30
 #define DESCRIPTION_BUFFER_LENGTH 1000
 

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -41,6 +41,10 @@
 #    include <pthread.h>
 #    include <signal.h>
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 // ============================================================================
 #    pragma mark - Constants -
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -35,6 +35,10 @@
 
 #import "SentryLog.h"
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 // ============================================================================
 #pragma mark - Globals -
 // ============================================================================

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -43,6 +43,10 @@
 #    include <stdlib.h>
 #    include <string.h>
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 // ============================================================================
 #    pragma mark - Globals -
 // ============================================================================

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -58,6 +58,10 @@
 #include <string.h>
 #include <unistd.h>
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 // ============================================================================
 #pragma mark - Constants -
 // ============================================================================

--- a/Tests/SentryTests/SentryCrash/SentryCrashCPU_Tests.m
+++ b/Tests/SentryTests/SentryCrash/SentryCrashCPU_Tests.m
@@ -33,6 +33,10 @@
 
 #import <mach/mach.h>
 
+#if defined( __clang__ ) && defined( __clang_major__ ) && __clang_major__ >= 17
+#pragma clang diagnostic ignored "-Wvla-cxx-extension"
+#endif
+
 @interface SentryCrashCPU_Tests : XCTestCase
 @end
 


### PR DESCRIPTION
## :scroll: Description

The Sentry SDK cannot be built with the upcoming Xcode 16.3 because of changes in the C++ library and compiler.

**1 - Vector of `const` elements in `SentryThreadMetadataCache.cpp`:**

    std::vector<const ThreadHandleMetadataPair> threadMetadataCache_;

Using `const` elements in a vector was disallowed before C++11 and has been relaxed since then.  
However, there's currently no explicit requirement for the elements of a vector in the current C++ standard.

Xcode 16.3 fails with the following error:

    Static assertion failed due to requirement '!is_const<const sentry::profiling::ThreadMetadataCache::ThreadHandleMetadataPair>::value': std::allocator does not support const types

**2 - Use of Clang extension for variable length arrays:**

The macro `SentryCrashMC_NEW_CONTEXT` makes use of variable length arrays.  
This now triggers a compiler error in Xcode 16.3.

The error is now silenced by ignoring `-Wvla-cxx-extension` with a `#pragma clang`.  
Unfortunately, this is a new flag, so it cannot be set in `SDK.xcconfig` as it would break builds on previous Xcode versions.

## :bulb: Motivation and Context

These changes allow the Sentry SDK to be built with Xcode 16.3 Beta.

## :green_heart: How did you test it?

The Sentry SDK now compiles with Xcode 16.3.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
