### PR TITLE
feat(feedback): manual widget display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Apps can now manually show and hide the included feedback widget button (#5236)
+
 ## 8.50.2
 
 ### Fixes

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -58,10 +58,7 @@ public enum SentrySDKOverrides {
 
         public var boolValue: Bool {
             get {
-                switch self {
-                case .disableAutoInject: return getBoolOverride(for: rawValue)
-                default: return getBoolOverride(for: rawValue)
-                }
+                return getBoolOverride(for: rawValue)
             }
             set(newValue) {
                 setBoolOverride(for: rawValue, value: newValue)

--- a/Samples/iOS-Swift/iOS-Swift-UITests/UserFeedbackUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/UserFeedbackUITests.swift
@@ -489,6 +489,8 @@ extension UserFeedbackUITests {
         XCTAssertEqual(try dictionaryFromSuccessHookFile(), ["name": testName, "message": "UITest user feedback", "email": testContactEmail])
     }
 
+    // MARK: Alternative widget control
+
     func testFormShowsAndDismissesProperlyWithCustomButton() {
         launchApp(args: ["--io.sentry.feedback.use-custom-feedback-button"])
 
@@ -510,6 +512,16 @@ extension UserFeedbackUITests {
 
         customButton.waitForExistence("Form should have been dismissed and custom button should be visible again.")
         XCTAssert(customButton.isHittable)
+        XCTAssertFalse(widgetButton.isHittable)
+    }
+
+    func testManuallyDisplayingWidget() {
+        launchApp(args: ["--io.sentry.feedback.no-auto-inject-widget"])
+        XCTAssertFalse(widgetButton.isHittable)
+        extrasAreaTabBarButton.tap()
+        app.buttons["io.sentry.ui-test.button.show-widget"].tap()
+        XCTAssert(widgetButton.isHittable)
+        app.buttons["io.sentry.ui-test.button.hide-widget"].tap()
         XCTAssertFalse(widgetButton.isHittable)
     }
 }

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -2,6 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="5CD-RQ-aBU">
     <device id="retina4_0" orientation="portrait" appearance="light"/>
     <dependencies>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -513,7 +514,7 @@
             <objects>
                 <viewController id="ikl-rF-hao" customClass="SplitRootViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="146-N0-BiP">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is Split Root ViewController" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5bi-2z-fqb">
@@ -640,7 +641,7 @@
             <objects>
                 <viewController id="ehF-Y7-8St" customClass="ViewLifecycleTestViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="dg3-hU-S5Q">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="dtj-rH-6fW">
@@ -811,7 +812,7 @@
             <objects>
                 <viewController id="g8o-dT-S6v" customClass="SecondarySplitViewController" customModule="iOS_Swift" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="BKf-tT-kLA">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="548"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="puK-Su-Cjb"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -1054,13 +1055,13 @@
                                 <rect key="frame" x="0.0" y="134" width="320" height="385"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="zhO-zJ-CAt">
-                                        <rect key="frame" x="0.0" y="0.0" width="304" height="447"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="304" height="455"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Yzg-QH-aPg">
-                                                <rect key="frame" x="0.0" y="0.0" width="304" height="366"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="304" height="374"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="FaL-DP-Rl6">
-                                                        <rect key="frame" x="0.0" y="0.0" width="152" height="366"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="152" height="374"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oag-iN-lAn">
                                                                 <rect key="frame" x="0.0" y="0.0" width="152" height="28"/>
@@ -1071,7 +1072,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FfQ-2y-q0S">
-                                                                <rect key="frame" x="0.0" y="30.5" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="28" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="uiEventTests"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="UI event tests"/>
@@ -1080,7 +1081,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Did-Hh-ggK">
-                                                                <rect key="frame" x="0.0" y="61.5" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="56" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="captureMessageButton"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="Message"/>
@@ -1089,7 +1090,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FrJ-bO-5YO">
-                                                                <rect key="frame" x="0.0" y="92" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="84" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="User Feedback"/>
                                                                 <connections>
@@ -1097,7 +1098,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z7p-dN-OxK">
-                                                                <rect key="frame" x="0.0" y="123" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="112" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="New User Feedback"/>
                                                                 <connections>
@@ -1105,7 +1106,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="b7Z-ga-DoR" userLabel="HighCpuLoad">
-                                                                <rect key="frame" x="0.0" y="153.5" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="140" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="HighCpuLoad"/>
                                                                 <connections>
@@ -1113,7 +1114,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="E4G-h5-Sio">
-                                                                <rect key="frame" x="0.0" y="184.5" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="168" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="permissions"/>
                                                                 <connections>
@@ -1121,7 +1122,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YeN-3i-awu">
-                                                                <rect key="frame" x="0.0" y="215" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="196" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Flush"/>
@@ -1130,7 +1131,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="chU-g8-yNX">
-                                                                <rect key="frame" x="0.0" y="246" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="224" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Cause frozen frames"/>
@@ -1139,7 +1140,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="M3X-e9-STj">
-                                                                <rect key="frame" x="0.0" y="276.5" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="252" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Web View"/>
@@ -1148,7 +1149,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Dq-nW-2pX">
-                                                                <rect key="frame" x="0.0" y="307.5" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="280" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Masking Preview"/>
@@ -1157,7 +1158,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kjB-TM-zTB" userLabel="View Lifecycle Test">
-                                                                <rect key="frame" x="0.0" y="338" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="308" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="view-lifecycle-test"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -1167,10 +1168,37 @@
                                                                     <segue destination="ehF-Y7-8St" kind="presentation" id="H7t-Et-KMM"/>
                                                                 </connections>
                                                             </button>
+                                                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="mOm-Ca-55v">
+                                                                <rect key="frame" x="0.0" y="336" width="152" height="38"/>
+                                                                <subviews>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YhG-k9-4vd">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="76" height="38"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="io.sentry.ui-test.button.show-widget"/>
+                                                                        <state key="normal" title="Button"/>
+                                                                        <buttonConfiguration key="configuration" style="plain" title="Show Wdget">
+                                                                            <fontDescription key="titleFontDescription" type="system" pointSize="10"/>
+                                                                        </buttonConfiguration>
+                                                                        <connections>
+                                                                            <action selector="showFeedbackWidget:" destination="VqS-l1-kwe" eventType="touchUpInside" id="WZV-QO-AXD"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqi-kr-TkL">
+                                                                        <rect key="frame" x="76" y="0.0" width="76" height="38"/>
+                                                                        <accessibility key="accessibilityConfiguration" identifier="io.sentry.ui-test.button.hide-widget"/>
+                                                                        <state key="normal" title="Button"/>
+                                                                        <buttonConfiguration key="configuration" style="plain" title="Hide Widget">
+                                                                            <fontDescription key="titleFontDescription" type="system" pointSize="10"/>
+                                                                        </buttonConfiguration>
+                                                                        <connections>
+                                                                            <action selector="hideFeedbackWidget:" destination="VqS-l1-kwe" eventType="touchUpInside" id="Dfw-vV-g61"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                </subviews>
+                                                            </stackView>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="ULj-Tl-kYs">
-                                                        <rect key="frame" x="152" y="0.0" width="152" height="366"/>
+                                                        <rect key="frame" x="152" y="0.0" width="152" height="374"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="weS-d7-IY1">
                                                                 <rect key="frame" x="0.0" y="0.0" width="152" height="28"/>
@@ -1181,7 +1209,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ckT-1E-GWZ">
-                                                                <rect key="frame" x="0.0" y="28" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="28.5" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="Close SDK"/>
                                                                 <connections>
@@ -1189,7 +1217,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rpD-Rf-xbz" userLabel="ANR Deadlock Button">
-                                                                <rect key="frame" x="0.0" y="56" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="57.5" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="ANR Deadlock"/>
                                                                 <connections>
@@ -1197,7 +1225,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="abd-lv-qoC">
-                                                                <rect key="frame" x="0.0" y="84" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="86" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="ANR fully blocking"/>
                                                                 <connections>
@@ -1205,7 +1233,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2e4-48-rLl">
-                                                                <rect key="frame" x="0.0" y="112" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="114.5" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="anrFillingRunLoopExtra"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="ANR filling run loop"/>
@@ -1214,7 +1242,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="6Jr-19-VhC">
-                                                                <rect key="frame" x="0.0" y="140" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="143.5" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="anrFillingRunLoopExtra"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <state key="normal" title="Pasteboard Contents"/>
@@ -1223,7 +1251,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="F0l-xf-cQd">
-                                                                <rect key="frame" x="0.0" y="168" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="172" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Start 100 threads"/>
@@ -1232,7 +1260,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Evt-B9-zEC">
-                                                                <rect key="frame" x="0.0" y="196" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="200.5" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="breadcrumbInfoButton"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -1242,7 +1270,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5U2-RQ-FCu">
-                                                                <rect key="frame" x="0.0" y="224" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="229.5" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="TOPVCBTN"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -1252,7 +1280,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="NEs-RL-K3q">
-                                                                <rect key="frame" x="0.0" y="252" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="258" width="152" height="28"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Show UI Test"/>
@@ -1261,7 +1289,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fVb-GU-NNp">
-                                                                <rect key="frame" x="0.0" y="280" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="286.5" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="io.sentry.ui-test.button.get-latest-envelope"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -1271,7 +1299,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GrG-53-N5h">
-                                                                <rect key="frame" x="0.0" y="308" width="152" height="28"/>
+                                                                <rect key="frame" x="0.0" y="315.5" width="152" height="28"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="io.sentry.ui-test.button.get-application-support-directory"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -1281,7 +1309,7 @@
                                                                 </connections>
                                                             </button>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yHr-LA-gOE">
-                                                                <rect key="frame" x="0.0" y="336" width="152" height="30"/>
+                                                                <rect key="frame" x="0.0" y="344" width="152" height="30"/>
                                                                 <state key="normal" title="Button"/>
                                                                 <buttonConfiguration key="configuration" style="plain" title="Feature flags">
                                                                     <fontDescription key="titleFontDescription" type="system" pointSize="13"/>
@@ -1295,7 +1323,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="omd-Rj-xhq">
-                                                <rect key="frame" x="0.0" y="366" width="304" height="81"/>
+                                                <rect key="frame" x="0.0" y="374" width="304" height="81"/>
                                                 <subviews>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMF-4u-JGE">
                                                         <rect key="frame" x="8" y="32" width="288" height="0.0"/>

--- a/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
+++ b/Samples/iOS-Swift/iOS-Swift/Base.lproj/Main.storyboard
@@ -1175,7 +1175,7 @@
                                                                         <rect key="frame" x="0.0" y="0.0" width="76" height="38"/>
                                                                         <accessibility key="accessibilityConfiguration" identifier="io.sentry.ui-test.button.show-widget"/>
                                                                         <state key="normal" title="Button"/>
-                                                                        <buttonConfiguration key="configuration" style="plain" title="Show Wdget">
+                                                                        <buttonConfiguration key="configuration" style="plain" title="Show Widget">
                                                                             <fontDescription key="titleFontDescription" type="system" pointSize="10"/>
                                                                         </buttonConfiguration>
                                                                         <connections>

--- a/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
@@ -348,4 +348,12 @@ class ExtraViewController: UIViewController {
             result["item_header_type"] = json["type"]
         }
     }
+
+    @IBAction func showFeedbackWidget(_ sender: Any) {
+        SentrySDK.showFeedbackWidget()
+    }
+
+    @IBAction func hideFeedbackWidget(_ sender: Any) {
+        SentrySDK.hideFeedbackWidget()
+    }
 }

--- a/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
@@ -351,7 +351,7 @@ class ExtraViewController: UIViewController {
 
     @IBAction func showFeedbackWidget(_ sender: Any) {
         if #available(iOS 13.0, *) {
-            SentrySDK.showFeedbackWidget()
+            SentrySDK.feedback.showWidget()
         } else {
             showToast(in: self, type: .warning, message: "Feedback widget only available in iOS 13 or later.")
         }
@@ -359,7 +359,7 @@ class ExtraViewController: UIViewController {
 
     @IBAction func hideFeedbackWidget(_ sender: Any) {
         if #available(iOS 13.0, *) {
-            SentrySDK.hideFeedbackWidget()
+            SentrySDK.feedback.hideWidget()
         } else {
             showToast(in: self, type: .warning, message: "Feedback widget only available in iOS 13 or later.")
         }

--- a/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/ExtraViewController.swift
@@ -350,10 +350,18 @@ class ExtraViewController: UIViewController {
     }
 
     @IBAction func showFeedbackWidget(_ sender: Any) {
-        SentrySDK.showFeedbackWidget()
+        if #available(iOS 13.0, *) {
+            SentrySDK.showFeedbackWidget()
+        } else {
+            showToast(in: self, type: .warning, message: "Feedback widget only available in iOS 13 or later.")
+        }
     }
 
     @IBAction func hideFeedbackWidget(_ sender: Any) {
-        SentrySDK.hideFeedbackWidget()
+        if #available(iOS 13.0, *) {
+            SentrySDK.hideFeedbackWidget()
+        } else {
+            showToast(in: self, type: .warning, message: "Feedback widget only available in iOS 13 or later.")
+        }
     }
 }

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -697,6 +697,8 @@
 		845C16D52A622A5B00EC9519 /* SentryTracer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 845C16D42A622A5B00EC9519 /* SentryTracer+Private.h */; };
 		845CEAEF2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEAEE2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift */; };
 		845CEB172D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEB162D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift */; };
