### PR TITLE
fix: Make setMeasurement thread safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Crash in setMeasurement when name is nil (#5064)
-- Make setMeasurement thread safe (#5067)
+- Make setMeasurement thread safe (#5067, #5078)
 
 ## 8.49.0
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -464,6 +464,13 @@ static BOOL appStartMeasurementRead;
     }
 }
 
+- (NSDictionary<NSString *, SentryMeasurementValue *> *)measurements
+{
+    @synchronized(_measurements) {
+        return _measurements.copy;
+    }
+}
+
 - (void)finish
 {
     [self finishWithStatus:kSentrySpanStatusOk];


### PR DESCRIPTION
Addition to #5067 to also make the getter of measurements thread safe.

