### PR TITLE
(ref): Move SentryEventDecodable to Swift

### DIFF
--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -181,7 +181,7 @@ NS_SWIFT_NAME(Event)
 /**
  * Init an @c SentryEvent will set all needed fields by default.
  */
-- (instancetype)init;
+- (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 /**
  * Init a @c SentryEvent with a @c SentryLevelError and set all needed fields by default.
@@ -193,26 +193,6 @@ NS_SWIFT_NAME(Event)
  * @param error The error of the event.
  */
 - (instancetype)initWithError:(NSError *)error;
-
-@end
-
-/**
- * Subclass of SentryEvent so we can add the Decodable implementation via a Swift extension. We need
- * this due to our mixed use of public Swift and ObjC classes. We could avoid this class by
- * converting SentryReplayEvent back to ObjC, but we rather accept this tradeoff as we want to
- * convert all public classes to Swift in the future. This class needs to be public as we can't add
- * the Decodable extension implementation to a class that is not public.
- *
- * @note: We can’t add the extension for Decodable directly on SentryEvent, because we get an error
- * in SentryReplayEvent: 'required' initializer 'init(from:)' must be provided by subclass of
- * 'Event' Once we add the initializer with required convenience public init(from decoder: any
- * Decoder) throws { fatalError("init(from:) has not been implemented")
- * }
- * we get the error initializer 'init(from:)' is declared in extension of 'Event' and cannot be
- * overridden. Therefore, we add the Decodable implementation not on the Event, but to a subclass of
- * the event.
- */
-@interface SentryEventDecodable : SentryEvent
 
 @end
 

--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -25,14 +25,23 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryEvent
 
+// This is a designated initializer so that it can be called by the Swift
+// sublcass that adds a `Decodable` conformance. It shares an implementation
+// with `initWithLevel:`.
 - (instancetype)init
 {
-    return [self initWithLevel:kSentryLevelNone];
+    self = [super init];
+    return [self commonInit:kSentryLevelNone];
 }
 
 - (instancetype)initWithLevel:(enum SentryLevel)level
 {
     self = [super init];
+    return [self commonInit:level];
+}
+
+- (instancetype)commonInit:(enum SentryLevel)level
+{
     if (self) {
         self.eventId = [[SentryId alloc] init];
         self.level = level;
@@ -207,10 +216,6 @@ NS_ASSUME_NONNULL_BEGIN
         [SentryAppHangTypeMapper
             isExceptionTypeAppHangWithExceptionType:self.exceptions.firstObject.type];
 }
-
-@end
-
-@implementation SentryEventDecodable
 
 @end
 

--- a/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
@@ -1,7 +1,25 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryEventDecodable: Decodable {
+/**
+ * Subclass of SentryEvent so we can add the Decodable implementation via a Swift extension. We need
+ * this due to our mixed use of public Swift and ObjC classes. We could avoid this class by
+ * converting SentryReplayEvent back to ObjC, but we rather accept this tradeoff as we want to
+ * convert all public classes to Swift in the future. This does not need to be public, but was previously
+ * defined in objc and was public. In the next major version of the SDK we should make it `internal` and `final`
+ * and remove the `@objc` annotation.
+ *
+ * @note: We can’t add the extension for Decodable directly on SentryEvent, because we get an error
+ * in SentryReplayEvent: 'required' initializer 'init(from:)' must be provided by subclass of
+ * 'Event' Once we add the initializer with required convenience public init(from decoder: any
+ * Decoder) throws { fatalError("init(from:) has not been implemented")
+ * }
+ * we get the error initializer 'init(from:)' is declared in extension of 'Event' and cannot be
+ * overridden. Therefore, we add the Decodable implementation not on the Event, but to a subclass of
+ * the event.
+ */
+@objc(SentryEventDecodable)
+open class SentryEventDecodable: Event, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case eventId = "event_id"

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -7413,7 +7413,7 @@
               "ObjC",
               "Dynamic"
             ],
-            "init_kind": "Convenience"
+            "init_kind": "Designated"
           },
           {
             "kind": "Constructor",
@@ -26457,215 +26457,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "SentryEventDecodable",
-        "printedName": "SentryEventDecodable",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecodable",
-                "printedName": "Sentry.SentryEventDecodable",
-                "usr": "c:objc(cs)SentryEventDecodable"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:objc(cs)SentryEvent(im)init",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "implicit": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "Override",
-              "Required",
-              "ObjC",
-              "Dynamic"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(level:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecodable",
-                "printedName": "Sentry.SentryEventDecodable",
-                "usr": "c:objc(cs)SentryEventDecodable"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevel",
-                "printedName": "Sentry.SentryLevel",
-                "usr": "c:@M@Sentry@E@SentryLevel"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:objc(cs)SentryEvent(im)initWithLevel:",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "implicit": true,
-            "objc_name": "initWithLevel:",
-            "declAttributes": [
-              "Override",
-              "ObjC",
-              "Dynamic"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(error:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecodable",
-                "printedName": "Sentry.SentryEventDecodable",
-                "usr": "c:objc(cs)SentryEventDecodable"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Error",
-                "printedName": "any Swift.Error",
-                "usr": "s:s5ErrorP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:objc(cs)SentryEvent(im)initWithError:",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "implicit": true,
-            "objc_name": "initWithError:",
-            "declAttributes": [
-              "Override",
-              "ObjC",
-              "Dynamic"
-            ],
-            "init_kind": "Convenience"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecodable",
-                "printedName": "Sentry.SentryEventDecodable",
-                "usr": "c:objc(cs)SentryEventDecodable"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Decoder",
-                "printedName": "any Swift.Decoder",
-                "usr": "s:s7DecoderP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:So20SentryEventDecodableC0A0E4fromABs7Decoder_p_tKcfc",
-            "mangledName": "$sSo20SentryEventDecodableC0A0E4fromABs7Decoder_p_tKcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Required"
-            ],
-            "isFromExtension": true,
-            "throwing": true,
-            "init_kind": "Convenience"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:objc(cs)SentryEventDecodable",
-        "moduleName": "Sentry",
-        "isOpen": true,
-        "objc_name": "SentryEventDecodable",
-        "declAttributes": [
-          "ObjC",
-          "Dynamic"
-        ],
-        "superclassUsr": "c:objc(cs)SentryEvent",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "Sentry.Event",
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "SentrySerializable",
-            "printedName": "SentrySerializable",
-            "usr": "c:objc(pl)SentrySerializable"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Decodable",
-            "printedName": "Decodable",
-            "usr": "s:Se",
-            "mangledName": "$sSe"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryFeedbackAPI",
         "printedName": "SentryFeedbackAPI",
         "children": [
@@ -44677,6 +44468,150 @@
             "name": "SentrySerializable",
             "printedName": "SentrySerializable",
             "usr": "c:objc(pl)SentrySerializable"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SentryEventDecodable",
+        "printedName": "SentryEventDecodable",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(from:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryEventDecodable",
+                "printedName": "Sentry.SentryEventDecodable",
+                "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Decoder",
+                "printedName": "any Swift.Decoder",
+                "usr": "s:s7DecoderP"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:6Sentry0A14EventDecodableC4fromACs7Decoder_p_tKcfc",
+            "mangledName": "$s6Sentry0A14EventDecodableC4fromACs7Decoder_p_tKcfc",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "Required"
+            ],
+            "throwing": true,
+            "init_kind": "Convenience"
+          },
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "SentryEventDecodable",
+                "printedName": "Sentry.SentryEventDecodable",
+                "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable(im)init",
+            "mangledName": "$s6Sentry0A14EventDecodableCACycfc",
+            "moduleName": "Sentry",
+            "overriding": true,
+            "objc_name": "init",
+            "declAttributes": [
+              "ObjC",
+              "Dynamic",
+              "Required"
+            ],
+            "init_kind": "Designated"
+          }
+        ],
+        "declKind": "Class",
+        "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable",
+        "mangledName": "$s6Sentry0A14EventDecodableC",
+        "moduleName": "Sentry",
+        "isOpen": true,
+        "objc_name": "SentryEventDecodable",
+        "declAttributes": [
+          "ObjC"
+        ],
+        "superclassUsr": "c:objc(cs)SentryEvent",
+        "superclassNames": [
+          "Sentry.Event",
+          "ObjectiveC.NSObject"
+        ],
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Decodable",
+            "printedName": "Decodable",
+            "usr": "s:Se",
+            "mangledName": "$sSe"
+          },
+          {
+            "kind": "Conformance",
+            "name": "SentrySerializable",
+            "printedName": "SentrySerializable",
+            "usr": "c:objc(pl)SentrySerializable"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "NSObjectProtocol",
+            "printedName": "NSObjectProtocol",
+            "usr": "c:objc(pl)NSObject"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CVarArg",
+            "printedName": "CVarArg",
+            "usr": "s:s7CVarArgP",
+            "mangledName": "$ss7CVarArgP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomStringConvertible",
+            "printedName": "CustomStringConvertible",
+            "usr": "s:s23CustomStringConvertibleP",
+            "mangledName": "$ss23CustomStringConvertibleP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "CustomDebugStringConvertible",
+            "printedName": "CustomDebugStringConvertible",
+            "usr": "s:s28CustomDebugStringConvertibleP",
+            "mangledName": "$ss28CustomDebugStringConvertibleP"
           }
         ]
       },


### PR DESCRIPTION
Moves SentryEventDecodable from objc to Swift, incremental progress to making more of the API in Swift. Also solves an SPM issue which is that Swift and objc are in different modules, and you can't add a protocol conformance across module boundaries

#skip-changelog