### PR TITLE
Remove header swift imports

### DIFF
--- a/Sources/Sentry/SentryANRTrackerV1.m
+++ b/Sources/Sentry/SentryANRTrackerV1.m
@@ -16,7 +16,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     kSentryANRTrackerStopping
 };
 
-@interface SentryANRTrackerV1 ()
+@interface SentryANRTrackerV1 () <SentryANRTracker>
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
@@ -45,6 +45,10 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         threadLock = [[NSObject alloc] init];
         state = kSentryANRTrackerNotRunning;
     }
+    return self;
+}
+
+- (id<SentryANRTracker>)asProtocol {
     return self;
 }
 

--- a/Sources/Sentry/SentryANRTrackerV1.m
+++ b/Sources/Sentry/SentryANRTrackerV1.m
@@ -48,7 +48,8 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     return self;
 }
 
-- (id<SentryANRTracker>)asProtocol {
+- (id<SentryANRTracker>)asProtocol
+{
     return self;
 }
 

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -56,7 +56,8 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     return self;
 }
 
-- (id<SentryANRTracker>)asProtocol {
+- (id<SentryANRTracker>)asProtocol
+{
     return self;
 }
 

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -21,7 +21,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     kSentryANRTrackerStopping
 };
 
-@interface SentryANRTrackerV2 ()
+@interface SentryANRTrackerV2 () <SentryANRTracker>
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
@@ -53,6 +53,10 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         threadLock = [[NSObject alloc] init];
         state = kSentryANRTrackerNotRunning;
     }
+    return self;
+}
+
+- (id<SentryANRTracker>)asProtocol {
     return self;
 }
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_duration";
 
-@interface SentryANRTrackingIntegration ()
+@interface SentryANRTrackingIntegration () <SentryANRTrackerDelegate>
 
 @property (nonatomic, strong) id<SentryANRTracker> tracker;
 @property (nonatomic, strong) SentryOptions *options;

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -413,10 +413,10 @@ static NSObject *sentryDependencyContainerLock;
         @synchronized(sentryDependencyContainerLock) {
             if (_anrTracker == nil) {
                 _anrTracker =
-                    [[SentryANRTrackerV1 alloc] initWithTimeoutInterval:timeout
-                                                           crashWrapper:self.crashWrapper
-                                                   dispatchQueueWrapper:self.dispatchQueueWrapper
-                                                          threadWrapper:self.threadWrapper];
+                [[[SentryANRTrackerV1 alloc] initWithTimeoutInterval:timeout
+                                                                           crashWrapper:self.crashWrapper
+                                                                   dispatchQueueWrapper:self.dispatchQueueWrapper
+                                                                          threadWrapper:self.threadWrapper] asProtocol];
             }
         }
     }
@@ -433,12 +433,12 @@ static NSObject *sentryDependencyContainerLock;
         if (_anrTracker == nil) {
             @synchronized(sentryDependencyContainerLock) {
                 if (_anrTracker == nil) {
-                    _anrTracker = [[SentryANRTrackerV2 alloc]
-                        initWithTimeoutInterval:timeout
-                                   crashWrapper:self.crashWrapper
-                           dispatchQueueWrapper:self.dispatchQueueWrapper
-                                  threadWrapper:self.threadWrapper
-                                  framesTracker:self.framesTracker];
+                    _anrTracker = [[[SentryANRTrackerV2 alloc]
+                                    initWithTimeoutInterval:timeout
+                                               crashWrapper:self.crashWrapper
+                                       dispatchQueueWrapper:self.dispatchQueueWrapper
+                                              threadWrapper:self.threadWrapper
+                                              framesTracker:self.framesTracker] asProtocol];
                 }
             }
         }

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -412,11 +412,11 @@ static NSObject *sentryDependencyContainerLock;
     if (_anrTracker == nil) {
         @synchronized(sentryDependencyContainerLock) {
             if (_anrTracker == nil) {
-                _anrTracker =
-                [[[SentryANRTrackerV1 alloc] initWithTimeoutInterval:timeout
-                                                                           crashWrapper:self.crashWrapper
-                                                                   dispatchQueueWrapper:self.dispatchQueueWrapper
-                                                                          threadWrapper:self.threadWrapper] asProtocol];
+                _anrTracker = [[[SentryANRTrackerV1 alloc]
+                    initWithTimeoutInterval:timeout
+                               crashWrapper:self.crashWrapper
+                       dispatchQueueWrapper:self.dispatchQueueWrapper
+                              threadWrapper:self.threadWrapper] asProtocol];
             }
         }
     }
