### PR TITLE
ref: remove replay import in uikitless umbrella header

### DIFF
--- a/Sources/Sentry/Public/SentryWithoutUIKit.h
+++ b/Sources/Sentry/Public/SentryWithoutUIKit.h
@@ -32,7 +32,6 @@ FOUNDATION_EXPORT const unsigned char SentryVersionString[];
 #    import <SentryWithoutUIKit/SentryMessage.h>
 #    import <SentryWithoutUIKit/SentryNSError.h>
 #    import <SentryWithoutUIKit/SentryOptions.h>
-#    import <SentryWithoutUIKit/SentryReplayApi.h>
 #    import <SentryWithoutUIKit/SentryRequest.h>
 #    import <SentryWithoutUIKit/SentrySDK.h>
 #    import <SentryWithoutUIKit/SentrySampleDecision.h>


### PR DESCRIPTION
Since Session Replay implementation requires UIKit, it doesn't make sense to include this file in the UIKitless SDK variant's  umbrella header.

#skip-changelog