### PR TITLE
fix(ci): Add missing update parameter to bump.sh

### DIFF
--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Create fake xcframework for update-package-sha.sh
         run: |
           mkdir -p Carthage
-          echo "<FAKE ZIP>" > Carthage/Sentry.xcframework.zip
-          echo "<FAKE ZIP>" > Carthage/Sentry-Dynamic.xcframework.zip
+          echo "<FAKE STATIC ZIP>" > Carthage/Sentry.xcframework.zip
+          echo "<FAKE DYNAMIC ZIP>" > Carthage/Sentry-Dynamic.xcframework.zip
 
       - name: Bump version
         run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
@@ -75,18 +75,18 @@ jobs:
 
       - name: Verify checksum of static xcframework in Package.swift
         run: |
-          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep checksum | cut -d '"' -f 2)
-          EXPECTED_CHECKSUM="704140318d3b69098d1386b82b9c74faba3408585c1d51bf210cdbdeafeb6894"
+          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep "checksum.*Sentry-Static" | cut -d '"' -f 2)
+          EXPECTED_CHECKSUM="7062a80f8a80f8b6d812698af87384751567a6aaa0df6f03b0596d728b22dcfd"
 
           if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_CHECKSUM" ]; then
-            echo "Expected checksum to be$EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"
+            echo "Expected checksum to be $EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"
             exit 1
           fi
 
       - name: Verify checksum of dynamic xcframework in Package.swift
         run: |
-          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep checksum | cut -d '"' -f 2)
-          EXPECTED_CHECKSUM="704140318d3b69098d1386b82b9c74faba3408585c1d51bf210cdbdeafeb6894"
+          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep "checksum.*Sentry-Dynamic" | cut -d '"' -f 2)
+          EXPECTED_CHECKSUM="f6325cd8f05523d60222451fa61b3cd3d58148e5a21236f82abfd3f92750c87c"
 
           if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_CHECKSUM" ]; then
             echo "Expected checksum to be $EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -22,15 +22,35 @@ on:
 
 jobs:
   run-version-bump:
-    name: Run Version Bump
+    # The release workflow uses the Makefile to bump the version.
+    name: Run Version Bump (Makefile)
     # We intentionally run this on ubuntu because the release workflow also runs on ubuntu, which uses the version bump util.
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Generate Version Number
+        id: generate-version-number
         run: |
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          echo "VERSION=100.0.$TIMESTAMP" >> $GITHUB_ENV
+          echo "VERSION=100.0.$TIMESTAMP" >> $GITHUB_OUTPUT
       # We don't care which version we bump to, as long as it's a valid semver
-      - run: make bump-version TO=${{ env.VERSION }}
-      - run: make verify-version TO=${{ env.VERSION }}
+      - run: make bump-version TO=${{ steps.generate-version-number.outputs.VERSION }}
+      - run: make verify-version TO=${{ steps.generate-version-number.outputs.VERSION }}
+
+  run-version-bump-script:
+    # Craft uses the shell script to bump the version.
+    name: Run Version Bump (Shell Script)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate Version Number
+        id: generate-version-number
+        run: |
+          FROM_VERSION=$(cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2 | tr -d ' ')
+          echo "FROM_VERSION=${FROM_VERSION}" >> $GITHUB_OUTPUT
+
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          echo "VERSION=100.0.$TIMESTAMP" >> $GITHUB_OUTPUT
+
+      - run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.FROM }} ${{ steps.generate-version-number.outputs.VERSION }}
+      - run: make verify-version TO=${{ steps.generate-version-number.outputs.VERSION }}

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -70,33 +70,11 @@ jobs:
       - name: Bump version
         run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
 
-      - name: Verify outputs of bump util
+      - name: Verify outputs of bump.sh
         run: make verify-version TO=${{ steps.generate-version-number.outputs.NEW_VERSION }}
 
-      - name: Verify checksum of static xcframework in Package.swift
-        run: |
-          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep "checksum.*Sentry-Static" | cut -d '"' -f 2)
-          EXPECTED_CHECKSUM="7062a80f8a80f8b6d812698af87384751567a6aaa0df6f03b0596d728b22dcfd"
-
-          if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_CHECKSUM" ]; then
-            echo "Expected checksum to be $EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"
-            exit 1
-          fi
-
-      - name: Verify checksum of dynamic xcframework in Package.swift
-        run: |
-          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep "checksum.*Sentry-Dynamic" | cut -d '"' -f 2)
-          EXPECTED_CHECKSUM="f6325cd8f05523d60222451fa61b3cd3d58148e5a21236f82abfd3f92750c87c"
-
-          if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_CHECKSUM" ]; then
-            echo "Expected checksum to be $EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"
-            exit 1
-          fi
-
-      - name: Verify last-release-runid
-        run: |
-          LAST_RELEASE_RUNID=$(cat .github/last-release-runid)
-          if [ "$LAST_RELEASE_RUNID" != "$GITHUB_RUN_ID" ]; then
-            echo "Expected last-release-runid to be $GITHUB_RUN_ID but got $LAST_RELEASE_RUNID"
-            exit 1
-          fi
+      - name: Verify outputs of update-package-sha.sh
+        run: ./scripts/verify-package-sha.sh \
+          --static-checksum "7062a80f8a80f8b6d812698af87384751567a6aaa0df6f03b0596d728b22dcfd" \
+          --dynamic-checksum "f6325cd8f05523d60222451fa61b3cd3d58148e5a21236f82abfd3f92750c87c" \
+          --last-release-runid "${{ github.run_id }}"

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -19,6 +19,7 @@ on:
       - "./Sources/Configuration/Versioning.xcconfig"
       - "./Sources/Configuration/SentrySwiftUI.xcconfig"
       - "./Samples/Shared/Config/Versioning.xcconfig"
+      - "./scripts/bump.sh"
 
 jobs:
   run-version-bump:

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   run-version-bump:
-    # The release workflow uses the Makefile to bump the version.
+    # The release workflow uses the Makefile to bump the version so it needs to be tested.
     name: Run Version Bump (Makefile)
     # We intentionally run this on ubuntu because the release workflow also runs on ubuntu, which uses the version bump util.
     runs-on: ubuntu-latest
@@ -39,7 +39,7 @@ jobs:
       - run: make verify-version TO=${{ steps.generate-version-number.outputs.VERSION }}
 
   run-version-bump-script:
-    # Craft uses the shell script to bump the version.
+    # Craft uses the shell script to bump the version so it needs to be tested.
     name: Run Version Bump (Shell Script)
     runs-on: ubuntu-latest
     steps:
@@ -47,11 +47,6 @@ jobs:
       - name: Generate Version Number
         id: generate-version-number
         run: |
-          cat ./Sources/Configuration/Versioning.xcconfig
-          cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION
-          cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2
-          cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2 | tr -d ' '
-
           OLD_VERSION=$(cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2 | tr -d ' ')
           echo "Read old version: ${OLD_VERSION}"
           echo "OLD_VERSION=${OLD_VERSION}" >> $GITHUB_OUTPUT
@@ -66,5 +61,42 @@ jobs:
           echo "OLD_VERSION is not defined"
           exit 1
 
-      - run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
-      - run: make verify-version TO=${{ steps.generate-version-number.outputs.NEW_VERSION }}
+      - name: Create fake xcframework for update-package-sha.sh
+        run: |
+          mkdir -p Carthage
+          echo "<FAKE ZIP>" > Carthage/Sentry.xcframework.zip
+          echo "<FAKE ZIP>" > Carthage/Sentry-Dynamic.xcframework.zip
+
+      - name: Bump version
+        run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
+
+      - name: Verify outputs of bump util
+        run: make verify-version TO=${{ steps.generate-version-number.outputs.NEW_VERSION }}
+
+      - name: Verify checksum of static xcframework in Package.swift
+        run: |
+          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep checksum | cut -d '"' -f 2)
+          EXPECTED_CHECKSUM="704140318d3b69098d1386b82b9c74faba3408585c1d51bf210cdbdeafeb6894"
+
+          if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_CHECKSUM" ]; then
+            echo "Expected checksum to be$EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"
+            exit 1
+          fi
+
+      - name: Verify checksum of dynamic xcframework in Package.swift
+        run: |
+          UPDATED_PACKAGE_SHA=$(cat Package.swift | grep checksum | cut -d '"' -f 2)
+          EXPECTED_CHECKSUM="704140318d3b69098d1386b82b9c74faba3408585c1d51bf210cdbdeafeb6894"
+
+          if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_CHECKSUM" ]; then
+            echo "Expected checksum to be $EXPECTED_CHECKSUM but got $UPDATED_PACKAGE_SHA"
+            exit 1
+          fi
+
+      - name: Verify last-release-runid
+        run: |
+          LAST_RELEASE_RUNID=$(cat .github/last-release-runid)
+          if [ "$LAST_RELEASE_RUNID" != "$GITHUB_RUN_ID" ]; then
+            echo "Expected last-release-runid to be $GITHUB_RUN_ID but got $LAST_RELEASE_RUNID"
+            exit 1
+          fi

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -47,11 +47,24 @@ jobs:
       - name: Generate Version Number
         id: generate-version-number
         run: |
-          FROM_VERSION=$(cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2 | tr -d ' ')
-          echo "FROM_VERSION=${FROM_VERSION}" >> $GITHUB_OUTPUT
+          cat ./Sources/Configuration/Versioning.xcconfig
+          cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION
+          cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2
+          cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2 | tr -d ' '
 
-          TIMESTAMP=$(date +%Y%m%d%H%M%S)
-          echo "VERSION=100.0.$TIMESTAMP" >> $GITHUB_OUTPUT
+          OLD_VERSION=$(cat ./Sources/Configuration/Versioning.xcconfig | grep MARKETING_VERSION | cut -d '=' -f 2 | tr -d ' ')
+          echo "Read old version: ${OLD_VERSION}"
+          echo "OLD_VERSION=${OLD_VERSION}" >> $GITHUB_OUTPUT
 
-      - run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.FROM }} ${{ steps.generate-version-number.outputs.VERSION }}
-      - run: make verify-version TO=${{ steps.generate-version-number.outputs.VERSION }}
+          NEW_VERSION="100.0.$(date +%Y%m%d%H%M%S)"
+          echo "Generated new version: ${NEW_VERSION}"
+          echo "NEW_VERSION=${NEW_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Verify OLD_VERSION is defined
+        if: ${{ steps.generate-version-number.outputs.OLD_VERSION == '' }}
+        run: |
+          echo "OLD_VERSION is not defined"
+          exit 1
+
+      - run: ./scripts/bump.sh ${{ steps.generate-version-number.outputs.OLD_VERSION }} ${{ steps.generate-version-number.outputs.NEW_VERSION }}
+      - run: make verify-version TO=${{ steps.generate-version-number.outputs.NEW_VERSION }}

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Verify OLD_VERSION is defined
         if: ${{ steps.generate-version-number.outputs.OLD_VERSION == '' }}
         run: |
-          echo "OLD_VERSION is not defined"
+          echo "OLD_VERSION is not defined. Make sure this script is reading the version from the correct file."
           exit 1
 
       - name: Create fake xcframework for update-package-sha.sh

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -74,7 +74,8 @@ jobs:
         run: make verify-version TO=${{ steps.generate-version-number.outputs.NEW_VERSION }}
 
       - name: Verify outputs of update-package-sha.sh
-        run: ./scripts/verify-package-sha.sh \
-          --static-checksum "7062a80f8a80f8b6d812698af87384751567a6aaa0df6f03b0596d728b22dcfd" \
-          --dynamic-checksum "f6325cd8f05523d60222451fa61b3cd3d58148e5a21236f82abfd3f92750c87c" \
-          --last-release-runid "${{ github.run_id }}"
+        run: |
+          ./scripts/verify-package-sha.sh \
+            --static-checksum "7062a80f8a80f8b6d812698af87384751567a6aaa0df6f03b0596d728b22dcfd" \
+            --dynamic-checksum "f6325cd8f05523d60222451fa61b3cd3d58148e5a21236f82abfd3f92750c87c" \
+            --last-release-runid "${{ github.run_id }}"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -eux
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR/.."
 
 OLD_VERSION="${1}"
