### PR TITLE
fix: Fix default values and dictionary values for session replay options

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -829,6 +829,9 @@
 		D456B4322D706BDF007068CB /* SentrySpanOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = D456B4312D706BDD007068CB /* SentrySpanOperation.h */; };
 		D456B4362D706BF2007068CB /* SentryTraceOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = D456B4352D706BEE007068CB /* SentryTraceOrigin.h */; };
 		D456B4382D706BFE007068CB /* SentrySpanDataKey.h in Headers */ = {isa = PBXBuildFile; fileRef = D456B4372D706BFB007068CB /* SentrySpanDataKey.h */; };
+		D467125E2DCCFF2500D4074A /* SentryReplayOptionsObjcTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D467125D2DCCFF2500D4074A /* SentryReplayOptionsObjcTests.m */; };
+		D46712622DCD059900D4074A /* SentryRedactDefaultOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46712612DCD059500D4074A /* SentryRedactDefaultOptionsTests.swift */; };
+		D46712642DCD063800D4074A /* PreviewRedactOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D46712632DCD062700D4074A /* PreviewRedactOptionsTests.swift */; };
 		D468C0622D3669A200964230 /* SentryFileIOTracker+SwiftHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D468C0612D3669A200964230 /* SentryFileIOTracker+SwiftHelpers.swift */; };
 		D473ACD72D8090FC000F1CC6 /* FileManager+SentryTracing.swift in Sources */ = {isa = PBXBuildFile; fileRef = D473ACD62D8090FC000F1CC6 /* FileManager+SentryTracing.swift */; };
 		D48724E02D3549CA005DE483 /* SentrySpanOperationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D48724DF2D3549C6005DE483 /* SentrySpanOperationTests.swift */; };
