### PR TITLE
fix: Fix removing value from context not updating observer context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Correctly finish TTFD span when no new frame (#4941)
+- Fix removing value from context not updating observer context ()
 
 ### Improvements
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -246,7 +246,7 @@ NS_ASSUME_NONNULL_BEGIN
         [_contextDictionary removeObjectForKey:key];
 
         for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setExtras:_contextDictionary];
+            [observer setContext:_contextDictionary];
         }
     }
 }

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -773,7 +773,77 @@ class SentryScopeSwiftTests: XCTestCase {
             scope.setUser(user)
         })
     }
-    
+
+    func testRemoveContextForKey_keyNotFound_shouldNotChangeContext() {
+        // -- Arrange --
+        let scope = Scope()
+        scope.setContext(value: ["AA": 1], key: "A")
+        scope.setContext(value: ["BB": "2"], key: "B")
+
+        // -- Act --
+        scope.removeContext(key: "C")
+
+        // -- Assert --
+        let actual = scope.serialize()["context"] as? NSDictionary
+        let expected: NSDictionary = ["A": ["AA": 1], "B": ["BB": "2"]]
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testRemoveContextForKey_keyFound_shouldRemoveKeyValuePairFromContext() {
+        // -- Arrange --
+        let scope = Scope()
+        scope.setContext(value: ["AA": 1], key: "A")
+        scope.setContext(value: ["BB": "2"], key: "B")
+
+        // -- Act --
+        scope.removeContext(key: "B")
+
+        // -- Assert --
+        let actual = scope.serialize()["context"] as? NSDictionary
+        let expected: NSDictionary = ["A": ["AA": 1]]
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testRemoveContextForKey_keyNotFound_shouldUpdateAllObserverContexts() {
+        // -- Arrange --
+        let scope = Scope()
+        scope.setContext(value: ["AA": 1], key: "A")
+        scope.setContext(value: ["BB": "2"], key: "B")
+
+        let observer1 = TestScopeObserver()
+        scope.add(observer1)
+        let observer2 = TestScopeObserver()
+        scope.add(observer2)
+
+        // -- Act --
+        scope.removeContext(key: "C")
+
+        // -- Assert --
+        let expected: NSDictionary = ["A": ["AA": 1], "B": ["BB": "2"]]
+        XCTAssertEqual(observer1.context as? NSDictionary, expected)
+        XCTAssertEqual(observer2.context as? NSDictionary, expected)
+    }
+
+    func testRemoveContextForKey_keyFound_shouldUpdateAllObserverContexts() {
+        // -- Arrange --
+        let scope = Scope()
+        scope.setContext(value: ["AA": 1], key: "A")
+        scope.setContext(value: ["BB": "2"], key: "B")
+
+        let observer1 = TestScopeObserver()
+        scope.add(observer1)
+        let observer2 = TestScopeObserver()
+        scope.add(observer2)
+
+        // -- Act --
+        scope.removeContext(key: "B")
+
+        // -- Assert --
+        let expected: NSDictionary = ["A": ["AA": 1]]
+        XCTAssertEqual(observer1.context as? NSDictionary, expected)
+        XCTAssertEqual(observer2.context as? NSDictionary, expected)
+    }
+
     private class TestScopeObserver: NSObject, SentryScopeObserver {
         var tags: [String: String]?
         func setTags(_ tags: [String: String]?) {

--- a/Tests/SentryTests/SentryScopeTests.m
+++ b/Tests/SentryTests/SentryScopeTests.m
@@ -114,19 +114,6 @@
     XCTAssertTrue([expected isEqualToDictionary:actual]);
 }
 
-- (void)testRemoveContextForKey
-{
-    SentryScope *scope = [[SentryScope alloc] init];
-    [scope setContextValue:@{ @"AA" : @1 } forKey:@"A"];
-    [scope setContextValue:@{ @"BB" : @"2" } forKey:@"B"];
-
-    [scope removeContextForKey:@"B"];
-
-    NSDictionary *actual = scope.serialize[@"context"];
-    NSDictionary *expected = @{ @"A" : @ { @"AA" : @1 } };
-    XCTAssertTrue([expected isEqualToDictionary:actual]);
-}
-
 - (void)testDistSerializes
 {
     SentryScope *scope = [[SentryScope alloc] init];


### PR DESCRIPTION
## :scroll: Description

Replaces `setExtras` to `setContext` of scope observers when removing a value from scope.
Moves existing test from Objective-C to Swift.

## :bulb: Motivation and Context

Fixes #2588 

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
