### PR TITLE
ci: Build XCFramework with Xcode 15.2 on macos-14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,11 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+      # We have to compile on Xcode 15.2 because compiling on Xcode 15.4 fails with
+      # Data+SentryTracing.swift:21:62: error: 'ReadingOptions' aliases 'Foundation.ReadingOptions'
+      # and cannot be used here because C++ types from imported module 'Foundation' do not support
+      # library evolution; this is an error in the Swift 6 language mode
+      # We also can't use Xcode 16.x because validating the XCFramework then fails with Xcode 15.x.
       - run: ./scripts/ci-select-xcode.sh 15.2
       - run: echo "FRAMEWORK_RUN_ID=$(./scripts/xcframework-generated-run.sh)" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
     name: Build XCFramework
     # We must compile this on an arm64 runner, cause it's required for visionOS. macos-14 uses arm64.
     # To see the available runners see https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.
-
+    # Don't bump this to an xlarge runner when this is too slow. Instead consider parallelizing the build as proposed in https://github.com/getsentry/sentry-cocoa/issues/4925.
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 15.4
+      - run: ./scripts/ci-select-xcode.sh 15.2
       - run: echo "FRAMEWORK_RUN_ID=$(./scripts/xcframework-generated-run.sh)" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,10 +91,10 @@ jobs:
     # We must compile this on an arm64 runner, cause it's required for visionOS. macos-14 uses arm64.
     # To see the available runners see https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.
 
-    runs-on: macos-15
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.3
+      - run: ./scripts/ci-select-xcode.sh 15.4
       - run: echo "FRAMEWORK_RUN_ID=$(./scripts/xcframework-generated-run.sh)" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,12 +88,13 @@ jobs:
 
   build-xcframework:
     name: Build XCFramework
-    # The macos-13 uses an Intel processor and doesn't compile the XCFramework for visionOS.
-    # The large image compiles on arm64 and successfully creates the XCFramework for visionOS.
-    runs-on: macos-13-xlarge
+    # We must compile this on an arm64 runner, cause it's required for visionOS. macos-14 uses arm64.
+    # To see the available runners see https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.
+
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 15.2
+      - run: ./scripts/ci-select-xcode.sh 16.3
       - run: echo "FRAMEWORK_RUN_ID=$(./scripts/xcframework-generated-run.sh)" >> $GITHUB_ENV
 
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Replace the xlarge runner with macos-15 and compile the XCFramework on Xcode 16.3.

If this works fine, we can also consider replacing https://github.com/getsentry/sentry-cocoa/blob/500abd8a216eb7e05a4a3383039c79a84998d71b/.github/workflows/release.yml#L19 but I think we should do that in a minor release and not a bugfix.
