### PR TITLE
Add API stability check

### DIFF
--- a/.github/workflows/api-stability.yml
+++ b/.github/workflows/api-stability.yml
@@ -1,0 +1,69 @@
+name: API Stability Check
+
+on:
+  pull_request:
+    paths:
+      - "Sources/**"
+      - "test-server/**"
+      - ".github/workflows/api-stability.yml"
+      - Sentry.xcworkspace/**
+      - Sentry.xcodeproj/**
+      - "Package.swift"
+      - "scripts/build-xcframework.sh"
+
+jobs:
+  api-stability:
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: ./scripts/ci-select-xcode.sh 16.3
+
+      - name: Build SDK
+        run: |
+          ./scripts/build-xcframework.sh iOSOnly
+
+      - name: Dump SDK at HEAD
+        run: |
+          xcrun --sdk iphoneos swift-api-digester \
+            -dump-sdk \
+            -o out_head.json \
+            -abort-on-module-fail \
+            -avoid-tool-args \
+            -avoid-location \
+            -module Sentry \
+            -target arm64-apple-ios10.0 \
+            -iframework ./Carthage/Sentry-Dynamic.xcframework/ios-arm64_arm64e
+
+      - name: Checkout PR base
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+
+      - name: Build SDK
+        run: |
+          ./scripts/build-xcframework.sh iOSOnly
+
+      - name: Dump SDK at BASE
+        run: |
+          xcrun --sdk iphoneos swift-api-digester \
+            -dump-sdk \
+            -o out_base.json \
+            -abort-on-module-fail \
+            -avoid-tool-args \
+            -avoid-location \
+            -module Sentry \
+            -target arm64-apple-ios10.0 \
+            -iframework ./Carthage/Sentry-Dynamic.xcframework/ios-arm64_arm64e
+
+      - name: Diagnose breaking changes
+        run: |
+          xcrun --sdk iphoneos swift-api-digester \
+            -diagnose-sdk \
+            -o result.json \
+            -input-paths out_base.json \
+            -input-paths out_head.json \
+            -json \
+            -v
+          cat result.json


### PR DESCRIPTION
SPM has built in support for determining if a change breaks the public API of a framework using `swift package diagnose-api-breaking-changes` However I couldn't get this to work with a prebuilt binary. Internally that command uses `swift-api-digester` which is not very documented but I found a few threads on like [this one](https://forums.swift.org/t/using-swift-api-digester/22956). 

This PR runs swift-api-digester to get a report of anything that change in the API which may be a breaking change. This does not do any checking of the report to prevent any change from landing, it just generates the report so if anyone is interested they can look at it on their PRs. I think it's good to have running in main as a sanity check, and to ensure the processes used to generate the report doesn't break.

I stopped short of having a breaking diff fail the CI check for two reasons:
1. Sometimes we do want to merge breaking changes, for example a feature that we are still working on and isn't released yet. Also adding a new default parameter to a function is considered a breaking change. Although it requires re-building the app since the exported symbol did change, it is still source code compatible and this tool doesn't check for that.
2. A false sense of security. Not every breaking change is caught by this, for example this is a Swift only tool so it won't detect if you drop an `@objc` annotation.


You can see the results of running this in the CI check logs. Here's a diff with no breaking changes
```
/* Generic Signature Changes */
/* RawRepresentable Changes */
/* Removed Decls */
/* Moved Decls */
/* Renamed Decls */
/* Type Changes */
/* Decl Attribute changes */
/* Fixed-layout Type Changes */
/* Protocol Conformance Change */
/* Protocol Requirement Change */
/* Class Inheritance Change */
/* Others */
```

This only checks iOS, but we could add others if this turns out to be useful!

#skip-changelog
