### PR TITLE
fix: Make setMeasurement thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - Continuous profile stop requests are cancelled by subsequent timely calls to start (#4993)
 - Crash in setMeasurement when name is nil (#5064)
+- Make setMeasurement thread safe (#5067)
 
 ### Improvements
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -444,7 +444,9 @@ static BOOL appStartMeasurementRead;
         return;
     }
 
-    _measurements[name] = measurement;
+    @synchronized(_measurements) {
+        _measurements[name] = measurement;
+    }
 }
 
 - (void)finish

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -1005,6 +1005,47 @@ class SentryTracerTests: XCTestCase {
         XCTAssertNil(serializedTransaction?["measurements"])
     }
 
+    func testMeasurementsFromDifferentThreads_SetsAllMeasurements() throws {
+        // Arrange
+        let iterations = 100
+        let unit = MeasurementUnitFraction.percent
+
+        let sut = fixture.getSut()
+        let childSpan = sut.startChild(operation: "operation")
+
+        let dispatchQueue = DispatchQueue(label: "testQueue", attributes: .concurrent)
+        let expectation = XCTestExpectation(description: "Set measurements")
+        expectation.expectedFulfillmentCount = iterations
+
+        // Act
+        for i in 0..<iterations {
+            dispatchQueue.async {
+                sut.setMeasurement(name: "transaction \(i)", value: 12.0, unit: unit)
+                childSpan.setMeasurement(name: "span \(i)", value: 10.0, unit: unit)
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+
+        // Assert
+        childSpan.finish()
+        sut.finish()
+        XCTAssertEqual(1, fixture.hub.capturedEventsWithScopes.count)
+        let serializedTransaction = fixture.hub.capturedEventsWithScopes.first?.event.serialize()
+
+        let measurements = try XCTUnwrap(serializedTransaction?["measurements"] as? [String: [String: Any]])
+        XCTAssertEqual(measurements.count, iterations * 2)
+
+        for i in 0..<iterations {
+            let transactionMeasurement = try XCTUnwrap(measurements["transaction \(i)"])
+            XCTAssertEqual(try XCTUnwrap(transactionMeasurement["value"] as? NSNumber), 12.0)
+
+            let spanMeasurement = try XCTUnwrap(measurements["span \(i)"])
+            XCTAssertEqual(try XCTUnwrap(spanMeasurement["value"] as? NSNumber), 10.0)
+        }
+    }
+
     func testFinish_WithUnfinishedChildren() {
         let sut = fixture.getSut(waitForChildren: false)
         let child1 = sut.startChild(operation: fixture.transactionOperation)


### PR DESCRIPTION


## :scroll: Description

Calling setMeasurement on transactions ans spans could lead to crashes. This is fixed now by making it thread safe.

## :bulb: Motivation and Context

A customer reported this crash and we see a few occurrences in our internal [SDK crash detection](https://sentry.sentry.io/issues/4684233446/?project=4505469596663808&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D%20setmeasurement&referrer=issue-stream&sort=user&stream_index=0).

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
