### PR TITLE
fix(session-replay): Use wider compatible video encoding options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Use wider compatible video encoding options for Session Replay (#5134)
+
 ## 8.49.1
 
 ### Fixes

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -244,7 +244,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         return frames
     }
 
-    private func createVideoSettings(width: CGFloat, height: CGFloat) -> [String: Any] {
+    internal func createVideoSettings(width: CGFloat, height: CGFloat) -> [String: Any] {
         return [
             // The codec type for the video. H.264 (AVC) is the most widely supported codec across platforms,
             // including web browsers, QuickTime, VLC, and mobile devices.

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import Foundation
 @testable import Sentry
 import SentryTestUtils
@@ -204,6 +205,65 @@ class SentryOnDemandReplayTests: XCTestCase {
         XCTAssertEqual(secondVideo.width, 20)
         XCTAssertEqual(secondVideo.height, 10)
     }
-    
+
+    // This test case with zero size is not particularly handled, but used
+    // to lock down the expected behaviour.
+    func testCreateVideoSettings_zeroSize_shouldReturnFullSettings() throws {
+        // -- Arrange --
+        let sut = getSut()
+
+        // -- Act --
+        let settings = sut.createVideoSettings(width: 0, height: 0)
+
+        // -- Assert --
+        XCTAssertEqual(settings.count, 5)
+        XCTAssertEqual(settings[AVVideoCodecKey] as? AVVideoCodecType, AVVideoCodecType.h264)
+        XCTAssertEqual(settings[AVVideoWidthKey] as? CGFloat, 0)
+        XCTAssertEqual(settings[AVVideoHeightKey] as? CGFloat, 0)
+        
+        let compressionProperties = try XCTUnwrap(settings[AVVideoCompressionPropertiesKey] as? [String: Any], "Compression properties not found")
+
+        XCTAssertEqual(compressionProperties.count, 4)
+        XCTAssertEqual(compressionProperties[AVVideoAverageBitRateKey] as? Int, sut.bitRate)
+        XCTAssertEqual(compressionProperties[AVVideoProfileLevelKey] as? String, AVVideoProfileLevelH264MainAutoLevel)
+        XCTAssertEqual(compressionProperties[AVVideoAllowFrameReorderingKey] as? Bool, false)
+        XCTAssertEqual(compressionProperties[AVVideoMaxKeyFrameIntervalKey] as? Int, sut.frameRate)
+        
+        let colorProperties = try XCTUnwrap(settings[AVVideoColorPropertiesKey] as? [String: Any], "Color properties not found")
+
+        XCTAssertEqual(colorProperties.count, 3)
+        XCTAssertEqual(colorProperties[AVVideoColorPrimariesKey] as? String, AVVideoColorPrimaries_ITU_R_709_2)
+        XCTAssertEqual(colorProperties[AVVideoTransferFunctionKey] as? String, AVVideoTransferFunction_ITU_R_709_2)
+        XCTAssertEqual(colorProperties[AVVideoYCbCrMatrixKey] as? String, AVVideoYCbCrMatrix_ITU_R_709_2)
+    }
+
+    func testCreateVideoSettings_anySize_shouldReturnFullSettings() throws {
+        // -- Arrange --
+        let sut = getSut()
+
+        // -- Act --
+        let settings = sut.createVideoSettings(width: 100, height: 100)
+
+        // -- Assert --
+        XCTAssertEqual(settings.count, 5)
+        XCTAssertEqual(settings[AVVideoCodecKey] as? AVVideoCodecType, AVVideoCodecType.h264)
+        XCTAssertEqual(settings[AVVideoWidthKey] as? CGFloat, 100)
+        XCTAssertEqual(settings[AVVideoHeightKey] as? CGFloat, 100)
+        
+        let compressionProperties = try XCTUnwrap(settings[AVVideoCompressionPropertiesKey] as? [String: Any], "Compression properties not found")
+
+        XCTAssertEqual(compressionProperties.count, 4)
+        XCTAssertEqual(compressionProperties[AVVideoAverageBitRateKey] as? Int, sut.bitRate)
+        XCTAssertEqual(compressionProperties[AVVideoProfileLevelKey] as? String, AVVideoProfileLevelH264MainAutoLevel)
+        XCTAssertEqual(compressionProperties[AVVideoAllowFrameReorderingKey] as? Bool, false)
+        XCTAssertEqual(compressionProperties[AVVideoMaxKeyFrameIntervalKey] as? Int, sut.frameRate)
+        
+        let colorProperties = try XCTUnwrap(settings[AVVideoColorPropertiesKey] as? [String: Any], "Color properties not found")
+
+        XCTAssertEqual(colorProperties.count, 3)
+        XCTAssertEqual(colorProperties[AVVideoColorPrimariesKey] as? String, AVVideoColorPrimaries_ITU_R_709_2)
+        XCTAssertEqual(colorProperties[AVVideoTransferFunctionKey] as? String, AVVideoTransferFunction_ITU_R_709_2)
+        XCTAssertEqual(colorProperties[AVVideoYCbCrMatrixKey] as? String, AVVideoYCbCrMatrix_ITU_R_709_2)
+    }
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

Optimized compatibility of video segments created by session replay on iOS.

## :bulb: Motivation and Context

Due to issues with video segments taken on iOS not being playable by VLC, I went through the list of video encoding settings available in AVFoundation: https://developer.apple.com/documentation/avfoundation/video-settings

After research I ruled out the ones not applicable to our use-case. The comments should give more context on why they are chosen.

## :green_heart: How did you test it?

- Used the sample app to create replays and viewed them in browser.
- Used `ffprobe -v` and `VLC -vvv` to investigate detailed logs.

Example Replay Video:
https://sentry-sdks.sentry.io/explore/replays/039d49b612d245a7a85352eea4b4f425/?project=5428557&query=&referrer=%2Fexplore%2Freplays%2F%3AreplaySlug%2F&statsPeriod=1h&yAxis=count%28%29&t=18

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
