### PR TITLE
feat: Allow Hybrid SDKs to `setTrace`

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -9,6 +9,7 @@
 #import "SentryInternalDefines.h"
 #import "SentryMeta.h"
 #import "SentryOptions+Private.h"
+#import "SentryPropagationContext.h"
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import "SentrySessionReplayIntegration+Private.h"
@@ -197,6 +198,14 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 + (NSDictionary *)getExtraContext
 {
     return [SentryDependencyContainer.sharedInstance.extraContextProvider getExtraContext];
+}
+
++ (void)setTrace:(SentryId *)traceId spanId:(SentrySpanId *)spanId
+{
+    [SentrySDK.currentHub configureScope:^(SentryScope *scope) {
+        scope.propagationContext = [[SentryPropagationContext alloc] initWithTraceId:traceId
+                                                                              spanId:spanId];
+    }];
 }
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Sentry/SentryPropagationContext.h
+++ b/Sources/Sentry/SentryPropagationContext.h
@@ -12,6 +12,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, readonly) SentrySpanId *spanId;
 @property (nonatomic, readonly) SentryTraceHeader *traceHeader;
 
+- (instancetype)initWithTraceId:(SentryId *)traceId spanId:(SentrySpanId *)spanId;
+
 - (NSDictionary<NSString *, NSString *> *)traceContextForEvent;
 
 @end

--- a/Sources/Sentry/SentryPropagationContext.m
+++ b/Sources/Sentry/SentryPropagationContext.m
@@ -14,6 +14,15 @@
     return self;
 }
 
