### PR TITLE
ci: install swiftlint on more recent ci macOS images

### DIFF
--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -11,6 +11,7 @@ on:
       - "**/*.m"
       - "**/*.mm"
       - ".github/workflows/lint-clang-formatting.yml"
+      - ".clang-format"
 
   pull_request:
     paths:
@@ -21,6 +22,7 @@ on:
       - "**/*.m"
       - "**/*.mm"
       - ".github/workflows/lint-clang-formatting.yml"
+      - ".clang-format"
 
 jobs:
   format-code:

--- a/.github/workflows/lint-swift-formatting.yml
+++ b/.github/workflows/lint-swift-formatting.yml
@@ -6,19 +6,23 @@ on:
     paths:
       - "**/*.swift"
       - ".github/workflows/lint-swift-formatting.yml"
+      - ".swiftlint.yml"
 
   pull_request:
     paths:
       - "**/*.swift"
       - ".github/workflows/lint-swift-formatting.yml"
+      - ".swiftlint.yml"
 
 jobs:
   format-code:
     name: Check Formatting of Swiftlint Code
-    # As of June 3rd 2025, swiftlint is only available on macos-13, even though the runner images spec of macos-14 and macos-15 claim to have it.
-    runs-on: macos-13
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+
+      - name: Install tooling
+        run: make init-ci-format
 
       - name: Run SwiftLint
         run: make format-swift-all

--- a/Brewfile
+++ b/Brewfile
@@ -1,8 +1,5 @@
-brew 'clang-format'
-brew 'swiftlint'
 brew 'pre-commit'
 brew 'python3'
 brew 'xcbeautify'
 brew 'rbenv'
-brew 'xcodegen'
 brew 'dprint'

--- a/Brewfile-ci-format
+++ b/Brewfile-ci-format
@@ -1,2 +1,2 @@
- # swiftlint is preinstalled
 brew 'clang-format'
+brew 'swiftlint'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: init
-init:
+init: init-local init-ci-build init-ci-test init-ci-deploy init-ci-format
+
+.PHONY: init-local
+init-local:
 	which brew || /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 	brew bundle
 	pre-commit install

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1884,6 +1884,7 @@
 		845C16D42A622A5B00EC9519 /* SentryTracer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryTracer+Private.h"; path = "include/SentryTracer+Private.h"; sourceTree = "<group>"; };
 		845CEAEE2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryProfilingPublicAPITests.swift; sourceTree = "<group>"; };
 		845CEB162D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAppStartProfilingConfigurationTests.swift; sourceTree = "<group>"; };
+		846628B82DF0E52C00F11CD9 /* Brewfile-ci-format */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = "Brewfile-ci-format"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		846F90332D56F59D009E86C1 /* Brewfile-ci-deploy */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; path = "Brewfile-ci-deploy"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		8482FA992DD7C397000E9283 /* SentryFeedbackAPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryFeedbackAPI.h; path = ../../../Sentry/Public/SentryFeedbackAPI.h; sourceTree = "<group>"; };
 		8482FA9A2DD7C397000E9283 /* SentryFeedbackAPI.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SentryFeedbackAPI.m; path = ../../../Sentry/SentryFeedbackAPI.m; sourceTree = "<group>"; };
@@ -4270,6 +4271,7 @@
 				849DF0522D00270A00A202DF /* Brewfile-ci-test */,
 				8452E77D2DBC43CF0087020B /* Brewfile-ci-build */,
 				846F90332D56F59D009E86C1 /* Brewfile-ci-deploy */,
+				846628B82DF0E52C00F11CD9 /* Brewfile-ci-format */,
 			);
 			name = Aux;
 			sourceTree = "<group>";


### PR DESCRIPTION
I noticed we wanted to pin the swift format job to macOS 13 due to what is or isn't installed on the machines, but we already brew install clang-format, so figured we could do that for this too. Eventually 13 will be deprecated anyways.

Also add the format config files to the list of file triggers for the jobs, dedupe the makefile tasks that correspond to the different brewfiles we have, and add Brewfile-ci-format to the xcworkspace.