### PR TITLE
test: Add separate test plan for HTTPTransport unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -317,6 +317,9 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
+          # Ignore test coverage of tests
+          files: slather/coverage/**/*.xml
+          exclude: "*.xctest.coverage.txt"
 
       # Sometimes codecov uploads etc can fail. Retry one time to rule out e.g. intermittent network failures.
       - name: Push code coverage to codecov
@@ -327,3 +330,5 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
+          files: slather/coverage/**/*.xml
+          exclude: "*.xctest.coverage.txt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,13 +253,16 @@ jobs:
           done
 
       - name: List generated test reports
-        run: ls -laR build/reports
+        run: ls -lR build/reports
+
+      - name: List generated test coverage
+        run: ls -lR slather/coverage
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         if: always()
         with:
-          report_paths: "**/build/reports*/junit.xml"
+          report_paths: "**/build/reports/**/*.xml"
           fail_on_failure: true
           fail_on_parse_error: true
           detailed_summary: true
@@ -282,8 +285,7 @@ jobs:
         with:
           name: junit-reports-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
-            build/reports/junit.xml
-            build/reports-*/junit.xml
+            build/reports/**/*.xml
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
@@ -319,7 +321,6 @@ jobs:
           verbose: true
           # Ignore test coverage of tests
           files: slather/coverage/**/*.xml
-          exclude: "*.xctest.coverage.txt"
 
       # Sometimes codecov uploads etc can fail. Retry one time to rule out e.g. intermittent network failures.
       - name: Push code coverage to codecov
@@ -331,4 +332,3 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           files: slather/coverage/**/*.xml
-          exclude: "*.xctest.coverage.txt"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -214,20 +214,20 @@ jobs:
             --configuration TestCI \
             --scheme ${{matrix.scheme}}
 
-      # - name: Run tests
-      #   # We call a script with the platform so the destination
-      #   # passed to xcodebuild doesn't end up in the job name,
-      #   # because GitHub Actions don't provide an easy way of
-      #   # manipulating string in expressions.
-      #   run: |
-      #     ./scripts/sentry-xcodebuild.sh \
-      #       --platform ${{matrix.platform}} \
-      #       --os ${{matrix.test-destination-os}} \
-      #       --ref ${{ github.ref_name }} \
-      #       --command test-without-building \
-      #       --device "${{matrix.device}}" \
-      #       --configuration TestCI \
-      #       --scheme ${{matrix.scheme}}
+      - name: Run tests
+        # We call a script with the platform so the destination
+        # passed to xcodebuild doesn't end up in the job name,
+        # because GitHub Actions don't provide an easy way of
+        # manipulating string in expressions.
+        run: |
+          ./scripts/sentry-xcodebuild.sh \
+            --platform ${{matrix.platform}} \
+            --os ${{matrix.test-destination-os}} \
+            --ref ${{ github.ref_name }} \
+            --command test-without-building \
+            --device "${{matrix.device}}" \
+            --configuration TestCI \
+            --scheme ${{matrix.scheme}}
 
       - name: Run additional test plans
         if: ${{ matrix.additional-test-plans }}
@@ -256,7 +256,7 @@ jobs:
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         if: always()
         with:
-          report_paths: "build/reports/junit.xml"
+          report_paths: "build/reports/junit*.xml"
           fail_on_failure: true
           fail_on_parse_error: true
           detailed_summary: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -238,6 +238,8 @@ jobs:
           for test_plan in "${TEST_PLANS[@]}"; do
             echo "::notice::Running with Xcode test plan: $test_plan"
 
+            echo "::debug::Enable command logging for easier copying to local testing"
+            set -x
             ./scripts/sentry-xcodebuild.sh \
               --platform ${{matrix.platform}} \
               --os ${{matrix.test-destination-os}} \
@@ -247,6 +249,7 @@ jobs:
               --configuration TestCI \
               --scheme ${{matrix.scheme}} \
               --test-plan $test_plan
+            set +x
           done
 
       - name: Publish Test Report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,14 +252,14 @@ jobs:
             set +x
           done
 
