### PR TITLE
fix(profiling): ui profiling trace lifecycle root span tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- New continuous profiling configuration API (#4952)
+- New continuous profiling configuration API (#4952 and #5063)
 
 > [!Important]
 > With the addition of the new profiling configuation API, the previous profiling API are deprecated and will be removed in the next major version of the SDK:

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -224,9 +224,9 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return payload;
 }
 
-+ (void)discardProfilerForTrace:(SentryId *)traceId traceSampled:(BOOL)isProfiling;
++ (void)discardProfilerForTrace:(SentryId *)traceId;
 {
-    sentry_discardProfilerCorrelatedToTrace(traceId, SentrySDK.currentHub, isProfiling);
+    sentry_discardProfilerCorrelatedToTrace(traceId, SentrySDK.currentHub);
 }
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -24,7 +24,7 @@
 
 #    pragma mark - Private
 
-NSTimeInterval kSentryProfilerChunkExpirationInterval = 60;
+NSTimeInterval kSentryProfilerChunkExpirationInterval = 5;
 
 namespace {
 /** @warning: Must be used from a synchronized context. */

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -24,7 +24,7 @@
 
 #    pragma mark - Private
 
-NSTimeInterval kSentryProfilerChunkExpirationInterval = 5;
+NSTimeInterval kSentryProfilerChunkExpirationInterval = 60;
 
 namespace {
 /** @warning: Must be used from a synchronized context. */

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -249,11 +249,8 @@ sentry_stopProfilerDueToFinishedTransaction(
 #    endif // SENTRY_HAS_UIKIT
 )
 {
-    if (isProfiling && [hub.getClient.options isProfilingCorrelatedToTraces]) {
-        if (![SentryContinuousProfiler isCurrentlyProfiling]) {
-            SENTRY_TEST_FATAL(
-                @"Expected a continuous profiler to be running for this configuration.");
-        }
+    if (isProfiling && [hub.getClient.options isContinuousProfilingV2Enabled] &&
+        [hub.getClient.options isProfilingCorrelatedToTraces]) {
         SENTRY_LOG_DEBUG(@"Stopping tracking root span tracer with profilerReferenceId %@",
             transaction.trace.profilerReferenceID.sentryIdString);
         sentry_stopTrackingRootSpanForContinuousProfilerV2();

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -330,19 +330,14 @@ SentryId *_Nullable sentry_startProfilerForTrace(SentryTracerConfiguration *conf
         // codepath
         return _sentry_startContinuousProfilerV2ForTrace(
             configuration.profileOptions, transactionContext);
-    } else if ([hub.getClient.options isContinuousProfilingEnabled]) {
+    } else if ([hub.getClient.options isContinuousProfilingV2Enabled]) {
         // non launch profile
-        SentryProfileOptions *profileOptions = hub.getClient.options.profiling;
-        if (profileOptions == nil) {
-            SENTRY_LOG_DEBUG(
-                @"Continuous profiling v1 configured; will not start automatically for trace.");
-            return nil;
-        }
         if (transactionContext.parentSpanId != nil) {
             SENTRY_LOG_DEBUG(@"Not a root span, will not start automatically for trace lifecycle.");
             return nil;
         }
-        return _sentry_startContinuousProfilerV2ForTrace(profileOptions, transactionContext);
+        return _sentry_startContinuousProfilerV2ForTrace(
+            hub.getClient.options.profiling, transactionContext);
     } else {
         BOOL profileShouldBeSampled
             = configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes;

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
 
-    if (_parentSpanId == nil) {
+    if (_parentSpanId == context.parentSpanId) {
         SENTRY_LOG_DEBUG(@"Started root span with id %@", _spanId.sentrySpanIdString);
     } else {
         SENTRY_LOG_DEBUG(@"Started span with id %@; parent id %@", _spanId.sentrySpanIdString,

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -155,8 +155,6 @@ NS_ASSUME_NONNULL_BEGIN
 
         _tracer = tracer;
 
-        // !!!: this method is only called from SentryTracer startChildWithParentId... but the
-        // parentSpanID never gets set
         if (context.parentSpanId == nil) {
             SENTRY_LOG_DEBUG(@"Starting root span with tracer with profilerReferenceId %@",
                 tracer.profilerReferenceID.sentryIdString);

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -112,10 +112,10 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     if (context.parentSpanId == nil) {
-        SENTRY_LOG_DEBUG(@"Started root span with id %@", _spanId.sentrySpanIdString);
+        SENTRY_LOG_DEBUG(@"Started root span with id %@", context.spanId.sentrySpanIdString);
     } else {
-        SENTRY_LOG_DEBUG(@"Started span with id %@; parent id %@", _spanId.sentrySpanIdString,
-            _parentSpanId.sentrySpanIdString);
+        SENTRY_LOG_DEBUG(@"Started span with id %@; parent id %@",
+            context.spanId.sentrySpanIdString, _parentSpanId.sentrySpanIdString);
     }
     return self;
 }

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -111,7 +111,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
 
-    if (_parentSpanId == context.parentSpanId) {
+    if (context.parentSpanId == nil) {
         SENTRY_LOG_DEBUG(@"Started root span with id %@", _spanId.sentrySpanIdString);
     } else {
         SENTRY_LOG_DEBUG(@"Started span with id %@; parent id %@", _spanId.sentrySpanIdString,

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -115,7 +115,7 @@ NS_ASSUME_NONNULL_BEGIN
         SENTRY_LOG_DEBUG(@"Started root span with id %@", context.spanId.sentrySpanIdString);
     } else {
         SENTRY_LOG_DEBUG(@"Started span with id %@; parent id %@",
-            context.spanId.sentrySpanIdString, _parentSpanId.sentrySpanIdString);
+            context.spanId.sentrySpanIdString, context.parentSpanId.sentrySpanIdString);
     }
     return self;
 }

--- a/Sources/Sentry/SentrySpanContext.m
+++ b/Sources/Sentry/SentrySpanContext.m
@@ -87,10 +87,16 @@ NS_ASSUME_NONNULL_BEGIN
         _spanDescription = description;
         _origin = origin;
 
-        SENTRY_LOG_DEBUG(
-            @"Created span context with trace ID %@; span ID %@; parent span ID %@; operation %@",
-            traceId.sentryIdString, spanId.sentrySpanIdString, parentId.sentrySpanIdString,
-            operation);
+        if (parentId == nil) {
+            SENTRY_LOG_DEBUG(
+                @"Created root span context with trace ID %@; span ID %@; operation %@",
+                traceId.sentryIdString, spanId.sentrySpanIdString, operation);
+        } else {
+            SENTRY_LOG_DEBUG(@"Created span context with trace ID %@; span ID %@; parent span ID "
+                             @"%@; operation %@",
+                traceId.sentryIdString, spanId.sentrySpanIdString, parentId.sentrySpanIdString,
+                operation);
+        }
     }
     return self;
 }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -183,7 +183,17 @@ static BOOL appStartMeasurementRead;
     _isProfiling = _profilerReferenceID != nil;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-    SENTRY_LOG_DEBUG(@"Started tracer with id: %@", transactionContext.traceId.sentryIdString);
+    if (transactionContext.parentSpanId == nil) {
+        SENTRY_LOG_DEBUG(
+            @"Started root span tracer with id: %@; profilerReferenceId: %@; span id: %@",
+            transactionContext.traceId.sentryIdString, _profilerReferenceID.sentryIdString,
+            self.spanId.sentrySpanIdString);
+    } else {
+        SENTRY_LOG_DEBUG(@"Started child span tracer with id: %@; profilerReferenceId: %@; span "
+                         @"id: %@; parent span id: %@",
+            transactionContext.traceId.sentryIdString, _profilerReferenceID.sentryIdString,
+            self.spanId.sentrySpanIdString, transactionContext.parentSpanId.sentrySpanIdString);
+    }
 
     return self;
 }
@@ -191,7 +201,9 @@ static BOOL appStartMeasurementRead;
 - (void)dealloc
 {
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-    sentry_discardProfilerCorrelatedToTrace(_profilerReferenceID, self.hub, self.isProfiling);
+    if (self.isProfiling) {
+        sentry_discardProfilerCorrelatedToTrace(_profilerReferenceID, self.hub);
+    }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     [self cancelDeadlineTimeout];
 }
@@ -396,6 +408,9 @@ static BOOL appStartMeasurementRead;
             @"Cannot call finish on span with id %@", finishedSpan.spanId.sentrySpanIdString);
         return;
     }
+
+    SENTRY_LOG_DEBUG(@"Checking if tracer %@ (profileReferenceId %@) can be finished",
+        self.traceId.sentryIdString, _profilerReferenceID.sentryIdString);
     [self canBeFinished];
 }
 
@@ -440,7 +455,7 @@ static BOOL appStartMeasurementRead;
 
 - (void)finishWithStatus:(SentrySpanStatus)status
 {
-    SENTRY_LOG_DEBUG(@"Finished trace with traceID: %@ and status: %@",
+    SENTRY_LOG_DEBUG(@"Finished trace with tracer profilerReferenceId: %@ and status: %@",
         self.profilerReferenceID.sentryIdString, nameForSentrySpanStatus(status));
     @synchronized(self) {
         self.wasFinishCalled = YES;
@@ -496,6 +511,9 @@ static BOOL appStartMeasurementRead;
         }
     }
 
+    SENTRY_LOG_DEBUG(@"Can finish tracer %@ (profileReferenceId %@)", self.traceId.sentryIdString,
+        _profilerReferenceID.sentryIdString);
+
     [self finishInternal];
 }
 
@@ -523,6 +541,8 @@ static BOOL appStartMeasurementRead;
     BOOL discardTransaction = [self finishTracer:kSentrySpanStatusDeadlineExceeded
                                    shouldCleanUp:YES];
     if (discardTransaction) {
+        SENTRY_LOG_DEBUG(@"Discarding transaction for trace %@ (profileReferenceId %@)",
+            self.traceId.sentryIdString, _profilerReferenceID.sentryIdString);
         return;
     }
 
@@ -777,7 +797,7 @@ static BOOL appStartMeasurementRead;
         return nil;
     }
 
-    SENTRY_LOG_DEBUG(@"Returning app start measurements for trace id %@",
+    SENTRY_LOG_DEBUG(@"Returning app start measurements for tracer with profilerReferenceId %@",
         self.profilerReferenceID.sentryIdString);
     return measurement;
 }

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -121,11 +121,8 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 /**
  * Discard profiler session data associated with the given @c SentryId.
  * This only needs to be called in case you haven't collected the profile (and don't intend to).
- * @note For continuous profiling with trace lifecycle, you must indicate whether or not the trace
- * associated with this profiler was sampled for proper bookkeeping to align automatic continuous
- * profiling to root spans, and provide the configuration options.
  */
-+ (void)discardProfilerForTrace:(SentryId *)traceId traceSampled:(BOOL)isProfiling;
++ (void)discardProfilerForTrace:(SentryId *)traceId;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 @property (class, nullable, nonatomic, copy)

--- a/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
@@ -58,8 +58,7 @@ void sentry_trackTransactionProfilerForTrace(SentryProfiler *profiler, SentryId 
  * For transactions that will be discarded, clean up the bookkeeping state associated with them to
  * reclaim the memory they're using.
  */
-void sentry_discardProfilerCorrelatedToTrace(
-    SentryId *internalTraceId, SentryHub *hub, BOOL isProfiling);
+void sentry_discardProfilerCorrelatedToTrace(SentryId *internalTraceId, SentryHub *hub);
 
 /**
  * Return the profiler instance associated with the tracer. If it was the last tracer for the


### PR DESCRIPTION
Fixes a couple edge cases where bookkeeping of root spans became imbalanced for trace lifecycle in UI profiling.

#skip-changelog