### PR TITLE
fix(profiling): start cancels prior stop request

### DIFF
--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -99,6 +99,8 @@ _sentry_unsafe_stopTimerAndCleanup()
     {
         std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
 
+        _stopCalled = NO;
+
         if ([_threadUnsafe_gContinuousCurrentProfiler isRunning]) {
             SENTRY_LOG_DEBUG(@"A continuous profiler is already running.");
             return;
@@ -109,8 +111,6 @@ _sentry_unsafe_stopTimerAndCleanup()
             SENTRY_LOG_WARN(@"Continuous profiler was unable to be initialized.");
             return;
         }
-
-        _stopCalled = NO;
 
         static dispatch_once_t onceToken;
         dispatch_once(&onceToken, ^{ _profileSessionID = [[SentryId alloc] init]; });

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -161,6 +161,34 @@ final class SentryContinuousProfilerTests: XCTestCase {
         SentryContinuousProfiler.stop()
         try assertContinuousProfileStoppage()
     }
+
+    func testStoppingAndStartingAgainBeforeFinalChunkCompletesResultsInOneProfile() throws {
+        // arrange
+        SentryContinuousProfiler.start()
+        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+
+        // act
+        fixture.currentDateProvider.advanceBy(interval: 1)
+        SentryContinuousProfiler.stop()
+
+        fixture.currentDateProvider.advanceBy(interval: 1)
+        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+
+        fixture.currentDateProvider.advanceBy(interval: 1)
+        SentryContinuousProfiler.start()
+
+        fixture.currentDateProvider.advanceBy(interval: 60)
+        try fixture.timeoutTimerFactory.check()
+        XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
+
+        fixture.currentDateProvider.advanceBy(interval: 1)
+        SentryContinuousProfiler.stop()
+
+        // assert
+        fixture.currentDateProvider.advanceBy(interval: 60)
+        try fixture.timeoutTimerFactory.check()
+        XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
+    }
 }
 
 private extension SentryContinuousProfilerTests {


### PR DESCRIPTION
After some discussion around how stop should work for the upcoming API changes, I realized this was incorrectly coded (or, correctly coded an incorrect assumption).

Stopping the continuous profiler doesn't immediately stop it, rather, it allows the current in-flight chunk to complete, then stops it. If a new call to start comes in, it should "cancel" the pending stop request, and simply allow the same continuous profiler to continue running.