### PR TITLE
Update imports format

### DIFF
--- a/Sources/Sentry/Public/SentryError.h
+++ b/Sources/Sentry/Public/SentryError.h
@@ -1,7 +1,9 @@
 #if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/SentryDefines.h>
-#else
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
 #    import <SentryWithoutUIKit/SentryDefines.h>
+#else
+#    import <SentryDefines.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/Public/SentryFeedbackAPI.h
+++ b/Sources/Sentry/Public/SentryFeedbackAPI.h
@@ -1,7 +1,9 @@
-#if __has_include(<Sentry/SentryDefines.h>)
+#if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/SentryDefines.h>
-#else
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
 #    import <SentryWithoutUIKit/SentryDefines.h>
+#else
+#    import <SentryDefines.h>
 #endif
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -1,10 +1,11 @@
 #if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/SentryDefines.h>
-#    import <Sentry/SentryProfilingConditionals.h>
-#else
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
 #    import <SentryWithoutUIKit/SentryDefines.h>
-#    import <SentryWithoutUIKit/SentryProfilingConditionals.h>
+#else
+#    import <SentryDefines.h>
 #endif
+#import SENTRY_HEADER(SentryProfilingConditionals)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/Public/SentryReplayApi.h
+++ b/Sources/Sentry/Public/SentryReplayApi.h
@@ -1,7 +1,9 @@
-#if __has_include(<Sentry/SentryDefines.h>)
+#if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/SentryDefines.h>
-#else
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
 #    import <SentryWithoutUIKit/SentryDefines.h>
+#else
+#    import <SentryDefines.h>
 #endif
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED

--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -1,12 +1,12 @@
 #if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/SentryDefines.h>
-#    import <Sentry/SentrySerializable.h>
-#    import <Sentry/SentrySpanContext.h>
-#else
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
 #    import <SentryWithoutUIKit/SentryDefines.h>
-#    import <SentryWithoutUIKit/SentrySerializable.h>
-#    import <SentryWithoutUIKit/SentrySpanContext.h>
+#else
+#    import <SentryDefines.h>
 #endif
+#import SENTRY_HEADER(SentrySerializable)
+#import SENTRY_HEADER(SentrySpanContext)
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Sentry/Public/SentryTraceHeader.h
+++ b/Sources/Sentry/Public/SentryTraceHeader.h
@@ -1,10 +1,11 @@
 #if __has_include(<Sentry/Sentry.h>)
 #    import <Sentry/SentryDefines.h>
-#    import <Sentry/SentrySampleDecision.h>
-#else
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
 #    import <SentryWithoutUIKit/SentryDefines.h>
-#    import <SentryWithoutUIKit/SentrySampleDecision.h>
+#else
+#    import <SentryDefines.h>
 #endif
+#import SENTRY_HEADER(SentrySampleDecision)
 
 @class SentryId;
 @class SentrySpanId;

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -1,10 +1,12 @@
 #if __has_include(<Sentry/Sentry.h>)
-#    import <Sentry/SentrySampleDecision.h>
-#    import <Sentry/SentrySpanContext.h>
+#    import <Sentry/SentryDefines.h>
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
+#    import <SentryWithoutUIKit/SentryDefines.h>
 #else
-#    import <SentryWithoutUIKit/SentrySampleDecision.h>
-#    import <SentryWithoutUIKit/SentrySpanContext.h>
+#    import <SentryDefines.h>
 #endif
+#import SENTRY_HEADER(SentrySampleDecision)
+#import SENTRY_HEADER(SentrySpanContext)
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
Continuing the changes from this PR: https://github.com/getsentry/sentry-cocoa/pull/5247 into more header files. This import format lets use use these files from targets other than Sentry and SentryWithoutUIKit

#skip-changelog