### PR TITLE
fix: Change status used to map Kernel error to NSError

### DIFF
--- a/Sources/Sentry/SentrySystemWrapper.mm
+++ b/Sources/Sentry/SentrySystemWrapper.mm
@@ -69,7 +69,7 @@
         if (threadInfoStatus != KERN_SUCCESS) {
             if (error) {
                 *error = NSErrorFromSentryErrorWithKernelError(
-                    kSentryErrorKernel, @"task_threads reported an error.", taskThreadsStatus);
+                    kSentryErrorKernel, @"task_threads reported an error.", threadInfoStatus);
             }
             vm_deallocate(
                 mach_task_self(), reinterpret_cast<vm_address_t>(list), sizeof(*list) * count);


### PR DESCRIPTION
Seems to be a copy-paste error from couple of lines above where the `taskThreadsStatus` was converted to an error.

Not sure if worth a changelog entry, but happy to add one.

#skip-changelog