### PR TITLE
fix(testflight): generate project, and use correct path

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           bundler-cache: true
 
+      - run: brew bundle --file Brewfile-ci-build
+      - run: make xcode
+
       # We upload a new version to TestFlight on every commit on main
       # So we need to bump the build number each time
       - name: Bump Build Version

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - run: brew bundle --file Brewfile-ci-build
+      - run: make init-ci-build
       - run: make xcode
 
       # We upload a new version to TestFlight on every commit on main

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -16,14 +16,14 @@ platform :ios do
   # for App Store Connect. If we are on a preview we to remove these suffixes.
   lane :remove_preview_version_suffixes do
     version = get_version_number(
-      xcodeproj: "Samples/iOS-Swift.xcodeproj",
+      xcodeproj: "Samples/iOS-Swift/iOS-Swift.xcodeproj",
       target: "iOS-Swift"
       )
     new_version = version.split("-", -1)[0]
 
     # We also need to replace the MARKETING_VERSION otherwise the build will fail with
     # error: The CFBundleShortVersionString of an App Clip ('8.9.0-beta.1') must match that of its containing parent app ('8.9.0').
-    sh "sed -i '' 's/MARKETING_VERSION = #{version}/MARKETING_VERSION = #{new_version}/g' ../Samples/iOS-Swift.xcodeproj/project.pbxproj"
+    sh "sed -i '' 's/MARKETING_VERSION = #{version}/MARKETING_VERSION = #{new_version}/g' ../Samples/iOS-Swift/iOS-Swift.xcodeproj/project.pbxproj"
 
     set_info_plist_value(
       path: ios_swift_infoplist_path,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,8 +1,8 @@
 default_platform(:ios)
 
 platform :ios do
-  ios_swift_infoplist_path = "./Samples/iOS-Swift/Info.plist"
-  ios_swift_clip_infoplist_path = "./Samples/iOS-SwiftClip/Info.plist"
+  ios_swift_infoplist_path = "./Samples/iOS-Swift/iOS-Swift/Info.plist"
+  ios_swift_clip_infoplist_path = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
   configuration = if is_ci then 'TestCI' else 'Test' end
 
   lane :bump_build_number do

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -8,7 +8,7 @@ platform :ios do
   lane :bump_build_number do
     increment_build_number(
       build_number: ENV["FASTLANE_BUILD_NUMBER"],
-      xcodeproj: "./Samples/iOS-Swift.xcodeproj"
+      xcodeproj: "./Samples/iOS-Swift/iOS-Swift.xcodeproj"
     )
   end
 


### PR DESCRIPTION
didn't update the path to the generated project, and didn't generate it beforehand

#skip-changelog