### PR TITLE
Fix: Assigns Experimental View Renderer options in SentryReplayOptions init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Slightly speed up adding breadcrumbs (#4984)
 
+### Fixes
+
+- Fixes experimental Replay view renderer options initialisation (#4988)
+
 ## 8.47.0
 
 > [!Important]

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -206,6 +206,8 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
         self.onErrorSampleRate = onErrorSampleRate
         self.maskAllText = maskAllText
         self.maskAllImages = maskAllImages
+        self.enableExperimentalViewRenderer = enableExperimentalViewRenderer
+        self.enableFastViewRendering = enableFastViewRendering
     }
 
     convenience init(dictionary: [String: Any]) {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
@@ -173,6 +173,44 @@ class SentryReplayOptionsTests: XCTestCase {
         ])
         XCTAssertTrue(options.maskAllImages)
     }
+    
+    func testInitFromDictEnableExperimentalViewRendererWithBool() {
+        let options = SentryReplayOptions(dictionary: [
+            "enableExperimentalViewRenderer": true
+        ])
+        XCTAssertTrue(options.enableExperimentalViewRenderer)
+
+        let options2 = SentryReplayOptions(dictionary: [
+            "enableExperimentalViewRenderer": false
+        ])
+        XCTAssertFalse(options2.enableExperimentalViewRenderer)
+    }
+
+    func testInitFromDictEnableExperimentalViewRendererWithString() {
+        let options = SentryReplayOptions(dictionary: [
+            "enableExperimentalViewRenderer": "invalid_value"
+        ])
+        XCTAssertFalse(options.enableExperimentalViewRenderer)
+    }
+    
+    func testInitFromDictEnableFastViewRenderingWithBool() {
+        let options = SentryReplayOptions(dictionary: [
+            "enableFastViewRendering": true
+        ])
+        XCTAssertTrue(options.enableFastViewRendering)
+
+        let options2 = SentryReplayOptions(dictionary: [
+            "enableFastViewRendering": false
+        ])
+        XCTAssertFalse(options2.enableFastViewRendering)
+    }
+
+    func testInitFromDictEnableFastViewRenderingWithString() {
+        let options = SentryReplayOptions(dictionary: [
+            "enableFastViewRendering": "invalid_value"
+        ])
+        XCTAssertFalse(options.enableFastViewRendering)
+    }
 
     func testInitFromDictQualityWithString() {
         let options = SentryReplayOptions(dictionary: [
@@ -217,6 +255,8 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.onErrorSampleRate, 0.8)
         XCTAssertFalse(options.maskAllText)
         XCTAssertTrue(options.maskAllImages)
+        XCTAssertFalse(options.enableExperimentalViewRenderer)
+        XCTAssertFalse(options.enableFastViewRendering)
         XCTAssertEqual(options.maskedViewClasses.count, 1)
         XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses.first!), ObjectIdentifier(NSString.self))
         XCTAssertEqual(options.unmaskedViewClasses.count, 1)


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->
Assigns `enableExperimentalViewRenderer`, `enableFastViewRendering` in `SentryReplayOptions` `init`

## :bulb: Motivation and Context
I've noticed those are always false while working on https://github.com/getsentry/sentry-react-native/pull/4660 for https://github.com/getsentry/sentry-react-native/issues/4658
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Manual, Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