+		8482FA9B2DD7C397000E9283 /* SentryFeedbackAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8482FA9C2DD7C397000E9283 /* SentryFeedbackAPI.m in Sources */ = {isa = PBXBuildFile; fileRef = 8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */; };
 		848A45192BBF8D33006AAAEC /* SentryContinuousProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.mm */; };
 		848A451A2BBF8D33006AAAEC /* SentryContinuousProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */; };
 		848A451D2BBF9504006AAAEC /* SentryProfilerTestHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 848A451C2BBF9504006AAAEC /* SentryProfilerTestHelpers.m */; };
@@ -1864,6 +1866,8 @@
 		845CEAEE2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryProfilingPublicAPITests.swift; sourceTree = "<group>"; };
 		845CEB162D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAppStartProfilingConfigurationTests.swift; sourceTree = "<group>"; };
 		846F90332D56F59D009E86C1 /* Brewfile-ci-deploy */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = "Brewfile-ci-deploy"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryFeedbackAPI.h; sourceTree = "<group>"; };
+		8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryFeedbackAPI.m; sourceTree = "<group>"; };
 		848A45172BBF8D33006AAAEC /* SentryContinuousProfiler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryContinuousProfiler.h; path = ../include/SentryContinuousProfiler.h; sourceTree = "<group>"; };
 		848A45182BBF8D33006AAAEC /* SentryContinuousProfiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryContinuousProfiler.mm; sourceTree = "<group>"; };
 		848A451B2BBF9504006AAAEC /* SentryProfilerTestHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilerTestHelpers.h; path = ../include/SentryProfilerTestHelpers.h; sourceTree = "<group>"; };
@@ -3770,6 +3774,8 @@
 			children = (
 				849B8F9E2C70091A00148E1F /* Configuration */,
 				849B8F962C6E906900148E1F /* SentryUserFeedbackIntegrationDriver.swift */,
