### PR TITLE
ci: Clean up workflow paths for Samples

### DIFF
--- a/.github/workflows/benchmarking.yml
+++ b/.github/workflows/benchmarking.yml
@@ -16,10 +16,6 @@ on:
       - "fastlane/**"
       - "scripts/ci-select-xcode.sh"
       - "scripts/build-xcframework.sh"
-      - "Samples/iOS-Swift/iOS-Swift.yml"
-      - "Samples/iOS-Swift/iOS-Swift.xcconfig"
-      - "Samples/iOS-Swift/iOS-SwiftClilp.xcconfig"
-      - "Samples/iOS-Swift/iOS-Benchmarking.xcconfig"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -12,17 +12,10 @@ on:
       - "fastlane/**"
       - ".sauce/config.yml"
       - "scripts/ci-select-xcode.sh"
-      - "Samples/iOS-Swift/**"
       - "**/*.xctestplan"
-      - "Samples/iOS-SwiftUI/iOS-SwiftUI.yml"
-      - "Samples/iOS-SwiftUI/iOS-SwiftUI.xcconfig"
-      - "Samples/iOS-SwiftUI/iOS-SwiftUI-UITests.xcconfig"
-      - "Samples/iOS-Swift/iOS-Swift.yml"
-      - "Samples/iOS-Swift/iOS-Swift.xcconfig"
-      - "Samples/iOS-Swift/iOS-Swift-UITests.xcconfig"
-      - "Samples/iOS-Swift6/iOS-Swift6.yml"
-      - "Samples/iOS-Swift6/iOS-Swift6.xcconfig"
-      - "Samples/iOS-Swift6/iOS-Swift6-UITests.xcconfig"
+      - "Samples/iOS-SwiftUI/**"
+      - "Samples/iOS-Swift/**"
+      - "Samples/iOS-Swift6/**"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:


### PR DESCRIPTION
Removed specific Sample paths from benchmarking.yml and ui-tests.yml as they are already covered by broader patterns. This simplifies the configuration and reduces redundancy.

Benchmarking already uses the following 
https://github.com/getsentry/sentry-cocoa/blob/e421584c7e358dbc534483654f83e52d7c85ac08/.github/workflows/benchmarking.yml#L13

Follow up on https://github.com/getsentry/sentry-cocoa/pull/5291.

#skip-changelog
