### PR TITLE
fix: Wrongly applying scope to crash events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-> [!WARNING] > **This version fixes an important bug for applying scope data to crash events (#4968).**
+> [!Important] > **This version fixes an important bug for applying scope data to crash events (#4969).**
 >
 > Previously, the SDK always set the event's user to the user of the scope of the app launch after the crash event, which could result in incorrect user data if the user changed between the crash and the next launch.
 > Additionally, if specific properties on the crash event were nil, the SDK replaced them with values from the scope of the app launch after the crash event. This affected the following event properties: tags, extra, fingerprints, breadcrumbs, dist, environment, level, and trace context. However, since most of these properties are infrequently nil, the fix should have minimal impact on most users.
@@ -18,7 +18,7 @@
 - Only delete envelopes when receiving HTTP 200 (#4956)
 - Set foreground true for watchdog terminations (#4953)
 - Fix removing value from context not updating observer context (#4960)
-- Fix wrongly applying scope to crash events (#4968)
+- Fix wrongly applying scope to crash events (#4969)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+> [!WARNING] > **This version fixes an important bug for applying scope data to crash events (#4968).**
+>
+> Previously, the SDK always set the event's user to the user of the scope of the app launch after the crash event, which could result in incorrect user data if the user changed between the crash and the next launch.
+> Additionally, if specific properties on the crash event were nil, the SDK replaced them with values from the scope of the app launch after the crash event. This affected the following event properties: tags, extra, fingerprints, breadcrumbs, dist, environment, level, and trace context. However, since most of these properties are infrequently nil, the fix should have minimal impact on most users.
+
 ### Features
 
 - Add extension for `Data` to track file I/O operations with Sentry (#4862)
@@ -13,6 +18,7 @@
 - Only delete envelopes when receiving HTTP 200 (#4956)
 - Set foreground true for watchdog terminations (#4953)
 - Fix removing value from context not updating observer context (#4960)
+- Fix wrongly applying scope to crash events (#4968)
 
 ### Improvements
 

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -757,7 +757,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 #endif
 
-    event = [scope applyToEvent:event maxBreadcrumb:self.options.maxBreadcrumbs];
+    // Crash events are from a previous run. Applying the current scope would potentially apply
+    // current data.
+    if (!isCrashEvent) {
+        event = [scope applyToEvent:event maxBreadcrumb:self.options.maxBreadcrumbs];
+    }
 
     if (!eventIsNotReplay) {
         event.breadcrumbs = nil;

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -583,18 +583,6 @@ NS_ASSUME_NONNULL_BEGIN
         event.level = level;
     }
 
-    NSMutableDictionary *newContext = [self context].mutableCopy;
-    if (event.context != nil) {
-        [SentryDictionary mergeEntriesFromDictionary:event.context intoDictionary:newContext];
-    }
-
-    // Don't add the trace context of a current trace to a crash event because crash events are from
-    // a previous run.
-    if (event.isCrashEvent) {
-        event.context = newContext;
-        return event;
-    }
-
     id<SentrySpan> span;
 
     if (self.span != nil) {
@@ -609,6 +597,11 @@ NS_ASSUME_NONNULL_BEGIN
                 event.transaction = [[(SentryTracer *)span transactionContext] name];
             }
         }
+    }
+
+    NSMutableDictionary *newContext = [self context].mutableCopy;
+    if (event.context != nil) {
+        [SentryDictionary mergeEntriesFromDictionary:event.context intoDictionary:newContext];
     }
 
     newContext[@"trace"] = [self buildTraceContext:span];

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -529,6 +529,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (SentryEvent *__nullable)applyToEvent:(SentryEvent *)event
                           maxBreadcrumb:(NSUInteger)maxBreadcrumbs
 {
+    if (event.isCrashEvent) {
+        SENTRY_LOG_WARN(@"Won't apply scope to a crash event. This is not allowed as crash "
+                        @"events are from a previous run of the app and the current scope might "
+                        @"have different data than the scope that was active during the crash.");
+        return event;
+    }
+
     if (event.tags == nil) {
         event.tags = [self tags];
     } else {

--- a/Tests/Perf/metrics-test.yml
+++ b/Tests/Perf/metrics-test.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 200 KiB
-  diffMax: 850 KiB
+  diffMax: 870 KiB

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1425,9 +1425,6 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(sessionStatus, session?.status)
         XCTAssertEqual(abnormalMechanism, session?.abnormalMechanism)
         XCTAssertEqual(fixture.options.environment, session?.environment)
-        
-        let event = argument?.scope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
-        XCTAssertEqual(event?.environment, scopeEnvironment)
     }
     
     private func assertSessionWithIncrementedErrorCountedAdded() throws {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -231,17 +231,6 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(trace?["span_id"] as? String, fixture.transaction.spanId.sentrySpanIdString)
     }
     
-    func testApplyToEvent_ScopeWithSpan_NotAppliedToCrashEvent() {
-        let scope = fixture.scope
-        scope.span = fixture.transaction
-        let event = fixture.event
-        event.isCrashEvent = true
-        
-        let actual = scope.applyTo(event: event, maxBreadcrumbs: 10)
-        XCTAssertNil(fixture.event.context?["trace"])
-        XCTAssertNil(actual?.transaction)
-    }
-    
     func testApplyToEvent_EventWithDist() {
         let event = fixture.event
         event.dist = "myDist"

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -261,6 +261,16 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(event.environment, actual?.environment)
     }
 
+    func testApplyToEvent_ForCrashEvent_DoesNotApplyScope() {
+        let event = fixture.event
+        event.isCrashEvent = true
+
+        let actual = fixture.scope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
+
+        XCTAssertNil(actual?.tags)
+        XCTAssertNil(actual?.extra)
+    }
+
     @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of useSpan")
     func testUseSpan() {
         fixture.scope.span = fixture.transaction


### PR DESCRIPTION
## :scroll: Description

The client wrongly applied the scope to crash events, which wasn't a problem in most cases because applying the scope only overwrites event data such as tags, user, environment, level, and context if these properties are nil. The client no longer applies the scope to crash events to avoid setting irrelevant values.

## :bulb: Motivation and Context

Fixes GH-4937

## :green_heart: How did you test it?
Unit tests, smoke test on a simulator

This feature branch
https://sentry-sdks.sentry.io/issues/5992437707/?project=5428557&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=0
![CleanShot 2025-03-11 at 14 23 53@2x](https://github.com/user-attachments/assets/1225e7cb-c468-45d1-af45-2426ac8182dc)

Main Branch
https://sentry-sdks.sentry.io/issues/5992437707/events/543c0f451cc64233b984df68da2970b8/?project=5428557

![CleanShot 2025-03-11 at 14 24 30@2x](https://github.com/user-attachments/assets/18cf8ea6-28d8-4e2a-b941-b8dcaeb7e3dd)


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
