### PR TITLE
fix(ci): change failing saucelabs step to marked as failed

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -95,7 +95,6 @@ jobs:
       - run: npm install -g saucectl@0.186.0
       - name: Run Benchmarks in SauceLab
         id: run-benchmarks-in-sauce-lab
-        continue-on-error: true
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
@@ -109,7 +108,7 @@ jobs:
 
       - name: Recovery - Extract Test ID from output
         id: should-retry-test
-        if: ${{ steps.run-benchmarks-in-sauce-lab.outcome == 'failure' }}
+        if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'failure' }}
         uses: actions/github-script@v7
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -99,6 +99,9 @@ jobs:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         run: |
+          # TODO: Remove this once we have a real test
+          exit 1
+
           set -o pipefail && saucectl run \
             --select-suite "${{matrix.suite}}" \
             --config .sauce/benchmarking-config.yml \
@@ -115,6 +118,10 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         with:
           script: |
+            // TODO: Remove this once we have a real test
+            core.setOutput('RETRY_TEST', 'true');
+            return;
+
             const fs = require('fs');
             const { execSync } = require('child_process');
 
@@ -149,7 +156,7 @@ jobs:
 
       - name: Run Benchmarks in SauceLab - Retry 1
         id: run-benchmarks-in-sauce-lab-retry-1
-        if: ${{ steps.should-retry-test.outputs.RETRY_TEST == 'true' }}
+        if: ${{ always() && steps.should-retry-test.outputs.RETRY_TEST == 'true' }}
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}

--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -98,10 +98,8 @@ jobs:
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+        # Note: We are not setting continue-on-error here, because we want the step to be marked as failed.
         run: |
-          # TODO: Remove this once we have a real test
-          exit 1
-
           set -o pipefail && saucectl run \
             --select-suite "${{matrix.suite}}" \
             --config .sauce/benchmarking-config.yml \
@@ -111,6 +109,7 @@ jobs:
 
       - name: Recovery - Extract Test ID from output
         id: should-retry-test
+        # Note: We need to use always() here, because the previous run step might be marked as failed.
         if: ${{ always() && steps.run-benchmarks-in-sauce-lab.outcome == 'failure' }}
         uses: actions/github-script@v7
         env:
@@ -118,10 +117,6 @@ jobs:
           SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
         with:
           script: |
-            // TODO: Remove this once we have a real test
-            core.setOutput('RETRY_TEST', 'true');
-            return;
-
             const fs = require('fs');
             const { execSync } = require('child_process');
 
@@ -156,6 +151,7 @@ jobs:
 
       - name: Run Benchmarks in SauceLab - Retry 1
         id: run-benchmarks-in-sauce-lab-retry-1
+        # Note: We need to use always() here, because the previous run step might be marked as failed.
         if: ${{ always() && steps.should-retry-test.outputs.RETRY_TEST == 'true' }}
         env:
           SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}


### PR DESCRIPTION
This PR intends to make sure the step "Run Benchmarks in SauceLab" is actually showing up as failing when failing.

Reference: https://github.com/getsentry/sentry-cocoa/actions/runs/14522145712/job/40745594880#step:5:234

<img width="848" alt="Screenshot 2025-04-25 at 10 00 28" src="https://github.com/user-attachments/assets/1728380d-ecda-49e0-a764-355e290f0807" />

- [This run](https://github.com/getsentry/sentry-cocoa/actions/runs/14663965563/job/41154651595) shows how it looks like if the first attempt fails (step "Run benchmark" is marked ❌), but a retry is detected and run again.
- [This run](https://github.com/getsentry/sentry-cocoa/actions/runs/14659838641/job/41141946259) shows how it looks like when it fails without a retry.
- [This run](https://github.com/getsentry/sentry-cocoa/actions/runs/14664182495/job/41155643996?pr=5136) shows how it looks like if the checks are fine (no retry attempted).

#skip-changelog
