### PR TITLE
test: Wait for Sim to boot and print its details

### DIFF
--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -48,3 +48,9 @@ esac
 
 echo "Booting simulator $SIMULATOR"
 xcrun simctl boot "$SIMULATOR"
+
+# Wait for the simulator to boot
+xcrun simctl bootstatus "$SIMULATOR"
+
+# Print details about the booted simulator, iOS version, etc.
+xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.value[] | .state == "Booted")'


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

Adds wait for simulator to boot and print details about the sim, so in case of a failure we can inspect the iOS version useds and other details

#skip-changelog


Example output:
```bash
➜ xcrun simctl list devices --json | jq '.devices | to_entries[] | select(.value[] | .state == "Booted")'
{
  "key": "com.apple.CoreSimulator.SimRuntime.iOS-18-2",
  "value": [
    {
      "lastBootedAt": "2025-04-15T11:03:03Z",
      "dataPath": "/Users/krystofwoldrich/Library/Developer/CoreSimulator/Devices/3BC9A608-0042-414F-B35C-7ADB869BC572/data",
      "dataPathSize": 3387273216,
      "logPath": "/Users/krystofwoldrich/Library/Logs/CoreSimulator/3BC9A608-0042-414F-B35C-7ADB869BC572",
      "udid": "3BC9A608-0042-414F-B35C-7ADB869BC572",
      "isAvailable": true,
      "logPathSize": 589824,
      "deviceTypeIdentifier": "com.apple.CoreSimulator.SimDeviceType.iPhone-16",
      "state": "Booted",
      "name": "iPhone 16"
    }
  ]
}
```