### PR TITLE
Use job instead of run-id

### DIFF
--- a/.github/actions/capture-screenshot/action.yml
+++ b/.github/actions/capture-screenshot/action.yml
@@ -10,5 +10,5 @@ runs:
     - name: Store screenshot
       uses: actions/upload-artifact@v4
       with:
-        name: screenshot-${{ github.run_id }}
+        name: screenshot-${{ github.job }}
         path: /tmp/screenshot.png


### PR DESCRIPTION
## :scroll: Description

Replace `github.run_id` with `github.job`

## :bulb: Motivation and Context

`github.run_id` is the same for all jobs in the same workflow

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
