### PR TITLE
test: Fewer iterations in abnormal session IO test

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -567,6 +567,11 @@ class SentryFileManagerTests: XCTestCase {
     
     func testAbnormalSessionAsync_DoesNotCrash() {
         // Arrange
+
+        // Using 100 iterations because it's still enough to find race conditions and
+        // synchronization issues that could lead to crashes, but it's small enough to not
+        // time out in CI.
+        // If you want to use this to find synchronization issues, you should increase the number of iterations.
         let iterations = 100
         let expectation = expectation(description: "complete all abnormal session interactions")
         expectation.expectedFulfillmentCount = iterations * 3

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -567,7 +567,7 @@ class SentryFileManagerTests: XCTestCase {
     
     func testAbnormalSessionAsync_DoesNotCrash() {
         // Arrange
-        let iterations = 1_000
+        let iterations = 100
         let expectation = expectation(description: "complete all abnormal session interactions")
         expectation.expectedFulfillmentCount = iterations * 3
         let dispatchQueue = DispatchQueue(label: "testAbnormalSessionAsync_DoesNotCrash", qos: .userInitiated, attributes: [.concurrent])


### PR DESCRIPTION
Reduce the iterations from 1000 to 100 to reduce the risk of the test expectation to time out.

The test timed out here https://github.com/getsentry/sentry-cocoa/actions/runs/13856567413/job/38774995706. The test logs didn't show anything suspicious. Maybe 3000 file IO operations are to much within 10 seconds when CI is super busy.