### PR TITLE
test: Return create-simulator to compare flakiness

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -86,8 +86,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Boot Default Simulator
+        if: ${{ matrix.device == 'default' && matrix.os-version == 'default' }}
+        run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
+
       - name: Create ${{matrix.device}} (${{matrix.os-version}}) Simulator using Xcode ${{matrix.xcode}}
-        if: ${{ matrix.os-version != 'default' }} # Only create simulator if os-version is set
+        if: ${{ matrix.device != 'default' && matrix.os-version != 'default' }} # Only create simulator if os-version is set
         run: ./scripts/create-simulator.sh "${{matrix.xcode}}" "${{matrix.os-version}}" "${{matrix.device}}" "${{matrix.force-sim-runtime}}"
 
       - name: Install tooling
@@ -97,14 +102,6 @@ jobs:
         with:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
-
-      - name: Boot Default Simulator
-        if: ${{ matrix.device == 'default' }}
-        run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
-
-      - name: Boot ${{matrix.device}} Simulator
-        if: ${{ matrix.device != 'default' }}
-        run: ./scripts/ci-boot-simulator.sh --device "${{matrix.device}}"
 
       - name: Install App
         run: xcrun simctl install booted ${{env.APP_PATH}}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -34,7 +34,7 @@ jobs:
           path: TestSamples/SwiftUITestSample/DerivedData/Build/Products/Debug-iphonesimulator/SwiftUITestSample.app
 
   run-tests:
-    name: Test iOS on Xcode ${{matrix.xcode}}
+    name: ${{matrix.name}}
     needs: [build-sample]
     runs-on: ${{matrix.runs-on}}
     env:
@@ -53,18 +53,42 @@ jobs:
         include:
           # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
-          - runs-on: macos-13
+          - name: Test iOS on Xcode 14.3.1
+            runs-on: macos-13
             xcode: "14.3.1"
+            device: "default"
+            os-version: "default"
+
+          # Added for testing flakiness of the tests (without the new simulator test became more flaky up to 50%)
+          - name: Test iOS on Xcode 14.3.1 with iPhone 14 (16.4) - Reverted
+            runs-on: macos-13
+            xcode: "14.3.1"
+            device: "iPhone 14"
+            os-version: "16.4"
+            force-sim-runtime: true
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
-          - runs-on: macos-15
+          - name: Test iOS on Xcode 16.2
+            runs-on: macos-15
             xcode: "16.2"
+            device: "default"
+            os-version: "default"
+
+          # Added for testing flakiness of the tests (without the new simulator test became more flaky up to 50%)
+          - name: Test iOS on Xcode 16.2 with iPhone 16 (18.2) - Reverted
+            runs-on: macos-15
+            xcode: "16.2"
+            device: "iPhone 16"
+            os-version: "18.2"
 
     steps:
       - uses: actions/checkout@v4
+      - name: Create ${{matrix.device}} (${{matrix.os-version}}) Simulator using Xcode ${{matrix.xcode}}
+        if: ${{ matrix.os-version != 'default' }} # Only create simulator if os-version is set
+        run: ./scripts/create-simulator.sh "${{matrix.xcode}}" "${{matrix.os-version}}" "${{matrix.device}}" "${{matrix.force-sim-runtime}}"
 
       - name: Install tooling
         run: make init-ci-test
@@ -74,7 +98,13 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
-      - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
+      - name: Boot Default Simulator
+        if: ${{ matrix.device == 'default' }}
+        run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
+
+      - name: Boot ${{matrix.device}} Simulator
+        if: ${{ matrix.device != 'default' }}
+        run: ./scripts/ci-boot-simulator.sh --device "${{matrix.device}}"
 
       - name: Install App
         run: xcrun simctl install booted ${{env.APP_PATH}}
@@ -83,17 +113,21 @@ jobs:
         run: |
           maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}
 
+      - name: Delete Simulator
+        if: always()
+        run: ./scripts/delete-simulator.sh
+
       - name: Store Maestro Logs
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: maestro-logs-${{matrix.xcode}}
+          name: maestro-logs-${{matrix.xcode}}-${{matrix.device}}-${{matrix.os-version}}
           path: ${{env.MAESTRO_LOGS_PATH}}
 
       - name: Archiving Crash Logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
