### PR TITLE
Remove unnecessary version check

### DIFF
--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -291,7 +291,7 @@ _sentry_nondeduplicated_startLaunchProfile(void)
         return;
     }
 
-    SENTRY_LOG_INFO(@"Starting app launch trace profile at %llu.", [[[SentryDefaultCurrentDateProvider alloc] init] systemTime]);
+    SENTRY_LOG_INFO(@"Starting app launch trace profile at %llu.", [SentryDefaultCurrentDateProvider getAbsoluteTime]);
     sentry_isTracingAppLaunch = YES;
 
     SentryTransactionContext *context

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -291,7 +291,7 @@ _sentry_nondeduplicated_startLaunchProfile(void)
         return;
     }
 
-    SENTRY_LOG_INFO(@"Starting app launch trace profile at %llu.", getAbsoluteTime());
+    SENTRY_LOG_INFO(@"Starting app launch trace profile at %llu.", [[[SentryDefaultCurrentDateProvider alloc] init] systemTime]);
     sentry_isTracingAppLaunch = YES;
 
     SentryTransactionContext *context

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -291,7 +291,8 @@ _sentry_nondeduplicated_startLaunchProfile(void)
         return;
     }
 
-    SENTRY_LOG_INFO(@"Starting app launch trace profile at %llu.", [SentryDefaultCurrentDateProvider getAbsoluteTime]);
+    SENTRY_LOG_INFO(@"Starting app launch trace profile at %llu.",
+        [SentryDefaultCurrentDateProvider getAbsoluteTime]);
     sentry_isTracingAppLaunch = YES;
 
     SentryTransactionContext *context

--- a/Sources/Sentry/SentrySysctl.m
+++ b/Sources/Sentry/SentrySysctl.m
@@ -1,9 +1,9 @@
 #import "SentrySysctl.h"
 #import "SentryCrashSysCtl.h"
+#import "SentrySwift.h"
 #import "SentryTime.h"
 #include <stdio.h>
 #include <time.h>
-#import "SentrySwift.h"
 
 static NSDate *moduleInitializationTimestamp;
 static uint64_t runtimeInitSystemTimestamp;

--- a/Sources/Sentry/SentrySysctl.m
+++ b/Sources/Sentry/SentrySysctl.m
@@ -3,6 +3,7 @@
 #import "SentryTime.h"
 #include <stdio.h>
 #include <time.h>
+#import "SentrySwift.h"
 
 static NSDate *moduleInitializationTimestamp;
 static uint64_t runtimeInitSystemTimestamp;
@@ -35,7 +36,7 @@ sentryModuleInitializationHook(void)
     // there's no guarantee on whether that or this load method will be called first, the difference
     // in time has been observed to only be on the order of single milliseconds, not significant
     // enough to make a difference in outcomes
-    runtimeInitSystemTimestamp = getAbsoluteTime();
+    runtimeInitSystemTimestamp = [[[SentryDefaultCurrentDateProvider alloc] init] systemTime];
 }
 
 - (NSDate *)runtimeInitTimestamp

--- a/Sources/Sentry/SentrySysctl.m
+++ b/Sources/Sentry/SentrySysctl.m
@@ -36,7 +36,7 @@ sentryModuleInitializationHook(void)
     // there's no guarantee on whether that or this load method will be called first, the difference
     // in time has been observed to only be on the order of single milliseconds, not significant
     // enough to make a difference in outcomes
-    runtimeInitSystemTimestamp = [[[SentryDefaultCurrentDateProvider alloc] init] systemTime];
+    runtimeInitSystemTimestamp = [SentryDefaultCurrentDateProvider getAbsoluteTime];
 }
 
 - (NSDate *)runtimeInitTimestamp

--- a/Sources/Sentry/SentryTime.mm
+++ b/Sources/Sentry/SentryTime.mm
@@ -22,12 +22,6 @@ nanosecondsToTimeInterval(uint64_t nanoseconds)
     return (double)nanoseconds / NSEC_PER_SEC;
 }
 
