### PR TITLE
docs: move change of #4863 to unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add extension for `FileManager` to track file I/O operations with Sentry (#4863)
+
 ### Improvements
 
 - Slightly speed up adding breadcrumbs (#4984)
@@ -23,7 +27,6 @@
 - Add extension for `Data` to track file I/O operations with Sentry (#4862)
 - Send fatal app hang session updates (#4921) only when enabling the option `enableAppHangTrackingV2`.
 - Add experimental flag `options.sessionReplay.enableExperimentalViewRenderer` to enable up to 5x times more performance in Session Replay (#4940)
-- Add extension for `FileManager` to track file I/O operations with Sentry (#4863)
 
 ### Fixes
 


### PR DESCRIPTION
Merge added changelog to wrong section

#skip-changelog