### PR TITLE
Revert "fix: change identifier iOS-SwiftUITests to iOS-Swift-UITests …

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
+++ b/Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj
@@ -742,7 +742,7 @@
 			name = "iOS-Swift-UITests";
 			packageProductDependencies = (
 			);
-			productName = "iOS-Swift-UITests";
+			productName = "iOS-SwiftUITests";
 			productReference = 7B64386826A6C544000D0F65 /* iOS-Swift-UITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
@@ -761,7 +761,7 @@
 				848A2563286E3351008A8858 /* PBXTargetDependency */,
 			);
 			name = PerformanceBenchmarks;
-			productName = "iOS-Swift-UITests";
+			productName = "iOS-SwiftUITests";
 			productReference = 848A2573286E3351008A8858 /* PerformanceBenchmarks.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
@@ -1563,7 +1563,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.iOS-Swift-UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-Swift-UITests.xctrunner";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-SwiftUITests.xctrunner";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SENTRY_UI_TEST $(inherited)";
 				SWIFT_VERSION = 5.0;
@@ -1588,7 +1588,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.iOS-Swift-UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.iOS-Swift-UITests.xctrunner";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore io.sentry.iOS-SwiftUITests.xctrunner";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SENTRY_UI_TEST $(inherited)";
 				SWIFT_VERSION = 5.0;
@@ -1755,7 +1755,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.iOS-Swift-UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-Swift-UITests.xctrunner";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-SwiftUITests.xctrunner";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SENTRY_UI_TEST $(inherited)";
 				SWIFT_VERSION = 5.0;
@@ -1995,7 +1995,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "io.sentry.iOS-Swift-UITests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-Swift-UITests.xctrunner";
+				PROVISIONING_PROFILE_SPECIFIER = "match Development io.sentry.iOS-SwiftUITests.xctrunner";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "SENTRY_UI_TEST $(inherited)";
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
This change was similarly made in https://github.com/getsentry/sentry-cocoa/pull/5115 which I already had open, and is now making it difficult to merge that branch with `main`. I would appreciate if we could back this out and let it happen as part of that PR.

#skip-changelog