### PR TITLE
test: Increase ANR tracker test wait timeout

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -5,7 +5,7 @@ import XCTest
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class SentryANRTrackerV2Tests: XCTestCase {
     
-    private let waitTimeout: TimeInterval = 1.0
+    private let waitTimeout: TimeInterval = 5.0
     private var timeoutInterval: TimeInterval = 2
         
     private func getSut() throws -> (SentryANRTracker, TestCurrentDateProvider, TestDisplayLinkWrapper, TestSentryCrashWrapper, SentryTestThreadWrapper, SentryFramesTracker) {


### PR DESCRIPTION
Modify the wait timeout in SentryANRTrackerV2Tests to provide more reliable test execution by extending the timeout from 1.0 to 5.0 seconds.

#skip-changelog