+				8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */,
+				8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */,
 				84DBC62B2CE82F0E000C4904 /* SentryFeedback.swift */,
 				84CFA4CB2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.h */,
 				84CFA4CC2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.m */,
@@ -4348,6 +4354,7 @@
 				0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */,
 				D8BBD32728FD9FC00011F850 /* SentrySwift.h in Headers */,
 				84CFA4CE2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.h in Headers */,
+				8482FA9B2DD7C397000E9283 /* SentryFeedbackAPI.h in Headers */,
 				8E4E7C7425DAAB49006AB9E2 /* SentrySpanProtocol.h in Headers */,
 				8EC4CF4A25C38DAA0093DEE9 /* SentrySpanStatus.h in Headers */,
 				8ECC673D25C23996000E2BF6 /* SentrySpanId.h in Headers */,
@@ -5260,6 +5267,7 @@
 				63FE710B20DA4C1000CDBAE8 /* SentryCrashMach.c in Sources */,
 				63FE707720DA4C1000CDBAE8 /* SentryDictionaryDeepSearch.m in Sources */,
 				621D9F2F2B9B0320003D94DE /* SentryCurrentDateProvider.swift in Sources */,
+				8482FA9C2DD7C397000E9283 /* SentryFeedbackAPI.m in Sources */,
 				7BC9A20628F41781001E7C4C /* SentryMeasurementUnit.m in Sources */,
 				63FE71A020DA4C1100CDBAE8 /* SentryCrashInstallation.m in Sources */,
 				63FE713520DA4C1100CDBAE8 /* SentryCrashMemory.c in Sources */,

