### PR TITLE
fix(ci): Add missing parameters to delete high-risk comments

### DIFF
--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -37,13 +37,20 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const comments = await github.rest.issues.listComments({
+            core.debug('Listing comments')
+            const response = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo
             })
-            for (const comment of comments.data) {
+            if (!response.data) {
+              core.info('No comments found')
+              return
+            }
+            core.debug(`Found ${response.data.length} comments`)
+            for (const comment of response.data) {
               if (comment.user.login === 'github-actions[bot]' && comment.body.includes('### 🚨 Detected changes in high risk code 🚨')) {
+                core.info(`Deleting comment ${comment.id}`)
                 await github.rest.issues.deleteComment({
                   comment_id: comment.id
                 })
@@ -57,6 +64,7 @@ jobs:
           script: |
             const highRiskFiles = process.env.high_risk_code;
             const fileList = highRiskFiles.split(',').map(file => `- [ ] ${file}`).join('\n');
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -50,14 +50,12 @@ jobs:
             core.debug(`Found ${response.data.length} comments`)
             for (const comment of response.data) {
               if (comment.user.login === 'github-actions[bot]' && comment.body.includes('### 🚨 Detected changes in high risk code 🚨')) {
-                try {
-                  core.info(`Deleting comment ${comment.id}`)
-                  await github.rest.issues.deleteComment({
-                    comment_id: comment.id
-                  })
-                } catch (error) {
-                  core.error(`Error deleting comment ${comment.id}: ${error}`)
-                }
+                core.info(`Deleting comment ${comment.id}`)
+                await github.rest.issues.deleteComment({
+                  comment_id: comment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                })
               }
             }
       - name: Comment on PR to notify of changes in high risk files

--- a/.github/workflows/changes-in-high-risk-code.yml
+++ b/.github/workflows/changes-in-high-risk-code.yml
@@ -50,10 +50,14 @@ jobs:
             core.debug(`Found ${response.data.length} comments`)
             for (const comment of response.data) {
               if (comment.user.login === 'github-actions[bot]' && comment.body.includes('### 🚨 Detected changes in high risk code 🚨')) {
-                core.info(`Deleting comment ${comment.id}`)
-                await github.rest.issues.deleteComment({
-                  comment_id: comment.id
-                })
+                try {
+                  core.info(`Deleting comment ${comment.id}`)
+                  await github.rest.issues.deleteComment({
+                    comment_id: comment.id
+                  })
+                } catch (error) {
+                  core.error(`Error deleting comment ${comment.id}: ${error}`)
+                }
               }
             }
       - name: Comment on PR to notify of changes in high risk files


### PR DESCRIPTION
After merging #5183 the removal of comments is still failing, see [this workflow run ](https://github.com/getsentry/sentry-cocoa/actions/runs/14859484969/job/41720575603?pr=5162) after updating the PR to latest main.

The reason were missing `owner` and `repo` parameters in the delete call.

To verify the changes, delete the comment "🚨 Detected changes in high risk code 🚨", then run [this job](https://github.com/getsentry/sentry-cocoa/actions/runs/14859907534/job/41722119335?pr=5185) again.

The comment will be created.

Next add any comment to this PR and run the job again. The previous comment before yours will be deleted and a new one posted to the PR.

#skip-changelog