### PR TITLE
chore(ci): Fail job if build output is not found in UI tests

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -39,6 +39,8 @@ jobs:
         with:
           name: SwiftUITestSample
           path: TestSamples/SwiftUITestSample/DerivedData/Build/Products/Debug-iphonesimulator/SwiftUITestSample.app
+          # If no files are found, fail the job with an error, because they are required for the next step
+          if-no-files-found: error
 
   run-tests:
     name: Test iOS on Xcode ${{matrix.xcode}} - V2 # Up the version with every change to keep track of flaky tests


### PR DESCRIPTION
Small improvement to make sure our CI fails early with missing files.

#skip-changelog