### PR TITLE
fix: profiling sampling only noncontinuous

### DIFF
--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -12,7 +12,7 @@
 #import "SentryLevelMapper.h"
 #import "SentryLog.h"
 #import "SentryNSTimerFactory.h"
-#import "SentryOptions.h"
+#import "SentryOptions+Private.h"
 #import "SentryPerformanceTracker.h"
 #import "SentryProfilingConditionals.h"
 #import "SentrySDK+Private.h"
@@ -429,10 +429,11 @@ NS_ASSUME_NONNULL_BEGIN
                                        sampleRand:tracesSamplerDecision.sampleRand];
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    SentrySamplerDecision *profilesSamplerDecision
-        = sentry_sampleTraceProfile(samplingContext, tracesSamplerDecision, self.client.options);
-
-    configuration.profilesSamplerDecision = profilesSamplerDecision;
+    if (![self.client.options isContinuousProfilingEnabled]) {
+        SentrySamplerDecision *profilesSamplerDecision = sentry_sampleTraceProfile(
+            samplingContext, tracesSamplerDecision, self.client.options);
+        configuration.profilesSamplerDecision = profilesSamplerDecision;
+    }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED"
 
     SentryTracer *tracer = [[SentryTracer alloc] initWithTransactionContext:transactionContext


### PR DESCRIPTION
I noticed this working on another branch, we were computing trace profile sample rates even when unnecessary due to continuous profiling being used.

#skip-changelog