### PR TITLE
 fix: Async safe log for backtrace in CPPException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - Truncation of Swift crash messages (#5036)
 - Async safe log for backtrace in CPPException (#5098)
 
-
 ## 8.49.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Crash in setMeasurement when name is nil (#5064)
 - Make setMeasurement thread safe (#5067, #5078)
+- Async safe log for backtrace in CPPException (#5098)
 
 ## 8.49.0
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		62885DA729E946B100554F38 /* TestConncurrentModifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62885DA629E946B100554F38 /* TestConncurrentModifications.swift */; };
 		628B89022D841D7F004B6F2A /* SentryDateUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 628B89012D841D7F004B6F2A /* SentryDateUtilsTests.swift */; };
 		629194A92D51F976000F7C6B /* SentryDebugMetaCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629194A82D51F976000F7C6B /* SentryDebugMetaCodable.swift */; };
+		629258552DAF91940049388F /* SentryCrashStackCursorSelfThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 629258542DAF91940049388F /* SentryCrashStackCursorSelfThreadTests.swift */; };
 		6293F5752D422A95002BC3BD /* SentryStacktraceCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6293F5742D422A8A002BC3BD /* SentryStacktraceCodable.swift */; };
 		629428802CB3BF69002C454C /* SwizzleClassNameExclude.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294287F2CB3BF4E002C454C /* SwizzleClassNameExclude.swift */; };
 		6294774C2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */; };
@@ -1203,6 +1204,7 @@
 		62885DA629E946B100554F38 /* TestConncurrentModifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestConncurrentModifications.swift; sourceTree = "<group>"; };
 		628B89012D841D7F004B6F2A /* SentryDateUtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDateUtilsTests.swift; sourceTree = "<group>"; };
 		629194A82D51F976000F7C6B /* SentryDebugMetaCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDebugMetaCodable.swift; sourceTree = "<group>"; };
+		629258542DAF91940049388F /* SentryCrashStackCursorSelfThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCrashStackCursorSelfThreadTests.swift; sourceTree = "<group>"; };
 		6293F5742D422A8A002BC3BD /* SentryStacktraceCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStacktraceCodable.swift; sourceTree = "<group>"; };
 		6294287F2CB3BF4E002C454C /* SwizzleClassNameExclude.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzleClassNameExclude.swift; sourceTree = "<group>"; };
 		6294774B2C6F255F00846CBC /* SentryANRTrackerV2Delegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryANRTrackerV2Delegate.swift; sourceTree = "<group>"; };
@@ -3059,6 +3061,7 @@
 				0ADC33EF28D9BE690078D980 /* TestSentryUIDeviceWrapper.swift */,
 				7B984A9E28E572AF001F4BEE /* CrashReport.swift */,
 				7BF69E062987D1FE002EBCA4 /* SentryCrashDoctorTests.swift */,
+				629258542DAF91940049388F /* SentryCrashStackCursorSelfThreadTests.swift */,
 			);
 			path = SentryCrash;
 			sourceTree = "<group>";
@@ -5301,6 +5304,7 @@
 				7B01CE3D271993AC00B5AF31 /* SentryTransportFactoryTests.swift in Sources */,
 				7B30B68026527C3C006B2752 /* SentryFramesTrackerTests.swift in Sources */,
 				0A9BF4EB28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift in Sources */,
+				629258552DAF91940049388F /* SentryCrashStackCursorSelfThreadTests.swift in Sources */,
 				8F0D6AA22B04115A00D048B1 /* SentryInstallation+Test.h in Sources */,
 				7BF65064292B905A00BBA5A8 /* SentryMXCallStackTreeTests.swift in Sources */,
 				631501BB1EE6F30B00512C5B /* SentrySwizzleTests.m in Sources */,

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_SelfThread.m
@@ -25,7 +25,7 @@
 
 #include "SentryCrashStackCursor_SelfThread.h"
 #include "SentryCrashStackCursor_Backtrace.h"
-#import "SentryLog.h"
+#import <Foundation/Foundation.h>
 #include <execinfo.h>
 
 #include "SentryAsyncSafeLog.h"
