### PR TITLE
fix: Detect AppHangsV2 when tracing not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Detect AppHangsV2 when tracing not enabled (#5184)
+
 ## 8.50.0
 
 > [!Important]

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -176,10 +176,10 @@ NS_ASSUME_NONNULL_BEGIN
     // for this.
     if (integrationOptions & kIntegrationOptionStartFramesTracker) {
 
+#if SENTRY_HAS_UIKIT
         BOOL performanceDisabled
             = !options.enableAutoPerformanceTracing || !options.isTracingEnabled;
-        BOOL appHangsV2Disabled
-            = !options.enableAppHangTrackingV2 || options.appHangTimeoutInterval <= 0;
+        BOOL appHangsV2Disabled = options.isAppHangTrackingV2Disabled;
 
         if (performanceDisabled && appHangsV2Disabled) {
             if (appHangsV2Disabled) {
@@ -196,6 +196,7 @@ NS_ASSUME_NONNULL_BEGIN
 
             return NO;
         }
+#endif // SENTRY_HAS_UIKIT
     }
 
     return YES;

--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -172,6 +172,32 @@ NS_ASSUME_NONNULL_BEGIN
     }
 #endif
 
+    // The frames tracker runs when tracing is enabled or AppHangsV2. We have to use an extra option
+    // for this.
+    if (integrationOptions & kIntegrationOptionStartFramesTracker) {
+
+        BOOL performanceDisabled
+            = !options.enableAutoPerformanceTracing || !options.isTracingEnabled;
+        BOOL appHangsV2Disabled
+            = !options.enableAppHangTrackingV2 || options.appHangTimeoutInterval <= 0;
+
+        if (performanceDisabled && appHangsV2Disabled) {
+            if (appHangsV2Disabled) {
+                SENTRY_LOG_DEBUG(@"Not going to enable %@ because enableAppHangTrackingV2 is "
+                                 @"disabled or the appHangTimeoutInterval is 0.",
+                    self.integrationName);
+            }
+
+            if (performanceDisabled) {
+                SENTRY_LOG_DEBUG(@"Not going to enable %@ because enableAutoPerformanceTracing and "
+                                 @"isTracingEnabled are disabled.",
+                    self.integrationName);
+            }
+
+            return NO;
+        }
+    }
+
     return YES;
 }
 

--- a/Sources/Sentry/SentryFramesTrackingIntegration.m
+++ b/Sources/Sentry/SentryFramesTrackingIntegration.m
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (SentryIntegrationOption)integrationOptions
 {
-    return kIntegrationOptionEnableAutoPerformanceTracing | kIntegrationOptionIsTracingEnabled;
+    return kIntegrationOptionStartFramesTracker;
 }
 
 - (void)uninstall

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -170,7 +170,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         }
 #endif // TARGET_OS_OSX
 
-        // Use the name of the bundle’s executable file as inAppInclude, so SentryInAppLogic
+        // Use the name of the bundle's executable file as inAppInclude, so SentryInAppLogic
         // marks frames coming from there as inApp. With this approach, the SDK marks public
         // frameworks such as UIKitCore, CoreFoundation, GraphicsServices, and so forth, as not
         // inApp. For private frameworks, such as Sentry, dynamic and static frameworks differ.
@@ -831,6 +831,13 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
 #endif // defined(RELEASE)
 }
 
+#if SENTRY_HAS_UIKIT
+- (BOOL)isAppHangTrackingV2Disabled
+{
+    return !self.enableAppHangTrackingV2 || self.appHangTimeoutInterval <= 0;
+}
+#endif // SENTRY_HAS_UIKIT
+
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 - (void)setConfigureUserFeedback:(SentryUserFeedbackConfigurationBlock)configureUserFeedback
 {
@@ -862,4 +869,5 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
     return [NSString stringWithFormat:@"<%@: {\n%@\n}>", self, propertiesDescription];
 }
 #endif // defined(DEBUG) || defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+
 @end

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -213,7 +213,7 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
 
 #    if SENTRY_HAS_UIKIT
     // if SentryOptions.enableAutoPerformanceTracing is NO and appHangsV2Disabled, which uses the
-    // frames tracker, then we need to stop the frames tracker from running outside of profiles
+    // frames tracker, is YES, then we need to stop the frames tracker from running outside of profiles
     // because it isn't needed for anything else
 
     BOOL autoPerformanceTracingDisabled

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -212,9 +212,16 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
     }
 
 #    if SENTRY_HAS_UIKIT
