### PR TITLE
fix(ci): Add all output logs to the upload artifact step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,12 +232,14 @@ jobs:
           path: |
             /Users/runner/Library/Developer/Xcode/DerivedData/**/Logs/**
 
-      - name: Archiving Raw Test Logs
+      - name: Archiving Raw Logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
-          name: raw-test-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
+          name: raw-output-${{matrix.platform}}-xcode-${{matrix.xcode}}-os-${{matrix.test-destination-os}}
           path: |
+            raw-build-output.log
+            raw-build-for-testing-output.log
             raw-test-output.log
 
       - name: Archiving Crash Logs


### PR DESCRIPTION
Adds all logs that are created during building and testing to the upload artifact.

Without these, the `xcbeautify` settings are too aggressive to see the actual error:

https://github.com/getsentry/sentry-cocoa/actions/runs/15160949791/job/42626770540

#skip-changelog