### PR TITLE
ci: fastlane match fixes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -82,13 +82,7 @@ platform :ios do
 
     sync_code_signing(
       type: "appstore",
-      readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift",  "io.sentry.sample.iOS-Swift.Clip"],
-      
-      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
-      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
-      git_branch: "master",
-      clone_branch_directly: true
     )
 
     # We must use build_ios_app because otherwise the build will succeed but it will not create the .ipa file. 
@@ -114,13 +108,7 @@ platform :ios do
 
     sync_code_signing(
       type: "development",
-      readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip"],
-      
-      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
-      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
-      git_branch: "master",
-      clone_branch_directly: true
     )
 
     build_app(
@@ -141,13 +129,7 @@ platform :ios do
 
     sync_code_signing(
       type: "development",
-      readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Swift-UITests.xctrunner"],
-      
-      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
-      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
-      git_branch: "master",
-      clone_branch_directly: true
     )
 
     # don't use gym here because it always appends a "build" command which fails, since this is a test target not configured for running
@@ -164,14 +146,7 @@ platform :ios do
 
     sync_code_signing(
       type: "development",
-      readonly: true,
       app_identifier: ["io.sentry.sample.iOS-Swift", "io.sentry.sample.iOS-Swift.Clip", "io.sentry.iOS-Benchmarking.xctrunner"],
-      
-      
-      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
-      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
-      git_branch: "master",
-      clone_branch_directly: true
     )
 
     build_app(
@@ -317,13 +292,7 @@ platform :ios do
 
     sync_code_signing(
       type: "development",
-      readonly: true,
-      app_identifier: ["io.sentry.cocoa.perf-test-app-plain"],
-      
-      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
-      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
-      git_branch: "master",
-      clone_branch_directly: true
+      app_identifier: ["io.sentry.cocoa.perf-test-app-plain"]
     )
 
     build_app(
@@ -347,13 +316,7 @@ platform :ios do
 
     sync_code_signing(
       type: "development",
-      readonly: true,
       app_identifier: ["io.sentry.cocoa.perf-test-app-sentry"],
-      
-      # Directly cloning the branch instead of using a shallow clone fixes the rare error:
-      #   fatal: a branch named 'master' already exists in GitHub Action workflows.
-      git_branch: "master",
-      clone_branch_directly: true
     )
 
     build_app(

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,4 +2,10 @@ git_url("git@github.com:getsentry/codesigning.git")
 storage_mode("git")
 username("bot@getsentry.com") # Your Apple Developer Portal username
 
+# Directly cloning the branch instead of using a shallow clone fixes the rare error:
+#   fatal: a branch named 'master' already exists in GitHub Action workflows.
+git_branch("master")
+clone_branch_directly(true)
+readonly(true)
+
 # The docs are available on https://docs.fastlane.tools/actions/match

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,7 +2,6 @@ git_url("git@github.com:getsentry/codesigning.git")
 storage_mode("git")
 username("bot@getsentry.com") # Your Apple Developer Portal username
 
-git_branch("master")
 shallow_clone(true)
 clone_branch_directly(true)
 readonly(true)

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -2,9 +2,8 @@ git_url("git@github.com:getsentry/codesigning.git")
 storage_mode("git")
 username("bot@getsentry.com") # Your Apple Developer Portal username
 
-# Directly cloning the branch instead of using a shallow clone fixes the rare error:
-#   fatal: a branch named 'master' already exists in GitHub Action workflows.
 git_branch("master")
+shallow_clone(true)
 clone_branch_directly(true)
 readonly(true)
 

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -3,7 +3,6 @@ storage_mode("git")
 username("bot@getsentry.com") # Your Apple Developer Portal username
 
 shallow_clone(true)
-clone_branch_directly(true)
 readonly(true)
 
 # The docs are available on https://docs.fastlane.tools/actions/match


### PR DESCRIPTION
This is an intermittent failure that's plagued us for a long time. The latest fix was attempted in https://github.com/getsentry/sentry-cocoa/pull/4597 but that still didn't get it, I see a failure today in https://github.com/getsentry/sentry-cocoa/actions/runs/15146553011/job/42583551906?pr=5264#step:10:96

`clone_branch_directly` attempts to create a new branch, which seems like it should _always_ fail since master is the default branch for the repo.

specifying `git_branch` as `master` is just reiterating the default value for that parameter.

Also, centralizes these settings in Matchfile since they're copied at every invocations of `sync_code_signing`

#skip-changelog