### PR TITLE
test: Disable flaky testProfilingGPUInfo

### DIFF
--- a/Plans/iOS-Swift_Base.xctestplan
+++ b/Plans/iOS-Swift_Base.xctestplan
@@ -18,6 +18,9 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "ProfilingUITests\/testProfilingGPUInfo()"
+      ],
       "target" : {
         "containerPath" : "container:iOS-Swift.xcodeproj",
         "identifier" : "0217293F044A3AEED8E37A25",


### PR DESCRIPTION
#skip-changelog

Failed here https://github.com/getsentry/sentry-cocoa/actions/runs/15415368588/job/43376783821

Related issue to fix https://github.com/getsentry/sentry-cocoa/issues/5345