@@ -434,11 +434,11 @@ static NSObject *sentryDependencyContainerLock;
             @synchronized(sentryDependencyContainerLock) {
                 if (_anrTracker == nil) {
                     _anrTracker = [[[SentryANRTrackerV2 alloc]
-                                    initWithTimeoutInterval:timeout
-                                               crashWrapper:self.crashWrapper
-                                       dispatchQueueWrapper:self.dispatchQueueWrapper
-                                              threadWrapper:self.threadWrapper
-                                              framesTracker:self.framesTracker] asProtocol];
+                        initWithTimeoutInterval:timeout
+                                   crashWrapper:self.crashWrapper
+                           dispatchQueueWrapper:self.dispatchQueueWrapper
+                                  threadWrapper:self.threadWrapper
+                                  framesTracker:self.framesTracker] asProtocol];
                 }
             }
         }

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface SentryMetricKitIntegration ()
+@interface SentryMetricKitIntegration () <SentryMXManagerDelegate>
 
 @property (nonatomic, strong, nullable) SentryMXManager *metricKitManager;
 @property (nonatomic, strong) NSMeasurementFormatter *measurementFormatter;

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -39,7 +39,7 @@ static NSString *SENTRY_LAST_REPLAY = @"replay.last";
  */
 static SentryTouchTracker *_touchTracker;
 
-@interface SentrySessionReplayIntegration () <SentryReachabilityObserver>
+@interface SentrySessionReplayIntegration () <SentryReachabilityObserver, SentrySessionListener, SentrySessionReplayDelegate>
 - (void)newSceneActivate;
 @end
 

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -39,7 +39,8 @@ static NSString *SENTRY_LAST_REPLAY = @"replay.last";
  */
 static SentryTouchTracker *_touchTracker;
 
-@interface SentrySessionReplayIntegration () <SentryReachabilityObserver, SentrySessionListener, SentrySessionReplayDelegate>
+@interface SentrySessionReplayIntegration () <SentryReachabilityObserver, SentrySessionListener,
+    SentrySessionReplayDelegate>
 - (void)newSceneActivate;
 @end
 

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -20,7 +20,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryWatchdogTerminationTrackingIntegration ()
+@interface SentryWatchdogTerminationTrackingIntegration () <SentryANRTrackerDelegate>
 
 @property (nonatomic, strong) SentryWatchdogTerminationTracker *tracker;
 @property (nonatomic, strong) id<SentryANRTracker> anrTracker;

--- a/Sources/Sentry/include/SentryANRTrackerV1.h
+++ b/Sources/Sentry/include/SentryANRTrackerV1.h
@@ -29,7 +29,7 @@ SENTRY_NO_INIT
                    dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                           threadWrapper:(SentryThreadWrapper *)threadWrapper;
 
--(id<SentryANRTracker>)asProtocol;
+- (id<SentryANRTracker>)asProtocol;
 
 @end
 

--- a/Sources/Sentry/include/SentryANRTrackerV1.h
+++ b/Sources/Sentry/include/SentryANRTrackerV1.h
@@ -1,10 +1,10 @@
 #import "SentryDefines.h"
-#import "SentrySwift.h"
 
 @class SentryOptions;
 @class SentryCrashWrapper;
 @class SentryDispatchQueueWrapper;
 @class SentryThreadWrapper;
+@protocol SentryANRTracker;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,13 +21,15 @@ NS_ASSUME_NONNULL_BEGIN
  * seconds, and it executes all events in time. Instead, what matters is how long the main thread
  * needs to execute a newly added event to the run loop.
  */
-@interface SentryANRTrackerV1 : NSObject <SentryANRTracker>
+@interface SentryANRTrackerV1 : NSObject
 SENTRY_NO_INIT
 
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
                            crashWrapper:(SentryCrashWrapper *)crashWrapper
                    dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                           threadWrapper:(SentryThreadWrapper *)threadWrapper;
+
+-(id<SentryANRTracker>)asProtocol;
 
 @end
 

--- a/Sources/Sentry/include/SentryANRTrackerV2.h
+++ b/Sources/Sentry/include/SentryANRTrackerV2.h
@@ -1,5 +1,4 @@
 #import "SentryDefines.h"
-#import "SentrySwift.h"
 
 #if SENTRY_HAS_UIKIT
 
