### PR TITLE
impr: Explicitly check malloc result for SRSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Improve session replay frame presentation timing calculations (#5133)
 - Use wider compatible video encoding options for Session Replay (#5134)
 - GA of better session replay view renderer V2 (#5054)
+- Explicitly check malloc result for SRSync to fix a Veracode Security Scan warning (#5160)
 
 ## 8.49.2
 

--- a/Sources/Sentry/SentrySessionReplaySyncC.c
+++ b/Sources/Sentry/SentrySessionReplaySyncC.c
@@ -23,14 +23,14 @@ sentrySessionReplaySync_start(const char *const path)
 
     size_t buffer_size = sizeof(char) * (strlen(path) + 1); // Add a byte for the null-terminator.
     crashReplay.path = malloc(buffer_size);
-    if (crashReplay.path) {
-        strlcpy(crashReplay.path, path, buffer_size);
-    } else {
-        crashReplay.path = NULL;
+
+    if (crashReplay.path == NULL) {
         SENTRY_ASYNC_SAFE_LOG_ERROR(
-            "Could not copy the path to save session replay in case of an error. File path: %s",
-            path);
+            "Failed to allocate memory for crash replay path. File path: %s", path);
+        return;
     }
+
+    strlcpy(crashReplay.path, path, buffer_size);
 }
 
 void


### PR DESCRIPTION




## :scroll: Description

Fix a veracode security scan warning by more explicitly checking the return value of malloc for NULL.

## :bulb: Motivation and Context

Fixes GH-4428

## :green_heart: How did you test it?

Unit tests still green.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs
