### PR TITLE
fix(ci): add existence check for Benchmarking tab bar item

### DIFF
--- a/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
+++ b/Samples/iOS-Swift/PerformanceBenchmarks/SentrySDKPerformanceBenchmarkTests.m
@@ -37,8 +37,15 @@
 
         [app.buttons[@"startTransactionMainThread"] tap];
 
-        [app.tabBars[@"Tab Bar"].buttons[@"More"] tap];
-        [app.staticTexts[@"Benchmarking"] tap];
+        // On iPhone the tab "Benchmarking" is in the collapsed "More" tab bar item.
+        // On iPad it is directly in the tab bar.
+        // The test needs to be universal, therefore we just check where it exists.
+        if ([app.tabBars[@"Tab Bar"].buttons[@"Benchmarking"] waitForExistenceWithTimeout:1.0]) {
+            [app.tabBars[@"Tab Bar"].buttons[@"Benchmarking"] tap];
+        } else {
+            [app.tabBars[@"Tab Bar"].buttons[@"More"] tap];
+            [app.staticTexts[@"Benchmarking"] tap];
+        }
 
         [app.buttons[@"Benchmark start"] tap];
 


### PR DESCRIPTION
PR #5104 changed the benchmarking UI test to tab the tab bar overflow item "More" to the select "Benchmarking". While this is correct for iPhone, we are running benchmarking tests with iPad where the tab bar is **not** collpased, therefore the tests will fail with this error:

```
error: Failed to tap "More" Button: No matches found for Elements matching predicate '"More" IN identifiers' from input {(
    Button, label: 'Errors',
    Button, label: 'Transactions', Selected,
    Button, label: 'Extra',
    Button, label: 'Profiling',
    Button, label: 'Benchmarking',
    Button, label: 'Features'
)}}
```

Looking at the error, the PR actually got merged even though the workflow checks indicated [here](https://github.com/getsentry/sentry-cocoa/actions/runs/14522145712/job/40745594880#step:6:50) that the tests failed, with the error message displayed [here](https://github.com/getsentry/sentry-cocoa/actions/runs/14522145712/job/40745594880#step:5:234).

I do acknowledge that a "passed" step "Run Benchmarks in SauceLab" can be misleading.

This PR is intending to make the UI test universal to get passing checks again.

#skip-changelog