### PR TITLE
fix(ci): Use response data in changes-in-high-risk-code.yml

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -1,6 +1,7 @@
 # This is used by the action https://github.com/dorny/paths-filter
 
 high_risk_code: &high_risk_code
+  - ".github/workflows/changes-in-high-risk-code.yml"
   - "Sources/Sentry/SentryNSURLSessionTaskSearch.m"
   - "Sources/Sentry/SentryNetworkTracker.m"
   - "Sources/Sentry/SentryUIViewControllerSwizzling.m"

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -42,10 +42,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             })
-            if (!comments) {
-              return
-            }
-            for (const comment of comments) {
+            for (const comment of comments.data) {
               if (comment.user.login === 'github-actions[bot]' && comment.body.includes('### 🚨 Detected changes in high risk code 🚨')) {
                 await github.rest.issues.deleteComment({
                   comment_id: comment.id


### PR DESCRIPTION
- Adds the `changes-in-high-risk-code.yml` to the list of risky files to make sure the action is executed when changing the workflow too
- Uses the `comments.data` instead of `comments`. See [this workflow run](https://github.com/getsentry/sentry-cocoa/actions/runs/14859106773/job/41719320930) for details on the actual value of `comments` and the error.

The bug was introduced in #5147 and we already tried to fix it in #5157.

#skip-changelog