### PR TITLE
ref: PerformanceTracker remove not needed __block

### DIFF
--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
         activeSpan = [self.activeSpanStack lastObject];
     }
 
-    __block id<SentrySpan> newSpan;
+    id<SentrySpan> newSpan;
     if (activeSpan != nil) {
         newSpan = [activeSpan startChildWithOperation:operation description:name];
         newSpan.origin = origin;


### PR DESCRIPTION
Remove the not required __block keyword for the newSpan variable. This is a leftover from getting the current span on the scope via a block callback, and should have been removed with https://github.com/getsentry/sentry-cocoa/pull/4520.

#skip-changelog