### PR TITLE
feat: Make app hangs V2 GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Features
 
 - Added ability to bring your own button for user feedback form display (#5107)
+- Make enableAppHangTrackingV2 general available (#5149)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -646,8 +646,6 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @note This flag wins over enableAppHangTracking. When enabling both enableAppHangTracking and
  enableAppHangTrackingV2, the SDK only enables enableAppHangTrackingV2 and disables
  enableAppHangTracking.
- *
- * @warning This is an experimental feature and may still have bugs.
  */
 @property (nonatomic, assign) BOOL enableAppHangTrackingV2;
 


### PR DESCRIPTION
Remove the experimental warning for enableAppHangTrackingV2.
