### PR TITLE
test: Remove clearing state in serialization tests

### DIFF
--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -20,16 +20,6 @@ class SentrySerializationTests: XCTestCase {
         )
     }
 
-    override func setUp() {
-        super.setUp()
-        clearTestState()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        clearTestState()
-    }
-
     func testSerializationFailsWithInvalidJSONObject() {
         let json: [String: Any] = [
             "valid object": "hi, i'm a valid object",


### PR DESCRIPTION
The SentrySerializationTests have no global state and don't need to clear the test state.