@@ -1996,6 +1999,9 @@
 		D456B4312D706BDD007068CB /* SentrySpanOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpanOperation.h; path = include/SentrySpanOperation.h; sourceTree = "<group>"; };
 		D456B4352D706BEE007068CB /* SentryTraceOrigin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTraceOrigin.h; path = include/SentryTraceOrigin.h; sourceTree = "<group>"; };
 		D456B4372D706BFB007068CB /* SentrySpanDataKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpanDataKey.h; path = include/SentrySpanDataKey.h; sourceTree = "<group>"; };
+		D467125D2DCCFF2500D4074A /* SentryReplayOptionsObjcTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryReplayOptionsObjcTests.m; sourceTree = "<group>"; };
+		D46712612DCD059500D4074A /* SentryRedactDefaultOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryRedactDefaultOptionsTests.swift; sourceTree = "<group>"; };
+		D46712632DCD062700D4074A /* PreviewRedactOptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewRedactOptionsTests.swift; sourceTree = "<group>"; };
 		D468C0612D3669A200964230 /* SentryFileIOTracker+SwiftHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SentryFileIOTracker+SwiftHelpers.swift"; sourceTree = "<group>"; };
 		D46D45E12D5F3FD600A1CB35 /* Sentry_Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sentry_Base.xctestplan; sourceTree = "<group>"; };
 		D46D45E82D5F40FA00A1CB35 /* SentryProfilerTests_Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = SentryProfilerTests_Base.xctestplan; path = Plans/SentryProfilerTests_Base.xctestplan; sourceTree = SOURCE_ROOT; };
@@ -3099,6 +3105,7 @@
 		7B3D0474249A3D5800E106B6 /* Protocol */ = {
 			isa = PBXGroup;
 			children = (
+				D46712612DCD059500D4074A /* SentryRedactDefaultOptionsTests.swift */,
 				620078762D3906AD0022CB67 /* Codable */,
 				7BC6EBF7255C05060059822A /* TestData.swift */,
 				7B869EBB249B91D8004F4FDB /* SentryDebugMetaEquality.swift */,
@@ -3950,6 +3957,7 @@
 				D82DD1CC2BEEB1A0001AB556 /* SentrySRDefaultBreadcrumbConverterTests.swift */,
 				D8DBE0C92C0E093000FAB1FD /* SentryTouchTrackerTests.swift */,
 				D8DBE0D12C0EFFC300FAB1FD /* SentryReplayOptionsTests.swift */,
+				D467125D2DCCFF2500D4074A /* SentryReplayOptionsObjcTests.m */,
 			);
 			path = SessionReplay;
 			sourceTree = "<group>";
@@ -4040,6 +4048,7 @@
 		D833D60F2D1320DF00961E7A /* SentrySwiftUITests */ = {
 			isa = PBXGroup;
 			children = (
+				D46712632DCD062700D4074A /* PreviewRedactOptionsTests.swift */,
 				D833D6152D13215900961E7A /* SentryRedactModifierTests.swift */,
 				D833D6162D13215900961E7A /* SentryTraceViewModelTest.swift */,
 				D833D74D2D1323F800961E7A /* SentryTests-Bridging-Header.h */,
@@ -5399,6 +5408,7 @@
 				7B984A9F28E572AF001F4BEE /* CrashReport.swift in Sources */,
 				D4AF00252D2E93C400F5F3D7 /* SentryNSFileManagerSwizzlingTests.m in Sources */,
 				7BED3576266F7BFF00EAA70D /* TestSentryCrashWrapper.m in Sources */,
+				D46712622DCD059900D4074A /* SentryRedactDefaultOptionsTests.swift in Sources */,
 				7BC6EC18255C44540059822A /* SentryDebugMetaTests.swift in Sources */,
 				D8CCFC632A1520C900DE232E /* SentryBinaryImageCacheTests.m in Sources */,
 				A811D867248E2770008A41EA /* SentrySystemEventBreadcrumbsTest.swift in Sources */,
@@ -5520,6 +5530,7 @@
 				7BAF3DD2243DD05C008A5414 /* SentryTransportInitializerTests.swift in Sources */,
 				7B68D93625FF5F1A0082D139 /* SentryAppState+Equality.m in Sources */,
 				7B5CAF7E27F5AD3500ED0DB6 /* TestNSURLRequestBuilder.m in Sources */,
+				D467125E2DCCFF2500D4074A /* SentryReplayOptionsObjcTests.m in Sources */,
 				7BF69E072987D1FE002EBCA4 /* SentryCrashDoctorTests.swift in Sources */,
 				7B4F22DC294089530067EA17 /* FormatHexAddress.swift in Sources */,
 				8EAC7FF8265C8910005B44E5 /* SentryTracerTests.swift in Sources */,
@@ -5629,6 +5640,7 @@
 			files = (
 				D833D73B2D1321FF00961E7A /* SentryRedactModifierTests.swift in Sources */,
 				D833D73C2D13220500961E7A /* SentryTraceViewModelTest.swift in Sources */,
+				D46712642DCD063800D4074A /* PreviewRedactOptionsTests.swift in Sources */,
 				D8CD158F2D39405900EFF8AB /* TestFramesTracker.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -9,7 +9,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      */
     @objc
     public enum SentryReplayQuality: Int, CustomStringConvertible {
-        fileprivate static let defaultQuality: SentryReplayQuality = .medium
+        internal static let defaultQuality: SentryReplayQuality = .medium
 
         /**
          * Video Scale: 80%
@@ -48,6 +48,28 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
             default: return defaultQuality
             }
         }
+
+        /// Converts a nullable Int to a SentryReplayQuality.
+        ///
+        /// This method extends the ``SentryReplayQuality.init(rawValue:)`` by supporting nil values.
+        ///
+        /// - Parameter rawValue: The raw value to convert.
+        /// - Returns: Corresponding ``SentryReplayQuality`` or `nil` if not a valid raw value or no value is provided.
+        fileprivate static func from(rawValue: Int?) -> SentryReplayOptions.SentryReplayQuality? {
+            guard let rawValue = rawValue else {
+                return nil
+            }
+            return SentryReplayOptions.SentryReplayQuality(rawValue: rawValue)
+        }
+
+        fileprivate var bitrate: Int {
+            self.rawValue * 20_000 + 20_000
+        }
+
+        fileprivate var sizeScale: Float {
+            self == .low ? 0.8 : 1.0
+        }
+
     }
 
     /**
@@ -74,7 +96,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - note: The default is true
      */
-    public var maskAllText = true
+    public var maskAllText: Bool
 
     /**
      * Indicates whether session replay should redact all non-bundled image
@@ -82,13 +104,13 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - note: The default is true
      */
-    public var maskAllImages = true
+    public var maskAllImages: Bool
 
     /**
      * Indicates the quality of the replay.
      * The higher the quality, the higher the CPU and bandwidth usage.
      */
-    public var quality = SentryReplayQuality.defaultQuality
+    public var quality: SentryReplayQuality
 
     /**
      * A list of custom UIView subclasses that need
@@ -96,7 +118,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * By default Sentry already mask text and image elements from UIKit
      * Every child of a view that is redacted will also be redacted.
      */
-    public var maskedViewClasses = [AnyClass]()
+    public var maskedViewClasses: [AnyClass]
 
     /**
      * A list of custom UIView subclasses to be ignored
@@ -104,7 +126,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * The views of given classes will not be redacted but their children may be.
      * This property has precedence over `redactViewTypes`.
      */
-    public var unmaskedViewClasses = [AnyClass]()
+    public var unmaskedViewClasses: [AnyClass]
 
     /**
      * Alias for ``enableViewRendererV2``.
@@ -125,19 +147,19 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     /**
      * Enables the up to 5x faster new view renderer used by the Session Replay integration.
      *
-     * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing 
+     * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing
      * interruptions and visual lag. [Our benchmarks](https://github.com/getsentry/sentry-cocoa/pull/4940) have shown a significant improvement of
      * **up to 4-5x faster rendering** (reducing `~160ms` to `~36ms` per frame) on older devices.
      *
-     * - Experiment: In case you are noticing issues with the new view renderer, please report the issue on [GitHub](https://github.com/getsentry/sentry-cocoa). 
+     * - Experiment: In case you are noticing issues with the new view renderer, please report the issue on [GitHub](https://github.com/getsentry/sentry-cocoa).
      *               Eventually, we will remove this feature flag and use the new view renderer by default.
      */
-    public var enableViewRendererV2 = true
+    public var enableViewRendererV2: Bool
 
     /**
      * Enables up to 5x faster but incommpelte view rendering used by the Session Replay integration.
-     * 
-     * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing 
+     *
+     * Enabling this flag will reduce the amount of time it takes to render each frame of the session replay on the main thread, therefore reducing
      * interruptions and visual lag. [Our benchmarks](https://github.com/getsentry/sentry-cocoa/pull/4940) have shown a significant improvement of
      * up to **5x faster render times** (reducing `~160ms` to `~30ms` per frame).
      *
@@ -153,21 +175,21 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *               view renderer, please report the issue on [GitHub](https://github.com/getsentry/sentry-cocoa). Eventually, we will
      *               mark this feature as stable and remove the experimental flag, but will keep it disabled by default.
      */
-    public var enableFastViewRendering = false
+    public var enableFastViewRendering: Bool
 
     /**
      * Defines the quality of the session replay.
      * Higher bit rates better quality, but also bigger files to transfer.
      */
-    var replayBitRate: Int {
-        quality.rawValue * 20_000 + 20_000
+    internal var replayBitRate: Int {
+        quality.bitrate
     }
 
     /**
      * The scale related to the window size at which the replay will be created
      */
-    var sizeScale: Float {
-        quality == .low ? 0.8 : 1.0
+    internal var sizeScale: Float {
+        quality.sizeScale
     }
 
     /**
@@ -175,38 +197,78 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      * The more the havier the process is.
      * The minimum is 1, if set to zero this will change to 1.
      */
-    var frameRate: UInt = 1 {
+    internal var frameRate: UInt {
         didSet {
-            if frameRate < 1 { frameRate = 1 }
+            if frameRate < 1 {
+                frameRate = 1
+            }
         }
     }
 
     /**
      * The maximum duration of replays for error events.
      */
-    let errorReplayDuration = TimeInterval(30)
+    internal var errorReplayDuration: TimeInterval
 
     /**
      * The maximum duration of the segment of a session replay.
      */
-    let sessionSegmentDuration = TimeInterval(5)
+    internal var sessionSegmentDuration: TimeInterval
 
     /**
      * The maximum duration of a replay session.
      */
-    let maximumDuration = TimeInterval(3_600)
+    internal var maximumDuration: TimeInterval
 
     /**
      * Used by hybrid SDKs to be able to configure SDK info for Session Replay
      */
-    var sdkInfo: [String: Any]?
-    
+    internal var sdkInfo: [String: Any]?
+
     /**
-     * Inittialize session replay options disabled
+     * Initialize session replay options disabled
+     *
+     * - Note: This initializer is added for Objective-C compatibility, as constructors with default values
+     *         are not supported in Objective-C.
      */
-    public override init() {
-        self.sessionSampleRate = 0
-        self.onErrorSampleRate = 0
+    public convenience override init() {
+        self.init(
+            // We need to set at least one parameter to avoid the initializer to call itself.
+            //
+            // MAKE SURE THIS DEFAULT VALUE IS ALIGNED WITH THE DEFAULT VALUE IN THE INITIALIZER BELOW.
+            sessionSampleRate: 0,
+        )
+    }
+
+    /// Initializes a new instance of ``SentryReplayOptions`` using a dictionary.
+    ///
+    /// - Parameter dictionary: A dictionary containing the configuration options for the session replay.
+    ///
+    /// - Warning: This initializer is primarily used by Hybrid SDKs and is not intended for public use.
+    convenience init(dictionary: [String: Any]) {
+        // This initalizer is calling the one with optional parameters, so that defaults can be applied
+        // for absent values.
+        self.init(
+            sessionSampleRate: (dictionary["sessionSampleRate"] as? NSNumber)?.floatValue,
+            onErrorSampleRate: (dictionary["errorSampleRate"] as? NSNumber)?.floatValue,
+            maskAllText: (dictionary["maskAllText"] as? NSNumber)?.boolValue,
+            maskAllImages: (dictionary["maskAllImages"] as? NSNumber)?.boolValue,
+            enableViewRendererV2: (dictionary["enableViewRendererV2"] as? NSNumber)?.boolValue
+            ?? (dictionary["enableExperimentalViewRenderer"] as? NSNumber)?.boolValue,
+            enableFastViewRendering: (dictionary["enableFastViewRendering"] as? NSNumber)?.boolValue,
+            maskedViewClasses: (dictionary["maskedViewClasses"] as? NSArray)?.compactMap({ element in
+                NSClassFromString((element as? String) ?? "")
+            }),
+            unmaskedViewClasses: (dictionary["unmaskedViewClasses"] as? NSArray)?.compactMap({ element in
+                NSClassFromString((element as? String) ?? "")
+            }),
+            quality: SentryReplayQuality.from(rawValue: dictionary["quality"] as? Int),
+            sdkInfo: dictionary["sdkInfo"] as? [String: Any],
+            frameRate: (dictionary["frameRate"] as? NSNumber)?.uintValue,
+            errorReplayDuration: (dictionary["errorReplayDuration"] as? NSNumber)?.doubleValue,
+            sessionSegmentDuration: (dictionary["sessionSegmentDuration"] as? NSNumber)?.doubleValue,
+            maximumDuration: (dictionary["maximumDuration"] as? NSNumber)?.doubleValue
+        )
     }
 
     /**
@@ -216,39 +278,108 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *  - errorSampleRate Indicates the percentage in which a 30 seconds replay will be send with
      * error events.
      */
-    public init(sessionSampleRate: Float = 0, onErrorSampleRate: Float = 0, maskAllText: Bool = true, maskAllImages: Bool = true, enableViewRendererV2: Bool = false, enableFastViewRendering: Bool = false) {
+    public init(
+        sessionSampleRate: Float = 0,
+        onErrorSampleRate: Float = 0,
+        maskAllText: Bool = true,
+        maskAllImages: Bool = true,
+        enableViewRendererV2: Bool = true,
+        enableFastViewRendering: Bool = false
+    ) {
+        // Note for future maintainers:
+        // - This initializer is publicly available for Swift, but not for Objective-C.
+        // - Each parameter has a default value, so the parameter can be omitted.
+        // - The values are not optional, because SDK users should not be able to set them to nil.
+
+        // WHEN CHANGING ANY DEFAULT VALUE IN THE INITIALIZER, UPDATE THE PROPERTY DOCUMENTATION
+
         self.sessionSampleRate = sessionSampleRate
         self.onErrorSampleRate = onErrorSampleRate
         self.maskAllText = maskAllText
         self.maskAllImages = maskAllImages
         self.enableViewRendererV2 = enableViewRendererV2
         self.enableFastViewRendering = enableFastViewRendering
+
+        // These are the default values for the properties.
+        // Do not add any default values at the property declaration, because they will be overridden by the initializer.
+        self.maskedViewClasses = []
+        self.unmaskedViewClasses = []
+        self.quality = SentryReplayQuality.defaultQuality
+        self.frameRate = 1
+        self.errorReplayDuration = 30
+        self.sessionSegmentDuration = 5
+        self.maximumDuration = 60 * 60
+
+        super.init()
     }
 
-    convenience init(dictionary: [String: Any]) {
-        let sessionSampleRate = (dictionary["sessionSampleRate"] as? NSNumber)?.floatValue ?? 0
-        let onErrorSampleRate = (dictionary["errorSampleRate"] as? NSNumber)?.floatValue ?? 0
-        let maskAllText = (dictionary["maskAllText"] as? NSNumber)?.boolValue ?? true
-        let maskAllImages = (dictionary["maskAllImages"] as? NSNumber)?.boolValue ?? true
-        let enableViewRendererV2 = (dictionary["enableViewRendererV2"] as? NSNumber)?.boolValue ?? (dictionary["enableExperimentalViewRenderer"] as? NSNumber)?.boolValue ?? false
-        let enableFastViewRendering = (dictionary["enableFastViewRendering"] as? NSNumber)?.boolValue ?? false
+    // swiftlint:disable:next function_parameter_count cyclomatic_complexity
+    private convenience init(
+        sessionSampleRate: Float?,
+        onErrorSampleRate: Float?,
+        maskAllText: Bool?,
+        maskAllImages: Bool?,
+        enableViewRendererV2: Bool?,
+        enableFastViewRendering: Bool?,
+        maskedViewClasses: [AnyClass]?,
+        unmaskedViewClasses: [AnyClass]?,
+        quality: SentryReplayQuality?,
+        sdkInfo: [String: Any]?,
+        frameRate: UInt?,
+        errorReplayDuration: TimeInterval?,
+        sessionSegmentDuration: TimeInterval?,
+        maximumDuration: TimeInterval?
+    ) {
+        // We need to call the designated initializer to set the default values defined directly in the initializer.
+        // Afterwards, we can override default values with the optional parameters.
         self.init(
-            sessionSampleRate: sessionSampleRate,
-            onErrorSampleRate: onErrorSampleRate,
-            maskAllText: maskAllText,
-            maskAllImages: maskAllImages,
-            enableViewRendererV2: enableViewRendererV2,
-            enableFastViewRendering: enableFastViewRendering
+            // We need to set at least one parameter to avoid calling initializer without any parameters.
+            // This could cause a initializer recursion.
+            //
+            // MAKE SURE THIS DEFAULT VALUE IS ALIGNED WITH THE DEFAULT VALUE IN THE INITIALIZER BELOW.
+            sessionSampleRate: 0
         )
-        self.maskedViewClasses = ((dictionary["maskedViewClasses"] as? NSArray) ?? []).compactMap({ element in
-            NSClassFromString((element as? String) ?? "")
-        })
-        self.unmaskedViewClasses = ((dictionary["unmaskedViewClasses"] as? NSArray) ?? []).compactMap({ element in
-            NSClassFromString((element as? String) ?? "")
-        })
-        if let quality = SentryReplayQuality(rawValue: dictionary["quality"] as? Int ?? -1) {
+        if let sessionSampleRate = sessionSampleRate {
+            self.sessionSampleRate = sessionSampleRate
+        }
+        if let onErrorSampleRate = onErrorSampleRate {
+            self.onErrorSampleRate = onErrorSampleRate
+        }
+        if let maskAllText = maskAllText {
+            self.maskAllText = maskAllText
+        }
+        if let maskAllImages = maskAllImages {
+            self.maskAllImages = maskAllImages
+        }
+        if let enableViewRendererV2 = enableViewRendererV2 {
+            self.enableViewRendererV2 = enableViewRendererV2
+        }
+        if let enableFastViewRendering = enableFastViewRendering {
+            self.enableFastViewRendering = enableFastViewRendering
+        }
+        if let maskedViewClasses = maskedViewClasses {
+            self.maskedViewClasses = maskedViewClasses
+        }
+        if let unmaskedViewClasses = unmaskedViewClasses {
+            self.unmaskedViewClasses = unmaskedViewClasses
+        }
+        if let quality = quality {
             self.quality = quality
         }
-        sdkInfo = dictionary["sdkInfo"] as? [String: Any]
+        if let sdkInfo = sdkInfo {
+            self.sdkInfo = sdkInfo
+        }
+        if let frameRate = frameRate {
+            self.frameRate = frameRate
+        }
+        if let errorReplayDuration = errorReplayDuration {
+            self.errorReplayDuration = errorReplayDuration
+        }
+        if let sessionSegmentDuration = sessionSegmentDuration {
+            self.sessionSegmentDuration = sessionSegmentDuration
+        }
+        if let maximumDuration = maximumDuration {
+            self.maximumDuration = maximumDuration
+        }
     }
 }

--- a/Tests/SentrySwiftUITests/PreviewRedactOptionsTests.swift
+++ b/Tests/SentrySwiftUITests/PreviewRedactOptionsTests.swift
@@ -1,0 +1,140 @@
+@testable import SentrySwiftUI
+import XCTest
+
+class PreviewRedactOptionsTests: XCTestCase {
+    func testInit_whenWithoutArguments_shouldUseDefaultOptions() {
+        // -- Act --
+        let options = PreviewRedactOptions()
+
+        // -- Assert --
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertTrue(options.maskedViewClasses.isEmpty)
+        XCTAssertTrue(options.unmaskedViewClasses.isEmpty)
+        XCTAssertFalse(options.enableViewRendererV2)
+    }
+
+    func testInit_withAllArguments_shouldSetOptions() {
+        // -- Arrange --
+        let options = PreviewRedactOptions(
+            maskAllText: false,
+            maskAllImages: false,
+            maskedViewClasses: [UIView.self],
+            unmaskedViewClasses: [UIButton.self],
+            enableViewRendererV2: true
+        )
+        // -- Assert --
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        for maskedViewClass in options.maskedViewClasses {
+            XCTAssertEqual(String(describing: maskedViewClass), String(describing: UIView.self))
+        }
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        for unmaskedViewClass in options.unmaskedViewClasses {
+            XCTAssertEqual(String(describing: unmaskedViewClass), String(describing: UIButton.self))
+        }
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+
+    func testInit_maskAllTextOmitted_shouldUseDefault() {
+        // -- Arrange --
+        let options = PreviewRedactOptions(
+            maskAllImages: true,
+            maskedViewClasses: [UIView.self], 
+            unmaskedViewClasses: [UIButton.self], 
+            enableViewRendererV2: true
+        )
+
+        // -- Assert --
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        for maskedViewClass in options.maskedViewClasses {
+            XCTAssertEqual(String(describing: maskedViewClass), String(describing: UIView.self))
+        }
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        for unmaskedViewClass in options.unmaskedViewClasses {
+            XCTAssertEqual(String(describing: unmaskedViewClass), String(describing: UIButton.self))
+        }
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+
+    func testInit_maskAllImagesOmitted_shouldUseDefault() {
+        // -- Arrange --
+        let options = PreviewRedactOptions(
+            maskAllText: true,
+            maskedViewClasses: [UIView.self],
+            unmaskedViewClasses: [UIButton.self],
+            enableViewRendererV2: true
+        )
+
+        // -- Assert --
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        for maskedViewClass in options.maskedViewClasses {
+            XCTAssertEqual(String(describing: maskedViewClass), String(describing: UIView.self))
+        }
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        for unmaskedViewClass in options.unmaskedViewClasses {
+            XCTAssertEqual(String(describing: unmaskedViewClass), String(describing: UIButton.self))
+        }
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+
+    func testInit_maskedViewClassesOmitted_shouldUseDefault() {
+        // -- Arrange --
+        let options = PreviewRedactOptions(
+            maskAllText: true,
+            maskAllImages: true,
+            unmaskedViewClasses: [UIButton.self],
+            enableViewRendererV2: true
+        )
+
+        // -- Assert --
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        XCTAssertEqual(String(describing: options.unmaskedViewClasses[0]), String(describing: UIButton.self))
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+
+    func testInit_unmaskedViewClassesOmitted_shouldUseDefault() {
+        // -- Arrange --
+        let options = PreviewRedactOptions(
+            maskAllText: true,
+            maskAllImages: true,
+            maskedViewClasses: [UIView.self],
+            enableViewRendererV2: true
+        )
+
+        // -- Assert --
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        XCTAssertEqual(String(describing: options.maskedViewClasses[0]), String(describing: UIView.self))
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+
+    func testInit_enableViewRendererV2Omitted_shouldUseDefault() {
+        // -- Arrange --
+        let options = PreviewRedactOptions(
+            maskAllText: true,
+            maskAllImages: true,
+            maskedViewClasses: [UIView.self],
+            unmaskedViewClasses: [UIButton.self]
+        )
+
+        // -- Assert --
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        XCTAssertEqual(String(describing: options.maskedViewClasses[0]), String(describing: UIView.self))
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        XCTAssertEqual(String(describing: options.unmaskedViewClasses[0]), String(describing: UIButton.self))
+        XCTAssertTrue(options.enableViewRendererV2)
+    }   
+}

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsObjcTests.m
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsObjcTests.m
@@ -1,0 +1,41 @@
+#import "SentryOptions+Private.h"
+#import <SentrySwift.h>
+#import <XCTest/XCTest.h>
+
+@interface SentryReplayOptionsObjcTests : XCTestCase
+
+@end
+
+@implementation SentryReplayOptionsObjcTests
+
+- (void)testInit_withoutArguments_shouldUseDefaults
+{
+    // Note for future maintainers:
+    // - `SentryReplayOptions` is a Swift class, therefore the preferred approach is an initializer
+    // with default values to allow omission of arguments.
+    // - Swift initializers with default values are not available in Objective-C.
+    // - Therefore we have to explicitly provide a default constructor without any arguments.
+    // - This test is to ensure that the default constructor works as the one with default values in
+    // Swift.
+
+    // -- Act --
+    SentryReplayOptions *options = [[SentryReplayOptions alloc] init];
+
+    // -- Assert --
+    XCTAssertEqual(options.sessionSampleRate, 0);
+    XCTAssertEqual(options.onErrorSampleRate, 0);
+    XCTAssertTrue(options.maskAllText);
+    XCTAssertTrue(options.maskAllImages);
+    XCTAssertTrue(options.enableViewRendererV2);
+    XCTAssertFalse(options.enableFastViewRendering);
+
+    XCTAssertEqual(options.maskedViewClasses.count, 0);
+    XCTAssertEqual(options.unmaskedViewClasses.count, 0);
+    XCTAssertEqual(options.quality, SentryReplayQualityMedium);
+    XCTAssertEqual(options.frameRate, 1);
+    XCTAssertEqual(options.errorReplayDuration, 30);
+    XCTAssertEqual(options.sessionSegmentDuration, 5);
+    XCTAssertEqual(options.maximumDuration, 60 * 60);
+}
+
+@end

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryReplayOptionsTests.swift
@@ -3,34 +3,217 @@ import Foundation
 import XCTest
 
 class SentryReplayOptionsTests: XCTestCase {
+    // MARK: - Initializer
 
-    func testQualityConversion() {
+    func testInit_withoutArguments_shouldUseDefaults() {
+        // -- Act --
+        let options = SentryReplayOptions()
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0)
+        XCTAssertEqual(options.onErrorSampleRate, 0)
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertTrue(options.enableViewRendererV2)
+        XCTAssertFalse(options.enableFastViewRendering)
+
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+        XCTAssertEqual(options.quality, SentryReplayOptions.SentryReplayQuality.defaultQuality)
+        XCTAssertEqual(options.frameRate, 1)
+        XCTAssertEqual(options.errorReplayDuration, 30)
+        XCTAssertEqual(options.sessionSegmentDuration, 5)
+        XCTAssertEqual(options.maximumDuration, 60 * 60)
+    }
+
+    func testInit_withAllArguments_shouldSetValues() {
+        // -- Act --
+        // Use the opposite of the default values to check if they are set correctly
+        let options = SentryReplayOptions(
+            sessionSampleRate: 0.5,
+            onErrorSampleRate: 0.8,
+            maskAllText: false,
+            maskAllImages: false,
+            enableViewRendererV2: false,
+            enableFastViewRendering: true
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableFastViewRendering)
+
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+        XCTAssertEqual(options.quality, SentryReplayOptions.SentryReplayQuality.defaultQuality)
+        XCTAssertEqual(options.frameRate, 1)
+        XCTAssertEqual(options.errorReplayDuration, 30)
+        XCTAssertEqual(options.sessionSegmentDuration, 5)
+        XCTAssertEqual(options.maximumDuration, 60 * 60)
+    }
+
+    func testInit_sessionSampleRateOmitted_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(
+            onErrorSampleRate: 0.8,
+            maskAllText: false,
+            maskAllImages: false,
+            enableViewRendererV2: false,
+            enableFastViewRendering: true
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableFastViewRendering)
+    }
+
+    func testInit_onErrorSampleRateOmitted_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(
+            sessionSampleRate: 0.5,
+            maskAllText: false,
+            maskAllImages: false,
+            enableViewRendererV2: false,
+            enableFastViewRendering: true
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableFastViewRendering)
+    }
+
+    func testInit_maskAllTextOmitted_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(
+            sessionSampleRate: 0.5,
+            onErrorSampleRate: 0.8,
+            maskAllImages: false,
+            enableViewRendererV2: false,
+            enableFastViewRendering: true
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableFastViewRendering)
+    }
+
+    func testInit_maskAllImagesOmitted_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(
+            sessionSampleRate: 0.5,
+            onErrorSampleRate: 0.8,
+            maskAllText: false,
+            enableViewRendererV2: false,
+            enableFastViewRendering: true
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableFastViewRendering)
+    }
+
+    func testInit_enableViewRendererV2Omitted_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(
+            sessionSampleRate: 0.5,
+            onErrorSampleRate: 0.8,
+            maskAllText: false,
+            maskAllImages: false,
+            enableFastViewRendering: true
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertTrue(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableFastViewRendering)
+    }
+
+    func testInit_enableFastViewRenderingOmitted_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(
+            sessionSampleRate: 0.5,
+            onErrorSampleRate: 0.8,
+            maskAllText: false,
+            maskAllImages: false,
+            enableViewRendererV2: false
+        )
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.5)
+        XCTAssertEqual(options.onErrorSampleRate, 0.8)
+        XCTAssertFalse(options.maskAllText)
+        XCTAssertFalse(options.maskAllImages)
+        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertFalse(options.enableFastViewRendering)
+    }
+
+    // MARK: - Quality Options
+
+    func testQualityDefault() {
+        // This test case is used to lock down the default quality to notice if gets changed by accident.
+        XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.defaultQuality, .medium)
+    }
+
+    func testQuality_fromName_shouldParseKnownValues() {
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("low"), .low)
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("medium"), .medium)
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("high"), .high)
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("invalid_value"), .medium)
     }
 
+    func testQuality_fromName_shouldReturnMediumForUnknownValues() {
+        XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("unknown_value"), .defaultQuality)
+        XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName(""), .defaultQuality)
+    }
+
     func testQualityLow() {
+        // -- Act --
         let options = SentryReplayOptions()
         options.quality = .low
 
+        // -- Assert --
         XCTAssertEqual(options.replayBitRate, 20_000)
         XCTAssertEqual(options.sizeScale, 0.8)
     }
 
     func testQualityMedium() {
+        // -- Act --
         let options = SentryReplayOptions()
         options.quality = .medium
 
+        // -- Assert --
         XCTAssertEqual(options.replayBitRate, 40_000)
         XCTAssertEqual(options.sizeScale, 1.0)
     }
 
     func testQualityHigh() {
+        // -- Act --
         let options = SentryReplayOptions()
         options.quality = .high
 
+        // -- Assert --
         XCTAssertEqual(options.replayBitRate, 60_000)
         XCTAssertEqual(options.sizeScale, 1.0)
     }
@@ -39,142 +222,396 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("low"), .low)
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("medium"), .medium)
         XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("high"), .high)
-        XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("invalid_value"), .medium)
     }
 
