### PR TITLE
chore(session-replay): Add detailed debug logging for session replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - GA of better session replay view renderer V2 (#5054)
 - Explicitly check malloc result for SRSync to fix a Veracode Security Scan warning (#5160)
 - Revert max key-frame interval to once per session replayvideo segment (#5156)
-- Add detailed debug logging for session replay (#5173)
+- Add more detailed debug logs for session replay (#5173)
 
 ## 8.49.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - GA of better session replay view renderer V2 (#5054)
 - Explicitly check malloc result for SRSync to fix a Veracode Security Scan warning (#5160)
 - Revert max key-frame interval to once per session replayvideo segment (#5156)
+- Add detailed debug logging for session replay (#5173)
 
 ## 8.49.2
 

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -29,7 +29,7 @@ struct SentrySDKWrapper {
         
         if #available(iOS 16.0, *), !SentrySDKOverrides.Other.disableSessionReplay.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: 1,
+                sessionSampleRate: 0,
                 onErrorSampleRate: 1,
                 maskAllText: true,
                 maskAllImages: true

--- a/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
+++ b/Samples/iOS-Swift/iOS-Swift/SentrySDKWrapper.swift
@@ -29,7 +29,7 @@ struct SentrySDKWrapper {
         
         if #available(iOS 16.0, *), !SentrySDKOverrides.Other.disableSessionReplay.boolValue {
             options.sessionReplay = SentryReplayOptions(
-                sessionSampleRate: 0,
+                sessionSampleRate: 1,
                 onErrorSampleRate: 1,
                 maskAllText: true,
                 maskAllImages: true

--- a/Sources/Sentry/SentryReplayApi.m
+++ b/Sources/Sentry/SentryReplayApi.m
@@ -4,6 +4,7 @@
 
 #    import "SentryHub+Private.h"
 #    import "SentryInternalCDefines.h"
+#    import "SentryLog.h"
 #    import "SentryOptions+Private.h"
 #    import "SentrySDK+Private.h"
 #    import "SentrySessionReplayIntegration+Private.h"
@@ -24,6 +25,7 @@
 
 - (void)pause
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Pausing session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -32,6 +34,7 @@
 
 - (void)resume
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Resuming session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -40,6 +43,7 @@
 
 - (void)start SENTRY_DISABLE_THREAD_SANITIZER("double-checked lock produce false alarms")
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Starting session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -52,6 +56,7 @@
             replayIntegration = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
                 getInstalledIntegration:SentrySessionReplayIntegration.class];
             if (replayIntegration == nil) {
+                SENTRY_LOG_DEBUG(@"[Session Replay] Initializing replay integration");
                 SentryOptions *currentOptions = SentrySDK.currentHub.client.options;
                 replayIntegration =
                     [[SentrySessionReplayIntegration alloc] initForManualUse:currentOptions];
@@ -67,6 +72,7 @@
 
 - (void)stop
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Stopping session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -75,11 +81,13 @@
 
 - (void)showMaskPreview
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Showing mask preview");
     [self showMaskPreview:1];
 }
 
 - (void)showMaskPreview:(CGFloat)opacity
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Showing mask preview with opacity: %f", opacity);
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -89,6 +97,7 @@
 
 - (void)hideMaskPreview
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Hiding mask preview");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];

--- a/Sources/Sentry/SentryReplayApi.m
+++ b/Sources/Sentry/SentryReplayApi.m
@@ -25,7 +25,7 @@
 
 - (void)pause
 {
-    SENTRY_LOG_DEBUG(@"[Session Replay] Pausing session");
+    SENTRY_LOG_INFO(@"[Session Replay] Pausing session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -34,7 +34,7 @@
 
 - (void)resume
 {
-    SENTRY_LOG_DEBUG(@"[Session Replay] Resuming session");
+    SENTRY_LOG_INFO(@"[Session Replay] Resuming session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -43,7 +43,7 @@
 
 - (void)start SENTRY_DISABLE_THREAD_SANITIZER("double-checked lock produce false alarms")
 {
-    SENTRY_LOG_DEBUG(@"[Session Replay] Starting session");
+    SENTRY_LOG_INFO(@"[Session Replay] Starting session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
@@ -72,7 +72,7 @@
 
 - (void)stop
 {
-    SENTRY_LOG_DEBUG(@"[Session Replay] Stopping session");
+    SENTRY_LOG_INFO(@"[Session Replay] Stopping session");
     SentrySessionReplayIntegration *replayIntegration
         = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -198,7 +198,7 @@ static SentryTouchTracker *_touchTracker;
             @"[Session Replay] Previous session replay is a buffer, using error sample rate");
         float errorSampleRate = [jsonObject[@"errorSampleRate"] floatValue];
         if ([SentryDependencyContainer.sharedInstance.random nextNumber] >= errorSampleRate) {
-            SENTRY_LOG_DEBUG(
+            SENTRY_LOG_INFO(
                 @"[Session Replay] Buffer session replay event not sampled, dropping replay");
             return;
         }

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -102,9 +102,12 @@ static SentryTouchTracker *_touchTracker;
 
     id<SentryViewRenderer> viewRenderer;
     if (enableViewRendererV2) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] Setting up view renderer v2, fast view rendering: %@",
+            enableFastViewRendering ? @"YES" : @"NO");
         viewRenderer =
             [[SentryViewRendererV2 alloc] initWithEnableFastViewRendering:enableFastViewRendering];
     } else {
+        SENTRY_LOG_DEBUG(@"[Session Replay] Setting up default view renderer");
         viewRenderer = [[SentryDefaultViewRenderer alloc] init];
     }
     // We are using the flag for the experimental view renderer also for the experimental mask
@@ -115,6 +118,8 @@ static SentryTouchTracker *_touchTracker;
                                                     enableMaskRendererV2:enableViewRendererV2];
 
     if (touchTracker) {
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] Setting up touch tracker, scale: %f", replayOptions.sizeScale);
         _touchTracker = [[SentryTouchTracker alloc] initWithDateProvider:_dateProvider
                                                                    scale:replayOptions.sizeScale];
         [self swizzleApplicationTouch];
@@ -148,6 +153,7 @@ static SentryTouchTracker *_touchTracker;
     NSData *lastReplay = [NSData dataWithContentsOfURL:lastReplayUrl];
 
     if (lastReplay == nil) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] No last replay info found");
         return nil;
     }
 
@@ -162,10 +168,13 @@ static SentryTouchTracker *_touchTracker;
  */
 - (void)resumePreviousSessionReplay:(SentryEvent *)event
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Resuming previous session replay");
     NSURL *dir = [self replayDirectory];
     NSDictionary<NSString *, id> *jsonObject = [self lastReplayInfo];
 
     if (jsonObject == nil) {
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] No last replay info found, not resuming previous session replay");
         return;
     }
 
@@ -185,8 +194,12 @@ static SentryTouchTracker *_touchTracker;
     int segmentId = hasCrashInfo ? crashInfo.segmentId + 1 : 0;
 
     if (type == SentryReplayTypeBuffer) {
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] Previous session replay is a buffer, using error sample rate");
         float errorSampleRate = [jsonObject[@"errorSampleRate"] floatValue];
         if ([SentryDependencyContainer.sharedInstance.random nextNumber] >= errorSampleRate) {
+            SENTRY_LOG_DEBUG(
+                @"[Session Replay] Buffer session replay event not sampled, dropping replay");
             return;
         }
     }
@@ -200,6 +213,7 @@ static SentryTouchTracker *_touchTracker;
         ? [NSDate dateWithTimeIntervalSinceReferenceDate:crashInfo.lastSegmentEnd]
         : [resumeReplayMaker oldestFrameDate];
     if (beginning == nil) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] No frames to send, dropping replay");
         return; // no frames to send
     }
     NSDate *end = [beginning dateByAddingTimeInterval:duration];
@@ -209,9 +223,12 @@ static SentryTouchTracker *_touchTracker;
                                                                                  end:end
                                                                                error:&error];
     if (videos == nil) {
-        SENTRY_LOG_ERROR(@"Could not create replay video, reason: %@", error);
+        SENTRY_LOG_ERROR(@"[Session Replay] Could not create replay video, reason: no videos "
+                         @"available, error: %@",
+            error);
         return;
     }
+    SENTRY_LOG_DEBUG(@"[Session Replay] Created replay with %lu video segments", videos.count);
 
     // For each segment we need to create a new event with the video.
     int _segmentId = segmentId;
@@ -230,8 +247,11 @@ static SentryTouchTracker *_touchTracker;
     NSError *_Nullable removeError;
     BOOL result = [NSFileManager.defaultManager removeItemAtURL:lastReplayURL error:&removeError];
     if (result == NO) {
-        SENTRY_LOG_ERROR(@"Can't delete '%@' with file item at url: '%@', reason: %@",
+        SENTRY_LOG_ERROR(
+            @"[Session Replay] Can't delete '%@' with file item at url: '%@', reason: %@",
             SENTRY_LAST_REPLAY, lastReplayURL, removeError);
+    } else {
+        SENTRY_LOG_DEBUG(@"[Session Replay] Deleted last replay file at path: %@", lastReplayURL);
     }
 }
 
@@ -262,11 +282,14 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)startSession
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Starting session");
     [self.sessionReplay pause];
 
     _startedAsFullSession = [self shouldReplayFullSession:_replayOptions.sessionSampleRate];
 
     if (!_startedAsFullSession && _replayOptions.onErrorSampleRate == 0) {
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] Not full session and onErrorSampleRate is 0, not starting session");
         return;
     }
 
@@ -276,9 +299,12 @@ static SentryTouchTracker *_touchTracker;
 - (void)runReplayForAvailableWindow
 {
     if (SentryDependencyContainer.sharedInstance.application.windows.count > 0) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] Running replay for available window");
         // If a window its already available start replay right away
         [self startWithOptions:_replayOptions fullSession:_startedAsFullSession];
     } else if (@available(iOS 13.0, tvOS 13.0, *)) {
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] Waiting for a scene to be available to started the replay");
         // Wait for a scene to be available to started the replay
         [_notificationCenter addObserver:self
                                 selector:@selector(newSceneActivate)
@@ -289,6 +315,7 @@ static SentryTouchTracker *_touchTracker;
 - (void)newSceneActivate
 {
     if (@available(iOS 13.0, tvOS 13.0, *)) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] Scene is available, starting replay");
         [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
             removeObserver:self
                       name:UISceneDidActivateNotification];
@@ -299,6 +326,7 @@ static SentryTouchTracker *_touchTracker;
 - (void)startWithOptions:(SentryReplayOptions *)replayOptions
              fullSession:(BOOL)shouldReplayFullSession
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Starting session");
     [self startWithOptions:replayOptions
          screenshotProvider:_currentScreenshotProvider ?: _viewPhotographer
         breadcrumbConverter:_currentBreadcrumbConverter
@@ -311,11 +339,13 @@ static SentryTouchTracker *_touchTracker;
      breadcrumbConverter:(id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
              fullSession:(BOOL)shouldReplayFullSession
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Starting session");
     NSURL *docs = [self replayDirectory];
     NSString *currentSession = [NSUUID UUID].UUIDString;
     docs = [docs URLByAppendingPathComponent:currentSession];
 
     if (![NSFileManager.defaultManager fileExistsAtPath:docs.path]) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] Creating directory at path: %@", docs.path);
         [NSFileManager.defaultManager createDirectoryAtURL:docs
                                withIntermediateDirectories:YES
                                                 attributes:nil
@@ -377,6 +407,8 @@ static SentryTouchTracker *_touchTracker;
                           path:(NSString *)path
                        options:(SentryReplayOptions *)options
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Saving current session info for session: %@ to path: %@",
+        sessionId, path);
     NSDictionary *info =
         [[NSDictionary alloc] initWithObjectsAndKeys:sessionId.sentryIdString, @"replayId",
             path.lastPathComponent, @"path", @(options.onErrorSampleRate), @"errorSampleRate", nil];
@@ -386,16 +418,20 @@ static SentryTouchTracker *_touchTracker;
     NSString *infoPath = [[path stringByDeletingLastPathComponent]
         stringByAppendingPathComponent:SENTRY_CURRENT_REPLAY];
     if ([NSFileManager.defaultManager fileExistsAtPath:infoPath]) {
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] Removing existing current replay info at path: %@", infoPath);
         [NSFileManager.defaultManager removeItemAtPath:infoPath error:nil];
     }
     [data writeToFile:infoPath atomically:YES];
 
+    SENTRY_LOG_DEBUG(@"[Session Replay] Saved current session info at path: %@", infoPath);
     sentrySessionReplaySync_start([[path stringByAppendingPathComponent:@"crashInfo"]
         cStringUsingEncoding:NSUTF8StringEncoding]);
 }
 
 - (void)moveCurrentReplay
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Moving current replay");
     NSFileManager *fileManager = NSFileManager.defaultManager;
 
     NSURL *path = [self replayDirectory];
@@ -404,30 +440,33 @@ static SentryTouchTracker *_touchTracker;
 
     NSError *error;
     if ([fileManager fileExistsAtPath:last.path]) {
-        SENTRY_LOG_DEBUG(@"Removing last replay file at path: %@", last);
+        SENTRY_LOG_DEBUG(@"[Session Replay] Removing last replay file at path: %@", last);
         if ([NSFileManager.defaultManager removeItemAtURL:last error:&error] == NO) {
-            SENTRY_LOG_ERROR(@"Could not delete last replay file, reason: %@", error);
+            SENTRY_LOG_ERROR(
+                @"[Session Replay] Could not delete last replay file, reason: %@", error);
             return;
         }
-        SENTRY_LOG_DEBUG(@"Removed last replay file at path: %@", last);
+        SENTRY_LOG_DEBUG(@"[Session Replay] Removed last replay file at path: %@", last);
     } else {
-        SENTRY_LOG_DEBUG(@"No last replay file to remove at path: %@", last);
+        SENTRY_LOG_DEBUG(@"[Session Replay] No last replay file to remove at path: %@", last);
     }
 
     if ([fileManager fileExistsAtPath:current.path]) {
-        SENTRY_LOG_DEBUG(@"Moving current replay file at path: %@ to: %@", current, last);
+        SENTRY_LOG_DEBUG(
+            @"[Session Replay] Moving current replay file at path: %@ to: %@", current, last);
         if ([fileManager moveItemAtURL:current toURL:last error:&error] == NO) {
-            SENTRY_LOG_ERROR(@"Could not move replay file, reason: %@", error);
+            SENTRY_LOG_ERROR(@"[Session Replay] Could not move replay file, reason: %@", error);
             return;
         }
-        SENTRY_LOG_DEBUG(@"Moved current replay file at path: %@", current);
+        SENTRY_LOG_DEBUG(@"[Session Replay] Moved current replay file at path: %@", current);
     } else {
-        SENTRY_LOG_DEBUG(@"No current replay file to move at path: %@", current);
+        SENTRY_LOG_DEBUG(@"[Session Replay] No current replay file to move at path: %@", current);
     }
 }
 
 - (void)cleanUp
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Cleaning up");
     NSURL *replayDir = [self replayDirectory];
     NSDictionary<NSString *, id> *lastReplayInfo = [self lastReplayInfo];
     NSString *lastReplayFolder = lastReplayInfo[@"path"];
@@ -437,6 +476,7 @@ static SentryTouchTracker *_touchTracker;
     // listing files and creating a new replay session.
     NSArray *replayFiles = [fileManager allFilesInFolder:replayDir.path];
     if (replayFiles.count == 0) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] No replay files to clean up");
         return;
     }
 
@@ -444,6 +484,7 @@ static SentryTouchTracker *_touchTracker;
         for (NSString *file in replayFiles) {
             // Skip the last replay folder.
             if ([file isEqualToString:lastReplayFolder]) {
+                SENTRY_LOG_DEBUG(@"[Session Replay] Skipping last replay folder: %@", file);
                 continue;
             }
 
@@ -451,6 +492,8 @@ static SentryTouchTracker *_touchTracker;
 
             // Check if the file is a directory before deleting it.
             if ([fileManager isDirectory:filePath]) {
+                SENTRY_LOG_DEBUG(
+                    @"[Session Replay] Removing replay directory at path: %@", filePath);
                 [fileManager removeFileAtPath:filePath];
             }
         }
@@ -459,24 +502,28 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)pause
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Pausing session");
     [self.sessionReplay pause];
 }
 
 - (void)resume
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Resuming session");
     [self.sessionReplay resume];
 }
 
 - (void)start
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Starting session");
     if (_rateLimited) {
-        SENTRY_LOG_WARN(
-            @"This session was rate limited. Not starting session replay until next app session");
+        SENTRY_LOG_WARN(@"[Session Replay] This session was rate limited. Not starting session "
+                        @"replay until next app session");
         return;
     }
 
     if (self.sessionReplay != nil) {
         if (self.sessionReplay.isFullSession == NO) {
+            SENTRY_LOG_DEBUG(@"[Session Replay] Not full session, capturing replay");
             [self.sessionReplay captureReplay];
         }
         return;
@@ -488,12 +535,14 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)stop
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Stopping session");
     [self.sessionReplay pause];
     self.sessionReplay = nil;
 }
 
 - (void)sentrySessionEnded:(SentrySession *)session
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Session ended");
     [self pause];
     [_notificationCenter removeObserver:self
                                    name:UIApplicationDidEnterBackgroundNotification
@@ -506,18 +555,21 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)sentrySessionStarted:(SentrySession *)session
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Session started");
     _rateLimited = NO;
     [self startSession];
 }
 
 - (BOOL)captureReplay
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Capturing replay");
     return [self.sessionReplay captureReplay];
 }
 
 - (void)configureReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
          screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Configuring replay");
     if (breadcrumbConverter) {
         _currentBreadcrumbConverter = breadcrumbConverter;
         self.sessionReplay.breadcrumbConverter = breadcrumbConverter;
@@ -531,6 +583,7 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)setReplayTags:(NSDictionary<NSString *, id> *)tags
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Setting replay tags: %@", tags);
     self.sessionReplay.replayTags = [tags copy];
 }
 
