### PR TITLE
chore: Remove destination for analyzer

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 15.4
+      - run: ./scripts/ci-select-xcode.sh 16.2
       - run: make analyze
 
   lint-podspec:

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test-ui-critical:
 
 analyze:
 	rm -rf analyzer
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild analyze -workspace Sentry.xcworkspace -scheme Sentry -configuration Release CLANG_ANALYZER_OUTPUT=html CLANG_ANALYZER_OUTPUT_DIR=analyzer -destination "platform=iOS Simulator,OS=latest,name=iPhone 11" CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify && [[ -z `find analyzer -name "*.html"` ]]
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild analyze -workspace Sentry.xcworkspace -scheme Sentry -configuration Release CLANG_ANALYZER_OUTPUT=html CLANG_ANALYZER_OUTPUT_DIR=analyzer CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify && [[ -z `find analyzer -name "*.html"` ]]
 
 # Since Carthage 0.38.0 we need to create separate .framework.zip and .xcframework.zip archives.
 # After creating the zips we create a JSON to be able to test Carthage locally.

--- a/Sources/Sentry/SentryDsn.m
+++ b/Sources/Sentry/SentryDsn.m
@@ -96,23 +96,23 @@ NS_ASSUME_NONNULL_BEGIN
     NSSet *allowedSchemes = [NSSet setWithObjects:@"http", @"https", nil];
     NSURL *url = [NSURL URLWithString:trimmedDsnString];
     NSString *errorMessage = nil;
-    if (nil == url.scheme) {
+    if (url.scheme == nil) {
         errorMessage = @"URL scheme of DSN is missing";
         url = nil;
     }
-    if (![allowedSchemes containsObject:url.scheme]) {
+    if (url != nil && ![allowedSchemes containsObject:url.scheme]) {
         errorMessage = @"Unrecognized URL scheme in DSN";
         url = nil;
     }
-    if (nil == url.host || url.host.length == 0) {
+    if (url != nil && (nil == url.host || url.host.length == 0)) {
         errorMessage = @"Host component of DSN is missing";
         url = nil;
     }
-    if (nil == url.user) {
+    if (url != nil && url.user == nil) {
         errorMessage = @"User component of DSN is missing";
         url = nil;
     }
-    if (url.pathComponents.count < 2) {
+    if (url != nil && url.pathComponents.count < 2) {
         errorMessage = @"Project ID path component of DSN is missing";
         url = nil;
     }


### PR DESCRIPTION
We don't need to specify the destination and analyze with Xcode 16.2.

#skip-changelog.