### PR TITLE
chore(deps): bump Fastlane Sentry from 1.22.1 to 1.28.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3, < 2.0.0)
-    fastlane-plugin-sentry (1.22.1)
+    fastlane-plugin-sentry (1.28.0)
       os (~> 1.1, >= 1.1.4)
     fastlane-sirp (1.0.0)
       sysrandom (~> 1.0)


### PR DESCRIPTION
#skip-changelog