### PR TITLE
fix(session-replay): improve frame presentation timing calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Improve session replay frame presentation timing calculations (#5133)
+
 ## 8.49.1
 
 ### Fixes


### PR DESCRIPTION
## :scroll: Description

Updated the calculation of presentation time for video frames to use integer math, ensuring frame-accurate timing and avoiding floating-point rounding issues. 

## :bulb: Motivation and Context

This change is crucial for maintaining consistent frame spacing, especially at low frame rates like 1 FPS.

This should also fix crashes when changing the FPS to higher values, which is not possible (yet).

## :green_heart: How did you test it?

- Used the sample app to run locally, viewing session replay video in Sentry product.
- Used `ffprobe` to view information on file:

```
$ ffprobe -show_streams -show_format -v error /Users/philip/Library/Developer/CoreSimulator/Devices/B406E97C-4EC0-483F-82EA-32B594AB6038/data/Containers/Data/Application/424CFD83-82C0-4765-A58C-645960512C4F/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/replay/A2EF1E73-C047-48E5-9205-3C09D81C9F8D/767188156.357788.mp4
[STREAM]
index=0
codec_name=h264
codec_long_name=H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10
profile=Constrained Baseline
codec_type=video
codec_tag_string=avc1
codec_tag=0x31637661
width=393
height=852
coded_width=393
coded_height=852
closed_captions=0
film_grain=0
has_b_frames=0
sample_aspect_ratio=1:1
display_aspect_ratio=131:284
pix_fmt=yuv420p
level=30
color_range=tv
color_space=unknown
color_transfer=unknown
color_primaries=unknown
chroma_location=left
field_order=progressive
refs=1
is_avc=true
nal_length_size=4
id=0x1
r_frame_rate=1/1
avg_frame_rate=1/1
time_base=1/600
start_pts=0
start_time=0.000000
duration_ts=3000
duration=5.000000
bit_rate=7680
max_bit_rate=N/A
bits_per_raw_sample=8
nb_frames=5
nb_read_frames=N/A
nb_read_packets=N/A
extradata_size=36
DISPOSITION:default=1
DISPOSITION:dub=0
DISPOSITION:original=0
DISPOSITION:comment=0
DISPOSITION:lyrics=0
DISPOSITION:karaoke=0
DISPOSITION:forced=0
DISPOSITION:hearing_impaired=0
DISPOSITION:visual_impaired=0
DISPOSITION:clean_effects=0
DISPOSITION:attached_pic=0
DISPOSITION:timed_thumbnails=0
DISPOSITION:non_diegetic=0
DISPOSITION:captions=0
DISPOSITION:descriptions=0
DISPOSITION:metadata=0
DISPOSITION:dependent=0
DISPOSITION:still_image=0
DISPOSITION:multilayer=0
TAG:creation_time=2025-04-24T11:49:21.000000Z
TAG:language=und
TAG:handler_name=Core Media Video
TAG:vendor_id=[0][0][0][0]
[/STREAM]
[FORMAT]
filename=/Users/philip/Library/Developer/CoreSimulator/Devices/B406E97C-4EC0-483F-82EA-32B594AB6038/data/Containers/Data/Application/424CFD83-82C0-4765-A58C-645960512C4F/Library/Caches/io.sentry/b810aaca937def33af3796f237e6793ec907f1e4/replay/A2EF1E73-C047-48E5-9205-3C09D81C9F8D/767188156.357788.mp4
nb_streams=1
nb_programs=0
nb_stream_groups=0
format_name=mov,mp4,m4a,3gp,3g2,mj2
format_long_name=QuickTime / MOV
start_time=0.000000
duration=5.000000
size=5584
bit_rate=8934
probe_score=100
TAG:major_brand=mp42
TAG:minor_version=1
TAG:compatible_brands=isommp41mp42
TAG:creation_time=2025-04-24T11:49:21.000000Z
[/FORMAT]
```

Relevant output:

```
r_frame_rate=1/1
avg_frame_rate=1/1
```

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
