### PR TITLE
ci: Add microphone permissions to simulator

### DIFF
--- a/.github/actions/add-microphone-permissions.yml
+++ b/.github/actions/add-microphone-permissions.yml
@@ -1,0 +1,22 @@
+name: "Add Microphone permissions for simulator"
+description: "Adds microphone permissions for simulator process"
+runs:
+  using: "composite"
+  steps:
+    - name: Grant microphone permissions
+      run: |
+        #!/usr/bin/env bash
+        if csrutil status | grep -q 'disabled'; then
+            epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
+            macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
+            if [[ $macos_major_version -le 10 ]]; then
+                tcc_update="replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"${ORB_VAL_PERMISSION_TYPE}\",\"${ORB_VAL_BUNDLE_ID}\",0,1,1,\"UNUSED\",0,$epochdate);"
+            else
+                tcc_update="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"${ORB_VAL_PERMISSION_TYPE}\",\"${ORB_VAL_BUNDLE_ID}\",0,2,1,1,\"UNUSED\",0,$epochdate);"
+            fi
+            sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_update"
+            sudo sqlite3 "/Users/$USER/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_update"
+        else
+            echo "Unable to add permissions! System Integrity Protection is enabled on this image"
+            exit 1
+        fi

--- a/.github/actions/add-microphone-permissions/action.yml
+++ b/.github/actions/add-microphone-permissions/action.yml
@@ -4,8 +4,8 @@ runs:
   using: "composite"
   steps:
     - name: Grant microphone permissions
+      shell: bash
       run: |
-        #!/usr/bin/env bash
         if csrutil status | grep -q 'disabled'; then
             epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
             macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')

--- a/.github/actions/add-microphone-permissions/action.yml
+++ b/.github/actions/add-microphone-permissions/action.yml
@@ -10,9 +10,9 @@ runs:
             epochdate=$(($(date +'%s * 1000 + %-N / 1000000')))
             macos_major_version=$(sw_vers -productVersion | awk -F. '{ print $1 }')
             if [[ $macos_major_version -le 10 ]]; then
-                tcc_update="replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"${ORB_VAL_PERMISSION_TYPE}\",\"${ORB_VAL_BUNDLE_ID}\",0,1,1,\"UNUSED\",0,$epochdate);"
+                tcc_update="replace into access (service,client,client_type,allowed,prompt_count,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceMicrophone\",\"com.apple.CoreSimulator.SimulatorTrampoline\",0,1,1,\"UNUSED\",0,$epochdate);"
             else
-                tcc_update="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"${ORB_VAL_PERMISSION_TYPE}\",\"${ORB_VAL_BUNDLE_ID}\",0,2,1,1,\"UNUSED\",0,$epochdate);"
+                tcc_update="replace into access (service,client,client_type,auth_value,auth_reason,auth_version,indirect_object_identifier,flags,last_modified) values (\"kTCCServiceMicrophone\",\"com.apple.CoreSimulator.SimulatorTrampoline\",0,2,1,1,\"UNUSED\",0,$epochdate);"
             fi
             sudo sqlite3 "/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_update"
             sudo sqlite3 "/Users/$USER/Library/Application Support/com.apple.TCC/TCC.db" "$tcc_update"

--- a/.github/actions/capture-screenshot/action.yml
+++ b/.github/actions/capture-screenshot/action.yml
@@ -1,0 +1,14 @@
+name: "Capture screenshot"
+description: "Captures a screenshot of the machine"
+runs:
+  using: "composite"
+  steps:
+    - name: Capture screenshot
+      shell: bash
+      run: |
+        screencapture -x /tmp/screenshot.png
+    - name: Store screenshot
+      uses: actions/upload-artifact@v4
+      with:
+        name: screenshot
+        path: /tmp/screenshot.png

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -83,6 +83,8 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
+      - uses: ./.github/actions/add-microphone-permissions
+
       - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
 
       - name: Install App

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -83,7 +83,7 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - uses: ./.github/actions/add-microphone-permissions.yml
 
       - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
 

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -83,7 +83,8 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
 
       - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
 

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -83,7 +83,7 @@ jobs:
           name: ${{env.APP_ARTIFACT_NAME}}
           path: ${{env.APP_PATH}}
 
