### PR TITLE
test: Use non optional data for string to data

### DIFF
--- a/Tests/SentryTests/Helper/SentryFileManagerTestExtension.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTestExtension.swift
@@ -9,8 +9,8 @@ extension SentryFileManager {
     static func prepareInitError() {
         deleteInternalPath()
         do {
-            let data = "hello".data(using: .utf8)
-            try data?.write(to: getInternalPath())
+            let data = Data("hello".utf8)
+            try data.write(to: getInternalPath())
         } catch {
             XCTFail("Couldn't create file for init error of SentryFileManager.")
         }

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -182,7 +182,7 @@ class SentryFileManagerTests: XCTestCase {
         
         let dsStoreFile = "\(sut.basePath)/.DS_Store"
         
-        let result = FileManager.default.createFile(atPath: dsStoreFile, contents: "some data".data(using: .utf8))
+        let result = FileManager.default.createFile(atPath: dsStoreFile, contents: Data("some data".utf8))
         XCTAssertEqual(result, true)
         
         sut.deleteOldEnvelopeItems()
@@ -205,7 +205,7 @@ class SentryFileManagerTests: XCTestCase {
         
         let textFilePath = "\(sut.basePath)/something.txt"
         
-        let result = FileManager.default.createFile(atPath: textFilePath, contents: "some data".data(using: .utf8))
+        let result = FileManager.default.createFile(atPath: textFilePath, contents: Data("some data".utf8))
         XCTAssertEqual(result, true)
         
         sut.deleteOldEnvelopeItems()
@@ -785,8 +785,8 @@ class SentryFileManagerTests: XCTestCase {
         let fileManager = FileManager.default
         let appHangEventFilePath = try XCTUnwrap(Dynamic(sut).appHangEventFilePath.asString)
         
-        fileManager.createFile(atPath: appHangEventFilePath, contents: "garbage".data(using: .utf8)!, attributes: nil)
-        
+        fileManager.createFile(atPath: appHangEventFilePath, contents: Data("garbage".utf8), attributes: nil)
+
         // Act
         XCTAssertNil(sut.readAppHangEvent())
     }
@@ -822,8 +822,8 @@ class SentryFileManagerTests: XCTestCase {
         let fileManager = FileManager.default
         let appHangEventFilePath = try XCTUnwrap(Dynamic(sut).appHangEventFilePath.asString)
         
-        fileManager.createFile(atPath: appHangEventFilePath, contents: "garbage".data(using: .utf8)!, attributes: nil)
-        
+        fileManager.createFile(atPath: appHangEventFilePath, contents: Data("garbage".utf8), attributes: nil)
+
         // Act && Assert
         XCTAssertTrue(sut.appHangEventExists())
     }

--- a/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
@@ -11,8 +11,8 @@ class DataSentryTracingIntegrationTests: XCTestCase {
             return provider
         }()
 
-        let data = "SOME DATA".data(using: .utf8)!
-        
+        let data = Data("SOME DATA".utf8)
+
         var fileUrlToRead: URL!
         var fileUrlToWrite: URL!
         var ignoredFileUrlToRead: URL!

--- a/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
@@ -12,7 +12,7 @@ class FileManagerSentryTracingIntegrationTests: XCTestCase {
             return provider
         }()
 
-        let data = "SOME DATA".data(using: .utf8)!
+        let data = Data("SOME DATA".utf8)
 
         var fileSrcUrl: URL!
         var fileDestUrl: URL!

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
@@ -11,7 +11,7 @@ class SentryFileIOTrackerTests: XCTestCase {
         let sentryPath = try! TestFileManager(options: Options()).sentryPath
         let sentryUrl = URL(fileURLWithPath: try! TestFileManager(options: Options()).sentryPath)
         let dateProvider = TestCurrentDateProvider()
-        let data = "SOME DATA".data(using: .utf8)!
+        let data = Data("SOME DATA".utf8)
         let threadInspector = TestThreadInspector.instance
         let imageProvider = TestDebugImageProvider()
 

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class SentryFileIOTrackingIntegrationTests: XCTestCase {
 
     private class Fixture {
-        let data = "SOME DATA".data(using: .utf8) ?? Data()
+        let data = Data("SOME DATA".utf8)
         let filePath: String!
         let fileURL: URL!
         let fileDirectory: URL!

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -1011,13 +1011,13 @@ class SentryNetworkTrackerTests: XCTestCase {
             var request = $0
             
             request.httpMethod = "POST"
-            request.httpBody = """
+            request.httpBody = Data("""
             {
                 "operationName": "someOperationName",
                 "variables": { "a": 1 },
                 "query": "query someOperationName { someField }"
             }
-            """.data(using: .utf8)
+            """.utf8)
             request.allHTTPHeaderFields = ["content-type": "application/json"]
             
             return request

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -165,7 +165,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         let end = dateProvider.date()
         
         //Creating a file where the replay would be written to cause an error in the writer
-        try "tempFile".data(using: .utf8)?.write(to: outputPath.appendingPathComponent("0.0.mp4"))
+        try Data("tempFile".utf8).write(to: outputPath.appendingPathComponent("0.0.mp4"))
         
         XCTAssertThrowsError(try sut.createVideoWith(beginning: start, end: end))
     }

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -11,7 +11,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
 
         init() {
             let testViewHierarchy = TestSentryViewHierarchy()
-            testViewHierarchy.result = "view hierarchy".data(using: .utf8) ?? Data()
+            testViewHierarchy.result = Data("view hierarchy".utf8)
             viewHierarchy = testViewHierarchy
         }
 

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -117,12 +117,12 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     }
 
     func testEnvelopeWithData() throws {
-        let itemData = "{}\n{\"length\":0,\"type\":\"attachment\"}\n".data(using: .utf8)!
+        let itemData = Data("{}\n{\"length\":0,\"type\":\"attachment\"}\n".utf8)
         XCTAssertNotNil(PrivateSentrySDKOnly.envelope(with: itemData))
     }
     
     func testEnvelopeWithDataLengthGtZero() throws {
-        let itemData = "{}\n{\"length\":1,\"type\":\"attachment\"}\n".data(using: .utf8)!
+        let itemData = Data("{}\n{\"length\":1,\"type\":\"attachment\"}\n".utf8)
         XCTAssertNil(PrivateSentrySDKOnly.envelope(with: itemData))
     }
 

--- a/Tests/SentryTests/Protocol/Codable/ArbitraryDataTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/ArbitraryDataTests.swift
@@ -6,14 +6,14 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecode_StringValues() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": {
                 "some": "value",
                 "empty": "",
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -25,7 +25,7 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecode_IntValues() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "data": {
                 "positive": 1,
@@ -35,7 +35,7 @@ class ArbitraryDataTests: XCTestCase {
                 "min": \(Int.min)
             }
         }
-        """.data(using: .utf8)!
+        """.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -50,7 +50,7 @@ class ArbitraryDataTests: XCTestCase {
 
     func testDecode_DoubleValues() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "data": {
                 "positive": 0.1,
@@ -59,7 +59,7 @@ class ArbitraryDataTests: XCTestCase {
                 "min": \(Double.leastNormalMagnitude)
             }
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -73,7 +73,7 @@ class ArbitraryDataTests: XCTestCase {
 
     func testDecode_DoubleWithoutFractionalPart_IsDecodedAsInt() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "data": {
                 "zero": 0.0,
@@ -82,7 +82,7 @@ class ArbitraryDataTests: XCTestCase {
 
             }
         }
-        """.data(using: .utf8)!
+        """.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -95,14 +95,14 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecode_BoolValues() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": {
                 "true": true,
                 "false": false
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -115,13 +115,13 @@ class ArbitraryDataTests: XCTestCase {
     func testDecode_DateValue() throws {
         // Arrange
         let date = TestCurrentDateProvider().date().addingTimeInterval(0.001)
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": {
                 "date": "\#(sentry_toIso8601String(date))"
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -133,7 +133,7 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecode_Dict() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": {
                 "dict": { 
@@ -143,7 +143,7 @@ class ArbitraryDataTests: XCTestCase {
                 },
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -157,13 +157,13 @@ class ArbitraryDataTests: XCTestCase {
 
     func testDecode_IntArray() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": {
                 "array": [1, 2, 3]
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -175,7 +175,7 @@ class ArbitraryDataTests: XCTestCase {
     func testDecode_ArrayOfDicts() throws {
         // Arrange
         let date = TestCurrentDateProvider().date().addingTimeInterval(0.001)
-        let jsonData = #"""
+        let jsonData = Data(#"""
        {
            "data": {
                "array": [
@@ -190,7 +190,7 @@ class ArbitraryDataTests: XCTestCase {
                 ]
             }
        }
-       """#.data(using: .utf8)!
+       """#.utf8)
 
        // Act
        let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -212,11 +212,11 @@ class ArbitraryDataTests: XCTestCase {
 
     func testDecode_NullValue() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": { "null": null }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -227,13 +227,13 @@ class ArbitraryDataTests: XCTestCase {
 
     func testDecode_GarbageJSON() {
          // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "data": {
                 1: "garbage"
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act & Assert
         XCTAssertNil(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -241,11 +241,11 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecode_Null() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
        {
            "data": null
        }
-       """#.data(using: .utf8)!
+       """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -256,7 +256,7 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecodeNestedData_Values() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "nestedData": { 
                 "value": {
@@ -265,7 +265,7 @@ class ArbitraryDataTests: XCTestCase {
                 } 
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -278,14 +278,14 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecodeNestedData_Empty() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "nestedData": { 
                 "value": {
                 } 
             }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -297,11 +297,11 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecodeNestedData_Null() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "nestedData": { "value": {"nested": null} }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)
@@ -313,11 +313,11 @@ class ArbitraryDataTests: XCTestCase {
     
     func testDecodeNestedData_Garbage() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "nestedData": { "value": "wrong" }
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as DataWrapper?)

--- a/Tests/SentryTests/Protocol/Codable/NSNumberDecodableWrapperTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/NSNumberDecodableWrapperTests.swift
@@ -6,11 +6,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_BoolTrue() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "number": true
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -22,11 +22,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
     
     func testDecode_BoolFalse() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "number": false
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -38,11 +38,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_PositiveInt() throws {
         // Arrange
-        let jsonData = #"""
+        let jsonData = Data(#"""
         {
             "number": 1
         }
-        """#.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -54,11 +54,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_IntMax() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data(#"""
         {
             "number": \(Int.max)
         }
-        """.data(using: .utf8)!
+        """#.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -70,11 +70,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
     
     func testDecode_IntMin() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": \(Int.min)
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -86,11 +86,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_UInt32Max() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": \(UInt32.max)
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -102,11 +102,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
     
     func testDecode_UInt64Max() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": \(UInt64.max)
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -122,11 +122,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
         let UInt64MaxPlusOne = Double(UInt64.max) + 1
         
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": \(UInt64MaxPlusOne)
         }
-        """.data(using: .utf8)!
+        """.utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -139,11 +139,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_Zero() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": 0.0
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -155,11 +155,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_Double() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": 0.1
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -171,11 +171,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_DoubleMax() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": \(Double.greatestFiniteMagnitude)
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -187,11 +187,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_DoubleMin() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": \(Double.leastNormalMagnitude)
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -203,11 +203,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_Nil() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": null
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)
@@ -216,11 +216,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_String() throws {
         // Arrange
-        let jsonData = """
+        let jsonData = Data("""
         {
             "number": "hello"
         }
-        """.data(using: .utf8)!
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)

--- a/Tests/SentryTests/Protocol/Codable/NSNumberDecodableWrapperTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/NSNumberDecodableWrapperTests.swift
@@ -54,11 +54,11 @@ class NSNumberDecodableWrapperTests: XCTestCase {
 
     func testDecode_IntMax() throws {
         // Arrange
-        let jsonData = Data(#"""
+        let jsonData = Data("""
         {
             "number": \(Int.max)
         }
-        """#.utf8)
+        """.utf8)
 
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: jsonData) as ClassWithNSNumber?)

--- a/Tests/SentryTests/Protocol/Codable/SentryCodableTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/SentryCodableTests.swift
@@ -8,12 +8,12 @@ class SentryCodableTests: XCTestCase {
     }
     
     func testDecodeWithGarbageData_ReturnsNil() {
-        let data = "garbage".data(using: .utf8)!
+        let data = Data("garbage".utf8)
         XCTAssertNil(decodeFromJSONData(jsonData: data) as Geo?)
     }
     
     func testDecodeWithWrongJSON_ReturnsEmptyObject() {
-        let wrongJSON = "{\"wrong\": \"json\"}".data(using: .utf8)!
+        let wrongJSON = Data("{\"wrong\": \"json\"}".utf8)
         let actual = decodeFromJSONData(jsonData: wrongJSON) as Geo?
         let expected = Geo()
         
@@ -21,7 +21,7 @@ class SentryCodableTests: XCTestCase {
     }
     
     func testDecodeWithBrokenJSON_ReturnsNil() {
-        let brokenJSON = "{\"broken\": \"json\"".data(using: .utf8)!
+        let brokenJSON = Data("{\"broken\": \"json\"".utf8)
         XCTAssertNil(decodeFromJSONData(jsonData: brokenJSON) as Geo?)
     }
 

--- a/Tests/SentryTests/Protocol/Codable/SentryDateCodableTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/SentryDateCodableTests.swift
@@ -9,7 +9,7 @@ final class SentryDateCodableTests: XCTestCase {
         let timestamp = 0.012345678
         let date = Date(timeIntervalSince1970: timestamp)
         
-        let json = "{\"date\": \(timestamp)}".data(using: .utf8)!
+        let json = Data("{\"date\": \(timestamp)}".utf8)
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
         
@@ -27,7 +27,7 @@ final class SentryDateCodableTests: XCTestCase {
         // Therefore, we convert the ISO date string back to the date.
         let expectedDate = try XCTUnwrap(sentry_fromIso8601String(isoString))
 
-        let json = "{\"date\": \"\(isoString)\"}".data(using: .utf8)!
+        let json = Data("{\"date\": \"\(isoString)\"}".utf8)
         
         // Act
         let actual = try XCTUnwrap(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
@@ -38,7 +38,7 @@ final class SentryDateCodableTests: XCTestCase {
     
     func testDecodeDate_WithWrongDateFormat() throws {
         //Arrange
-        let json = "{\"date\": \"hello\"}".data(using: .utf8)!
+        let json = Data("{\"date\": \"hello\"}".utf8)
         
         // Act & Assert
         XCTAssertNil(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
@@ -46,8 +46,8 @@ final class SentryDateCodableTests: XCTestCase {
     
     func testDecodeDate_WithBool() throws {
         //Arrange
-        let json = "{\"date\": true}".data(using: .utf8)!
-        
+        let json = Data("{\"date\": true}".utf8)
+
         // Act & Assert
         XCTAssertNil(decodeFromJSONData(jsonData: json) as SentryDateTestDecodable?)
     }

--- a/Tests/SentryTests/Protocol/SentryAttachmentTests.swift
+++ b/Tests/SentryTests/Protocol/SentryAttachmentTests.swift
@@ -6,7 +6,7 @@ class SentryAttachmentTests: XCTestCase {
         let defaultContentType = "application/octet-stream"
         let contentType = "application/json"
         let filename = "logs.txt"
-        let data = "content".data(using: .utf8)!
+        let data = Data("content".utf8)
         let path: String
         
         let dataAttachment: Attachment

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -9,7 +9,7 @@ class SentryEnvelopeTests: XCTestCase {
         @available(*, deprecated, message: "SentryUserFeedback is deprecated in favor of SentryFeedback.")
         let userFeedback: UserFeedback = TestData.userFeedback
         let path = "test.log"
-        let data = "hello".data(using: .utf8)
+        let data = Data("hello".utf8)
         
         let maxAttachmentSize: UInt = 5 * 1_024 * 1_024
         let dataAllowed: Data
@@ -240,7 +240,7 @@ class SentryEnvelopeTests: XCTestCase {
     }
     
     func testInitWithFileAttachment() {
-        writeDataToFile(data: fixture.data ?? Data())
+        writeDataToFile(data: fixture.data)
         
         let attachment = Attachment(path: fixture.path)
         
@@ -253,13 +253,13 @@ class SentryEnvelopeTests: XCTestCase {
 
         XCTAssertEqual(header.attachmentType, .eventAttachment)
         XCTAssertEqual("attachment", envelopeItem.header.type)
-        XCTAssertEqual(UInt(fixture.data?.count ?? 0), envelopeItem.header.length)
+        XCTAssertEqual(UInt(fixture.data.count), envelopeItem.header.length)
         XCTAssertEqual(attachment.filename, envelopeItem.header.filename)
         XCTAssertEqual(attachment.contentType, envelopeItem.header.contentType)
     }
 
     func testInitWith_ViewHierarchy_Attachment() {
-        writeDataToFile(data: fixture.data ?? Data())
+        writeDataToFile(data: fixture.data)
 
         let attachment = Attachment(path: fixture.path, filename: "filename", contentType: "text", attachmentType: .viewHierarchy)
 

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -234,7 +234,7 @@ class TestData {
     }
     
     static var dataAttachment: Attachment {
-        return Attachment(data: "hello".data(using: .utf8)!, filename: "file.txt")
+        return Attachment(data: Data("hello".utf8), filename: "file.txt")
     }
 
     static var spanContext: SpanContext {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1927,7 +1927,7 @@ class SentryClientTest: XCTestCase {
         let scope = Scope()
 
         let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("view-hierarchy.json")
-        try "data".data(using: .utf8)?.write(to: tempFile)
+        try Data("data".utf8).write(to: tempFile)
 
         scope.addCrashReportAttachment(inPath: tempFile.path)
 

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -382,11 +382,11 @@ class SentrySDKTests: XCTestCase {
         
         let fileManager = try SentryFileManager(options: fixture.options)
         
-        let corruptedEnvelopeData = """
+        let corruptedEnvelopeData = Data("""
                        {"event_id":"1990b5bc31904b7395fd07feb72daf1c","sdk":{"name":"sentry.cocoa","version":"8.33.0"}}
                        {"type":"test","length":50}
-                       """.data(using: .utf8)!
-        
+                       """.utf8)
+
         try corruptedEnvelopeData.write(to: URL(fileURLWithPath: "\(fileManager.envelopesPath)/corrupted-envelope.json"))
         
         SentrySDK.start(options: fixture.options)


### PR DESCRIPTION
Prefer using Data(foo.utf8) over using foo.data(using: .utf8)

As discussed in https://github.com/getsentry/sentry-cocoa/pull/5019#discussion_r2012468356. 

We can enable the SwiftLint rule [non_optional_string_data_conversion](https://realm.github.io/SwiftLint/non_optional_string_data_conversion.html)  after merging https://github.com/getsentry/sentry-cocoa/pull/5019.  

#skip-changelog