@@ -10,6 +10,6 @@ echo "--> Clean VersionBump"
 cd Utils/VersionBump && swift build
 cd "$SCRIPT_DIR/.."
 echo "--> Bumping version to ${OLD_VERSION} ${NEW_VERSION}"
-./Utils/VersionBump/.build/debug/VersionBump "${NEW_VERSION}"
+./Utils/VersionBump/.build/debug/VersionBump --update "${NEW_VERSION}"
 
 ./scripts/update-package-sha.sh

--- a/scripts/verify-package-sha.sh
+++ b/scripts/verify-package-sha.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script is used to verify the checksum of the static and dynamic xcframeworks in Package.swift
+# and the last-release-runid in .github/last-release-runid.
+# It is used to verify the outputs of the update-package-sha.sh script.
+
+# Parse command line arguments
+EXPECTED_STATIC_CHECKSUM=""
+EXPECTED_DYNAMIC_CHECKSUM=""
+EXPECTED_LAST_RELEASE_RUNID=""
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+    --static-checksum)
+        EXPECTED_STATIC_CHECKSUM="$2"
+        shift 2
+        ;;
+    --dynamic-checksum)
+        EXPECTED_DYNAMIC_CHECKSUM="$2"
+        shift 2
+        ;;
+    --last-release-runid)
+        EXPECTED_LAST_RELEASE_RUNID="$2"
+        shift 2
+        ;;
+    *)
+        echo "Unknown option: $1"
+        exit 1
+        ;;
+    esac
+done
+
+# Validate required arguments
+if [ -z "$EXPECTED_STATIC_CHECKSUM" ]; then
+    echo "Error: --static-checksum is required"
+    exit 1
+fi
+
+if [ -z "$EXPECTED_DYNAMIC_CHECKSUM" ]; then
+    echo "Error: --dynamic-checksum is required"
+    exit 1
+fi
+
+if [ -z "$EXPECTED_LAST_RELEASE_RUNID" ]; then
+    echo "Error: --last-release-runid is required"
+    exit 1
+fi
+
+echo "Verify checksum of static xcframework in Package.swift"
+UPDATED_PACKAGE_SHA=$(grep "checksum.*Sentry-Static" Package.swift | cut -d '"' -f 2)
+if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_STATIC_CHECKSUM" ]; then
+    echo "::error::Expected checksum to be $EXPECTED_STATIC_CHECKSUM but got $UPDATED_PACKAGE_SHA"
+    exit 1
+fi
+
+echo "Verify checksum of dynamic xcframework in Package.swift"
+UPDATED_PACKAGE_SHA=$(grep "checksum.*Sentry-Dynamic" Package.swift | cut -d '"' -f 2)
+if [ "$UPDATED_PACKAGE_SHA" != "$EXPECTED_DYNAMIC_CHECKSUM" ]; then
+    echo "::error::Expected checksum to be $EXPECTED_DYNAMIC_CHECKSUM but got $UPDATED_PACKAGE_SHA"
+    exit 1
+fi
+
+echo "Verify last-release-runid"
+LAST_RELEASE_RUNID=$(cat .github/last-release-runid)
+if [ "$LAST_RELEASE_RUNID" != "$EXPECTED_LAST_RELEASE_RUNID" ]; then
+    echo "::error::Expected last-release-runid to be $EXPECTED_LAST_RELEASE_RUNID but got $LAST_RELEASE_RUNID"
+    exit 1
+fi


### PR DESCRIPTION
The release workflow uses `make bump` while the craft script uses `./scripts/bump.sh`.
The version bump utility was updated and tested for the Makefil, but not for the script.

This PR adds a fix and extends the test workflows to cover both.
It also adds tests for the `update-package-sha.sh` which is used by `bump.sh`.

#skip-changelog