-    func testInitFromDictOnErrorSampleRateAsDouble() {
+    func testQualityFromName_invalidValue_shouldReturnDefaultQuality() {
+        XCTAssertEqual(SentryReplayOptions.SentryReplayQuality.fromName("unknown_value"), .defaultQuality)
+    }
+
+    // MARK: - Dictionary Initialization
+
+    func testInitFromDict_emptyDictionary_shouldUseDefaultValues() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [:])
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0)
+        XCTAssertEqual(options.onErrorSampleRate, 0)
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertTrue(options.enableViewRendererV2)
+        XCTAssertFalse(options.enableFastViewRendering)
+
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+        XCTAssertEqual(options.quality, SentryReplayOptions.SentryReplayQuality.defaultQuality)
+        XCTAssertEqual(options.frameRate, 1)
+        XCTAssertEqual(options.errorReplayDuration, 30)
+        XCTAssertEqual(options.sessionSegmentDuration, 5)
+        XCTAssertEqual(options.maximumDuration, 60 * 60)
+    }
+
+    func testInitFromDict_allValues_shouldSetValues() throws {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "sessionSampleRate": 0.44,
+            "errorSampleRate": 0.44,
+            "maskAllText": true,
+            "maskAllImages": true,
+            "enableViewRendererV2": true,
+            "enableFastViewRendering": false,
+            "maskedViewClasses": ["NSString"],
+            "unmaskedViewClasses": ["NSNumber"],
+            "quality": 0,
+            "frameRate": 2,
+            "errorReplayDuration": 300,
+            "sessionSegmentDuration": 10,
+            "maximumDuration": 120
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSampleRate, 0.44)
+        XCTAssertEqual(options.onErrorSampleRate, 0.44)
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertTrue(options.enableViewRendererV2)
+        XCTAssertFalse(options.enableFastViewRendering)
+
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        let maskedViewClass: AnyClass = try XCTUnwrap(options.maskedViewClasses.first)
+        XCTAssertEqual(ObjectIdentifier(maskedViewClass), ObjectIdentifier(NSString.self))
+
+        XCTAssertEqual(options.unmaskedViewClasses.count, 1)
+        let unmaskedViewClass: AnyClass = try XCTUnwrap(options.unmaskedViewClasses.first)
+        XCTAssertEqual(ObjectIdentifier(unmaskedViewClass), ObjectIdentifier(NSNumber.self))
+
+        XCTAssertEqual(options.quality, .low)
+        XCTAssertEqual(options.frameRate, 2)
+        XCTAssertEqual(options.errorReplayDuration, 300)
+        XCTAssertEqual(options.sessionSegmentDuration, 10)
+        XCTAssertEqual(options.maximumDuration, 120)
+    }
+
+    // MARK: onErrorSampleRate
+
+    func testInitFromDict_onErrorSampleRate_whenDoubleValue_shouldSetValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "errorSampleRate": 0.44
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.onErrorSampleRate, 0.44)
     }
 
