### PR TITLE
tests: change test coverage targets to Sentry and SentrySwiftUI

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -7,5 +7,5 @@ scheme: Sentry
 source_directory: Sources
 output_directory: slather
 ignore:
-  - 'Tests/**'
-  - 'SentryTestUtils/**'
+  - '**/Tests/**'
+  - '**/SentryTestUtils/**'

--- a/.slather.yml
+++ b/.slather.yml
@@ -6,3 +6,6 @@ workspace: Sentry.xcworkspace
 scheme: Sentry
 source_directory: Sources
 output_directory: slather
+ignore:
+  - 'Tests/**'
+  - 'SentryTestUtils/**'

--- a/Plans/SentrySwiftUI_Base.xctestplan
+++ b/Plans/SentrySwiftUI_Base.xctestplan
@@ -9,6 +9,20 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Sentry.xcodeproj",
+          "identifier" : "D8199DA929376E9B0074249E",
+          "name" : "SentrySwiftUI"
+        },
+        {
+          "containerPath" : "container:Sentry.xcodeproj",
+          "identifier" : "63AA759A1EB8AEF500D153DE",
+          "name" : "Sentry"
+        }
+      ]
+    },
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/SentryTests_Base.xctestplan
+++ b/Plans/SentryTests_Base.xctestplan
@@ -9,7 +9,20 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Sentry.xcodeproj",
+          "identifier" : "63AA759A1EB8AEF500D153DE",
+          "name" : "Sentry"
+        },
+        {
+          "containerPath" : "container:Sentry.xcodeproj",
+          "identifier" : "D8199DA929376E9B0074249E",
+          "name" : "SentrySwiftUI"
+        }
+      ]
+    },
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -9,6 +9,20 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:Sentry.xcodeproj",
+          "identifier" : "63AA759A1EB8AEF500D153DE",
+          "name" : "Sentry"
+        },
+        {
+          "containerPath" : "container:Sentry.xcodeproj",
+          "identifier" : "D8199DA929376E9B0074249E",
+          "name" : "SentrySwiftUI"
+        }
+      ]
+    },
     "environmentVariableEntries" : [
       {
         "key" : "TSAN_OPTIONS",

--- a/Plans/SwiftUITestSample_Base.xctestplan
+++ b/Plans/SwiftUITestSample_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/iOS-ObjectiveC_Base.xctestplan
+++ b/Plans/iOS-ObjectiveC_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/iOS-Swift6_Base.xctestplan
+++ b/Plans/iOS-Swift6_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/iOS-Swift_Base.xctestplan
+++ b/Plans/iOS-Swift_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "commandLineArgumentEntries" : [
       {
         "argument" : "--io.sentry.disable-everything",

--- a/Plans/iOS15-SwiftUI.xctestplan
+++ b/Plans/iOS15-SwiftUI.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/macOS-SwiftUI_Base.xctestplan
+++ b/Plans/macOS-SwiftUI_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/visionOS-Swift_Base.xctestplan
+++ b/Plans/visionOS-Swift_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : false,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [


### PR DESCRIPTION
According to the Codecov reports we are collecting coverage data about the test files, rather than only the framework.

This PR should reduce the collected code coverage to the targets `Sentry` and `SentrySwiftUI`.

#skip-changelog