### PR TITLE
chore: Makefile fix make format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ format-clang:
 		| xargs clang-format -i -style=file
 
 # Format all Swift files
-format-swift:
+format-swift-all:
 	@echo "Running swiftlint --fix on all files"
 	swiftlint --fix
 


### PR DESCRIPTION
Make format requires format-swift-all, which doesn't exist. Renamed format-swift to format-swift-all to fix this.

#skip-changelog