### PR TITLE
ref: Rename captureCrashEvent to captureFatalEvent

### DIFF
--- a/SentryTestUtils/TestClient.swift
+++ b/SentryTestUtils/TestClient.swift
@@ -96,15 +96,15 @@ public class TestClient: SentryClient {
         return SentryId()
     }
     
-    public var captureCrashEventInvocations = Invocations<(event: Event, scope: Scope)>()
-    public override func captureCrash(_ event: Event, with scope: Scope) -> SentryId {
-        captureCrashEventInvocations.record((event, scope))
+    public var captureFatalEventInvocations = Invocations<(event: Event, scope: Scope)>()
+    public override func captureFatalEvent(_ event: Event, with scope: Scope) -> SentryId {
+        captureFatalEventInvocations.record((event, scope))
         return SentryId()
     }
     
-    public var captureCrashEventWithSessionInvocations = Invocations<(event: Event, session: SentrySession, scope: Scope)>()
-    public override func captureCrash(_ event: Event, with session: SentrySession, with scope: Scope) -> SentryId {
-        captureCrashEventWithSessionInvocations.record((event, session, scope))
+    public var captureFatalEventWithSessionInvocations = Invocations<(event: Event, session: SentrySession, scope: Scope)>()
+    public override func captureFatalEvent(_ event: Event, with session: SentrySession, with scope: Scope) -> SentryId {
+        captureFatalEventWithSessionInvocations.record((event, session, scope))
         return SentryId()
     }
     

--- a/SentryTestUtils/TestHub.swift
+++ b/SentryTestUtils/TestHub.swift
@@ -26,14 +26,14 @@ public class TestHub: SentryHub {
         endSessionTimestamp = timestamp
     }
     
-    public var sentCrashEvents = Invocations<Event>()
-    public override func captureCrash(_ event: Event) {
-        sentCrashEvents.record(event)
+    public var sentFatalEvents = Invocations<Event>()
+    public override func captureFatalEvent(_ event: Event) {
+        sentFatalEvents.record(event)
     }
     
-    public var sentCrashEventsWithScope = Invocations<(event: Event, scope: Scope)>()
-    public override func captureCrash(_ event: Event, with scope: Scope) {
-        sentCrashEventsWithScope.record((event, scope))
+    public var sentFatalEventsWithScope = Invocations<(event: Event, scope: Scope)>()
+    public override func captureFatalEvent(_ event: Event, with scope: Scope) {
+        sentFatalEventsWithScope.record((event, scope))
     }
     
     public var capturedEventsWithScopes = Invocations<(event: Event, scope: Scope, additionalEnvelopeItems: [SentryEnvelopeItem])>()

--- a/Sources/Sentry/SentryCrashReportSink.m
+++ b/Sources/Sentry/SentryCrashReportSink.m
@@ -100,7 +100,7 @@ static const NSTimeInterval SENTRY_APP_START_CRASH_FLUSH_DURATION = 5.0;
         }
     }
 
-    [SentrySDK captureCrashEvent:event withScope:scope];
+    [SentrySDK captureFatalEvent:event withScope:scope];
 }
 
 @end

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -228,9 +228,9 @@ NS_ASSUME_NONNULL_BEGIN
     return sessionCopy;
 }
 
-- (void)captureCrashEvent:(SentryEvent *)event
+- (void)captureFatalEvent:(SentryEvent *)event
 {
-    [self captureCrashEvent:event withScope:self.scope];
+    [self captureFatalEvent:event withScope:self.scope];
 }
 
 /**
@@ -239,7 +239,7 @@ NS_ASSUME_NONNULL_BEGIN
  * currently no way to know which one belongs to the crashed session, so we send the session with
  * the first crash event we receive.
  */
