### PR TITLE
ci: revert duplication test to its own logic not using ui-tests-commo…

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -26,16 +26,6 @@ on:
         required: false
         default: false
         type: boolean
-      build_xcframework:
-        description: "Build xcframework"
-        required: false
-        default: false
-        type: boolean
-      xcframework_type:
-        description: "Parameters for the build script"
-        required: false
-        default: ""
-        type: string
       macos_version:
         description: "macOS version"
         required: true
@@ -67,10 +57,6 @@ jobs:
       - run: make xcode
         shell: sh
         if: ${{ inputs.build_with_make }}
-
-      - run: ./scripts/build-xcframework.sh ${{ inputs.xcframework_type }}
-        shell: sh
-        if: ${{ inputs.build_xcframework }}
 
       - name: Add Microphone permissions
         uses: ./.github/actions/add-microphone-permissions

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -80,11 +80,51 @@ jobs:
       macos_version: macos-15
 
   duplication-tests:
-    name: UI Tests for project with Sentry duplicated - V4 # Up the version with every change to keep track of flaky tests
-    uses: ./.github/workflows/ui-tests-common.yml
-    with:
-      fastlane_command: duplication_test
-      xcode_version: 16.4
-      build_xcframework: true
-      xcframework_type: gameOnly
-      macos_version: macos-15
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Print hardware info
+        run: system_profiler SPHardwareDataType
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - run: ./scripts/ci-select-xcode.sh "16.4"
+
+      - run: ./scripts/build-xcframework.sh gameOnly
+
+      - name: Add Microphone permissions
+        uses: ./.github/actions/add-microphone-permissions
+
+      - name: Run Fastlane
+        run: bundle exec fastlane duplication_test
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@65fe03598d8d251738592a497a9e8547a5c48eaa # v5.6.0
+        if: always()
+        with:
+          report_paths: "build/reports/junit.xml"
+          fail_on_failure: true
+          fail_on_parse_error: true
+          detailed_summary: true
+
+      - name: Upload Result Bundle
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
+        with:
+          name: duplication-test.xcresult
+          path: fastlane/test_results/duplication-test.xcresult
+
+      - name: Archiving Raw Test Logs
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: duplication-test-raw-output
+          path: |
+            ~/Library/Logs/scan/*.log
+            ./fastlane/test_output/**
+      - name: Store screenshot
+        uses: ./.github/actions/capture-screenshot
+        if: failure()


### PR DESCRIPTION
Need to revert the change from #5375 for the one test that requires an xcframework to be built, because there's no way to set conditional dependencies between jobs, which would be needed to merge it together with the changes from #5218.

#skip-changelog