### PR TITLE
Full spm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      # Only watchOS is compiling with SPM so far, the rest of the targets need profiling support which is still a work in progress due to the ObjC++ usage
       - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace && EXPERIMENTAL_SPM_BUILDS=1 xcodebuild build -scheme SentrySPM -sdk watchos -destination 'generic/platform=watchOS'
         shell: sh
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,6 +87,13 @@ jobs:
           name: raw-build-output-scheme-${{matrix.scheme}}
           path: |
             raw-build-output.log
+  build-spm:
+    name: Build with SPM
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace && EXPERIMENTAL_SPM_BUILDS=1 xcodebuild build -scheme SentrySPM -sdk watchos -destination 'generic/platform=watchOS'
+        shell: sh
 
   check-debug-without-UIKit:
     name: Check no UIKit linkage (DebugWithoutUIKit)

--- a/Package.swift
+++ b/Package.swift
@@ -1,41 +1,90 @@
 // swift-tools-version:5.3
+import Darwin.C
 import PackageDescription
+
+var products: [Product] = [
+    .library(name: "Sentry", targets: ["Sentry"]),
+    .library(name: "Sentry-Dynamic", targets: ["Sentry-Dynamic"]),
+    .library(name: "SentrySwiftUI", targets: ["Sentry", "SentrySwiftUI"])
+]
+
+var targets: [Target] = [
+    .binaryTarget(
+        name: "Sentry",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.52.1/Sentry.xcframework.zip",
+        checksum: "48a6c6693148a3f9096108164eb938a931b964395fcf38e169383b9e4cffcfc5" //Sentry-Static
+    ),
+    .binaryTarget(
+        name: "Sentry-Dynamic",
+        url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.52.1/Sentry-Dynamic.xcframework.zip",
+        checksum: "b9d9054c65ee5ac0591c27826edddc54490a96c2a83dee25519cae0c1a593231" //Sentry-Dynamic
+    ),
+    .target (
+        name: "SentrySwiftUI",
+        dependencies: ["Sentry", "SentryInternal"],
+        path: "Sources/SentrySwiftUI",
+        exclude: ["SentryInternal/", "module.modulemap"],
+        linkerSettings: [
+            .linkedFramework("Sentry")
+        ]),
+    .target(
+        name: "SentryInternal",
+        path: "Sources/SentrySwiftUI",
+        sources: [
+            "SentryInternal/"
+        ],
+        publicHeadersPath: "SentryInternal/")
+]
+
+let env = getenv("EXPERIMENTAL_SPM_BUILDS")
+if let env, String(cString: env, encoding: .utf8) == "1" {
+    products.append(.library(name: "SentrySPM", type: .dynamic, targets: ["SentryObjc"]))
+    targets.append(contentsOf: [
+        // At least one source file is required
+        .target(name: "SentryHeaders", path: "Sources/Sentry", sources: ["SentryDsn.m"], publicHeadersPath: "Public"),
+        .target(
+            name: "_SentryPrivate",
+            dependencies: ["SentryHeaders"],
+            path: "Sources/Sentry",
+            sources: ["NSLocale+Sentry.m"],
+            publicHeadersPath: "include",
+            cSettings: [.headerSearchPath("include/HybridPublic")]),
+        .target(
+            name: "SentrySwift",
+            dependencies: ["_SentryPrivate", "SentryHeaders"],
+            path: "Sources/Swift",
+            swiftSettings: [
+                // The application extension flag is required due to https://github.com/getsentry/sentry-cocoa/issues/5371
+                .unsafeFlags(["-enable-library-evolution", "-Xfrontend", "-application-extension"]),
+                // This flag is used to make some API breaking changes necessary for the framework to compile with SPM.
+                // We can either make more extensive changes to allow it to be backwards compatible, or release them as part of a V9 release.
+                // For now we use this flag so that CI can compile the SPM version.
+                    .define("SENTRY_SWIFT_PACKAGE")
+            ],
+            linkerSettings: [
+                .unsafeFlags(["-Xlinker", "-application_extension"])
+            ]),
+        .target(
+            name: "SentryObjc",
+            dependencies: ["SentrySwift"],
+            path: "Sources",
+            exclude: ["Sentry/SentryDsn.m", "Sentry/NSLocale+Sentry.m", "Swift", "SentrySwiftUI", "Resources", "Configuration"],
+            cSettings: [
+                .headerSearchPath("Sentry/include/HybridPublic"),
+                .headerSearchPath("Sentry"),
+                .headerSearchPath("SentryCrash/Recording"),
+                .headerSearchPath("SentryCrash/Recording/Monitors"),
+                .headerSearchPath("SentryCrash/Recording/Tools"),
+                .headerSearchPath("SentryCrash/Installations"),
+                .headerSearchPath("SentryCrash/Reporting/Filters"),
+                .headerSearchPath("SentryCrash/Reporting/Filters/Tools")])
+    ])
+}
 
 let package = Package(
     name: "Sentry",
     platforms: [.iOS(.v11), .macOS(.v10_13), .tvOS(.v11), .watchOS(.v4)],
-    products: [
-        .library(name: "Sentry", targets: ["Sentry"]),
-        .library(name: "Sentry-Dynamic", targets: ["Sentry-Dynamic"]),
-        .library(name: "SentrySwiftUI", targets: ["Sentry", "SentrySwiftUI"])
-    ],
-    targets: [
-        .binaryTarget(
-                    name: "Sentry",
-                    url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.52.1/Sentry.xcframework.zip",
-                    checksum: "48a6c6693148a3f9096108164eb938a931b964395fcf38e169383b9e4cffcfc5" //Sentry-Static
-                ),
-        .binaryTarget(
-                    name: "Sentry-Dynamic",
-                    url: "https://github.com/getsentry/sentry-cocoa/releases/download/8.52.1/Sentry-Dynamic.xcframework.zip",
-                    checksum: "b9d9054c65ee5ac0591c27826edddc54490a96c2a83dee25519cae0c1a593231" //Sentry-Dynamic
-                ),
-        .target ( name: "SentrySwiftUI",
-                  dependencies: ["Sentry", "SentryInternal"],
-                  path: "Sources/SentrySwiftUI",
-                  exclude: ["SentryInternal/", "module.modulemap"],
-                  linkerSettings: [
-                     .linkedFramework("Sentry")
-                  ]
-                ),
-        .target( name: "SentryInternal",
-                 path: "Sources/SentrySwiftUI",
-                 sources: [
-                    "SentryInternal/"
-                 ],
-                 publicHeadersPath: "SentryInternal/"
-               ),
-        .target(name: "SentryCoreSwift", path: "Sources/Swift/Core")
-    ],
+    products: products,
+    targets: targets,
     cxxLanguageStandard: .cxx14
 )

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1071,6 +1071,8 @@
 		FA67DD192DDBD4EA00896B02 /* SwizzleClassNameExclude.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCD52DDBD4EA00896B02 /* SwizzleClassNameExclude.swift */; };
 		FA8A36182DEAA1EB0058D883 /* SentryThread+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8A36172DEAA1EB0058D883 /* SentryThread+Private.h */; };
 		FA90FAFD2E070A3B008CAAE8 /* SentryURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90FAFC2E070A3B008CAAE8 /* SentryURLRequestFactory.swift */; };