--- a/Sources/Sentry/Public/Sentry.h
+++ b/Sources/Sentry/Public/Sentry.h
@@ -20,6 +20,7 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #    import <Sentry/SentryError.h>
 #    import <Sentry/SentryEvent.h>
 #    import <Sentry/SentryException.h>
+#    import <Sentry/SentryFeedbackAPI.h>
 #    import <Sentry/SentryFrame.h>
 #    import <Sentry/SentryGeo.h>
 #    import <Sentry/SentryHttpStatusCodeRange.h>

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -798,6 +798,7 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * either this block to configure a widget and UI form to gather feedback, or directly submits
  * feedback you've gathered using your own UI by calling the method @c SentrySDK.captureFeedback
  * (se https://docs.sentry.io/platforms/apple/user-feedback/configuration/).
+ * @note User feedback widget is only available for iOS 13 or later.
  */
 @property (nonatomic, copy, nullable)
     SentryUserFeedbackConfigurationBlock configureUserFeedback API_AVAILABLE(ios(13.0));

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -9,6 +9,7 @@
 @class SentryBreadcrumb;
 @class SentryEvent;
 @class SentryFeedback;
+@class SentryFeedbackAPI;
 @class SentryId;
 @class SentryMetricsAPI;
 @class SentryOptions;
@@ -273,21 +274,7 @@ SENTRY_NO_INIT
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
-/**
- * Show the feedback widget button.
- * @warning This is an experimental feature and may still have bugs.
- * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
- * @note User feedback widget is only available for iOS 13 or later.
- */
-+ (void)showFeedbackWidget API_AVAILABLE(ios(13.0));
-
-/**
- * Hide the feedback widget button.
- * @warning This is an experimental feature and may still have bugs.
- * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
- * @note User feedback widget is only available for iOS 13 or later.
- */
-+ (void)hideFeedbackWidget API_AVAILABLE(ios(13.0));
+@property (nonatomic, class, readonly) SentryFeedbackAPI *feedback API_AVAILABLE(ios(13.0));
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -270,6 +270,10 @@ SENTRY_NO_INIT
  */
 + (void)captureFeedback:(SentryFeedback *)feedback NS_SWIFT_NAME(capture(feedback:));
 
++ (void)showFeedbackWidget;
+
++ (void)hideFeedbackWidget;
+
 /**
  * Adds a Breadcrumb to the current Scope of the current Hub. If the total number of breadcrumbs
  * exceeds the @c SentryOptions.maxBreadcrumbs  the SDK removes the oldest breadcrumb.

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -263,6 +263,7 @@ SENTRY_NO_INIT
 
 /**
  * Captures user feedback that was manually gathered and sends it to Sentry.
+ * @warning This is an experimental feature and may still have bugs.
  * @param feedback The feedback to send to Sentry.
  * @note If you'd prefer not to have to build the UI required to gather the feedback from the user,
  * see @c SentryOptions.configureUserFeedback to customize a fully managed integration. See
@@ -270,9 +271,21 @@ SENTRY_NO_INIT
  */
 + (void)captureFeedback:(SentryFeedback *)feedback NS_SWIFT_NAME(capture(feedback:));
 
-+ (void)showFeedbackWidget;
+/**
+ * Show the feedback widget button.
+ * @warning This is an experimental feature and may still have bugs.
+ * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
+ * @note User feedback widget is only available for iOS 13 or later.
+ */
++ (void)showFeedbackWidget API_AVAILABLE(ios(13.0));
 
-+ (void)hideFeedbackWidget;
+/**
+ * Hide the feedback widget button.
+ * @warning This is an experimental feature and may still have bugs.
+ * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
+ * @note User feedback widget is only available for iOS 13 or later.
+ */
++ (void)hideFeedbackWidget API_AVAILABLE(ios(13.0));
 
 /**
  * Adds a Breadcrumb to the current Scope of the current Hub. If the total number of breadcrumbs

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -271,6 +271,8 @@ SENTRY_NO_INIT
  */
 + (void)captureFeedback:(SentryFeedback *)feedback NS_SWIFT_NAME(capture(feedback:));
 
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
 /**
  * Show the feedback widget button.
  * @warning This is an experimental feature and may still have bugs.
@@ -286,6 +288,8 @@ SENTRY_NO_INIT
  * @note User feedback widget is only available for iOS 13 or later.
  */
 + (void)hideFeedbackWidget API_AVAILABLE(ios(13.0));
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 /**
  * Adds a Breadcrumb to the current Scope of the current Hub. If the total number of breadcrumbs

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -432,6 +432,8 @@ static NSDate *_Nullable startTimestamp = nil;
     [SentrySDK.currentHub captureFeedback:feedback];
 }
 
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
 + (void)showFeedbackWidget
 {
     if (@available(iOS 13.0, *)) {
@@ -453,6 +455,8 @@ static NSDate *_Nullable startTimestamp = nil;
         SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
     }
 }
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
 + (void)addBreadcrumb:(SentryBreadcrumb *)crumb
 {

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -26,6 +26,7 @@
 #import "SentrySerialization.h"
 #import "SentrySwift.h"
 #import "SentryTransactionContext.h"
+#import "SentryUserFeedbackIntegration.h"
 
 #if TARGET_OS_OSX
 #    import "SentryCrashExceptionApplication.h"
@@ -429,6 +430,25 @@ static NSDate *_Nullable startTimestamp = nil;
 + (void)captureFeedback:(SentryFeedback *)feedback
 {
     [SentrySDK.currentHub captureFeedback:feedback];
+}
+
+
++ (void)showFeedbackWidget {
+    if (@available(iOS 13.0, *)) {
+        SentryUserFeedbackIntegration *feedback = [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        [feedback showWidget];
+    } else {
+        SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
+    }
+}
+
++ (void)hideFeedbackWidget {
+    if (@available(iOS 13.0, *)) {
+        SentryUserFeedbackIntegration *feedback = [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        [feedback hideWidget];
+    } else {
+        SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
+    }
 }
 
 + (void)addBreadcrumb:(SentryBreadcrumb *)crumb

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -35,6 +35,9 @@
 #if SENTRY_HAS_UIKIT
 #    import "SentryUIDeviceWrapper.h"
 #    import "SentryUIViewControllerPerformanceTracker.h"
+#    if TARGET_OS_IOS
+#        import "SentryFeedbackAPI.h"
+#    endif // TARGET_OS_IOS
 #endif // SENTRY_HAS_UIKIT
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -434,26 +437,12 @@ static NSDate *_Nullable startTimestamp = nil;
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
-+ (void)showFeedbackWidget
++ (SentryFeedbackAPI *)feedback
 {
-    if (@available(iOS 13.0, *)) {
-        SentryUserFeedbackIntegration *feedback =
-            [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
-        [feedback showWidget];
-    } else {
-        SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
-    }
-}
-
-+ (void)hideFeedbackWidget
-{
-    if (@available(iOS 13.0, *)) {
-        SentryUserFeedbackIntegration *feedback =
-            [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
-        [feedback hideWidget];
-    } else {
-        SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
-    }
+    static SentryFeedbackAPI *feedbackAPI;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{ feedbackAPI = [[SentryFeedbackAPI alloc] init]; });
+    return feedbackAPI;
 }
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -432,19 +432,22 @@ static NSDate *_Nullable startTimestamp = nil;
     [SentrySDK.currentHub captureFeedback:feedback];
 }
 
-
-+ (void)showFeedbackWidget {
++ (void)showFeedbackWidget
+{
     if (@available(iOS 13.0, *)) {
-        SentryUserFeedbackIntegration *feedback = [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        SentryUserFeedbackIntegration *feedback =
+            [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
         [feedback showWidget];
     } else {
         SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
     }
 }
 
-+ (void)hideFeedbackWidget {
++ (void)hideFeedbackWidget
+{
     if (@available(iOS 13.0, *)) {
-        SentryUserFeedbackIntegration *feedback = [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        SentryUserFeedbackIntegration *feedback =
+            [currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
         [feedback hideWidget];
     } else {
         SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");

--- a/Sources/Sentry/SentryUserFeedbackIntegration.m
+++ b/Sources/Sentry/SentryUserFeedbackIntegration.m
@@ -27,11 +27,13 @@
     return YES;
 }
 
-- (void)showWidget {
+- (void)showWidget
+{
     [_driver showWidget];
 }
 
-- (void)hideWidget {
+- (void)hideWidget
+{
     [_driver hideWidget];
 }
 

--- a/Sources/Sentry/SentryUserFeedbackIntegration.m
+++ b/Sources/Sentry/SentryUserFeedbackIntegration.m
@@ -27,6 +27,14 @@
     return YES;
 }
 
+- (void)showWidget {
+    [_driver showWidget];
+}
+
+- (void)hideWidget {
+    [_driver hideWidget];
+}
+
 // MARK: SentryUserFeedbackIntegrationDriverDelegate
 
 - (void)captureWithFeedback:(SentryFeedback *)feedback

--- a/Sources/Sentry/include/SentryUserFeedbackIntegration.h
+++ b/Sources/Sentry/include/SentryUserFeedbackIntegration.h
@@ -8,7 +8,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 API_AVAILABLE(ios(13.0))
 @interface SentryUserFeedbackIntegration : SentryBaseIntegration
-
+- (void)showWidget;
+- (void)hideWidget;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.h
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.h
@@ -1,0 +1,36 @@
+#if __has_include(<Sentry/SentryDefines.h>)
+#    import <Sentry/SentryDefines.h>
+#else
+#    import <SentryWithoutUIKit/SentryDefines.h>
+#endif
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+#    import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_AVAILABLE(ios(13.0))
+@interface SentryFeedbackAPI : NSObject
+
+/**
+ * Show the feedback widget button.
+ * @warning This is an experimental feature and may still have bugs.
+ * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
+ * @note User feedback widget is only available for iOS 13 or later.
+ */
+- (void)showWidget API_AVAILABLE(ios(13.0));
+
+/**
+ * Hide the feedback widget button.
+ * @warning This is an experimental feature and may still have bugs.
+ * @seealso See @c SentryOptions.configureUserFeedback to configure the widget.
+ * @note User feedback widget is only available for iOS 13 or later.
+ */
+- (void)hideWidget API_AVAILABLE(ios(13.0));
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.m
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedbackAPI.m
@@ -1,0 +1,41 @@
+#if __has_include(<Sentry/SentryDefines.h>)
+#    import <Sentry/SentryDefines.h>
+#else
+#    import <SentryWithoutUIKit/SentryDefines.h>
+#endif
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+#    import "SentryFeedbackAPI.h"
+#    import "SentryHub+Private.h"
+#    import "SentryLog.h"
+#    import "SentrySDK+Private.h"
+#    import "SentryUserFeedbackIntegration.h"
+
+@implementation SentryFeedbackAPI
+
+- (void)showWidget
+{
+    if (@available(iOS 13.0, *)) {
+        SentryUserFeedbackIntegration *feedback =
+            [[SentrySDK currentHub] getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        [feedback showWidget];
+    } else {
+        SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
+    }
+}
+
+- (void)hideWidget
+{
+    if (@available(iOS 13.0, *)) {
+        SentryUserFeedbackIntegration *feedback =
+            [SentrySDK.currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        [feedback hideWidget];
+    } else {
+        SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
+    }
+}
+
+@end
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -54,6 +54,17 @@ class SentryUserFeedbackIntegrationDriver: NSObject {
         customButton?.removeTarget(self, action: #selector(showForm(sender:)), for: .touchUpInside)
     }
 
+    @objc public func showWidget() {
+        if widget == nil {
+            widget = SentryUserFeedbackWidget(config: configuration, delegate: self)
+        }
+        
+    }
+
+    @objc public func hideWidget() {
+        widget?.rootVC.setWidget(visible: false, animated: configuration.animations)
+    }
+
     @objc func showForm(sender: UIButton) {
         presenter?.present(SentryUserFeedbackFormController(config: configuration, delegate: self, screenshot: nil), animated: configuration.animations) {
             self.configuration.onFormOpen?()

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -57,8 +57,9 @@ class SentryUserFeedbackIntegrationDriver: NSObject {
     @objc public func showWidget() {
         if widget == nil {
             widget = SentryUserFeedbackWidget(config: configuration, delegate: self)
+        } else {
+            widget?.rootVC.setWidget(visible: true, animated: configuration.animations)
         }
-        
     }
 
     @objc public func hideWidget() {
@@ -83,6 +84,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
             self.configuration.onFormClose?()
         }
         widget?.rootVC.setWidget(visible: true, animated: configuration.animations)
+        displayingForm = false
     }
 }
 
@@ -99,6 +101,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate 
 extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         widget?.rootVC.setWidget(visible: true, animated: configuration.animations)
+        displayingForm = false
         configuration.onFormClose?()
     }
 }
@@ -110,6 +113,7 @@ private extension SentryUserFeedbackIntegrationDriver {
         let form = SentryUserFeedbackFormController(config: configuration, delegate: self, screenshot: screenshot)
         form.presentationController?.delegate = self
         widget?.rootVC.setWidget(visible: false, animated: configuration.animations)
+        displayingForm = true
         presenter?.present(form, animated: configuration.animations) {
             self.configuration.onFormOpen?()
         }

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
@@ -100,8 +100,6 @@ class SentryUserFeedbackWidget {
             } else {
                 button?.isHidden = !visible
             }
-
-            displayingForm = !visible
         }
     }
 }


### PR DESCRIPTION
In order to solve the SDK init and widget display ordering problem for SwiftUI access to connected scenes in https://github.com/getsentry/sentry-cocoa/pull/5223, we provide an API to manually show the widget (as well as the analogous hide method).