### PR TITLE
style: Run linter only on modified swift files on pre hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
         language: system
         types_or: ["swift"]
         args:
-          - "format-swift"
+          - "format-swift-staged"
 
       - id: format-markdown
         name: Format Markdown

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -90,4 +90,4 @@ repos:
         language: system
         types_or: ["swift", "objective-c", "objective-c++", "c", "c++"]
         args:
-          - "lint"
+          - "lint-staged"

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,8 @@ format-swift:
 	swiftlint --fix
 
 format-swift-staged:
-	git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | while IFS= read -r filename; do \
-		swiftlint --fix "$$filename"; \
-	done
+	echo "Running swiftlint --fix on staged files"
+	swiftlint --fix $(shell git diff --cached --diff-filter=d --name-only | grep '\.swift$$')
 
 # Format Markdown
 format-markdown:

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,11 @@ format-clang:
 format-swift:
 	swiftlint --fix
 
+format-swift-staged:
+	git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | while IFS= read -r filename; do \
+		swiftlint --fix "$$filename"; \
+	done
+
 # Format Markdown
 format-markdown:
 	dprint fmt "**/*.md"

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ endef
 STAGED_SWIFT_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | awk '{printf "\"%s\" ", $$0}')
 
 lint:
-	$(call run-lint-tools,'')
+# calling run-lint-tools with no arguments will run swift lint on all files
+	$(call run-lint-tools)
 .PHONY: lint
 
 lint-staged:

--- a/Makefile
+++ b/Makefile
@@ -42,12 +42,15 @@ define run-lint-tools
 	dprint check "**/*.{md,json,yaml,yml}"
 endef
 
+# Get staged Swift files
+STAGED_SWIFT_FILES := $(shell git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | awk '{printf "\"%s\" ", $$0}')
+
 lint:
 	$(call run-lint-tools,'')
 .PHONY: lint
 
 lint-staged:
-	$(call run-lint-tools,$(shell git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | awk '{printf "\"%s\" ", $$0}'))
+	$(call run-lint-tools,$(STAGED_SWIFT_FILES))
 .PHONY: lint-staged
 
 format: format-clang format-swift-all format-markdown format-json format-yaml
@@ -67,7 +70,7 @@ format-swift:
 .PHONY: format-swift-staged
 format-swift-staged:
 	@echo "Running swiftlint --fix on staged files"
-	swiftlint --fix $(shell git diff --cached --diff-filter=d --name-only | grep '\.swift$$' | awk '{printf "\"%s\" ", $$0}')
+	swiftlint --fix $(STAGED_SWIFT_FILES)
 
 # Format Markdown
 format-markdown:


### PR DESCRIPTION
## :scroll: Description

Add a new Makefile script to run linter only on modified files

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

Running `time git commit -m "Any message"`

Previous time: 46s
Actual time: 26s

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog
