### PR TITLE
chore: change order of pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,14 +55,6 @@ repos:
         args:
           - "format-swift"
 
-      - id: lint
-        name: Run Linters
-        entry: make
-        language: system
-        types_or: ["swift", "objective-c", "objective-c++", "c", "c++" ]
-        args:
-          - "lint"
-
       - id: format-markdown
         name: Format Markdown
         description: 'Format Markdown'
@@ -80,3 +72,11 @@ repos:
         types_or: [json]
         entry: prettier --write --ignore-unknown --config .prettierrc
         additional_dependencies: ["prettier@3.5.0"]
+
+      - id: lint
+        name: Run Linters
+        entry: make
+        language: system
+        types_or: ["swift", "objective-c", "objective-c++", "c", "c++" ]
+        args:
+          - "lint"


### PR DESCRIPTION
Changes the order of pre-commit hooks to fix formatting automatically before linting in the final step.

#skip-changelog