### PR TITLE
ref: Improve ClientAttachmentProcessor

### DIFF
--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -59,8 +59,9 @@ saveScreenShot(const char *path)
     [client removeAttachmentProcessor:self];
 }
 
-- (NSArray<SentryAttachment *> *)processAttachments:(NSArray<SentryAttachment *> *)attachments
-                                           forEvent:(nonnull SentryEvent *)event
+- (nonnull NSArray<SentryAttachment *> *)processAttachments:
+                                             (nonnull NSArray<SentryAttachment *> *)attachments
+                                                   forEvent:(nonnull SentryEvent *)event
 {
 
     // We don't take screenshots if there is no exception/error.

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -66,8 +66,9 @@ saveViewHierarchy(const char *reportDirectoryPath)
     [client removeAttachmentProcessor:self];
 }
 
-- (NSArray<SentryAttachment *> *)processAttachments:(NSArray<SentryAttachment *> *)attachments
-                                           forEvent:(nonnull SentryEvent *)event
+- (nonnull NSArray<SentryAttachment *> *)processAttachments:
+                                             (nonnull NSArray<SentryAttachment *> *)attachments
+                                                   forEvent:(nonnull SentryEvent *)event
 {
     // We don't attach the view hierarchy if there is no exception/error.
     // We don't attach the view hierarchy if the event is a crash or metric kit event.

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -15,9 +15,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol SentryClientAttachmentProcessor <NSObject>
 
-- (nullable NSArray<SentryAttachment *> *)processAttachments:
-                                              (nullable NSArray<SentryAttachment *> *)attachments
-                                                    forEvent:(SentryEvent *)event;
+- (NSArray<SentryAttachment *> *)processAttachments:(NSArray<SentryAttachment *> *)attachments
+                                           forEvent:(SentryEvent *)event;
 
 @end
 

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -70,7 +70,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 1)
+        XCTAssertEqual(newAttachmentList.count, 1)
     }
     
     func test_attachScreenShot_withException() {
@@ -80,7 +80,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 1)
+        XCTAssertEqual(newAttachmentList.count, 1)
     }
     
     func test_attachScreenShot_withError_keepAttachments() {
@@ -91,8 +91,8 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([attachment], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 2)
-        XCTAssertEqual(newAttachmentList?.first, attachment)
+        XCTAssertEqual(newAttachmentList.count, 2)
+        XCTAssertEqual(newAttachmentList.first, attachment)
     }
     
     func test_attachScreenShot_withException_keepAttachments() {
@@ -104,8 +104,8 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([attachment], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 2)
-        XCTAssertEqual(newAttachmentList?.first, attachment)
+        XCTAssertEqual(newAttachmentList.count, 2)
+        XCTAssertEqual(newAttachmentList.first, attachment)
     }
     
     func test_noScreenshot_attachment() {
@@ -114,7 +114,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
     
     func test_noScreenShot_FatalEvent() {
@@ -124,7 +124,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
 
 #if os(iOS) || targetEnvironment(macCatalyst)
@@ -133,7 +133,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([], for: TestData.metricKitEvent)
         
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
 #endif // os(iOS) || targetEnvironment(macCatalyst)
     
@@ -154,7 +154,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         wait(for: [expectation], timeout: 1.0)
         
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
     
     func test_noScreenshot_keepAttachment() {
@@ -165,8 +165,8 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([attachment], for: event)
         
-        XCTAssertEqual(newAttachmentList?.count, 1)
-        XCTAssertEqual(newAttachmentList?.first, attachment)
+        XCTAssertEqual(newAttachmentList.count, 1)
+        XCTAssertEqual(newAttachmentList.first, attachment)
     }
     
     func test_Attachments_Info() {
@@ -174,7 +174,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         let event = Event(error: NSError(domain: "", code: -1))
         fixture.screenshot.result = [Data(repeating: 0, count: 1), Data(repeating: 0, count: 2), Data(repeating: 0, count: 3)]
         
-        let newAttachmentList = sut.processAttachments([], for: event) ?? []
+        let newAttachmentList = sut.processAttachments([], for: event)
         
         XCTAssertEqual(newAttachmentList.count, 3)
         XCTAssertEqual(try XCTUnwrap(newAttachmentList.first).filename, "screenshot.png")

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -78,9 +78,9 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         let newAttachmentList = sut.processAttachments([], for: event)
 
-        XCTAssertEqual(newAttachmentList?.first?.filename, "view-hierarchy.json")
-        XCTAssertEqual(newAttachmentList?.first?.contentType, "application/json")
-        XCTAssertEqual(newAttachmentList?.first?.attachmentType, .viewHierarchy)
+        XCTAssertEqual(newAttachmentList.first?.filename, "view-hierarchy.json")
+        XCTAssertEqual(newAttachmentList.first?.contentType, "application/json")
+        XCTAssertEqual(newAttachmentList.first?.attachmentType, .viewHierarchy)
     }
 
     func test_noViewHierarchy_attachment() {
@@ -89,7 +89,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         let newAttachmentList = sut.processAttachments([], for: event)
 
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
 
     func test_noViewHierarchy_CrashEvent() {
@@ -99,7 +99,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         let newAttachmentList = sut.processAttachments([], for: event)
 
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
 
 #if os(iOS) || targetEnvironment(macCatalyst)
@@ -108,7 +108,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
         
         let newAttachmentList = sut.processAttachments([], for: TestData.metricKitEvent)
 
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
 #endif // os(iOS) || targetEnvironment(macCatalyst)
     
@@ -130,7 +130,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1.0)
 
-        XCTAssertEqual(newAttachmentList?.count, 0)
+        XCTAssertEqual(newAttachmentList.count, 0)
     }
 
     func test_noViewHierarchy_keepAttachment() {
@@ -141,8 +141,8 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         let newAttachmentList = sut.processAttachments([attachment], for: event)
 
-        XCTAssertEqual(newAttachmentList?.count, 1)
-        XCTAssertEqual(newAttachmentList?.first, attachment)
+        XCTAssertEqual(newAttachmentList.count, 1)
+        XCTAssertEqual(newAttachmentList.first, attachment)
     }
     
     func test_backgroundForAppHangs() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -406,7 +406,7 @@ class SentryClientTest: XCTestCase {
 
         let expectProcessorCall = expectation(description: "Processor Call")
         let processor = TestAttachmentProcessor { atts, e in
-            var result = atts ?? []
+            var result = atts
             result.append(extraAttachment)
             XCTAssertEqual(event, e)
             expectProcessorCall.fulfill()
@@ -429,7 +429,7 @@ class SentryClientTest: XCTestCase {
         let extraAttachment = Attachment(data: Data(), filename: "ExtraAttachment")
 
         let processor = TestAttachmentProcessor { atts, _ in
-            var result = atts ?? []
+            var result = atts
             result.append(extraAttachment)
             return result
         }
@@ -451,7 +451,7 @@ class SentryClientTest: XCTestCase {
         let extraAttachment = Attachment(data: Data(), filename: "ExtraAttachment")
         
         let processor = TestAttachmentProcessor { atts, _ in
-            var result = atts ?? []
+            var result = atts
             result.append(extraAttachment)
             return result
         }
@@ -2238,13 +2238,13 @@ private extension SentryClientTest {
     
     class TestAttachmentProcessor: NSObject, SentryClientAttachmentProcessor {
         
-        var callback: (([Attachment]?, Event) -> [Attachment]?)
+        var callback: (([Attachment], Event) -> [Attachment])
         
-        init(callback: @escaping ([Attachment]?, Event) -> [Attachment]?) {
+        init(callback: @escaping ([Attachment], Event) -> [Attachment]) {
             self.callback = callback
         }
         
-        func processAttachments(_ attachments: [Attachment]?, for event: Event) -> [Attachment]? {
+        func processAttachments(_ attachments: [Attachment], for event: Event) -> [Attachment] {
             return callback(attachments, event)
         }
     }


### PR DESCRIPTION
Specify types for NSArrays, rename attachmentsForEvent to processAttachmentsForEvent, only pass attachments to processAttachmentsForEvent, remove not required nullable for SentryClientAttachmentProcessor.

Came up while investigating GH-4936.

#skip-changelog