-    func testInitFromDictOnErrorSampleRateMissing() {
-        let options = SentryReplayOptions(dictionary: [:])
-
-        XCTAssertEqual(options.onErrorSampleRate, 0)
-    }
-
-    func testInitFromDictOnErrorSampleRateAsString() {
+    func testInitFromDict_onErrorSampleRate_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
-            "onErrorSampleRate": "0.44"
+            "errorSampleRate": "0.44"
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.onErrorSampleRate, 0)
     }
 
-    func testInitFromDictSessionSampleRateAsDouble() {
+    // MARK: sessionSampleRate
+
+    func testInitFromDict_sessionSampleRate_whenDoubleValue_shouldSetValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "sessionSampleRate": 0.44
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.sessionSampleRate, 0.44)
     }
 
-    func testInitFromDictSessionSampleRateMissing() {
-        let options = SentryReplayOptions(dictionary: [:])
-
-        XCTAssertEqual(options.sessionSampleRate, 0)
-    }
-
-    func testInitFromDictSessionSampleRateAsString() {
+    func testInitFromDict_sessionSampleRate_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "sessionSampleRate": "0.44"
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.sessionSampleRate, 0)
     }
 
-    func testInitFromDictMaskedViewClasses() {
+    // MARK: maskedViewClasses
+
+    func testInitFromDict_maskedViewClasses_whenValidValue_shouldSetValue() throws {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "maskedViewClasses": ["NSString"]
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.maskedViewClasses.count, 1)
-        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses.first!), ObjectIdentifier(NSString.self))
+        let maskedClass: AnyClass = try XCTUnwrap(options.maskedViewClasses.first)
+        XCTAssertEqual(ObjectIdentifier(maskedClass), ObjectIdentifier(NSString.self))
     }
 
