### PR TITLE
impr: Compile the XCFramework with Xcode 16.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,14 +16,14 @@ on:
 
 jobs:
   prepare_framework:
-    runs-on: macos-13-xlarge
+    runs-on: macos-15
     name: "Create XCFramework"
     steps:
       - uses: actions/checkout@v4
 
       - name: "Generate XCFramework"
         run: |
-          ./scripts/ci-select-xcode.sh 15.2
+          ./scripts/ci-select-xcode.sh 16.3
           make bump-version TO=${{ github.event.inputs.version }}
           # We need to build the framework during release to get it's SHA value
           # the framework will be saved as an artefact and we will use the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Improvements
 
+- Build XCFramework with Xcode 16.3 (#5152). This change only impacts users using the precompiled XCFramework, which is the default when integrating the SDK via Swift Package Manager.
 - More logging for Session Replay video info (#5132)
 - Improve session replay frame presentation timing calculations (#5133)
 - Use wider compatible video encoding options for Session Replay (#5134)


### PR DESCRIPTION

## :scroll: Description

Compile the XCFramework used for releases with Xcode 16.3, which has the positive side effect of ditching the xlarge runner.

We first should merge https://github.com/getsentry/sentry-cocoa/pull/5151.

## :bulb: Motivation and Context

This came up cause we ran into GH action runner billing problems.

## :green_heart: How did you test it?

Checking the XCFramework of https://github.com/getsentry/sentry-cocoa/actions/runs/14732449146/job/41349889538?pr=5151.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
