### PR TITLE
ci: Use non xl macos-15 for benchmarks

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -166,11 +166,11 @@ jobs:
 
   app-metrics:
     name: Collect app metrics
-    runs-on: macos-13-xlarge
+    runs-on: macos-15
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 15.2
+      - run: ./scripts/ci-select-xcode.sh 16.3
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
Switch to a non xl runner for benchmarking cause it's not required and xl runners are expensive.

#skip-changelog