### PR TITLE
test(feedback): Add Xcode previews

### DIFF
--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
@@ -128,7 +128,7 @@ extension SentryUserFeedbackFormController: UITextViewDelegate {
     }
 }
 
-#if DEBUG
+#if DEBUG && swift(>=5.10)
 import SwiftUI
 
 @available(iOS 13.0, *)
@@ -166,8 +166,7 @@ struct ViewControllerWrapper: UIViewControllerRepresentable {
             screenshot: nil))
     .dynamicTypeSize(.accessibility5)
 }
-
-#endif // DEBUG
+#endif // DEBUG && swift(>=5.10)
 
 #endif // os(iOS) && !SENTRY_NO_UIKIT
 

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
@@ -11,10 +11,9 @@ protocol SentryUserFeedbackFormDelegate: NSObjectProtocol {
 }
 
 @available(iOS 13.0, *)
-@objcMembers
 class SentryUserFeedbackFormController: UIViewController {
     let config: SentryUserFeedbackConfiguration
-    weak var delegate: (any SentryUserFeedbackFormDelegate)?
+    weak var delegate: SentryUserFeedbackFormDelegate?
     let screenshot: UIImage?
     lazy var viewModel = SentryUserFeedbackFormViewModel(config: config, controller: self, screenshot: screenshot)
     
@@ -24,7 +23,7 @@ class SentryUserFeedbackFormController: UIViewController {
         viewModel.updateLayout()
     }
     
-    init(config: SentryUserFeedbackConfiguration, delegate: any SentryUserFeedbackFormDelegate, screenshot: UIImage?) {
+    init(config: SentryUserFeedbackConfiguration, delegate: SentryUserFeedbackFormDelegate?, screenshot: UIImage?) {
         self.config = config
         self.delegate = delegate
         self.screenshot = screenshot
@@ -52,6 +51,7 @@ extension SentryUserFeedbackFormController {
         NSLayoutConstraint.activate(viewModel.allConstraints(view: view))
     }
     
+    @objc
     func showedKeyboard(note: Notification) {
         guard let keyboardValue = note.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue else {
             SentryLog.warning("Received a keyboard display notification with no frame information.")
@@ -61,6 +61,7 @@ extension SentryUserFeedbackFormController {
         viewModel.setScrollViewBottomInset(keyboardViewEndFrame.height - self.view.safeAreaInsets.bottom)
     }
     
+    @objc
     func hidKeyboard() {
         viewModel.setScrollViewBottomInset(0)
     }
@@ -126,6 +127,47 @@ extension SentryUserFeedbackFormController: UITextViewDelegate {
         viewModel.updateSubmitButtonAccessibilityHint()
     }
 }
+
+#if DEBUG
+import SwiftUI
+
+@available(iOS 13.0, *)
+struct ViewControllerWrapper: UIViewControllerRepresentable {
+    let viewController: UIViewController
+
+    func makeUIViewController(context: Context) -> UIViewController {
+        return viewController
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) { }
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    SentryUserFeedbackFormController(config: .init(), delegate: nil, screenshot: nil)
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    ViewControllerWrapper(
+        viewController: SentryUserFeedbackFormController(
+            config: .init(),
+            delegate: nil,
+            screenshot: nil))
+    .preferredColorScheme(.dark).colorScheme(.dark)
+}
+
+@available(iOS 17.0, *)
+#Preview {
+    ViewControllerWrapper(
+        viewController: SentryUserFeedbackFormController(
+            config: .init(),
+            delegate: nil,
+            screenshot: nil))
+    .dynamicTypeSize(.accessibility5)
+}
+
+#endif // DEBUG
 
 #endif // os(iOS) && !SENTRY_NO_UIKIT
 


### PR DESCRIPTION
## :scroll: Description

New version of https://github.com/getsentry/sentry-cocoa/pull/5186 with correct access now

## :bulb: Motivation and Context

Makes it easier to iterate on the UI, could eventually use it for snapshot tests

## :green_heart: How did you test it?

Ran the preview locally in xcode

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog