### PR TITLE
feat(replay): Redact React Native text and images by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Improvements
 
 - Slightly reduce performance impact by removing unnecessary lock in SentryLog.configure (#5297)
+- Redact React Native text and images by default without the RN SDK (#5302)
 
 ## 8.51.1
 

--- a/Sources/Swift/Core/Tools/ViewCapture/UIRedactBuilder.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/UIRedactBuilder.swift
@@ -75,6 +75,9 @@ class UIRedactBuilder {
         
         if options.maskAllText {
             redactClasses += [ UILabel.self, UITextView.self, UITextField.self ]
+            // These classes are used by React Native to display text.
+            // We are including them here to avoid leaking text from RN apps with manually initialized sentry-cocoa.
+            redactClasses += ["RCTTextView", "RCTParagraphComponentView"].compactMap(NSClassFromString(_:))
         }
         
         if options.maskAllImages {
@@ -83,6 +86,10 @@ class UIRedactBuilder {
              "_TtC7SwiftUIP33_A34643117F00277B93DEBAB70EC0697122_UIShapeHitTestingView",
              "SwiftUI._UIGraphicsView", "SwiftUI.ImageLayer"
             ].compactMap(NSClassFromString(_:))
+
+            // These classes are used by React Native to display images/vectors.
+            // We are including them here to avoid leaking images from RN apps with manually initialized sentry-cocoa.
+            redactClasses += ["RCTImageView"].compactMap(NSClassFromString(_:))
             
             redactClasses.append(UIImageView.self)
         }

--- a/Tests/SentryTests/ViewCapture/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/ViewCapture/UIRedactBuilderTests.swift
@@ -53,7 +53,7 @@ class UIRedactBuilderTests: XCTestCase {
         }
     }
     
-    private var rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+    private let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
     
     private func getSut(_ option: RedactOptions = RedactOptions()) -> UIRedactBuilder {
         return UIRedactBuilder(options: option)

--- a/Tests/SentryTests/ViewCapture/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/ViewCapture/UIRedactBuilderTests.swift
@@ -56,7 +56,6 @@ class UIRedactBuilderTests: XCTestCase {
     private var rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
     
     private func getSut(_ option: RedactOptions = RedactOptions()) -> UIRedactBuilder {
-        rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         return UIRedactBuilder(options: option)
     }
     

--- a/Tests/SentryTests/ViewCapture/UIRedactBuilderTests.swift
+++ b/Tests/SentryTests/ViewCapture/UIRedactBuilderTests.swift
@@ -19,6 +19,27 @@ class RedactOptions: SentryRedactOptions {
     }
 }
 
+/*
+ * Mocked RCTTextView to test the redaction of text from React Native apps.
+ */
+@objc(RCTTextView)
+class RCTTextView: UIView {
+}
+
+/*
+ * Mocked RCTParagraphComponentView to test the redaction of text from React Native apps.
+ */
+@objc(RCTParagraphComponentView)
+class RCTParagraphComponentView: UIView {
+}
+
+/*
+ * Mocked RCTImageView to test the redaction of images from React Native apps.
+ */
+@objc(RCTImageView)
+class RCTImageView: UIView {
+}
+
 class UIRedactBuilderTests: XCTestCase {
     private class CustomVisibilityView: UIView {
         class CustomLayer: CALayer {
@@ -32,9 +53,10 @@ class UIRedactBuilderTests: XCTestCase {
         }
     }
     
-    private let rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
+    private var rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
     
     private func getSut(_ option: RedactOptions = RedactOptions()) -> UIRedactBuilder {
+        rootView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         return UIRedactBuilder(options: option)
     }
     
@@ -77,6 +99,69 @@ class UIRedactBuilderTests: XCTestCase {
         let label = UILabel(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
         label.textColor = .purple
         rootView.addSubview(label)
+        
+        let result = sut.redactRegionsFor(view: rootView)
+        
+        XCTAssertEqual(result.count, 0)
+    }
+    
+    func testRedactRCTTextView() {
+        let sut = getSut(RedactOptions(maskAllText: true))
+        let textView = RCTTextView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        rootView.addSubview(textView)
+        
+        let result = sut.redactRegionsFor(view: rootView)
+        
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.size, CGSize(width: 40, height: 40))
+    }
+
+    func testDoNotRedactRCTTextView() {
+        let sut = getSut(RedactOptions(maskAllText: false))
+        let textView = RCTTextView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        rootView.addSubview(textView)
+        
+        let result = sut.redactRegionsFor(view: rootView)
+        
+        XCTAssertEqual(result.count, 0)
+    }
+    
+    func testRedactRCTParagraphComponentView() {
+        let sut = getSut(RedactOptions(maskAllText: true))
+        let textView = RCTParagraphComponentView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        rootView.addSubview(textView)
+        
+        let result = sut.redactRegionsFor(view: rootView)
+        
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.size, CGSize(width: 40, height: 40))
+    }
+    
+    func testDoNotRedactRCTParagraphComponentView() {
+        let sut = getSut(RedactOptions(maskAllText: false))
+        let textView = RCTParagraphComponentView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        rootView.addSubview(textView)
+        
+        let result = sut.redactRegionsFor(view: rootView)
+        
+        XCTAssertEqual(result.count, 0)
+    }
+    
+    func testRedactRCTImageView() {
+        let sut = getSut(RedactOptions(maskAllImages: true))
+        let imageView = RCTImageView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        rootView.addSubview(imageView)
+        
+        let result = sut.redactRegionsFor(view: rootView)
+        
+        XCTAssertEqual(result.count, 1)
+        XCTAssertEqual(result.first?.size, CGSize(width: 40, height: 40))
+    }
+    
+    func testDoNotRedactRCTImageView() {
+        let sut = getSut(RedactOptions(maskAllImages: false))
+        let imageView = RCTImageView(frame: CGRect(x: 20, y: 20, width: 40, height: 40))
+        rootView.addSubview(imageView)
         
         let result = sut.redactRegionsFor(view: rootView)
         


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

The cocoa SDK can be manually initialized in RN applications with or without the RN SDK. This can lead to unexpected behavior where RN text and images are not masked correctly.

This PR adds the RN text and images classes to be redacted when `maskAllText` and `maskAllImages` are used.

I have not included the RN SVG class as cocoa doesn't have `maskAllVectors`. 

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

fixes: https://github.com/getsentry/sentry-cocoa/issues/5301

## :green_heart: How did you test it?

Added unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
