### PR TITLE
chore: Change codecov.yml to recursively ignore test files

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,7 @@ coverage:
   round: down
 
 ignore:
+  - "SentryTestUtilsTests/**"
   - "Tests/**"
 
 comment:


### PR DESCRIPTION
- Codecov is picking up coverage of test files, which is not helpful in PR comments when trying to hit patch coverage goals.
- According to internal support we need to match the file structure recursively with double asteriks.

#skip-changelog