### PR TITLE
chore: add toggle to enable/disable Sentry in sample on-demand

### DIFF
--- a/Samples/SessionReplay-CameraTest/Sources/AppDelegate.swift
+++ b/Samples/SessionReplay-CameraTest/Sources/AppDelegate.swift
@@ -4,6 +4,7 @@ import UIKit
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
+    static var isSentryEnabled = true
     static var isSessionReplayEnabled = true
     static var isViewRendererV2Enabled = true
 
@@ -17,6 +18,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         if SentrySDK.isEnabled {
             print("SentrySDK already started, closing it")
             SentrySDK.close()
+        }
+
+        if !isSentryEnabled {
+            print("SentrySDK disabled")
+            return
         }
 
         SentrySDK.start { options in

--- a/Samples/SessionReplay-CameraTest/Sources/Base.lproj/Main.storyboard
+++ b/Samples/SessionReplay-CameraTest/Sources/Base.lproj/Main.storyboard
@@ -23,10 +23,10 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5YZ-1e-IzZ">
-                                <rect key="frame" x="0.0" y="698" width="393" height="86"/>
+                                <rect key="frame" x="0.0" y="659" width="393" height="125"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="oa3-e8-uvT">
-                                        <rect key="frame" x="8" y="8" width="377" height="70"/>
+                                        <rect key="frame" x="8" y="8" width="377" height="109"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="opk-jT-uwJ">
                                                 <rect key="frame" x="0.0" y="0.0" width="377" height="31"/>
@@ -34,10 +34,27 @@
                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="On Demand Replay Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="4WQ-YN-9zT">
                                                         <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
                                                         <connections>
-                                                            <action selector="didChangeToggleValue:" destination="BYZ-38-t0r" eventType="valueChanged" id="Sim-ZR-9wS"/>
+                                                            <action selector="didChangeToggleValue:" destination="BYZ-38-t0r" eventType="valueChanged" id="daL-zN-qOm"/>
                                                         </connections>
                                                     </switch>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Session Replay Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QIZ-C7-cxI">
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Is Sentry enabled?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QIZ-C7-cxI">
+                                                        <rect key="frame" x="57" y="0.0" width="320" height="31"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
+                                            <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2XN-Za-rcz">
+                                                <rect key="frame" x="0.0" y="39" width="377" height="31"/>
+                                                <subviews>
+                                                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="On Demand Replay Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="k2J-0x-ddd">
+                                                        <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
+                                                        <connections>
+                                                            <action selector="didChangeToggleValue:" destination="BYZ-38-t0r" eventType="valueChanged" id="UV2-uO-ayX"/>
+                                                        </connections>
+                                                    </switch>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Is Session Replay enabled?" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oQ5-uS-5I5">
                                                         <rect key="frame" x="57" y="0.0" width="320" height="31"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
@@ -46,7 +63,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dGk-rO-wU0">
-                                                <rect key="frame" x="0.0" y="39" width="377" height="31"/>
+                                                <rect key="frame" x="0.0" y="78" width="377" height="31"/>
                                                 <subviews>
                                                     <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" title="On Demand Replay Enabled" translatesAutoresizingMaskIntoConstraints="NO" id="WOe-Ha-XHR">
                                                         <rect key="frame" x="0.0" y="0.0" width="51" height="31"/>
@@ -87,6 +104,7 @@
                     <connections>
                         <outlet property="backgroundLabel" destination="5r7-mb-ufO" id="aDg-zV-JST"/>
                         <outlet property="controlsContainerView" destination="5YZ-1e-IzZ" id="EUS-T5-IdQ"/>
+                        <outlet property="enableSentrySwitch" destination="4WQ-YN-9zT" id="dmw-tZ-OYZ"/>
                         <outlet property="enableSessionReplaySwitch" destination="4WQ-YN-9zT" id="WNt-tk-Hs7"/>
                         <outlet property="useViewRendererV2Switch" destination="WOe-Ha-XHR" id="efd-0g-nYG"/>
                     </connections>

--- a/Samples/SessionReplay-CameraTest/Sources/ViewController.swift
+++ b/Samples/SessionReplay-CameraTest/Sources/ViewController.swift
@@ -7,6 +7,7 @@ class ViewController: UIViewController {
     @IBOutlet weak var backgroundLabel: UILabel!
     @IBOutlet weak var controlsContainerView: UIView!
 
+    @IBOutlet weak var enableSentrySwitch: UISwitch!
     @IBOutlet weak var enableSessionReplaySwitch: UISwitch!
     @IBOutlet weak var useViewRendererV2Switch: UISwitch!
 
@@ -94,6 +95,9 @@ class ViewController: UIViewController {
         } else if sender === useViewRendererV2Switch {
             AppDelegate.isViewRendererV2Enabled = sender.isOn
             print("Use view renderer V2 flag changed to: \(AppDelegate.isViewRendererV2Enabled)")
+        } else if sender === enableSentrySwitch {
+            AppDelegate.isSentryEnabled = sender.isOn
+            print("Enable Sentry flag changed to: \(AppDelegate.isSentryEnabled)")
         }
         AppDelegate.reloadSentrySDK()
     }


### PR DESCRIPTION
Adds a toggle switch to the camera sample app to disable Sentry SDK after it started.

I use this to see how well the SDK is cleaned up to fix #5069
Can also be used for #5124 

This is a side-product so it's a different PR for easy review, extracted from draft PRs

#skip-changelog