### PR TITLE
fix(session-replay): improve multi-threading of session replay processing

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -19,7 +19,7 @@ struct SentrySDKWrapper {
         options.debug = true
         
         if #available(iOS 16.0, *), enableSessionReplay {
-            options.sessionReplay = SentryReplayOptions(sessionSampleRate: 0, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
+            options.sessionReplay = SentryReplayOptions(sessionSampleRate: 1.0, onErrorSampleRate: 1, maskAllText: true, maskAllImages: true)
             options.sessionReplay.quality = .high
         }
         

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -819,6 +819,8 @@
 		D43B26D62D70964C007747FD /* SentrySpanOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = D43B26D52D709648007747FD /* SentrySpanOperation.m */; };
 		D43B26D82D70A550007747FD /* SentryTraceOrigin.m in Sources */ = {isa = PBXBuildFile; fileRef = D43B26D72D70A54A007747FD /* SentryTraceOrigin.m */; };
 		D43B26DA2D70A612007747FD /* SentrySpanDataKey.m in Sources */ = {isa = PBXBuildFile; fileRef = D43B26D92D70A60E007747FD /* SentrySpanDataKey.m */; };
+		D451ED5D2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D451ED5C2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift */; };
+		D451ED5F2D92ECDE00C9BEA8 /* SentryReplayFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = D451ED5E2D92ECDE00C9BEA8 /* SentryReplayFrame.swift */; };
 		D456B4322D706BDF007068CB /* SentrySpanOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = D456B4312D706BDD007068CB /* SentrySpanOperation.h */; };
 		D456B4362D706BF2007068CB /* SentryTraceOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = D456B4352D706BEE007068CB /* SentryTraceOrigin.h */; };
 		D456B4382D706BFE007068CB /* SentrySpanDataKey.h in Headers */ = {isa = PBXBuildFile; fileRef = D456B4372D706BFB007068CB /* SentrySpanDataKey.h */; };
@@ -1977,6 +1979,8 @@
 		D43B26D52D709648007747FD /* SentrySpanOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpanOperation.m; sourceTree = "<group>"; };
 		D43B26D72D70A54A007747FD /* SentryTraceOrigin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTraceOrigin.m; sourceTree = "<group>"; };
 		D43B26D92D70A60E007747FD /* SentrySpanDataKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpanDataKey.m; sourceTree = "<group>"; };
+		D451ED5C2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryOnDemandReplayError.swift; sourceTree = "<group>"; };
+		D451ED5E2D92ECDE00C9BEA8 /* SentryReplayFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReplayFrame.swift; sourceTree = "<group>"; };
 		D456B4312D706BDD007068CB /* SentrySpanOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpanOperation.h; path = include/SentrySpanOperation.h; sourceTree = "<group>"; };
 		D456B4352D706BEE007068CB /* SentryTraceOrigin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTraceOrigin.h; path = include/SentryTraceOrigin.h; sourceTree = "<group>"; };
 		D456B4372D706BFB007068CB /* SentrySpanDataKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpanDataKey.h; path = include/SentrySpanDataKey.h; sourceTree = "<group>"; };
@@ -4259,6 +4263,8 @@
 				D8CAC02A2BA0663E00E38F34 /* SentryReplayOptions.swift */,
 				D8CAC02B2BA0663E00E38F34 /* SentryVideoInfo.swift */,
 				D802994D2BA836EF000F0081 /* SentryOnDemandReplay.swift */,
+				D451ED5E2D92ECDE00C9BEA8 /* SentryReplayFrame.swift */,
+				D451ED5C2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift */,
 				D802994F2BA83A88000F0081 /* SentryPixelBuffer.swift */,
 				D8AFC03C2BDA79BF00118BE1 /* SentryReplayVideoMaker.swift */,
 				D8F67B1A2BE9728600C9197B /* SentrySRDefaultBreadcrumbConverter.swift */,
@@ -5028,6 +5034,7 @@
 				7B30B67E26527894006B2752 /* SentryDisplayLinkWrapper.m in Sources */,
 				63FE711D20DA4C1000CDBAE8 /* SentryCrashCPU_arm64.c in Sources */,
 				844EDC77294144DB00C86F34 /* SentrySystemWrapper.mm in Sources */,
+				D451ED5F2D92ECDE00C9BEA8 /* SentryReplayFrame.swift in Sources */,
 				D8739CF92BECFFB5007D2F66 /* SentryTransactionNameSource.swift in Sources */,
 				630435FF1EBCA9D900C4D3FA /* SentryNSURLRequest.m in Sources */,
 				6281C5722D3E4F12009D0978 /* DecodeArbitraryData.swift in Sources */,
@@ -5120,6 +5127,7 @@
 				D83D079C2B7F9D1C00CC9674 /* SentryMsgPackSerializer.m in Sources */,
 				7B6D1261265F784000C9BE4B /* PrivateSentrySDKOnly.mm in Sources */,
 				63BE85711ECEC6DE00DC44F5 /* SentryDateUtils.m in Sources */,
