### PR TITLE
refactor: Add factory for SentryClient to dependency container

### DIFF
--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -58,7 +58,14 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
         [SentryDependencyContainer.sharedInstance getANRTracker:options.appHangTimeoutInterval];
 
 #endif // SENTRY_HAS_UIKIT
-    self.fileManager = SentryDependencyContainer.sharedInstance.fileManager;
+    SentryFileManager *_Nullable fileManager =
+        [SentryDependencyContainer.sharedInstance getFileManagerForOptions:options];
+    if (!fileManager) {
+        SENTRY_LOG_ERROR(
+            @"Failed to install ANR tracking integration, because file manager is not available.");
+        return NO;
+    }
+    self.fileManager = fileManager;
     self.dispatchQueueWrapper = SentryDependencyContainer.sharedInstance.dispatchQueueWrapper;
     self.crashWrapper = SentryDependencyContainer.sharedInstance.crashWrapper;
     [self.tracker addListener:self];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -72,27 +72,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (_Nullable instancetype)initWithOptions:(SentryOptions *)options
 {
-    return [self initWithOptions:options
-                   dispatchQueue:[[SentryDispatchQueueWrapper alloc] init]
-          deleteOldEnvelopeItems:YES];
-}
-
-/** Internal constructor for testing purposes. */
-- (nullable instancetype)initWithOptions:(SentryOptions *)options
-                           dispatchQueue:(SentryDispatchQueueWrapper *)dispatchQueue
-                  deleteOldEnvelopeItems:(BOOL)deleteOldEnvelopeItems
-{
-    NSError *error;
-    SentryFileManager *fileManager = [[SentryFileManager alloc] initWithOptions:options
-                                                           dispatchQueueWrapper:dispatchQueue
-                                                                          error:&error];
-    if (error != nil) {
-        SENTRY_LOG_FATAL(@"Failed to initialize file system: %@", error.localizedDescription);
+    SentryFileManager *fileManager =
+        [SentryDependencyContainer.sharedInstance getFileManagerForOptions:options];
+    if (fileManager == nil) {
+        SENTRY_LOG_FATAL(
+            @"Failed to initialize the client, because the file manager could not be created.");
         return nil;
     }
-    return [self initWithOptions:options
-                     fileManager:fileManager
-          deleteOldEnvelopeItems:deleteOldEnvelopeItems];
+    return [self initWithOptions:options fileManager:fileManager deleteOldEnvelopeItems:YES];
 }
 
 /** Internal constructor for testing purposes. */

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -237,7 +237,8 @@ static NSDate *_Nullable startTimestamp = nil;
     startInvocations++;
     startTimestamp = [SentryDependencyContainer.sharedInstance.dateProvider date];
 
-    SentryClient *newClient = [[SentryClient alloc] initWithOptions:options];
+    SentryClient *newClient =
+        [SentryDependencyContainer.sharedInstance getClientWithOptions:options];
     [newClient.fileManager moveAppStateToPreviousAppState];
     [newClient.fileManager moveBreadcrumbsToPreviousBreadcrumbs];
 

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -4,9 +4,9 @@
 #    import "SentryDefines.h"
 #endif
 
-@protocol SentryANRTracker;
 @class SentryAppStateManager;
 @class SentryBinaryImageCache;
+@class SentryClient;
 @class SentryCrash;
 @class SentryCrashWrapper;
 @class SentryDebugImageProvider;
@@ -17,12 +17,15 @@
 @class SentryNSNotificationCenterWrapper;
 @class SentryNSProcessInfoWrapper;
 @class SentryNSTimerFactory;
+@class SentryOptions;
 @class SentrySwizzleWrapper;
 @class SentrySysctl;
 @class SentrySystemWrapper;
 @class SentryThreadWrapper;
 @class SentryThreadInspector;
 @class SentryFileIOTracker;
+
+@protocol SentryANRTracker;
 @protocol SentryRandom;
 @protocol SentryCurrentDateProvider;
 @protocol SentryRateLimits;
@@ -102,11 +105,6 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryFileIOTracker *fileIOTracker;
 @property (nonatomic, strong) SentryCrash *crashReporter;
 
-- (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout;
-#if SENTRY_HAS_UIKIT
-- (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout isV2Enabled:(BOOL)isV2Enabled;
-#endif // SENTRY_HAS_UIKIT
-
 @property (nonatomic, strong) SentrySystemWrapper *systemWrapper;
 @property (nonatomic, strong) SentryDispatchFactory *dispatchFactory;
 @property (nonatomic, strong) id<SentryDispatchQueueProviderProtocol> dispatchQueueProvider;
@@ -125,6 +123,16 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryMXManager *metricKitManager API_AVAILABLE(
     ios(15.0), macos(12.0), macCatalyst(15.0)) API_UNAVAILABLE(tvos, watchos);
 #endif // SENTRY_HAS_METRIC_KIT
+
+#pragma mark - Factories
+
+- (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout;
+#if SENTRY_HAS_UIKIT
+- (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout isV2Enabled:(BOOL)isV2Enabled;
+#endif // SENTRY_HAS_UIKIT
+
+- (SentryClient *_Nullable)getClientWithOptions:(SentryOptions *)options;
+- (SentryFileManager *_Nullable)getFileManagerForOptions:(SentryOptions *)options;
 
 @end
 


### PR DESCRIPTION
- This PR is a draft of changes while working on #5242.
- The draft is moving the initialization of the SentryClient to the dependency container.
- I added a factory to create file manager using options.
- This clearly shows that the file manager is a global object that relies on `SentrySDK.options`. While this is set during bootstrapping of the SDK, it can lead to inconsistencies if other parts rely on different options (especially relevant in isolated tests).
- If we want to use factory pattern for the file manager, we should consider keeping weak references to the file manager per DSN (encapsulated in an hash) so we can reuse them.
- The nullability of the client is also inconsistent.

Closes #5296

@philipphofmann @armcknight I'm looking for feedback here on what you think of the approach of using a file manager factory where possible (e.g. in the ANR integration in the diff).

#skip-changelog