### PR TITLE
test: fix continuous launch profile test

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
@@ -8,8 +8,9 @@ class ProfilingUITests: BaseUITest {
     override func setUp() {
         super.setUp()
 
-        // make sure there are no previous configuration files or profile files written
-        app.launchArguments.append("--io.sentry.wipe-data")
+        app.launchArguments.append(contentsOf: [
+            "--io.sentry.wipe-data" // make sure there are no previous configuration files or profile files written
+        ])
     }
     
     func testAppLaunchesWithTraceProfiler() throws {
@@ -147,15 +148,18 @@ extension ProfilingUITests {
             "--disable-uiviewcontroller-tracing",
             
             // opt into launch profiling
-            "--profile-app-launches",
-            
+            "--io.sentry.profile-app-launches",
+
             // sets a marker function to run in a load command that the launch profile should detect
-            "--io.sentry.slow-load-method"
+            "--io.sentry.slow-load-method",
+
+            // override full chunk completion before stoppage introduced in https://github.com/getsentry/sentry-cocoa/pull/4214
+            "--io.sentry.continuous-profiler-immediate-stop"
         ])
         if continuousProfiling {
-            app.launchArguments.append("--io.sentry.enable-continuous-profiling")
+            app.launchArguments.append("--io.sentry.enableContinuousProfiling")
         }
-        
+
         launchApp()
         
         goToProfiling()

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -117,14 +117,14 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
     
     @IBAction func viewLastProfile(_ sender: Any) {
         profilingUITestDataMarshalingTextField.text = "<fetching...>"
-        withProfile(first: false) { file in
+        withProfile(continuous: false) { file in
             handleContents(file: file)
         }
     }
     
     @IBAction func viewFirstContinuousProfileChunk(_ sender: Any) {
         profilingUITestDataMarshalingTextField.text = "<fetching...>"
-        withProfile(first: true) { file in
+        withProfile(continuous: true) { file in
             handleContents(file: file)
         }
     }
@@ -135,18 +135,18 @@ class ProfilingViewController: UIViewController, UITextFieldDelegate {
         textField.resignFirstResponder()
     }
     
-    private func withProfile(first: Bool, block: (URL?) -> Void) {
+    private func withProfile(continuous: Bool, block: (URL?) -> Void) {
         let cachesDirectory = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
         let fm = FileManager.default
-        let dir = "\(cachesDirectory)/io.sentry/profiles"
+        let dir = "\(cachesDirectory)/io.sentry/" + (continuous ? "continuous-profiles" : "trace-profiles")
         let count = try! fm.contentsOfDirectory(atPath: dir).count
         //swiftlint:disable empty_count
-        guard first || count > 0 else {
+        guard continuous || count > 0 else {
             //swiftlint:enable empty_count
             profilingUITestDataMarshalingTextField.text = "<missing>"
             return
         }
-        let fileName = "profile\(first ? 0 : count - 1)"
+        let fileName = "profile\(continuous ? 0 : count - 1)"
         let fullPath = "\(dir)/\(fileName)"
         
         if fm.fileExists(atPath: fullPath) {

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -424,7 +424,7 @@ extension SentrySDKWrapper {
         }
     }
     
-    var enableAppLaunchProfiling: Bool { args.contains("--profile-app-launches") }
+    var enableAppLaunchProfiling: Bool { args.contains("--io.sentry.profile-app-launches") }
 }
 
 // swiftlint:enable file_length function_body_length

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -79,6 +79,15 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
     );
     [SentrySDK captureEnvelope:envelope];
 }
+
+void
+_sentry_unsafe_stopTimerAndCleanup()
+{
+    disableTimer();
+
+    [_threadUnsafe_gContinuousCurrentProfiler stopForReason:SentryProfilerTruncationReasonNormal];
+    _threadUnsafe_gContinuousCurrentProfiler = nil;
+}
 } // namespace
 
 @implementation SentryContinuousProfiler
@@ -143,6 +152,22 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
             SENTRY_LOG_DEBUG(@"No continuous profiler is currently running.");
             return;
         }
+
+        SENTRY_LOG_DEBUG(@"Stopping continuous profiler after current chunk completes.");
+
+#    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+        // we want to allow immediately stopping a continuous profile for a UI test, since those
+        // currently only test launch profiles, and there is no reliable way to make the UI test
+        // wait until the continuous profile chunk would finish (behavior introduced in
+        // https://github.com/getsentry/sentry-cocoa/pull/4214). we just want to look in its samples
+        // for a call to main()
+        if ([NSProcessInfo.processInfo.arguments
+                containsObject:@"--io.sentry.continuous-profiler-immediate-stop"]) {
+            _sentry_threadUnsafe_transmitChunkEnvelope();
+            _sentry_unsafe_stopTimerAndCleanup();
+            return;
+        }
+#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
         _stopCalled = YES;
     }
