### PR TITLE
ci: Use installed simulators for critical UI tests

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -51,12 +51,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
+
+          # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see 
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
           - runs-on: macos-13
             xcode: "14.3.1"
             device: "iPhone 14"
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
+          # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see 
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
           - runs-on: macos-15
             xcode: "16.2"
             device: "iPhone 16"

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -72,6 +72,7 @@ jobs:
 
       - name: Run Maestro Flows
         run: |
+          maestro start-device --platform ios
           xcrun simctl install booted ${{env.APP_PATH}}
 
           maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -72,11 +72,14 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
+      - name: Boot Simulator
+        run: xcrun simctl boot "${{matrix.device}}"
+
+      - name: Install App
+        run: xcrun simctl install booted ${{env.APP_PATH}}
+
       - name: Run Maestro Flows
         run: |
-          xcrun simctl boot "${{matrix.device}}"
-          xcrun simctl install booted ${{env.APP_PATH}}
-
           maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}
 
       - name: Store Maestro Logs

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -53,11 +53,13 @@ jobs:
         include:
           - runs-on: macos-13
             xcode: "14.3.1"
+            device: "iPhone 14"
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           - runs-on: macos-15
             xcode: "16.2"
+            device: "iPhone 16"
 
     steps:
       - uses: actions/checkout@v4
@@ -72,7 +74,7 @@ jobs:
 
       - name: Run Maestro Flows
         run: |
-          maestro start-device --platform ios
+          xcrun simctl boot "${{matrix.device}}"
           xcrun simctl install booted ${{env.APP_PATH}}
 
           maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -34,7 +34,7 @@ jobs:
           path: TestSamples/SwiftUITestSample/DerivedData/Build/Products/Debug-iphonesimulator/SwiftUITestSample.app
 
   run-tests:
-    name: Test iOS ${{matrix.os-version}} on ${{matrix.device}} Simulator
+    name: Test iOS on Xcode ${{matrix.xcode}}
     needs: [build-sample]
     runs-on: ${{matrix.runs-on}}
     env:
@@ -53,21 +53,15 @@ jobs:
         include:
           - runs-on: macos-13
             xcode: "14.3.1"
-            device: "iPhone 14"
-            os-version: "16.4"
-            force-sim-runtime: true
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           - runs-on: macos-15
             xcode: "16.2"
-            device: "iPhone 16"
-            os-version: "18.2"
 
     steps:
       - uses: actions/checkout@v4
-      - name: Create ${{matrix.device}} (${{matrix.os-version}}) Simulator using Xcode ${{matrix.xcode}}
-        run: ./scripts/create-simulator.sh "${{matrix.xcode}}" "${{matrix.os-version}}" "${{matrix.device}}" "${{matrix.force-sim-runtime}}"
+
       - name: Install tooling
         run: make init-ci-test
 
@@ -82,13 +76,9 @@ jobs:
 
           maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}
 
-      - name: Delete Simulator
-        if: always()
-        run: ./scripts/delete-simulator.sh
-
       - name: Store Maestro Logs
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: maestro-logs-${{matrix.device}}-${{matrix.os-version}}
+          name: maestro-logs-${{matrix.xcode}}
           path: ${{env.MAESTRO_LOGS_PATH}}


### PR DESCRIPTION
Stop creating simulators, which can take around 5 minutes, and use the already installed simulators on the GH action.

#skip-changelog