@@ -541,6 +594,7 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)uninstall
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Uninstalling");
     [SentrySDK.currentHub unregisterSessionListener:self];
     _touchTracker = nil;
     [self pause];
@@ -558,6 +612,7 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)swizzleApplicationTouch
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Swizzling application touch tracker");
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wshadow"
     SEL selector = NSSelectorFromString(@"sendEvent:");
@@ -583,6 +638,9 @@ static SentryTouchTracker *_touchTracker;
                                                 level:(enum SentryLevel)level
                                                  data:(nullable NSDictionary<NSString *, id> *)data
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Creating breadcrumb with timestamp: %@, category: %@, "
+                     @"message: %@, level: %lu, data: %@",
+        timestamp, category, message, level, data);
     return [[SentryRRWebBreadcrumbEvent alloc] initWithTimestamp:timestamp
                                                         category:category
                                                          message:message
@@ -596,6 +654,9 @@ static SentryTouchTracker *_touchTracker;
                                                  description:(NSString *)description
                                                         data:(NSDictionary<NSString *, id> *)data
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Creating network breadcrumb with timestamp: %@, "
+                     @"endTimestamp: %@, operation: %@, description: %@, data: %@",
+        timestamp, endTimestamp, operation, description, data);
     return [[SentryRRWebSpanEvent alloc] initWithTimestamp:timestamp
                                               endTimestamp:endTimestamp
                                                  operation:operation
@@ -605,6 +666,7 @@ static SentryTouchTracker *_touchTracker;
 
 + (id<SentryReplayBreadcrumbConverter>)createDefaultBreadcrumbConverter
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Creating default breadcrumb converter");
     return [[SentrySRDefaultBreadcrumbConverter alloc] init];
 }
 
