### PR TITLE
test: fix compile error for SentrySwiftUITests

### DIFF
--- a/Tests/SentrySwiftUITests/SentryTraceViewModelTest.swift
+++ b/Tests/SentrySwiftUITests/SentryTraceViewModelTest.swift
@@ -1,6 +1,6 @@
 #if canImport(UIKit) && canImport(SwiftUI)
 @testable import Sentry
-@_implementationOnly import SentryInternal
+import SentryInternal
 @testable import SentrySwiftUI
 import XCTest
 


### PR DESCRIPTION
Fixes a compiler error seen locally:
![image](https://github.com/user-attachments/assets/e19ba777-2a74-46aa-8180-594dc3d085fb)

fixed:
<img width="1234" alt="image" src="https://github.com/user-attachments/assets/cb58994e-8d12-4428-8d73-a5f516ab5f8b" />


#skip-changelog