-- (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope
+- (void)captureFatalEvent:(SentryEvent *)event withScope:(SentryScope *)scope
 {
     event.isFatalEvent = YES;
 
@@ -255,10 +255,10 @@ NS_ASSUME_NONNULL_BEGIN
     // users didn't start a manual session yet, and there is a previous crash on disk. In this case,
     // we just send the crash event.
     if (crashedSession != nil) {
-        [client captureCrashEvent:event withSession:crashedSession withScope:scope];
+        [client captureFatalEvent:event withSession:crashedSession withScope:scope];
         [fileManager deleteCrashedSession];
     } else {
-        [client captureCrashEvent:event withScope:scope];
+        [client captureFatalEvent:event withScope:scope];
     }
 }
 
@@ -285,14 +285,14 @@ NS_ASSUME_NONNULL_BEGIN
     // users didn't start a manual session yet, and there is a previous fatal app hang on disk. In
     // this case, we just send the fatal app hang event.
     if (abnormalSession == nil) {
-        [client captureCrashEvent:event withScope:self.scope];
+        [client captureFatalEvent:event withScope:self.scope];
         return;
     }
 
     // Users won't see the anr_foreground mechanism in the UI. The Sentry UI will present release
     // health and session statistics as app hangs.
     abnormalSession.abnormalMechanism = @"anr_foreground";
-    [client captureCrashEvent:event withSession:abnormalSession withScope:self.scope];
+    [client captureFatalEvent:event withSession:abnormalSession withScope:self.scope];
     [fileManager deleteAbnormalSession];
 }
 

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -227,7 +227,7 @@ NS_ASSUME_NONNULL_BEGIN
         event.debugMeta = [self extractDebugMetaFromMXCallStacks:callStackTree.callStacks];
 
         // The crash event can be way from the past. We don't want to impact the current session.
-        // Therefore we don't call captureCrashEvent.
+        // Therefore we don't call captureFatalEvent.
         [self captureEvent:event withDiagnosticJSON:diagnosticJSON];
     } else {
         for (SentryMXCallStack *callStack in callStackTree.callStacks) {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -274,14 +274,14 @@ static NSDate *_Nullable startTimestamp = nil;
     [SentrySDK startWithOptions:options];
 }
 
-+ (void)captureCrashEvent:(SentryEvent *)event
++ (void)captureFatalEvent:(SentryEvent *)event
 {
-    [SentrySDK.currentHub captureCrashEvent:event];
+    [SentrySDK.currentHub captureFatalEvent:event];
 }
 
-+ (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope
++ (void)captureFatalEvent:(SentryEvent *)event withScope:(SentryScope *)scope
 {
-    [SentrySDK.currentHub captureCrashEvent:event withScope:scope];
+    [SentrySDK.currentHub captureFatalEvent:event withScope:scope];
 }
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -86,7 +86,7 @@
             // We don't need to update the releaseName of the event to the previous app state as we
             // assume it's not a watchdog termination when the releaseName changed between app
             // starts.
-            [SentrySDK captureCrashEvent:event];
+            [SentrySDK captureFatalEvent:event];
         }
     }];
 #else // !SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryClient+Private.h
+++ b/Sources/Sentry/include/SentryClient+Private.h
@@ -36,9 +36,9 @@ NS_ASSUME_NONNULL_BEGIN
                      withScope:(SentryScope *)scope
         incrementSessionErrors:(SentrySession * (^)(void))sessionBlock;
 
-- (SentryId *)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope;
+- (SentryId *)captureFatalEvent:(SentryEvent *)event withScope:(SentryScope *)scope;
 
-- (SentryId *)captureCrashEvent:(SentryEvent *)event
+- (SentryId *)captureFatalEvent:(SentryEvent *)event
                     withSession:(SentrySession *)session
                       withScope:(SentryScope *)scope;
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -34,9 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (SentryClient *_Nullable)client;
 
-- (void)captureCrashEvent:(SentryEvent *)event;
+- (void)captureFatalEvent:(SentryEvent *)event;
 
