### PR TITLE
ci: Run UI Tests for SwiftUI with Xcode 16

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -76,15 +76,15 @@ jobs:
 
   # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:
-    name: UI Tests for SwiftUI - V3 # Up the version with every change to keep track of flaky tests
-    runs-on: macos-13
+    name: UI Tests for SwiftUI - V4 # Up the version with every change to keep track of flaky tests
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
 
-      - run: ./scripts/ci-select-xcode.sh 14.3.1
+      - run: ./scripts/ci-select-xcode.sh 16.2
       - run: make init-ci-build
       - run: make xcode
         name: XcodeGen iOS-Swift project


### PR DESCRIPTION
These tests fail with some error when showing the xcode build setting. Using a more up to date runner and Xcode version could help and anyways makes sense.

The job failed here: https://github.com/getsentry/sentry-cocoa/actions/runs/14877481283/job/41784031333.

#skip-changelog