### PR TITLE
ref: Remove unused import for SentrySysctl

### DIFF
--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -20,7 +20,6 @@
 #import <SentryCrashScopeObserver.h>
 #import <SentryDependencyContainer.h>
 #import <SentrySDK+Private.h>
-#import <SentrySysctl.h>
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryUIApplication.h"


### PR DESCRIPTION
Remove unused import for SentrySysctl in SentryCrashIntegration.m

#skip-changelog