-- (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope;
+- (void)captureFatalEvent:(SentryEvent *)event withScope:(SentryScope *)scope;
 
 #if SENTRY_HAS_UIKIT
 - (void)captureFatalAppHangEvent:(SentryEvent *)event;

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -20,9 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentrySDK ()
 
-+ (void)captureCrashEvent:(SentryEvent *)event;
++ (void)captureFatalEvent:(SentryEvent *)event;
 
-+ (void)captureCrashEvent:(SentryEvent *)event withScope:(SentryScope *)scope;
++ (void)captureFatalEvent:(SentryEvent *)event withScope:(SentryScope *)scope;
 
 #if SENTRY_HAS_UIKIT
 + (void)captureFatalAppHangEvent:(SentryEvent *)event;

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -437,7 +437,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker(enableV2: true)
         
         // Assert
-        try assertCrashEventWithScope { event, _ in
+        try assertFatalEventWithScope { event, _ in
             XCTAssertEqual(event?.level, SentryLevel.fatal)
             
             let ex = try XCTUnwrap(event?.exceptions?.first)
@@ -481,8 +481,8 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         // Assert
         let client = try XCTUnwrap(SentrySDK.currentHub().getClient() as? TestClient)
         
-        XCTAssertEqual(1, client.captureCrashEventWithSessionInvocations.count, "Wrong number of `Crashs` captured.")
-        let capture = try XCTUnwrap(client.captureCrashEventWithSessionInvocations.first)
+        XCTAssertEqual(1, client.captureFatalEventWithSessionInvocations.count, "Wrong number of `Crashs` captured.")
+        let capture = try XCTUnwrap(client.captureFatalEventWithSessionInvocations.first)
         let event = capture.event
         XCTAssertEqual(event.level, SentryLevel.fatal)
         

--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -98,10 +98,10 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
             // Almost always the AutoSessionTrackingIntegration is faster
             // than the SentryCrashIntegration creating the event from the
             // crash report on a background thread.
-            let crashEvent = Event()
-            crashEvent.level = SentryLevel.fatal
-            crashEvent.message = SentryMessage(formatted: "Crash for SentrySessionGeneratorTests")
-            SentrySDK.captureCrash(crashEvent)
+            let fatalEvent = Event()
+            fatalEvent.level = SentryLevel.fatal
+            fatalEvent.message = SentryMessage(formatted: "Crash for SentrySessionGeneratorTests")
+            SentrySDK.captureFatalEvent(fatalEvent)
         }
         sentryCrash.internalCrashedLastLaunch = false
         
@@ -118,7 +118,7 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
             autoSessionTrackingIntegration.install(with: options)
             goToForeground()
             
-            SentrySDK.captureCrash(TestData.oomEvent)
+            SentrySDK.captureFatalEvent(TestData.oomEvent)
         }
         fileManager.deleteAppState()
         #endif

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -505,7 +505,7 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func assertNoInitSessionSent() {
-        let eventWithSessions = fixture.client.captureCrashEventWithSessionInvocations.invocations.map({ triple in triple.session })
+        let eventWithSessions = fixture.client.captureFatalEventWithSessionInvocations.invocations.map({ triple in triple.session })
         let errorWithSessions = fixture.client.captureErrorWithSessionInvocations.invocations.map({ triple in triple.session })
         let exceptionWithSessions = fixture.client.captureExceptionWithSessionInvocations.invocations.map({ triple in triple.session })
         
@@ -519,7 +519,7 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func assertSessionsSent(count: Int) {
-        let eventWithSessions = fixture.client.captureCrashEventWithSessionInvocations.count
+        let eventWithSessions = fixture.client.captureFatalEventWithSessionInvocations.count
         let errorWithSessions = fixture.client.captureErrorWithSessionInvocations.count
         let exceptionWithSessions = fixture.client.captureExceptionWithSessionInvocations.count
         let sessions = fixture.client.captureSessionInvocations.count
@@ -551,9 +551,9 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.fileManager.storeCrashedSession(crashedSession)
         
         sut.start()
-        SentrySDK.captureCrash(Event())
+        SentrySDK.captureFatalEvent(Event())
         
-        if let session = fixture.client.captureCrashEventWithSessionInvocations.last?.session {
+        if let session = fixture.client.captureFatalEventWithSessionInvocations.last?.session {
             assertSession(session: session, started: sessionStartTime, status: SentrySessionStatus.crashed, duration: 5)
         } else {
             XCTFail("No session sent with event.")

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -92,7 +92,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
         XCTAssertEqual(newAttachmentList?.count, 0)
     }
 
-    func test_noViewHierarchy_CrashEvent() {
+    func test_noViewHierarchy_FatalEvent() {
         let sut = fixture.getSut()
         let event = Event(error: NSError(domain: "", code: -1))
         event.isFatalEvent = true

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -727,13 +727,13 @@ class SentryClientTest: XCTestCase {
         eventId.assertIsEmpty()
     }
 
-    func testCaptureCrashEventWithSession() throws {
+    func testCaptureFatalEventWithSession() throws {
         let scope = fixture.scope
         scope.setLevel(SentryLevel.info)
         let user = fixture.user
         scope.setUser(user)
 
-        let eventId = fixture.getSut().captureCrash(fixture.event, with: fixture.session, with: scope)
+        let eventId = fixture.getSut().captureFatalEvent(fixture.event, with: fixture.session, with: scope)
 
         eventId.assertIsNotEmpty()
         
@@ -751,7 +751,7 @@ class SentryClientTest: XCTestCase {
         event.threads = nil
         event.debugMeta = nil
         
-        fixture.getSut().captureCrash(event, with: fixture.session, with: fixture.scope)
+        fixture.getSut().captureFatalEvent(event, with: fixture.session, with: fixture.scope)
         
         XCTAssertNotNil(fixture.transportAdapter.sentEventsWithSessionTraceState.last)
         let args = try XCTUnwrap(fixture.transportAdapter.sentEventsWithSessionTraceState.last)
@@ -759,8 +759,8 @@ class SentryClientTest: XCTestCase {
         XCTAssertNil(args.event.debugMeta)
     }
     
-    func testCaptureCrashEvent() throws {
-        let eventId = fixture.getSut().captureCrash(fixture.event, with: fixture.scope)
+    func testCaptureFatalEvent() throws {
+        let eventId = fixture.getSut().captureFatalEvent(fixture.event, with: fixture.scope)
 
         eventId.assertIsNotEmpty()
         
@@ -789,7 +789,7 @@ class SentryClientTest: XCTestCase {
         ]
 
         // Act
-        _ = fixture.getSut().captureCrash(oomEvent, with: fixture.scope)
+        _ = fixture.getSut().captureFatalEvent(oomEvent, with: fixture.scope)
 
         // Assert
         let event = try lastSentEventWithAttachment()
@@ -807,7 +807,7 @@ class SentryClientTest: XCTestCase {
     func testCaptureOOMEvent_WithNoContext_ContextNotModified() throws {
         let oomEvent = TestData.oomEvent
         
-        _ = fixture.getSut().captureCrash(oomEvent, with: Scope())
+        _ = fixture.getSut().captureFatalEvent(oomEvent, with: Scope())
 
         let actual = try lastSentEvent()
         XCTAssertEqual(oomEvent.eventId, actual.eventId)
@@ -819,14 +819,14 @@ class SentryClientTest: XCTestCase {
         let scope = Scope()
         scope.setContext(value: ["some": "thing"], key: "any")
         
-        _ = fixture.getSut().captureCrash(oomEvent, with: scope)
+        _ = fixture.getSut().captureFatalEvent(oomEvent, with: scope)
 
         let actual = try lastSentEvent()
         XCTAssertEqual(oomEvent.eventId, actual.eventId)
         XCTAssertEqual(oomEvent.context?.count, actual.context?.count)
     }
 
-    func testCaptureCrashEventWithSession_DoesntApplyCurrentScope() throws {
+    func testCaptureFatalEventWithSession_DoesntApplyCurrentScope() throws {
         // Arrange
         let scope = fixture.scope
         scope.setLevel(SentryLevel.info)
@@ -835,7 +835,7 @@ class SentryClientTest: XCTestCase {
         scope.setUser(user)
 
         // Act
-        let eventId = fixture.getSut().captureCrash(fixture.eventWithCrash, with: fixture.session, with: scope)
+        let eventId = fixture.getSut().captureFatalEvent(fixture.eventWithCrash, with: fixture.session, with: scope)
 
         // Assert
         eventId.assertIsNotEmpty()
@@ -848,14 +848,14 @@ class SentryClientTest: XCTestCase {
         XCTAssertEqual(event.context?.count, expectedContext.count)
     }
 
-    func testCaptureCrashEventWithSession_ScopeWithSpan_NotAppliedToCrashEvent() throws {
+    func testCaptureFatalEventWithSession_ScopeWithSpan_NotAppliedToFatalEvent() throws {
         // Arrange
         let scope = fixture.scope
         scope.span = SentryTracer(transactionContext: TransactionContext(name: "", operation: ""), hub: nil)
         let event = fixture.eventWithCrash
 
         // Act
-        let eventId = fixture.getSut().captureCrash(event, with: fixture.session, with: scope)
+        let eventId = fixture.getSut().captureFatalEvent(event, with: fixture.session, with: scope)
 
         // Assert
         eventId.assertIsNotEmpty()
@@ -869,7 +869,7 @@ class SentryClientTest: XCTestCase {
         event.threads = nil
         event.debugMeta = nil
         
-        fixture.getSut().captureCrash(event, with: fixture.scope)
+        fixture.getSut().captureFatalEvent(event, with: fixture.scope)
         
         let actual = try lastSentEventWithAttachment()
         XCTAssertNil(actual.threads)
@@ -883,7 +883,7 @@ class SentryClientTest: XCTestCase {
         event.context = ["my": expectedMyContext]
 
         // Act
-        fixture.getSut().captureCrash(event, with: fixture.scope)
+        fixture.getSut().captureFatalEvent(event, with: fixture.scope)
 
         // Assert
         let actual = try lastSentEventWithAttachment()
@@ -1111,7 +1111,7 @@ class SentryClientTest: XCTestCase {
             session
         }
             .assertIsNotEmpty()
-        fixture.getSut().captureCrash(fixture.event, with: session, with: Scope())
+        fixture.getSut().captureFatalEvent(fixture.event, with: session, with: Scope())
             .assertIsNotEmpty()
         
         // No sessions sent
@@ -1283,7 +1283,7 @@ class SentryClientTest: XCTestCase {
         _ = SentryEnvelope(event: Event())
         let eventId = fixture.getSut(configureOptions: { options in
             options.dsn = nil
-        }).captureCrash(Event(), with: fixture.session, with: fixture.scope)
+        }).captureFatalEvent(Event(), with: fixture.session, with: fixture.scope)
 
         eventId.assertIsEmpty()
         assertNothingSent()
@@ -1810,7 +1810,7 @@ class SentryClientTest: XCTestCase {
             options.onCrashedLastRun = { _ in
                 onCrashedLastRunCalled = true
             }
-        }).captureCrash(event, with: fixture.session, with: fixture.scope)
+        }).captureFatalEvent(event, with: fixture.session, with: fixture.scope)
         
         XCTAssertTrue(onCrashedLastRunCalled)
     }
@@ -1826,7 +1826,7 @@ class SentryClientTest: XCTestCase {
             options.onCrashedLastRun = { _ in
                 onCrashedLastRunCalled = true
             }
-        }).captureCrash(event, with: fixture.session, with: fixture.scope)
+        }).captureFatalEvent(event, with: fixture.session, with: fixture.scope)
         
         XCTAssertFalse(onCrashedLastRunCalled)
     }
@@ -1842,15 +1842,15 @@ class SentryClientTest: XCTestCase {
             }
         })
         
-        client.captureCrash(event, with: fixture.scope)
-        client.captureCrash(TestData.event, with: fixture.scope)
+        client.captureFatalEvent(event, with: fixture.scope)
+        client.captureFatalEvent(TestData.event, with: fixture.scope)
         
         XCTAssertTrue(onCrashedLastRunCalled)
     }
     
     func testOnCrashedLastRun_WithoutCallback_DoesNothing() {
         let client = fixture.getSut()
-        client.captureCrash(TestData.event, with: fixture.scope)
+        client.captureFatalEvent(TestData.event, with: fixture.scope)
     }
     
     func testOnCrashedLastRun_CallingCaptureCrash_OnlyInvokeCallbackOnce() {
@@ -1866,9 +1866,9 @@ class SentryClientTest: XCTestCase {
                 captureCrash!()
             }
         })
-        captureCrash = { client.captureCrash(event, with: self.fixture.scope) }
+        captureCrash = { client.captureFatalEvent(event, with: self.fixture.scope) }
         
-        client.captureCrash(event, with: fixture.scope)
+        client.captureFatalEvent(event, with: fixture.scope)
         
         wait(for: [callbackExpectation], timeout: 0.1)
     }
@@ -2091,7 +2091,7 @@ class SentryClientTest: XCTestCase {
         event.isFatalEvent = true
         let scope = Scope()
         event.context = ["replay": ["replay_id": "someReplay"]]
-        sut.captureCrash(event, with: SentrySession(releaseName: "", distinctId: ""), with: scope)
+        sut.captureFatalEvent(event, with: SentrySession(releaseName: "", distinctId: ""), with: scope)
         XCTAssertEqual(scope.replayId, "someReplay")
     }
 }

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -23,7 +23,7 @@ class SentryCrashInstallationReporterTests: XCTestCase {
             XCTAssertEqual(filteredReports?.count, 1)
         }
         
-        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 1)
+        XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 1)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
     }
     
@@ -39,10 +39,10 @@ class SentryCrashInstallationReporterTests: XCTestCase {
             XCTAssertEqual(filteredReports?.count, 1)
         }
         
-        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 1)
+        XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 1)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
         
