### PR TITLE
feat: Add class loaded twice validator

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -991,6 +991,7 @@
 		D8F8F5572B835BC600AC5465 /* SentryMsgPackSerializerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D8F8F5562B835BC600AC5465 /* SentryMsgPackSerializerTests.m */; };
 		D8FC98AB2CD0DAB30009824C /* BreadcrumbExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FC98AA2CD0DAAC0009824C /* BreadcrumbExtension.swift */; };
 		D8FFE50C2703DBB400607131 /* SwizzlingCallTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8FFE50B2703DAAE00607131 /* SwizzlingCallTests.swift */; };
+		F4046F9B2DE4F6C2000B855B /* LoadValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4046F9A2DE4F6C2000B855B /* LoadValidator.swift */; };
 		FA034AC82DD3DB4900FE3107 /* SentryIntegrationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA67DCC12DDBD4C800896B02 /* SentryLog+Configure.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCC02DDBD4C800896B02 /* SentryLog+Configure.swift */; };
 		FA67DCF42DDBD4EA00896B02 /* SentryExperimentalOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCF12DDBD4EA00896B02 /* SentryExperimentalOptions.swift */; };
@@ -2192,6 +2193,7 @@
 		D8F8F5562B835BC600AC5465 /* SentryMsgPackSerializerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMsgPackSerializerTests.m; sourceTree = "<group>"; };
 		D8FC98AA2CD0DAAC0009824C /* BreadcrumbExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BreadcrumbExtension.swift; sourceTree = "<group>"; };
 		D8FFE50B2703DAAE00607131 /* SwizzlingCallTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwizzlingCallTests.swift; sourceTree = "<group>"; };
+		F4046F9A2DE4F6C2000B855B /* LoadValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadValidator.swift; sourceTree = "<group>"; };
 		FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = Public/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
 		FA67DCC02DDBD4C800896B02 /* SentryLog+Configure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SentryLog+Configure.swift"; sourceTree = "<group>"; };
 		FA67DCC22DDBD4EA00896B02 /* NSLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSLock.swift; sourceTree = "<group>"; };
@@ -4391,6 +4393,7 @@
 				FA67DCED2DDBD4EA00896B02 /* UIImageHelper.swift */,
 				FA67DCEE2DDBD4EA00896B02 /* UrlSanitized.swift */,
 				FA67DCEF2DDBD4EA00896B02 /* URLSessionTaskHelper.swift */,
+				F4046F9A2DE4F6C2000B855B /* LoadValidator.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -5297,6 +5300,7 @@
 				03F84D3527DD4191008FE43F /* SentryThreadHandle.cpp in Sources */,
 				0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */,
 				D84D2CDD2C2BF7370011AF8A /* SentryReplayEvent.swift in Sources */,
+				F4046F9B2DE4F6C2000B855B /* LoadValidator.swift in Sources */,
 				D8BC28CC2BFF78220054DA4D /* SentryRRWebTouchEvent.swift in Sources */,
 				8EA1ED0B2668F8C400E62B98 /* SentryUIViewControllerSwizzling.m in Sources */,
 				7B98D7CF25FB650F00C5A389 /* SentryWatchdogTerminationTrackingIntegration.m in Sources */,

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -225,6 +225,8 @@ static NSDate *_Nullable startTimestamp = nil;
     // thread could lead to deadlocks.
     SENTRY_LOG_DEBUG(@"Starting SDK...");
 
+    [LoadValidator validateLoadedOnce];
+
 #if defined(DEBUG) || defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
     SENTRY_LOG_DEBUG(@"Configured options: %@", options.debugDescription);
 #endif // defined(DEBUG) || defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)

--- a/Sources/Swift/Core/Tools/LoadValidator.swift
+++ b/Sources/Swift/Core/Tools/LoadValidator.swift
@@ -1,0 +1,69 @@
+//
+//  LoadValidator.swift
+//  Sentry
+//
+//  Created by Itay Brenner on 26/5/25.
+//  Copyright © 2025 Sentry. All rights reserved.
+//
+
+import Foundation
+import MachO
+
+@objc
+class LoadValidator: NSObject {
+    // Any class should be fine
+    static let targetClassName = "PrivateSentrySDKOnly"
+    
+    @objc
+    class func validateLoadedOnce() {
+        let imageCount = _dyld_image_count()
+        
+        var imagesWhereSentryIsFound: [String] = [String]()
+        
+        // Iterate over all images to make sure none of them contains a Sentry implementation twice
+        for i in 0..<imageCount {
+            guard let cImageName = _dyld_get_image_name(i) else { continue }
+            
+            // Skip Apple Frameworks
+            let imagePath = String(cString: cImageName)
+            
+            let systemLibraryPath = "/usr/lib/"
+#if targetEnvironment(simulator)
+            let ignoredPath = "/Library/Developer/CoreSimulator/Profiles/Runtimes/"
+#else
+            let ignoredPath = "/System/Library/"
+#endif
+            if imagePath.contains(ignoredPath) || imagePath.hasPrefix(systemLibraryPath) {
+                continue
+            }
+            
+            var classCount: UInt32 = 0
+            if let classNames = objc_copyClassNamesForImage(cImageName, &classCount) {
+                for j in 0..<Int(classCount) {
+                    let name = String(cString: classNames[j])
+                    if name.contains(self.targetClassName) {
+                        imagesWhereSentryIsFound.append(imagePath)
+                        break
+                    }
+                }
+                free(classNames)
+            }
+        }
+        
+        if imagesWhereSentryIsFound.count > 1 {
+#if DEBUG
+            var message = ["❌ Sentry SDK was loaded multiple times in the binary ❌"]
+            message.append("⚠️ This can cause undefined behavior, crashes, or duplicate reporting.")
+            message.append("Ensure the SDK is linked only once")
+            imagesWhereSentryIsFound.forEach { path in
+                message.append("  - \(path)")
+            }
+            SentryLog.log(message: message.joined(separator: "\n"), andLevel: SentryLevel.debug)
+            // Raise a debugger breakpoint
+            raise(SIGTRAP)
+#else
+            SentryLog.log(message: "❌ Sentry SDK was loaded multiple times in the binary ❌", andLevel: SentryLevel.warning)
+#endif
+        }
+    }
+}


### PR DESCRIPTION
## :scroll: Description

Add a log message when Sentry SDK is found to be present twice + Added a breakpoint

## :bulb: Motivation and Context

Fixes #4566 

## :green_heart: How did you test it?

Running duplicated SDK app + Unit Tests cases

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
