### PR TITLE
Experimental options in Swift

### DIFF
--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -27,7 +27,7 @@ NS_SWIFT_NAME(Event)
 /**
  * This will be set by the initializer.
  */
-@property (nonatomic, strong) SentryId *eventId;
+@property (nonatomic, strong) NSObject *_swiftEventId;
 
 /**
  * Message of the event.

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -10,7 +10,6 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryDsn;
-@class SentryExperimentalOptions;
 @class SentryHttpStatusCodeRange;
 @class SentryMeasurementValue;
 @class SentryReplayOptions;
@@ -782,11 +781,9 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  */
 @property (nonatomic, copy) NSString *spotlightUrl;
 
-/**
- * This aggregates options for experimental features.
- * Be aware that the options available for experimental can change at any time.
- */
-@property (nonatomic, readonly) SentryExperimentalOptions *experimental;
+// Do not use this directly, instead use the non-underscored `experimental` property that is
+// defined through a Swift extension.
+@property (nonatomic, readonly) NSObject *_swiftExperimentalOptions;
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -125,7 +125,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.enableTimeToFullDisplayTracing = NO;
 
         self.initialScope = ^SentryScope *(SentryScope *scope) { return scope; };
-        _experimental = [[SentryExperimentalOptions alloc] init];
+        __swiftExperimentalOptions = [[SentryExperimentalOptions alloc] init];
         _enableTracing = NO;
         _enableTracingManual = NO;
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -3,6 +3,7 @@
 #import "SentryEvent.h"
 #import "SentryOptions.h"
 #import "SentryUserFeedback.h"
+#import "SentrySwift.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -69,3 +69,19 @@ import Foundation
     }
     // swiftlint:enable cyclomatic_complexity function_body_length
 }
+
+@objc
+extension Options {
+
+   /**
+    * This aggregates options for experimental features.
+    * Be aware that the options available for experimental can change at any time.
+    */
+    @objc
+    open var experimental: SentryExperimentalOptions {
+      // We know the type so it's fine to force cast.
+      // swiftlint:disable force_cast
+        _swiftExperimentalOptions as! SentryExperimentalOptions
+      // swiftlint:enable force_cast
+    }
+}

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
@@ -46,3 +46,20 @@ import Foundation
         return result
     }
 }
+
+@objc
+extension Event {
+
+  @objc
+  open var eventId: SentryId {
+    get {
+      // We know the type so it's fine to force cast.
+      // swiftlint:disable force_cast
+      _swiftEventId as! SentryId
+      // swiftlint:enable force_cast
+    }
+    set {
+      _swiftEventId = newValue
+    }
+  }
+}

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -4212,21 +4212,21 @@
         "children": [
           {
             "kind": "Var",
-            "name": "eventId",
-            "printedName": "eventId",
+            "name": "_swiftEventId",
+            "printedName": "_swiftEventId",
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "SentryId",
-                "printedName": "Sentry.SentryId",
-                "usr": "c:@M@Sentry@objc(cs)SentryId"
+                "name": "NSObject",
+                "printedName": "ObjectiveC.NSObject",
+                "usr": "c:objc(cs)NSObject"
               }
             ],
             "declKind": "Var",
-            "usr": "c:objc(cs)SentryEvent(py)eventId",
+            "usr": "c:objc(cs)SentryEvent(py)_swiftEventId",
             "moduleName": "Sentry",
             "isOpen": true,
-            "objc_name": "eventId",
+            "objc_name": "_swiftEventId",
             "declAttributes": [
               "ObjC",
               "Dynamic"
@@ -4239,16 +4239,16 @@
                 "children": [
                   {
                     "kind": "TypeNominal",
-                    "name": "SentryId",
-                    "printedName": "Sentry.SentryId",
-                    "usr": "c:@M@Sentry@objc(cs)SentryId"
+                    "name": "NSObject",
+                    "printedName": "ObjectiveC.NSObject",
+                    "usr": "c:objc(cs)NSObject"
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "c:objc(cs)SentryEvent(im)eventId",
+                "usr": "c:objc(cs)SentryEvent(im)_swiftEventId",
                 "moduleName": "Sentry",
                 "isOpen": true,
-                "objc_name": "eventId",
+                "objc_name": "_swiftEventId",
                 "declAttributes": [
                   "DiscardableResult",
                   "ObjC",
@@ -4275,16 +4275,16 @@
                   },
                   {
                     "kind": "TypeNominal",
-                    "name": "SentryId",
-                    "printedName": "Sentry.SentryId",
-                    "usr": "c:@M@Sentry@objc(cs)SentryId"
+                    "name": "NSObject",
+                    "printedName": "ObjectiveC.NSObject",
+                    "usr": "c:objc(cs)NSObject"
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "c:objc(cs)SentryEvent(im)setEventId:",
+                "usr": "c:objc(cs)SentryEvent(im)set_swiftEventId:",
                 "moduleName": "Sentry",
                 "isOpen": true,
-                "objc_name": "setEventId:",
+                "objc_name": "set_swiftEventId:",
                 "declAttributes": [
                   "ObjC",
                   "Dynamic"
@@ -7470,6 +7470,85 @@
               "Dynamic"
             ],
             "init_kind": "Convenience"
+          },
+          {
+            "kind": "Var",
+            "name": "eventId",
+            "printedName": "eventId",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryId",
+                "printedName": "Sentry.SentryId",
+                "usr": "c:@M@Sentry@objc(cs)SentryId"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "c:@CM@Sentry@@objc(cs)SentryEvent(py)eventId",
+            "mangledName": "$sSo11SentryEventC0A0E7eventIdAC0aD0Cvp",
+            "moduleName": "Sentry",
+            "isOpen": true,
+            "declAttributes": [
+              "Dynamic",
+              "ObjC"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryId",
+                    "printedName": "Sentry.SentryId",
+                    "usr": "c:@M@Sentry@objc(cs)SentryId"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "c:@CM@Sentry@@objc(cs)SentryEvent(im)eventId",
+                "mangledName": "$sSo11SentryEventC0A0E7eventIdAC0aD0Cvg",
+                "moduleName": "Sentry",
+                "isOpen": true,
+                "declAttributes": [
+                  "Dynamic",
+                  "ObjC"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "get"
+              },
+              {
+                "kind": "Accessor",
+                "name": "Set",
+                "printedName": "Set()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Void",
+                    "printedName": "()"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryId",
+                    "printedName": "Sentry.SentryId",
+                    "usr": "c:@M@Sentry@objc(cs)SentryId"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "c:@CM@Sentry@@objc(cs)SentryEvent(im)setEventId:",
+                "mangledName": "$sSo11SentryEventC0A0E7eventIdAC0aD0Cvs",
+                "moduleName": "Sentry",
+                "isOpen": true,
+                "objc_name": "setEventId:",
+                "declAttributes": [
+                  "Dynamic",
+                  "ObjC"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "set"
+              }
+            ]
           }
         ],
         "declKind": "Class",
@@ -21653,21 +21732,21 @@
           },
           {
             "kind": "Var",
-            "name": "experimental",
-            "printedName": "experimental",
+            "name": "_swiftExperimentalOptions",
+            "printedName": "_swiftExperimentalOptions",
             "children": [
               {
                 "kind": "TypeNominal",
-                "name": "SentryExperimentalOptions",
-                "printedName": "Sentry.SentryExperimentalOptions",
-                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions"
+                "name": "NSObject",
+                "printedName": "ObjectiveC.NSObject",
+                "usr": "c:objc(cs)NSObject"
               }
             ],
             "declKind": "Var",
-            "usr": "c:objc(cs)SentryOptions(py)experimental",
+            "usr": "c:objc(cs)SentryOptions(py)_swiftExperimentalOptions",
             "moduleName": "Sentry",
             "isOpen": true,
-            "objc_name": "experimental",
+            "objc_name": "_swiftExperimentalOptions",
             "declAttributes": [
               "ObjC",
               "Dynamic"
@@ -21680,16 +21759,16 @@
                 "children": [
                   {
                     "kind": "TypeNominal",
-                    "name": "SentryExperimentalOptions",
-                    "printedName": "Sentry.SentryExperimentalOptions",
-                    "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions"
+                    "name": "NSObject",
+                    "printedName": "ObjectiveC.NSObject",
+                    "usr": "c:objc(cs)NSObject"
                   }
                 ],
                 "declKind": "Accessor",
-                "usr": "c:objc(cs)SentryOptions(im)experimental",
+                "usr": "c:objc(cs)SentryOptions(im)_swiftExperimentalOptions",
                 "moduleName": "Sentry",
                 "isOpen": true,
-                "objc_name": "experimental",
+                "objc_name": "_swiftExperimentalOptions",
                 "declAttributes": [
                   "DiscardableResult",
                   "ObjC",
@@ -21914,6 +21993,55 @@
               "Dynamic"
             ],
             "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "experimental",
+            "printedName": "experimental",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryExperimentalOptions",
+                "printedName": "Sentry.SentryExperimentalOptions",
+                "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "c:@CM@Sentry@@objc(cs)SentryOptions(py)experimental",
+            "mangledName": "$sSo13SentryOptionsC0A0E12experimentalAC0a12ExperimentalB0Cvp",
+            "moduleName": "Sentry",
+            "isOpen": true,
+            "declAttributes": [
+              "Dynamic",
+              "ObjC"
+            ],
+            "isFromExtension": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryExperimentalOptions",
+                    "printedName": "Sentry.SentryExperimentalOptions",
+                    "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "c:@CM@Sentry@@objc(cs)SentryOptions(im)experimental",
+                "mangledName": "$sSo13SentryOptionsC0A0E12experimentalAC0a12ExperimentalB0Cvg",
+                "moduleName": "Sentry",
+                "isOpen": true,
+                "declAttributes": [
+                  "Dynamic",
+                  "ObjC"
+                ],
+                "isFromExtension": true,
+                "accessorKind": "get"
+              }
+            ]
           }
         ],
         "declKind": "Class",


### PR DESCRIPTION
As described in the SPM migration doc, this moves Swift types from the objc interface into extensions, making it visible from Swift in SPM. It unfortunately requires the force cast, but I think is very safe and the public API does not change, which is why none of the call-sites of these properties had to change.

#skip-changelog