+- (instancetype)initWithTraceId:(SentryId *)traceId spanId:(SentrySpanId *)spanId
+{
+    if (self = [super init]) {
+        _traceId = traceId;
+        _spanId = spanId;
+    }
+    return self;
+}
+
 - (SentryTraceHeader *)traceHeader
 {
     return [[SentryTraceHeader alloc] initWithTraceId:self.traceId

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -154,6 +154,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
+- (void)setPropagationContext:(SentryPropagationContext *)propagationContext
+{
+    @synchronized(_propagationContext) {
+        _propagationContext = propagationContext;
+
+        for (id<SentryScopeObserver> observer in self.observers) {
+            [observer setTraceContext:[self.propagationContext traceContextForEvent]];
+        }
+    }
+}
+
 - (nullable id<SentrySpan>)span
 {
     @synchronized(_spanLock) {

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -159,8 +159,11 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(_propagationContext) {
         _propagationContext = propagationContext;
 
-        for (id<SentryScopeObserver> observer in self.observers) {
-            [observer setTraceContext:[self.propagationContext traceContextForEvent]];
+        if (self.observers.count > 0) {
+            NSDictionary *traceContext = [self.propagationContext traceContextForEvent];
+            for (id<SentryScopeObserver> observer in self.observers) {
+                [observer setTraceContext:traceContext];
+            }
         }
     }
 }

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -105,7 +105,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 + (NSDictionary *)getExtraContext;
 
 /**
- * Allow Hybrids SDKs to set the current Trace.
+ * Allows Hybrids SDKs to thread-safe set the current trace.
  */
 + (void)setTrace:(SentryId *)traceId spanId:(SentrySpanId *)spanId;
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -18,6 +18,7 @@
 @class SentryUser;
 @class SentryEnvelope;
 @class SentryId;
+@class SentrySpanId;
 @class SentrySessionReplayIntegration;
 @class UIView;
 
@@ -102,6 +103,11 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * Retrieves extra context
  */
 + (NSDictionary *)getExtraContext;
+
+/**
+ * Allow Hybrids SDKs to set the current Trace.
+ */
++ (void)setTrace:(SentryId *)traceId spanId:(SentrySpanId *)spanId;
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 /**

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (atomic, strong) SentryUser *_Nullable userObject;
 
+/**
+ * The propagation context has a setter, requiring it to be nonatomic
+ */
 @property (nonatomic, strong) SentryPropagationContext *propagationContext;
 
 @property (nonatomic, nullable, copy) NSString *currentScreen;

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (atomic, strong) SentryUser *_Nullable userObject;
 
-@property (atomic, strong) SentryPropagationContext *propagationContext;
+@property (nonatomic, strong) SentryPropagationContext *propagationContext;
 
 @property (nonatomic, nullable, copy) NSString *currentScreen;
 

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -477,4 +477,18 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         event.exceptions?.first?.mechanism?.handled = false
         return SentryEnvelope(event: event)
     }
+    
+    func testSetTrace() {
+        let traceId = SentryId()
+        let spanId = SentrySpanId()
+        
+        let scope = Scope()
+        let hub = TestHub(client: nil, andScope: scope)
+        SentrySDK.setCurrentHub(hub)
+        
+        PrivateSentrySDKOnly.setTrace(traceId, spanId: spanId)
+        
+        XCTAssertEqual(scope.propagationContext?.traceId, traceId)
+        XCTAssertEqual(scope.propagationContext?.spanId, spanId)
+    }
 }

--- a/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
+++ b/Tests/SentryTests/PrivateSentrySDKOnlyTests.swift
@@ -479,6 +479,7 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
     }
     
     func testSetTrace() {
+        // -- Arrange --
         let traceId = SentryId()
         let spanId = SentrySpanId()
         
@@ -486,8 +487,10 @@ class PrivateSentrySDKOnlyTests: XCTestCase {
         let hub = TestHub(client: nil, andScope: scope)
         SentrySDK.setCurrentHub(hub)
         
+        // -- Act --
         PrivateSentrySDKOnly.setTrace(traceId, spanId: spanId)
         
+        // -- Assert --        
         XCTAssertEqual(scope.propagationContext?.traceId, traceId)
         XCTAssertEqual(scope.propagationContext?.spanId, spanId)
     }

--- a/Tests/SentryTests/SentryPropagationContextTests.swift
+++ b/Tests/SentryTests/SentryPropagationContextTests.swift
@@ -4,36 +4,45 @@ import XCTest
 class SentryPropagationContextTests: XCTestCase {
     
     func testInitWithTraceIdSpanId() {
+        // -- Arrange --
         let traceId = SentryId()
         let spanId = SpanId()
-        
+
+        // -- Act --
         let context = SentryPropagationContext(traceId: traceId, spanId: spanId)
         
+        // -- Assert --
         XCTAssertEqual(traceId, context.traceId)
         XCTAssertEqual(spanId, context.spanId)
     }
     
     func testTraceContextForEvent() {
+        // -- Arrange --
         let traceId = SentryId()
         let spanId = SpanId()
         
         let context = SentryPropagationContext(traceId: traceId, spanId: spanId)
         
+        // -- Act --
         let traceContext = context.traceContextForEvent()
         
+        // -- Assert --
         XCTAssertEqual(traceContext.count, 2)
         XCTAssertEqual(traceContext["trace_id"], traceId.sentryIdString)
         XCTAssertEqual(traceContext["span_id"], spanId.sentrySpanIdString)
     }
     
     func testTraceHeader() {
+        // -- Arrange
         let traceId = SentryId()
         let spanId = SpanId()
         
         let context = SentryPropagationContext(traceId: traceId, spanId: spanId)
         
+        // -- Act --
         let traceHeader = context.traceHeader
         
+        // -- Assert --
         XCTAssertNotNil(traceHeader)
         XCTAssertEqual(traceHeader.traceId, traceId)
         XCTAssertEqual(traceHeader.spanId, spanId)

--- a/Tests/SentryTests/SentryPropagationContextTests.swift
+++ b/Tests/SentryTests/SentryPropagationContextTests.swift
@@ -1,0 +1,41 @@
+@testable import Sentry
+import XCTest
+
+class SentryPropagationContextTests: XCTestCase {
+    
+    func testInitWithTraceIdSpanId() {
+        let traceId = SentryId()
+        let spanId = SpanId()
+        
+        let context = SentryPropagationContext(traceId: traceId, spanId: spanId)
+        
+        XCTAssertEqual(traceId, context.traceId)
+        XCTAssertEqual(spanId, context.spanId)
+    }
+    
+    func testTraceContextForEvent() {
+        let traceId = SentryId()
+        let spanId = SpanId()
+        
+        let context = SentryPropagationContext(traceId: traceId, spanId: spanId)
+        
+        let traceContext = context.traceContextForEvent()
+        
+        XCTAssertEqual(traceContext.count, 2)
+        XCTAssertEqual(traceContext["trace_id"], traceId.sentryIdString)
+        XCTAssertEqual(traceContext["span_id"], spanId.sentrySpanIdString)
+    }
+    
+    func testTraceHeader() {
+        let traceId = SentryId()
+        let spanId = SpanId()
+        
+        let context = SentryPropagationContext(traceId: traceId, spanId: spanId)
+        
+        let traceHeader = context.traceHeader
+        
+        XCTAssertNotNil(traceHeader)
+        XCTAssertEqual(traceHeader.traceId, traceId)
+        XCTAssertEqual(traceHeader.spanId, spanId)
+    }
+} 

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -843,6 +843,26 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(observer2.context as? NSDictionary, expected)
     }
 
+    func testSetPropagationContext_UpdatesTraceContext() throws {
+        // -- Arrange --
+        let sut = Scope()
+        let observer = fixture.observer
+        sut.add(observer)
+        
+        let traceId = SentryId(uuidString: "12345678123456781234567812345678")
+        let spanId = SpanId(value: "1234567812345678")
+        let propagationContext = SentryPropagationContext(trace: traceId, spanId: spanId)
+        
+        // -- Act --
+        sut.propagationContext = propagationContext
+        
+        // -- Assert -- 
+        let traceContext = try XCTUnwrap(observer.traceContext)
+        XCTAssertEqual(2, traceContext.count)
+        XCTAssertEqual(traceId.sentryIdString, traceContext["trace_id"] as? String)
+        XCTAssertEqual(spanId.sentrySpanIdString, traceContext["span_id"] as? String)
+    }
+
     private class TestScopeObserver: NSObject, SentryScopeObserver {
         var tags: [String: String]?
         func setTags(_ tags: [String: String]?) {

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -843,7 +843,7 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(observer2.context as? NSDictionary, expected)
     }
 
-    func testSetPropagationContext_UpdatesTraceContext() throws {
+    func testScopeObserver_setPropagationContext_UpdatesTraceContext() throws {
         // -- Arrange --
         let sut = Scope()
         let observer = fixture.observer


### PR DESCRIPTION
## :scroll: Description

This PR allows Hybrid SDKs to explicitly set the `PropagationContext` on the scope via the `PrivateSentrySDKOnly`. 

## :bulb: Motivation and Context

The basic idea is that the Cocoa SDK, when brought in via a Hybrid SDK, should accept a trace from the Head SDK to connect errors on all layers of the application. This PR makes use of the fact that the Hybrid SDKs rely on their own performance instrumentation right now, allowing us to leverage the propagation context to achieve this.

Originates from the Unity SDK: https://github.com/getsentry/sentry-unity/issues/1998 
Unblocks the React Native SDK: https://github.com/getsentry/sentry-react-native/issues/3918
Mirror-PR on the Java SDK: https://github.com/getsentry/sentry-java/pull/4137

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog