### PR TITLE
fix: Only delete envelopes when receiving HTTP 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Correctly finish TTFD span when no new frame (#4941)
+- Only delete envelopes when receiving HTTP 200 (#4956)
 
 ### Improvements
 

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -393,14 +393,22 @@
                 [weakSelf recordLostEventFor:envelope.items];
             }
 
-            if (nil != response) {
-                SENTRY_LOG_DEBUG(@"Envelope sent successfully!");
-                [weakSelf.rateLimits update:response];
-                [weakSelf deleteEnvelopeAndSendNext:envelopePath];
-            } else {
+            if (response == nil) {
                 SENTRY_LOG_DEBUG(@"No internet connection.");
                 [weakSelf finishedSending];
+                return;
             }
+
+            [weakSelf.rateLimits update:response];
+
+            if (response.statusCode == 200) {
+                SENTRY_LOG_DEBUG(@"Envelope sent successfully!");
+                [weakSelf deleteEnvelopeAndSendNext:envelopePath];
+                return;
+            }
+
+            SENTRY_LOG_DEBUG(@"Received non-200 response code: %li", (long)response.statusCode);
+            [weakSelf finishedSending];
         }];
 }
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -679,6 +679,36 @@ class SentryHttpTransportTests: XCTestCase {
         assertRequestsSent(requestCount: 1)
     }
     
+    func testSendEnvelope_HTTPResponse199_DoesNotDeleteEnvelopeAndStopsSending() throws {
+        // Arrange
+        let sentryUrl = try XCTUnwrap(URL(string: "https://sentry.io"))
+        let response = HTTPURLResponse(url: sentryUrl, statusCode: 199, httpVersion: nil, headerFields: nil)
+        
+        fixture.requestManager.returnResponse(response: response)
+        
+        // Act
+        sendEvent()
+        
+        // Assert
+        assertEnvelopesStored(envelopeCount: 1)
+        assertRequestsSent(requestCount: 1)
+    }
+    
+    func testSendEnvelope_HTTPResponse201_DoesNotDeleteEnvelopeAndStopsSending() throws {
+        // Arrange
+        let sentryUrl = try XCTUnwrap(URL(string: "https://sentry.io"))
+        let response = HTTPURLResponse(url: sentryUrl, statusCode: 201, httpVersion: nil, headerFields: nil)
+        
+        fixture.requestManager.returnResponse(response: response)
+        
+        // Act
+        sendEvent()
+        
+        // Assert
+        assertEnvelopesStored(envelopeCount: 1)
+        assertRequestsSent(requestCount: 1)
+    }
+    
     func testDeallocated_CachedEnvelopesNotAllSent() throws {
         givenNoInternetConnection()
         givenCachedEvents(amount: 10)


### PR DESCRIPTION




## :scroll: Description

Check in the HTTPTransport if the server returns a 200 HTTP status code. Only if it does delete the envelope. If not, stop sending.

## :bulb: Motivation and Context

Fixes GH-4458

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
