### PR TITLE
chore: Remove next steps from pull_request_template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,5 +20,3 @@ You have to check all boxes before merging:
 - [ ] Review from the native team if needed.
 - [ ] No breaking change or entry added to the changelog.
 - [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
-
-## :crystal_ball: Next steps


### PR DESCRIPTION
We hardly ever put info for next steps. Let's remove it.

#skip-changelog