-    // if SentryOptions.enableAutoPerformanceTracing is NO, then we need to stop the frames tracker
-    // from running outside of profiles because it isn't needed for anything else
-    if (![[[[SentrySDK currentHub] getClient] options] enableAutoPerformanceTracing]) {
+    // if SentryOptions.enableAutoPerformanceTracing is NO and appHangsV2Disabled, which uses the
+    // frames tracker, then we need to stop the frames tracker from running outside of profiles
+    // because it isn't needed for anything else
+
+    BOOL autoPerformanceTracingDisabled
+        = ![[[[SentrySDK currentHub] getClient] options] enableAutoPerformanceTracing];
+    BOOL appHangsV2Disabled =
+        [[[[SentrySDK currentHub] getClient] options] isAppHangTrackingV2Disabled];
+
+    if (autoPerformanceTracingDisabled && appHangsV2Disabled) {
         [SentryDependencyContainer.sharedInstance.framesTracker stop];
     }
 #    endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/HybridPublic/SentryBaseIntegration.h
+++ b/Sources/Sentry/include/HybridPublic/SentryBaseIntegration.h
@@ -23,6 +23,7 @@ typedef NS_OPTIONS(NSUInteger, SentryIntegrationOption) {
     kIntegrationOptionEnableCrashHandler = 1 << 16,
     kIntegrationOptionEnableMetricKit = 1 << 17,
     kIntegrationOptionEnableReplay = 1 << 18,
+    kIntegrationOptionStartFramesTracker = 1 << 19,
 };
 
 @class SentryOptions;

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -24,6 +24,9 @@ FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
 
 SENTRY_EXTERN BOOL sentry_isValidSampleRate(NSNumber *sampleRate);
 
+#if SENTRY_HAS_UIKIT
+- (BOOL)isAppHangTrackingV2Disabled;
+#endif // SENTRY_HAS_UIKIT
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -75,7 +75,21 @@ final class SentryContinuousProfilerTests: XCTestCase {
     func testStartingContinuousProfilerWithZeroSampleRate() throws {
         fixture.options.profilesSampleRate = 0
         try performContinuousProfilingTest()
-    }    
+    }
+
+    func testStopsFramesTracker_WhenAutoPerformanceAndAppHangsV2Disabled() throws {
+        fixture.options.enableAutoPerformanceTracing = false
+        try performContinuousProfilingTest()
+
+        XCTAssertFalse(SentryDependencyContainer.sharedInstance().framesTracker.isRunning)
+    }
+
+    func testDoesNotStopFramesTracker_WhenAppHangsV2Enabled() throws {
+        fixture.options.enableAppHangTrackingV2 = true
+        try performContinuousProfilingTest()
+
+        XCTAssertTrue(SentryDependencyContainer.sharedInstance().framesTracker.isRunning)
+    }
 
     #if !os(macOS)
     // test that receiving a background notification stops the continuous

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -77,6 +77,8 @@ final class SentryContinuousProfilerTests: XCTestCase {
         try performContinuousProfilingTest()
     }
 
+#if !os(macOS)
+
     func testStopsFramesTracker_WhenAutoPerformanceAndAppHangsV2Disabled() throws {
         fixture.options.enableAutoPerformanceTracing = false
         try performContinuousProfilingTest()
@@ -91,7 +93,6 @@ final class SentryContinuousProfilerTests: XCTestCase {
         XCTAssertTrue(SentryDependencyContainer.sharedInstance().framesTracker.isRunning)
     }
 
-    #if !os(macOS)
     // test that receiving a background notification stops the continuous
     // profiler after it has been started manually
     func testStoppingContinuousProfilerStopsOnBackground() throws {

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackingIntegrationTests.swift
@@ -46,7 +46,24 @@ class SentryFramesTrackingIntegrationTests: XCTestCase {
         
         XCTAssertNotNil(Dynamic(sut).tracker.asObject)
     }
-    
+
+    func testAppHangV2Enabled_MeasuresFrames() {
+        let options = fixture.options
+        options.enableAppHangTrackingV2 = true
+        sut.install(with: options)
+
+        XCTAssertNotNil(Dynamic(sut).tracker.asObject)
+    }
+
+    func testAppHangV2Enabled_ButIntervalZero_DoestNotMeasuresFrames() {
+        let options = fixture.options
+        options.enableAppHangTrackingV2 = true
+        options.appHangTimeoutInterval = 0.0
+        sut.install(with: options)
+
+        XCTAssertNil(Dynamic(sut).tracker.asObject)
+    }
+
     func testZeroTracesSampleRate_DoesNotMeasureFrames() {
         let options = fixture.options
         options.tracesSampleRate = 0.0

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1515,6 +1515,36 @@
     XCTAssertEqualObjects(options3.spotlightUrl, @"http://localhost:8969/stream");
 }
 
+#if SENTRY_HAS_UIKIT
+- (void)testIsAppHangTrackingV2Disabled_WhenBothOptionsDisabled
+{
+    SentryOptions *options = [self
+        getValidOptions:@{ @"enableAppHangTrackingV2" : @NO, @"appHangTimeoutInterval" : @0 }];
+    XCTAssertTrue(options.isAppHangTrackingV2Disabled);
+}
+
+- (void)testIsAppHangTrackingV2Disabled_WhenOnlyEnableAppHangTrackingV2Disabled
+{
+    SentryOptions *options = [self
+        getValidOptions:@{ @"enableAppHangTrackingV2" : @NO, @"appHangTimeoutInterval" : @2.0 }];
+    XCTAssertTrue(options.isAppHangTrackingV2Disabled);
+}
+
+- (void)testIsAppHangTrackingV2Disabled_WhenOnlyAppHangTimeoutIntervalZero
+{
+    SentryOptions *options = [self
+        getValidOptions:@{ @"enableAppHangTrackingV2" : @YES, @"appHangTimeoutInterval" : @0 }];
+    XCTAssertTrue(options.isAppHangTrackingV2Disabled);
+}
+
+- (void)testIsAppHangTrackingV2Disabled_WhenBothOptionsEnabled
+{
+    SentryOptions *options = [self
+        getValidOptions:@{ @"enableAppHangTrackingV2" : @YES, @"appHangTimeoutInterval" : @2.0 }];
+    XCTAssertFalse(options.isAppHangTrackingV2Disabled);
+}
+#endif // SENTRY_HAS_UIKIT
+
 #pragma mark - Private
 
 - (void)assertArrayEquals:(NSArray<NSString *> *)expected actual:(NSArray<NSString *> *)actual


### PR DESCRIPTION

## :scroll: Description

AppHangsV2 didn't detect any app hangs when tracing was disabled. This is fixed now.

## :bulb: Motivation and Context

Brought up in an internal Slack discussion.

## :green_heart: How did you test it?
Unit tests and simulator: [sample event](https://sentry-sdks.sentry.io/issues/6588735286/events/743520cb05f54781b31e731482ad52a1/?project=5428557) when having tracing disabled

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