+				D451ED5D2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift in Sources */,
 				D4E829D82D75E57900D375AD /* SentryMaskRenderer.swift in Sources */,
 				7BD4BD4927EB2A5D0071F4FF /* SentryDiscardedEvent.m in Sources */,
 				628308612D50ADAC00EAEF77 /* SentryRequestCodable.swift in Sources */,

--- a/Sources/Sentry/SentryDispatchQueueWrapper.m
+++ b/Sources/Sentry/SentryDispatchQueueWrapper.m
@@ -105,6 +105,14 @@ NS_ASSUME_NONNULL_BEGIN
     return dispatch_block_create(0, block);
 }
 
++ (SentryDispatchQueueWrapper *)createBackgroundDispatchQueueWithName:(const char *)name
+                                                     relativePriority:(int)relativePriority
+
+{
+    dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
+        DISPATCH_QUEUE_SERIAL, QOS_CLASS_BACKGROUND, relativePriority);
+    return [[SentryDispatchQueueWrapper alloc] initWithName:name attributes:attributes];
+}
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryDispatchQueueWrapper.h
+++ b/Sources/Sentry/include/SentryDispatchQueueWrapper.h
@@ -32,6 +32,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (nullable dispatch_block_t)createDispatchBlock:(void (^)(void))block;
 
++ (SentryDispatchQueueWrapper *)createBackgroundDispatchQueueWithName:(const char *)name
+                                                     relativePriority:(int)relativePriority;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -7,27 +7,17 @@ import CoreGraphics
 import Foundation
 import UIKit
 
-struct SentryReplayFrame {
-    let imagePath: String
-    let time: Date
-    let screenName: String?
-}
-
-enum SentryOnDemandReplayError: Error {
-    case cantReadVideoSize
-    case cantCreatePixelBuffer
-    case errorRenderingVideo
-}
-
+// swiftlint:disable type_body_length
 @objcMembers
 class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         
     private let _outputPath: String
     private var _totalFrames = 0
     private let dateProvider: SentryCurrentDateProvider
-    private let workingQueue: SentryDispatchQueueWrapper
+    private let processingQueue: SentryDispatchQueueWrapper
+    private let assetWorkerQueue: SentryDispatchQueueWrapper
     private var _frames = [SentryReplayFrame]()
