### PR TITLE
ci: fix ui-test-critical archive name collisions

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -108,7 +108,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
-          name: crash-logs-${{matrix.platform.xcode}}
+          name: crash-logs-${{matrix.platform.xcode}}-${{matrix.test.name}}
           path: ~/Library/Logs/DiagnosticReports/**
 
       - name: Store screenshot


### PR DESCRIPTION
These are colliding because we run two types of test per Xcode version: https://github.com/getsentry/sentry-cocoa/actions/runs/15521723107/job/43695867451?pr=5377#step:12:36

#skip-changelog