### PR TITLE
refactor: Rename SentryViewHierarchy to SentryViewHierarchyProvider

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -35,9 +35,9 @@
 		0A2D8D8728992260008720F6 /* SentryBaseIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D8628992260008720F6 /* SentryBaseIntegrationTests.swift */; };
 		0A2D8D9628997845008720F6 /* NSLocale+Sentry.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8D9428997845008720F6 /* NSLocale+Sentry.m */; };
 		0A2D8D9828997887008720F6 /* NSLocale+Sentry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */; };
-		0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */; };
-		0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */; };
-		0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */; };
+		0A2D8DA8289BC905008720F6 /* SentryViewHierarchyProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2D8DA6289BC905008720F6 /* SentryViewHierarchyProvider.h */; };
+		0A2D8DA9289BC905008720F6 /* SentryViewHierarchyProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A2D8DA7289BC905008720F6 /* SentryViewHierarchyProvider.m */; };
+		0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyProviderTests.swift */; };
 		0A56DA5F28ABA01B00C400D5 /* SentryTransactionContext+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */; };
 		0A80E433291017C300095219 /* SentryWatchdogTerminationScopeObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A80E432291017C300095219 /* SentryWatchdogTerminationScopeObserver.m */; };
 		0A80E435291017D500095219 /* SentryWatchdogTerminationScopeObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A80E434291017D500095219 /* SentryWatchdogTerminationScopeObserver.h */; };
@@ -45,7 +45,7 @@
 		0A9415BA28F96CAC006A5DD1 /* TestSentryReachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9415B928F96CAC006A5DD1 /* TestSentryReachability.swift */; };
 		0A9BF4E228A114940068D266 /* SentryViewHierarchyIntegration.m in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */; };
 		0A9BF4E428A114B50068D266 /* SentryViewHierarchyIntegration.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */; };
-		0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */; };
+		0A9BF4E928A125390068D266 /* TestSentryViewHierarchyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4E628A123270068D266 /* TestSentryViewHierarchyProvider.swift */; };
 		0A9BF4EB28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */; };
 		0A9E917128DC7E7000FB4182 /* SentryInternalCDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A9E917028DC7E7000FB4182 /* SentryInternalCDefines.h */; };
 		0AAE201E28ED9B9400D0CD80 /* SentryReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 0AAE201D28ED9B9400D0CD80 /* SentryReachability.m */; };
@@ -1180,9 +1180,9 @@
 		0A2D8D8628992260008720F6 /* SentryBaseIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBaseIntegrationTests.swift; sourceTree = "<group>"; };
 		0A2D8D9428997845008720F6 /* NSLocale+Sentry.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+Sentry.m"; sourceTree = "<group>"; };
 		0A2D8D9728997887008720F6 /* NSLocale+Sentry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "NSLocale+Sentry.h"; path = "include/NSLocale+Sentry.h"; sourceTree = "<group>"; };
-		0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchy.h; path = include/SentryViewHierarchy.h; sourceTree = "<group>"; };
-		0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchy.m; sourceTree = "<group>"; };
-		0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyTests.swift; sourceTree = "<group>"; };
+		0A2D8DA6289BC905008720F6 /* SentryViewHierarchyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyProvider.h; path = include/SentryViewHierarchyProvider.h; sourceTree = "<group>"; };
+		0A2D8DA7289BC905008720F6 /* SentryViewHierarchyProvider.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyProvider.m; sourceTree = "<group>"; };
+		0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyProviderTests.swift; sourceTree = "<group>"; };
 		0A56DA5E28ABA01B00C400D5 /* SentryTransactionContext+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryTransactionContext+Private.h"; path = "include/SentryTransactionContext+Private.h"; sourceTree = "<group>"; };
 		0A80E432291017C300095219 /* SentryWatchdogTerminationScopeObserver.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryWatchdogTerminationScopeObserver.m; sourceTree = "<group>"; };
 		0A80E434291017D500095219 /* SentryWatchdogTerminationScopeObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryWatchdogTerminationScopeObserver.h; path = include/SentryWatchdogTerminationScopeObserver.h; sourceTree = "<group>"; };
@@ -1190,7 +1190,7 @@
 		0A9415B928F96CAC006A5DD1 /* TestSentryReachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryReachability.swift; sourceTree = "<group>"; };
 		0A9BF4E128A114940068D266 /* SentryViewHierarchyIntegration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryViewHierarchyIntegration.m; sourceTree = "<group>"; };
 		0A9BF4E328A114B50068D266 /* SentryViewHierarchyIntegration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryViewHierarchyIntegration.h; path = include/SentryViewHierarchyIntegration.h; sourceTree = "<group>"; };
-		0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryViewHierarchy.swift; sourceTree = "<group>"; };
+		0A9BF4E628A123270068D266 /* TestSentryViewHierarchyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryViewHierarchyProvider.swift; sourceTree = "<group>"; };
 		0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyIntegrationTests.swift; sourceTree = "<group>"; };
 		0A9E917028DC7E7000FB4182 /* SentryInternalCDefines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryInternalCDefines.h; path = include/SentryInternalCDefines.h; sourceTree = "<group>"; };
 		0AAE201D28ED9B9400D0CD80 /* SentryReachability.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryReachability.m; sourceTree = "<group>"; };
@@ -2175,7 +2175,7 @@
 		D867063A27C3BC2400048851 /* SentryCoreDataTrackingIntegration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryCoreDataTrackingIntegration.h; path = include/SentryCoreDataTrackingIntegration.h; sourceTree = "<group>"; };
 		D867063B27C3BC2400048851 /* SentryCoreDataSwizzling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryCoreDataSwizzling.h; path = include/SentryCoreDataSwizzling.h; sourceTree = "<group>"; };
 		D867063C27C3BC2400048851 /* SentryCoreDataTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryCoreDataTracker.h; path = include/SentryCoreDataTracker.h; sourceTree = "<group>"; };
-		D86B6820293F39E000B8B1FC /* TestSentryViewHierarchy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSentryViewHierarchy.h; sourceTree = "<group>"; };
+		D86B6820293F39E000B8B1FC /* TestSentryViewHierarchyProvider.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestSentryViewHierarchyProvider.h; sourceTree = "<group>"; };
 		D86B6834294348A400B8B1FC /* SentryAttachment+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryAttachment+Private.h"; path = "include/SentryAttachment+Private.h"; sourceTree = "<group>"; };
 		D86F419727C8FEFA00490520 /* SentryCoreDataTrackerExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCoreDataTrackerExtension.swift; sourceTree = "<group>"; };
 		D8709AC32D3E9C5C006C491E /* SentryReplayMaskPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReplayMaskPreview.swift; sourceTree = "<group>"; };
@@ -2399,8 +2399,8 @@
 			isa = PBXGroup;
 			children = (
 				0A9BF4EA28A127120068D266 /* SentryViewHierarchyIntegrationTests.swift */,
-				0A9BF4E628A123270068D266 /* TestSentryViewHierarchy.swift */,
-				D86B6820293F39E000B8B1FC /* TestSentryViewHierarchy.h */,
+				0A9BF4E628A123270068D266 /* TestSentryViewHierarchyProvider.swift */,
+				D86B6820293F39E000B8B1FC /* TestSentryViewHierarchyProvider.h */,
 			);
 			path = ViewHierarchy;
 			sourceTree = "<group>";
@@ -3913,8 +3913,8 @@
 				D85852B827EDDC5900C6D8AE /* SentryUIApplication.m */,
 				D8F6A24A2885515B00320515 /* SentryPredicateDescriptor.h */,
 				D8F6A2452885512100320515 /* SentryPredicateDescriptor.m */,
-				0A2D8DA6289BC905008720F6 /* SentryViewHierarchy.h */,
-				0A2D8DA7289BC905008720F6 /* SentryViewHierarchy.m */,
+				0A2D8DA6289BC905008720F6 /* SentryViewHierarchyProvider.h */,
+				0A2D8DA7289BC905008720F6 /* SentryViewHierarchyProvider.m */,
 				D83D07992B7F9D1C00CC9674 /* SentryMsgPackSerializer.h */,
 				D83D079A2B7F9D1C00CC9674 /* SentryMsgPackSerializer.m */,
 				D43A2A0F2DD47FB700114724 /* SentryWeakMap.h */,
@@ -4192,7 +4192,7 @@
 				D4009EA02D77196F0007AF30 /* ViewCapture */,
 				D81FDF10280EA0080045E0E4 /* SentryScreenShotTests.swift */,
 				D8F6A24C2885534E00320515 /* SentryPredicateDescriptorTests.swift */,
-				0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyTests.swift */,
+				0A5370A028A3EC2400B2DCDE /* SentryViewHierarchyProviderTests.swift */,
 				D8CB742A294B1DD000A5F964 /* SentryUIApplicationTests.swift */,
 				D8CB742C294B294B00A5F964 /* MockUIScene.h */,
 				D8CB742D294B294B00A5F964 /* MockUIScene.m */,
@@ -4636,7 +4636,7 @@
 				84354E1129BF944900CDBB8B /* SentryProfileTimeseries.h in Headers */,
 				D8ACE3CD2762187D00F5A213 /* SentryNSDataSwizzling.h in Headers */,
 				7B08A3452924CF6C0059603A /* SentryMetricKitIntegration.h in Headers */,
-				0A2D8DA8289BC905008720F6 /* SentryViewHierarchy.h in Headers */,
+				0A2D8DA8289BC905008720F6 /* SentryViewHierarchyProvider.h in Headers */,
 				8EAE980C261E9F530073B6B3 /* SentryUIViewControllerPerformanceTracker.h in Headers */,
 				63FE717D20DA4C1100CDBAE8 /* SentryCrashCachedData.h in Headers */,
 				7BC9A20028F41016001E7C4C /* SentryMeasurementValue.h in Headers */,
@@ -5524,7 +5524,7 @@
 				63FE713120DA4C1100CDBAE8 /* SentryCrashDynamicLinker.c in Sources */,
 				8E25C95325F836D000DC215B /* SentryRandom.m in Sources */,
 				03F84D3527DD4191008FE43F /* SentryThreadHandle.cpp in Sources */,
-				0A2D8DA9289BC905008720F6 /* SentryViewHierarchy.m in Sources */,
+				0A2D8DA9289BC905008720F6 /* SentryViewHierarchyProvider.m in Sources */,
 				D84D2CDD2C2BF7370011AF8A /* SentryReplayEvent.swift in Sources */,
 				D8BC28CC2BFF78220054DA4D /* SentryRRWebTouchEvent.swift in Sources */,
 				D452FC592DDB4B1700AFF56F /* SentryWatchdogTerminationBreadcrumbProcessor.m in Sources */,
@@ -5656,7 +5656,7 @@
 				8431EE5B29ADB8EA00D8DC56 /* SentryTimeTests.m in Sources */,
 				7B0A54562523178700A71716 /* SentryScopeSwiftTests.swift in Sources */,
 				7B5B94332657A816002E474B /* SentryAppStartTrackingIntegrationTests.swift in Sources */,
-				0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyTests.swift in Sources */,
+				0A5370A128A3EC2400B2DCDE /* SentryViewHierarchyProviderTests.swift in Sources */,
 				D8FFE50C2703DBB400607131 /* SwizzlingCallTests.swift in Sources */,
 				7BFAA6E7297AA16A00E7E02E /* SentryCrashMonitor_CppException_Tests.mm in Sources */,
 				9286059929A50BAB00F96038 /* SentryGeoTests.swift in Sources */,
@@ -5722,7 +5722,7 @@
 				63FE720320DA66EC00CDBAE8 /* SentryCrashCPU_Tests.m in Sources */,
 				927A5CC42DD7626B00B82404 /* SentryEnvelopeItemHeaderTests.swift in Sources */,
 				63FE721020DA66EC00CDBAE8 /* SentryCrashCachedData_Tests.m in Sources */,
-				0A9BF4E928A125390068D266 /* TestSentryViewHierarchy.swift in Sources */,
+				0A9BF4E928A125390068D266 /* TestSentryViewHierarchyProvider.swift in Sources */,
 				7BC6EC10255C3F560059822A /* SentryMechanismTests.swift in Sources */,
 				63FE721B20DA66EC00CDBAE8 /* Container+DeepSearch_Tests.m in Sources */,
 				8EA05EED267C2AB200C82B30 /* SentryNetworkTrackerTests.swift in Sources */,

--- a/Sources/Sentry/PrivateSentrySDKOnly.mm
+++ b/Sources/Sentry/PrivateSentrySDKOnly.mm
@@ -15,7 +15,7 @@
 #import "SentrySessionReplayIntegration+Private.h"
 #import "SentryThreadHandle.hpp"
 #import "SentryUser+Private.h"
-#import "SentryViewHierarchy.h"
+#import "SentryViewHierarchyProvider.h"
 #import <SentryBreadcrumb.h>
 #import <SentryDependencyContainer.h>
 #import <SentryExtraPackages.h>
@@ -313,7 +313,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 + (NSData *)captureViewHierarchy
 {
 #if SENTRY_HAS_UIKIT
-    return [SentryDependencyContainer.sharedInstance.viewHierarchy appViewHierarchy];
+    return [SentryDependencyContainer.sharedInstance.viewHierarchyProvider appViewHierarchy];
 #else
     SENTRY_LOG_DEBUG(
         @"PrivateSentrySDKOnly.captureViewHierarchy only works with UIKit enabled. Ensure you're "

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -45,7 +45,7 @@
 #    import "SentryFramesTracker.h"
 #    import "SentryUIApplication.h"
 #    import <SentryScreenshot.h>
-#    import <SentryViewHierarchy.h>
+#    import <SentryViewHierarchyProvider.h>
 #    import <SentryWatchdogTerminationBreadcrumbProcessor.h>
 #endif // SENTRY_HAS_UIKIT
 
@@ -284,15 +284,15 @@ static BOOL isInitialializingDependencyContainer = NO;
 #endif
 
 #if SENTRY_UIKIT_AVAILABLE
-- (SentryViewHierarchy *)viewHierarchy SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+- (SentryViewHierarchyProvider *)viewHierarchyProvider SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
 #    if SENTRY_HAS_UIKIT
 
-    SENTRY_LAZY_INIT(_viewHierarchy, [[SentryViewHierarchy alloc] init]);
+    SENTRY_LAZY_INIT(_viewHierarchyProvider, [[SentryViewHierarchyProvider alloc] init]);
 #    else
     SENTRY_LOG_DEBUG(
-        @"SentryDependencyContainer.viewHierarchy only works with UIKit enabled. Ensure you're "
-        @"using the right configuration of Sentry that links UIKit.");
+        @"SentryDependencyContainer.viewHierarchyProvider only works with UIKit "
+        @"enabled. Ensure you're using the right configuration of Sentry that links UIKit.");
     return nil;
 #    endif // SENTRY_HAS_UIKIT
 }

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -9,7 +9,7 @@
 #    import "SentryHub+Private.h"
 #    import "SentryOptions.h"
 #    import "SentrySDK+Private.h"
-#    import "SentryViewHierarchy.h"
+#    import "SentryViewHierarchyProvider.h"
 #    if SENTRY_HAS_METRIC_KIT
 #        import "SentryMetricKitIntegration.h"
 #    endif // SENTRY_HAS_METRIC_KIT
@@ -25,7 +25,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
 {
     NSString *reportPath = [[NSString stringWithUTF8String:reportDirectoryPath]
         stringByAppendingPathComponent:@"view-hierarchy.json"];
-    [SentryDependencyContainer.sharedInstance.viewHierarchy saveViewHierarchy:reportPath];
+    [SentryDependencyContainer.sharedInstance.viewHierarchyProvider saveViewHierarchy:reportPath];
 }
 
 @interface SentryViewHierarchyIntegration ()
@@ -49,7 +49,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
 
     sentrycrash_setSaveViewHierarchy(&saveViewHierarchy);
 
-    SentryDependencyContainer.sharedInstance.viewHierarchy.reportAccessibilityIdentifier
+    SentryDependencyContainer.sharedInstance.viewHierarchyProvider.reportAccessibilityIdentifier
         = options.reportAccessibilityIdentifier;
     return YES;
 }
@@ -94,8 +94,8 @@ saveViewHierarchy(const char *reportDirectoryPath)
 
     NSMutableArray<SentryAttachment *> *result = [NSMutableArray arrayWithArray:attachments];
 
-    NSData *viewHierarchy =
-        [SentryDependencyContainer.sharedInstance.viewHierarchy appViewHierarchyFromMainThread];
+    NSData *viewHierarchy = [SentryDependencyContainer.sharedInstance
+            .viewHierarchyProvider appViewHierarchyFromMainThread];
 
     SentryAttachment *attachment =
         [[SentryAttachment alloc] initWithData:viewHierarchy

--- a/Sources/Sentry/SentryViewHierarchyProvider.m
+++ b/Sources/Sentry/SentryViewHierarchyProvider.m
@@ -1,4 +1,4 @@
-#import "SentryViewHierarchy.h"
+#import "SentryViewHierarchyProvider.h"
 
 #if SENTRY_HAS_UIKIT
 
@@ -27,7 +27,7 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
     return SentryCrashJSON_OK;
 }
 
-@implementation SentryViewHierarchy
+@implementation SentryViewHierarchyProvider
 
 - (instancetype)init
 {

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -39,7 +39,7 @@
 @class SentryFramesTracker;
 @class SentryScreenshot;
 @class SentryUIApplication;
-@class SentryViewHierarchy;
+@class SentryViewHierarchyProvider;
 @class SentryUIViewControllerPerformanceTracker;
 @class SentryWatchdogTerminationScopeObserver;
 @class SentryWatchdogTerminationContextProcessor;
@@ -123,7 +123,7 @@ SENTRY_NO_INIT
 #if SENTRY_UIKIT_AVAILABLE
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;
 @property (nonatomic, strong) SentryScreenshot *screenshot;
-@property (nonatomic, strong) SentryViewHierarchy *viewHierarchy;
+@property (nonatomic, strong) SentryViewHierarchyProvider *viewHierarchyProvider;
 @property (nonatomic, strong)
     SentryUIViewControllerPerformanceTracker *uiViewControllerPerformanceTracker;
 #endif // SENTRY_UIKIT_AVAILABLE

--- a/Sources/Sentry/include/SentryViewHierarchyProvider.h
+++ b/Sources/Sentry/include/SentryViewHierarchyProvider.h
@@ -4,7 +4,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryViewHierarchy : NSObject
+@interface SentryViewHierarchyProvider : NSObject
 
 /**
  * Whether we should add `accessibilityIdentifier` to the view hierarchy.

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -134,7 +134,7 @@ final class SentryDependencyContainerTests: XCTestCase {
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().swizzleWrapper)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().framesTracker)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().screenshot)
-                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().viewHierarchy)
+                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().viewHierarchyProvider)
 
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().uiViewControllerPerformanceTracker)
 #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -7,12 +7,12 @@ import XCTest
 class SentryViewHierarchyIntegrationTests: XCTestCase {
 
     private class Fixture {
-        let viewHierarchy: TestSentryViewHierarchy
+        let viewHierarchyProvider: TestSentryViewHierarchyProvider
 
         init() {
-            let testViewHierarchy = TestSentryViewHierarchy()
+            let testViewHierarchy = TestSentryViewHierarchyProvider()
             testViewHierarchy.result = Data("view hierarchy".utf8)
-            viewHierarchy = testViewHierarchy
+            viewHierarchyProvider = testViewHierarchy
         }
 
         func getSut() -> SentryViewHierarchyIntegration {
@@ -27,7 +27,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
         super.setUp()
         fixture = Fixture()
 
-        SentryDependencyContainer.sharedInstance().viewHierarchy = fixture.viewHierarchy
+        SentryDependencyContainer.sharedInstance().viewHierarchyProvider = fixture.viewHierarchyProvider
     }
 
     override func tearDown() {
@@ -69,7 +69,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
             $0.setIntegrations([SentryViewHierarchyIntegration.self])
         }
         saveViewHierarchy("/test/path")
-        XCTAssertEqual("/test/path/view-hierarchy.json", fixture.viewHierarchy.saveFilePathUsed)
+        XCTAssertEqual("/test/path/view-hierarchy.json", fixture.viewHierarchyProvider.saveFilePathUsed)
     }
 
     func test_processAttachments() {
@@ -147,9 +147,9 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
     
     func test_backgroundForAppHangs() {
         let sut = fixture.getSut()
-        let testVH = TestSentryViewHierarchy()
-        SentryDependencyContainer.sharedInstance().viewHierarchy = testVH
-        
+        let testVH = TestSentryViewHierarchyProvider()
+        SentryDependencyContainer.sharedInstance().viewHierarchyProvider = testVH
+
         let event = Event()
         event.exceptions = [Sentry.Exception(value: "test", type: "App Hanging")]
         
@@ -173,7 +173,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
             $0.attachViewHierarchy = true
             $0.setIntegrations([SentryViewHierarchyIntegration.self])
         }
-        XCTAssertTrue(SentryDependencyContainer.sharedInstance().viewHierarchy.reportAccessibilityIdentifier)
+        XCTAssertTrue(SentryDependencyContainer.sharedInstance().viewHierarchyProvider.reportAccessibilityIdentifier)
     }
     
     func testReportAccessibilityIdentifierFalse() {
@@ -182,7 +182,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
             $0.reportAccessibilityIdentifier = false
             $0.setIntegrations([SentryViewHierarchyIntegration.self])
         }
-        XCTAssertFalse(SentryDependencyContainer.sharedInstance().viewHierarchy.reportAccessibilityIdentifier)
+        XCTAssertFalse(SentryDependencyContainer.sharedInstance().viewHierarchyProvider.reportAccessibilityIdentifier)
     }
 }
 

--- a/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchyProvider.h
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchyProvider.h
@@ -3,11 +3,11 @@
 #if SENTRY_HAS_UIKIT
 
 #    import "SentryCrashJSONCodec.h"
-#    import "SentryViewHierarchy.h"
+#    import "SentryViewHierarchyProvider.h"
 
 void saveViewHierarchy(const char *path);
 
-@interface SentryViewHierarchy (Test)
+@interface SentryViewHierarchyProvider (Test)
 - (int)viewHierarchyFromView:(UIView *)view intoContext:(SentryCrashJSONEncodeContext *)context;
 - (BOOL)processViewHierarchy:(NSArray<UIView *> *)windows
                  addFunction:(SentryCrashJSONAddDataFunc)addJSONDataFunc

--- a/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchyProvider.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/TestSentryViewHierarchyProvider.swift
@@ -1,6 +1,6 @@
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
-class TestSentryViewHierarchy: SentryViewHierarchy {
+class TestSentryViewHierarchyProvider: SentryViewHierarchyProvider {
 
     var result: Data?
     var viewHierarchyResult: Int32 = 0
@@ -15,7 +15,7 @@ class TestSentryViewHierarchy: SentryViewHierarchy {
         return result
     }
 
-    override func save(_ filePath: String) -> Bool {
+    override func saveViewHierarchy(_ filePath: String) -> Bool {
         saveFilePathUsed = filePath
         return true
     }

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -236,8 +236,8 @@
 #import "SentryTransport.h"
 #import "SentryTransportAdapter.h"
 #import "SentryTransportFactory.h"
-#import "SentryViewHierarchy.h"
 #import "SentryViewHierarchyIntegration.h"
+#import "SentryViewHierarchyProvider.h"
 #import "SentryWatchdogTerminationLogic.h"
 #import "SentryWatchdogTerminationScopeObserver.h"
 #import "SentryWatchdogTerminationTracker.h"
@@ -245,7 +245,7 @@
 #import "TestNSURLRequestBuilder.h"
 #import "TestSentryCrashWrapper.h"
 #import "TestSentrySpan.h"
-#import "TestSentryViewHierarchy.h"
+#import "TestSentryViewHierarchyProvider.h"
 #import "URLSessionTaskMock.h"
 @import _SentryPrivate;
 #import "Helper/ExceptionCatcher.h"

--- a/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
@@ -2,12 +2,12 @@ import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-class SentryViewHierarchyTests: XCTestCase {
+class SentryViewHierarchyProviderTests: XCTestCase {
     private class Fixture {
         let uiApplication = TestSentryUIApplication()
 
-        var sut: SentryViewHierarchy {
-            return SentryViewHierarchy()
+        var sut: SentryViewHierarchyProvider {
+            return SentryViewHierarchyProvider()
         }
     }
 
@@ -142,7 +142,7 @@ class SentryViewHierarchyTests: XCTestCase {
         fixture.uiApplication.windows = [window]
 
         let path = FileManager.default.temporaryDirectory.appendingPathComponent("view.json").path
-        self.fixture.sut.save(path)
+        self.fixture.sut.saveViewHierarchy(path)
 
         let descriptions = (try? String(contentsOfFile: path)) ?? ""
 
@@ -158,7 +158,7 @@ class SentryViewHierarchyTests: XCTestCase {
         let path = FileManager.default.temporaryDirectory.appendingPathComponent("view.json").path
         let sut = self.fixture.sut
         sut.reportAccessibilityIdentifier = false
-        sut.save(path)
+        sut.saveViewHierarchy(path)
 
         let descriptions = try XCTUnwrap(String(contentsOfFile: path))
 
@@ -171,11 +171,11 @@ class SentryViewHierarchyTests: XCTestCase {
 
         fixture.uiApplication.windows = [window]
 
-        XCTAssertFalse(self.fixture.sut.save(""))
+        XCTAssertFalse(self.fixture.sut.saveViewHierarchy(""))
     }
 
     func test_invalidSerialization() {
-        let sut = TestSentryViewHierarchy()
+        let sut = TestSentryViewHierarchyProvider()
         sut.viewHierarchyResult = -1
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         window.accessibilityIdentifier = "WindowId"
@@ -186,7 +186,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_appViewHierarchyFromBackgroundTest() {
-        let sut = TestSentryViewHierarchy()
+        let sut = TestSentryViewHierarchyProvider()
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         fixture.uiApplication.windows = [window]
 
@@ -205,7 +205,7 @@ class SentryViewHierarchyTests: XCTestCase {
     }
 
     func test_appViewHierarchy_usesMainThread() {
-        let sut = TestSentryViewHierarchy()
+        let sut = TestSentryViewHierarchyProvider()
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         fixture.uiApplication.windows = [window]
 


### PR DESCRIPTION
This PR renames the `SentryViewHierarchy` to `SentryViewHierachyProvider`, including instance variable names like `viewHierarchy`.

My intention with this PR was disambiguate of the purpose of the class, as `SentryViewHierachy` seems to be a data structure representing a view hierachy, but instead it is a class to get/persist/load the view hierarchy from the memory or disk storage.

Furthermore this is an attempt to streamline the internal naming conventions in the SDK to give class name more semantic.

An additional step could be using a protocol to abstract the methods and change the type in the dependency container to `id<SentryViewHierachyProviderProtocol>`. This would allow us mocking the provider in unit tests more easily, but this is out of scope for this PR.

#skip-changelog