### PR TITLE
fix(session-replay): revert max key-frame interval to once per video segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Improve session replay frame presentation timing calculations (#5133)
 - Use wider compatible video encoding options for Session Replay (#5134)
 - GA of better session replay view renderer V2 (#5054)
+- Revert max key-frame interval to once per session replayvideo segment (#5156)
 
 ## 8.49.1
 

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -29,7 +29,7 @@ struct SentrySDKWrapper {
         
         if #available(iOS 16.0, *), !SentrySDKOverrides.Other.disableSessionReplay.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: 1,
+                sessionSampleRate: 0,
                 onErrorSampleRate: 1,
                 maskAllText: true,
                 maskAllImages: true

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -29,7 +29,7 @@ struct SentrySDKWrapper {
         
         if #available(iOS 16.0, *), !SentrySDKOverrides.Other.disableSessionReplay.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: 0,
+                sessionSampleRate: 1,
                 onErrorSampleRate: 1,
                 maskAllText: true,
                 maskAllImages: true

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -325,11 +325,12 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
                 // where each frame is independent and must be decodable on its own.
                 AVVideoAllowFrameReorderingKey: false,
 
-                // Ensures that every frame is a keyframe (also called an I-frame).
-                // This is crucial in a 1 FPS timelapse context because:
-                // 1. It guarantees that every frame can be displayed without relying on previous frames.
-                // 2. It enables precise seeking and smooth scrubbing across all video players.
-                AVVideoMaxKeyFrameIntervalKey: frameRate // e.g., 1 for 1 FPS
+                // Sets keyframe interval to one I-frame per video segment.
+                // This significantly reduces file size (e.g. from 19KB to 9KB) while maintaining
+                // acceptable seeking granularity. With our 1 FPS recording, this means a keyframe
+                // will be inserted once every 6 seconds of recorded content, but our video segments
+                // will never be longer than 5 seconds, resulting in a maximum of 1 I-frame per video.
+                AVVideoMaxKeyFrameIntervalKey: 6 // 5 + 1 interval for optimal compression
             ] as [String: Any],
 
             // Explicitly sets the video color space to ITU-R BT.709 (the standard for HD video).

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -324,7 +324,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         XCTAssertEqual(compressionProperties[AVVideoAverageBitRateKey] as? Int, sut.bitRate)
         XCTAssertEqual(compressionProperties[AVVideoProfileLevelKey] as? String, AVVideoProfileLevelH264MainAutoLevel)
         XCTAssertEqual(compressionProperties[AVVideoAllowFrameReorderingKey] as? Bool, false)
-        XCTAssertEqual(compressionProperties[AVVideoMaxKeyFrameIntervalKey] as? Int, sut.frameRate)
+        XCTAssertEqual(compressionProperties[AVVideoMaxKeyFrameIntervalKey] as? Int, 6)
         
         let colorProperties = try XCTUnwrap(settings[AVVideoColorPropertiesKey] as? [String: Any], "Color properties not found")
 
@@ -353,7 +353,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         XCTAssertEqual(compressionProperties[AVVideoAverageBitRateKey] as? Int, sut.bitRate)
         XCTAssertEqual(compressionProperties[AVVideoProfileLevelKey] as? String, AVVideoProfileLevelH264MainAutoLevel)
         XCTAssertEqual(compressionProperties[AVVideoAllowFrameReorderingKey] as? Bool, false)
-        XCTAssertEqual(compressionProperties[AVVideoMaxKeyFrameIntervalKey] as? Int, sut.frameRate)
+        XCTAssertEqual(compressionProperties[AVVideoMaxKeyFrameIntervalKey] as? Int, 6)
         
         let colorProperties = try XCTUnwrap(settings[AVVideoColorPropertiesKey] as? [String: Any], "Color properties not found")
 


### PR DESCRIPTION
## :scroll: Description

Changes the session replay video segment keyframe interval to 1.

## :bulb: Motivation and Context

H.264 uses different types of frames:

- `I‑frames` are the least compressible but don't require other video frames to decode.
- `P‑frames` can use data from previous frames to decompress and are more compressible than I‑frames.

In #5134 we introduced a change in the video segment configuration to only use `I-Frame` by setting `AVVideoMaxKeyFrameIntervalKey` to increase (browser) compatibility.

Further testing surfaced now that the browser compatibility is not affected by this option, but it increases the file size of video segments:

```
$ ffprobe -select_streams v:0 -show_frames -show_entries frame=pict_type,coded_picture_number -of csv -hide_banner pre-5134.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'older.mp4':
  Metadata:
    major_brand     : mp42
    minor_version   : 1
    compatible_brands: isommp41mp42
    creation_time   : 2025-04-24T14:50:59.000000Z
  Duration: 00:00:05.00, start: 0.000000, bitrate: 14 kb/s
  Stream #0:0[0x1](und): Video: h264 (Constrained Baseline) (avc1 / 0x31637661), yuv420p(tv, progressive), 393x852 [SAR 1:1 DAR 131:284], 13 kb/s, 1 fps, 1 tbr, 600 tbn (default)
      Metadata:
        creation_time   : 2025-04-24T14:50:59.000000Z
        handler_name    : Core Media Video
        vendor_id       : [0][0][0][0]
frame,I,H.26[45] User Data Unregistered SEI message
frame,P,H.26[45] User Data Unregistered SEI message
frame,P,H.26[45] User Data Unregistered SEI message
frame,P,H.26[45] User Data Unregistered SEI message
frame,P,H.26[45] User Data Unregistered SEI message
```

```
$ ffprobe -select_streams v:0 -show_frames -show_entries frame=pict_type,coded_picture_number -of csv -hide_banner post-5134.mp4
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from 'newer.mp4':
  Metadata:
    major_brand     : mp42
    minor_version   : 1
    compatible_brands: isommp41mp42
    creation_time   : 2025-04-24T14:49:05.000000Z
  Duration: 00:00:05.00, start: 0.000000, bitrate: 31 kb/s
  Stream #0:0[0x1](und): Video: h264 (Main) (avc1 / 0x31637661), yuv420p(tv, bt709, progressive), 393x852 [SAR 1:1 DAR 131:284], 29 kb/s, 1 fps, 1 tbr, 600 tbn (default)
      Metadata:
        creation_time   : 2025-04-24T14:49:05.000000Z
        handler_name    : Core Media Video
        vendor_id       : [0][0][0][0]
frame,I,H.26[45] User Data Unregistered SEI message
frame,I,H.26[45] User Data Unregistered SEI message
frame,I,H.26[45] User Data Unregistered SEI message
frame,I,H.26[45] User Data Unregistered SEI message
frame,I,H.26[45] User Data Unregistered SEI message
```

The actual difference in size varies depending on the amount of changes in the video, but we could see up to **100%** larger sizes.

Using the latest changes on main [this replay](https://sentry-sdks.sentry.io/explore/replays/43693f16a913493a871d3e937fe2306d/?project=5428557) works in Chrome, Firefox and Safari.

## :green_heart: How did you test it?

For [this replay](https://sentry-sdks.sentry.io/explore/replays/0ab78b0a6a184f33accbc79d905ed3c1/?project=5428557) I changed I-Frames interval to 6 (1 I-Frame per 5 second video segment at 1 FPS, the others are P-Frames) which reduced the size from 19KB to 6KB for the first segment, while it still works in all browsers.

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
