### PR TITLE
fix: Add nullability to deserialization method

### DIFF
--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -442,7 +442,7 @@
 - (void)recordLostSpans:(SentryEnvelopeItem *)envelopeItem reason:(SentryDiscardReason)reason
 {
     if ([SentryEnvelopeItemTypeTransaction isEqualToString:envelopeItem.header.type]) {
-        NSDictionary *transactionJson =
+        NSDictionary *_Nullable transactionJson =
             [SentrySerialization deserializeDictionaryFromJsonData:envelopeItem.data];
         if (transactionJson == nil) {
             return;

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -760,7 +760,7 @@ NS_ASSUME_NONNULL_BEGIN
     for (SentryEnvelopeItem *item in items) {
         if ([item.header.type isEqualToString:SentryEnvelopeItemTypeEvent]) {
             // If there is no level the default is error
-            NSDictionary *eventJson =
+            NSDictionary *_Nullable eventJson =
                 [SentrySerialization deserializeDictionaryFromJsonData:item.data];
             if (eventJson == nil) {
                 return NO;

--- a/Sources/Sentry/SentrySerialization.m
+++ b/Sources/Sentry/SentrySerialization.m
@@ -283,12 +283,12 @@ NS_ASSUME_NONNULL_BEGIN
     return [[SentryAppState alloc] initWithJSONObject:appSateDictionary];
 }
 
-+ (NSDictionary *)deserializeDictionaryFromJsonData:(NSData *)data
++ (NSDictionary *_Nullable)deserializeDictionaryFromJsonData:(NSData *)data
 {
     NSError *error = nil;
-    NSDictionary *eventDictionary = [NSJSONSerialization JSONObjectWithData:data
-                                                                    options:0
-                                                                      error:&error];
+    NSDictionary *_Nullable eventDictionary = [NSJSONSerialization JSONObjectWithData:data
+                                                                              options:0
+                                                                                error:&error];
     if (nil != error) {
         SENTRY_LOG_ERROR(@"Failed to deserialize json item dictionary: %@", error);
     }

--- a/Sources/Sentry/include/SentrySerialization.h
+++ b/Sources/Sentry/include/SentrySerialization.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Retrieves the json object from an event envelope item data.
  */
-+ (NSDictionary *)deserializeDictionaryFromJsonData:(NSData *)data;
++ (NSDictionary *_Nullable)deserializeDictionaryFromJsonData:(NSData *)data;
 
 /**
  * Extract the level from data of an envelopte item containing an event. Default is the 'error'


### PR DESCRIPTION
`SentrySerialization.deserializeDictionaryFromJsonData` is a wrapper around `NSJSONSerialization.JSONObjectWithData` which returns `nil` as defined in the [Apple Documentation](https://developer.apple.com/documentation/foundation/jsonserialization/jsonobject(with:options:)-8demi?language=objc#return-value).

The `SentrySerialization` is wrapped in `NS_ASSUME_NONNULL_BEGIN` and `NS_ASSUME_NONNULL_END` therefore all methods are defined as "won't return nil". This PR changes the nullability for the method to be correct.

This has no effect on Objective-C calls, but while working on #5242 I had to access the method from Swift, where nullability-handling is stronger and the compiler did not indicate the result to be nullable.

#skip-changelog