-    func testInitFromDictMaskedViewClassesAsString() {
+    func testInitFromDict_maskedViewClasses_whenMultipleValidValue_shouldKeepAll() throws {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
-            "maskedViewClasses": "ExampleView1"
+            "maskedViewClasses": ["NSString", "NSNumber"]
         ])
 
+        // -- Assert --
+        XCTAssertEqual(options.maskedViewClasses.count, 2)
+        guard options.maskedViewClasses.count == 2 else {
+            return XCTFail("Expected two masked view classes, can not proceed.")
+        }
+        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses[0]), ObjectIdentifier(NSString.self))
+        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses[1]), ObjectIdentifier(NSNumber.self))
+    }
+
+    func testInitFromDict_maskedViewClasses_whenInvalidValue_shouldExcludedClass() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "maskedViewClasses": "invalid_value"
+        ])
+
+        // -- Assert --
         XCTAssertEqual(options.maskedViewClasses.count, 0)
     }
 
-    func testInitFromDictMaskedViewClassesWithNumber() {
+    func testInitFromDict_maskedViewClasses_whenInvalidArrayValue_shouldFilterInvalidValues() throws {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
-            "maskedViewClasses": [123]
+            "maskedViewClasses": [
+                "NSString",         // Valid class
+                "some.class",       // Invalid class name
+                123,                // Invalid type (number)
+                true,               // Invalid type (boolean)
+                ["nested": "array"], // Invalid type (dictionary)
+                NSNull(),           // Invalid type (NSNull)
+                ""                  // Empty string
+            ] as [Any]
         ])
 