-      - uses: ./.github/actions/add-microphone-permissions.yml
+      - uses: ./.github/actions/add-microphone-permissions
 
       - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
 

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -109,3 +109,7 @@ jobs:
           name: crash-logs-${{matrix.xcode}}
           path: |
             ~/Library/Logs/DiagnosticReports/**
+
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.2
       - run: make init-ci-build
       - run: make xcode
-      - uses: ./.github/actions/add-microphone-permissions.yml
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_${{matrix.target}}
         shell: sh
@@ -88,7 +88,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions.yml
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swiftui
         shell: sh
@@ -150,7 +150,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions.yml
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift device:"${{matrix.device}}"
 
@@ -197,7 +197,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions.yml
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift6
 
@@ -243,7 +243,7 @@ jobs:
 
       - run: ./scripts/build-xcframework.sh gameOnly
 
-      - uses: ./.github/actions/add-microphone-permissions.yml
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane duplication_test
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.2
       - run: make init-ci-build
       - run: make xcode
-
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_${{matrix.target}}
         shell: sh
@@ -88,6 +88,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swiftui
         shell: sh
@@ -149,6 +150,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift device:"${{matrix.device}}"
 
@@ -195,6 +197,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift6
 
@@ -240,6 +243,7 @@ jobs:
 
       - run: ./scripts/build-xcframework.sh gameOnly
 
+      - uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane duplication_test
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -70,6 +70,10 @@ jobs:
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
 
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()
+
   # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:
     name: UI Tests for SwiftUI - V4 # Up the version with every change to keep track of flaky tests
@@ -118,6 +122,10 @@ jobs:
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
+
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()
 
   ui-tests-swift:
     name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}} - V4 # Up the version with every change to keep track of flaky tests
@@ -182,6 +190,10 @@ jobs:
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
 
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()
+
   ui-tests-swift6:
     name: UI Tests for iOS-Swift6 - V3 # Up the version with every change to keep track of flaky tests
     runs-on: macos-15
@@ -231,6 +243,10 @@ jobs:
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
 
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()
+
   duplication-tests:
     name: UI Tests for project with Sentry duplicated - V3 # Up the version with every change to keep track of flaky tests
     runs-on: macos-15
@@ -278,3 +294,7 @@ jobs:
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
+
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -31,7 +31,6 @@ jobs:
         target: ["ios_objc", "tvos_swift"]
     steps:
       - uses: actions/checkout@v4
-
       - name: Print hardware info
         run: system_profiler SPHardwareDataType
       - uses: ruby/setup-ruby@v1
@@ -40,7 +39,8 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.2
       - run: make init-ci-build
       - run: make xcode
-      - uses: ./.github/actions/add-microphone-permissions
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_${{matrix.target}}
         shell: sh
@@ -88,7 +88,8 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swiftui
         shell: sh
@@ -150,7 +151,9 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
+
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift device:"${{matrix.device}}"
 
@@ -197,7 +200,9 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
+
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift6
 
@@ -243,7 +248,9 @@ jobs:
 
       - run: ./scripts/build-xcframework.sh gameOnly
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
+
       - name: Run Fastlane
         run: bundle exec fastlane duplication_test
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
       - run: ./scripts/ci-select-xcode.sh 16.2
       - run: make init-ci-build
       - run: make xcode
-      - uses: ./.github/actions/add-microphone-permissions
+      - uses: ./.github/actions/add-microphone-permissions.yml
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_${{matrix.target}}
         shell: sh
@@ -88,7 +88,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - uses: ./.github/actions/add-microphone-permissions.yml
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swiftui
         shell: sh
@@ -150,7 +150,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - uses: ./.github/actions/add-microphone-permissions.yml
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift device:"${{matrix.device}}"
 
@@ -197,7 +197,7 @@ jobs:
       - run: make xcode
         name: XcodeGen iOS-Swift project
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - uses: ./.github/actions/add-microphone-permissions.yml
       - name: Run Fastlane
         run: bundle exec fastlane ui_tests_ios_swift6
 
@@ -243,7 +243,7 @@ jobs:
 
       - run: ./scripts/build-xcframework.sh gameOnly
 
-      - uses: ./.github/actions/add-microphone-permissions
+      - uses: ./.github/actions/add-microphone-permissions.yml
       - name: Run Fastlane
         run: bundle exec fastlane duplication_test
 


### PR DESCRIPTION
## :scroll: Description

Some tests are failing due to the UI loop not being idle.
Sometimes that can happen due to the microphone permissions on macOS.

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
