### PR TITLE
fix(ci): Add full path to xcresult for upload artifact

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -43,4 +43,4 @@ jobs:
         if: ${{ failure() }}
         with:
           name: integration-test-iOS-Cocoapods-Swift6.xcresult
-          path: fastlane/test_results/results.xcresult
+          path: Samples/iOS-Cocoapods-Swift6/fastlane/test_results/results.xcresult


### PR DESCRIPTION
The path to the `.xcresult` must be absolute.

#skip-changelog