+        // -- Assert --
+        XCTAssertEqual(options.maskedViewClasses.count, 1)
+        let maskedViewClass: AnyClass = try XCTUnwrap(options.maskedViewClasses.first)
+        XCTAssertEqual(ObjectIdentifier(maskedViewClass), ObjectIdentifier(NSString.self))
+    }
+
+    func testInitFromDict_maskedViewClasses_whenMixedValidAndInvalidValues_shouldKeepOnlyValidValues() throws {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "maskedViewClasses": [
+                "NSString",         // Valid class
+                "NSNumber",         // Valid class
+                "not.a.class",      // Invalid class name
+                123                 // Invalid type (number)
+            ] as [Any]
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.maskedViewClasses.count, 2)
+        guard options.maskedViewClasses.count == 2 else {
+            return XCTFail("Expected two masked view classes, can not proceed.")
+        }
+        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses[0]), ObjectIdentifier(NSString.self))
+        XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses[1]), ObjectIdentifier(NSNumber.self))
+    }
+
+    func testInitFromDict_maskedViewClasses_whenKeyOmitted_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [:])
+
+        // -- Assert --
         XCTAssertEqual(options.maskedViewClasses.count, 0)
     }
 
-    func testInitFromDictUnmaskedViewClasses() {
+    // MARK: unmaskedViewClasses
+
+    func testInitFromDict_unmaskedViewClasses_whenValidValue_shouldSetValue() throws {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "unmaskedViewClasses": ["NSString"]
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.unmaskedViewClasses.count, 1)
-        XCTAssertEqual(ObjectIdentifier(options.unmaskedViewClasses.first!), ObjectIdentifier(NSString.self))
+        let unmaskedClass: AnyClass = try XCTUnwrap(options.unmaskedViewClasses.first)
+        XCTAssertEqual(ObjectIdentifier(unmaskedClass), ObjectIdentifier(NSString.self))
     }
+    
+    func testInitFromDict_unmaskedViewClasses_whenMultipleValidValue_shouldKeepAll() throws {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "unmaskedViewClasses": ["NSString", "NSNumber"]
+        ])
 
