### PR TITLE
test: Use XCTUnwrap in NetworkTrackerTests

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -173,10 +173,10 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         dataTask.resume()
         wait(for: [expect], timeout: 5)
         
-        let children = Dynamic(transaction).children as [Span]?
-        
-        XCTAssertEqual(children?.count, 1) //Span was created in task resume swizzle.
-        let networkSpan = try XCTUnwrap(children?.first)
+        let children = try XCTUnwrap(Dynamic(transaction).children as [Span]?)
+
+        XCTAssertEqual(children.count, 1) //Span was created in task resume swizzle.
+        let networkSpan = try XCTUnwrap(children.first)
         XCTAssertTrue(networkSpan.isFinished) //Span was finished in task setState swizzle.
         XCTAssertEqual(SentrySpanOperationNetworkRequestOperation, networkSpan.operation)
         XCTAssertEqual("GET \(SentryNetworkTrackerIntegrationTests.testBaggageURL)", networkSpan.spanDescription)


### PR DESCRIPTION
Use XCTUnwrap in
testGetRequest_SpanCreatedAndBaggageHeaderAdded
instead of ? to get better failing asserts.

Came up while investigating flaky tests.

#skip-changelog