### PR TITLE
Fix Important heading in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-> [!Important] > **This version fixes an important bug for applying scope data to crash events (#4969).**
+> [!Important]
+> **This version fixes an important bug for applying scope data to crash events (#4969).**
 >
 > Previously, the SDK always set the event's user to the user of the scope of the app launch after the crash event, which could result in incorrect user data if the user changed between the crash and the next launch.
 > Additionally, if specific properties on the crash event were nil, the SDK replaced them with values from the scope of the app launch after the crash event. This affected the following event properties: tags, extra, fingerprints, breadcrumbs, dist, environment, level, and trace context. However, since most of these properties are infrequently nil, the fix should have minimal impact on most users.


### PR DESCRIPTION
Before
![CleanShot 2025-03-12 at 09 12 18@2x](https://github.com/user-attachments/assets/a67854e6-29ac-423b-ac4e-4d018a016d45)


After
![CleanShot 2025-03-12 at 09 12 32@2x](https://github.com/user-attachments/assets/44ed2e5b-ce79-4fd7-a30d-0d3ed3c247b8)

#skip-changelog