@@ -57,23 +57,24 @@ sentrycrashsc_initSelfThread(SentryCrashStackCursor *cursor, int skipEntries)
     int backtraceLength;
     if (@available(macOS 12.0, iOS 15.0, tvOS 15.0, watchOS 8.0, *)) {
         if (stitchSwiftAsync) {
-            SENTRY_LOG_DEBUG(@"Retrieving backtrace with async swift stitching...");
+            SENTRY_ASYNC_SAFE_LOG_DEBUG("Retrieving backtrace with async swift stitching...");
             backtraceLength
                 = (int)backtrace_async((void **)context->backtrace, MAX_BACKTRACE_LENGTH, NULL);
         } else {
-            SENTRY_LOG_DEBUG(@"Retrieving backtrace without async swift stitching...");
+            SENTRY_ASYNC_SAFE_LOG_DEBUG("Retrieving backtrace without async swift stitching...");
             backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
         }
     } else {
-        SENTRY_LOG_DEBUG(
-            @"Retrieving backtrace without async swift stitching (old platform versions)...");
+        SENTRY_ASYNC_SAFE_LOG_DEBUG(
+            "Retrieving backtrace without async swift stitching (old platform versions)...");
         backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
     }
 #else
-    SENTRY_LOG_DEBUG(@"Retrieving backtrace without async swift stitching (old Xcode versions)...");
+    SENTRY_ASYNC_SAFE_LOG_DEBUG(
+        "Retrieving backtrace without async swift stitching (old Xcode versions)...");
     int backtraceLength = backtrace((void **)context->backtrace, MAX_BACKTRACE_LENGTH);
 #endif
 
-    SENTRY_LOG_DEBUG(@"Finished retrieving backtrace.");
+    SENTRY_ASYNC_SAFE_LOG_DEBUG("Finished retrieving backtrace.");
     sentrycrashsc_initWithBacktrace(cursor, context->backtrace, backtraceLength, skipEntries + 1);
 }

--- a/Tests/SentryTests/SentryCrash/SentryCrashStackCursorSelfThreadTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashStackCursorSelfThreadTests.swift
@@ -1,0 +1,25 @@
+@testable import Sentry
+import XCTest
+
+final class SentryCrashStackCursorSelfThreadTests: XCTestCase {
+
+    func testInitSelfThread_DoesNotUseNonAsyncSafeLogging() throws {
+        let oldDebug = SentryLog.isDebug
+        let oldLevel = SentryLog.diagnosticLevel
+        let oldOutput = SentryLog.getLogOutput()
+
+        defer {
+            SentryLog.setLogOutput(oldOutput)
+            SentryLog.configure(oldDebug, diagnosticLevel: oldLevel)
+        }
+
+        let logOutput = TestLogOutput()
+        SentryLog.setLogOutput(logOutput)
+        SentryLog.configure(true, diagnosticLevel: .debug)
+
+        var cursor = SentryCrashStackCursor()
+        sentrycrashsc_initSelfThread(&cursor, 1)
+
+        XCTAssertEqual(logOutput.loggedMessages.count, 0, "sentrycrashsc_initSelfThread can be called when crashing and MUST NOT use non async safe logging. You must use SENTRY_ASYNC_SAFE_LOG instead.")
+    }
+}

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -90,6 +90,7 @@
 #import "SentryCrashReportSink.h"
 #import "SentryCrashReportStore.h"
 #import "SentryCrashScopeObserver.h"
+#import "SentryCrashStackCursor_SelfThread.h"
 #import "SentryCrashStackEntryMapper.h"
 #import "SentryCrashUUIDConversion.h"
 #import "SentryCrashWrapper.h"


### PR DESCRIPTION


## :scroll: Description

Use async safe logging when getting the backtrace for CPP Exceptions. When an unhandled CPPExceptions occurs, the crash monitor for CPPExceptions uses SentryCrashStackCursor_SelfThread, which uses non async safe SenryLog. This is fixed now by using async safe logging in SentryCrashStackCursor_SelfThread. Only users using debug = true or setting the log level to debug were impacted by this issue.

## :bulb: Motivation and Context

Came up while investigating https://github.com/getsentry/sentry-cocoa/issues/4226.

## :green_heart: How did you test it?
Unit tests are still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
