### PR TITLE
Remove log swift header

### DIFF
--- a/Sources/Sentry/Profiling/SentryTraceProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryTraceProfiler.mm
@@ -9,8 +9,8 @@
 #    import "SentryNSTimerFactory.h"
 #    import "SentryProfiledTracerConcurrency.h"
 #    import "SentryProfiler+Private.h"
+#    import "SentrySwift.h"
 #    include <mutex>
-#import "SentrySwift.h"
 
 #    pragma mark - Private
 

--- a/Sources/Sentry/Profiling/SentryTraceProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryTraceProfiler.mm
@@ -10,6 +10,7 @@
 #    import "SentryProfiledTracerConcurrency.h"
 #    import "SentryProfiler+Private.h"
 #    include <mutex>
+#import "SentrySwift.h"
 
 #    pragma mark - Private
 

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -14,9 +14,9 @@
 #import "SentryMechanism.h"
 #import "SentryMechanismMeta.h"
 #import "SentryStacktrace.h"
+#import "SentrySwift.h"
 #import "SentryThread.h"
 #import "SentryUser.h"
-#import "SentrySwift.h"
 
 @interface SentryCrashReportConverter ()
 

--- a/Sources/Sentry/SentryCrashReportConverter.m
+++ b/Sources/Sentry/SentryCrashReportConverter.m
@@ -16,6 +16,7 @@
 #import "SentryStacktrace.h"
 #import "SentryThread.h"
 #import "SentryUser.h"
+#import "SentrySwift.h"
 
 @interface SentryCrashReportConverter ()
 

--- a/Sources/Sentry/SentryCrashScopeObserver.m
+++ b/Sources/Sentry/SentryCrashScopeObserver.m
@@ -7,6 +7,7 @@
 #import <SentryNSDataUtils.h>
 #import <SentryScopeSyncC.h>
 #import <SentryUser.h>
+#import "SentrySwift.h"
 
 @implementation SentryCrashScopeObserver
 

--- a/Sources/Sentry/SentryCrashScopeObserver.m
+++ b/Sources/Sentry/SentryCrashScopeObserver.m
@@ -1,4 +1,5 @@
 #import "SentryLevelMapper.h"
+#import "SentrySwift.h"
 #import <SentryBreadcrumb.h>
 #import <SentryCrashJSONCodec.h>
 #import <SentryCrashJSONCodecObjC.h>
@@ -7,7 +8,6 @@
 #import <SentryNSDataUtils.h>
 #import <SentryScopeSyncC.h>
 #import <SentryUser.h>
-#import "SentrySwift.h"
 
 @implementation SentryCrashScopeObserver
 

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -14,6 +14,7 @@
 #import "SentrySession.h"
 #import "SentryTransaction.h"
 #import "SentryUserFeedback.h"
+#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -12,9 +12,9 @@
 #import "SentrySdkInfo.h"
 #import "SentrySerialization.h"
 #import "SentrySession.h"
+#import "SentrySwift.h"
 #import "SentryTransaction.h"
 #import "SentryUserFeedback.h"
-#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryLogC.m
+++ b/Sources/Sentry/SentryLogC.m
@@ -4,8 +4,70 @@
 #import "SentryInternalCDefines.h"
 #import "SentryLevelMapper.h"
 #import "SentryLog.h"
