### PR TITLE
ci: Make hang triggering more deterministic

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Tools/TriggerAppHang.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/TriggerAppHang.swift
@@ -20,18 +20,7 @@ func triggerNonFullyBlockingAppHang() {
     }
 }
 
-/// Schedules heavy UI rendering work on the main thread in a tight loop, which causes
-/// a fully blocking app hang without frames being rendered.
+/// Sleep on the main thread for long enough to trigger a hang
 func triggerFullyBlockingAppHang(button: UIButton) {
-    let buttonTitle = button.currentTitle
-    var i = 0
-
-    for _ in 0...5_000_000 {
-        i += Int.random(in: 0...10)
-        i -= 1
-
-        button.setTitle("\(i)", for: .normal)
-    }
-
-    button.setTitle(buttonTitle, for: .normal)
+  sleep(5)
 }


### PR DESCRIPTION
I've noticed tests related to app hangs frequently fail. Most recently there was this run that failed: https://github.com/getsentry/sentry-cocoa/actions/runs/15674734611/job/44152349015

The test failed because it tried to trigger an app hang, but then the app was hanging for too long and the UI test timed out trying to run the next step. The way we trigger an app hang does not create a very deterministic length hang, it will vary based on the performance of the machine. This PR just changes the app hang to be a `sleep` with a constant time, which I hope will fix these flaky tests by preventing the hang from taking too long.

#skip-changelog