### PR TITLE
fix: Change parameter of SDKInfo.initWithOptions to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,15 +13,12 @@
 - Only delete envelopes when receiving HTTP 200 (#4956)
 - Set foreground true for watchdog terminations (#4953)
 - Fix removing value from context not updating observer context (#4960)
+- Changed parameter of `SDKInfo.initWithOptions` to be nullable (#4968)
 
 ### Improvements
 
 - More debug logs for UIViewController tracing (#4942)
 - Avoid creating unnecessary User Interaction transactions (#4957)
-
-### Internal
-
-- Change parameter of `SDKInfo.initWithOptions` to be nullable (#4968)
 
 ## 8.46.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 ### Internal
 
-- Change parameter of `SDKInfo.initWithOptions` to be nullable
+- Change parameter of `SDKInfo.initWithOptions` to be nullable (#4968)
 
 ## 8.46.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 - More debug logs for UIViewController tracing (#4942)
 - Avoid creating unnecessary User Interaction transactions (#4957)
 
+### Internal
+
+- Change parameter of `SDKInfo.initWithOptions` to be nullable
+
 ## 8.46.0
 
 ### Features

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -17,10 +17,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)global
 {
-    return [[SentrySdkInfo alloc] initWithOptions:[SentrySDK.currentHub getClient].options];
+    SentryClient *_Nullable client = [SentrySDK.currentHub getClient];
+    return [[SentrySdkInfo alloc] initWithOptions:client.options];
 }
 
-- (instancetype)initWithOptions:(SentryOptions *)options
+- (instancetype)initWithOptions:(SentryOptions *_Nullable)options
 {
 
     NSArray<NSString *> *features =

--- a/Sources/Sentry/include/SentrySdkInfo.h
+++ b/Sources/Sentry/include/SentrySdkInfo.h
@@ -61,7 +61,7 @@ SENTRY_NO_INIT
  */
 @property (nonatomic, readonly, copy) NSArray<NSDictionary<NSString *, NSString *> *> *packages;
 
-- (instancetype)initWithOptions:(SentryOptions *)options;
+- (instancetype)initWithOptions:(SentryOptions *_Nullable)options;
 
 - (instancetype)initWithName:(NSString *)name
                      version:(NSString *)version

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -2,8 +2,10 @@ import Foundation
 
 @objcMembers class SentryEnabledFeaturesBuilder: NSObject {
     
-    static func getEnabledFeatures(options: Options) -> [String] {
-        
+    static func getEnabledFeatures(options: Options?) -> [String] {
+        guard let options = options else {
+            return []
+        }
         var features: [String] = []
         
         if options.enableCaptureFailedRequests {

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -62,4 +62,12 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         
         XCTAssert(features.contains("persistingTracesWhenCrashing"))
     }
+
+    func testGetEnabledFeatures_optionsAreNil_shouldReturnEmptyArray() {
+        // -- Act --
+        let result = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: nil)
+
+        // -- Assert --
+        XCTAssertEqual(result, [])
+    }
 }


### PR DESCRIPTION
## :scroll: Description

Changes the parameter `SDKInfo.initWithOptions` to be nullable.

## :bulb: Motivation and Context

The options can be nullable and will throw if doing something like `options.sessionReplay.enableExperimentalViewRenderer`.

This change is required for #4940.

## :green_heart: How did you test it?

Added a unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
