### PR TITLE
impr: Remove lock in SentryLog.configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Improvements
 
-- Remove unnecessary lock in SentryLog.configure (#5297)
+- Slightly reduce performance impact by removing unnecessary lock in SentryLog.configure (#5297)
 
 ## 8.51.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- Remove unnecessary lock in SentryLog.configure (#5297)
+
 ## 8.51.1
 
 ### Fixes

--- a/Sources/Resources/ThreadSanitizer.sup
+++ b/Sources/Resources/ThreadSanitizer.sup
@@ -8,3 +8,7 @@ race:disable
 race:URLSessionDataTaskMock
 race:getOriginalImplementation
 race:SentrySpanContext
+
+# False positives
+# SentryLog isn't 100% thread safe, which we accept. For more information read the code docs of SentryLog.
+race:SentryLog

--- a/Sources/Swift/Core/Tools/SentryLog.swift
+++ b/Sources/Swift/Core/Tools/SentryLog.swift
@@ -1,5 +1,15 @@
 import Foundation
 
+/// A note on the thread safety:
+/// The methods configure and log don't use synchronization mechanisms, meaning they aren't strictly speaking thread-safe.
+/// Still, you can use log from multiple threads. The problem is that when you call configure while
+/// calling log from multiple threads, you experience a race condition. It can take a bit until all
+/// threads know the new config. As the SDK should only call configure once when starting, we do accept
+/// this race condition. Adding locks for evaluating the log level for every log invocation isn't
+/// acceptable, as this adds a significant overhead for every log call. Therefore, we exclude SentryLog
+/// from the ThreadSanitizer as it produces false positives. The tests call configure multiple times,
+/// and the thread sanitizer would surface these race conditions. We accept these race conditions for
+/// the log messages in the tests over adding locking for all log messages.
 @objc
 class SentryLog: NSObject {
     
@@ -11,14 +21,11 @@ class SentryLog: NSObject {
      */
     static let alwaysLevel = SentryLevel.fatal
     private static var logOutput = SentryLogOutput()
-    private static var logConfigureLock = NSLock()
     private static var dateProvider: SentryCurrentDateProvider = SentryDefaultCurrentDateProvider()
 
     static func _configure(_ isDebug: Bool, diagnosticLevel: SentryLevel) {
-        logConfigureLock.synchronized {
-            self.isDebug = isDebug
-            self.diagnosticLevel = diagnosticLevel
-        }
+        self.isDebug = isDebug
+        self.diagnosticLevel = diagnosticLevel
     }
     
     @objc


### PR DESCRIPTION


## :scroll: Description

Remove unnecessary lock in SentryLog.configure as it's not required because we don't call configure from multiple threads anyways. Furthermore, SentryLog isn't fully thread safe anyways when calling configure and log from multiple threads. We accept these race conditions not leading to crashes because the SentrySDK only calls configure during start and making these methods thread-safe by using locks would add a significant overhead to all log messages. This PR ignores SentryLog for the ThreadSanitizer.

## :bulb: Motivation and Context

The thread sanitizer is disabled in CI. This brings us one step closer for enabling it again.

## :green_heart: How did you test it?

Unit tests and running the thread sanitizer locally.

## :pencil: Checklist

You have to check all boxes before merging:

-  [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
