### PR TITLE
fix: Correctly finish TTFD span when no new frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Correctly finish TTFD span when no new frame (#4941)
+
 ## 8.46.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 ## Unreleased
 
-### Fixes
-
-- Correctly finish TTFD span when no new frame (#4941)
 ### Features
 
 - Add extension for `Data` to track file I/O operations with Sentry (#4862)
+
+### Fixes
+
+- Correctly finish TTFD span when no new frame (#4941)
 
 ## 8.46.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Correctly finish TTFD span when no new frame (#4941)
+
 ### Improvements
 
 - More debug logs for UIViewController tracing (#4942)

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -140,6 +140,8 @@
 
 - (void)finishSpansIfNotFinished
 {
+    [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
+
     if (self.initialDisplaySpan.isFinished == NO) {
         [self.initialDisplaySpan finish];
     }
@@ -160,8 +162,6 @@
 
         [self.fullDisplaySpan finishWithStatus:kSentrySpanStatusDeadlineExceeded];
     }
-
-    [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
 }
 
 - (void)framesTrackerHasNewFrame:(NSDate *)newFrameDate

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -525,6 +525,25 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
         assertMeasurement(tracer: tracer, name: "time_to_full_display", duration: 3_000)
     }
     
+    func testFinishSpansIfNotFinished_FullyDisplayedRecorded_RemovesListener() throws {
+        // Arrange
+        fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))
+
+        let tracer = try fixture.getTracer()
+        
+        let sut = fixture.getSut(name: "UIViewController", waitForFullDisplay: true)
+
+        sut.start(for: tracer)
+
+        sut.reportFullyDisplayed()
+        
+        // Act
+        sut.finishSpansIfNotFinished()
+
+        // Assert
+        XCTAssertEqual(Dynamic(self.fixture.framesTracker).listeners.count, 0, "Frames tracker listener should be removed")
+    }
+    
     func testFinishSpansIfNotFinished_RemovesFramesTrackerListener() throws {
         // Arrange
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 9))


### PR DESCRIPTION


## :scroll: Description

This PR fixes wrongly finishing the TTFD span as the deadline exceeded when the user calls finishSpansIfNotFinished, and the UIViewControllerPerformanceTracker calls finishSpansIfNotFinished before a new frame gets drawn. This happened for a customer using a SplashScreenUIViewController. Now, the TimeToDisplayTracker finishes the TTFD span in finishSpansIfNotFinished when the user called finishSpansIfNotFinished.

## :bulb: Motivation and Context

A customer reported this bug via Slack.

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
