### PR TITLE
ref: Fix compiler errors for async safe logs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,3 +297,34 @@ jobs:
             --derived-data uikit-check-build
       - name: Ensure UIKit is linked
         run: ./scripts/check-uikit-linkage.sh Release uikit-check-build linked Sentry
+
+    # The compiler only evaluates SentryAsyncSafeLogs that get printed based on the SENTRY_ASYNC_SAFE_LOG_LEVEL.
+    # So if the level is set to error, which is the default, and a SENTRY_ASYNC_SAFE_LOG_DEBUG has a compiler error, 
+    # you only get the compiler error when setting the SENTRY_ASYNC_SAFE_LOG_LEVEL to SENTRY_ASYNC_SAFE_LOG_LEVEL_DEBUG or lower.
+  check-compiling-with-async-safe-logs:
+      name: Check compiling with Async Safe Logs
+      runs-on: macos-15
+      steps:
+        - uses: actions/checkout@v4
+  
+
+        # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
+        - name: Async Safe Log Level is Error
+          run: grep -c "SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR" Sources/Sentry/SentryAsyncSafeLog.h
+
+        - name: Set Async Safe Log Level to Debug
+          run: |
+            sed -i '' 's/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_TRACE/' Sources/Sentry/SentryAsyncSafeLog.h
+          shell: bash
+
+        - run: ./scripts/ci-select-xcode.sh 16.3
+
+        - name: Build for Debug
+          run: |
+            ./scripts/sentry-xcodebuild.sh \
+              --platform iOS \
+              --os latest \
+              --ref ${{ github.ref }} \
+              --command build \
+              --device "iPhone 16" \
+              --configuration Debug 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -301,13 +301,12 @@ jobs:
     # The compiler only evaluates SentryAsyncSafeLogs that get printed based on the SENTRY_ASYNC_SAFE_LOG_LEVEL.
     # So if the level is set to error, which is the default, and a SENTRY_ASYNC_SAFE_LOG_DEBUG has a compiler error, 
     # you only get the compiler error when setting the SENTRY_ASYNC_SAFE_LOG_LEVEL to SENTRY_ASYNC_SAFE_LOG_LEVEL_DEBUG or lower.
-  check-compiling-with-async-safe-logs:
-      name: Check compiling with Async Safe Logs
+  check-compiling-async-safe-logs:
+      name: Check compiling Async Safe Logs
       runs-on: macos-15
       steps:
         - uses: actions/checkout@v4
   
-
         # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
         - name: Async Safe Log Level is Error
           run: grep -c "SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR" Sources/Sentry/SentryAsyncSafeLog.h

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -299,31 +299,31 @@ jobs:
         run: ./scripts/check-uikit-linkage.sh Release uikit-check-build linked Sentry
 
     # The compiler only evaluates SentryAsyncSafeLogs that get printed based on the SENTRY_ASYNC_SAFE_LOG_LEVEL.
-    # So if the level is set to error, which is the default, and a SENTRY_ASYNC_SAFE_LOG_DEBUG has a compiler error, 
+    # So if the level is set to error, which is the default, and a SENTRY_ASYNC_SAFE_LOG_DEBUG has a compiler error,
     # you only get the compiler error when setting the SENTRY_ASYNC_SAFE_LOG_LEVEL to SENTRY_ASYNC_SAFE_LOG_LEVEL_DEBUG or lower.
   check-compiling-async-safe-logs:
-      name: Check compiling Async Safe Logs
-      runs-on: macos-15
-      steps:
-        - uses: actions/checkout@v4
-  
-        # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
-        - name: Async Safe Log Level is Error
-          run: grep -c "SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR" Sources/Sentry/SentryAsyncSafeLog.h
+    name: Check compiling Async Safe Logs
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
 
-        - name: Set Async Safe Log Level to Debug
-          run: |
-            sed -i '' 's/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_TRACE/' Sources/Sentry/SentryAsyncSafeLog.h
-          shell: bash
+      # If the SentryAsyncSafeLog doesn't contain the SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR this fails.
+      - name: Async Safe Log Level is Error
+        run: grep -c "SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR" Sources/Sentry/SentryAsyncSafeLog.h
 
