### PR TITLE
tests: Fix broken ANRTracking tests

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -526,7 +526,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         sut.pauseAppHangTracking()
 
         // Assert
-        try assertCrashEventWithScope { event, _ in
+        try assertFatalEventWithScope { event, _ in
             XCTAssertEqual(event?.level, SentryLevel.fatal)
 
             let ex = try XCTUnwrap(event?.exceptions?.first)


### PR DESCRIPTION
The feature branch didn't include the refactoring of renaming assertCrashEventWithScope to
assertFatalEventWithScope. This is fixed now.

#skip-changelog