@@ -620,6 +682,8 @@ static SentryTouchTracker *_touchTracker;
                                replayRecording:(SentryReplayRecording *)replayRecording
                                       videoUrl:(NSURL *)videoUrl
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] New segment with replay event, eventId: %@, segmentId: %lu",
+        replayEvent.eventId, replayEvent.segmentId);
     if ([_rateLimits isRateLimitActive:kSentryDataCategoryReplay] ||
         [_rateLimits isRateLimitActive:kSentryDataCategoryAll]) {
         SENTRY_LOG_DEBUG(
@@ -639,6 +703,7 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)sessionReplayStartedWithReplayId:(SentryId *)replayId
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Session replay started with replay id: %@", replayId);
     [SentrySDK.currentHub configureScope:^(
         SentryScope *_Nonnull scope) { scope.replayId = [replayId sentryIdString]; }];
 }
@@ -660,13 +725,15 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)showMaskPreview:(CGFloat)opacity
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Showing mask preview with opacity: %f", opacity);
     if ([SentryDependencyContainer.sharedInstance.crashWrapper isBeingTraced] == NO) {
+        SENTRY_LOG_DEBUG(@"[Session Replay] No tracing is active, not showing mask preview");
         return;
     }
 
     UIWindow *window = SentryDependencyContainer.sharedInstance.application.windows.firstObject;
     if (window == nil) {
-        SENTRY_LOG_WARN(@"There is no UIWindow available to display preview");
+        SENTRY_LOG_WARN(@"[Session Replay] No UIWindow available to display preview");
         return;
     }
 
@@ -681,6 +748,7 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)hideMaskPreview
 {
+    SENTRY_LOG_DEBUG(@"[Session Replay] Hiding mask preview");
     [_previewView removeFromSuperview];
     _previewView = nil;
 }
