### PR TITLE
ci: Delete temporary keychain in Fastfile for build sample

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -192,6 +192,8 @@ platform :ios do
       skip_archive: true,
       skip_package_dependencies_resolution: true
     )
+
+    delete_keychain(name: "fastlane_tmp_keychain") unless is_ci
   end
 
   desc "Upload iOS-Swift to TestFlight and symbols to Sentry"


### PR DESCRIPTION
All the other `build_...` lanes are cleaning up the temporary keychain except this one used by UI tests run using Maestro.

#skip-changelog