-        - run: ./scripts/ci-select-xcode.sh 16.3
+      - name: Set Async Safe Log Level to Debug
+        run: |
+          sed -i '' 's/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_TRACE/' Sources/Sentry/SentryAsyncSafeLog.h
+        shell: bash
 
-        - name: Build for Debug
-          run: |
-            ./scripts/sentry-xcodebuild.sh \
-              --platform iOS \
-              --os latest \
-              --ref ${{ github.ref }} \
-              --command build \
-              --device "iPhone 16" \
-              --configuration Debug 
+      - run: ./scripts/ci-select-xcode.sh 16.3
+
+      - name: Build for Debug
+        run: |
+          ./scripts/sentry-xcodebuild.sh \
+            --platform iOS \
+            --os latest \
+            --ref ${{ github.ref }} \
+            --command build \
+            --device "iPhone 16" \
+            --configuration Debug

--- a/Sources/Sentry/SentrySessionReplaySyncC.c
+++ b/Sources/Sentry/SentrySessionReplaySyncC.c
@@ -14,7 +14,7 @@ static SentryCrashReplay crashReplay = { 0 };
 void
 sentrySessionReplaySync_start(const char *const path)
 {
-    SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Starting session replay with path: %s", path);
+    SENTRY_ASYNC_SAFE_LOG_DEBUG("[Session Replay] Starting session replay with path: %s", path);
     crashReplay.lastSegmentEnd = 0;
     crashReplay.segmentId = 0;
 
@@ -38,7 +38,7 @@ void
 sentrySessionReplaySync_updateInfo(unsigned int segmentId, double lastSegmentEnd)
 {
     SENTRY_ASYNC_SAFE_LOG_DEBUG(
-        @"[Session Replay] Updating session info with segmentId: %u, lastSegmentEnd: %f", segmentId,
+        "[Session Replay] Updating session info with segmentId: %u, lastSegmentEnd: %f", segmentId,
         lastSegmentEnd);
     crashReplay.segmentId = segmentId;
     crashReplay.lastSegmentEnd = lastSegmentEnd;
@@ -47,7 +47,7 @@ sentrySessionReplaySync_updateInfo(unsigned int segmentId, double lastSegmentEnd
 void
 sentrySessionReplaySync_writeInfo(void)
 {
-    SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Writing session info");
+    SENTRY_ASYNC_SAFE_LOG_DEBUG("[Session Replay] Writing session info");
     if (crashReplay.path == NULL) {
         SENTRY_ASYNC_SAFE_LOG_ERROR("There is no path to write replay information");
         return;
@@ -81,7 +81,7 @@ sentrySessionReplaySync_writeInfo(void)
 bool
 sentrySessionReplaySync_readInfo(SentryCrashReplay *output, const char *const path)
 {
-    SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Reading session info from path: %s", path);
+    SENTRY_ASYNC_SAFE_LOG_DEBUG("[Session Replay] Reading session info from path: %s", path);
     int fd = open(path, O_RDONLY);
     if (fd < 0) {
         SENTRY_ASYNC_SAFE_LOG_ERROR(


### PR DESCRIPTION
When setting the SENTRY_ASYNC_SAFE_LOG_LEVEL to
SENTRY_ASYNC_SAFE_LOG_DEBUG, the project fails to compile because SentrySessionReplaySyncC contains compiler errors for the log levels. This is fixed now, and this PR also adds a check in CI to prevent this from happening again, by setting the SENTRY_ASYNC_SAFE_LOG_LEVEL to SENTRY_ASYNC_SAFE_LOG_TRACE and compiling the project.

CI failed successfully here https://github.com/getsentry/sentry-cocoa/actions/runs/14901950471/job/41855671564?pr=5207

```
Error: expected expression
   17 |     SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Starting session replay with path: %s", path);
      |                                 ^
Error: expected expression
   41 |         @"[Session Replay] Updating session info with segmentId: %u, lastSegmentEnd: %f", segmentId,
      |         ^
Error: expected expression
   50 |     SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Writing session info");
      |                                 ^
Error: expected expression
   84 |     SENTRY_ASYNC_SAFE_LOG_DEBUG(@"[Session Replay] Reading session info from path: %s", path);
```

CI succeeds after fixing the compiler issues above: https://github.com/getsentry/sentry-cocoa/actions/runs/14902525387/job/41857526390

#skip-changelog

