### PR TITLE
ci: Run maestro tests individually

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -42,23 +42,18 @@ jobs:
           if-no-files-found: error
 
   run-tests:
-    name: Test iOS on Xcode ${{matrix.xcode}} - V2 # Up the version with every change to keep track of flaky tests
+    name: Test iOS on Xcode ${{matrix.platform.xcode}} - ${{matrix.test.name}} - V3 # Up the version with every change to keep track of flaky tests
     needs: [build-sample]
-    runs-on: ${{matrix.runs-on}}
+    runs-on: ${{matrix.platform.runs-on}}
     env:
       APP_ARTIFACT_NAME: "SwiftUITestSample"
       APP_PATH: "Sample.app"
-
-      MAESTRO_FLOWS_PATH: "TestSamples/SwiftUITestSample/Maestro"
       MAESTRO_LOGS_PATH: "MaestroLogs"
-
-      # https://github.com/facebook/react-native/blob/24e7f7d25629a7af6d877a0b79fed2faaab96437/.github/actions/maestro-ios/action.yml#L57
       MAESTRO_DRIVER_STARTUP_TIMEOUT: 1500000 # 25 min, CI can be slow at times
-
     strategy:
       fail-fast: false
       matrix:
-        include:
+        platform:
           # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
           - runs-on: macos-13
@@ -70,6 +65,11 @@ jobs:
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
           - runs-on: macos-15
             xcode: "16.2"
+        test:
+          - name: "Crash"
+            maestro_flows_path: "TestSamples/SwiftUITestSample/Maestro/crash.yaml"
+          - name: "CorruptEnvelope"
+            maestro_flows_path: "TestSamples/SwiftUITestSample/Maestro/corruptEnvelope.yaml"
 
     steps:
       - uses: actions/checkout@v4
@@ -88,29 +88,28 @@ jobs:
       - name: Add Microphone permissions
         uses: ./.github/actions/add-microphone-permissions
 
-      - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
+      - run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.platform.xcode}}
 
       - name: Install App
         run: xcrun simctl install booted ${{env.APP_PATH}}
 
       - name: Run Maestro Flows
         run: |
-          maestro test ${{env.MAESTRO_FLOWS_PATH}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}} --flatten-debug-output
+          maestro test ${{matrix.test.maestro_flows_path}} --format junit --debug-output ${{env.MAESTRO_LOGS_PATH}} --flatten-debug-output
 
       - name: Store Maestro Logs
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: maestro-logs-${{matrix.xcode}}
+          name: maestro-logs-${{matrix.platform.xcode}}-${{matrix.test.name}}
           path: ${{env.MAESTRO_LOGS_PATH}}
 
       - name: Archiving Crash Logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
-          name: crash-logs-${{matrix.xcode}}
-          path: |
-            ~/Library/Logs/DiagnosticReports/**
+          name: crash-logs-${{matrix.platform.xcode}}
+          path: ~/Library/Logs/DiagnosticReports/**
 
       - name: Store screenshot
         uses: ./.github/actions/capture-screenshot


### PR DESCRIPTION
## :scroll: Description

Runs Maestro tests individually

## :bulb: Motivation and Context

Maestro workflows seem to be catching the previous error thus failing the tests incorrectly.
Splitting the tests should help this scenario

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