-    
+
     #if SENTRY_TEST || SENTRY_TEST_CI || DEBUG
     //This is exposed only for tests, no need to make it thread safe.
     var frames: [SentryReplayFrame] {
@@ -40,44 +30,57 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     var frameRate = 1
     var cacheMaxSize = UInt.max
         
-    init(outputPath: String, workingQueue: SentryDispatchQueueWrapper, dateProvider: SentryCurrentDateProvider) {
+    init(
+        outputPath: String,
+        processingQueue: SentryDispatchQueueWrapper,
+        assetWorkerQueue: SentryDispatchQueueWrapper,
+        dateProvider: SentryCurrentDateProvider
+    ) {
+        assert(processingQueue != assetWorkerQueue, "Processing and asset worker queue must not be the same.")
         self._outputPath = outputPath
         self.dateProvider = dateProvider
-        self.workingQueue = workingQueue
+        self.processingQueue = processingQueue
+        self.assetWorkerQueue = assetWorkerQueue
     }
         
-    convenience init(withContentFrom outputPath: String, workingQueue: SentryDispatchQueueWrapper, dateProvider: SentryCurrentDateProvider) {
-        self.init(outputPath: outputPath, workingQueue: workingQueue, dateProvider: dateProvider)
-        
+    convenience init(
+        withContentFrom outputPath: String,
+        processingQueue: SentryDispatchQueueWrapper,
+        assetWorkerQueue: SentryDispatchQueueWrapper,
+        dateProvider: SentryCurrentDateProvider
+    ) {
+        self.init(
+            outputPath: outputPath,
+            processingQueue: processingQueue,
+            assetWorkerQueue: assetWorkerQueue,
+            dateProvider: dateProvider
+        )
+        loadFrames(fromPath: outputPath)
+    }
+
+    /// Loads the frames from the given path.
+    ///
+    /// - Parameter path: The path to the directory containing the frames.
+    private func loadFrames(fromPath path: String) {
+        SentryLog.debug("[Session Replay] Loading frames from path: \(path)")
         do {
-            let content = try FileManager.default.contentsOfDirectory(atPath: outputPath)
-            _frames = content.compactMap {
-                guard $0.hasSuffix(".png") else { return SentryReplayFrame?.none }
-                guard let time = Double($0.dropLast(4)) else { return nil }
-                return SentryReplayFrame(imagePath: "\(outputPath)/\($0)", time: Date(timeIntervalSinceReferenceDate: time), screenName: nil)
+            let content = try FileManager.default.contentsOfDirectory(atPath: path)
+            _frames = content.compactMap { frameFilePath in
+                guard frameFilePath.hasSuffix(".png") else { return SentryReplayFrame?.none }
+                guard let time = Double(frameFilePath.dropLast(4)) else { return nil }
+                let timestamp = Date(timeIntervalSinceReferenceDate: time)
+                return SentryReplayFrame(imagePath: "\(path)/\(frameFilePath)", time: timestamp, screenName: nil)
             }.sorted { $0.time < $1.time }
+            SentryLog.debug("[Session Replay] Loaded \(content.count) files into \(_frames.count) frames from path: \(path)")
         } catch {
-            SentryLog.debug("Could not list frames from replay: \(error.localizedDescription)")
-            return
+            SentryLog.debug("[Session Replay] Could not list frames from replay: \(error.localizedDescription)")
         }
     }
-    
-    convenience init(outputPath: String) {
-        self.init(outputPath: outputPath,
-                  workingQueue: SentryDispatchQueueWrapper(name: "io.sentry.onDemandReplay", attributes: nil),
-                  dateProvider: SentryDefaultCurrentDateProvider())
-    }
-    
-    convenience init(withContentFrom outputPath: String) {
-        self.init(withContentFrom: outputPath,
-                  workingQueue: SentryDispatchQueueWrapper(name: "io.sentry.onDemandReplay", attributes: nil),
-                  dateProvider: SentryDefaultCurrentDateProvider())
-    }
-    
+
     func addFrameAsync(image: UIImage, forScreen: String?) {
-        workingQueue.dispatchAsync({
+        processingQueue.dispatchAsync {
             self.addFrame(image: image, forScreen: forScreen)
-        })
+        }
     }
     
     private func addFrame(image: UIImage, forScreen: String?) {
@@ -88,7 +91,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         do {
             try data.write(to: URL(fileURLWithPath: imagePath))
         } catch {
-            SentryLog.debug("Could not save replay frame. Error: \(error)")
+            SentryLog.debug("[Session Replay] Could not save replay frame. Error: \(error)")
             return
         }
         _frames.append(SentryReplayFrame(imagePath: imagePath, time: date, screenName: forScreen))
@@ -111,135 +114,247 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     }
     
     func releaseFramesUntil(_ date: Date) {
-        workingQueue.dispatchAsync ({
+        processingQueue.dispatchAsync {
+            SentryLog.debug("[Session Replay] Releasing frames until date: \(date), current queue: \(self.processingQueue.queue.label)")
             while let first = self._frames.first, first.time < date {
                 self._frames.removeFirst()
-                try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
+                let fileUrl = URL(fileURLWithPath: first.imagePath)
+                do {
+                    SentryLog.debug("[Session Replay] Removing frame at url: \(fileUrl.path)")
+                    try FileManager.default.removeItem(at: fileUrl)
+                    SentryLog.debug("[Session Replay] Removed frame at url: \(fileUrl.path)")
+                } catch {
+                    SentryLog.warning("[Session Replay] Failed to remove frame at: \(fileUrl.path), reason: \(error.localizedDescription), ignoring error")
+                }
             }
-        })
+        }
     }
         
     var oldestFrameDate: Date? {
         return _frames.first?.time
     }
-    
-    func createVideoWith(beginning: Date, end: Date) throws -> [SentryVideoInfo] {
-        let videoFrames = filterFrames(beginning: beginning, end: end)
-        var frameCount = 0
-        
-        var videos = [SentryVideoInfo]()
-        
-        while frameCount < videoFrames.count {
-            let outputFileURL = URL(fileURLWithPath: _outputPath.appending("/\(videoFrames[frameCount].time.timeIntervalSinceReferenceDate).mp4"))
-            if let videoInfo = try renderVideo(with: videoFrames, from: &frameCount, at: outputFileURL) {
-                videos.append(videoInfo)
-            } else {
-                frameCount++
-            }  
+
+    func createVideoAsyncWith(beginning: Date, end: Date, completion: @escaping ([SentryVideoInfo]?, Error?) -> Void) {
+        // Note: In Swift it is best practice to use `Result<Value, Error>` instead of `(Value?, Error?)`
+        //       Due to interoperability with Objective-C and @objc, we can not use Result here.
+        SentryLog.debug("[Session Replay] Creating video with beginning: \(beginning), end: \(end)")
+        let videoFrames = getFilteredFrames(beginning: beginning, end: end)
+
+        // Dispatch the video creation to a background queue to avoid blocking the calling queue.
+        let outputPath = self._outputPath
+        processingQueue.dispatchAsync {
+            SentryLog.debug("[Session Replay] Creating video with beginning: \(beginning), end: \(end), current queue: \(self.processingQueue.queue.label)")
+            
+            do {
+                // Use a semaphore to wait for each video segment to finish.
+                let semaphore = DispatchSemaphore(value: 0)
+                var currentError: Error?
+                var frameCount = 0
+                var videos = [SentryVideoInfo]()
+                while frameCount < videoFrames.count {
+                    let outputFileURL = URL(fileURLWithPath: outputPath.appending("/\(videoFrames[frameCount].time.timeIntervalSinceReferenceDate).mp4"))
+
+                    self.renderVideo(with: videoFrames, from: &frameCount, at: outputFileURL) { result in
+                        // Do not use `processingQueue` here, since it will be blocked by the semaphore.
+                        switch result {
+                        case .success(let videoInfo):
+                            if let videoInfo = videoInfo {
+                                videos.append(videoInfo)
+                            }
+                        case .failure(let error):
+                            currentError = error
+                        }
+                        semaphore.signal()
+                    }
+
+                    // Calling semaphore.wait will block the `processingQueue` until the video rendering completes or a timeout occurs.
+                    // It is imporant that the renderVideo completion block signals the semaphore.
+                    // The queue used by render video must have a higher priority than the processing queue to reduce thread inversion.
+                    // Otherwise, it could lead to queue starvation and a deadlock.
+                    if semaphore.wait(timeout: .now() + 2) == .timedOut {
+                        currentError = SentryOnDemandReplayError.errorRenderingVideo
+                        break
+                    }
+
+                    // If there was an error, throw it to exit the loop.
+                    if let error = currentError {
+                        throw error
+                    }
+                }
+                completion(videos, nil)
+            } catch {
+                SentryLog.debug("[Session Replay] Failed to create video with error: \(error)")
+                completion(nil, error)
+            }
         }
-        return videos
     }
-    
-    private func renderVideo(with videoFrames: [SentryReplayFrame], from: inout Int, at outputFileURL: URL) throws -> SentryVideoInfo? {
-        guard from < videoFrames.count, let image = UIImage(contentsOfFile: videoFrames[from].imagePath) else { return nil }
+
+    private func getFilteredFrames(beginning: Date, end: Date) -> [SentryReplayFrame] {
+        var frames = [SentryReplayFrame]()
+        // Using dispatch queue as sync mechanism since we need a queue already to generate the video.
+        processingQueue.dispatchSync {
+            frames = self._frames.filter { $0.time >= beginning && $0.time <= end }
+        }
+        return frames
+    }
+
+    // swiftlint:disable function_body_length
+    private func renderVideo(with videoFrames: [SentryReplayFrame], from: inout Int, at outputFileURL: URL, completion: @escaping (Result<SentryVideoInfo?, Error>) -> Void) {
+        SentryLog.debug("[Session Replay] Rendering video with \(videoFrames.count) frames, from index: \(from), to output url: \(outputFileURL)")
+        guard from < videoFrames.count, let image = UIImage(contentsOfFile: videoFrames[from].imagePath) else {
+            SentryLog.debug("[Session Replay] Failed to render video, reason: index out of bounds or can't read image at path: \(videoFrames[from].imagePath)")
+            return completion(.success(nil))
+        }
+        
         let videoWidth = image.size.width * CGFloat(videoScale)
         let videoHeight = image.size.height * CGFloat(videoScale)
-        
-        let videoWriter = try AVAssetWriter(url: outputFileURL, fileType: .mp4)
+        let pixelSize = CGSize(width: videoWidth, height: videoHeight)
+
+        let videoWriter: AVAssetWriter
+        do {
+            videoWriter = try AVAssetWriter(url: outputFileURL, fileType: .mp4)
+        } catch {
+            SentryLog.debug("[Session Replay] Failed to create video writer, reason: \(error)")
+            return completion(.failure(error))
+        }
+
+        SentryLog.debug("[Session Replay] Creating pixel buffer based video writer input")
         let videoWriterInput = AVAssetWriterInput(mediaType: .video, outputSettings: createVideoSettings(width: videoWidth, height: videoHeight))
-        
-        guard let currentPixelBuffer = SentryPixelBuffer(size: CGSize(width: videoWidth, height: videoHeight), videoWriterInput: videoWriterInput)
-        else { throw SentryOnDemandReplayError.cantCreatePixelBuffer }
-        
+        guard let currentPixelBuffer = SentryPixelBuffer(size: pixelSize, videoWriterInput: videoWriterInput) else {
+            SentryLog.debug("[Session Replay] Failed to create pixel buffer, reason: \(SentryOnDemandReplayError.cantCreatePixelBuffer)")
+            return completion(.failure(SentryOnDemandReplayError.cantCreatePixelBuffer))
+        }
         videoWriter.add(videoWriterInput)
+
         videoWriter.startWriting()
         videoWriter.startSession(atSourceTime: .zero)
-        
+
+        // Append frames to the video writer input in a pull-style manner when the input is ready to receive more media data.
+        //
+        // Inside the callback:
+        // 1. We append media data until `isReadyForMoreMediaData` becomes false
+        // 2. Or until there's no more media data to process (then we mark input as finished)
+        // 3. If we don't mark the input as finished, the callback will be invoked again
+        //    when the input is ready for more data
+        //
+        // By setting the queue to the asset worker queue, we ensure that the callback is invoked on the asset worker queue.
+        // This is important to avoid a deadlock, as this method is called on the processing queue.
         var lastImageSize: CGSize = image.size
         var usedFrames = [SentryReplayFrame]()
-        let group = DispatchGroup()
-        
-        var result: Result<SentryVideoInfo?, Error>?
         var frameCount = from
-        
-        group.enter()
-        videoWriterInput.requestMediaDataWhenReady(on: workingQueue.queue) {
+        videoWriterInput.requestMediaDataWhenReady(on: assetWorkerQueue.queue) { [weak self] in
+            guard let self = self else {
+                SentryLog.warning("[Session Replay] On-demand replay is deallocated, completing writing session without output video info")
+                return completion(.success(nil))
+            }
             guard videoWriter.status == .writing else {
+                SentryLog.warning("[Session Replay] Video writer is not writing anymore, cancelling the writing session, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
                 videoWriter.cancelWriting()
-                result = .failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo )
-                group.leave()
-                return
+                return completion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
             }
-            if frameCount >= videoFrames.count {
-                result = self.finishVideo(outputFileURL: outputFileURL, usedFrames: usedFrames, videoHeight: Int(videoHeight), videoWidth: Int(videoWidth), videoWriter: videoWriter)
-                group.leave()
-                return
+            guard frameCount < videoFrames.count else {
+                SentryLog.debug("[Session Replay] No more frames available to process, finishing the video")
+                return self.finishVideo(outputFileURL: outputFileURL, usedFrames: usedFrames, videoHeight: Int(videoHeight), videoWidth: Int(videoWidth), videoWriter: videoWriter, onCompletion: completion)
             }
+
             let frame = videoFrames[frameCount]
             if let image = UIImage(contentsOfFile: frame.imagePath) {
-                if lastImageSize != image.size {
-                    result = self.finishVideo(outputFileURL: outputFileURL, usedFrames: usedFrames, videoHeight: Int(videoHeight), videoWidth: Int(videoWidth), videoWriter: videoWriter)
-                    group.leave()
-                    return
+                guard lastImageSize == image.size else {
+                    SentryLog.debug("[Session Replay] Image size changed, finishing the video")
+                    return self.finishVideo(outputFileURL: outputFileURL, usedFrames: usedFrames, videoHeight: Int(videoHeight), videoWidth: Int(videoWidth), videoWriter: videoWriter, onCompletion: completion)
                 }
                 lastImageSize = image.size
-                
+
                 let presentTime = CMTime(seconds: Double(frameCount), preferredTimescale: CMTimeScale(1 / self.frameRate))
-                if currentPixelBuffer.append(image: image, presentationTime: presentTime) != true {
+                guard currentPixelBuffer.append(image: image, presentationTime: presentTime) == true else {
+                    SentryLog.debug("[Session Replay] Failed to append image to pixel buffer, cancelling the writing session, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
                     videoWriter.cancelWriting()
-                    result = .failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo )
-                    group.leave()
-                    return
+                    return completion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
                 }
                 usedFrames.append(frame)
             }
             frameCount += 1
         }
-        guard group.wait(timeout: .now() + 2) == .success else { throw SentryOnDemandReplayError.errorRenderingVideo }
-        from = frameCount
-        
-        return try result?.get()
     }
-        
-    private func finishVideo(outputFileURL: URL, usedFrames: [SentryReplayFrame], videoHeight: Int, videoWidth: Int, videoWriter: AVAssetWriter) -> Result<SentryVideoInfo?, Error> {
-        let group = DispatchGroup()
-        var finishError: Error?
-        var result: SentryVideoInfo?
-        
-        group.enter()
+    // swiftlint:enable function_body_length
+
+    private func finishVideo(
+        outputFileURL: URL,
+        usedFrames: [SentryReplayFrame],
+        videoHeight: Int,
+        videoWidth: Int,
+        videoWriter: AVAssetWriter,
+        onCompletion completion: @escaping (Result<SentryVideoInfo?, Error>) -> Void
+    ) {
+        // Note: This method is expected to be called from the asset worker queue and *not* the processing queue.
+        SentryLog.debug("[Session Replay] Finishing video with output file URL: \(outputFileURL.path)")
         videoWriter.inputs.forEach { $0.markAsFinished() }
-        videoWriter.finishWriting {
-            defer { group.leave() }
-            if videoWriter.status == .completed {
+        videoWriter.finishWriting { [weak self] in
+            SentryLog.debug("[Session Replay] Finished video writing, status: \(videoWriter.status)")
+            guard let strongSelf = self else {
+                SentryLog.warning("[Session Replay] On-demand replay is deallocated, completing writing session without output video info")
+                return completion(.success(nil))
+            }
+
+            switch videoWriter.status {
+            case .writing:
+                // noop
+                break
+            case .cancelled:
+                SentryLog.debug("[Session Replay] Finish writing video was cancelled, completing with no video info")
+                completion(.success(nil))
+            case .completed:
+                SentryLog.debug("[Session Replay] Finish writing video was completed, creating video info from file attributes")
                 do {
-                    let fileAttributes = try FileManager.default.attributesOfItem(atPath: outputFileURL.path)
-                    guard let fileSize = fileAttributes[FileAttributeKey.size] as? Int else {
-                        finishError = SentryOnDemandReplayError.cantReadVideoSize
-                        return
-                    }
-                    guard let start = usedFrames.min(by: { $0.time < $1.time })?.time else { return }
-                    let duration = TimeInterval(usedFrames.count / self.frameRate)
-                    result = SentryVideoInfo(path: outputFileURL, height: Int(videoHeight), width: Int(videoWidth), duration: duration, frameCount: usedFrames.count, frameRate: self.frameRate, start: start, end: start.addingTimeInterval(duration), fileSize: fileSize, screens: usedFrames.compactMap({ $0.screenName }))
+                    let result = try strongSelf.getVideoInfo(
+                        from: outputFileURL,
+                        usedFrames: usedFrames,
+                        videoWidth: Int(videoWidth),
+                        videoHeight: Int(videoHeight)
+                    )
+                    completion(.success(result))
                 } catch {
-                    finishError = error
+                    SentryLog.warning("[Session Replay] Failed to create video info from file attributes, reason: \(error.localizedDescription)")
+                    completion(.failure(error))
                 }
+            case .failed:
+                SentryLog.warning("[Session Replay] Finish writing video failed, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
+                completion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
+            case .unknown:
+                SentryLog.warning("[Session Replay] Finish writing video with unknown status, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
+                completion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
+            @unknown default:
+                SentryLog.warning("[Session Replay] Finish writing video failed, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
+                completion(.failure(SentryOnDemandReplayError.errorRenderingVideo))
             }
         }
-        group.wait()
-        
-        if let finishError = finishError { return .failure(finishError) }
-        return .success(result)
     }
-    
-    private func filterFrames(beginning: Date, end: Date) -> [SentryReplayFrame] {
-        var frames = [SentryReplayFrame]()
-        //Using dispatch queue as sync mechanism since we need a queue already to generate the video.
-        workingQueue.dispatchSync({
-            frames = self._frames.filter { $0.time >= beginning && $0.time <= end }
-        })
-        return frames
+
+    fileprivate func getVideoInfo(from outputFileURL: URL, usedFrames: [SentryReplayFrame], videoWidth: Int, videoHeight: Int) throws -> SentryVideoInfo {
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: outputFileURL.path)
+        guard let fileSize = fileAttributes[FileAttributeKey.size] as? Int else {
+            SentryLog.warning("[Session Replay] Failed to read video size from video file, reason: size attribute not found")
+            throw SentryOnDemandReplayError.cantReadVideoSize
+        }
+        guard let start = usedFrames.min(by: { $0.time < $1.time })?.time else {
+            SentryLog.warning("[Session Replay] Failed to read video start time from used frames, reason: no frames found")
+            throw SentryOnDemandReplayError.cantReadVideoStartTime
+        }
+        let duration = TimeInterval(usedFrames.count / self.frameRate)
+        return SentryVideoInfo(
+            path: outputFileURL,
+            height: videoHeight,
+            width: videoWidth,
+            duration: duration,
+            frameCount: usedFrames.count,
+            frameRate: self.frameRate,
+            start: start,
+            end: start.addingTimeInterval(duration),
+            fileSize: fileSize,
+            screens: usedFrames.compactMap({ $0.screenName })
+        )
     }
-    
+
     private func createVideoSettings(width: CGFloat, height: CGFloat) -> [String: Any] {
         return [
             AVVideoCodecKey: AVVideoCodecType.h264,
@@ -252,6 +367,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         ]
     }
 }
+// swiftlint:enable type_body_length
 
 #endif // os(iOS) || os(tvOS)
 #endif // canImport(UIKit)

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplayError.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplayError.swift
@@ -1,0 +1,6 @@
+enum SentryOnDemandReplayError: Error {
+    case cantReadVideoSize
+    case cantCreatePixelBuffer
+    case errorRenderingVideo
+    case cantReadVideoStartTime
+}

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayFrame.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayFrame.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct SentryReplayFrame {
+    let imagePath: String
+    let time: Date
+    let screenName: String?
+}

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
@@ -6,7 +6,7 @@ import UIKit
 protocol SentryReplayVideoMaker: NSObjectProtocol {
     func addFrameAsync(image: UIImage, forScreen: String?) 
     func releaseFramesUntil(_ date: Date)
-    func createVideoWith(beginning: Date, end: Date) throws -> [SentryVideoInfo]
+    func createVideoAsyncWith(beginning: Date, end: Date, completion: @escaping ([SentryVideoInfo]?, Error?) -> Void)
 }
 
 extension SentryReplayVideoMaker {

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -21,7 +21,7 @@ protocol SentrySessionReplayDelegate: NSObjectProtocol {
 class SentrySessionReplay: NSObject {
     private(set) var isFullSession = false
     private(set) var sessionReplayId: SentryId?
-
+    
     private var urlToCache: URL?
     private var rootView: UIView?
     private var lastScreenShot: Date?
@@ -39,7 +39,6 @@ class SentrySessionReplay: NSObject {
     private let displayLink: SentryDisplayLinkWrapper
     private let dateProvider: SentryCurrentDateProvider
     private let touchTracker: SentryTouchTracker?
-    private let dispatchQueue: SentryDispatchQueueWrapper
     private let lock = NSLock()
     var replayTags: [String: Any]?
     
@@ -50,18 +49,17 @@ class SentrySessionReplay: NSObject {
     var screenshotProvider: SentryViewScreenshotProvider
     var breadcrumbConverter: SentryReplayBreadcrumbConverter
     
-    init(replayOptions: SentryReplayOptions,
-         replayFolderPath: URL,
-         screenshotProvider: SentryViewScreenshotProvider,
-         replayMaker: SentryReplayVideoMaker,
-         breadcrumbConverter: SentryReplayBreadcrumbConverter,
-         touchTracker: SentryTouchTracker?,
-         dateProvider: SentryCurrentDateProvider,
-         delegate: SentrySessionReplayDelegate,
-         dispatchQueue: SentryDispatchQueueWrapper,
-         displayLinkWrapper: SentryDisplayLinkWrapper) {
-
-        self.dispatchQueue = dispatchQueue
+    init(
+        replayOptions: SentryReplayOptions,
+        replayFolderPath: URL,
+        screenshotProvider: SentryViewScreenshotProvider,
+        replayMaker: SentryReplayVideoMaker,
+        breadcrumbConverter: SentryReplayBreadcrumbConverter,
+        touchTracker: SentryTouchTracker?,
+        dateProvider: SentryCurrentDateProvider,
+        delegate: SentrySessionReplayDelegate,
+        displayLinkWrapper: SentryDisplayLinkWrapper
+    ) {
         self.replayOptions = replayOptions
         self.dateProvider = dateProvider
         self.delegate = delegate
@@ -74,7 +72,7 @@ class SentrySessionReplay: NSObject {
     }
     
     deinit { displayLink.invalidate() }
-
+    
     func start(rootView: UIView, fullSession: Bool) {
         guard !isRunning else { return }
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
@@ -84,19 +82,19 @@ class SentrySessionReplay: NSObject {
         currentSegmentId = 0
         sessionReplayId = SentryId()
         imageCollection = []
-
+        
         if fullSession {
             startFullReplay()
         }
     }
-
+    
     private func startFullReplay() {
         sessionStart = lastScreenShot
         isFullSession = true
         guard let sessionReplayId = sessionReplayId else { return }
         delegate?.sessionReplayStarted(replayId: sessionReplayId)
     }
-
+    
     func pauseSessionMode() {
         lock.lock()
         defer { lock.unlock() }
@@ -115,7 +113,7 @@ class SentrySessionReplay: NSObject {
         }
         isSessionPaused = false
     }
-
+    
     func resume() {
         lock.lock()
         defer { lock.unlock() }
@@ -131,57 +129,57 @@ class SentrySessionReplay: NSObject {
         videoSegmentStart = nil
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
     }
-  
+    
     func captureReplayFor(event: Event) {
         guard isRunning else { return }
-
+        
         if isFullSession {
             setEventContext(event: event)
             return
         }
-
+        
         guard (event.error != nil || event.exceptions?.isEmpty == false)
-        && captureReplay() else { return }
+                && captureReplay() else { return }
         
         setEventContext(event: event)
     }
-
+    
     @discardableResult
     func captureReplay() -> Bool {
         guard isRunning else { return false }
         guard !isFullSession else { return true }
-
+        
         guard delegate?.sessionReplayShouldCaptureReplayForError() == true else {
             return false
         }
-
+        
         startFullReplay()
         let replayStart = dateProvider.date().addingTimeInterval(-replayOptions.errorReplayDuration - (Double(replayOptions.frameRate) / 2.0))
-
-        createAndCapture(startedAt: replayStart, replayType: .buffer)
+        
+        createAndCaptureAsync(startedAt: replayStart, replayType: .buffer)
         return true
     }
-
+    
     private func setEventContext(event: Event) {
         guard let sessionReplayId = sessionReplayId, event.type != "replay_video" else { return }
-
+        
         var context = event.context ?? [:]
         context["replay"] = ["replay_id": sessionReplayId.sentryIdString]
         event.context = context
-
+        
         var tags = ["replayId": sessionReplayId.sentryIdString]
         if let eventTags = event.tags {
             tags.merge(eventTags) { (_, new) in new }
         }
         event.tags = tags
     }
-
+    
     @objc 
     private func newFrame(_ sender: CADisplayLink) {
         guard let lastScreenShot = lastScreenShot, isRunning &&
                 !(isFullSession && isSessionPaused) //If replay is in session mode but it is paused we dont take screenshots
         else { return }
-
+        
         let now = dateProvider.date()
         
         if let sessionStart = sessionStart, isFullSession && now.timeIntervalSince(sessionStart) > replayOptions.maximumDuration {
@@ -189,7 +187,7 @@ class SentrySessionReplay: NSObject {
             pause()
             return
         }
-
+        
         if now.timeIntervalSince(lastScreenShot) >= Double(1 / replayOptions.frameRate) {
             takeScreenshot()
             self.lastScreenShot = now
@@ -202,11 +200,11 @@ class SentrySessionReplay: NSObject {
             }
         }
     }
-
+    
     private func prepareSegmentUntil(date: Date) {
         guard var pathToSegment = urlToCache?.appendingPathComponent("segments") else { return }
         let fileManager = FileManager.default
-
+        
         if !fileManager.fileExists(atPath: pathToSegment.path) {
             do {
                 try fileManager.createDirectory(atPath: pathToSegment.path, withIntermediateDirectories: true, attributes: nil)
@@ -215,30 +213,32 @@ class SentrySessionReplay: NSObject {
                 return
             }
         }
-
+        
         pathToSegment = pathToSegment.appendingPathComponent("\(currentSegmentId).mp4")
         let segmentStart = videoSegmentStart ?? dateProvider.date().addingTimeInterval(-replayOptions.sessionSegmentDuration)
-
-        createAndCapture(startedAt: segmentStart, replayType: .session)
+        
+        createAndCaptureAsync(startedAt: segmentStart, replayType: .session)
     }
-
-    private func createAndCapture(startedAt: Date, replayType: SentryReplayType) {
-        //Creating a video is heavy and blocks the thread
-        //Since this function is always called in the main thread
-        //we dispatch it to a background thread.
-        dispatchQueue.dispatchAsync {
-            do {
-                let videos = try self.replayMaker.createVideoWith(beginning: startedAt, end: self.dateProvider.date())
+    
+    private func createAndCaptureAsync(startedAt: Date, replayType: SentryReplayType) {
+        SentryLog.debug("[Session Replay] Creating replay video started at date: \(startedAt), replayType: \(replayType)")
+        // Creating a video is computationally expensive, therefore perform it on a background queue.
+        self.replayMaker.createVideoAsyncWith(beginning: startedAt, end: self.dateProvider.date()) { videos, error in
+            if let error = error {
+                SentryLog.debug("[Session Replay] Could not create replay video - \(error.localizedDescription)")
+            } else if let videos = videos {
+                SentryLog.debug("[Session Replay] Created replay video with \(videos.count) segments")
                 for video in videos {
                     self.newSegmentAvailable(videoInfo: video, replayType: replayType)
                 }
-            } catch {
-                SentryLog.debug("Could not create replay video - \(error.localizedDescription)")
+            } else {
+                SentryLog.debug("[Session Replay] Finished replay video creation without any segments")
             }
         }
     }
-
+    
     private func newSegmentAvailable(videoInfo: SentryVideoInfo, replayType: SentryReplayType) {
+        SentryLog.debug("[Session Replay] New segment available for replayType: \(replayType), videoInfo: \(videoInfo)")
         guard let sessionReplayId = sessionReplayId else { return }
         captureSegment(segment: currentSegmentId, video: videoInfo, replayId: sessionReplayId, replayType: replayType)
         replayMaker.releaseFramesUntil(videoInfo.end)
@@ -254,7 +254,7 @@ class SentrySessionReplay: NSObject {
         replayEvent.urls = video.screens
         
         let breadcrumbs = delegate?.breadcrumbsForSessionReplay() ?? []
-
+        
         var events = convertBreadcrumbs(breadcrumbs: breadcrumbs, from: video.start, until: video.end)
         if let touchTracker = touchTracker {
             events.append(contentsOf: touchTracker.replayEvents(from: videoSegmentStart ?? video.start, until: video.end))
@@ -270,9 +270,9 @@ class SentrySessionReplay: NSObject {
         }
         
         let recording = SentryReplayRecording(segmentId: segment, video: video, extraEvents: events)
-                
+        
         delegate?.sessionReplayNewSegment(replayEvent: replayEvent, replayRecording: recording, videoUrl: video.path)
-
+        
         do {
             try FileManager.default.removeItem(at: video.path)
         } catch {
@@ -302,7 +302,7 @@ class SentrySessionReplay: NSObject {
     
     private func takeScreenshot() {
         guard let rootView = rootView, !processingScreenshot else { return }
- 
+        
         lock.lock()
         guard !processingScreenshot else {
             lock.unlock()
@@ -310,14 +310,14 @@ class SentrySessionReplay: NSObject {
         }
         processingScreenshot = true
         lock.unlock()
-
+        
         let screenName = delegate?.currentScreenNameForSessionReplay()
         
         screenshotProvider.image(view: rootView) { [weak self] screenshot in
             self?.newImage(image: screenshot, forScreen: screenName)
         }
     }
-
+    
     private func newImage(image: UIImage, forScreen screen: String?) {
         lock.synchronized {
             processingScreenshot = false


### PR DESCRIPTION
## :scroll: Description

- Changes the priorities of the background queues of session replay.
- Refactors the async dispatch handling of session replay.

## :bulb: Motivation and Context

Some of the methods of the session replay video processing are dispatched to a low priority background queue, which then dispatches additional AV work on another dispatch queue.

The current implementation does not respect queue priorities and can cause thread starvation, because the processing queue and the work queue are either on the same priority, or the work queue is on a lower priority.

In the worst case, the processing queue is blocked and waits for the work queue, but the work queue has a lower priority than the processing queue and is awaiting execution on the main thread.

This is what the thread inversion warning is showing.

Closes #4730

## :green_heart: How did you test it?

Manual testing.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
