### PR TITLE
ci: Remove redundant Sample paths for build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,6 @@ on:
       - Gemfile.lock
       - "Package.swift"
       - "scripts/build-xcframework.sh"
-      - "Samples/iOS-Swift/iOS-Swift.yml"
-      - "Samples/iOS-Swift/iOS-Swift.xcconfig"
-      - "Samples/iOS-Swift/iOS-SwiftClilp.xcconfig"
-      - "Samples/iOS13-Swift/iOS13-Swift.yml"
-      - "Samples/iOS13-Swift/iOS13-Swift.xcconfig"
-      - "Samples/SessionReplay-CameraTest/SessionReplay-CameraTest.yml"
-      - "Samples/SessionReplay-CameraTest/SessionReplay-CameraTest.xcconfig"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:


### PR DESCRIPTION
The build.yml already specifies Samples/**, so no need to specify all the Samples/.. paths.

https://github.com/getsentry/sentry-cocoa/blob/25e00aa395feb46c07df40f02805b43c8fd716cd/.github/workflows/build.yml#L12

#skip-changelog