+		FAB359982E05D7E90083D5E3 /* SentryEventSwiftHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */; };
+		FAB3599A2E05D8080083D5E3 /* SentryEventSwiftHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */; };
 		FAEC270E2DF3526000878871 /* SentryUserFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */; };
 		FAEC273D2DF3933A00878871 /* NSData+Unzip.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEC273C2DF3933200878871 /* NSData+Unzip.m */; };
 /* End PBXBuildFile section */
@@ -2322,6 +2324,8 @@
 		FA67DCF22DDBD4EA00896B02 /* SwiftDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDescriptor.swift; sourceTree = "<group>"; };
 		FA8A36172DEAA1EB0058D883 /* SentryThread+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryThread+Private.h"; path = "include/SentryThread+Private.h"; sourceTree = "<group>"; };
 		FA90FAFC2E070A3B008CAAE8 /* SentryURLRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryURLRequestFactory.swift; sourceTree = "<group>"; };
+		FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEventSwiftHelper.h; path = include/SentryEventSwiftHelper.h; sourceTree = "<group>"; };
+		FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEventSwiftHelper.m; sourceTree = "<group>"; };
 		FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUserFeedback.swift; sourceTree = "<group>"; };
 		FAEC273C2DF3933200878871 /* NSData+Unzip.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+Unzip.m"; sourceTree = "<group>"; };
 		FAEC273E2DF393E000878871 /* NSData+Unzip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+Unzip.h"; sourceTree = "<group>"; };
@@ -2796,6 +2800,8 @@
 				844EDC75294144DB00C86F34 /* SentrySystemWrapper.mm */,
 				844EDCE32947DC3100C86F34 /* SentryNSTimerFactory.h */,
 				844EDCE42947DC3100C86F34 /* SentryNSTimerFactory.m */,
