### PR TITLE
refactor(session-replay): add separate method to get video info with more logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- Add separate method to get video info with more logging (#5132)
+- More logging for Session Replay video info (#5132)
 
 ## 8.49.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Add separate method to get video info with more logging (#5132)
+
 ## 8.49.1
 
 ### Fixes

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -20,7 +20,7 @@ struct SentrySDKWrapper {
         
         if #available(iOS 16.0, *), !SentrySDKOverrides.Other.disableSessionReplay.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: 1,
+                sessionSampleRate: 0,
                 onErrorSampleRate: 1,
                 maskAllText: true,
                 maskAllImages: true

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -20,7 +20,7 @@ struct SentrySDKWrapper {
         
         if #available(iOS 16.0, *), !SentrySDKOverrides.Other.disableSessionReplay.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: 0,
+                sessionSampleRate: 1,
                 onErrorSampleRate: 1,
                 maskAllText: true,
                 maskAllImages: true

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -271,6 +271,9 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         }
         let minFrame = usedFrames.min(by: { $0.time < $1.time })
         guard let start = minFrame?.time else {
+            // Note: This code path is currently not reached, because the `getVideoInfo` method is only called after the video is successfully created, therefore at least one frame was used.
+            // The compiler still requires us to unwrap the optional value, and we
+            // do not permit force-unwrapping.
             SentryLog.warning("[Session Replay] Failed to read video start time from used frames, reason: no frames found")
             throw SentryOnDemandReplayError.cantReadVideoStartTime
         }

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -225,9 +225,9 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
             case .writing:
                 SentryLog.error("[Session Replay] Finish writing video was called with status writing, this is unexpected! Completing with no video info")
             case .cancelled:
-                SentryLog.warning("[Session Replay] Finish writing video was cancelled, completing with no video info")
+                SentryLog.warning("[Session Replay] Finish writing video was cancelled, completing with no video info.")
             case .completed:
-                SentryLog.debug("[Session Replay] Finish writing video was completed, creating video info from file attributes")
+                SentryLog.debug("[Session Replay] Finish writing video was completed, creating video info from file attributes.")
                 do {
                     result = try strongSelf.getVideoInfo(
                         from: outputFileURL,

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -272,8 +272,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         let minFrame = usedFrames.min(by: { $0.time < $1.time })
         guard let start = minFrame?.time else {
             // Note: This code path is currently not reached, because the `getVideoInfo` method is only called after the video is successfully created, therefore at least one frame was used.
-            // The compiler still requires us to unwrap the optional value, and we
-            // do not permit force-unwrapping.
+            // The compiler still requires us to unwrap the optional value, and we do not permit force-unwrapping.
             SentryLog.warning("[Session Replay] Failed to read video start time from used frames, reason: no frames found")
             throw SentryOnDemandReplayError.cantReadVideoStartTime
         }

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -212,21 +212,39 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         
         group.enter()
         videoWriter.inputs.forEach { $0.markAsFinished() }
-        videoWriter.finishWriting {
+        videoWriter.finishWriting { [weak self] in
             defer { group.leave() }
-            if videoWriter.status == .completed {
+
+            SentryLog.debug("[Session Replay] Finished video writing, status: \(videoWriter.status)")
+            guard let strongSelf = self else {
+                SentryLog.warning("[Session Replay] On-demand replay is deallocated, completing writing session without output video info")
+                return
+            }
+
+            switch videoWriter.status {
+            case .writing:
+                SentryLog.error("[Session Replay] Finish writing video was called with status writing, this is unexpected! Completing with no video info")
+            case .cancelled:
+                SentryLog.warning("[Session Replay] Finish writing video was cancelled, completing with no video info")
+            case .completed:
+                SentryLog.debug("[Session Replay] Finish writing video was completed, creating video info from file attributes")
                 do {
-                    let fileAttributes = try FileManager.default.attributesOfItem(atPath: outputFileURL.path)
-                    guard let fileSize = fileAttributes[FileAttributeKey.size] as? Int else {
-                        finishError = SentryOnDemandReplayError.cantReadVideoSize
-                        return
-                    }
-                    guard let start = usedFrames.min(by: { $0.time < $1.time })?.time else { return }
-                    let duration = TimeInterval(usedFrames.count / self.frameRate)
-                    result = SentryVideoInfo(path: outputFileURL, height: Int(videoHeight), width: Int(videoWidth), duration: duration, frameCount: usedFrames.count, frameRate: self.frameRate, start: start, end: start.addingTimeInterval(duration), fileSize: fileSize, screens: usedFrames.compactMap({ $0.screenName }))
+                    result = try strongSelf.getVideoInfo(
+                        from: outputFileURL,
+                        usedFrames: usedFrames,
+                        videoWidth: Int(videoWidth),
+                        videoHeight: Int(videoHeight)
+                    )
                 } catch {
+                    SentryLog.warning("[Session Replay] Failed to create video info from file attributes, reason: \(error.localizedDescription)")
                     finishError = error
                 }
+            case .failed, .unknown:
+                SentryLog.warning("[Session Replay] Finish writing video failed, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
+                finishError = videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo
+            @unknown default:
+                SentryLog.warning("[Session Replay] Finish writing video failed, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
+                finishError = videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo
             }
         }
         group.wait()
@@ -237,11 +255,38 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     
     private func filterFrames(beginning: Date, end: Date) -> [SentryReplayFrame] {
         var frames = [SentryReplayFrame]()
-        //Using dispatch queue as sync mechanism since we need a queue already to generate the video.
-        workingQueue.dispatchSync({
+        // Using dispatch queue as sync mechanism since we need a queue already to generate the video.
+        workingQueue.dispatchSync {
             frames = self._frames.filter { $0.time >= beginning && $0.time <= end }
-        })
+        }
         return frames
+    }
+
+    fileprivate func getVideoInfo(from outputFileURL: URL, usedFrames: [SentryReplayFrame], videoWidth: Int, videoHeight: Int) throws -> SentryVideoInfo {
+        SentryLog.debug("[Session Replay] Getting video info from file: \(outputFileURL.path), width: \(videoWidth), height: \(videoHeight), used frames count: \(usedFrames.count)")
+        let fileAttributes = try FileManager.default.attributesOfItem(atPath: outputFileURL.path)
+        guard let fileSize = fileAttributes[FileAttributeKey.size] as? Int else {
+            SentryLog.warning("[Session Replay] Failed to read video size from video file, reason: size attribute not found")
+            throw SentryOnDemandReplayError.cantReadVideoSize
+        }
+        let minFrame = usedFrames.min(by: { $0.time < $1.time })
+        guard let start = minFrame?.time else {
+            SentryLog.warning("[Session Replay] Failed to read video start time from used frames, reason: no frames found")
+            throw SentryOnDemandReplayError.cantReadVideoStartTime
+        }
+        let duration = TimeInterval(usedFrames.count / self.frameRate)
+        return SentryVideoInfo(
+            path: outputFileURL,
+            height: videoHeight,
+            width: videoWidth,
+            duration: duration,
+            frameCount: usedFrames.count,
+            frameRate: self.frameRate,
+            start: start,
+            end: start.addingTimeInterval(duration),
+            fileSize: fileSize,
+            screens: usedFrames.compactMap({ $0.screenName })
+        )
     }
 
     private func createVideoSettings(width: CGFloat, height: CGFloat) -> [String: Any] {

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -204,6 +204,21 @@ class SentryOnDemandReplayTests: XCTestCase {
         XCTAssertEqual(secondVideo.width, 20)
         XCTAssertEqual(secondVideo.height, 10)
     }
-    
+
+    func testGenerateVideoInfo_whenNoFramesAdded_shouldNotThrowError() throws {
+        // -- Arrange --
+        let sut = getSut()
+        dateProvider.driftTimeForEveryRead = true
+        dateProvider.driftTimeInterval = 1
+
+        // -- Act --
+        let videos = try sut.createVideoWith(
+            beginning: Date(timeIntervalSinceReferenceDate: 0),
+            end: Date(timeIntervalSinceReferenceDate: 10)
+        )
+
+        // -- Assert --
+        XCTAssertNil(videos.first)
+    }
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

Refactors the logic to get rendered session replay info to another method.
Furthermore it also adds more debug and error logging.

## :bulb: Motivation and Context

This change has been a side-product of #5018 and I extracted it into another PR for easier review.

## :green_heart: How did you test it?

- Unit tests & manual testing using sample.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
