### PR TITLE
WIP ref: Fix Decodable conformances for SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Crashes for uncaught NSExceptions will now report the stracktrace recorded within the exception (#5306)
 - Fix usage of `@available` to be `iOS` instead of `iOSApplicationExtension` (#5361)
 - Move SentryExperimentalOptions to a property defined in Swift (#5329)
+- Implement Decodable conformances in new Swift subclass (#5388) 
 
 ## 8.52.1
 

--- a/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Breadcrumb: Decodable {
+final class BreadcrumbDecodable: Breadcrumb, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case level

--- a/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension DebugMeta: Decodable {
+final class DebugMetaDecodable: DebugMeta, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case uuid

--- a/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
@@ -58,7 +58,7 @@ open class SentryEventDecodable: Event, Decodable {
 
         let eventIdAsString = try container.decode(String.self, forKey: .eventId)
         self.eventId = SentryId(uuidString: eventIdAsString)
-        self.message = try container.decodeIfPresent(SentryMessage.self, forKey: .message)
+        self.message = try container.decodeIfPresent(SentryMessageDecodable.self, forKey: .message)
         self.timestamp = try container.decode(Date.self, forKey: .timestamp)
         self.startTimestamp = try container.decodeIfPresent(Date.self, forKey: .startTimestamp)
 
@@ -89,27 +89,27 @@ open class SentryEventDecodable: Event, Decodable {
 
         self.modules = try container.decodeIfPresent([String: String].self, forKey: .modules)
         self.fingerprint = try container.decodeIfPresent([String].self, forKey: .fingerprint)
-        self.user = try container.decodeIfPresent(User.self, forKey: .user)
+        self.user = try container.decodeIfPresent(UserDecodable.self, forKey: .user)
         
         self.context = decodeArbitraryData {
             try container.decodeIfPresent([String: [String: ArbitraryData]].self, forKey: .context)
         }
 
-        if let rawThreads = try container.decodeIfPresent([String: [SentryThread]].self, forKey: .threads) {
+        if let rawThreads = try container.decodeIfPresent([String: [SentryThreadDecodable]].self, forKey: .threads) {
             self.threads = rawThreads["values"]
         }
             
-        if let rawExceptions = try container.decodeIfPresent([String: [Exception]].self, forKey: .exception) {
+        if let rawExceptions = try container.decodeIfPresent([String: [ExceptionDecodable]].self, forKey: .exception) {
             self.exceptions = rawExceptions["values"]
         }
         
-        self.stacktrace = try container.decodeIfPresent(SentryStacktrace.self, forKey: .stacktrace)
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
         
-        if let rawDebugMeta = try container.decodeIfPresent([String: [DebugMeta]].self, forKey: .debugMeta) {
+        if let rawDebugMeta = try container.decodeIfPresent([String: [DebugMetaDecodable]].self, forKey: .debugMeta) {
             self.debugMeta = rawDebugMeta["images"]
         }
         
-        self.breadcrumbs = try container.decodeIfPresent([Breadcrumb].self, forKey: .breadcrumbs)
-        self.request = try container.decodeIfPresent(SentryRequest.self, forKey: .request)
+        self.breadcrumbs = try container.decodeIfPresent([BreadcrumbDecodable].self, forKey: .breadcrumbs)
+        self.request = try container.decodeIfPresent(SentryRequestDecodable.self, forKey: .request)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Exception: Decodable {
+final class ExceptionDecodable: Exception, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case value
@@ -20,9 +20,9 @@ extension Exception: Decodable {
 
         self.init(value: value, type: type)
 
-        self.mechanism = try container.decodeIfPresent(Mechanism.self, forKey: .mechanism)
+        self.mechanism = try container.decodeIfPresent(MechanismDecodable.self, forKey: .mechanism)
         self.module = try container.decodeIfPresent(String.self, forKey: .module)
         self.threadId = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .threadId)?.value
-        self.stacktrace = try container.decodeIfPresent(SentryStacktrace.self, forKey: .stacktrace)
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Frame: Decodable {
+final class FrameDecodable: Frame, Decodable {
 
     enum CodingKeys: String, CodingKey {
         case symbolAddress = "symbol_addr"

--- a/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Geo: Decodable {
+final class GeoDecodable: Geo, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case city

--- a/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension Mechanism: Decodable {
+final class MechanismDecodable: Mechanism, Decodable {
 
     enum CodingKeys: String, CodingKey {
         case type
@@ -26,6 +26,6 @@ extension Mechanism: Decodable {
         self.handled = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .handled)?.value
         self.synthetic = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .synthetic)?.value
         self.helpLink = try container.decodeIfPresent(String.self, forKey: .helpLink)
-        self.meta = try container.decodeIfPresent(MechanismMeta.self, forKey: .meta)
+        self.meta = try container.decodeIfPresent(MechanismMetaDecodable.self, forKey: .meta)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension MechanismMeta: Decodable {
+final class MechanismMetaDecodable: MechanismMeta, Decodable {
 
     enum CodingKeys: String, CodingKey {
         case signal
@@ -19,6 +19,6 @@ extension MechanismMeta: Decodable {
         self.machException = decodeArbitraryData {
             try container.decodeIfPresent([String: ArbitraryData].self, forKey: .machException)
         }
-        self.error = try container.decodeIfPresent(SentryNSError.self, forKey: .error)
+        self.error = try container.decodeIfPresent(SentryNSErrorDecodable.self, forKey: .error)
     }
 }

--- a/Sources/Swift/Protocol/Codable/SentryMessage.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMessage.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryMessage: Decodable {
+final class SentryMessageDecodable: SentryMessage, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case formatted

--- a/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryNSError: Decodable {
+final class SentryNSErrorDecodable: SentryNSError, Decodable {
 
     enum CodingKeys: String, CodingKey {
         case domain

--- a/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryRequest: Decodable {
+final class SentryRequestDecodable: SentryRequest, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case bodySize = "body_size"

--- a/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryStacktrace: Decodable {
+final class SentryStacktraceDecodable: SentryStacktrace, Decodable {
 
     enum CodingKeys: String, CodingKey {
         case frames
@@ -12,7 +12,7 @@ extension SentryStacktrace: Decodable {
     required convenience public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
-        let frames = try container.decodeIfPresent([Frame].self, forKey: .frames) ?? []
+        let frames = try container.decodeIfPresent([FrameDecodable].self, forKey: .frames) ?? []
         let registers = try container.decodeIfPresent([String: String].self, forKey: .registers) ?? [:]
         self.init(frames: frames, registers: registers)
         

--- a/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension SentryThread: Decodable {
+final class SentryThreadDecodable: SentryThread, Decodable {
     
     private enum CodingKeys: String, CodingKey {
         case threadId = "id"
@@ -21,7 +21,7 @@ extension SentryThread: Decodable {
         
         self.init(threadId: threadId)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
-        self.stacktrace = try container.decodeIfPresent(SentryStacktrace.self, forKey: .stacktrace)
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
         self.crashed = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .crashed)?.value
         self.current = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .current)?.value
         self.isMain = try container.decodeIfPresent(NSNumberDecodableWrapper.self, forKey: .isMain)?.value

--- a/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
@@ -1,7 +1,7 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-extension User: Decodable {
+final class UserDecodable: User, Decodable {
     
     enum CodingKeys: String, CodingKey {
         case userId = "id"
@@ -32,7 +32,7 @@ extension User: Decodable {
         self.ipAddress = try container.decodeIfPresent(String.self, forKey: .ipAddress)
         self.segment = try container.decodeIfPresent(String.self, forKey: .segment)
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
-        self.geo = try container.decodeIfPresent(Geo.self, forKey: .geo)
+        self.geo = try container.decodeIfPresent(GeoDecodable.self, forKey: .geo)
         
         self.data = decodeArbitraryData {
             try container.decodeIfPresent([String: ArbitraryData].self, forKey: .data)


### PR DESCRIPTION
**This is still a WIP, no need to review yet**


This is the next step of the SPM migration doc, moving protocol conformances to not be across module boundaries. With SPM objc and swift are in separate modules, so this conformance cannot be added to a type defined in objc. Instead we can create a new class inheriting from the objc class, and add the conformance to this new class.

#skip-changelog