### PR TITLE
ci: Remove CameraTest xcconfig from version bump

### DIFF
--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -1,0 +1,18 @@
+name: Version Bump Util
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+
+jobs:
+    run-version-bump:
+        name: Run Version Bump
+        # We intentionally run this on ubuntu because the release workflow also runs on ubuntu, which uses the version bump util.
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            # We don't care which version we bump to, as long as it's a valid semver
+            - run: make bump-version TO=100.0.0

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -1,4 +1,4 @@
-name: Version Bump Util
+name: Test Version Bump Util
 
 on:
   push:

--- a/Utils/VersionBump/main.swift
+++ b/Utils/VersionBump/main.swift
@@ -19,7 +19,7 @@ let restrictFiles = [
     "./Sources/Configuration/SDK.xcconfig",
     "./Sources/Configuration/Versioning.xcconfig", 
     "./Sources/Configuration/SentrySwiftUI.xcconfig",
-    "./Samples/Shared/Config/Versioning.xcconfg",
+    "./Samples/Shared/Config/Versioning.xcconfig",
     "./Samples/iOS-Swift/iOS-Swift/Sample.xcconfig"
 ]
 

--- a/Utils/VersionBump/main.swift
+++ b/Utils/VersionBump/main.swift
@@ -19,7 +19,7 @@ let restrictFiles = [
     "./Sources/Configuration/SDK.xcconfig",
     "./Sources/Configuration/Versioning.xcconfig", 
     "./Sources/Configuration/SentrySwiftUI.xcconfig",
-    "./Samples/Shared/Config/Versioning.xcconfig",
+    "./Samples/Shared/Config/Versioning.xcconfg",
     "./Samples/iOS-Swift/iOS-Swift/Sample.xcconfig"
 ]
 

--- a/Utils/VersionBump/main.swift
+++ b/Utils/VersionBump/main.swift
@@ -20,7 +20,6 @@ let restrictFiles = [
     "./Sources/Configuration/Versioning.xcconfig", 
     "./Sources/Configuration/SentrySwiftUI.xcconfig",
     "./Samples/Shared/Config/Versioning.xcconfig",
-    "./Samples/SessionReplay-CameraTest/config/Versioning.xcconfig",
     "./Samples/iOS-Swift/iOS-Swift/Sample.xcconfig"
 ]
 


### PR DESCRIPTION


## :scroll: Description

The CameraTest doesn't contain a proper marketing version. We can ignore it. 

I also added a GH action to run the version util via the make file.

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

By intentionally breaking it here https://github.com/getsentry/sentry-cocoa/actions/runs/14886048089/job/41805819992?pr=5195.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