+				FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */,
+				FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */,
 				33042A0B29DAF5F400C60085 /* SentryExtraContextProvider.h */,
 				33042A0C29DAF79A00C60085 /* SentryExtraContextProvider.m */,
 				D858FA642A29EAB3002A3503 /* SentryBinaryImageCache.h */,
@@ -4781,6 +4787,7 @@
 				8E564AEF267AF24400FE117D /* SentryNetworkTracker.h in Headers */,
 				63FE715120DA4C1100CDBAE8 /* SentryCrashDebug.h in Headers */,
 				63FE70F520DA4C1000CDBAE8 /* SentryCrashMonitor_System.h in Headers */,
+				FAB359982E05D7E90083D5E3 /* SentryEventSwiftHelper.h in Headers */,
 				7B31C291277B04A000337126 /* SentryCrashPlatformSpecificDefines.h in Headers */,
 				D452FC732DDB553100AFF56F /* SentryWatchdogTerminationBreadcrumbProcessor.h in Headers */,
 				D456B4382D706BFE007068CB /* SentrySpanDataKey.h in Headers */,
@@ -5591,6 +5598,7 @@
 				63FE711520DA4C1000CDBAE8 /* SentryCrashJSONCodec.c in Sources */,
 				03F84D3327DD4191008FE43F /* SentryMachLogging.cpp in Sources */,
 				D85852BA27EDDC5900C6D8AE /* SentryUIApplication.m in Sources */,
+				FAB3599A2E05D8080083D5E3 /* SentryEventSwiftHelper.m in Sources */,
 				7B4E375F258231FC00059C93 /* SentryAttachment.m in Sources */,
 				636085141ED47BE600E8599E /* SentryFileManager.m in Sources */,
 				63FE710B20DA4C1000CDBAE8 /* SentryCrashMach.c in Sources */,

--- a/Sources/Sentry/SentryEventSwiftHelper.m
+++ b/Sources/Sentry/SentryEventSwiftHelper.m
@@ -2,6 +2,13 @@
 #import "SentryEvent.h"
 #import "SentrySwift.h"
 
+// This helper is to bridge Swift and ObjC when building with SPM.
+// SPM cannot use Swift types in public ObjC APIs. Since SentryId
+// is Swift and SentryEvent is ObjC, Swift code built with SPM
+// cannot modify the eventId. This helper makes that possible.
+// Other solutions involve a force cast, forward declaring in ObjC
+// or re-writing in Swift. We will explore those in the future, but for
+// now this enables CI to build with SPM.
 @implementation SentryEventSwiftHelper
 
 + (void)setEventIdString:(NSString *)idString event:(SentryEvent *)event