-          name: crash-logs-${{matrix.xcode}}
+          name: crash-logs-${{matrix.xcode}}-${{matrix.device}}-${{matrix.os-version}}
           path: |
             ~/Library/Logs/DiagnosticReports/**

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -53,14 +53,14 @@ jobs:
         include:
           # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
-          - name: Test iOS on Xcode 14.3.1
+          - name: Test iOS on Xcode 14.3.1 - V2
             runs-on: macos-13
             xcode: "14.3.1"
             device: "default"
             os-version: "default"
 
           # Added for testing flakiness of the tests (without the new simulator test became more flaky up to 50%)
-          - name: Test iOS on Xcode 14.3.1 with iPhone 14 (16.4) - Reverted
+          - name: Test iOS on Xcode 14.3.1 with iPhone 14 (16.4) - V2
             runs-on: macos-13
             xcode: "14.3.1"
             device: "iPhone 14"
@@ -71,14 +71,14 @@ jobs:
 
           # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
-          - name: Test iOS on Xcode 16.2
+          - name: Test iOS on Xcode 16.2 - V2
             runs-on: macos-15
             xcode: "16.2"
             device: "default"
             os-version: "default"
 
           # Added for testing flakiness of the tests (without the new simulator test became more flaky up to 50%)
-          - name: Test iOS on Xcode 16.2 with iPhone 16 (18.2) - Reverted
+          - name: Test iOS on Xcode 16.2 with iPhone 16 (18.2) - V2
             runs-on: macos-15
             xcode: "16.2"
             device: "iPhone 16"

--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -14,37 +14,51 @@ set -euo pipefail
 # Parse named arguments
 XCODE_VERSION="16.2" # Default value
 
+# Only allow one argument type
+if [[ $# -gt 2 ]]; then
+    echo "Error: Cannot specify both --xcode and --device"
+    echo "Usage: $0 [-x|--xcode <version>] OR [-d|--device <device>]"
+    exit 1
+fi
+
 while [[ $# -gt 0 ]]; do
     case $1 in
         -x|--xcode)
             XCODE_VERSION="$2"
             shift 2
             ;;
+        -d|--device)
+            SIMULATOR="$2"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1"
-            echo "Usage: $0 [-x|--xcode <version>]"
+            echo "Usage: $0 [-x|--xcode <version>] [-d|--device <device>]"
             exit 1
             ;;
     esac
 done
 
-SIMULATOR="iPhone 16"
-
 # Select simulator based on Xcode version
-case "$XCODE_VERSION" in
-    "14.3.1")
-        SIMULATOR="iPhone 14"
-        ;;
-    "15.4")
-        SIMULATOR="iPhone 15"
-        ;;
-    "16.2")
-        SIMULATOR="iPhone 16"
-        ;;
-    *)
-        SIMULATOR="iPhone 16" # Default fallback
-        ;;
-esac
+if [[ -z "${SIMULATOR}" ]]; then
+    case "$XCODE_VERSION" in
+        "14.3.1")
+            SIMULATOR="iPhone 14"
+            ;;
+        "15.4")
+            SIMULATOR="iPhone 15"
+            ;;
+        "16.2")
+            SIMULATOR="iPhone 16"
+            ;;
+        *)
+            SIMULATOR="iPhone 16" # Default fallback
+            ;;
+    esac
+fi
 
 echo "Booting simulator $SIMULATOR"
 xcrun simctl boot "$SIMULATOR"
+
+# Print details about the booted simulator, iOS version, etc.
+xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.value[] | .state == "Booted")'

--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -14,51 +14,43 @@ set -euo pipefail
 # Parse named arguments
 XCODE_VERSION="16.2" # Default value
 
-# Only allow one argument type
-if [[ $# -gt 2 ]]; then
-    echo "Error: Cannot specify both --xcode and --device"
-    echo "Usage: $0 [-x|--xcode <version>] OR [-d|--device <device>]"
-    exit 1
-fi
-
 while [[ $# -gt 0 ]]; do
     case $1 in
         -x|--xcode)
             XCODE_VERSION="$2"
             shift 2
             ;;
-        -d|--device)
-            SIMULATOR="$2"
-            shift 2
-            ;;
         *)
             echo "Unknown argument: $1"
-            echo "Usage: $0 [-x|--xcode <version>] [-d|--device <device>]"
+            echo "Usage: $0 [-x|--xcode <version>]"
             exit 1
             ;;
     esac
 done
 
+SIMULATOR="iPhone 16"
+
 # Select simulator based on Xcode version
-if [[ -z "${SIMULATOR}" ]]; then
-    case "$XCODE_VERSION" in
-        "14.3.1")
-            SIMULATOR="iPhone 14"
-            ;;
-        "15.4")
-            SIMULATOR="iPhone 15"
-            ;;
-        "16.2")
-            SIMULATOR="iPhone 16"
-            ;;
-        *)
-            SIMULATOR="iPhone 16" # Default fallback
-            ;;
-    esac
-fi
+case "$XCODE_VERSION" in
+    "14.3.1")
+        SIMULATOR="iPhone 14"
+        ;;
+    "15.4")
+        SIMULATOR="iPhone 15"
+        ;;
+    "16.2")
+        SIMULATOR="iPhone 16"
+        ;;
+    *)
+        SIMULATOR="iPhone 16" # Default fallback
+        ;;
+esac
 
 echo "Booting simulator $SIMULATOR"
 xcrun simctl boot "$SIMULATOR"
+
+# Wait for the simulator to boot
+xcrun simctl bootstatus "$SIMULATOR"
 
 # Print details about the booted simulator, iOS version, etc.
 xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.value[] | .state == "Booted")'

--- a/scripts/create-simulator.sh
+++ b/scripts/create-simulator.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Workaround with a symlink pointed out in: https://github.com/actions/virtual-environments/issues/551#issuecomment-637344435
+
+set -euo pipefail
+
+XCODE_VERSION="${1}"
+SIM_RUNTIME="${2}"
+DEVICE_TYPE="${3}" # A valid available device type. Find these by running "xcrun simctl list devicetypes".
+FORCE_SIM_RUNTIME="${4}"
+
+SIM_RUNTIME_WITH_DASH="${SIM_RUNTIME//./-}"
+SIM_NAME="Sentry ${DEVICE_TYPE} (${SIM_RUNTIME})"
+
+if [ "${FORCE_SIM_RUNTIME}" == "true" ]; then
+  sudo mkdir -p /Library/Developer/CoreSimulator/Profiles/Runtimes
+  sudo ln -s \
+    "/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer/Platforms/iPhoneOS.platform/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS.simruntime" \
+    "/Library/Developer/CoreSimulator/Profiles/Runtimes/iOS ${SIM_RUNTIME}.simruntime"
+fi
+
+uuid=$(xcrun simctl create \
+  "${SIM_NAME}" \
+  "${DEVICE_TYPE}" \
+  "com.apple.CoreSimulator.SimRuntime.iOS-${SIM_RUNTIME_WITH_DASH}")
+echo "Created simulator ${SIM_NAME} with UUID ${uuid}"
+
+xcrun simctl boot "${uuid}"
+xcrun simctl bootstatus "${uuid}"
+echo "Booted simulator ${SIM_NAME} with UUID ${uuid}"
+
+if [ -n "${GITHUB_ENV}" ]; then
+  echo "SENTRY_SIMULATOR_UUID=${uuid}" >> "${GITHUB_ENV}"
+fi

--- a/scripts/delete-simulator.sh
+++ b/scripts/delete-simulator.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# SENTRY_SIMULATOR_UUID is set by create-simulator.sh
+if [ -z "${SENTRY_SIMULATOR_UUID}" ]; then
+  echo "No simulator UUID provided"
+  exit 0
+fi
+
+uuid="${SENTRY_SIMULATOR_UUID}"
+
+xcrun simctl shutdown "${uuid}"
+echo "Shutdown simulator with UUID ${uuid}"
+
+xcrun simctl delete "${uuid}"
+echo "Deleted simulator with UUID ${uuid}"


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Returns sim creation removed in https://github.com/getsentry/sentry-cocoa/pull/5015 and https://github.com/getsentry/sentry-cocoa/pull/5030

Based on CI stats, the Xcode 14.3.1 test became very flaky; with this change, we can compare if creating the sim improves it.

Previous:
![Screenshot 2025-04-15 at 13 39 59](https://github.com/user-attachments/assets/ed04c978-69b2-473e-9b2b-895d87055bba)

Current:
![Screenshot 2025-04-15 at 13 39 37](https://github.com/user-attachments/assets/6d817a6b-7154-4e54-8ee4-0ddd2071fd68)

#skip-changelog 

Superseded by: https://github.com/getsentry/sentry-cocoa/pull/5093