### PR TITLE
fix(docs): Change section header Improvements to Fixes for 8.50.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 8.50.2
 
-### Improvements
+### Fixes
 
 - Improved time-to-display tracker to not crash when using view life cycle methods incorrectly (#5048)
 - Enable view renderer V2 by default in session replay and preview redact options when using initializer with default values (#5210)


### PR DESCRIPTION
Renames the section header according to the changes.