### PR TITLE
fix: dont use unsupported const vector member type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Move assignment of file IO span origin outside of block (#4888)
 - Deadline timeout crash in SentryTracer (#4911)
 - Improve memory-safety by converting Swift constants to Objective-C (#4910)
+- Fix C++ compilation error due to changes in Xcode 16.3 beta's compiler toolchain (#4917 and #4918)
 
 ## 8.45.0
 

--- a/Sources/Sentry/include/SentryThreadMetadataCache.hpp
+++ b/Sources/Sentry/include/SentryThreadMetadataCache.hpp
@@ -44,7 +44,7 @@ namespace profiling {
             ThreadHandle::NativeHandle handle;
             ThreadMetadata metadata;
         };
-        std::vector<const ThreadHandleMetadataPair> threadMetadataCache_;
+        std::vector<ThreadHandleMetadataPair> threadMetadataCache_;
     };
 
 } // namespace profiling


### PR DESCRIPTION
Remove the `const` qualifier for a vector member type, which is unsupported in mainstream C++, and becomes a build error in the upcoming Xcode version.

As reported in https://github.com/getsentry/sentry-cocoa/issues/4886 and demonstrated fixed in https://github.com/getsentry/sentry-cocoa/pull/4907.

