### PR TITLE
ci: Archive crash logs for UI tests critical

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -92,3 +92,11 @@ jobs:
         with:
           name: maestro-logs-${{matrix.device}}-${{matrix.os-version}}
           path: ${{env.MAESTRO_LOGS_PATH}}
+      
+      - name: Archiving Crash Logs
+        uses: actions/upload-artifact@v4
+        if: ${{  failure() || cancelled() }}
+        with:
+          name: crash-logs-${{matrix.device}}-${{matrix.os-version}}
+          path: |
+            ~/Library/Logs/DiagnosticReports/**

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -95,7 +95,7 @@ jobs:
       
       - name: Archiving Crash Logs
         uses: actions/upload-artifact@v4
-        if: ${{  failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         with:
           name: crash-logs-${{matrix.device}}-${{matrix.os-version}}
           path: |


### PR DESCRIPTION
Archive the crash logs for the critical UI tests, so we know what happened when the app crashes during the test run.

#skip-changelog