-        let event = self.testClient.captureCrashEventInvocations.last?.event
+        let event = self.testClient.captureFatalEventInvocations.last?.event
         XCTAssertEqual(event?.context?["device"]?["free_storage"] as? Int, 278_914_420_736)
         // total_storage got converted to storage_size
         XCTAssertEqual(event?.context?["device"]?["storage_size"] as? Int, 994_662_584_320)
@@ -57,10 +57,10 @@ class SentryCrashInstallationReporterTests: XCTestCase {
             XCTAssertEqual(filteredReports?.count, 1)
         }
         
-        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 1)
+        XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 1)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
         
-        let event = self.testClient.captureCrashEventInvocations.last?.event
+        let event = self.testClient.captureFatalEventInvocations.last?.event
         XCTAssertNil(event?.context?["device"])
         XCTAssertEqual(event?.context?["app"]?["app_name"] as? String, "iOS-Swift")
     }
@@ -74,7 +74,7 @@ class SentryCrashInstallationReporterTests: XCTestCase {
             XCTAssertEqual(filteredReports?.count, 0)
         }
         
-        XCTAssertEqual(self.testClient.captureCrashEventInvocations.count, 0)
+        XCTAssertEqual(self.testClient.captureFatalEventInvocations.count, 0)
         XCTAssertEqual(sentrycrash_getReportCount(), 0)
     }
     

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
@@ -40,7 +40,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
         
         let reportSink = fixture.sut
         reportSink.filterReports([report]) { _, _, _ in
-            self.assertCrashEventWithScope { _, scope in
+            self.assertFatalEventWithScope { _, scope in
                 let data = scope?.serialize()
                 XCTAssertEqual(data?["environment"] as? String, "testFilterReports_CopyHubScope")
                 expect.fulfill()
@@ -115,7 +115,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
     private func filterReportWithAttachment() {
         let report = ["attachments": ["file.png"]]
         fixture.sut.filterReports([report]) { _, _, _ in
-            self.assertCrashEventWithScope { _, scope in
+            self.assertFatalEventWithScope { _, scope in
                 XCTAssertEqual(scope?.attachments.count, 1)
             }
         }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -833,7 +833,7 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(0, fixture.client.captureExceptionWithScopeInvocations.count)
     }
     
-    func testCaptureCrashEvent_CrashedSessionExists() {
+    func testCaptureFatalEvent_CrashedSessionExists() {
         sut = fixture.getSut(fixture.options, fixture.scope)
         givenCrashedSession()
         
@@ -841,15 +841,15 @@ class SentryHubTests: XCTestCase {
         
         let environment = "test"
         sut.configureScope { $0.setEnvironment(environment) }
-        sut.captureCrash(fixture.event)
+        sut.captureFatalEvent(fixture.event)
         assertEventSentWithSession(scopeEnvironment: environment)
         
         // Make sure further crash events are sent
-        sut.captureCrash(fixture.event)
-        assertCrashEventSent()
+        sut.captureFatalEvent(fixture.event)
+        assertFatalEventSent()
     }
     
-    func testCaptureCrashEvent_ManualSessionTracking_CrashedSessionExists() {
+    func testCaptureFatalEvent_ManualSessionTracking_CrashedSessionExists() {
         givenAutoSessionTrackingDisabled()
         
         givenCrashedSession()
@@ -858,51 +858,51 @@ class SentryHubTests: XCTestCase {
         
         let environment = "test"
         sut.configureScope { $0.setEnvironment(environment) }
-        sut.captureCrash(fixture.event)
+        sut.captureFatalEvent(fixture.event)
         
         assertEventSentWithSession(scopeEnvironment: environment)
         
         // Make sure further crash events are sent
-        sut.captureCrash(fixture.event)
-        assertCrashEventSent()
+        sut.captureFatalEvent(fixture.event)
+        assertFatalEventSent()
     }
     
-    func testCaptureCrashEvent_CrashedSessionDoesNotExist() {
+    func testCaptureFatalEvent_CrashedSessionDoesNotExist() {
         sut.startSession() // there is already an existing session
-        sut.captureCrash(fixture.event)
+        sut.captureFatalEvent(fixture.event)
         
         assertNoCrashedSessionSent()
-        assertCrashEventSent()
+        assertFatalEventSent()
     }
     
     /**
      * When autoSessionTracking is just enabled and there is a previous crash on the disk there is no session on the disk.
      */
-    func testCaptureCrashEvent_CrashExistsButNoSessionExists() {
-        sut.captureCrash(fixture.event)
+    func testCaptureFatalEvent_CrashExistsButNoSessionExists() {
+        sut.captureFatalEvent(fixture.event)
         
-        assertCrashEventSent()
+        assertFatalEventSent()
     }
     
-    func testCaptureCrashEvent_WithoutExistingSessionAndAutoSessionTrackingEnabled() {
+    func testCaptureFatalEvent_WithoutExistingSessionAndAutoSessionTrackingEnabled() {
         givenAutoSessionTrackingDisabled()
         
-        sut.captureCrash(fixture.event)
+        sut.captureFatalEvent(fixture.event)
         
-        assertCrashEventSent()
+        assertFatalEventSent()
     }
     
-    func testCaptureCrashEvent_ClientIsNil() {
+    func testCaptureFatalEvent_ClientIsNil() {
         sut = fixture.getSut()
         sut.bindClient(nil)
         
         givenCrashedSession()
-        sut.captureCrash(fixture.event)
+        sut.captureFatalEvent(fixture.event)
         
         assertNoEventsSent()
     }
     
-    func testCaptureCrashEvent_ClientHasNoReleaseName() {
+    func testCaptureFatalEvent_ClientHasNoReleaseName() {
         sut = fixture.getSut()
         let options = fixture.options
         options.releaseName = nil
@@ -910,7 +910,7 @@ class SentryHubTests: XCTestCase {
         sut.bindClient(client)
         
         givenCrashedSession()
-        sut.captureCrash(fixture.event)
+        sut.captureFatalEvent(fixture.event)
         
         assertNoEventsSent()
     }
@@ -958,7 +958,7 @@ class SentryHubTests: XCTestCase {
         
         // Assert
         assertNoAbnormalSessionSent()
-        assertCrashEventSent()
+        assertFatalEventSent()
     }
     
     /**
@@ -969,7 +969,7 @@ class SentryHubTests: XCTestCase {
         sut.captureFatalAppHang(fixture.event)
         
         // Assert
-        assertCrashEventSent()
+        assertFatalEventSent()
     }
     
     func testCaptureFatalAppHangEvent_WithoutExistingSessionAndAutoSessionTrackingEnabled() {
@@ -980,7 +980,7 @@ class SentryHubTests: XCTestCase {
         sut.captureFatalAppHang(fixture.event)
         
         // Assert
-        assertCrashEventSent()
+        assertFatalEventSent()
     }
     
     func testCaptureFatalAppHangEvent_ClientIsNil() {
@@ -1395,8 +1395,8 @@ class SentryHubTests: XCTestCase {
     
     private func assertNoEventsSent() {
         XCTAssertEqual(0, fixture.client.captureEventInvocations.count)
-        XCTAssertEqual(0, fixture.client.captureCrashEventWithSessionInvocations.count)
-        XCTAssertEqual(0, fixture.client.captureCrashEventInvocations.count)
+        XCTAssertEqual(0, fixture.client.captureFatalEventWithSessionInvocations.count)
+        XCTAssertEqual(0, fixture.client.captureFatalEventInvocations.count)
     }
     
     private func assertEventSent() {
@@ -1406,15 +1406,15 @@ class SentryHubTests: XCTestCase {
         XCTAssertFalse(arguments.first?.event.isFatalEvent ?? true)
     }
     
-    private func assertCrashEventSent() {
-        let arguments = fixture.client.captureCrashEventInvocations
+    private func assertFatalEventSent() {
+        let arguments = fixture.client.captureFatalEventInvocations
         XCTAssertEqual(1, arguments.count)
         XCTAssertEqual(fixture.event, arguments.first?.event)
         XCTAssertTrue(arguments.first?.event.isFatalEvent ?? false)
     }
     
     private func assertEventSentWithSession(scopeEnvironment: String, sessionStatus: SentrySessionStatus = .crashed, abnormalMechanism: String? = nil) {
-        let arguments = fixture.client.captureCrashEventWithSessionInvocations
+        let arguments = fixture.client.captureFatalEventWithSessionInvocations
         XCTAssertEqual(1, arguments.count)
         
         let argument = arguments.first

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -53,14 +53,14 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         try callback(capture?.event, capture?.scope, capture?.additionalEnvelopeItems)
     }
     
-    func assertCrashEventWithScope(_ callback: (Event?, Scope?) throws -> Void) rethrows {
+    func assertFatalEventWithScope(_ callback: (Event?, Scope?) throws -> Void) rethrows {
         guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }
         
-        XCTAssertEqual(1, client.captureCrashEventInvocations.count, "Wrong number of `Crashs` captured.")
-        let capture = client.captureCrashEventInvocations.first
+        XCTAssertEqual(1, client.captureFatalEventInvocations.count, "Wrong number of `Crashs` captured.")
+        let capture = client.captureFatalEventInvocations.first
         try callback(capture?.event, capture?.scope)
     }
     

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -226,16 +226,16 @@ class SentrySDKTests: XCTestCase {
         XCTAssertFalse(SentrySDK.detectedStartUpCrash)
     }
     
-    func testCaptureCrashEvent() {
+    func testCaptureFatalEvent() {
         let hub = TestHub(client: nil, andScope: nil)
         SentrySDK.setCurrentHub(hub)
         
         let event = fixture.event
-        SentrySDK.captureCrash(event)
+        SentrySDK.captureFatalEvent(event)
     
-        XCTAssertEqual(1, hub.sentCrashEvents.count)
-        XCTAssertEqual(event.message, hub.sentCrashEvents.first?.message)
-        XCTAssertEqual(event.eventId, hub.sentCrashEvents.first?.eventId)
+        XCTAssertEqual(1, hub.sentFatalEvents.count)
+        XCTAssertEqual(event.message, hub.sentFatalEvents.first?.message)
+        XCTAssertEqual(event.eventId, hub.sentFatalEvents.first?.eventId)
     }
     
     func testCaptureEvent() {


### PR DESCRIPTION



## :scroll: Description

The captureCrashEvent is also used to capture watchdog terminations and fatal app hangs. Therefore, we rename it to captureFatalEvent to clearly communicate it's about fatal events and not only crashes.

#skip-changelog

## :bulb: Motivation and Context

Fixes GH-4936

## :green_heart: How did you test it?
Unit tests still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
