### PR TITLE
ci: when commenting about dangerous files, remove previous comments

### DIFF
--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -33,6 +33,22 @@ jobs:
     needs: files-changed
     runs-on: ubuntu-latest
     steps:
+      - name: Remove previous comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            })
+            for (const comment of comments) {
+              if (comment.user.login === 'github-actions[bot]' && comment.body.includes('### 🚨 Detected changes in high risk code 🚨')) {
+                await github.rest.issues.deleteComment({
+                  comment_id: comment.id
+                })
+              }
+            }
       - name: Comment on PR to notify of changes in high risk files
         uses: actions/github-script@v7
         env:


### PR DESCRIPTION
Remove previous commnents to avoid this noisy iteration:
<img width="971" alt="image" src="https://github.com/user-attachments/assets/10232690-bd07-474a-8ba1-bb64b14e041f" />


#skip-changelog