### PR TITLE
fix(session-replay): Use timestamp of screenshot for frames

### DIFF
--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -232,8 +232,7 @@ static SentryTouchTracker *_touchTracker;
     SentryOnDemandReplay *resumeReplayMaker =
         [[SentryOnDemandReplay alloc] initWithContentFrom:lastReplayURL.path
                                           processingQueue:_replayProcessingQueue
-                                         assetWorkerQueue:_replayAssetWorkerQueue
-                                             dateProvider:_dateProvider];
+                                         assetWorkerQueue:_replayAssetWorkerQueue];
     resumeReplayMaker.bitRate = _replayOptions.replayBitRate;
     resumeReplayMaker.videoScale = _replayOptions.sizeScale;
 
@@ -380,8 +379,7 @@ static SentryTouchTracker *_touchTracker;
     SentryOnDemandReplay *replayMaker =
         [[SentryOnDemandReplay alloc] initWithOutputPath:docs.path
                                          processingQueue:_replayProcessingQueue
-                                        assetWorkerQueue:_replayAssetWorkerQueue
-                                            dateProvider:_dateProvider];
+                                        assetWorkerQueue:_replayAssetWorkerQueue];
     replayMaker.bitRate = replayOptions.replayBitRate;
     replayMaker.videoScale = replayOptions.sizeScale;
     replayMaker.cacheMaxSize

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayVideoMaker.swift
@@ -4,15 +4,15 @@ import UIKit
 
 @objc
 protocol SentryReplayVideoMaker: NSObjectProtocol {
-    func addFrameAsync(image: UIImage, forScreen: String?) 
+    func addFrameAsync(timestamp: Date, image: UIImage, forScreen: String?)
     func releaseFramesUntil(_ date: Date)
     func createVideoInBackgroundWith(beginning: Date, end: Date, completion: @escaping ([SentryVideoInfo]) -> Void)
     func createVideoWith(beginning: Date, end: Date) -> [SentryVideoInfo]
 }
 
 extension SentryReplayVideoMaker {
-    func addFrameAsync(image: UIImage) {
-        self.addFrameAsync(image: image, forScreen: nil)
+    func addFrameAsync(timestamp: Date, image: UIImage) {
+        self.addFrameAsync(timestamp: timestamp, image: image, forScreen: nil)
     }
 }
 

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -347,19 +347,19 @@ class SentrySessionReplay: NSObject {
         processingScreenshot = true
         lock.unlock()
         
-        let screenName = delegate?.currentScreenNameForSessionReplay()
-
         SentryLog.debug("[Session Replay] Getting screenshot from screenshot provider")
+        let timestamp = dateProvider.date()
+        let screenName = delegate?.currentScreenNameForSessionReplay()
         screenshotProvider.image(view: rootView) { [weak self] screenshot in
-            self?.newImage(image: screenshot, forScreen: screenName)
+            self?.newImage(timestamp: timestamp, image: screenshot, forScreen: screenName)
         }
     }
 
-    private func newImage(image: UIImage, forScreen screen: String?) {
+    private func newImage(timestamp: Date, image: UIImage, forScreen screen: String?) {
         SentryLog.debug("[Session Replay] New frame available, for screen: \(screen ?? "nil")")
         lock.synchronized {
             processingScreenshot = false
-            replayMaker.addFrameAsync(image: image, forScreen: screen)
+            replayMaker.addFrameAsync(timestamp: timestamp, image: image, forScreen: screen)
         }
     }
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -8,9 +8,8 @@ import XCTest
 #if os(iOS) || os(tvOS)
 class SentryOnDemandReplayTests: XCTestCase {
     
-    private let dateProvider = TestCurrentDateProvider()
     private var outputPath = FileManager.default.temporaryDirectory.appendingPathComponent("replayTest")
-    
+
     override func setUpWithError() throws {
         try removeDirectoryIfExists(at: outputPath)
         try FileManager.default.createDirectory(at: outputPath, withIntermediateDirectories: true)
@@ -31,15 +30,14 @@ class SentryOnDemandReplayTests: XCTestCase {
         return SentryOnDemandReplay(
             outputPath: outputPath.path,
             processingQueue: trueDispatchQueueWrapper ? SentryDispatchQueueWrapper() : TestSentryDispatchQueueWrapper(),
-            assetWorkerQueue: trueDispatchQueueWrapper ? SentryDispatchQueueWrapper() : TestSentryDispatchQueueWrapper(),
-            dateProvider: dateProvider
+            assetWorkerQueue: trueDispatchQueueWrapper ? SentryDispatchQueueWrapper() : TestSentryDispatchQueueWrapper()
         )
     }
     
     func testAddFrame() {
         let sut = getSut()
-        sut.addFrameAsync(image: UIImage.add)
-       
+        sut.addFrameAsync(timestamp: Date(timeIntervalSinceReferenceDate: 0xBAAD_F00D), image: UIImage.add)
+
         guard let frame = sut.frames.first else {
             XCTFail("Frame was not saved")
             return
@@ -51,31 +49,35 @@ class SentryOnDemandReplayTests: XCTestCase {
     
     func testReleaseFrames() {
         let sut = getSut()
-        
-        for _ in 0..<10 {
-            sut.addFrameAsync(image: UIImage.add)
-            dateProvider.advance(by: 1)
+
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        for i in 0..<10 {
+            sut.addFrameAsync(
+                    timestamp: start.addingTimeInterval(TimeInterval(i)),
+                    image: UIImage.add
+                )
         }
+        let end = start.addingTimeInterval(10)
        
-        sut.releaseFramesUntil(dateProvider.date().addingTimeInterval(-5))
-        
+        sut.releaseFramesUntil(end.addingTimeInterval(-5))
+
         let frames = sut.frames
         
         XCTAssertEqual(frames.count, 5)
-        XCTAssertEqual(frames.first?.time, Date(timeIntervalSinceReferenceDate: 5))
-        XCTAssertEqual(frames.last?.time, Date(timeIntervalSinceReferenceDate: 9))
+        XCTAssertEqual(frames.first?.time, start.addingTimeInterval(5))
+        XCTAssertEqual(frames.last?.time, start.addingTimeInterval(9))
     }
     
     func testFramesWithScreenName() {
         let sut = getSut()
         
+        let start = Date(timeIntervalSinceReferenceDate: 0)
         for i in 0..<4 {
-            sut.addFrameAsync(image: UIImage.add, forScreen: "\(i)")
-            dateProvider.advance(by: 1)
+            sut.addFrameAsync(timestamp: start.addingTimeInterval(TimeInterval(i)), image: UIImage.add, forScreen: "\(i)")
         }
         
-        sut.releaseFramesUntil(dateProvider.date().addingTimeInterval(-5))
-        
+        sut.releaseFramesUntil(start)
+
         let frames = sut.frames
         
         for i in 0..<4 {
@@ -84,17 +86,21 @@ class SentryOnDemandReplayTests: XCTestCase {
     }
     
     func testGenerateVideo() throws {
+        // -- Arrange --
         let sut = getSut()
-        dateProvider.driftTimeForEveryRead = true
-        dateProvider.driftTimeInterval = 1
-        
-        for _ in 0..<10 {
-            sut.addFrameAsync(image: UIImage.add)
+
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        for i in 0..<10 {
+            sut.addFrameAsync(timestamp: start.addingTimeInterval(TimeInterval(i)), image: UIImage.add)
         }
-        
+        let end = start.addingTimeInterval(10)
+
         let videoExpectation = expectation(description: "Wait for video render")
-        
-        let videos = sut.createVideoWith(beginning: Date(timeIntervalSinceReferenceDate: 0), end: Date(timeIntervalSinceReferenceDate: 10))
+
+        // -- Act --
+        let videos = sut.createVideoWith(beginning: start, end: end)
+
+        // -- Assert --
         XCTAssertEqual(videos.count, 1)
         let info = try XCTUnwrap(videos.first)
         
@@ -117,18 +123,16 @@ class SentryOnDemandReplayTests: XCTestCase {
         let sut = SentryOnDemandReplay(
             outputPath: outputPath.path,
             processingQueue: processingQueue,
-            assetWorkerQueue: workerQueue,
-            dateProvider: dateProvider
+            assetWorkerQueue: workerQueue
         )
 
-        dateProvider.driftTimeForEveryRead = true
-        dateProvider.driftTimeInterval = 1
         let group = DispatchGroup()
         
-        for _ in 0..<10 {
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        for i in 0..<10 {
             group.enter()
             DispatchQueue.global().async {
-                sut.addFrameAsync(image: UIImage.add)
+                sut.addFrameAsync(timestamp: start.addingTimeInterval(TimeInterval(i)), image: UIImage.add)
                 group.leave()
             }
         }
@@ -144,8 +148,7 @@ class SentryOnDemandReplayTests: XCTestCase {
         let sut = SentryOnDemandReplay(
             outputPath: outputPath.path,
             processingQueue: processingQueue,
-            assetWorkerQueue: workerQueue,
-            dateProvider: dateProvider
+            assetWorkerQueue: workerQueue
         )
 
         sut.frames = (0..<100).map { SentryReplayFrame(imagePath: outputPath.path + "/\($0).png", time: Date(timeIntervalSinceReferenceDate: Double($0)), screenName: nil) }
@@ -173,20 +176,21 @@ class SentryOnDemandReplayTests: XCTestCase {
         let sut = SentryOnDemandReplay(
             outputPath: outputPath.path,
             processingQueue: processingQueue,
-            assetWorkerQueue: workerQueue,
-            dateProvider: dateProvider
+            assetWorkerQueue: workerQueue
         )
 
-        let start = dateProvider.date()
-        sut.addFrameAsync(image: UIImage.add)
+        let start = Date(timeIntervalSinceReferenceDate: 0xBAAD_F00D)
+        sut.addFrameAsync(timestamp: start, image: UIImage.add)
         processingQueue.dispatchSync {
             // Wait for the frame to be added by adding a sync operation to the serial queue
         }
-        dateProvider.advance(by: 1)
-        let end = dateProvider.date()
-        
+        let end = start.addingTimeInterval(1)
+
         // Creating a file where the replay would be written to cause an error in the writer
-        try Data("tempFile".utf8).write(to: outputPath.appendingPathComponent("0.0.mp4"))
+        let expectedOutputPath = outputPath
+            .appendingPathComponent("\(start.timeIntervalSinceReferenceDate)")
+            .appendingPathExtension("mp4")
+        try Data("tempFile".utf8).write(to: expectedOutputPath)
 
         // -- Act & Assert --
         let result = sut.createVideoWith(beginning: start, end: end)
@@ -194,19 +198,25 @@ class SentryOnDemandReplayTests: XCTestCase {
     }
     
     func testGenerateVideoForEachSize() throws {
+        // -- Arrange --
         let sut = getSut()
-        dateProvider.driftTimeForEveryRead = true
-        dateProvider.driftTimeInterval = 1
         
         let image1 = UIGraphicsImageRenderer(size: CGSize(width: 20, height: 19)).image { _ in }
         let image2 = UIGraphicsImageRenderer(size: CGSize(width: 20, height: 10)).image { _ in }
-        
+
+        let start = Date(timeIntervalSinceReferenceDate: 0)
         for i in 0..<10 {
-            sut.addFrameAsync(image: i < 5 ? image1 : image2)
+            sut.addFrameAsync(
+                timestamp: start.addingTimeInterval(TimeInterval(i)),
+                image: i < 5 ? image1 : image2
+            )
         }
-        
-        let videos = sut.createVideoWith(beginning: Date(timeIntervalSinceReferenceDate: 0), end: Date(timeIntervalSinceReferenceDate: 10))
-        
+        let end = start.addingTimeInterval(10)
+
+        // -- Act --
+        let videos = sut.createVideoWith(beginning: start, end: end)
+
+        // -- Assert --
         XCTAssertEqual(videos.count, 2)
         
         let firstVideo = try XCTUnwrap(videos.first)
@@ -215,11 +225,11 @@ class SentryOnDemandReplayTests: XCTestCase {
         XCTAssertEqual(firstVideo.duration, 5)
         XCTAssertEqual(secondVideo.duration, 5)
         
-        XCTAssertEqual(firstVideo.start, Date(timeIntervalSinceReferenceDate: 0))
-        XCTAssertEqual(secondVideo.start, Date(timeIntervalSinceReferenceDate: 5))
+        XCTAssertEqual(firstVideo.start, start)
+        XCTAssertEqual(secondVideo.start, start.addingTimeInterval(5))
         
-        XCTAssertEqual(firstVideo.end, Date(timeIntervalSinceReferenceDate: 5))
-        XCTAssertEqual(secondVideo.end, Date(timeIntervalSinceReferenceDate: 10))
+        XCTAssertEqual(firstVideo.end, start.addingTimeInterval(5))
+        XCTAssertEqual(secondVideo.end, end)
         
         XCTAssertEqual(firstVideo.width, 20)
         XCTAssertEqual(firstVideo.height, 19)
@@ -231,8 +241,6 @@ class SentryOnDemandReplayTests: XCTestCase {
     func testGenerateVideoInfo_whenNoFramesAdded_shouldNotThrowError() throws {
         // -- Arrange --
         let sut = getSut()
-        dateProvider.driftTimeForEveryRead = true
-        dateProvider.driftTimeInterval = 1
 
         // -- Act --
         let videos = sut.createVideoWith(

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayTests.swift
@@ -56,9 +56,11 @@ class SentrySessionReplayTests: XCTestCase {
             createVideoCallBack?(videoInfo)
             return [videoInfo]
         }
-        
+
+        var lastFrameTimestamp: Date?
         var lastFrame: UIImage?
-        func addFrameAsync(image: UIImage, forScreen: String?) {
+        func addFrameAsync(timestamp: Date, image: UIImage, forScreen: String?) {
+            lastFrameTimestamp = timestamp
             lastFrame = image
             guard let forScreen = forScreen else { return }
             screens.append(forScreen)


### PR DESCRIPTION
- When configuring a higher frame rate for session replay, the async dispatch of frame rendering caused delays in processing.
- The delay was then affecting the timestamps of frames as the date provider was used at a later stage than the actual screenshot
- This PR changes the timestamp of a frame to the timestamp when the screenshot was taken, which should also better align with other data points such as breadcrumbs.