### PR TITLE
fix: use a static const to define array size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Move assignment of file IO span origin outside of block (#4888)
 - Deadline timeout crash in SentryTracer (#4911)
 - Improve memory-safety by converting Swift constants to Objective-C (#4910)
+- Fix C++ compilation error due to changes in Xcode 16.3 beta's compiler toolchain (#4917)
 
 ## 8.45.0
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -91,12 +91,6 @@ getThreadList(SentryCrashMachineContext *context)
     return true;
 }
 
-int
-sentrycrashmc_contextSize(void)
-{
-    return sizeof(SentryCrashMachineContext);
-}
-
 SentryCrashThread
 sentrycrashmc_getThreadFromContext(const SentryCrashMachineContext *const context)
 {

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -29,6 +29,7 @@
 #define HDR_SentryCrashMachineContext_h
 
 #include "SentryCrashThread.h"
+#include "SentryCrashMachineContext_Apple.h"
 #include <mach/mach.h>
 #include <stdbool.h>
 
@@ -64,15 +65,11 @@ void sentrycrashmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_n
  * @param NAME The C identifier to give the pointer.
  */
 #define SentryCrashMC_NEW_CONTEXT(NAME)                                                            \
-    char sentrycrashmc_##NAME##_storage[sentrycrashmc_contextSize()];                              \
+    char sentrycrashmc_##NAME##_storage[sentrycrashmc_contextSize];                              \
     struct SentryCrashMachineContext *NAME                                                         \
         = (struct SentryCrashMachineContext *)sentrycrashmc_##NAME##_storage
 
 struct SentryCrashMachineContext;
-
-/** Get the internal size of a machine context.
- */
-int sentrycrashmc_contextSize(void);
 
 /** Fill in a machine context from a thread.
  *

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -28,8 +28,8 @@
 #ifndef HDR_SentryCrashMachineContext_h
 #define HDR_SentryCrashMachineContext_h
 
-#include "SentryCrashThread.h"
 #include "SentryCrashMachineContext_Apple.h"
+#include "SentryCrashThread.h"
 #include <mach/mach.h>
 #include <stdbool.h>
 
@@ -65,7 +65,7 @@ void sentrycrashmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_n
  * @param NAME The C identifier to give the pointer.
  */
 #define SentryCrashMC_NEW_CONTEXT(NAME)                                                            \
-    char sentrycrashmc_##NAME##_storage[sentrycrashmc_contextSize];                              \
+    char sentrycrashmc_##NAME##_storage[sentrycrashmc_contextSize];                                \
     struct SentryCrashMachineContext *NAME                                                         \
         = (struct SentryCrashMachineContext *)sentrycrashmc_##NAME##_storage
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
@@ -34,6 +34,7 @@ extern "C" {
 
 #include <mach/mach_types.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <sys/ucontext.h>
 
 #ifdef __arm64__

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
@@ -53,6 +53,8 @@ typedef struct SentryCrashMachineContext {
     STRUCT_MCONTEXT_L machineContext;
 } SentryCrashMachineContext;
 
+static const size_t sentrycrashmc_contextSize = sizeof(SentryCrashMachineContext);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
As pointed out in https://github.com/getsentry/sentry-cocoa/pull/4907, we have a variable-length static array being allocated, which currently breaks in the latest Xcode beta (16.3).

Instead of hiding the issue with a pragma, this PR attempts to fix the problem. I think it was just a matter of how the code was written, since at the end of the day, it's using something that _should_ be computable at compile time: the size of a struct. We just need to rewrite the code in a way that the compiler can know that. 

I originally tried using `constexpr` on the function definition, but that requires changing lots of C code to C++ which led to a bunch of other issues.