### PR TITLE
fix: add condtion to reference UIScreen

### DIFF
--- a/Sources/Sentry/SentryCrashWrapper.m
+++ b/Sources/Sentry/SentryCrashWrapper.m
@@ -1,4 +1,5 @@
 #import "SentryCrashWrapper.h"
+#import "Sentry/SentryOptions.h"
 #import "SentryCrash.h"
 #import "SentryCrashBinaryImageCache.h"
 #import "SentryCrashIntegration.h"
@@ -106,7 +107,7 @@ NS_ASSUME_NONNULL_BEGIN
     sentrycrashbic_stopCache();
 }
 
-- (void)enrichScope:(SentryScope *)scope
+- (void)enrichScope:(SentryScope *)scope withOption:(SentryOptions *)options;
 {
     // OS
     NSMutableDictionary *osData = [NSMutableDictionary new];
@@ -183,16 +184,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 // The UIWindowScene is unavailable on visionOS
 #if SENTRY_TARGET_REPLAY_SUPPORTED
-
-    NSArray<UIWindow *> *appWindows = SentryDependencyContainer.sharedInstance.application.windows;
-    if ([appWindows count] > 0) {
-        UIScreen *appScreen = appWindows.firstObject.screen;
-        if (appScreen != nil) {
-            [deviceData setValue:@(appScreen.bounds.size.height) forKey:@"screen_height_pixels"];
-            [deviceData setValue:@(appScreen.bounds.size.width) forKey:@"screen_width_pixels"];
+    if (options.enableAutoSessionTracking) {
+        NSArray<UIWindow *> *appWindows
+            = SentryDependencyContainer.sharedInstance.application.windows;
+        if ([appWindows count] > 0) {
+            UIScreen *appScreen = appWindows.firstObject.screen;
+            if (appScreen != nil) {
+                [deviceData setValue:@(appScreen.bounds.size.height)
+                              forKey:@"screen_height_pixels"];
+                [deviceData setValue:@(appScreen.bounds.size.width) forKey:@"screen_width_pixels"];
+            }
         }
     }
-
 #endif
 
     [scope setContextValue:deviceData forKey:DEVICE_KEY];

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -79,7 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
         _errorsBeforeSession = 0;
 
         if (_scope) {
-            [_crashWrapper enrichScope:_scope];
+            [_crashWrapper enrichScope:_scope withOption:_client.options];
         }
     }
 
@@ -594,7 +594,7 @@ NS_ASSUME_NONNULL_BEGIN
                 _scope = [[SentryScope alloc] init];
             }
 
-            [_crashWrapper enrichScope:_scope];
+            [_crashWrapper enrichScope:_scope withOption:_client.options];
         }
         return _scope;
     }

--- a/Sources/Sentry/include/SentryCrashWrapper.h
+++ b/Sources/Sentry/include/SentryCrashWrapper.h
@@ -1,3 +1,4 @@
+#import "Sentry/SentryOptions.h"
 #import "SentryDefines.h"
 #import "SentryInternalCDefines.h"
 
@@ -33,8 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (bytes)appMemorySize;
 
-- (void)enrichScope:(SentryScope *)scope;
-
+- (void)enrichScope:(SentryScope *)scope withOption:(SentryOptions *)options;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
+++ b/Tests/SentryTests/SentryCrash/TestSentryCrashWrapper.m
@@ -88,10 +88,10 @@
     return self.internalAppMemorySize;
 }
 
-- (void)enrichScope:(SentryScope *)scope
+- (void)enrichScope:(SentryScope *)scope withOption:(SentryOptions *)options
 {
     self.enrichScopeCalled = YES;
-    [super enrichScope:scope];
+    [super enrichScope:scope withOption:options];
 }
 
 @end


### PR DESCRIPTION
## :scroll: Description
<!--- Describe your changes in detail -->

- add a condition to reference UIScreen in `SentryCrashWrapper`

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

At first, I need your help. I'm using this SDK at face a runtime error like below.
![스크린샷 2025-04-02 오후 2 07 09](https://github.com/user-attachments/assets/b1b1bd33-1fb9-400f-bf8c-098820274d78)

I'm not familiar with Objective-C. and I can't understand your full codes, context, and philosophy. furthermore I'm not sure it's the problem only for session tracking.
If you agree this is the problem, could you help me to solve this problem?
thank you.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.