-uint64_t
-getAbsoluteTime(void)
-{
-    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
-}
-
 bool
 orderedChronologically(uint64_t a, uint64_t b)
 {

--- a/Sources/Sentry/SentryTime.mm
+++ b/Sources/Sentry/SentryTime.mm
@@ -25,10 +25,7 @@ nanosecondsToTimeInterval(uint64_t nanoseconds)
 uint64_t
 getAbsoluteTime(void)
 {
-    if (@available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *)) {
-        return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
-    }
-    return mach_absolute_time();
+    return clock_gettime_nsec_np(CLOCK_UPTIME_RAW);
 }
 
 bool

--- a/Sources/Sentry/include/SentryTime.h
+++ b/Sources/Sentry/include/SentryTime.h
@@ -15,12 +15,6 @@ uint64_t timeIntervalToNanoseconds(double seconds);
 double nanosecondsToTimeInterval(uint64_t nanoseconds);
 
 /**
- * Returns the absolute timestamp, which has no defined reference point or unit
- * as it is platform dependent.
- */
-uint64_t getAbsoluteTime(void);
-
-/**
  * Check whether two timestamps provided as 64 bit unsigned integers are in normal
  * chronological order, as a convenience runtime check before using @c getDurationNs.
  * Equal timestamps are considered to be valid chronological order.

--- a/Sources/Swift/Helper/SentryCurrentDateProvider.swift
+++ b/Sources/Swift/Helper/SentryCurrentDateProvider.swift
@@ -22,6 +22,10 @@ class SentryDefaultCurrentDateProvider: NSObject, SentryCurrentDateProvider {
         return TimeZone.current.secondsFromGMT()
     }
     
+    /**
+     * Returns the absolute timestamp, which has no defined reference point or unit
+     * as it is platform dependent.
+     */
     func systemTime() -> UInt64 {
         clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
     }

--- a/Sources/Swift/Helper/SentryCurrentDateProvider.swift
+++ b/Sources/Swift/Helper/SentryCurrentDateProvider.swift
@@ -27,10 +27,14 @@ class SentryDefaultCurrentDateProvider: NSObject, SentryCurrentDateProvider {
      * as it is platform dependent.
      */
     func systemTime() -> UInt64 {
-        clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
+        Self.getAbsoluteTime()
     }
     
     func systemUptime() -> TimeInterval {
         ProcessInfo.processInfo.systemUptime
+    }
+
+    static func getAbsoluteTime() -> UInt64 {
+        clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
     }
 }