-      - name: List test reports
+      - name: List generated test reports
         run: ls -la build/reports
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         if: always()
         with:
-          report_paths: "build/reports/junit*.xml"
+          report_paths: "**/build/reports/junit*.xml"
           fail_on_failure: true
           fail_on_parse_error: true
           detailed_summary: true
@@ -276,6 +276,14 @@ jobs:
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
+      - name: Archiving Raw JUnit Reports
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: junit-reports-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          path: |
+            build/reports/*.xml
+
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
@@ -283,6 +291,7 @@ jobs:
           name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
             raw-test-output.log
+            raw-test-output-*.log
 
       - name: Archiving Crash Logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,8 @@ jobs:
             test-destination-os: "16.4"
             device: "iPhone 14"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # iOS 17
           - runs-on: macos-14
@@ -94,6 +96,8 @@ jobs:
             test-destination-os: "17.2"
             device: "iPhone 15"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # iOS 18
           - runs-on: macos-15
@@ -102,6 +106,8 @@ jobs:
             test-destination-os: "18.2"
             device: "iPhone 16"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.
@@ -113,6 +119,8 @@ jobs:
             xcode: "15.4"
             test-destination-os: "latest"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # macOS 15
           - runs-on: macos-15
@@ -120,6 +128,8 @@ jobs:
             xcode: "16.2"
             test-destination-os: "latest"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
           # on an older iOS or macOS version is low.
@@ -129,12 +139,16 @@ jobs:
             xcode: "15.4"
             test-destination-os: "latest"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           - runs-on: macos-15
             platform: "Catalyst"
             xcode: "16.2"
             test-destination-os: "latest"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # We don't run the unit tests on tvOS 16 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, tvOS 15 or tvOS 16 is minimal.
@@ -146,6 +160,8 @@ jobs:
             xcode: "15.4"
             test-destination-os: "17.5"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
           # iOS 17
           - runs-on: macos-14
@@ -161,6 +177,8 @@ jobs:
             xcode: "16.2"
             test-destination-os: "18.1"
             scheme: "Sentry"
+            additional-test-plans:
+              - "Sentry_HTTPTransport"
 
     steps:
       - uses: actions/checkout@v4
@@ -196,20 +214,37 @@ jobs:
             --configuration TestCI \
             --scheme ${{matrix.scheme}}
 
-      - name: Run tests
-        # We call a script with the platform so the destination
-        # passed to xcodebuild doesn't end up in the job name,
-        # because GitHub Actions don't provide an easy way of
-        # manipulating string in expressions.
+      # - name: Run tests
+      #   # We call a script with the platform so the destination
+      #   # passed to xcodebuild doesn't end up in the job name,
+      #   # because GitHub Actions don't provide an easy way of
+      #   # manipulating string in expressions.
+      #   run: |
+      #     ./scripts/sentry-xcodebuild.sh \
+      #       --platform ${{matrix.platform}} \
+      #       --os ${{matrix.test-destination-os}} \
+      #       --ref ${{ github.ref_name }} \
+      #       --command test-without-building \
+      #       --device "${{matrix.device}}" \
+      #       --configuration TestCI \
+      #       --scheme ${{matrix.scheme}}
+
+      - name: Run additional test plans
+        if: ${{ matrix.additional-test-plans }}
         run: |
-          ./scripts/sentry-xcodebuild.sh \
-            --platform ${{matrix.platform}} \
-            --os ${{matrix.test-destination-os}} \
-            --ref ${{ github.ref_name }} \
-            --command test-without-building \
-            --device "${{matrix.device}}" \
-            --configuration TestCI \
-            --scheme ${{matrix.scheme}}
+          for test_plan in ${{ matrix.additional-test-plans }}; do
+            echo "::notice::Running with Xcode test plan: $test_plan"
+
+            ./scripts/sentry-xcodebuild.sh \
+              --platform ${{matrix.platform}} \
+              --os ${{matrix.test-destination-os}} \
+              --ref ${{ github.ref_name }} \
+              --command test-without-building \
+              --device "${{matrix.device}}" \
+              --configuration TestCI \
+              --scheme ${{matrix.scheme}} \
+              --test-plan $test_plan
+          done
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,13 +253,13 @@ jobs:
           done
 
       - name: List generated test reports
-        run: ls -la build/reports
+        run: ls -laR build/reports
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         if: always()
         with:
-          report_paths: "**/build/reports/junit*.xml"
+          report_paths: "**/build/reports*/junit.xml"
           fail_on_failure: true
           fail_on_parse_error: true
           detailed_summary: true
