### PR TITLE
chore(changelog): Add notes about issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 8.52.0
 
+> [!Warning]
+> This version has a [known issue](https://github.com/getsentry/sentry-cocoa/issues/5334) where events captured with `captureMessage` or `captureError` will have unsymbolicated stack traces. A fix is incoming and will be released in 8.52.1
+
 ### Features
 
 - XCFrameworks are now signed (#5271)
@@ -29,6 +32,9 @@
 - Redact React Native text and images by default without the RN SDK (#5302)
 
 ## 8.51.1
+
+> [!Warning]
+> This version introduces a [known issue](https://github.com/getsentry/sentry-cocoa/issues/5334) where events captured with `captureMessage` or `captureError` will have unsymbolicated stack traces. A fix is incoming and will be released in 8.52.1
 
 ### Fixes
 


### PR DESCRIPTION
adds notes about current issue with unsymbolicated stack traces for `captureError`/`captureMessage`: https://github.com/getsentry/sentry-cocoa/issues/5334

#skip-changelog