--- a/Sources/Swift/Helper/SentryCurrentDateProvider.swift
+++ b/Sources/Swift/Helper/SentryCurrentDateProvider.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 /**
@@ -24,7 +23,7 @@ class SentryDefaultCurrentDateProvider: NSObject, SentryCurrentDateProvider {
     }
     
     func systemTime() -> UInt64 {
-        getAbsoluteTime()
+        clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
     }
     
     func systemUptime() -> TimeInterval {

--- a/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
@@ -13,6 +13,7 @@
 #    import <iostream>
 #    import <pthread.h>
 #    import <thread>
+#import "SentrySwift.h"
 
 using namespace sentry::profiling;
 
@@ -41,7 +42,7 @@ using namespace sentry::profiling;
     XCTAssertFalse(profiler->isSampling());
 
     std::uint64_t start = 0;
-    profiler->startSampling([&start] { start = getAbsoluteTime(); });
+    profiler->startSampling([&start] { start = [[[SentryDefaultCurrentDateProvider alloc] init] systemTime]; });
     XCTAssertTrue(profiler->isSampling());
 
     // sleep long enough for 2 samples to be collected
@@ -53,7 +54,7 @@ using namespace sentry::profiling;
     XCTAssertFalse(profiler->isSampling());
 
     XCTAssertGreaterThan(start, static_cast<std::uint64_t>(0));
-    XCTAssertGreaterThan(getDurationNs(start, getAbsoluteTime()), 0ULL);
+    XCTAssertGreaterThan(getDurationNs(start, [[[SentryDefaultCurrentDateProvider alloc] init] systemTime]), 0ULL);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(numIdleSamples, 0);
 }

--- a/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
@@ -9,11 +9,11 @@
 #    import "SentryThreadMetadataCache.hpp"
 #    import "SentryTime.h"
 
+#    import "SentrySwift.h"
 #    import <chrono>
 #    import <iostream>
 #    import <pthread.h>
 #    import <thread>
-#import "SentrySwift.h"
 
 using namespace sentry::profiling;
 
@@ -42,7 +42,8 @@ using namespace sentry::profiling;
     XCTAssertFalse(profiler->isSampling());
 
     std::uint64_t start = 0;
-    profiler->startSampling([&start] { start = [SentryDefaultCurrentDateProvider getAbsoluteTime]; });
+    profiler->startSampling(
+        [&start] { start = [SentryDefaultCurrentDateProvider getAbsoluteTime]; });
     XCTAssertTrue(profiler->isSampling());
 
     // sleep long enough for 2 samples to be collected
@@ -54,7 +55,8 @@ using namespace sentry::profiling;
     XCTAssertFalse(profiler->isSampling());
 
     XCTAssertGreaterThan(start, static_cast<std::uint64_t>(0));
-    XCTAssertGreaterThan(getDurationNs(start, [SentryDefaultCurrentDateProvider getAbsoluteTime]), 0ULL);
+    XCTAssertGreaterThan(
+        getDurationNs(start, [SentryDefaultCurrentDateProvider getAbsoluteTime]), 0ULL);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(numIdleSamples, 0);
 }

--- a/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentrySamplingProfilerTests.mm
@@ -42,7 +42,7 @@ using namespace sentry::profiling;
     XCTAssertFalse(profiler->isSampling());
 
     std::uint64_t start = 0;
-    profiler->startSampling([&start] { start = [[[SentryDefaultCurrentDateProvider alloc] init] systemTime]; });
+    profiler->startSampling([&start] { start = [SentryDefaultCurrentDateProvider getAbsoluteTime]; });
     XCTAssertTrue(profiler->isSampling());
 
     // sleep long enough for 2 samples to be collected
@@ -54,7 +54,7 @@ using namespace sentry::profiling;
     XCTAssertFalse(profiler->isSampling());
 
     XCTAssertGreaterThan(start, static_cast<std::uint64_t>(0));
-    XCTAssertGreaterThan(getDurationNs(start, [[[SentryDefaultCurrentDateProvider alloc] init] systemTime]), 0ULL);
+    XCTAssertGreaterThan(getDurationNs(start, [SentryDefaultCurrentDateProvider getAbsoluteTime]), 0ULL);
     XCTAssertGreaterThan(profiler->numSamples(), static_cast<std::uint64_t>(0));
     XCTAssertGreaterThan(numIdleSamples, 0);
 }

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -833,9 +833,9 @@ class SentryHttpTransportTests: XCTestCase {
         fixture.requestManager.responseDelay = fixture.flushTimeout + 0.2
         
         SentryLog.withoutLogs {
-            let beforeFlush = getAbsoluteTime()
+            let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
             let result = sut.flush(fixture.flushTimeout)
-            let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
+            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
             
             XCTAssertGreaterThan(blockingDuration, fixture.flushTimeout)
             XCTAssertLessThan(blockingDuration, fixture.flushTimeout + 0.1)
@@ -849,9 +849,9 @@ class SentryHttpTransportTests: XCTestCase {
         
         SentryLog.withoutLogs {
             
-            let beforeFlush = getAbsoluteTime()
+            let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
-            let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
+            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
             XCTAssertLessThan(blockingDuration, fixture.flushTimeout)
             
         }
@@ -862,10 +862,10 @@ class SentryHttpTransportTests: XCTestCase {
         
         SentryLog.withoutLogs {
             
-            let beforeFlush = getAbsoluteTime()
+            let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
-            let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
+            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
             
             XCTAssertLessThan(blockingDuration, fixture.flushTimeout * 2.2,
                               "The blocking duration must not exceed the sum of the maximum flush duration.")
@@ -881,9 +881,9 @@ class SentryHttpTransportTests: XCTestCase {
         SentryLog.withoutLogs {
             
             for _ in  0..<flushInvocations {
-                let beforeFlush = getAbsoluteTime()
+                let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
                 XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
-                let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
+                let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
                 
                 blockingDurationSum += blockingDuration
             }
@@ -908,9 +908,9 @@ class SentryHttpTransportTests: XCTestCase {
         SentryLog.withoutLogs {
             
             for _ in  0..<flushInvocations {
-                let beforeFlush = getAbsoluteTime()
+                let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
                 XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
-                let blockingDuration = getDurationNs(beforeFlush, getAbsoluteTime()).toTimeInterval()
+                let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
                 
                 blockingDurationSum += blockingDuration
             }

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -833,9 +833,9 @@ class SentryHttpTransportTests: XCTestCase {
         fixture.requestManager.responseDelay = fixture.flushTimeout + 0.2
         
         SentryLog.withoutLogs {
-            let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
+            let beforeFlush = SentryDefaultCurrentDateProvider.getAbsoluteTime()
             let result = sut.flush(fixture.flushTimeout)
-            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
+            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider.getAbsoluteTime()).toTimeInterval()
             
             XCTAssertGreaterThan(blockingDuration, fixture.flushTimeout)
             XCTAssertLessThan(blockingDuration, fixture.flushTimeout + 0.1)
@@ -849,9 +849,9 @@ class SentryHttpTransportTests: XCTestCase {
         
         SentryLog.withoutLogs {
             
-            let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
+            let beforeFlush = SentryDefaultCurrentDateProvider.getAbsoluteTime()
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
-            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
+            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider.getAbsoluteTime()).toTimeInterval()
             XCTAssertLessThan(blockingDuration, fixture.flushTimeout)
             
         }
@@ -862,10 +862,10 @@ class SentryHttpTransportTests: XCTestCase {
         
         SentryLog.withoutLogs {
             
-            let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
+            let beforeFlush = SentryDefaultCurrentDateProvider.getAbsoluteTime()
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
             XCTAssertEqual(.success, sut.flush(fixture.flushTimeout), "Flush should not time out.")
-            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
+            let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider.getAbsoluteTime()).toTimeInterval()
             
             XCTAssertLessThan(blockingDuration, fixture.flushTimeout * 2.2,
                               "The blocking duration must not exceed the sum of the maximum flush duration.")
@@ -881,9 +881,9 @@ class SentryHttpTransportTests: XCTestCase {
         SentryLog.withoutLogs {
             
             for _ in  0..<flushInvocations {
-                let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
+                let beforeFlush = SentryDefaultCurrentDateProvider.getAbsoluteTime()
                 XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
-                let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
+                let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider.getAbsoluteTime()).toTimeInterval()
                 
                 blockingDurationSum += blockingDuration
             }
@@ -908,9 +908,9 @@ class SentryHttpTransportTests: XCTestCase {
         SentryLog.withoutLogs {
             
             for _ in  0..<flushInvocations {
-                let beforeFlush = SentryDefaultCurrentDateProvider().systemTime()
+                let beforeFlush = SentryDefaultCurrentDateProvider.getAbsoluteTime()
                 XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
-                let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider().systemTime()).toTimeInterval()
+                let blockingDuration = getDurationNs(beforeFlush, SentryDefaultCurrentDateProvider.getAbsoluteTime()).toTimeInterval()
                 
                 blockingDurationSum += blockingDuration
             }


### PR DESCRIPTION
We only support > iOS 10.0 now (and same for the other platforms) so we can delete this conditional and use `clock_gettime_nsec_np` directly now to prevent the extra swift/objc interop

#skip-changelog