### PR TITLE
revert: Run checks for release branches

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - release/**
 
   pull_request:
     paths:

--- a/.github/workflows/lint-clang-formatting.yml
+++ b/.github/workflows/lint-clang-formatting.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-      - release/**
-
     paths:
       - "**/*.h"
       - "**/*.hpp"

--- a/.github/workflows/lint-dprint.yml
+++ b/.github/workflows/lint-dprint.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      - release/**
-
     paths:
       - "**/*.yml"
       - "**/*.yaml"

--- a/.github/workflows/lint-shellcheck.yml
+++ b/.github/workflows/lint-shellcheck.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-      - release/**
-
     paths:
       - ".github/workflows/lint-shellcheck.yml"
       - "**/*.sh"

--- a/.github/workflows/lint-swift-formatting.yml
+++ b/.github/workflows/lint-swift-formatting.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-      - release/**
-
     paths:
       - "**/*.swift"
       - ".github/workflows/lint-swift-formatting.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - main
-      - release/**
-
     paths:
       - "Sources/**"
       - "Tests/**"

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - release/**
   pull_request:
     paths:
       - ".github/workflows/test-cross-platform.yml"

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - release/**
 
   pull_request:
     paths:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - release/**
 
   pull_request:
     paths:


### PR DESCRIPTION
This reverts commit 49e2bd0ee860b000d1ed31b9c628c636dfec8b9c because it causes the release workflow to fail:

https://github.com/getsentry/sentry-cocoa/actions/runs/15468574493/job/43548210375