### PR TITLE
ref: Rename isCrashEvent to isFatalEvent

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -489,7 +489,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     NSArray *attachments = [self attachmentsForEvent:event scope:scope];
 
-    if (event.isCrashEvent && event.context[@"replay"] &&
+    if (event.isFatalEvent && event.context[@"replay"] &&
         [event.context[@"replay"] isKindOfClass:NSDictionary.class]) {
         NSDictionary *replay = event.context[@"replay"];
         scope.replayId = replay[@"replay_id"];

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -241,7 +241,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope
 {
-    event.isCrashEvent = YES;
+    event.isFatalEvent = YES;
 
     SentryClient *client = _client;
     if (client == nil) {
@@ -271,7 +271,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)captureFatalAppHangEvent:(SentryEvent *)event
 {
     // We treat fatal app hang events similar to crashes.
-    event.isCrashEvent = YES;
+    event.isFatalEvent = YES;
 
     SentryClient *_Nullable client = _client;
     if (client == nil) {

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -529,7 +529,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (SentryEvent *__nullable)applyToEvent:(SentryEvent *)event
                           maxBreadcrumb:(NSUInteger)maxBreadcrumbs
 {
-    if (event.isCrashEvent) {
+    if (event.isFatalEvent) {
         SENTRY_LOG_WARN(@"Won't apply scope to a crash event. This is not allowed as crash "
                         @"events are from a previous run of the app and the current scope might "
                         @"have different data than the scope that was active during the crash.");

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -67,7 +67,7 @@ saveScreenShot(const char *path)
     // We don't take screenshots if the event is a metric kit event.
     // Screenshots are added via an alternate codepath for crashes, see
     // sentrycrash_setSaveScreenshots in SentryCrashC.c
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent
+    if ((event.exceptions == nil && event.error == nil) || event.isFatalEvent
 #    if SENTRY_HAS_METRIC_KIT
         || [event isMetricKitEvent]
 #    endif // SENTRY_HAS_METRIC_KIT

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -127,7 +127,7 @@ static SentryTouchTracker *_touchTracker;
     [SentrySDK.currentHub registerSessionListener:self];
     [SentryGlobalEventProcessor.shared
         addEventProcessor:^SentryEvent *_Nullable(SentryEvent *_Nonnull event) {
-            if (event.isCrashEvent) {
+            if (event.isFatalEvent) {
                 [self resumePreviousSessionReplay:event];
             } else {
                 [self.sessionReplay captureReplayForEvent:event];

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -71,7 +71,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
 {
     // We don't attach the view hierarchy if there is no exception/error.
     // We don't attach the view hierarchy if the event is a crash or metric kit event.
-    if ((event.exceptions == nil && event.error == nil) || event.isCrashEvent
+    if ((event.exceptions == nil && event.error == nil) || event.isFatalEvent
 #    if SENTRY_HAS_METRIC_KIT
         || [event isMetricKitEvent]
 #    endif // SENTRY_HAS_METRIC_KIT

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -6,9 +6,10 @@
 @interface SentryEvent ()
 
 /**
- * This indicates whether this event is a result of a crash.
+ * This indicates whether this event is a result of a fatal app termination, such as a crash,
+ * watchdog termination or a fatal app hang.
  */
-@property (nonatomic) BOOL isCrashEvent;
+@property (nonatomic) BOOL isFatalEvent;
 
 /**
  * This indicates whether this event represents an app hang.

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -117,10 +117,10 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         XCTAssertEqual(newAttachmentList?.count, 0)
     }
     
-    func test_noScreenShot_CrashEvent() {
+    func test_noScreenShot_FatalEvent() {
         let sut = fixture.getSut()
         let event = Event(error: NSError(domain: "", code: -1))
-        event.isCrashEvent = true
+        event.isFatalEvent = true
         
         let newAttachmentList = sut.processAttachments([], for: event)
         

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -224,7 +224,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         let crash = Event(error: NSError(domain: "Error", code: 1))
         crash.context = [:]
-        crash.isCrashEvent = true
+        crash.isFatalEvent = true
         SentryGlobalEventProcessor.shared().reportAll(crash)
         
         wait(for: [expectation], timeout: 1)
@@ -252,7 +252,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         let crash = Event(error: NSError(domain: "Error", code: 1))
         crash.context = [:]
-        crash.isCrashEvent = true
+        crash.isFatalEvent = true
         SentryGlobalEventProcessor.shared().reportAll(crash)
         
         wait(for: [expectation], timeout: 1)
@@ -280,7 +280,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         try createLastSessionReplay(writeSessionInfo: false, errorSampleRate: 0)
         let crash = Event(error: NSError(domain: "Error", code: 1))
         crash.context = [:]
-        crash.isCrashEvent = true
+        crash.isFatalEvent = true
         SentryGlobalEventProcessor.shared().reportAll(crash)
         
         wait(for: [expectation], timeout: 1)

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -95,7 +95,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
     func test_noViewHierarchy_CrashEvent() {
         let sut = fixture.getSut()
         let event = Event(error: NSError(domain: "", code: -1))
-        event.isCrashEvent = true
+        event.isFatalEvent = true
 
         let newAttachmentList = sut.processAttachments([], for: event)
 

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -2085,10 +2085,10 @@ class SentryClientTest: XCTestCase {
         XCTAssertEqual(header.sdkInfo?.version, "1.0.0")
     }
     
-    func testCaptureCrashEventSetReplayInScope() {
+    func testCaptureFatalEventSetReplayInScope() {
         let sut = fixture.getSut()
         let event = Event()
-        event.isCrashEvent = true
+        event.isFatalEvent = true
         let scope = Scope()
         event.context = ["replay": ["replay_id": "someReplay"]]
         sut.captureCrash(event, with: SentrySession(releaseName: "", distinctId: ""), with: scope)

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -1403,14 +1403,14 @@ class SentryHubTests: XCTestCase {
         let arguments = fixture.client.captureEventWithScopeInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
-        XCTAssertFalse(arguments.first?.event.isCrashEvent ?? true)
+        XCTAssertFalse(arguments.first?.event.isFatalEvent ?? true)
     }
     
     private func assertCrashEventSent() {
         let arguments = fixture.client.captureCrashEventInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
-        XCTAssertTrue(arguments.first?.event.isCrashEvent ?? false)
+        XCTAssertTrue(arguments.first?.event.isFatalEvent ?? false)
     }
     
     private func assertEventSentWithSession(scopeEnvironment: String, sessionStatus: SentrySessionStatus = .crashed, abnormalMechanism: String? = nil) {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -261,9 +261,9 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(event.environment, actual?.environment)
     }
 
-    func testApplyToEvent_ForCrashEvent_DoesNotApplyScope() {
+    func testApplyToEvent_ForFatalEvent_DoesNotApplyScope() {
         let event = fixture.event
-        event.isCrashEvent = true
+        event.isFatalEvent = true
 
         let actual = fixture.scope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
 


### PR DESCRIPTION
As the SDK handles fatal app hang events similarly to crashes, it uses isCrashEvent for fatal app hangs. Therefore, it makes sense to rename the property to isFatalEvent to communicate its purpose.

Fixes GH-4935

#skip-changelog