### PR TITLE
fix: change http transport flush timeout log to warning

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -226,7 +226,7 @@
         SENTRY_LOG_DEBUG(@"Finished flushing.");
         return kSentryFlushResultSuccess;
     } else {
-        SENTRY_LOG_DEBUG(@"Flushing timed out.");
+        SENTRY_LOG_WARN(@"Flushing timed out.");
         return kSentryFlushResultTimedOut;
     }
 }


### PR DESCRIPTION
It should be a warning

#skip-changelog