### PR TITLE
fix(ci): Add `--flatten-debug-output` to Maestro CLI to upload debug logs

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Run Maestro Flows
         run: |
-          maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}}
+          maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}} --flatten-debug-output
 
       - name: Store Maestro Logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This change should fix the Maestro Debug logs not being uploaded on failure of the UI Critical Tests.

#skip-changelog 