### PR TITLE
chore: remove nvm setup from make init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ init:
 	rbenv exec gem update bundler
 	rbenv exec bundle install
 	./scripts/update-tooling-versions.sh
-	
-	# The node version manager is optional, so we don't fail if it's not installed.
-	if [ -n "$NVM_DIR" ] && [ -d "$NVM_DIR" ]; then nvm use; fi
-	
 	yarn install
 	
 # installs the tools needed to run CI test tasks locally


### PR DESCRIPTION
The nvm setup is invalid, as the `$NVM_DIR` needs to be double-escaped like `$$NVM_DIR` otherwise it will access the env var `VM_DIR` instead.

After changing it I had issues to correctly resolve the path to the `nvm` command, therefore let's just remove it because everyone manages installed node versions differently.

#skip-changelog