@@ -7,6 +6,7 @@
 @class SentryDispatchQueueWrapper;
 @class SentryThreadWrapper;
 @class SentryFramesTracker;
+@protocol SentryANRTracker;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
  * seconds, it can still respond to user input to navigate to a different screen, for example. In
  * that scenario, the frame delay is around 97%.
  */
-@interface SentryANRTrackerV2 : NSObject <SentryANRTracker>
+@interface SentryANRTrackerV2 : NSObject
 SENTRY_NO_INIT
 
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
@@ -28,6 +28,8 @@ SENTRY_NO_INIT
                    dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                           threadWrapper:(SentryThreadWrapper *)threadWrapper
                           framesTracker:(SentryFramesTracker *)framesTracker;
+
+- (id<SentryANRTracker>)asProtocol;
 
 @end
 

--- a/Sources/Sentry/include/SentryANRTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryANRTrackingIntegration.h
@@ -1,12 +1,11 @@
 #import "SentryANRTrackerV1.h"
 #import "SentryBaseIntegration.h"
-#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 static NSString *const SentryANRExceptionType = @"App Hanging";
 
-@interface SentryANRTrackingIntegration : SentryBaseIntegration <SentryANRTrackerDelegate>
+@interface SentryANRTrackingIntegration : SentryBaseIntegration
 
 - (void)pauseAppHangTracking;
 - (void)resumeAppHangTracking;

--- a/Sources/Sentry/include/SentryAppStartTracker.h
+++ b/Sources/Sentry/include/SentryAppStartTracker.h
@@ -2,8 +2,6 @@
 
 #if SENTRY_HAS_UIKIT
 
-#    import "SentrySwift.h"
-
 @class SentryDispatchQueueWrapper;
 @class SentryAppStateManager;
 @class SentryFramesTracker;

--- a/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryAutoBreadcrumbTrackingIntegration.h
@@ -1,6 +1,5 @@
 #import "SentryBaseIntegration.h"
 #import "SentryBreadcrumbDelegate.h"
-#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/include/SentryMetricKitIntegration.h
+++ b/Sources/Sentry/include/SentryMetricKitIntegration.h
@@ -4,7 +4,8 @@
 
 #    import "SentryBaseIntegration.h"
 #    import "SentryEvent.h"
-#    import "SentrySwift.h"
+
+@protocol SentryMXManagerDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,7 +20,7 @@ static NSString *const SentryMetricKitHangDiagnosticMechanism = @"mx_hang_diagno
 
 API_AVAILABLE(ios(15.0), macos(12.0), macCatalyst(15.0))
 API_UNAVAILABLE(tvos, watchos)
-@interface SentryMetricKitIntegration : SentryBaseIntegration <SentryMXManagerDelegate>
+@interface SentryMetricKitIntegration : SentryBaseIntegration
 
 @end
 

--- a/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
+++ b/Sources/Sentry/include/SentrySessionReplayIntegration+Private.h
@@ -1,13 +1,12 @@
 #import "SentryBaseIntegration.h"
 #import "SentrySessionReplayIntegration.h"
-#import "SentrySwift.h"
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 
 @class SentrySessionReplay;
 @class SentryViewPhotographer;
 
-@interface SentrySessionReplayIntegration () <SentrySessionListener, SentrySessionReplayDelegate>
+@interface SentrySessionReplayIntegration ()
 
 @property (nonatomic, strong) SentrySessionReplay *sessionReplay;
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
@@ -5,8 +5,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryWatchdogTerminationTrackingIntegration
-    : SentryBaseIntegration
+@interface SentryWatchdogTerminationTrackingIntegration : SentryBaseIntegration
 
 @end
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTrackingIntegration.h
@@ -2,12 +2,11 @@
 
 #if SENTRY_HAS_UIKIT
 #    import "SentryBaseIntegration.h"
-#    import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryWatchdogTerminationTrackingIntegration
-    : SentryBaseIntegration <SentryANRTrackerDelegate>
+    : SentryBaseIntegration
 
 @end
 

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1IntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1IntegrationTests.swift
@@ -16,7 +16,7 @@ final class SentryANRTrackerV1IntegrationTests: XCTestCase {
             timeoutInterval: 0.01,
             crashWrapper: TestSentryCrashWrapper.sharedInstance(),
             dispatchQueueWrapper: SentryDispatchQueueWrapper(),
-            threadWrapper: SentryThreadWrapper())
+            threadWrapper: SentryThreadWrapper()) as! SentryANRTracker
 
         anrTracker.add(listener: listener)
 

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -38,7 +38,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
             timeoutInterval: fixture.timeoutInterval,
             crashWrapper: fixture.crashWrapper,
             dispatchQueueWrapper: fixture.dispatchQueue,
