### PR TITLE
ci: build sample apps on latest macOS image and Xcode version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,10 @@ jobs:
   # With this we catch potential issues already in the PR.
   ios-swift-release:
     name: Release Build of iOS Swift
-    runs-on: macos-14
+    runs-on: macos15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -66,12 +66,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 16.3
-
-      - name: List Xcode Build Schemes
-        run: >-
-          xcodebuild
-          -workspace Sentry.xcworkspace
-          -list
 
       # Note: Due to complexity in implementing the CODE_SIGNING_ALLOWED flag in the sentry-xcodebuild.sh script,
       #       we did not yet migrate this step to use the script yet.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
 
   build-sample:
     name: Sample ${{ matrix.scheme }}
-    runs-on: macos-latest
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,41 +50,22 @@ jobs:
 
   build-sample:
     name: Sample ${{ matrix.scheme }}
-    runs-on: ${{ matrix.runs-on }}
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         # other sample projects are built in ui-tests
         include:
           - scheme: macOS-Swift
-            xcode: 15.4
-            runs-on: macos-14
           - scheme: iOS13-Swift
-            xcode: 15.4
-            runs-on: macos-14
           - scheme: watchOS-Swift WatchKit App
-            xcode: 15.4
-            runs-on: macos-14
-          # Only compiles on Xcode 16+
           - scheme: macOS-SwiftUI
-            xcode: 16.2
-            runs-on: macos-15
-
           - scheme: SessionReplay-CameraTest
-            xcode: 16.2
-            runs-on: macos-15
-
-            # We have to compile on Xcode 16.3 because compiling on Xcode 16.2 fails with
-            # Data+SentryTracing.swift:21:62: error: 'ReadingOptions' aliases 'Foundation.ReadingOptions'
-            # and cannot be used here because C++ types from imported module 'Foundation' do not support
-            # library evolution; this is an error in the Swift 6 language mode
           - scheme: visionOS-Swift
-            xcode: 16.3
-            runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh ${{ matrix.xcode }}
+      - run: ./scripts/ci-select-xcode.sh 16.3
 
       - name: List Xcode Build Schemes
         run: >-
@@ -107,7 +88,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
-          name: raw-build-output-os-${{matrix.runs-on}}-xcode-${{matrix.xcode}}-scheme-${{matrix.scheme}}
+          name: raw-build-output-scheme-${{matrix.scheme}}
           path: |
             raw-build-output.log
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
   # With this we catch potential issues already in the PR.
   ios-swift-release:
     name: Release Build of iOS Swift
-    runs-on: macos15
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 16.3

--- a/scripts/ci-select-xcode.sh
+++ b/scripts/ci-select-xcode.sh
@@ -7,8 +7,7 @@
 
 set -euo pipefail
 
-# 14.3 is the default
-XCODE_VERSION="${1:-14.3}"
+XCODE_VERSION="${1}"
 
 # We prefer this over calling `sudo xcode-select` because it will fail if the Xcode version
 # is not installed. Also xcodes is preinstalled on the GH runners.


### PR DESCRIPTION
- use `macos-15` and Xcode 16.3 for sample app build jobs (they were a mixture of older ones, but this is just to make sure they compile at all, so we should be able to use the same thing for them all, and that should be what we're all presumably using on our local machines as well)
- remove the default for the xcode version parameter in ci-select-xcode.sh: it's better to see exactly what version is being used in the workflow config files. if we were to change the default in the bash script, that change is invisible in the workflow configs. also, we didn't have any naked invocations anyways

`make session-replay-camera-test-xcode` will generate the project, although in the future we might want a small script to do this that can take some parameters like platform/version/language/UI-lib

#skip-changelog