### PR TITLE
(fix) Fix usage of app extension availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Improvements
 
 - Crashes for uncaught NSExceptions will now report the stracktrace recorded within the exception (#5306)
+- Fix usage of `@available` to be `iOS` instead of `iOSApplicationExtension` (#5361)
 
 ## 8.52.1
 

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -74,7 +74,7 @@ class SentryUserFeedbackIntegrationDriver: NSObject {
 }
 
 // MARK: SentryUserFeedbackFormDelegate
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
     func finished(with feedback: SentryFeedback?) {
         if let feedback = feedback {
@@ -89,7 +89,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
 }
 
 // MARK: SentryUserFeedbackWidgetDelegate
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate {
     func showForm() {
         showForm(screenshot: nil)
@@ -97,7 +97,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate 
 }
 
 // MARK: UIAdaptivePresentationControllerDelegate
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerDelegate {
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         widget?.rootVC.setWidget(visible: true, animated: configuration.animations)
@@ -107,7 +107,7 @@ extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerD
 }
 
 // MARK: Private
-@available(iOSApplicationExtension 13.0, *)
+@available(iOS 13.0, *)
 private extension SentryUserFeedbackIntegrationDriver {
     func showForm(screenshot: UIImage?) {
         let form = SentryUserFeedbackFormController(config: configuration, delegate: self, screenshot: screenshot)


### PR DESCRIPTION
This used `iOSApplicationExtension` for extensions but the class definition used `@available(iOS 13.0, *)`. That works when compiling with `APPLICATION_EXTENSION_API_ONLY` but not without it. Let's just change all to `iOS` so that it works with our without the extension-only flag.

#skip-changelog