### PR TITLE
ci: Update ios versions and handle prewarmed ui test launches

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -118,7 +118,7 @@ jobs:
             ./fastlane/test_output/**
 
   ui-tests-swift:
-    name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}} - V4 # Up the version with every change to keep track of flaky tests
+    name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}} - V5 # Up the version with every change to keep track of flaky tests
     runs-on: ${{matrix.runs-on}}
     strategy:
       fail-fast: false
@@ -131,8 +131,8 @@ jobs:
             xcode: "15.4"
             device: "iPhone 15 (17.5)"
           - runs-on: macos-15
-            xcode: "16.3"
-            device: "iPhone 16 (18.4)"
+            xcode: "16.4"
+            device: "iPhone 16 (18.5)"
 
     steps:
       - uses: actions/checkout@v4
@@ -224,7 +224,7 @@ jobs:
             ./fastlane/test_output/**
 
   duplication-tests:
-    name: UI Tests for project with Sentry duplicated - V3 # Up the version with every change to keep track of flaky tests
+    name: UI Tests for project with Sentry duplicated - V4 # Up the version with every change to keep track of flaky tests
     runs-on: macos-15
 
     steps:
@@ -236,7 +236,7 @@ jobs:
         with:
           bundler-cache: true
 
-      - run: ./scripts/ci-select-xcode.sh "16.2"
+      - run: ./scripts/ci-select-xcode.sh "16.4"
 
       - run: ./scripts/build-xcframework.sh gameOnly
 

--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -37,6 +37,9 @@ extension BaseUITest {
         for (k, v) in env {
             app.launchEnvironment[k] = v
         }
+        // App prewarming can sometimes cause simulators to get stuck in UI tests, activating them
+        // before launching clears any prewarming state.
+        app.activate()
         app.launch()
         waitForExistenceOfMainScreen()
     }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -295,6 +295,7 @@ platform :ios do
     run_tests(
       project: "./Tests/DuplicatedSDKTest/DuplicatedSDKTest.xcodeproj",
       scheme: "DuplicatedSDKTest",
+      device: "iPhone 16 (18.5)",
       xcodebuild_formatter: "xcbeautify --report junit",
       result_bundle: true,
       result_bundle_path: "fastlane/#{result_bundle_path}"


### PR DESCRIPTION
I looked at a few of the tests that have been failing on my recent PRs and found a couple opportunities for improvements.

1 - The duplicated SDK test was running on iOS 18.0 and on that failed test the entire simulator had crashed (see screenshot) I'm trying updating it to 18.5 which has some simulator fixes that might make it not crash as much
![Screenshot 2025-06-05 at 10 48 17 AM](https://github.com/user-attachments/assets/0d8b9050-7581-4b6c-bf29-4628a2bbe8a4)

2 - Another test was stuck with "app event loop idle notification not received". We saw things like this at Emerge sometimes that was from the app launch being prewarmed. UI tests don't know how to handle this and get stuck, we can fix it by first activating the app, and then launching it. There might be other reasons this happens, I read one is from permissions dialogs popping up on the host macOS machine, but at least this will fix one possible cause.
![Screenshot 2025-06-05 at 10 52 00 AM](https://github.com/user-attachments/assets/a01d3071-181a-4ffe-8367-8e7083708ae7)


#skip-changelog