@@ -282,7 +282,8 @@ jobs:
         with:
           name: junit-reports-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
-            build/reports/*.xml
+            build/reports/junit.xml
+            build/reports-*/junit.xml
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,8 +231,11 @@ jobs:
 
       - name: Run additional test plans
         if: ${{ matrix.additional-test-plans }}
+        # Array inputs are not supported in GitHub Actions, so we need to join the array into a string and then split it again.
+        # When joining the array, use any character which will not be present in the array elements.
         run: |
-          for test_plan in ${{ matrix.additional-test-plans }}; do
+          IFS='|' read -ra TEST_PLANS <<< "${{ join(matrix.additional-test-plans, '|') }}"
+          for test_plan in "${TEST_PLANS[@]}"; do
             echo "::notice::Running with Xcode test plan: $test_plan"
 
             ./scripts/sentry-xcodebuild.sh \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -252,6 +252,9 @@ jobs:
             set +x
           done
 
+      - name: List test reports
+        run: ls -la build/reports
+
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857 # v5.5.1
         if: always()

--- a/Plans/Sentry_HTTPTransport.xctestplan
+++ b/Plans/Sentry_HTTPTransport.xctestplan
@@ -24,16 +24,7 @@
   },
   "testTargets" : [
     {
-      "skippedTests" : [
-        "SentryANRTrackerTests\/testANRButAppInBackground_NoANR()",
-        "SentryANRTrackerTests\/testMultipleListeners()",
-        "SentryCoreDataTrackerTests\/testFetchRequestBackgroundThread()",
-        "SentryCoreDataTrackerTests\/testSaveBackgroundThread()",
-        "SentryCrashIntegrationTests\/testStartUpCrash_CallsFlush()",
-        "SentryCrashReportStore_Tests\/testCrashReportCount1",
-        "SentryCrashReportStore_Tests\/testDeleteAllReports",
-        "SentryCrashReportStore_Tests\/testStoresLoadsMultipleReports",
-        "SentryHttpTransportTests",
+      "selectedTests" : [
         "SentryHttpTransportTests\/testActiveRateLimitForAllCachedEnvelopeItems()",
         "SentryHttpTransportTests\/testActiveRateLimitForAllEnvelopeItems()",
         "SentryHttpTransportTests\/testActiveRateLimitForSomeCachedEnvelopeItems()",
@@ -90,35 +81,12 @@
         "SentryHttpTransportTests\/testSendOneEvent()",
         "SentryHttpTransportTests\/testSendUserFeedback()",
         "SentryHttpTransportTests\/testSendsWhenNetworkComesBack()",
-        "SentryHttpTransportTests\/testTransactionRateLimited_RecordsLostSpans()",
-        "SentryNetworkTrackerIntegrationTests\/testGetCaptureFailedRequestsEnabled()",
-        "SentryNetworkTrackerIntegrationTests\/testGetRequest_CompareSentryTraceHeader()",
-        "SentryOnDemandReplayTests\/testAddFrameIsThreadSafe()",
-        "SentryProfilerSwiftTests\/testConcurrentSpansWithTimeout()",
-        "SentryReachabilityTest\/testMultipleReachabilityObservers",
-        "SentrySDKIntegrationTestsBase",
-        "SentrySDKTests\/testStartOnTheMainThread()",
-        "SentrySessionGeneratorTests\/testSendSessions()",
-        "SentrySubClassFinderTests\/testActOnSubclassesOfViewController()",
-        "SentryThreadInspectorTests\/testGetCurrentThreadsWithStacktrace_WithSymbolication()",
-        "SentryThreadInspectorTests\/testStacktraceHasFrames_forEveryThread()",
-        "SentryThreadWrapperTests\/testOnMainThreadFromNonMainContext()",
-        "SentryTracerTests\/testDeadlineTimer_StartedAndCancelledOnMainThread()"
+        "SentryHttpTransportTests\/testTransactionRateLimited_RecordsLostSpans()"
       ],
       "target" : {
         "containerPath" : "container:Sentry.xcodeproj",
         "identifier" : "63AA76641EB8CB2F00D153DE",
         "name" : "SentryTests"
-      }
-    },
-    {
-      "skippedTests" : [
-        "SentryProfilerTests\/testProfilerMutationDuringSlicing"
-      ],
-      "target" : {
-        "containerPath" : "container:Sentry.xcodeproj",
-        "identifier" : "8431EECF29B27B1100D8DC56",
-        "name" : "SentryProfilerTests"
       }
     }
   ],

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1996,6 +1996,7 @@
 		D456B4312D706BDD007068CB /* SentrySpanOperation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpanOperation.h; path = include/SentrySpanOperation.h; sourceTree = "<group>"; };
 		D456B4352D706BEE007068CB /* SentryTraceOrigin.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTraceOrigin.h; path = include/SentryTraceOrigin.h; sourceTree = "<group>"; };
 		D456B4372D706BFB007068CB /* SentrySpanDataKey.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpanDataKey.h; path = include/SentrySpanDataKey.h; sourceTree = "<group>"; };
+		D46712F42DCDFC8200D4074A /* Sentry_HTTPTransport.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sentry_HTTPTransport.xctestplan; sourceTree = "<group>"; };
 		D468C0612D3669A200964230 /* SentryFileIOTracker+SwiftHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SentryFileIOTracker+SwiftHelpers.swift"; sourceTree = "<group>"; };
 		D46D45E12D5F3FD600A1CB35 /* Sentry_Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Sentry_Base.xctestplan; sourceTree = "<group>"; };
 		D46D45E82D5F40FA00A1CB35 /* SentryProfilerTests_Base.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; name = SentryProfilerTests_Base.xctestplan; path = Plans/SentryProfilerTests_Base.xctestplan; sourceTree = SOURCE_ROOT; };
@@ -3879,6 +3880,7 @@
 			isa = PBXGroup;
 			children = (
 				D46D45E12D5F3FD600A1CB35 /* Sentry_Base.xctestplan */,
+				D46712F42DCDFC8200D4074A /* Sentry_HTTPTransport.xctestplan */,
 				D46D45E82D5F40FA00A1CB35 /* SentryProfilerTests_Base.xctestplan */,
 				D46D45E92D5F411700A1CB35 /* SentrySwiftUI_Base.xctestplan */,
 				D46D45EA2D5F412100A1CB35 /* SentryTests_Base.xctestplan */,

--- a/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
+++ b/Sentry.xcodeproj/xcshareddata/xcschemes/Sentry.xcscheme
@@ -49,6 +49,9 @@
             reference = "container:Plans/Sentry_Base.xctestplan"
             default = "YES">
          </TestPlanReference>
+         <TestPlanReference
+            reference = "container:Plans/Sentry_HTTPTransport.xctestplan">
+         </TestPlanReference>
       </TestPlans>
       <Testables>
          <TestableReference

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -189,8 +189,13 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             -testPlan "$TEST_PLAN" \
             test-without-building 2>&1 |
             tee "$OUTPUT_FILE" |
-            xcbeautify --report junit --report-path "build/reports-${TEST_PLAN}" &&        
-            slather coverage --configuration "$CONFIGURATION" --scheme "$TEST_SCHEME"
+            xcbeautify \
+                --report junit \
+                --report-path "build/reports-${TEST_PLAN}" &&
+            slather coverage \
+                --configuration "$CONFIGURATION" \
+                --scheme "$TEST_SCHEME" \
+                --output-directory "slather/coverage/${TEST_PLAN}"
     else
         set -o pipefail && NSUnbufferedIO=YES xcodebuild \
             -workspace "$WORKSPACE" \
@@ -199,7 +204,12 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             -destination "$DESTINATION" \
             test-without-building 2>&1 |
             tee "$OUTPUT_FILE" |
-            xcbeautify --report junit &&
-            slather coverage --configuration "$CONFIGURATION" --scheme "$TEST_SCHEME"
+            xcbeautify \
+                --report junit \
+                --report-path "build/reports" &&
+            slather coverage \
+                --configuration "$CONFIGURATION" \
+                --scheme "$TEST_SCHEME" \
+                --output-directory "slather/coverage/default"
     fi
 fi

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -177,6 +177,8 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
     # We can not pass an empty test plan to xcodebuild, because it is not the same as not passing the argument.
     # So we need to check if the test plan is set and if not, we need to run the command without the test plan.
     # Running without a test plan will fall back to the default test plan of the scheme.
+
+    # Use a suffix for the report path to avoid overwriting the default report
     if [ -n "$TEST_PLAN" ]; then
         OUTPUT_FILE="raw-test-output-${TEST_PLAN}.log"
         set -o pipefail && NSUnbufferedIO=YES xcodebuild \
@@ -187,7 +189,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             -testPlan "$TEST_PLAN" \
             test-without-building 2>&1 |
             tee "$OUTPUT_FILE" |
-            xcbeautify --report junit --report-path "build/reports/junit-${TEST_PLAN}.xml" &&
+            xcbeautify --report junit --report-path "build/reports-${TEST_PLAN}" &&        
             slather coverage --configuration "$CONFIGURATION" --scheme "$TEST_SCHEME"
     else
         set -o pipefail && NSUnbufferedIO=YES xcodebuild \
@@ -197,7 +199,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             -destination "$DESTINATION" \
             test-without-building 2>&1 |
             tee "$OUTPUT_FILE" |
-            xcbeautify --report junit --report-path "build/reports/junit.xml" &&
+            xcbeautify --report junit &&
             slather coverage --configuration "$CONFIGURATION" --scheme "$TEST_SCHEME"
     fi
 fi

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -180,7 +180,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             -scheme "$TEST_SCHEME" \
             -configuration "$CONFIGURATION" \
             -destination "$DESTINATION" \
-            -test-plan "$TEST_PLAN" \
+            -testPlan "$TEST_PLAN" \
             test-without-building 2>&1 |
             tee "$OUTPUT_FILE" |
             xcbeautify --report junit &&

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -191,7 +191,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             tee "$OUTPUT_FILE" |
             xcbeautify \
                 --report junit \
-                --report-path "build/reports-${TEST_PLAN}" &&
+                --report-path "build/reports/${TEST_PLAN}" &&
             slather coverage \
                 --configuration "$CONFIGURATION" \
                 --scheme "$TEST_SCHEME" \
@@ -206,7 +206,7 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
             tee "$OUTPUT_FILE" |
             xcbeautify \
                 --report junit \
-                --report-path "build/reports" &&
+                --report-path "build/reports/default" &&
             slather coverage \
                 --configuration "$CONFIGURATION" \
                 --scheme "$TEST_SCHEME" \


### PR DESCRIPTION
# Description

- Changes the `Sentry_Base.xctestplan` to skip tests defined for `HTTPTransport`. This test plan is still configured to include all newly added tests to this test plan.
- Adds a separate test plan `Sentry_HTTPTransport.xctestplan` with explicitly defined tests to run separately.

We need to discuss the impact on the developer experience, because running tests in Xcode will only execute the default scheme (`Sentry_Base`).

# Context

- Test plans do not support name globs
- Executing tests in separate test plans will isolate execution context, therefore reduce tests interfering with each other.
- This is not intended to improve test isolation, just to reduce failing CI

#skip-changelog