### PR TITLE
impr: Remove char limit of 8192 for SentryMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Continuous profile stop requests are cancelled by subsequent timely calls to start (#4993)
 
+### Improvements
+
+- Remove SDK side character limit of 8192 for SentryMessage (#5005) Now, the backend handles the character limit, which has the advantage of showing in the UI when the message was truncated.
+
 ## 8.48.0
 
 ### Features

--- a/Sources/Sentry/Public/SentryMessage.h
+++ b/Sources/Sentry/Public/SentryMessage.h
@@ -20,7 +20,7 @@ SENTRY_NO_INIT
 /**
  * Returns a @c SentryMessage with setting formatted.
  * @param formatted The fully formatted message. If missing, Sentry will try to interpolate the
- * message. It must not exceed 8192 characters. Longer messages will be truncated.
+ * message. The backend will truncate messages longer than 8192 characters.
  */
 - (instancetype)initWithFormatted:(NSString *)formatted;
 

--- a/Sources/Sentry/SentryMessage.m
+++ b/Sources/Sentry/SentryMessage.m
@@ -2,29 +2,19 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-const NSUInteger MAX_STRING_LENGTH = 8192;
-
 @implementation SentryMessage
 
 - (instancetype)initWithFormatted:(NSString *)formatted
 {
     if (self = [super init]) {
-        if (nil != formatted && formatted.length > MAX_STRING_LENGTH) {
-            _formatted = [formatted substringToIndex:MAX_STRING_LENGTH];
-        } else {
-            _formatted = formatted;
-        }
+        _formatted = formatted;
     }
     return self;
 }
 
 - (void)setMessage:(NSString *_Nullable)message
 {
-    if (nil != message && message.length > MAX_STRING_LENGTH) {
-        _message = [message substringToIndex:MAX_STRING_LENGTH];
-    } else {
-        _message = message;
-    }
+    _message = message;
 }
 
 - (NSDictionary<NSString *, id> *)serialize

--- a/Tests/SentryTests/Protocol/SentryMessageTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMessageTests.swift
@@ -17,31 +17,32 @@ class SentryMessageTests: XCTestCase {
             message.message = "A message %s %s"
             message.params = ["my", "params"]
         }
-        
     }
     
     private let fixture = Fixture()
     
-    func testTruncateFormatted() {
+    func testFormatted_NotTruncated() {
         let message = SentryMessage(formatted: "aaaaa")
         XCTAssertEqual(5, message.formatted.count)
         
         XCTAssertEqual(fixture.stringMaxCount, SentryMessage(formatted: fixture.maximumCount).formatted.count)
-        
-        XCTAssertEqual(fixture.stringMaxCount, SentryMessage(formatted: fixture.tooLong).formatted.count)
+
+        // Let Relay do the truncation
+        XCTAssertEqual(fixture.tooLong.count, SentryMessage(formatted: fixture.tooLong).formatted.count)
     }
     
-    func testTruncateMessage() {
+    func testMessage_NotTruncated() {
         let message = SentryMessage(formatted: "")
         message.message = "aaaaa %s"
-        
+
         XCTAssertEqual(8, message.message?.count)
-        
+
         message.message = fixture.maximumCount
         XCTAssertEqual(fixture.stringMaxCount, message.message?.count)
-        
+
+        // Let Relay do the truncation
         message.message = fixture.tooLong
-        XCTAssertEqual(fixture.stringMaxCount, message.message?.count)
+        XCTAssertEqual(fixture.tooLong.count, message.message?.count)
     }
     
     func testSerialize() {


### PR DESCRIPTION




## :scroll: Description

Let Relay truncate the max char length. The benefit is that users see that the message was truncated.

## :bulb: Motivation and Context

Fixes GH-5004

## :green_heart: How did you test it?

Unit tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

## :crystal_ball: Next steps
