### PR TITLE
ci: Exclude `sdk_api.json` from end of line fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,7 @@ repos:
         args: [--allow-multiple-documents]
       - id: detect-private-key
       - id: end-of-file-fixer
+        exclude: ^sdk_api.json$
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.27.3


### PR DESCRIPTION
## :scroll: Description

Exclude `sdk_api.json` from the new end of line linter

## :bulb: Motivation and Context

This linter is modifying the output of the file, which causes other checks to fail.
We should respect swift's format for this file

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
