### PR TITLE
test: Add testToIso8601StringNil_ReturnsNil

### DIFF
--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -130,7 +130,7 @@
     XCTAssertEqual([date timeIntervalSince1970], 1582803326.0);
 }
 
-- (void)testToIs08691StringNil_ReturnsNil
+- (void)testToIso8601StringNil_ReturnsNil
 {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnonnull"

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -130,4 +130,13 @@
     XCTAssertEqual([date timeIntervalSince1970], 1582803326.0);
 }
 
+- (void)testToIs08691StringNil_ReturnsNil
+{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
+    NSString *dateAsString = sentry_toIso8601String(nil);
+#pragma clang diagnostic pop
+    XCTAssertNil(dateAsString);
+}
+
 @end


### PR DESCRIPTION
Add a test to ensure we don't crash when passing nil to sentry_toIso8601String.

Came up while investigating https://github.com/getsentry/sentry-cocoa/issues/4582.

#skip-changelog