@@ -689,7 +757,8 @@ static SentryTouchTracker *_touchTracker;
 
 - (void)connectivityChanged:(BOOL)connected typeDescription:(nonnull NSString *)typeDescription
 {
-
+    SENTRY_LOG_DEBUG(@"[Session Replay] Connectivity changed to: %@, type: %@",
+        connected ? @"connected" : @"disconnected", typeDescription);
     if (connected) {
         [_sessionReplay resume];
     } else {

--- a/Sources/Sentry/SentrySessionReplaySyncC.c
+++ b/Sources/Sentry/SentrySessionReplaySyncC.c
@@ -14,6 +14,7 @@ static SentryCrashReplay crashReplay = { 0 };
 void
 sentrySessionReplaySync_start(const char *const path)
 {
+    SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Starting session replay with path: %s", path);
     crashReplay.lastSegmentEnd = 0;
     crashReplay.segmentId = 0;
 
@@ -36,6 +37,9 @@ sentrySessionReplaySync_start(const char *const path)
 void
 sentrySessionReplaySync_updateInfo(unsigned int segmentId, double lastSegmentEnd)
 {
+    SENTRY_ASYNC_SAFE_LOG_DEBUG(
+        @"[Session Replay] Updating session info with segmentId: %u, lastSegmentEnd: %f", segmentId,
+        lastSegmentEnd);
     crashReplay.segmentId = segmentId;
     crashReplay.lastSegmentEnd = lastSegmentEnd;
 }
@@ -43,6 +47,7 @@ sentrySessionReplaySync_updateInfo(unsigned int segmentId, double lastSegmentEnd
 void
 sentrySessionReplaySync_writeInfo(void)
 {
+    SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Writing session info");
     if (crashReplay.path == NULL) {
         SENTRY_ASYNC_SAFE_LOG_ERROR("There is no path to write replay information");
         return;
@@ -76,6 +81,7 @@ sentrySessionReplaySync_writeInfo(void)
 bool
 sentrySessionReplaySync_readInfo(SentryCrashReplay *output, const char *const path)
 {
+    SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Reading session info from path: %s", path);
     int fd = open(path, O_RDONLY);
     if (fd < 0) {
         SENTRY_ASYNC_SAFE_LOG_ERROR(

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 #if canImport(UIKit) && !SENTRY_NO_UIKIT
 #if os(iOS) || os(tvOS)
 
@@ -79,11 +80,16 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     }
     
     private func addFrame(image: UIImage, forScreen: String?) {
-        guard let data = rescaleImage(image)?.pngData() else { return }
+        SentryLog.debug("[Session Replay] Adding frame to replay, screen: \(forScreen ?? "nil")")
+        guard let data = rescaleImage(image)?.pngData() else { 
+            SentryLog.error("[Session Replay] Could not rescale image, dropping frame")
+            return
+        }
         
         let date = dateProvider.date()
         let imagePath = (_outputPath as NSString).appendingPathComponent("\(date.timeIntervalSinceReferenceDate).png")
         do {
+            SentryLog.debug("[Session Replay] Saving frame to path: \(imagePath)")
             try data.write(to: URL(fileURLWithPath: imagePath))
         } catch {
             SentryLog.error("[Session Replay] Could not save replay frame. Error: \(error)")
@@ -94,13 +100,19 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         // Remove the oldest frames if the cache size exceeds the maximum size.
         while _frames.count > cacheMaxSize {
             let first = _frames.removeFirst()
+            SentryLog.debug("[Session Replay] Removing oldest frame at path: \(first.imagePath)")
             try? FileManager.default.removeItem(at: URL(fileURLWithPath: first.imagePath))
         }
         _totalFrames += 1
+        SentryLog.debug("[Session Replay] Increased total frames to: \(_totalFrames)")
     }
     
     private func rescaleImage(_ originalImage: UIImage) -> UIImage? {
-        guard originalImage.scale > 1 else { return originalImage }
+        SentryLog.debug("[Session Replay] Rescaling image with scale: \(originalImage.scale)")
+        guard originalImage.scale > 1 else { 
+            SentryLog.debug("[Session Replay] Image is already at the correct scale, returning original image")
+            return originalImage
+        }
         
         UIGraphicsBeginImageContextWithOptions(originalImage.size, false, 1)
         defer { UIGraphicsEndImageContext() }
@@ -110,8 +122,8 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     }
     
     func releaseFramesUntil(_ date: Date) {
-        SentryLog.debug("[Session Replay] Releasing frames until date: \(date)")
         workingQueue.dispatchAsync ({
+            SentryLog.debug("[Session Replay] Releasing frames until date: \(date)")
             while let first = self._frames.first, first.time < date {
                 self._frames.removeFirst()
                 let fileUrl = URL(fileURLWithPath: first.imagePath)
@@ -119,9 +131,10 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
                     try FileManager.default.removeItem(at: fileUrl)
                     SentryLog.debug("[Session Replay] Removed frame at url: \(fileUrl.path)")
                 } catch {
-                    SentryLog.error("[Session Replay] Failed to remove frame at: \(fileUrl.path), reason: \(error.localizedDescription), ignoring error")
+                    SentryLog.error("[Session Replay] Failed to remove frame at: \(fileUrl.path), reason: \(error), ignoring error")
                 }
             }
+            SentryLog.debug("[Session Replay] Frames released, remaining frames count: \(self._frames.count)")
         })
     }
         
@@ -130,6 +143,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     }
     
     func createVideoWith(beginning: Date, end: Date) throws -> [SentryVideoInfo] {
+        SentryLog.debug("[Session Replay] Creating video with beginning: \(beginning), end: \(end)")
         let videoFrames = filterFrames(beginning: beginning, end: end)
         var frameCount = 0
         
@@ -137,27 +151,34 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         
         while frameCount < videoFrames.count {
             let outputFileURL = URL(fileURLWithPath: _outputPath.appending("/\(videoFrames[frameCount].time.timeIntervalSinceReferenceDate).mp4"))
+            SentryLog.debug("[Session Replay] Rendering video with output file URL: \(outputFileURL)")
             if let videoInfo = try renderVideo(with: videoFrames, from: &frameCount, at: outputFileURL) {
                 videos.append(videoInfo)
             } else {
                 frameCount++
-            }  
+            }
         }
         return videos
     }
 
     // swiftlint:disable:next function_body_length
     private func renderVideo(with videoFrames: [SentryReplayFrame], from: inout Int, at outputFileURL: URL) throws -> SentryVideoInfo? {
-        guard from < videoFrames.count, let image = UIImage(contentsOfFile: videoFrames[from].imagePath) else { return nil }
+        SentryLog.debug("[Session Replay] Rendering video with \(videoFrames.count) video frames, from index: \(from), output file URL: \(outputFileURL)")
+        guard from < videoFrames.count, let image = UIImage(contentsOfFile: videoFrames[from].imagePath) else { 
+            SentryLog.error("[Session Replay] Could not render video, reason: frame not found")
+            return nil 
+        }
         let videoWidth = image.size.width * CGFloat(videoScale)
         let videoHeight = image.size.height * CGFloat(videoScale)
         
         let videoWriter = try AVAssetWriter(url: outputFileURL, fileType: .mp4)
         let videoWriterInput = AVAssetWriterInput(mediaType: .video, outputSettings: createVideoSettings(width: videoWidth, height: videoHeight))
         
-        guard let currentPixelBuffer = SentryPixelBuffer(size: CGSize(width: videoWidth, height: videoHeight), videoWriterInput: videoWriterInput)
-        else { throw SentryOnDemandReplayError.cantCreatePixelBuffer }
-        
+        guard let currentPixelBuffer = SentryPixelBuffer(size: CGSize(width: videoWidth, height: videoHeight), videoWriterInput: videoWriterInput) else {
+            SentryLog.error("[Session Replay] Failed to render video, reason: pixel buffer creation failed")
+            throw SentryOnDemandReplayError.cantCreatePixelBuffer
+        }
+
         videoWriter.add(videoWriterInput)
         videoWriter.startWriting()
         videoWriter.startSession(atSourceTime: .zero)
@@ -171,20 +192,25 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
         
         group.enter()
         videoWriterInput.requestMediaDataWhenReady(on: workingQueue.queue) {
+            SentryLog.debug("[Session Replay] Video writer input is ready, status: \(videoWriter.status)")
             guard videoWriter.status == .writing else {
+                SentryLog.error("[Session Replay] Video writer status is not writing, cancelling video writing")
                 videoWriter.cancelWriting()
                 result = .failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo )
                 group.leave()
                 return
             }
             if frameCount >= videoFrames.count {
+                SentryLog.debug("[Session Replay] Frame count is greater than video frames count, finishing video")
                 result = self.finishVideo(outputFileURL: outputFileURL, usedFrames: usedFrames, videoHeight: Int(videoHeight), videoWidth: Int(videoWidth), videoWriter: videoWriter)
                 group.leave()
                 return
             }
             let frame = videoFrames[frameCount]
             if let image = UIImage(contentsOfFile: frame.imagePath) {
+                SentryLog.debug("[Session Replay] Image is ready, size: \(image.size)")
                 if lastImageSize != image.size {
+                    SentryLog.debug("[Session Replay] Image size has changed, finishing video")
                     result = self.finishVideo(outputFileURL: outputFileURL, usedFrames: usedFrames, videoHeight: Int(videoHeight), videoWidth: Int(videoWidth), videoWriter: videoWriter)
                     group.leave()
                     return
@@ -212,6 +238,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     }
         
     private func finishVideo(outputFileURL: URL, usedFrames: [SentryReplayFrame], videoHeight: Int, videoWidth: Int, videoWriter: AVAssetWriter) -> Result<SentryVideoInfo?, Error> {
+        SentryLog.debug("[Session Replay] Finishing video with output file URL: \(outputFileURL), used frames count: \(usedFrames.count), video height: \(videoHeight), video width: \(videoWidth)")
         let group = DispatchGroup()
         var finishError: Error?
         var result: SentryVideoInfo?
@@ -382,3 +409,4 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
 
 #endif // os(iOS) || os(tvOS)
 #endif // canImport(UIKit)
+// swiftlint:enable file_length

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -238,7 +238,7 @@ class SentryOnDemandReplay: NSObject, SentryReplayVideoMaker {
     }
         
     private func finishVideo(outputFileURL: URL, usedFrames: [SentryReplayFrame], videoHeight: Int, videoWidth: Int, videoWriter: AVAssetWriter) -> Result<SentryVideoInfo?, Error> {
-        SentryLog.debug("[Session Replay] Finishing video with output file URL: \(outputFileURL), used frames count: \(usedFrames.count), video height: \(videoHeight), video width: \(videoWidth)")
+        SentryLog.info("[Session Replay] Finishing video with output file URL: \(outputFileURL), used frames count: \(usedFrames.count), video height: \(videoHeight), video width: \(videoWidth)")
         let group = DispatchGroup()
         var finishError: Error?
         var result: SentryVideoInfo?

--- a/Sources/Swift/Integrations/SessionReplay/SentryPixelBuffer.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryPixelBuffer.swift
@@ -26,7 +26,11 @@ class SentryPixelBuffer {
     }
     
     func append(image: UIImage, presentationTime: CMTime) -> Bool {
-        guard let pixelBuffer = pixelBuffer else { return false }
+        SentryLog.debug("[Session Replay] Appending image to pixel buffer with presentation time: \(presentationTime)")
+        guard let pixelBuffer = pixelBuffer else { 
+            SentryLog.error("[Session Replay] Could not append image to pixel buffer, reason: pixel buffer is nil")
+            return false 
+        }
         
         CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
         let pixelData = CVPixelBufferGetBaseAddress(pixelBuffer)
@@ -42,6 +46,7 @@ class SentryPixelBuffer {
                 space: rgbColorSpace,
                 bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
             ) else {
+            SentryLog.error("[Session Replay] Failed to append image to pixel buffer, reason: could not create CGContext")
             return false
         }
 

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayType.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayType.swift
@@ -14,3 +14,9 @@ extension SentryReplayType {
         }
     }
 }
+
+extension SentryReplayType: CustomStringConvertible {
+    var description: String {
+        return toString()
+    }
+}

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -135,7 +135,7 @@ class SentrySessionReplay: NSObject {
         }
         
         guard !reachedMaximumDuration else { 
-            SentryLog.debug("[Session Replay] Reached maximum duration, not resuming")
+            SentryLog.warning("[Session Replay] Reached maximum duration, not resuming")
             return 
         }
         guard !isRunning else { 
@@ -155,7 +155,7 @@ class SentrySessionReplay: NSObject {
         }
 
         if isFullSession {
-            SentryLog.debug("[Session Replay] Session replay is full, setting event context")
+            SentryLog.info("[Session Replay] Session replay is in full session mode, setting event context")
             setEventContext(event: event)
             return
         }
@@ -354,12 +354,12 @@ class SentrySessionReplay: NSObject {
     }
     
     private func takeScreenshot() {
-        SentryLog.debug("[Session Replay] Taking screenshot")
         guard let rootView = rootView, !processingScreenshot else { 
             SentryLog.debug("[Session Replay] Not taking screenshot, reason: root view is nil or processing screenshot")
             return 
         }
-
+        SentryLog.debug("[Session Replay] Taking screenshot of root view: \(rootView)")
+        
         lock.lock()
         guard !processingScreenshot else {
             SentryLog.debug("[Session Replay] Not taking screenshot, reason: processing screenshot")

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -17,6 +17,7 @@ protocol SentrySessionReplayDelegate: NSObjectProtocol {
     func currentScreenNameForSessionReplay() -> String?
 }
 
+// swiftlint:disable type_body_length
 @objcMembers
 class SentrySessionReplay: NSObject {
     private(set) var isFullSession = false
@@ -76,7 +77,11 @@ class SentrySessionReplay: NSObject {
     deinit { displayLink.invalidate() }
 
     func start(rootView: UIView, fullSession: Bool) {
-        guard !isRunning else { return }
+        SentryLog.debug("[Session Replay] Starting session replay with full session: \(fullSession)")
+        guard !isRunning else { 
+            SentryLog.debug("[Session Replay] Session replay is already running, not starting again")
+            return 
+        }
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
         self.rootView = rootView
         lastScreenShot = dateProvider.date()
@@ -91,6 +96,7 @@ class SentrySessionReplay: NSObject {
     }
 
     private func startFullReplay() {
+        SentryLog.debug("[Session Replay] Starting full session replay")
         sessionStart = lastScreenShot
         isFullSession = true
         guard let sessionReplayId = sessionReplayId else { return }
@@ -98,6 +104,7 @@ class SentrySessionReplay: NSObject {
     }
 
     func pauseSessionMode() {
+        SentryLog.debug("[Session Replay] Pausing session mode")
         lock.lock()
         defer { lock.unlock() }
         
@@ -106,6 +113,7 @@ class SentrySessionReplay: NSObject {
     }
     
     func pause() {
+        SentryLog.debug("[Session Replay] Pausing session")
         lock.lock()
         defer { lock.unlock() }
         
@@ -117,6 +125,7 @@ class SentrySessionReplay: NSObject {
     }
 
     func resume() {
+        SentryLog.debug("[Session Replay] Resuming session")
         lock.lock()
         defer { lock.unlock() }
         
@@ -125,22 +134,34 @@ class SentrySessionReplay: NSObject {
             return
         }
         
-        guard !reachedMaximumDuration else { return }
-        guard !isRunning else { return }
+        guard !reachedMaximumDuration else { 
+            SentryLog.debug("[Session Replay] Reached maximum duration, not resuming")
+            return 
+        }
+        guard !isRunning else { 
+            SentryLog.debug("[Session Replay] Session is already running, not resuming")
+            return 
+        }
         
         videoSegmentStart = nil
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
     }
 
     func captureReplayFor(event: Event) {
-        guard isRunning else { return }
+        SentryLog.debug("[Session Replay] Capturing replay for event: \(event)")
+        guard isRunning else { 
+            SentryLog.debug("[Session Replay] Session replay is not running, not capturing replay")
+            return 
+        }
 
         if isFullSession {
+            SentryLog.debug("[Session Replay] Session replay is full, setting event context")
             setEventContext(event: event)
             return
         }
 
         guard (event.error != nil || event.exceptions?.isEmpty == false) && captureReplay() else { 
+            SentryLog.debug("[Session Replay] Not capturing replay, reason: event is not an error or exceptions are empty")
             return
         }
         
@@ -149,10 +170,17 @@ class SentrySessionReplay: NSObject {
 
     @discardableResult
     func captureReplay() -> Bool {
-        guard isRunning else { return false }
-        guard !isFullSession else { return true }
+        guard isRunning else { 
+            SentryLog.debug("[Session Replay] Session replay is not running, not capturing replay")
+            return false 
+        }
+        guard !isFullSession else { 
+            SentryLog.debug("[Session Replay] Session replay is full, not capturing replay")
+            return true 
+        }
 
         guard delegate?.sessionReplayShouldCaptureReplayForError() == true else {
+            SentryLog.debug("[Session Replay] Not capturing replay, reason: delegate should not capture replay")
             return false
         }
 
@@ -164,7 +192,11 @@ class SentrySessionReplay: NSObject {
     }
 
     private func setEventContext(event: Event) {
-        guard let sessionReplayId = sessionReplayId, event.type != "replay_video" else { return }
+        SentryLog.debug("[Session Replay] Setting event context")
+        guard let sessionReplayId = sessionReplayId, event.type != "replay_video" else { 
+            SentryLog.debug("[Session Replay] Not setting event context, reason: session replay id is nil or event type is replay_video")
+            return 
+        }
 
         var context = event.context ?? [:]
         context["replay"] = ["replay_id": sessionReplayId.sentryIdString]
@@ -186,6 +218,7 @@ class SentrySessionReplay: NSObject {
         let now = dateProvider.date()
         
         if let sessionStart = sessionStart, isFullSession && now.timeIntervalSince(sessionStart) > replayOptions.maximumDuration {
+            SentryLog.debug("[Session Replay] Reached maximum duration, pausing session")
             reachedMaximumDuration = true
             pause()
             return
@@ -205,12 +238,17 @@ class SentrySessionReplay: NSObject {
     }
 
     private func prepareSegmentUntil(date: Date) {
-        guard var pathToSegment = urlToCache?.appendingPathComponent("segments") else { return }
-        let fileManager = FileManager.default
+        SentryLog.debug("[Session Replay] Preparing segment until date: \(date)")
+        guard var pathToSegment = urlToCache?.appendingPathComponent("segments") else { 
+            SentryLog.debug("[Session Replay] Not preparing segment, reason: could not create path to segments folder")
+            return 
+        }
 
+        let fileManager = FileManager.default
         if !fileManager.fileExists(atPath: pathToSegment.path) {
             do {
                 try fileManager.createDirectory(atPath: pathToSegment.path, withIntermediateDirectories: true, attributes: nil)
+                SentryLog.debug("[Session Replay] Created segments folder at path: \(pathToSegment.path)")
             } catch {
                 SentryLog.debug("Can't create session replay segment folder. Error: \(error.localizedDescription)")
                 return
@@ -231,6 +269,7 @@ class SentrySessionReplay: NSObject {
         dispatchQueue.dispatchAsync {
             do {
                 let videos = try self.replayMaker.createVideoWith(beginning: startedAt, end: self.dateProvider.date())
+                SentryLog.debug("[Session Replay] Created \(videos.count) segments")
                 for video in videos {
                     self.newSegmentAvailable(videoInfo: video, replayType: replayType)
                 }
@@ -243,7 +282,10 @@ class SentrySessionReplay: NSObject {
 
     private func newSegmentAvailable(videoInfo: SentryVideoInfo, replayType: SentryReplayType) {
         SentryLog.debug("[Session Replay] New segment available for replayType: \(replayType), videoInfo: \(videoInfo)")
-        guard let sessionReplayId = sessionReplayId else { return }
+        guard let sessionReplayId = sessionReplayId else { 
+            SentryLog.debug("[Session Replay] Not capturing segment, reason: session replay id is nil")
+            return 
+        }
         captureSegment(segment: currentSegmentId, video: videoInfo, replayId: sessionReplayId, replayType: replayType)
         replayMaker.releaseFramesUntil(videoInfo.end)
         videoSegmentStart = videoInfo.end
@@ -251,6 +293,7 @@ class SentrySessionReplay: NSObject {
     }
     
     private func captureSegment(segment: Int, video: SentryVideoInfo, replayId: SentryId, replayType: SentryReplayType) {
+        SentryLog.debug("[Session Replay] Capturing segment: \(segment), replayId: \(replayId), replayType: \(replayType)")
         let replayEvent = SentryReplayEvent(eventId: replayId, replayStartTimestamp: video.start, replayType: replayType, segmentId: segment)
         
         replayEvent.sdk = self.replayOptions.sdkInfo
@@ -261,11 +304,13 @@ class SentrySessionReplay: NSObject {
 
         var events = convertBreadcrumbs(breadcrumbs: breadcrumbs, from: video.start, until: video.end)
         if let touchTracker = touchTracker {
+            SentryLog.debug("[Session Replay] Adding touch tracker events")
             events.append(contentsOf: touchTracker.replayEvents(from: videoSegmentStart ?? video.start, until: video.end))
             touchTracker.flushFinishedEvents()
         }
         
         if segment == 0 {
+            SentryLog.debug("[Session Replay] Adding options event to segment 0")
             if let customOptions = replayTags {
                 events.append(SentryRRWebOptionsEvent(timestamp: video.start, customOptions: customOptions))
             } else {
@@ -279,17 +324,21 @@ class SentrySessionReplay: NSObject {
 
         do {
             try FileManager.default.removeItem(at: video.path)
+            SentryLog.debug("[Session Replay] Deleted replay segment from disk")
         } catch {
-            SentryLog.debug("Could not delete replay segment from disk: \(error.localizedDescription)")
+            SentryLog.debug("[Session Replay] Could not delete replay segment from disk: \(error)")
         }
     }
     
     private func convertBreadcrumbs(breadcrumbs: [Breadcrumb], from: Date, until: Date) -> [any SentryRRWebEventProtocol] {
+        SentryLog.debug("[Session Replay] Converting breadcrumbs from: \(from) until: \(until)")
         var filteredResult: [Breadcrumb] = []
         var lastNavigationTime: Date = from.addingTimeInterval(-1)
         
         for breadcrumb in breadcrumbs {
-            guard let time = breadcrumb.timestamp, time >= from && time < until else { continue }
+            guard let time = breadcrumb.timestamp, time >= from && time < until else { 
+                continue
+            }
             
             // If it's a "navigation" breadcrumb, check the timestamp difference from the previous breadcrumb.
             // Skip any breadcrumbs that have occurred within 50ms of the last one,
@@ -305,10 +354,15 @@ class SentrySessionReplay: NSObject {
     }
     
     private func takeScreenshot() {
-        guard let rootView = rootView, !processingScreenshot else { return }
+        SentryLog.debug("[Session Replay] Taking screenshot")
+        guard let rootView = rootView, !processingScreenshot else { 
+            SentryLog.debug("[Session Replay] Not taking screenshot, reason: root view is nil or processing screenshot")
+            return 
+        }
 
         lock.lock()
         guard !processingScreenshot else {
+            SentryLog.debug("[Session Replay] Not taking screenshot, reason: processing screenshot")
             lock.unlock()
             return
         }
@@ -316,18 +370,21 @@ class SentrySessionReplay: NSObject {
         lock.unlock()
         
         let screenName = delegate?.currentScreenNameForSessionReplay()
-        
+
+        SentryLog.debug("[Session Replay] Getting screenshot from screenshot provider")
         screenshotProvider.image(view: rootView) { [weak self] screenshot in
             self?.newImage(image: screenshot, forScreen: screenName)
         }
     }
 
     private func newImage(image: UIImage, forScreen screen: String?) {
+        SentryLog.debug("[Session Replay] New frame available, for screen: \(screen ?? "nil")")
         lock.synchronized {
             processingScreenshot = false
             replayMaker.addFrameAsync(image: image, forScreen: screen)
         }
     }
 }
+// swiftlint:enable type_body_length
 
 #endif

--- a/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
@@ -118,6 +118,7 @@ class SentryTouchTracker: NSObject {
     }
     
     func flushFinishedEvents() {
+        SentryLog.debug("[Session Replay] Flushing finished events")
         dispatchQueue.dispatchSync { [self] in
             trackedTouches = trackedTouches.filter { $0.value.endEvent == nil }
         }


### PR DESCRIPTION
## :scroll: Description

Adds debug logging to session replay integration.

## :bulb: Motivation and Context

It must become easier to debug issues with the integration.
I tried to add only relevant information for SDK users trying not to produce spam-like amount of logs.

## :green_heart: How did you test it?

Ran sample app in iOS simulator, looked at logs.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