+#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
+
+void sendLog(NSInteger level, const char file[], int line, NSString *format, va_list args) {
+  NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
+
+  [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",
+                            [[[NSString stringWithUTF8String:file]
+                                lastPathComponent] stringByDeletingPathExtension],
+                            line, formattedMessage]
+                andLevel:level];
+}
+
+bool debugEnabled(void) {
+    return [SentryLog willLogAtLevel:kSentryLevelDebug];
+}
+bool infoEnabled(void) {
+    return [SentryLog willLogAtLevel:kSentryLevelInfo];
+}
+bool warnEnabled(void) {
+    return [SentryLog willLogAtLevel:kSentryLevelWarning];
+}
+bool errorEnabled(void) {
+    return [SentryLog willLogAtLevel:kSentryLevelError];
+}
+bool fatalEnabled(void) {
+    return [SentryLog willLogAtLevel:kSentryLevelFatal];
+}
+
+void logDebug(const char file[], int line, NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    sendLog(kSentryLevelDebug, file, line, format, args);
+    va_end(args);
+}
+
+void logInfo(const char file[], int line, NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    sendLog(kSentryLevelInfo, file, line, format, args);
+    va_end(args);
+}
+
+void logWarn(const char file[], int line, NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    sendLog(kSentryLevelWarning, file, line, format, args);
+    va_end(args);
+}
+
+void logError(const char file[], int line, NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    sendLog(kSentryLevelError, file, line, format, args);
+    va_end(args);
+}
+
+void logFatal(const char file[], int line, NSString *format, ...) {
+    va_list args;
+    va_start(args, format);
+    sendLog(kSentryLevelFatal, file, line, format, args);
+    va_end(args);
+}
 
 @implementation SentryAsyncLogWrapper
 + (void)initializeAsyncLogFile

--- a/Sources/Sentry/SentryLogC.m
+++ b/Sources/Sentry/SentryLogC.m
@@ -8,61 +8,83 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-void sendLog(NSInteger level, const char file[], int line, NSString *format, va_list args) {
-  NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
+void
+sendLog(NSInteger level, const char file[], int line, NSString *format, va_list args)
+{
+    NSString *formattedMessage = [[NSString alloc] initWithFormat:format arguments:args];
 
-  [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",
-                            [[[NSString stringWithUTF8String:file]
-                                lastPathComponent] stringByDeletingPathExtension],
-                            line, formattedMessage]
-                andLevel:level];
+    [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",
+                                  [[[NSString stringWithUTF8String:file] lastPathComponent]
+                                      stringByDeletingPathExtension],
+                                  line, formattedMessage]
+                     andLevel:level];
 }
 
