### PR TITLE
ci: Fix paths for prettier

### DIFF
--- a/.github/workflows/lint-prettier.yml
+++ b/.github/workflows/lint-prettier.yml
@@ -8,19 +8,17 @@ on:
     branches:
       - main
     paths:
-      - ".github/workflows/lint-prettier.yml"
-      - "*.yml"
-      - "*.yaml"
-      - "*.json"
-      - "*.md"
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "**/*.json"
+      - "**/*.md"
 
   pull_request:
     paths:
-      - ".github/workflows/lint-prettier.yml"
-      - "*.yml"
-      - "*.yaml"
-      - "*.json"
-      - "*.md"
+      - "**/*.yml"
+      - "**/*.yaml"
+      - "**/*.json"
+      - "**/*.md"
 
 jobs:
   lint-prettier:

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -16,7 +16,7 @@ on:
       - "./Sources/Sentry/SentryMeta.m"
       - "./Tests/HybridSDKTest/HybridPod.podspec"
       - "./Sources/Configuration/SDK.xcconfig"
-      - "./Sources/Configuration/Versioning.xcconfig" 
+      - "./Sources/Configuration/Versioning.xcconfig"
       - "./Sources/Configuration/SentrySwiftUI.xcconfig"
       - "./Samples/Shared/Config/Versioning.xcconfig"
 


### PR DESCRIPTION
The path filters only applied to the root dir. Now they work for any files of .yml, .yaml, .json or .md in any directory.

#skip-changelog