@@ -209,11 +234,7 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
 + (void)stopTimerAndCleanup
 {
     std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
-
-    disableTimer();
-
-    [_threadUnsafe_gContinuousCurrentProfiler stopForReason:SentryProfilerTruncationReasonNormal];
-    _threadUnsafe_gContinuousCurrentProfiler = nil;
+    _sentry_unsafe_stopTimerAndCleanup();
 }
 
 #    pragma mark - Testing

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -138,6 +138,7 @@ _sentry_nondeduplicated_startLaunchProfile(void)
 
     NSDictionary<NSString *, NSNumber *> *launchConfig = appLaunchProfileConfiguration();
     if ([launchConfig[kSentryLaunchProfileConfigKeyContinuousProfiling] boolValue]) {
+        SENTRY_LOG_DEBUG(@"Starting launch continuous profile");
         [SentryContinuousProfiler start];
         return;
     }
@@ -195,8 +196,10 @@ sentry_configureLaunchProfiling(SentryOptions *options)
         NSMutableDictionary<NSString *, NSNumber *> *configDict =
             [NSMutableDictionary<NSString *, NSNumber *> dictionary];
         if ([options isContinuousProfilingEnabled]) {
+            SENTRY_LOG_DEBUG(@"Configuring launch continuous profile");
             configDict[kSentryLaunchProfileConfigKeyContinuousProfiling] = @YES;
         } else {
+            SENTRY_LOG_DEBUG(@"Configuring launch trace profile");
             configDict[kSentryLaunchProfileConfigKeyTracesSampleRate]
                 = config.tracesDecision.sampleRate;
             configDict[kSentryLaunchProfileConfigKeyTracesSampleRand]

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.mm
@@ -335,7 +335,7 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
 #    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
     // only write profile payloads to disk for UI tests
     if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] != nil) {
-        sentry_writeProfileFile(JSONData);
+        sentry_writeProfileFile(JSONData, true /*continuous*/);
     }
 #    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
@@ -386,7 +386,7 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(SentryHub *hub,
     }
 
 #    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
-    sentry_writeProfileFile(JSONData);
+    sentry_writeProfileFile(JSONData, false /*continuous*/);
 #    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
     const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -24,11 +24,11 @@ sentry_threadSanitizerIsPresent(void)
 #    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 
 void
-sentry_writeProfileFile(NSData *JSONData)
+sentry_writeProfileFile(NSData *JSONData, BOOL continuous)
 {
     NSFileManager *fm = [NSFileManager defaultManager];
-    NSString *testProfileDirPath =
-        [sentryStaticCachesPath() stringByAppendingPathComponent:@"profiles"];
+    NSString *testProfileDirPath = [sentryStaticCachesPath()
+        stringByAppendingPathComponent:continuous ? @"continuous-profiles" : @"trace-profiles"];
 
     if (![fm fileExistsAtPath:testProfileDirPath]) {
         SENTRY_LOG_DEBUG(@"Creating Sentry static cache directory.");

--- a/Sources/Sentry/include/SentryProfilerTestHelpers.h
+++ b/Sources/Sentry/include/SentryProfilerTestHelpers.h
@@ -23,7 +23,7 @@ SENTRY_EXTERN BOOL sentry_threadSanitizerIsPresent(void);
  * Write a file to the disk cache containing the profile data. This is an affordance for UI
  * tests to be able to validate the contents of a profile.
  */
-SENTRY_EXTERN void sentry_writeProfileFile(NSData *JSONData);
+SENTRY_EXTERN void sentry_writeProfileFile(NSData *JSONData, BOOL continuous);
 
 #    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 


### PR DESCRIPTION
I noticed while working on #4856 that this test wasn't functioning correctly. It's a combination of things:
 - first, https://github.com/getsentry/sentry-cocoa/pull/4024 changed a launch argument in iOS-Swift that switches between trace and continuous profiling, but didn't change it in the UI test. what wound up happening is that the UI test would run a trace profile, and since trace and continuous profile chunk data were both written to the same debug file, the assertions didn't know it was looking at a trace profile when they should've been checking a continuous profile. to mitigate this in the future, i've changed `SentryProfilerTestHelperssentry_writeProfileFile` so that it either writes to `trace-profiles/` or `continuous-profiles/`.
 - then, we changed the behavior of calling stop on a continuous profiler in https://github.com/getsentry/sentry-cocoa/pull/4214 so that it doesn't actually stop the profile, it lets the chunk finish. due to the bug above, the UI tests didn't fail. it didn't occur to us that this new asynchronous behavior needed to be accounted for in the UI test.
 - then, we extended the duration of a profile chunk from 10s to 60s in https://github.com/getsentry/sentry-cocoa/pull/4826. this doesn't really have any bearing on the issue, but would've been the most recent opportunity to fix this test
 
Because this is a UI test, we can't simply inject `TestSentryNSTimerFactory` from the test code like we do with unit tests, and really can't even do it using launch args handled in the app/sdk code, since that mock utility only exists in the unit tests. For now, I've settled on conditionally compiling behavior, additionally protected with a launch argument set from the UI tests, that will immediately stop a continuous profile when stop is called.