### PR TITLE
Move swift dependant code out of objc++

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1031,6 +1031,8 @@
 		D8FC98AB2CD0DAB30009824C /* BreadcrumbExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC98AA2CD0DAAC0009824C /* BreadcrumbExtension.swift */; };
 		D8FFE50C2703DBB400607131 /* SwizzlingCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFE50B2703DAAE00607131 /* SwizzlingCallTests.swift */; };
 		FA034AC82DD3DB4900FE3107 /* SentryIntegrationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FA91CC0D2DDB9E32009BF9C6 /* PrivateSentrySDKOnly+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = FA91CC0C2DDB9E2B009BF9C6 /* PrivateSentrySDKOnly+Swift.m */; };
+		FA91CC0F2DDBA026009BF9C6 /* PrivateSentrySDKOnly+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = FA91CC0E2DDBA026009BF9C6 /* PrivateSentrySDKOnly+Swift.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2232,6 +2234,8 @@
 		D8FC98AA2CD0DAAC0009824C /* BreadcrumbExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbExtension.swift; sourceTree = "<group>"; };
 		D8FFE50B2703DAAE00607131 /* SwizzlingCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzlingCallTests.swift; sourceTree = "<group>"; };
 		FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = Public/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
+		FA91CC0C2DDB9E2B009BF9C6 /* PrivateSentrySDKOnly+Swift.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "PrivateSentrySDKOnly+Swift.m"; sourceTree = "<group>"; };
+		FA91CC0E2DDBA026009BF9C6 /* PrivateSentrySDKOnly+Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "PrivateSentrySDKOnly+Swift.h"; path = "include/HybridPublic/PrivateSentrySDKOnly+Swift.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2838,8 +2842,10 @@
 				33EB2A8F2C3411AE004FED3D /* SentryWithoutUIKit.h */,
 				D8B665BA2B95F54200BD0E7B /* SentryPrivate.h */,
 				D8BBD32628FD9FBF0011F850 /* SentrySwift.h */,
+				FA91CC0E2DDBA026009BF9C6 /* PrivateSentrySDKOnly+Swift.h */,
 				D81A346B291AECC7005A27A9 /* PrivateSentrySDKOnly.h */,
 				7B6D1260265F784000C9BE4B /* PrivateSentrySDKOnly.mm */,
+				FA91CC0C2DDB9E2B009BF9C6 /* PrivateSentrySDKOnly+Swift.m */,
 				63AA76941EB9C1C200D153DE /* SentryClient.h */,
 				63AA75ED1EB8B3C400D153DE /* SentryClient.m */,
 				7B85DC1C24EFAFCD007D01D2 /* SentryClient+Private.h */,
@@ -4407,6 +4413,7 @@
 				7B08A3452924CF6C0059603A /* SentryMetricKitIntegration.h in Headers */,
 				0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */,
 				8EAE980C261E9F530073B6B3 /* SentryUIViewControllerPerformanceTracker.h in Headers */,
+				FA91CC0F2DDBA026009BF9C6 /* PrivateSentrySDKOnly+Swift.h in Headers */,
 				63FE717D20DA4C1100CDBAE8 /* SentryCrashCachedData.h in Headers */,
 				7BC9A20028F41016001E7C4C /* SentryMeasurementValue.h in Headers */,
 				7BBC826D25DFCFDE005F1ED8 /* SentryInAppLogic.h in Headers */,
@@ -5004,6 +5011,7 @@
 				63FE712F20DA4C1100CDBAE8 /* SentryCrashSysCtl.c in Sources */,
 				62212B872D520CB00062C2FA /* SentryEventCodable.swift in Sources */,
 				7B3B473825D6CC7E00D01640 /* SentryNSError.m in Sources */,
+				FA91CC0D2DDB9E32009BF9C6 /* PrivateSentrySDKOnly+Swift.m in Sources */,
 				621AE74D2C626C510012E730 /* SentryANRTrackerV2.m in Sources */,
 				84CFA4CA2C9DF884008DA5F4 /* SentryUserFeedbackWidget.swift in Sources */,
 				D8ACE3C82762187200F5A213 /* SentryFileIOTracker.m in Sources */,