--- a/Sources/Sentry/SentryEventSwiftHelper.m
+++ b/Sources/Sentry/SentryEventSwiftHelper.m
@@ -1,0 +1,17 @@
+#import "SentryEventSwiftHelper.h"
+#import "SentryEvent.h"
+#import "SentrySwift.h"
+
+@implementation SentryEventSwiftHelper
+
++ (void)setEventIdString:(NSString *)idString event:(SentryEvent *)event
+{
+    event.eventId = [[SentryId alloc] initWithUUIDString:idString];
+}
+
++ (NSString *)getEventIdString:(SentryEvent *)event
+{
+    return event.eventId.sentryIdString;
+}
+
+@end

--- a/Sources/Sentry/include/SentryEventSwiftHelper.h
+++ b/Sources/Sentry/include/SentryEventSwiftHelper.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+@class SentryEvent;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryEventSwiftHelper : NSObject
+
++ (void)setEventIdString:(NSString *)idString event:(SentryEvent *)event;
+
++ (NSString *)getEventIdString:(SentryEvent *)event;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -3,6 +3,7 @@
 #import "NSLocale+Sentry.h"
 #import "SentryCrashExceptionApplicationHelper.h"
 #import "SentryDispatchQueueWrapper.h"
+#import "SentryEventSwiftHelper.h"
 #import "SentryNSDataUtils.h"
 #import "SentryRandom.h"
 #import "SentryTime.h"

--- a/Sources/Swift/Exports.swift
+++ b/Sources/Swift/Exports.swift
@@ -1,0 +1,8 @@
+// This file is only for SPM, it allows all Swift
+// files to use code in SentryHeaders without needing
+// to add an import. This allows the same source to
+// compile in SPM and xcodebuild (which doesn't separate
+// ObjC into the SentryHeaders target)
+#if SENTRY_SWIFT_PACKAGE
+@_exported import SentryHeaders
+#endif

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
@@ -28,7 +28,7 @@ import Foundation
         self.segmentId = segmentId
         
         super.init()
-        self.eventId = eventId
+        SentryEventSwiftHelper.setEventIdString(eventId.sentryIdString, event: self)
         self.type = "replay_video"
     }
     
@@ -40,7 +40,7 @@ import Foundation
         var result = super.serialize()
         result["urls"] = urls
         result["replay_start_timestamp"] = replayStartTimestamp.timeIntervalSince1970
-        result["replay_id"] = eventId.sentryIdString
+        result["replay_id"] = SentryEventSwiftHelper.getEventIdString(self)
         result["segment_id"] = segmentId
         result["replay_type"] = replayType.toString()
         return result