-bool debugEnabled(void) {
+bool
+debugEnabled(void)
+{
     return [SentryLog willLogAtLevel:kSentryLevelDebug];
 }
-bool infoEnabled(void) {
+bool
+infoEnabled(void)
+{
     return [SentryLog willLogAtLevel:kSentryLevelInfo];
 }
-bool warnEnabled(void) {
+bool
+warnEnabled(void)
+{
     return [SentryLog willLogAtLevel:kSentryLevelWarning];
 }
-bool errorEnabled(void) {
+bool
+errorEnabled(void)
+{
     return [SentryLog willLogAtLevel:kSentryLevelError];
 }
-bool fatalEnabled(void) {
+bool
+fatalEnabled(void)
+{
     return [SentryLog willLogAtLevel:kSentryLevelFatal];
 }
 
-void logDebug(const char file[], int line, NSString *format, ...) {
+void
+logDebug(const char file[], int line, NSString *format, ...)
+{
     va_list args;
     va_start(args, format);
     sendLog(kSentryLevelDebug, file, line, format, args);
     va_end(args);
 }
 
-void logInfo(const char file[], int line, NSString *format, ...) {
+void
+logInfo(const char file[], int line, NSString *format, ...)
+{
     va_list args;
     va_start(args, format);
     sendLog(kSentryLevelInfo, file, line, format, args);
     va_end(args);
 }
 
-void logWarn(const char file[], int line, NSString *format, ...) {
+void
+logWarn(const char file[], int line, NSString *format, ...)
+{
     va_list args;
     va_start(args, format);
     sendLog(kSentryLevelWarning, file, line, format, args);
     va_end(args);
 }
 
-void logError(const char file[], int line, NSString *format, ...) {
+void
+logError(const char file[], int line, NSString *format, ...)
+{
     va_list args;
     va_start(args, format);
     sendLog(kSentryLevelError, file, line, format, args);
     va_end(args);
 }
 
-void logFatal(const char file[], int line, NSString *format, ...) {
+void
+logFatal(const char file[], int line, NSString *format, ...)
+{
     va_list args;
     va_start(args, format);
     sendLog(kSentryLevelFatal, file, line, format, args);

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -5,6 +5,7 @@
 #    import "SentryInternalDefines.h"
 #    import "SentryOptions.h"
 #    import "SentryScope.h"
+#    import "SentrySwift.h"
 #    import <Foundation/Foundation.h>
 #    import <SentryAttachment.h>
 #    import <SentryDebugMeta.h>
@@ -19,7 +20,6 @@
 #    import <SentrySDK+Private.h>
 #    import <SentryStacktrace.h>
 #    import <SentryThread.h>
-#import "SentrySwift.h"
 
 /**
  * We need to check if MetricKit is available for compatibility on iOS 12 and below. As there are no

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -19,6 +19,7 @@
 #    import <SentrySDK+Private.h>
 #    import <SentryStacktrace.h>
 #    import <SentryThread.h>
+#import "SentrySwift.h"
 
 /**
  * We need to check if MetricKit is available for compatibility on iOS 12 and below. As there are no

--- a/Sources/Sentry/SentryMigrateSessionInit.m
+++ b/Sources/Sentry/SentryMigrateSessionInit.m
@@ -5,6 +5,7 @@
 #import "SentryLog.h"
 #import "SentrySerialization.h"
 #import "SentrySession+Private.h"
+#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryNSDataSwizzling.m
+++ b/Sources/Sentry/SentryNSDataSwizzling.m
@@ -1,9 +1,9 @@
 #import "SentryNSDataSwizzling.h"
 #import "SentryLog.h"
+#import "SentrySwift.h"
 #import "SentrySwizzle.h"
 #import "SentryTraceOrigin.h"
 #import <objc/runtime.h>
-#import "SentrySwift.h"
 
 @interface SentryNSDataSwizzling ()
 

--- a/Sources/Sentry/SentryNSDataSwizzling.m
+++ b/Sources/Sentry/SentryNSDataSwizzling.m
@@ -3,6 +3,7 @@
 #import "SentrySwizzle.h"
 #import "SentryTraceOrigin.h"
 #import <objc/runtime.h>
+#import "SentrySwift.h"
 
 @interface SentryNSDataSwizzling ()
 

--- a/Sources/Sentry/SentryNSFileManagerSwizzling.m
+++ b/Sources/Sentry/SentryNSFileManagerSwizzling.m
@@ -3,6 +3,7 @@
 #import "SentrySwizzle.h"
 #import "SentryTraceOrigin.h"
 #import <objc/runtime.h>
+#import "SentrySwift.h"
 
 @interface SentryNSFileManagerSwizzling ()
 

--- a/Sources/Sentry/SentryNSFileManagerSwizzling.m
+++ b/Sources/Sentry/SentryNSFileManagerSwizzling.m
@@ -1,9 +1,9 @@
 #import "SentryNSFileManagerSwizzling.h"
 #import "SentryLog.h"
+#import "SentrySwift.h"
 #import "SentrySwizzle.h"
 #import "SentryTraceOrigin.h"
 #import <objc/runtime.h>
-#import "SentrySwift.h"
 
 @interface SentryNSFileManagerSwizzling ()
 

--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -11,7 +11,7 @@
 #        import "SentryFormatter.h"
 #        import "SentryTime.h"
 #    endif // SENTRY_HAS_UIKIT
-#import "SentrySwift.h"
+#    import "SentrySwift.h"
 
 namespace {
 /**

--- a/Sources/Sentry/SentryProfileTimeseries.mm
+++ b/Sources/Sentry/SentryProfileTimeseries.mm
@@ -11,6 +11,7 @@
 #        import "SentryFormatter.h"
 #        import "SentryTime.h"
 #    endif // SENTRY_HAS_UIKIT
+#import "SentrySwift.h"
 
 namespace {
 /**

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -11,10 +11,10 @@
 #import "SentryScopeObserver.h"
 #import "SentrySession.h"
 #import "SentrySpan.h"
+#import "SentrySwift.h"
 #import "SentryTracer.h"
 #import "SentryTransactionContext.h"
 #import "SentryUser.h"
-#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -14,6 +14,7 @@
 #import "SentryTracer.h"
 #import "SentryTransactionContext.h"
 #import "SentryUser.h"
+#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -13,6 +13,7 @@
 #    import <SentryTraceOrigin.h>
 #    import <SentryTracer.h>
 #    import <SentryTransactionContext+Private.h>
+#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -2,6 +2,7 @@
 
 #if SENTRY_HAS_UIKIT
 
+#    import "SentrySwift.h"
 #    import <SentryDependencyContainer.h>
 #    import <SentryHub+Private.h>
 #    import <SentryLog.h>
@@ -13,7 +14,6 @@
 #    import <SentryTraceOrigin.h>
 #    import <SentryTracer.h>
 #    import <SentryTransactionContext+Private.h>
-#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -18,6 +18,7 @@
 #    import <UIKit/UIKit.h>
 #    import <UIViewController+Sentry.h>
 #    import <objc/runtime.h>
+#import "SentrySwift.h"
 
 /**
  * @c swizzleRootViewControllerFromUIApplication: requires an object that conforms to

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -9,6 +9,7 @@
 #    import "SentryLog.h"
 #    import "SentryNSProcessInfoWrapper.h"
 #    import "SentrySubClassFinder.h"
+#    import "SentrySwift.h"
 #    import "SentrySwizzle.h"
 #    import "SentryUIViewControllerPerformanceTracker.h"
 #    import <SentryDispatchQueueWrapper.h>
@@ -18,7 +19,6 @@
 #    import <UIKit/UIKit.h>
 #    import <UIViewController+Sentry.h>
 #    import <objc/runtime.h>
-#import "SentrySwift.h"
 
 /**
  * @c swizzleRootViewControllerFromUIApplication: requires an object that conforms to

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -14,6 +14,7 @@
 #import <SentrySDK+Private.h>
 #import <SentryWatchdogTerminationLogic.h>
 #import <SentryWatchdogTerminationTracker.h>
+#import "SentrySwift.h"
 
 @interface SentryWatchdogTerminationTracker ()
 

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -1,6 +1,7 @@
 #import "SentryDateUtils.h"
 #import "SentryEvent+Private.h"
 #import "SentryFileManager.h"
+#import "SentrySwift.h"
 #import <SentryAppState.h>
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>
@@ -14,7 +15,6 @@
 #import <SentrySDK+Private.h>
 #import <SentryWatchdogTerminationLogic.h>
 #import <SentryWatchdogTerminationTracker.h>
-#import "SentrySwift.h"
 
 @interface SentryWatchdogTerminationTracker ()
 

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -1,19 +1,27 @@
 #import "SentryDefines.h"
-#import "SentrySwift.h"
 
-#define SENTRY_LOG(_SENTRY_LOG_LEVEL, ...)                                                         \
-    if ([SentryLog willLogAtLevel:_SENTRY_LOG_LEVEL]) {                                            \
-        [SentryLog logWithMessage:[NSString stringWithFormat:@"[%@:%d] %@",                        \
-                                      [[[NSString stringWithUTF8String:__FILE__]                   \
-                                          lastPathComponent] stringByDeletingPathExtension],       \
-                                      __LINE__, [NSString stringWithFormat:__VA_ARGS__]]           \
-                         andLevel:_SENTRY_LOG_LEVEL];                                              \
-    }
-#define SENTRY_LOG_DEBUG(...) SENTRY_LOG(kSentryLevelDebug, __VA_ARGS__)
-#define SENTRY_LOG_INFO(...) SENTRY_LOG(kSentryLevelInfo, __VA_ARGS__)
-#define SENTRY_LOG_WARN(...) SENTRY_LOG(kSentryLevelWarning, __VA_ARGS__)
-#define SENTRY_LOG_ERROR(...) SENTRY_LOG(kSentryLevelError, __VA_ARGS__)
-#define SENTRY_LOG_FATAL(...) SENTRY_LOG(kSentryLevelFatal, __VA_ARGS__)
+#ifdef __cplusplus
+extern "C" {
+#endif
+bool debugEnabled(void);
+bool infoEnabled(void);
+bool warnEnabled(void);
+bool errorEnabled(void);
+bool fatalEnabled(void);
+void logDebug(const char file[], int line, NSString *format, ...);
+void logInfo(const char file[], int line, NSString *format, ...);
+void logWarn(const char file[], int line, NSString *format, ...);
+void logError(const char file[], int line, NSString *format, ...);
+void logFatal(const char file[], int line, NSString *format, ...);
+#ifdef __cplusplus
+}
+#endif
+
+#define SENTRY_LOG_DEBUG(...) if (debugEnabled()) logDebug(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_INFO(...) if (infoEnabled()) logInfo(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_WARN(...) if (warnEnabled()) logWarn(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_ERROR(...) if (errorEnabled()) logError(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_FATAL(...) if (fatalEnabled()) logFatal(__FILE__, __LINE__, __VA_ARGS__);
 
 /**
  * If @c errno is set to a non-zero value after @c statement finishes executing,

--- a/Sources/Sentry/include/SentryLog.h
+++ b/Sources/Sentry/include/SentryLog.h
@@ -17,11 +17,21 @@ void logFatal(const char file[], int line, NSString *format, ...);
 }
 #endif
 
-#define SENTRY_LOG_DEBUG(...) if (debugEnabled()) logDebug(__FILE__, __LINE__, __VA_ARGS__);
-#define SENTRY_LOG_INFO(...) if (infoEnabled()) logInfo(__FILE__, __LINE__, __VA_ARGS__);
-#define SENTRY_LOG_WARN(...) if (warnEnabled()) logWarn(__FILE__, __LINE__, __VA_ARGS__);
-#define SENTRY_LOG_ERROR(...) if (errorEnabled()) logError(__FILE__, __LINE__, __VA_ARGS__);
-#define SENTRY_LOG_FATAL(...) if (fatalEnabled()) logFatal(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_DEBUG(...)                                                                      \
+    if (debugEnabled())                                                                            \
+        logDebug(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_INFO(...)                                                                       \
+    if (infoEnabled())                                                                             \
+        logInfo(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_WARN(...)                                                                       \
+    if (warnEnabled())                                                                             \
+        logWarn(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_ERROR(...)                                                                      \
+    if (errorEnabled())                                                                            \
+        logError(__FILE__, __LINE__, __VA_ARGS__);
+#define SENTRY_LOG_FATAL(...)                                                                      \
+    if (fatalEnabled())                                                                            \
+        logFatal(__FILE__, __LINE__, __VA_ARGS__);
 
 /**
  * If @c errno is set to a non-zero value after @c statement finishes executing,

--- a/Tests/SentryTests/TestUtils/SentryTestLogConfig.m
+++ b/Tests/SentryTests/TestUtils/SentryTestLogConfig.m
@@ -1,6 +1,6 @@
 #import "SentryLog.h"
-#import <Foundation/Foundation.h>
 #import "SentrySwift.h"
+#import <Foundation/Foundation.h>
 
 /**
  * Confgures a the sentry log output for testing when this class is loaded.

--- a/Tests/SentryTests/TestUtils/SentryTestLogConfig.m
+++ b/Tests/SentryTests/TestUtils/SentryTestLogConfig.m
@@ -1,5 +1,6 @@
 #import "SentryLog.h"
 #import <Foundation/Foundation.h>
+#import "SentrySwift.h"
 
 /**
  * Confgures a the sentry log output for testing when this class is loaded.


### PR DESCRIPTION
## :scroll: Description

Remove swift import from last header file (SentryLog.h). Removing this triggered many missing imports in .m/.mm files which are now added

## :bulb: Motivation and Context

Same as https://github.com/getsentry/sentry-cocoa/pull/5227 and https://github.com/getsentry/sentry-cocoa/pull/5232 this is to address circular dependencies in swift/objc references and follow best practices from https://developer.apple.com/documentation/swift/importing-swift-into-objective-c#Include-Swift-Classes-in-Objective-C-Headers-Using-Forward-Declarations

## :green_heart: How did you test it?

Locally building

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog
