### PR TITLE
ci: avoid upload failures with unique screenshot names with optional suffixes

### DIFF
--- a/.github/actions/capture-screenshot/action.yml
+++ b/.github/actions/capture-screenshot/action.yml
@@ -15,5 +15,5 @@ runs:
     - name: Store screenshot
       uses: actions/upload-artifact@v4
       with:
-        name: screenshot-${{ github.job }}-${{ inputs.suffix }}
+        name: screenshot-${{ github.job }}${{ inputs.suffix }}
         path: /tmp/screenshot.png

--- a/.github/actions/capture-screenshot/action.yml
+++ b/.github/actions/capture-screenshot/action.yml
@@ -1,5 +1,10 @@
 name: "Capture screenshot"
 description: "Captures a screenshot of the machine"
+inputs:
+  suffix:
+    description: "The suffix of the screenshot"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -10,5 +15,5 @@ runs:
     - name: Store screenshot
       uses: actions/upload-artifact@v4
       with:
-        name: screenshot-${{ github.job }}
+        name: screenshot-${{ github.job }}-${{ inputs.suffix }}
         path: /tmp/screenshot.png

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -111,4 +111,4 @@ jobs:
         uses: ./.github/actions/capture-screenshot
         if: failure()
         with:
-          suffix: "raw_output"
+          suffix: ${{ inputs.files_suffix }}

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -12,8 +12,8 @@ on:
         required: false
         default: ""
         type: string
-      xcresult_suffix:
-        description: "Suffix for the xcresult artifact (if needed)"
+      files_suffix:
+        description: "Suffix for the files to upload"
         required: false
         default: ""
         type: string
@@ -95,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: ${{ inputs.fastlane_command }}${{inputs.xcresult_suffix}}
+          name: ${{ inputs.fastlane_command }}${{inputs.xcresult_suffix}}.xcresult
           path: fastlane/test_results/${{ inputs.fastlane_command }}.xcresult
 
       - name: Archiving Raw Test Logs
@@ -110,3 +110,5 @@ jobs:
       - name: Store screenshot
         uses: ./.github/actions/capture-screenshot
         if: failure()
+        with:
+          suffix: "raw_output"

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -95,14 +95,14 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
-          name: ${{ inputs.fastlane_command }}${{inputs.xcresult_suffix}}.xcresult
+          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}.xcresult
           path: fastlane/test_results/${{ inputs.fastlane_command }}.xcresult
 
       - name: Archiving Raw Test Logs
         uses: actions/upload-artifact@v4
         if: ${{ failure() || cancelled() }}
         with:
-          name: ${{ inputs.fastlane_command }}${{inputs.xcresult_suffix}}_raw_output
+          name: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}_raw_output
           path: |
             ~/Library/Logs/scan/*.log
             ./fastlane/test_output/**
@@ -111,4 +111,4 @@ jobs:
         uses: ./.github/actions/capture-screenshot
         if: failure()
         with:
-          suffix: ${{ inputs.files_suffix }}
+          suffix: ${{ inputs.fastlane_command }}${{ inputs.files_suffix }}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -30,6 +30,7 @@ jobs:
       build_with_make: true
       xcode_version: ${{matrix.platform.xcode}}
       macos_version: ${{matrix.platform.runs-on}}
+      files_suffix: _${{matrix.platform.xcode}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -69,7 +69,7 @@ jobs:
     with:
       fastlane_command: ui_tests_ios_swift
       fastlane_command_extra_arguments: device:"${{matrix.device}}"
-      xcresult_suffix: _xcode_${{matrix.xcode}}-${{matrix.device}}
+      files_suffix: _xcode_${{matrix.xcode}}-${{matrix.device}}
       xcode_version: ${{matrix.xcode}}
       build_with_make: true
       macos_version: ${{matrix.runs-on}}


### PR DESCRIPTION
## :scroll: Description

Some jobs use matrixes, so they have the same job id, adding optional suffix so we get all screenshots

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog