### PR TITLE
impr: Improve warn log in SentryTracer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - Add `itemCount` to `SentryEnvelopeItemHeader` ([#5230](https://github.com/getsentry/sentry-cocoa/pull/5230))
+- Improve warn log in SentryTracer (#5248)
 
 ### Features
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -368,8 +368,9 @@ static BOOL appStartMeasurementRead;
     [self cancelIdleTimeout];
 
     if (self.isFinished) {
-        SENTRY_LOG_WARN(
-            @"Starting a child on a finished span is not supported; it won't be sent to Sentry.");
+        SENTRY_LOG_WARN(@"Starting a child with operation %@ and description %@ on a finished span "
+                        @"is not supported; it won't be sent to Sentry.",
+            operation, description);
         return [SentryNoOpSpan shared];
     }
 

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -410,7 +410,9 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(childSpan.parentSpanId)
         XCTAssertEqual(childSpan.operation, "")
         XCTAssertNil(childSpan.spanDescription)
-        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(" Starting a child on a finished span is not supported; it won\'t be sent to Sentry.") }).isEmpty)
+
+        let expectedLogMessage = "Starting a child with operation \(fixture.someOperation) and description \(fixture.someDescription) on a finished span is not supported; it won\'t be sent to Sentry."
+        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(expectedLogMessage) }).isEmpty, "Couldn't find expected log message: \(expectedLogMessage)")
     }
     
     func testStartGrandChildOnFinishedSpan() {
@@ -423,7 +425,9 @@ class SentrySpanTests: XCTestCase {
         XCTAssertNil(grandChild.parentSpanId)
         XCTAssertEqual(grandChild.operation, "")
         XCTAssertNil(grandChild.spanDescription)
-        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(" Starting a child on a finished span is not supported; it won\'t be sent to Sentry.") }).isEmpty)
+
+        let expectedLogMessage = "Starting a child with operation \(fixture.someOperation) and description \(fixture.someDescription) on a finished span is not supported; it won\'t be sent to Sentry."
+        XCTAssertFalse(logOutput.loggedMessages.filter({ $0.contains(expectedLogMessage) }).isEmpty, "Couldn't find expected log message: \(expectedLogMessage)")
     }
     
     func testAddAndRemoveData() {


### PR DESCRIPTION


## :scroll: Description

Added operation and description for warn log when starting child span on a finished span.

## :bulb: Motivation and Context

While analysing debug logs from a customer, seeing operation and description would have been helpful.

## :green_heart: How did you test it?
Unit tests still green and checked a printed log message.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