-            threadWrapper: fixture.threadWrapper)
+            threadWrapper: fixture.threadWrapper) as? SentryANRTracker
     }
     
     override func tearDown() {

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -35,7 +35,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
             crashWrapper: crashWrapper,
             dispatchQueueWrapper: dispatchQueue,
             threadWrapper: threadWrapper,
-            framesTracker: framesTracker), currentDate, displayLinkWrapper, crashWrapper, threadWrapper, framesTracker)
+            framesTracker: framesTracker) as! SentryANRTracker, currentDate, displayLinkWrapper, crashWrapper, threadWrapper, framesTracker)
     }
     
     /// When no frame gets rendered its a fully blocking app hang.

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -78,7 +78,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let sut = SentryMetricKitIntegration()
             givenInstalledWithEnabled(sut)
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveCrashDiagnostic(MXCrashDiagnostic(), callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             try assertPerThread(exceptionType: "MXCrashDiagnostic", exceptionValue: "MachException Type:(null) Code:(null) Signal:(null)", exceptionMechanism: "MXCrashDiagnostic", handled: false)
@@ -92,7 +92,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let sut = SentryMetricKitIntegration()
             givenInstalledWithEnabled(sut) { $0.enableMetricKitRawPayload = true }
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             let diagnostic = MXCrashDiagnostic()
             mxDelegate.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
@@ -110,7 +110,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             
             let sut = SentryMetricKitIntegration()
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             let diagnostic = MXCrashDiagnostic()
             mxDelegate.didReceiveCrashDiagnostic(diagnostic, callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
@@ -131,7 +131,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
                 options.add(inAppInclude: "iOS-Swift")
             }
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveCrashDiagnostic(MXCrashDiagnostic(), callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             try assertEventWithScopeCaptured { event, _, _ in
@@ -151,7 +151,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let sut = SentryMetricKitIntegration()
             givenInstalledWithEnabled(sut)
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveCpuExceptionDiagnostic(TestMXCPUExceptionDiagnostic(), callStackTree: callStackTreePerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             assertNothingCaptured()
@@ -165,7 +165,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let sut = SentryMetricKitIntegration()
             givenInstalledWithEnabled(sut)
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveCpuExceptionDiagnostic(TestMXCPUExceptionDiagnostic(), callStackTree: callStackTreeNotPerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             try assertNotPerThread(exceptionType: "MXCPUException", exceptionValue: "MXCPUException totalCPUTime:2.2 ms totalSampledTime:5.5 ms", exceptionMechanism: "mx_cpu_exception")
@@ -182,7 +182,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let contents = try contentsOfResource("MetricKitCallstacks/not-per-thread-only-one-frame")
             let callStackTree = try SentryMXCallStackTree.from(data: contents)
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveCpuExceptionDiagnostic(TestMXCPUExceptionDiagnostic(), callStackTree: callStackTree, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
@@ -216,7 +216,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let sut = SentryMetricKitIntegration()
             givenInstalledWithEnabled(sut)
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveDiskWriteExceptionDiagnostic(TestMXDiskWriteExceptionDiagnostic(), callStackTree: callStackTreeNotPerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             try assertNotPerThread(exceptionType: "MXDiskWriteException", exceptionValue: "MXDiskWriteException totalWritesCaused:5.5 Mib", exceptionMechanism: "mx_disk_write_exception")
@@ -230,7 +230,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let sut = SentryMetricKitIntegration()
             givenInstalledWithEnabled(sut)
             
-            let mxDelegate = sut as SentryMXManagerDelegate
+            let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveHangDiagnostic(TestMXHangDiagnostic(), callStackTree: callStackTreeNotPerThread, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
             try assertNotPerThread(exceptionType: "MXHangDiagnostic", exceptionValue: "MXHangDiagnostic hangDuration:6.6 sec", exceptionMechanism: "mx_hang_diagnostic")

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -191,7 +191,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testScreenNameFromSentryUIApplication() throws {
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
-        let sut: SentrySessionReplayDelegate = try getSut()
+        let sut: SentrySessionReplayDelegate = try getSut() as! SentrySessionReplayDelegate
         uiApplication.screenName = "Test Screen"
         XCTAssertEqual(sut.currentScreenNameForSessionReplay(), "Test Screen")
     }
@@ -203,7 +203,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
             scope.currentScreen = "Scope Screen"
         }
         
-        let sut: SentrySessionReplayDelegate = try getSut()
+        let sut: SentrySessionReplayDelegate = try getSut() as! SentrySessionReplayDelegate
         uiApplication.screenName = "Test Screen"
         XCTAssertEqual(sut.currentScreenNameForSessionReplay(), "Scope Screen")
     }
@@ -376,7 +376,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let videoInfo = SentryVideoInfo(path: videoUrl, height: 1_024, width: 480, duration: 5, frameCount: 5, frameRate: 1, start: Date(), end: Date(), fileSize: 10, screens: [])
         let replayEvent = SentryReplayEvent(eventId: SentryId(), replayStartTimestamp: Date(), replayType: .session, segmentId: 0)
         
-        (sut as SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
+        (sut as! SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
                                                                      replayRecording: SentryReplayRecording(segmentId: 0, video: videoInfo, extraEvents: []),
                                                                      videoUrl: videoUrl)
         
@@ -399,7 +399,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let videoInfo = SentryVideoInfo(path: videoUrl, height: 1_024, width: 480, duration: 5, frameCount: 5, frameRate: 1, start: Date(), end: Date(), fileSize: 10, screens: [])
         let replayEvent = SentryReplayEvent(eventId: SentryId(), replayStartTimestamp: Date(), replayType: .session, segmentId: 0)
         
-        (sut as SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
+        (sut as! SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
                                                                      replayRecording: SentryReplayRecording(segmentId: 0, video: videoInfo, extraEvents: []),
                                                                      videoUrl: videoUrl)
         
@@ -422,7 +422,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let videoInfo = SentryVideoInfo(path: videoUrl, height: 1_024, width: 480, duration: 5, frameCount: 5, frameRate: 1, start: Date(), end: Date(), fileSize: 10, screens: [])
         let replayEvent = SentryReplayEvent(eventId: SentryId(), replayStartTimestamp: Date(), replayType: .session, segmentId: 0)
         
-        (sut as SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
+        (sut as! SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
                                                                      replayRecording: SentryReplayRecording(segmentId: 0, video: videoInfo, extraEvents: []),
                                                                      videoUrl: videoUrl)
         
@@ -451,7 +451,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let videoInfo = SentryVideoInfo(path: videoUrl, height: 1_024, width: 480, duration: 5, frameCount: 5, frameRate: 1, start: Date(), end: Date(), fileSize: 10, screens: [])
         let replayEvent = SentryReplayEvent(eventId: SentryId(), replayStartTimestamp: Date(), replayType: .session, segmentId: 0)
         
-        (sut as SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
+        (sut as! SentrySessionReplayDelegate).sessionReplayNewSegment(replayEvent: replayEvent,
                                                                      replayRecording: SentryReplayRecording(segmentId: 0, video: videoInfo, extraEvents: []),
                                                                      videoUrl: videoUrl)
         XCTAssertNil(sut.sessionReplay)
@@ -459,7 +459,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         sut.start()
         XCTAssertNil(sut.sessionReplay)
         
-        (sut as SentrySessionListener).sentrySessionStarted(SentrySession(releaseName: "", distinctId: ""))
+        (sut as! SentrySessionListener).sentrySessionStarted(SentrySession(releaseName: "", distinctId: ""))
         
         sut.start()
         XCTAssertTrue(sut.sessionReplay?.isRunning ?? false)


### PR DESCRIPTION
## :scroll: Description

Follow up to https://github.com/getsentry/sentry-cocoa/pull/5227 this PR removes more uses of swift imports in header files and replaces them with forward declarations. In most cases the protocol conformance could be moved into a .m file, but in some cases the `asProtocol` trick had to be used for the conformance to be available outside of the .m file. You cannot use a forward declaration for a conformance, but you can use it for the return value of a function.

## :bulb: Motivation and Context

Helps to avoid the circular dependency issue, and is a best practice when bridging objc/swift: https://developer.apple.com/documentation/swift/importing-swift-into-objective-c#Include-Swift-Classes-in-Objective-C-Headers-Using-Forward-Declarations

## :green_heart: How did you test it?

Built test app

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog
