### PR TITLE
ci: Move shellcheck into its on workflow

### DIFF
--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - ci/shellcheck
     paths:
       - ".github/workflows/lint-shellcheck.yml"
       - "*.sh"

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -1,3 +1,8 @@
+# We want only to run the shellcheck when sh files change without running the other linters, which are
+# expensive. For example, pod lib lint doesn't need to run for sh changes. Therefore, we run it in an
+# extra workflow.
+
+
 name: lint-shellcheck
 on:
   push:

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -2,7 +2,6 @@
 # expensive. For example, pod lib lint doesn't need to run for sh changes. Therefore, we run it in an
 # extra workflow.
 
-
 name: lint-shellcheck
 on:
   push:

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -1,0 +1,22 @@
+name: lint-shellcheck
+on:
+  push:
+    branches:
+      - main
+      - ci/shellcheck
+    paths:
+      - ".github/workflows/lint-shellcheck.yml"
+      - "*.sh"
+
+  pull_request:
+    paths:
+      - ".github/workflows/lint-shellcheck.yml"
+      - "*.sh"
+
+jobs:
+  shellcheck:
+    name: Run Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: shellcheck **/*.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,14 +79,6 @@ jobs:
       - name: Validate HybridPod Podspec
         run: pod lib lint ./Tests/HybridSDKTest/HybridPod.podspec --allow-warnings --verbose --platforms=ios "--include-podspecs={Sentry.podspec}"
 
-  shellcheck:
-    name: Run Shellcheck
-    runs-on: macos-13
-    steps:
-      - uses: actions/checkout@v4
-      - run: brew install shellcheck
-      - run: shellcheck **/*.sh
-
   lint-prettier:
     name: Run Prettier
     runs-on: ubuntu-latest


### PR DESCRIPTION
Move the shellcheck into its on workflow so it always runs when sh files change. We can also run it on ubuntu and its preinstalled.

#skip-changelog
