### PR TITLE
ci: Use installed simulators for UI tests

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 15.2; see 
+          # As of 25th March 2025, the preinstalled iOS simulator version is 17.2 for macOS 13 and Xcode 15.2; see 
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
           - runs-on: macos-13
             xcode: "15.2"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -107,7 +107,7 @@ jobs:
             ./fastlane/test_output/**
 
   ui-tests-swift:
-    name: UI Tests for iOS-Swift with Xcode ${{matrix.xcode}}s
+    name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}}
     runs-on: ${{matrix.runs-on}}
     strategy:
       fail-fast: false

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -107,7 +107,7 @@ jobs:
             ./fastlane/test_output/**
 
   ui-tests-swift:
-    name: UI Tests for iOS-Swift ${{matrix.device}} Simulator
+    name: UI Tests for iOS-Swift with Xcode ${{matrix.xcode}}s
     runs-on: ${{matrix.runs-on}}
     strategy:
       fail-fast: false
@@ -115,21 +115,16 @@ jobs:
         include:
           - runs-on: macos-13
             xcode: "15.2"
-            device: "iPhone 14 (16.4)"
 
           - runs-on: macos-14
             xcode: "15.4"
-            device: "iPhone 15 (17.2)"
+            
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh ${{matrix.xcode}}
 
-      - name: Create iOS 16.4 simulator
-        if: ${{ matrix.device == 'iPhone 14 (16.4)' }}
-        run: ./scripts/create-simulator.sh 14.3.1 16.4 "iPhone 14" true
-
       - name: Run Fastlane
-        run: fastlane ui_tests_ios_swift device:"${{matrix.device}}"
+        run: fastlane ui_tests_ios_swift
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@97744eca465b8df9e6e33271cb155003f85327f1 # v5.5.0
@@ -144,14 +139,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: ui-tests-ios-swift-${{matrix.device}}.xcresult
+          name: ui-tests-ios-swift-${{matrix.xcode}}.xcresult
           path: fastlane/test_results/ui-tests-ios-swift.xcresult
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{  failure() || cancelled() }}
         with:
-          name: ui-tests-ios-swift-raw-logs-${{matrix.device}}
+          name: ui-tests-ios-swift-raw-logs-${{matrix.xcode}}
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -113,9 +113,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 15.2; see 
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
           - runs-on: macos-13
             xcode: "15.2"
 
+          # As of 25th March 2025, the default iOS simulator version is 17.5 for macOS 14 and Xcode 15.4; see 
+          # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-sdks
           - runs-on: macos-14
             xcode: "15.4"
             

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -113,10 +113,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # As of 25th March 2025, the preinstalled iOS simulator version is 17.2 for macOS 13 and Xcode 15.2; see 
+          # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see 
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
           - runs-on: macos-13
-            xcode: "15.2"
+            xcode: "14.3.1"
 
           # As of 25th March 2025, the default iOS simulator version is 17.5 for macOS 14 and Xcode 15.4; see 
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-sdks


### PR DESCRIPTION
Stop creating simulators which can take around 5 minutes and use the already installed simulators on the GH action.

#skip-changelog