### PR TITLE
fix: Fix xcode 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Crashes for uncaught NSExceptions will now report the stracktrace recorded within the exception (#5306)
 - Fix usage of `@available` to be `iOS` instead of `iOSApplicationExtension` (#5361)
 - Move SentryExperimentalOptions to a property defined in Swift (#5329)
+- Fix building with Xcode 26 (#5386)
 
 ## 8.52.1
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashCxaThrowSwapper.c
@@ -134,7 +134,7 @@ addPair(SentryCrashImageToOriginalCxaThrowPair pair)
 static void
 __cxa_throw_decorator(void *thrown_exception, void *tinfo, void (*dest)(void *))
 {
-    const int k_requiredFrames = 2;
+#define REQUIRED_FRAMES 2
 
     if (g_cxa_throw_handler != NULL) {
         SENTRY_ASYNC_SAFE_LOG_DEBUG(
@@ -142,11 +142,11 @@ __cxa_throw_decorator(void *thrown_exception, void *tinfo, void (*dest)(void *))
         g_cxa_throw_handler(thrown_exception, tinfo, dest);
     }
 
-    void *backtraceArr[k_requiredFrames];
-    int count = backtrace(backtraceArr, k_requiredFrames);
+    void *backtraceArr[REQUIRED_FRAMES];
+    int count = backtrace(backtraceArr, REQUIRED_FRAMES);
 
     Dl_info info;
-    if (count < k_requiredFrames) {
+    if (count < REQUIRED_FRAMES) {
         // This can happen if the throw happened in a signal handler. This is an edge case we ignore
         // for now. It can also happen with concurrency frameworks for which backtrace does not work
         // reliably, such as Swift async. It can be that we have to use backtrace_async which uses
@@ -160,7 +160,7 @@ __cxa_throw_decorator(void *thrown_exception, void *tinfo, void (*dest)(void *))
         return;
     }
 
-    if (dladdr(backtraceArr[k_requiredFrames - 1], &info) == 0) {
+    if (dladdr(backtraceArr[REQUIRED_FRAMES - 1], &info) == 0) {
         SENTRY_ASYNC_SAFE_LOG_ERROR(
             "dladdr failed for throwsite. Can't identify image of throwsite.");
         return;

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.h
@@ -65,7 +65,7 @@ void sentrycrashmc_resumeEnvironment(thread_act_array_t threads, mach_msg_type_n
  * @param NAME The C identifier to give the pointer.
  */
 #define SentryCrashMC_NEW_CONTEXT(NAME)                                                            \
-    char sentrycrashmc_##NAME##_storage[sentrycrashmc_contextSize];                                \
+    char sentrycrashmc_##NAME##_storage[sizeof(SentryCrashMachineContext)];                        \
     struct SentryCrashMachineContext *NAME                                                         \
         = (struct SentryCrashMachineContext *)sentrycrashmc_##NAME##_storage
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext_Apple.h
@@ -54,8 +54,6 @@ typedef struct SentryCrashMachineContext {
     STRUCT_MCONTEXT_L machineContext;
 } SentryCrashMachineContext;
 
-static const size_t sentrycrashmc_contextSize = sizeof(SentryCrashMachineContext);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## :scroll: Description

Fix for Xcode 26

## :bulb: Motivation and Context

Fixes this error in Xcode 26:
![Screenshot 2025-06-09 at 1 09 58 PM](https://github.com/user-attachments/assets/748a6346-c612-4f24-8b15-16b002975832)

## :green_heart: How did you test it?

Build with xcode

## :pencil: Checklist

You have to check all boxes before merging:

- [X] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [X] No breaking change or entry added to the changelog.
- [X] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