-    func testInitFromDictUnmaskedViewClassesAsString() {
+        // -- Assert --
+        XCTAssertEqual(options.unmaskedViewClasses.count, 2)
+        guard options.unmaskedViewClasses.count == 2 else {
+            return XCTFail("Expected two unmasked view classes, can not proceed.")
+        }
+        XCTAssertEqual(ObjectIdentifier(options.unmaskedViewClasses[0]), ObjectIdentifier(NSString.self))
+        XCTAssertEqual(ObjectIdentifier(options.unmaskedViewClasses[1]), ObjectIdentifier(NSNumber.self))
+    }
+        
+    func testInitFromDict_unmaskedViewClasses_whenNotValidValue_shouldUseDefaultValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "unmaskedViewClasses": "invalid_value"
         ])
 
+        // -- Assert --
         XCTAssertEqual(options.unmaskedViewClasses.count, 0)
     }
 
-    func testInitFromDictUnmaskedViewClassesWithInvalidValues() {
+    func testInitFromDict_unmaskedViewClasses_whenInvalidArrayValues_shouldUseDefaultValue() throws {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
-            "unmaskedViewClasses": [123, "not.class"] as [Any]
+            "unmaskedViewClasses": [
+                "not.a.class",      // Invalid class name
+                123,                // Invalid type (number)
+                true,               // Invalid type (boolean)
+                ["nested": "array"], // Invalid type (dictionary)
+                NSNull(),           // Invalid type (NSNull)
+                ""                  // Empty string
+            ] as [Any]
         ])
 
+        // -- Assert --
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+    }
+    
+    func testInitFromDict_unmaskedViewClasses_whenMixedValidAndInvalidValues_shouldKeepOnlyValidValues() throws {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "unmaskedViewClasses": [
+                "NSString",         // Valid class
+                "NSNumber",         // Valid class
+                "not.a.class",      // Invalid class name
+                123                 // Invalid type (number)
+            ] as [Any]
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.unmaskedViewClasses.count, 2)
+        guard options.unmaskedViewClasses.count == 2 else {
+            return XCTFail("Expected two unmasked view classes, can not proceed.")
+        }
+        XCTAssertEqual(ObjectIdentifier(options.unmaskedViewClasses[0]), ObjectIdentifier(NSString.self))
+        XCTAssertEqual(ObjectIdentifier(options.unmaskedViewClasses[1]), ObjectIdentifier(NSNumber.self))
+    }
+
+    func testInitFromDict_unmaskedViewClasses_whenKeyOmitted_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [:])
+
+        // -- Assert --
         XCTAssertEqual(options.unmaskedViewClasses.count, 0)
     }
 
-    func testInitFromDictMaskAllTextWithBool() {
+    // MARK: maskAllText
+
+    func testInitFromDict_maskAllText_whenValidValue_shouldSetValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "maskAllText": true
         ])
+
+        // -- Assert --
         XCTAssertTrue(options.maskAllText)
 
         let options2 = SentryReplayOptions(dictionary: [
             "maskAllText": false
         ])
+
+        // -- Assert --
         XCTAssertFalse(options2.maskAllText)
     }
 
-    func testInitFromDictMaskAllTextWithString() {
+    func testInitFromDict_maskAllText_whenNotValidValue_shouldUseDefaultValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "maskAllText": "invalid_value"
         ])
+
+        // -- Assert --
         XCTAssertTrue(options.maskAllText)
     }
 
-    func testInitFromDictMaskAllImagesWithBool() {
+    func testInitFromDict_maskAllImages_whenValidValue_shouldSetValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "maskAllImages": true
         ])
+
+        // -- Assert --
         XCTAssertTrue(options.maskAllImages)
 
         let options2 = SentryReplayOptions(dictionary: [
             "maskAllImages": false
         ])
+
+        // -- Assert --
         XCTAssertFalse(options2.maskAllImages)
     }
 
-    func testInitFromDictMaskAllImagesWithString() {
+    func testInitFromDict_maskAllImages_whenNotValidValue_shouldUseDefaultValue() {
+        // -- Act --
         let options = SentryReplayOptions(dictionary: [
             "maskAllImages": "invalid_value"
         ])
+
+        // -- Assert --
         XCTAssertTrue(options.maskAllImages)
     }
     
-    func testInitFromDictEnableExperimentalViewRendererWithBool() {
+    // MARK: enableViewRendererV2
+    
+    func testInitFromDict_enableViewRendererV2_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "enableViewRendererV2": true
+        ])
+
+        // -- Assert --
+        XCTAssertTrue(options.enableViewRendererV2)
+
+        let options2 = SentryReplayOptions(dictionary: [
+            "enableViewRendererV2": false
+        ])
+
+        // -- Assert --
+        XCTAssertFalse(options2.enableViewRendererV2)
+    }
+
+    func testInitFromDict_enableViewRendererV2_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "enableViewRendererV2": "invalid_value"
+        ])
+
+        // -- Assert --
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+    
+    func testInitFromDict_enableViewRendererV2_whenNotSpecified_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [:])
+
+        // -- Assert --
+        XCTAssertTrue(options.enableViewRendererV2)
+    }
+    
+    func testInitFromDict_enableViewRendererV2_precedenceOverEnableExperimentalViewRenderer() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "enableViewRendererV2": false,
+            "enableExperimentalViewRenderer": true
+        ])
+
+        // -- Assert --
+        XCTAssertFalse(options.enableViewRendererV2)
+    }
+    
+    func testInitFromDict_enableExperimentalViewRenderer_whenValidValue_shouldSetValue() {
         // To support backwards compatibility we keep support for the old key
         // "experimentalViewRenderer" until we remove it in a future version.
 
@@ -182,6 +619,10 @@ class SentryReplayOptionsTests: XCTestCase {
         let options = SentryReplayOptions(dictionary: [
             "enableExperimentalViewRenderer": true
         ])
+
+        // -- Assert --
+        XCTAssertTrue(options.enableViewRendererV2)
+
         let options2 = SentryReplayOptions(dictionary: [
             "enableExperimentalViewRenderer": false
         ])
@@ -191,7 +632,7 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertFalse(options2.enableViewRendererV2)
     }
 
-    func testInitFromDictEnableExperimentalViewRendererWithString() {
+    func testInitFromDict_enableExperimentalViewRenderer_whenInvalidValue_shouldUseDefaultValue() {
         // To support backwards compatibility we keep support for the old key
         // "experimentalViewRenderer" until we remove it in a future version.
 
@@ -201,7 +642,7 @@ class SentryReplayOptionsTests: XCTestCase {
         ])
 
         // -- Assert --
-        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableViewRendererV2)
     }
 
     func testInitFromDict_enableViewRendererV2WithBool_shouldIgnoreValue() {
@@ -225,10 +666,10 @@ class SentryReplayOptionsTests: XCTestCase {
         ])
 
         // -- Assert --
-        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableViewRendererV2)
     }
 
-    func testInitFromDictEnableFastViewRenderingWithBool() {
+    func testInitFromDict_enableFastViewRendering_whenValidValue_shouldSetValue() {
         let options = SentryReplayOptions(dictionary: [
             "enableFastViewRendering": true
         ])
@@ -240,14 +681,14 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertFalse(options2.enableFastViewRendering)
     }
 
-    func testInitFromDictEnableFastViewRenderingWithString() {
+    func testInitFromDict_enableFastViewRendering_whenInvalidValue_shouldUseDefaultValue() {
         let options = SentryReplayOptions(dictionary: [
             "enableFastViewRendering": "invalid_value"
         ])
         XCTAssertFalse(options.enableFastViewRendering)
     }
 
-    func testInitFromDictQualityWithString() {
+    func testInitFromDict_quality_whenValidValue_shouldSetValue() {
         let options = SentryReplayOptions(dictionary: [
             "quality": 0 // low
         ])
@@ -264,7 +705,7 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options3.quality, .high)
     }
 
-    func testInitFromDictQualityWithInvalidValue() {
+    func testInitFromDict_quality_whenInvalidValue_shouldUseDefaultValue() {
         let options = SentryReplayOptions(dictionary: [
             "quality": "invalid_value"
         ])
@@ -276,7 +717,7 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options2.quality, .medium)
     }
 
-    func testInitFromDictWithMultipleOptions() {
+    func testInitFromDict_withMultipleOptions_shouldSetAllValues() {
         let options = SentryReplayOptions(dictionary: [
             "sessionSampleRate": 0.5,
             "errorSampleRate": 0.8,
@@ -290,7 +731,7 @@ class SentryReplayOptionsTests: XCTestCase {
         XCTAssertEqual(options.onErrorSampleRate, 0.8)
         XCTAssertFalse(options.maskAllText)
         XCTAssertTrue(options.maskAllImages)
-        XCTAssertFalse(options.enableViewRendererV2)
+        XCTAssertTrue(options.enableViewRendererV2)
         XCTAssertFalse(options.enableFastViewRendering)
         XCTAssertEqual(options.maskedViewClasses.count, 1)
         XCTAssertEqual(ObjectIdentifier(options.maskedViewClasses.first!), ObjectIdentifier(NSString.self))
@@ -319,5 +760,129 @@ class SentryReplayOptionsTests: XCTestCase {
 
         XCTAssertFalse(options.enableViewRendererV2)
         XCTAssertFalse(options.enableExperimentalViewRenderer)
+    }
+
+    // MARK: frameRate
+
+    func testInitFromDict_frameRate_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "frameRate": 5
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.frameRate, 5)
+    }
+
+    func testInitFromDict_frameRate_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "frameRate": "invalid_value"
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.frameRate, 1)
+    }
+
+    func testFrameRate_whenSetToZero_shouldBeSetToOne() {
+        // -- Arrange --
+        let options = SentryReplayOptions()
+        
+        // -- Act --
+        options.frameRate = 0
+        
+        // -- Assert --
+        XCTAssertEqual(options.frameRate, 1)
+    }
+
+    // MARK: errorReplayDuration
+
+    func testInitFromDict_errorReplayDuration_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "errorReplayDuration": 60
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.errorReplayDuration, 60)
+    }
+
+    func testInitFromDict_errorReplayDuration_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "errorReplayDuration": "invalid_value"
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.errorReplayDuration, 30)
+    }
+
+    // MARK: sessionSegmentDuration
+
+    func testInitFromDict_sessionSegmentDuration_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "sessionSegmentDuration": 10
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSegmentDuration, 10)
+    }
+
+    func testInitFromDict_sessionSegmentDuration_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "sessionSegmentDuration": "invalid_value"
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.sessionSegmentDuration, 5)
+    }
+
+    // MARK: maximumDuration
+
+    func testInitFromDict_maximumDuration_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "maximumDuration": 120
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.maximumDuration, 120)
+    }
+
+    func testInitFromDict_maximumDuration_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "maximumDuration": "invalid_value"
+        ])
+
+        // -- Assert --
+        XCTAssertEqual(options.maximumDuration, 60 * 60)
+    }
+    
+    // MARK: sdkInfo
+    
+    func testInitFromDict_sdkInfo_whenValidValue_shouldSetValue() {
+        // -- Act --
+        let sdkInfo: [String: Any] = ["name": "sentry.cocoa", "version": "1.0.0"]
+        let options = SentryReplayOptions(dictionary: [
+            "sdkInfo": sdkInfo
+        ])
+
+        // -- Assert --
+        XCTAssertNotNil(options.sdkInfo)
+        XCTAssertEqual(options.sdkInfo?["name"] as? String, "sentry.cocoa")
+        XCTAssertEqual(options.sdkInfo?["version"] as? String, "1.0.0")
+    }
+    
+    func testInitFromDict_sdkInfo_whenInvalidValue_shouldUseDefaultValue() {
+        // -- Act --
+        let options = SentryReplayOptions(dictionary: [
+            "sdkInfo": "invalid_value"
+        ])
+
+        // -- Assert --
+        XCTAssertNil(options.sdkInfo)
     }
 }

--- a/Tests/SentryTests/Protocol/SentryRedactDefaultOptionsTests.swift
+++ b/Tests/SentryTests/Protocol/SentryRedactDefaultOptionsTests.swift
@@ -1,0 +1,16 @@
+@testable import Sentry
+import XCTest
+
+class SentryRedactDefaultOptionsTests: XCTestCase {
+
+    func testDefaultOptions() {
+        // -- Act --
+        let options = SentryRedactDefaultOptions()
+
+        // -- Assert --
+        XCTAssertTrue(options.maskAllText)
+        XCTAssertTrue(options.maskAllImages)
+        XCTAssertEqual(options.maskedViewClasses.count, 0)
+        XCTAssertEqual(options.unmaskedViewClasses.count, 0)
+    }
+}


### PR DESCRIPTION
# :scroll Description

This commit introduces several enhancements to the SentryReplayOptions class, including new properties for better configuration and handling of session replay options. Key changes include:

- Added internal methods for converting raw values to SentryReplayQuality.
- Introduced new properties for bitrate and size scale calculations.
- Updated initializers to support dictionary-based configuration.
- Added comprehensive unit tests for SentryReplayOptions and related classes, ensuring default values and custom configurations are correctly handled.
- Introduced new test files for Objective-C compatibility and SwiftUI integration.

Covered cases:
- Init without args in Swift
- Init with all args in Swift
- Init with some args ommitted in Swift (fallback to default value)
- No nullable args
- Init without args in Objective-C
- Init with all args in Objective-C
- Init with missing value in dictionary, fallback to default value

## :bulb: Motivation and Context

- The default values are inconsistent (i.e. `enableViewRendererV2` was not enabled by default everywhere)
- The default values set in the Swift initializer made an initializer without arguments unavailable to Objective-C, and the replacement fix (empty init) was setting default values inconsistently.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
