### PR TITLE
impr: Slightly reduce size of SentryCrashReports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Log message when setting user before starting the SDK (#4882)
 - Add experimental flag to disable swizzling of `NSData` individually (#4859)
 - Replace calls of `SentryScope.useSpan` with callback to direct span accessor (#4896)
+- Slightly reduce size of SentryCrashReports (#4915)
 
 ### Fixes
 

--- a/Sources/SentryCrash/Recording/SentryCrashReport.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReport.c
@@ -1169,10 +1169,6 @@ writeBinaryImage(const SentryCrashReportWriter *const writer, const char *const 
         writer->addUUIDElement(writer, SentryCrashField_UUID, image->uuid);
         writer->addIntegerElement(writer, SentryCrashField_CPUType, image->cpuType);
         writer->addIntegerElement(writer, SentryCrashField_CPUSubType, image->cpuSubType);
-        writer->addUIntegerElement(writer, SentryCrashField_ImageMajorVersion, image->majorVersion);
-        writer->addUIntegerElement(writer, SentryCrashField_ImageMinorVersion, image->minorVersion);
-        writer->addUIntegerElement(
-            writer, SentryCrashField_ImageRevisionVersion, image->revisionVersion);
         if (image->crashInfoMessage != NULL) {
             writer->addStringElement(
                 writer, SentryCrashField_ImageCrashInfoMessage, image->crashInfoMessage);

--- a/Sources/SentryCrash/Recording/SentryCrashReportFields.h
+++ b/Sources/SentryCrash/Recording/SentryCrashReportFields.h
@@ -110,9 +110,6 @@
 #define SentryCrashField_ImageAddress "image_addr"
 #define SentryCrashField_ImageVmAddress "image_vmaddr"
 #define SentryCrashField_ImageSize "image_size"
-#define SentryCrashField_ImageMajorVersion "major_version"
-#define SentryCrashField_ImageMinorVersion "minor_version"
-#define SentryCrashField_ImageRevisionVersion "revision_version"
 #define SentryCrashField_ImageCrashInfoMessage "crash_info_message"
 #define SentryCrashField_ImageCrashInfoMessage2 "crash_info_message2"
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
@@ -366,7 +366,6 @@ sentrycrashdl_getBinaryImageForHeader(const void *const header_ptr, const char *
     // Also look for a UUID command.
     uint64_t imageSize = 0;
     uint64_t imageVmAddr = 0;
-    uint64_t version = 0;
     uint8_t *uuid = NULL;
 
     for (uint32_t iCmd = 0; iCmd < header->ncmds; iCmd++) {
@@ -393,12 +392,6 @@ sentrycrashdl_getBinaryImageForHeader(const void *const header_ptr, const char *
             uuid = uuidCmd->uuid;
             break;
         }
-        case LC_ID_DYLIB: {
-
-            struct dylib_command *dc = (struct dylib_command *)cmdPtr;
-            version = dc->dylib.current_version;
-            break;
-        }
         }
         cmdPtr += loadCmd->cmdsize;
     }
@@ -410,9 +403,6 @@ sentrycrashdl_getBinaryImageForHeader(const void *const header_ptr, const char *
     buffer->uuid = uuid;
     buffer->cpuType = header->cputype;
     buffer->cpuSubType = header->cpusubtype;
-    buffer->majorVersion = version >> 16;
-    buffer->minorVersion = (version >> 8) & 0xff;
-    buffer->revisionVersion = version & 0xff;
     if (isCrash) {
         getCrashInfo(header, buffer);
     }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.h
@@ -44,9 +44,6 @@ typedef struct {
     const uint8_t *uuid;
     int cpuType;
     int cpuSubType;
-    uint64_t majorVersion;
-    uint64_t minorVersion;
-    uint64_t revisionVersion;
     const char *crashInfoMessage;
     const char *crashInfoMessage2;
 } SentryCrashBinaryImage;

--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -146,9 +146,6 @@ class SentryBinaryImageCacheTests: XCTestCase {
             uuid: nil,
             cpuType: 1,
             cpuSubType: 1,
-            majorVersion: 1,
-            minorVersion: 0,
-            revisionVersion: 0,
             crashInfoMessage: nil,
             crashInfoMessage2: nil
         )
@@ -173,9 +170,6 @@ class SentryBinaryImageCacheTests: XCTestCase {
             uuid: nil,
             cpuType: 1,
             cpuSubType: 1,
-            majorVersion: 1,
-            minorVersion: 0,
-            revisionVersion: 0,
             crashInfoMessage: nil,
             crashInfoMessage2: nil
         )
@@ -251,9 +245,6 @@ func createCrashBinaryImage(_ address: UInt, vmAddress: UInt64 = 0, name: String
         uuid: uuidPointer,
         cpuType: 1,
         cpuSubType: 1,
-        majorVersion: 1,
-        minorVersion: 0,
-        revisionVersion: 0,
         crashInfoMessage: nil,
         crashInfoMessage2: nil
     )

--- a/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashStackEntryMapperTests.swift
@@ -126,9 +126,6 @@ class SentryCrashStackEntryMapperTests: XCTestCase {
             uuid: nil,
             cpuType: 1,
             cpuSubType: 1,
-            majorVersion: 1,
-            minorVersion: 0,
-            revisionVersion: 0,
             crashInfoMessage: nil,
             crashInfoMessage2: nil
         )

--- a/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryDebugImageProviderTests.swift
@@ -387,9 +387,6 @@ class SentryDebugImageProviderTests: XCTestCase {
             uuid: uuidPointer,
             cpuType: 0,
             cpuSubType: 0,
-            majorVersion: 0,
-            minorVersion: 0,
-            revisionVersion: 0,
             crashInfoMessage: nil,
             crashInfoMessage2: nil
         )


### PR DESCRIPTION


## :scroll: Description

Remove majorVersion, minorVersion, and revisionVersion, which the SentryCrashReport writes, but the SentryCrashReportConverter doesn't pick up, so we never send them to Sentry. Also, the SentryBinaryImageInfo that the SentryBinaryImageCache uses, doesn't access these properties. This improvement slightly reduces the size of SentryCrash reports.

## :bulb: Motivation and Context

Came up while investigating https://github.com/getsentry/sentry-cocoa/issues/4618.

## :green_heart: How did you test it?
Unit tests are still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
