### PR TITLE
chore: Remove no-commit-to-branch pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,6 @@ repos:
         args: [--allow-multiple-documents]
       - id: detect-private-key
       - id: end-of-file-fixer
-      - id: no-commit-to-branch
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.27.3


### PR DESCRIPTION
The  hook prevents committing directly to the main branch, but this can be annoying for developers who use a different Git workflow. If you accidentally try to commit to main, you have to create a new branch and rerun all pre-commit checks.

Since we already enforce branch protection rules for main via GitHub, this hook adds little value while reducing flexibility. Removing it allows for a more streamlined workflow without unnecessary friction.

#skip-changelog