### PR TITLE
impr: More debug logs for UIViewController tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add extension for `Data` to track file I/O operations with Sentry (#4862)
 
+### Improvements
+
+- More debug logs for UIViewController tracing (#4942)
+
 ## 8.46.0
 
 ### Features

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -126,11 +126,13 @@
 
 - (void)reportInitialDisplay
 {
+    SENTRY_LOG_DEBUG(@"Reporting initial display for %@", _name);
     _initialDisplayReported = YES;
 }
 
 - (void)reportFullyDisplayed
 {
+    SENTRY_LOG_DEBUG(@"Reporting full display for %@", _name);
     // All other accesses to _fullyDisplayedReported run on the main thread.
     // To avoid using locks, we execute this on the main queue instead.
     [_dispatchQueueWrapper dispatchAsyncOnMainQueue:^{ self->_fullyDisplayedReported = YES; }];

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -220,6 +220,8 @@
         if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
             // We are no longer tracking this UIViewController, just call the base
             // method.
+            SENTRY_LOG_DEBUG(
+                @"Not tracking UIViewController.viewWillAppear because there is no active span.");
             callbackToOrigin();
             return;
         }
@@ -287,6 +289,8 @@
         if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
             // We are no longer tracking this UIViewController, just call the base
             // method.
+            SENTRY_LOG_DEBUG(@"Not tracking UIViewController.%@ because there is no active span.",
+                lifecycleMethod);
             callbackToOrigin();
             return;
         }
@@ -331,6 +335,8 @@
         if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
             // We are no longer tracking this UIViewController, just call the base
             // method.
+            SENTRY_LOG_DEBUG(@"Not tracking UIViewController.viewWillLayoutSubviews because there "
+                             @"is no active span.");
             callbackToOrigin();
             return;
         }
@@ -381,6 +387,8 @@
         if (spanId == nil || ![self.tracker isSpanAlive:spanId]) {
             // We are no longer tracking this UIViewController, just call the base
             // method.
+            SENTRY_LOG_DEBUG(@"Not tracking UIViewController.viewDidLayoutSubviews because there "
+                             @"is no active span.");
             callbackToOrigin();
             return;
         }
@@ -441,6 +449,9 @@
         block();
         [spansInExecution removeObject:description];
     } else {
+        SENTRY_LOG_DEBUG(@"Skipping tracking the method %@ for %@, cause we're already tracking it "
+                         @"for a parent or child class.",
+            description, viewController);
         callbackToOrigin();
     }
 }


### PR DESCRIPTION


## :scroll: Description

Added extra debug logs for SentryTimeToDisplayTracker and SentryUIViewControllerPerformanceTracker to have more insights on whats going on.

## :bulb: Motivation and Context

This will help us to investigate missing spans for `viewDidLoad` and `viewWillAppear` for a customer.

## :green_heart: How did you test it?
Unit tests still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
