### PR TITLE
ci: use availabe iphone model for macos-15 arm64 image

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -133,7 +133,7 @@ jobs:
             device: "iPhone 15 (17.5)"
           - runs-on: macos-15
             xcode: "16.3"
-            device: "iPhone 15 (18.4)"
+            device: "iPhone 16 (18.4)"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Seen at https://github.com/getsentry/sentry-cocoa/actions/runs/15145687017/job/42580715867?pr=5264#step:7:35
![image](https://github.com/user-attachments/assets/8576f318-09b2-4182-87e5-9035fec0b3eb)

per https://github.com/actions/runner-images/blob/be36d1d06526af1f07c78aa924dd5bf8a82ec2bd/images/macos/macos-15-arm64-Readme.md?plain=1#L221 
![image](https://github.com/user-attachments/assets/8610eb5b-4fcf-491f-acfc-def3dcc9dd04)


#skip-changelog