### PR TITLE
chore(file-io): add data and file manager swizzling to enabled features

### DIFF
--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -57,7 +57,18 @@ import Foundation
             features.append("fastViewRendering")
         }
 #endif // #if os(iOS) && !SENTRY_NO_UIKIT
+
+        addFileIOFeatures(options: options, to: &features)
         return features
     }
     // swiftlint:enable cyclomatic_complexity
+
+    private static func addFileIOFeatures(options: Options, to features: inout [String]) {
+        if options.experimental.enableDataSwizzling {
+            features.append("dataSwizzling")
+        }
+        if options.experimental.enableFileManagerSwizzling {
+            features.append("fileManagerSwizzling")
+        }
+    }
 }

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -2,7 +2,7 @@ import Foundation
 
 @objcMembers class SentryEnabledFeaturesBuilder: NSObject {
 
-    // swiftlint:disable cyclomatic_complexity
+    // swiftlint:disable cyclomatic_complexity function_body_length
     static func getEnabledFeatures(options: Options?) -> [String] {
         guard let options = options else {
             return []
@@ -58,17 +58,13 @@ import Foundation
         }
 #endif // #if os(iOS) && !SENTRY_NO_UIKIT
 
-        addFileIOFeatures(options: options, to: &features)
-        return features
-    }
-    // swiftlint:enable cyclomatic_complexity
-
-    private static func addFileIOFeatures(options: Options, to features: inout [String]) {
         if options.experimental.enableDataSwizzling {
             features.append("dataSwizzling")
         }
         if options.experimental.enableFileManagerSwizzling {
             features.append("fileManagerSwizzling")
         }
+        return features
     }
+    // swiftlint:enable cyclomatic_complexity function_body_length
 }

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -11,7 +11,7 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
         // -- Assert --
-        XCTAssertEqual(features, ["captureFailedRequests"])
+        XCTAssertEqual(features, ["captureFailedRequests", "dataSwizzling"])
     }
 
     func testEnableAllFeatures() throws {
@@ -112,5 +112,57 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
 #else
         throw XCTSkip("Test not supported on this platform")
 #endif
+    }
+
+    func testEnableDataSwizzling_isEnabled_shouldAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+
+        options.experimental.enableDataSwizzling = true
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssert(features.contains("dataSwizzling"))
+    }
+
+    func testEnableDataSwizzling_isDisabled_shouldNotAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+
+        options.experimental.enableDataSwizzling = false
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertFalse(features.contains("dataSwizzling"))
+    }
+
+    func testEnableFileManagerSwizzling_isEnabled_shouldAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+
+        options.experimental.enableFileManagerSwizzling = true
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssert(features.contains("fileManagerSwizzling"))
+    }
+
+    func testEnableFileManagerSwizzling_isDisabled_shouldNotAddFeature() throws {
+        // -- Arrange --
+        let options = Options()
+
+        options.experimental.enableFileManagerSwizzling = false
+
+        // -- Act --
+        let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
+
+        // -- Assert --
+        XCTAssertFalse(features.contains("fileManagerSwizzling"))
     }
 }


### PR DESCRIPTION
## :scroll: Description

Adds two flags for data and file manager swizzling adoption tracking

## :bulb: Motivation and Context

Closes #4906

## :green_heart: How did you test it?

Added tests

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog