### PR TITLE
Remove extra imports

### DIFF
--- a/Sources/Swift/Integrations/Performance/IO/SentryFileIOTracker+SwiftHelpers.swift
+++ b/Sources/Swift/Integrations/Performance/IO/SentryFileIOTracker+SwiftHelpers.swift
@@ -1,4 +1,5 @@
 @_implementationOnly import _SentryPrivate
+import Foundation
 
 extension SentryFileIOTracker {
     func measureReadingData(

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebBreadcrumbEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebBreadcrumbEvent.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 class SentryRRWebBreadcrumbEvent: SentryRRWebCustomEvent {

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebSpanEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebSpanEvent.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objc class SentryRRWebSpanEvent: SentryRRWebCustomEvent {

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebVideoEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebVideoEvent.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -1,5 +1,4 @@
 // swiftlint:disable file_length
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayRecording.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayRecording.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayDelegate.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayDelegate.swift
@@ -1,6 +1,5 @@
 import Foundation
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 
 @objc
 protocol SentrySessionReplayDelegate: NSObjectProtocol {

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
@@ -1,6 +1,5 @@
 import Foundation
 #if os(iOS) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 import UIKit
 
 /**

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackFormConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackFormConfiguration.swift
@@ -1,6 +1,5 @@
 import Foundation
 #if os(iOS) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 import UIKit
 
 /**

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackThemeConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackThemeConfiguration.swift
@@ -1,6 +1,5 @@
 import Foundation
 #if os(iOS) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 import UIKit
 
 /**

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
@@ -1,6 +1,5 @@
 import Foundation
 #if os(iOS) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 import UIKit
 
 /**

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
@@ -1,4 +1,3 @@
-@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackFormController.swift
@@ -2,7 +2,6 @@
 
 import Foundation
 #if os(iOS) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 import UIKit
 
 @available(iOS 13.0, *)

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
@@ -2,7 +2,6 @@
 
 import Foundation
 #if os(iOS) && !SENTRY_NO_UIKIT
-@_implementationOnly import _SentryPrivate
 import UIKit
 
 var displayingForm = false

--- a/Sources/Swift/Protocol/Codable/DecodeArbitraryData.swift
+++ b/Sources/Swift/Protocol/Codable/DecodeArbitraryData.swift
@@ -1,4 +1,4 @@
-@_implementationOnly import _SentryPrivate
+import Foundation
 
 /// Represents arbitrary data that can be decoded from JSON with Decodable.
 ///

--- a/Sources/Swift/Tools/SentryLog+Configure.swift
+++ b/Sources/Swift/Tools/SentryLog+Configure.swift
@@ -1,4 +1,5 @@
 @_implementationOnly import _SentryPrivate
+import Foundation
 
 // This helper class exists because if it was just an extension on SentryLog the linker would strip this code unless the "-ObjC" flag was passed.
 // The result would be the selector would be missing at runtime and objc code that calls the method would crash.


### PR DESCRIPTION
I noticed quite a few swift files imported _SentryPrivate despite not using any objc code, this removes those unnecessary imports 

#skip-changelog