--- a/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class BreadcrumbDecodable: Breadcrumb {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Breadcrumb: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class BreadcrumbDecodable: Breadcrumb {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias BreadcrumbDecodable = Breadcrumb
+#endif
+extension BreadcrumbDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case level
@@ -13,7 +22,13 @@ extension Breadcrumb: Decodable {
         case origin
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.init()

--- a/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class DebugMetaDecodable: DebugMeta {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension DebugMeta: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class DebugMetaDecodable: DebugMeta {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias DebugMetaDecodable = DebugMeta
+#endif
+extension DebugMetaDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case uuid
@@ -14,7 +23,13 @@ extension DebugMeta: Decodable {
         case codeFile = "code_file"
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.init()

--- a/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
@@ -57,8 +57,8 @@ open class SentryEventDecodable: Event, Decodable {
         self.init()
 
         let eventIdAsString = try container.decode(String.self, forKey: .eventId)
-        self.eventId = SentryId(uuidString: eventIdAsString)
-        self.message = try container.decodeIfPresent(SentryMessage.self, forKey: .message)
+        SentryEventSwiftHelper.setEventIdString(eventIdAsString, event: self)
+        self.message = try container.decodeIfPresent(SentryMessageDecodable.self, forKey: .message)
         self.timestamp = try container.decode(Date.self, forKey: .timestamp)
         self.startTimestamp = try container.decodeIfPresent(Date.self, forKey: .startTimestamp)
 
@@ -89,27 +89,27 @@ open class SentryEventDecodable: Event, Decodable {
 
         self.modules = try container.decodeIfPresent([String: String].self, forKey: .modules)
         self.fingerprint = try container.decodeIfPresent([String].self, forKey: .fingerprint)
-        self.user = try container.decodeIfPresent(User.self, forKey: .user)
+        self.user = try container.decodeIfPresent(UserDecodable.self, forKey: .user)
         
         self.context = decodeArbitraryData {
             try container.decodeIfPresent([String: [String: ArbitraryData]].self, forKey: .context)
         }
 
-        if let rawThreads = try container.decodeIfPresent([String: [SentryThread]].self, forKey: .threads) {
+        if let rawThreads = try container.decodeIfPresent([String: [SentryThreadDecodable]].self, forKey: .threads) {
             self.threads = rawThreads["values"]
         }
             
-        if let rawExceptions = try container.decodeIfPresent([String: [Exception]].self, forKey: .exception) {
+        if let rawExceptions = try container.decodeIfPresent([String: [ExceptionDecodable]].self, forKey: .exception) {
             self.exceptions = rawExceptions["values"]
         }
         
-        self.stacktrace = try container.decodeIfPresent(SentryStacktrace.self, forKey: .stacktrace)
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
         
-        if let rawDebugMeta = try container.decodeIfPresent([String: [DebugMeta]].self, forKey: .debugMeta) {
+        if let rawDebugMeta = try container.decodeIfPresent([String: [DebugMetaDecodable]].self, forKey: .debugMeta) {
             self.debugMeta = rawDebugMeta["images"]
         }
         
-        self.breadcrumbs = try container.decodeIfPresent([Breadcrumb].self, forKey: .breadcrumbs)
-        self.request = try container.decodeIfPresent(SentryRequest.self, forKey: .request)
+        self.breadcrumbs = try container.decodeIfPresent([BreadcrumbDecodable].self, forKey: .breadcrumbs)
+        self.request = try container.decodeIfPresent(SentryRequestDecodable.self, forKey: .request)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Exception: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class ExceptionDecodable: Exception {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias ExceptionDecodable = Exception
+#endif
+extension ExceptionDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case value
@@ -11,8 +20,14 @@ extension Exception: Decodable {
         case threadId = "thread_id"
         case stacktrace   
     }
-    
+
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         let value = try container.decode(String.self, forKey: .value)
@@ -20,9 +35,9 @@ extension Exception: Decodable {
 
         self.init(value: value, type: type)
 
-        self.mechanism = try container.decodeIfPresent(Mechanism.self, forKey: .mechanism)
+        self.mechanism = try container.decodeIfPresent(MechanismDecodable.self, forKey: .mechanism)
         self.module = try container.decodeIfPresent(String.self, forKey: .module)
         self.threadId = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .threadId)?.value
-        self.stacktrace = try container.decodeIfPresent(SentryStacktrace.self, forKey: .stacktrace)
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class ExceptionDecodable: Exception {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Frame: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class FrameDecodable: Frame {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias FrameDecodable = Frame
+#endif
+extension FrameDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case symbolAddress = "symbol_addr"
@@ -21,8 +30,14 @@ extension Frame: Decodable {
         case inApp = "in_app"
         case stackStart = "stack_start"
     }
-    
+
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         self.init()
         
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class FrameDecodable: Frame {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class GeoDecodable: Geo {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Geo: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class GeoDecodable: Geo {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias GeoDecodable = Geo
+#endif
+extension GeoDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case city
@@ -9,7 +18,13 @@ extension Geo: Decodable {
         case region
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.init()

--- a/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Mechanism: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class MechanismDecodable: Mechanism {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias MechanismDecodable = Mechanism
+#endif
+extension MechanismDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case type
@@ -13,7 +22,13 @@ extension Mechanism: Decodable {
         case meta
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         let type = try container.decode(String.self, forKey: .type)
@@ -26,6 +41,6 @@ extension Mechanism: Decodable {
         self.handled = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .handled)?.value
         self.synthetic = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .synthetic)?.value
         self.helpLink = try container.decodeIfPresent(String.self, forKey: .helpLink)
-        self.meta = try container.decodeIfPresent(MechanismMeta.self, forKey: .meta)
+        self.meta = try container.decodeIfPresent(MechanismMetaDecodable.self, forKey: .meta)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class MechanismDecodable: Mechanism {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class MechanismMetaDecodable: MechanismMeta {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension MechanismMeta: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class MechanismMetaDecodable: MechanismMeta {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias MechanismMetaDecodable = MechanismMeta
+#endif
+extension MechanismMetaDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case signal
@@ -9,7 +18,13 @@ extension MechanismMeta: Decodable {
         case error = "ns_error"
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         self.init()
         
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -19,6 +34,6 @@ extension MechanismMeta: Decodable {
         self.machException = decodeArbitraryData {
             try container.decodeIfPresent([String: ArbitraryData].self, forKey: .machException)
         }
-        self.error = try container.decodeIfPresent(SentryNSError.self, forKey: .error)
+        self.error = try container.decodeIfPresent(SentryNSErrorDecodable.self, forKey: .error)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryMessage.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMessage.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryMessage: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class SentryMessageDecodable: SentryMessage {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias SentryMessageDecodable = SentryMessage
+#endif
+extension SentryMessageDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case formatted
@@ -9,7 +18,13 @@ extension SentryMessage: Decodable {
         case params
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         let formatted = try container.decode(String.self, forKey: .formatted)

--- a/Sources/Swift/Protocol/Codable/SentryMessage.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMessage.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class SentryMessageDecodable: SentryMessage {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class SentryNSErrorDecodable: SentryNSError {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
@@ -1,14 +1,29 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryNSError: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class SentryNSErrorDecodable: SentryNSError {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias SentryNSErrorDecodable = SentryNSError
+#endif
+extension SentryNSErrorDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case domain
         case code
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         let domain = try container.decode(String.self, forKey: .domain)

--- a/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class SentryRequestDecodable: SentryRequest {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryRequest: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class SentryRequestDecodable: SentryRequest {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias SentryRequestDecodable = SentryRequest
+#endif
+extension SentryRequestDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case bodySize = "body_size"
@@ -13,7 +22,13 @@ extension SentryRequest: Decodable {
         case url
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         self.init()

--- a/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class SentryStacktraceDecodable: SentryStacktrace {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryStacktrace: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class SentryStacktraceDecodable: SentryStacktrace {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias SentryStacktraceDecodable = SentryStacktrace
+#endif
+extension SentryStacktraceDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case frames
@@ -9,10 +18,16 @@ extension SentryStacktrace: Decodable {
         case snapshot
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
-        let frames = try container.decodeIfPresent([Frame].self, forKey: .frames) ?? []
+        let frames = try container.decodeIfPresent([FrameDecodable].self, forKey: .frames) ?? []
         let registers = try container.decodeIfPresent([String: String].self, forKey: .registers) ?? [:]
         self.init(frames: frames, registers: registers)
         

--- a/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
@@ -1,7 +1,16 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryThread: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class SentryThreadDecodable: SentryThread {
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias SentryThreadDecodable = SentryThread
+#endif
+extension SentryThreadDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case threadId = "id"
@@ -11,8 +20,14 @@ extension SentryThread: Decodable {
         case current
         case isMain = "main"
     }
-    
+
+    #if !SENTRY_SWIFT_PACKAGE
     required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
         guard let threadId = try container.decode(NSNumberDecodableWrapper.self, forKey: .threadId).value else {
@@ -21,7 +36,7 @@ extension SentryThread: Decodable {
         
         self.init(threadId: threadId)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
-        self.stacktrace = try container.decodeIfPresent(SentryStacktrace.self, forKey: .stacktrace)
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
         self.crashed = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .crashed)?.value
         self.current = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .current)?.value
         self.isMain = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .isMain)?.value

--- a/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class SentryThreadDecodable: SentryThread {
     convenience public init(from decoder: any Decoder) throws {

--- a/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
@@ -1,7 +1,17 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension User: Decodable {
+#if SENTRY_SWIFT_PACKAGE
+final class UserDecodable: User {
+    @available(*, deprecated)
+    convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+}
+#else
+typealias UserDecodable = User
+#endif
+extension UserDecodable: Decodable {
     
     enum CodingKeys: String, CodingKey {
         case userId = "id"
@@ -14,6 +24,13 @@ extension User: Decodable {
         case data
     }
     
+    #if !SENTRY_SWIFT_PACKAGE
+    @available(*, deprecated)
+    required convenience public init(from decoder: any Decoder) throws {
+        try self.init(decodedFrom: decoder)
+    }
+    #endif
+    
      @available(*, deprecated, message: """
      This method is only deprecated to silence the deprecation warning of the property \
      segment. Our Xcode project has deprecations as warnings and warnings as errors \
@@ -23,7 +40,7 @@ extension User: Decodable {
      init method as deprecated because we don't expect many users to use it. Sadly, \
      Swift doesn't offer a better way of silencing a deprecation warning.
      """)
-    required convenience public init(from decoder: any Decoder) throws {
+    private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init()
         self.userId = try container.decodeIfPresent(String.self, forKey: .userId)
@@ -32,7 +49,7 @@ extension User: Decodable {
         self.ipAddress = try container.decodeIfPresent(String.self, forKey: .ipAddress)
         self.segment = try container.decodeIfPresent(String.self, forKey: .segment)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
-        self.geo = try container.decodeIfPresent(Geo.self, forKey: .geo)
+        self.geo = try container.decodeIfPresent(GeoDecodable.self, forKey: .geo)
         
         self.data = decodeArbitraryData {
             try container.decodeIfPresent([String: ArbitraryData].self, forKey: .data)

--- a/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
@@ -1,6 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
+// See `develop-docs/README.md` for an explanation of this pattern.
 #if SENTRY_SWIFT_PACKAGE
 final class UserDecodable: User {
     @available(*, deprecated)

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -273,3 +273,13 @@ Useful resources:
 - Sample GH Repo for [mixed Swift ObjC Framework](https://github.com/danieleggert/mixed-swift-objc-framework)
 - [Swift Forum Discussion](https://forums.swift.org/t/mixing-swift-and-objective-c-in-a-framework-and-private-headers/27787/6)
 - [Apple Docs: Importing Objective-C into Swift](https://developer.apple.com/documentation/swift/importing-objective-c-into-swift#Import-Code-Within-a-Framework-Target)
+
+## Decodable conformances to ObjC types
+
+A few types that are defined in ObjC have Decodable conformances in "Sources/Swift/Protocol/Codable/". This works for xcodebuild where ObjC and Swift are in the same target
+but not for SPM where ObjC and Swift have to be in different targets. This is because Swift does not support adding a protocol conformance to a type in a different module
+than the one the type/protocol is defined in. To work around this Swift code subclasses the ObjC type and adds the conformance to the subclass. It is then decoded as a
+subclass and cast back to the superclass. This is only done for SPM, not xcodebuild, because the Codable conformance is part of the public API and therefore requires a
+major version bump to change.
+
+Future types conforming to Decodable can be written in Swift from the start and therefore have the conformance added directly to the type.


### PR DESCRIPTION
This enables SPM support for building the entire SDK, and gets it building in CI. The approach follows from our slack discussion about introducing a new flag for any changes that are breaking the public API.

The PR is separated into 3 commits for easier reviewing. The first commit is the changes to `Decodable` conformances which is the part that changes the public API. The second commit is enabling accessing sentryId from Swift. Previously I had done this with a force cast, but this is a simpler way to get it compiling in CI without needing to introduce the force cast. The last commit just sets up CI/Package.swift

If we didn't want to modify the public API we could convert all these classes to Swift, as I started doing here: https://github.com/getsentry/sentry-cocoa/pull/5390 but the focus of this PR is just to get CI building with SPM without making as extensive changes.



#skip-changelog