--- a/Sources/Resources/Sentry.modulemap
+++ b/Sources/Resources/Sentry.modulemap
@@ -7,6 +7,7 @@ framework module Sentry {
     explicit module _Hybrid {
         // Headers that are not part of the public API and should only be used by hybrid SDKs
         header "PrivateSentrySDKOnly.h"
+        header "PrivateSentrySDKOnly+Swift.h"
         header "PrivatesHeader.h"
         header "SentryAppStartMeasurement.h"
         header "SentryBinaryImageCache.h"

--- a/Sources/Sentry/PrivateSentrySDKOnly+Swift.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly+Swift.m
@@ -1,0 +1,92 @@
+#import "PrivateSentrySDKOnly+Swift.h"
+#import "SentrySwift.h"
+#import "SentrySDK+Private.h"
+#import "SentryHub+Private.h"
+#import "SentrySessionReplayIntegration.h"
+#import "SentrySessionReplayIntegration+Private.h"
+#import "SentryTraceProfiler.h"
+#import "SentryDependencyContainer.h"
+
+@implementation PrivateSentrySDKOnly (Swift)
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
++ (uint64_t)startProfilerForTrace:(SentryId *)traceId;
+{
+    [SentryTraceProfiler startWithTracer:traceId];
+    return SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
+}
+#endif
+
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+
++ (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options
+{
+    return [[SentryMaskingPreviewView alloc] initWithRedactOptions:options];
+}
+
++ (nullable SentrySessionReplayIntegration *)getReplayIntegration
+{
+
+    NSArray *integrations = [[SentrySDK currentHub] installedIntegrations];
+    SentrySessionReplayIntegration *replayIntegration;
+    for (id obj in integrations) {
+        if ([obj isKindOfClass:[SentrySessionReplayIntegration class]]) {
+            replayIntegration = obj;
+            break;
+        }
+    }
+
+    return replayIntegration;
+}
+
++ (void)captureReplay
+{
+    [[PrivateSentrySDKOnly getReplayIntegration] captureReplay];
+}
+
++ (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
+                screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider
+{
+    [[PrivateSentrySDKOnly getReplayIntegration] configureReplayWith:breadcrumbConverter
+                                                  screenshotProvider:screenshotProvider];
+}
+
++ (NSString *__nullable)getReplayId
+{
+    __block NSString *__nullable replayId;
+
+    [SentrySDK configureScope:^(SentryScope *_Nonnull scope) { replayId = scope.replayId; }];
+
+    return replayId;
+}
+
++ (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes
+{
+    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer addIgnoreClasses:classes];
+}
+
++ (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes
+{
+    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer addRedactClasses:classes];
+}
+
++ (void)setIgnoreContainerClass:(Class _Nonnull)containerClass
+{
+    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
+        setIgnoreContainerClass:containerClass];
+}
+
++ (void)setRedactContainerClass:(Class _Nonnull)containerClass
+{
+    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
+        setRedactContainerClass:containerClass];
+}
+
++ (void)setReplayTags:(NSDictionary<NSString *, id> *)tags
+{
+    [[PrivateSentrySDKOnly getReplayIntegration] setReplayTags:tags];
+}
+
+#endif
+
+@end

--- a/Sources/Sentry/PrivateSentrySDKOnly+Swift.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly+Swift.m
@@ -1,11 +1,11 @@
 #import "PrivateSentrySDKOnly+Swift.h"
-#import "SentrySwift.h"
-#import "SentrySDK+Private.h"
-#import "SentryHub+Private.h"
-#import "SentrySessionReplayIntegration.h"
-#import "SentrySessionReplayIntegration+Private.h"
-#import "SentryTraceProfiler.h"
 #import "SentryDependencyContainer.h"
+#import "SentryHub+Private.h"
+#import "SentrySDK+Private.h"
+#import "SentrySessionReplayIntegration+Private.h"
+#import "SentrySessionReplayIntegration.h"
+#import "SentrySwift.h"
+#import "SentryTraceProfiler.h"
 
 @implementation PrivateSentrySDKOnly (Swift)
 

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -13,7 +13,6 @@
 #import "SentrySDK+Private.h"
 #import "SentrySerialization.h"
 #import "SentrySessionReplayIntegration+Private.h"
-#import "SentrySwift.h"
 #import "SentryThreadHandle.hpp"
 #import "SentryUser+Private.h"
 #import "SentryViewHierarchy.h"
@@ -209,12 +208,6 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 }
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
-+ (uint64_t)startProfilerForTrace:(SentryId *)traceId;
-{
-    [SentryTraceProfiler startWithTracer:traceId];
-    return SentryDependencyContainer.sharedInstance.dateProvider.systemTime;
-}
-
 + (nullable NSMutableDictionary<NSString *, id> *)collectProfileBetween:(uint64_t)startSystemTime
                                                                     and:(uint64_t)endSystemTime
                                                                forTrace:(SentryId *)traceId;
@@ -328,77 +321,5 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 {
     return [[SentryBreadcrumb alloc] initWithDictionary:dictionary];
 }
-
-#if SENTRY_TARGET_REPLAY_SUPPORTED
-
-+ (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options
-{
-    return [[SentryMaskingPreviewView alloc] initWithRedactOptions:options];
-}
-
-+ (nullable SentrySessionReplayIntegration *)getReplayIntegration
-{
-
-    NSArray *integrations = [[SentrySDK currentHub] installedIntegrations];
-    SentrySessionReplayIntegration *replayIntegration;
-    for (id obj in integrations) {
-        if ([obj isKindOfClass:[SentrySessionReplayIntegration class]]) {
-            replayIntegration = obj;
-            break;
-        }
-    }
-
-    return replayIntegration;
-}
-
-+ (void)captureReplay
-{
-    [[PrivateSentrySDKOnly getReplayIntegration] captureReplay];
-}
-
-+ (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
-                screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider
-{
-    [[PrivateSentrySDKOnly getReplayIntegration] configureReplayWith:breadcrumbConverter
-                                                  screenshotProvider:screenshotProvider];
-}
-
-+ (NSString *__nullable)getReplayId
-{
-    __block NSString *__nullable replayId;
-
-    [SentrySDK configureScope:^(SentryScope *_Nonnull scope) { replayId = scope.replayId; }];
-
-    return replayId;
-}
-
-+ (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes
-{
-    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer addIgnoreClasses:classes];
-}
-
-+ (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes
-{
-    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer addRedactClasses:classes];
-}
-
-+ (void)setIgnoreContainerClass:(Class _Nonnull)containerClass
-{
-    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
-        setIgnoreContainerClass:containerClass];
-}
-
-+ (void)setRedactContainerClass:(Class _Nonnull)containerClass
-{
-    [[PrivateSentrySDKOnly getReplayIntegration].viewPhotographer
-        setRedactContainerClass:containerClass];
-}
-
-+ (void)setReplayTags:(NSDictionary<NSString *, id> *)tags
-{
-    [[PrivateSentrySDKOnly getReplayIntegration] setReplayTags:tags];
-}
-
-#endif
 
 @end

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly+Swift.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly+Swift.h
@@ -1,0 +1,45 @@
+#import "PrivateSentrySDKOnly.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface PrivateSentrySDKOnly (Swift)
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+/**
+ * Start a profiler session associated with the given @c SentryId.
+ * @return The system time when the profiler session started.
+ */
++ (uint64_t)startProfilerForTrace:(SentryId *)traceId;
+
+#endif
+
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+
+/**
+ * Return an instance of SentryRedactOptions with given option
+ * To be used from SentrySwiftUI, which cannot access the private
+ * `SentryRedactOptions` class.
+ */
++ (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options;
+
+/**
+ * Configure session replay with different breadcrumb converter
+ * and screeshot provider. Used by the Hybrid SDKs.
+ * Passing nil will keep the previous value.
+ */
++ (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
+                screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider;
+
++ (void)captureReplay;
++ (NSString *__nullable)getReplayId;
++ (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes;
++ (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes;
++ (void)setIgnoreContainerClass:(Class _Nonnull)containerClass;
++ (void)setRedactContainerClass:(Class _Nonnull)containerClass;
++ (void)setReplayTags:(NSDictionary<NSString *, id> *)tags;
+
+#endif
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -111,12 +111,6 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 /**
- * Start a profiler session associated with the given @c SentryId.
- * @return The system time when the profiler session started.
- */
-+ (uint64_t)startProfilerForTrace:(SentryId *)traceId;
-
-/**
  * Collect a profiler session data associated with the given @c SentryId.
  * This also discards the profiler.
  */
@@ -190,32 +184,6 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if SENTRY_TARGET_REPLAY_SUPPORTED
-
-/**
- * Return an instance of SentryRedactOptions with given option
- * To be used from SentrySwiftUI, which cannot access the private
- * `SentryRedactOptions` class.
- */
-+ (UIView *)sessionReplayMaskingOverlay:(id<SentryRedactOptions>)options;
-
-/**
- * Configure session replay with different breadcrumb converter
- * and screeshot provider. Used by the Hybrid SDKs.
- * Passing nil will keep the previous value.
- */
-+ (void)configureSessionReplayWith:(nullable id<SentryReplayBreadcrumbConverter>)breadcrumbConverter
-                screenshotProvider:(nullable id<SentryViewScreenshotProvider>)screenshotProvider;
-
-+ (void)captureReplay;
-+ (NSString *__nullable)getReplayId;
-+ (void)addReplayIgnoreClasses:(NSArray<Class> *_Nonnull)classes;
-+ (void)addReplayRedactClasses:(NSArray<Class> *_Nonnull)classes;
-+ (void)setIgnoreContainerClass:(Class _Nonnull)containerClass;
-+ (void)setRedactContainerClass:(Class _Nonnull)containerClass;
-+ (void)setReplayTags:(NSDictionary<NSString *, id> *)tags;
-
-#endif
 + (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans;
 
 + (SentryUser *)userWithDictionary:(NSDictionary *)dictionary;


### PR DESCRIPTION
Objective C++ and Swift interop doesn't work with SPM, so I moved the swift code used by PrivateSentrySDKOnly.mm into a category that is in a .m file, that allowed removing the `#import "SentrySwift.h"` from PrivateSentrySDKOnly.mm

#skip-changelog