### PR TITLE
ci: Set timeout for Thread Sanitizer to 30 minutes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -279,7 +279,7 @@ jobs:
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
     runs-on: macos-14
-    timeout-minutes: 20
+    timeout-minutes: 30
     needs: [build-test-server]
 
     # There are several ways this test can flake. Sometimes threaded tests will just hang and the job will time out, other times waiting on expectations will take much longer than in a non-TSAN run and the test case will fail. We're making this nonfailable and will grep the logs to extract any actual thread sanitizer warnings to push to the PR, and ignore everything else.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -278,7 +278,7 @@ jobs:
   # that adds a significant overhead.
   thread-sanitizer:
     name: Unit iOS - Thread Sanitizer
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 30
     needs: [build-test-server]
 
@@ -300,7 +300,7 @@ jobs:
       - name: Check test-server runs
         run: curl http://localhost:8080/echo-baggage-header
 
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.3
 
       - name: Running tests with ThreadSanitizer
         run: ./scripts/tests-with-thread-sanitizer.sh

--- a/scripts/tests-with-thread-sanitizer.sh
+++ b/scripts/tests-with-thread-sanitizer.sh
@@ -5,10 +5,10 @@ set -euox pipefail
 # the logs only show failing tests, but don't highlight the threading issues.
 # Therefore we print a hint to find the threading issues. Profiler doesn't
 # run when it detects TSAN is present, so we skip those tests.
-set -o pipefail && NSUnbufferedIO=YES CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO xcodebuild \
+set -o pipefail && NSUnbufferedIO=YES xcodebuild \
     -workspace Sentry.xcworkspace \
     -scheme Sentry \
-    -configuration Test \
+    -configuration TestCI \
     -enableThreadSanitizer YES \
     -destination "platform=iOS Simulator,OS=latest,name=iPhone 16" \
     -skip-testing:"SentryProfilerTests" \


### PR DESCRIPTION
The tests continue to timeout in CI. While 30 minutes isn't ideal, it's better than timing out.

#skip-changelog