### PR TITLE
ci: use gha workflow property that can handle expressions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
-name: Release ${{ github.event.inputs.version }}
+name: Release
+run-name: Release ${{ github.event.inputs.version }}
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
The current change from #4844 broke parsing the workflow description because you can't access `github` in the `name` property. But you can do so in [`run-name`](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#run-name)