### PR TITLE
refactor: Move singleton of SentryGlobalEventProcessor to dependency container

### DIFF
--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -44,7 +44,6 @@ class TestCleanup: NSObject {
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         
         SentryDependencyContainer.reset()
-        Dynamic(SentryGlobalEventProcessor.shared()).removeAllProcessors()
         SentryPerformanceTracker.shared.clear()
 
         SentryTracer.resetAppStartMeasurementRead()

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -912,9 +912,11 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
 - (SentryEvent *_Nullable)callEventProcessors:(SentryEvent *)event
 {
-    SentryEvent *newEvent = event;
+    SentryGlobalEventProcessor *globalEventProcessor
+        = SentryDependencyContainer.sharedInstance.globalEventProcessor;
 
-    for (SentryEventProcessor processor in SentryGlobalEventProcessor.shared.processors) {
+    SentryEvent *newEvent = event;
+    for (SentryEventProcessor processor in globalEventProcessor.processors) {
         newEvent = processor(newEvent);
         if (newEvent == nil) {
             SENTRY_LOG_DEBUG(@"SentryScope callEventProcessors: An event processor decided to "

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -25,6 +25,7 @@
 #import <SentryDebugImageProvider.h>
 #import <SentryDefaultRateLimits.h>
 #import <SentryDependencyContainer.h>
+#import <SentryGlobalEventProcessor.h>
 #import <SentryHttpDateParser.h>
 #import <SentryInternalDefines.h>
 #import <SentryNSNotificationCenterWrapper.h>
@@ -417,7 +418,8 @@ static BOOL isInitialializingDependencyContainer = NO;
                    fileManager:self.fileManager];
 }
 
-- (SentryWatchdogTerminationContextProcessor *)watchdogTerminationContextProcessor
+- (SentryWatchdogTerminationContextProcessor *)
+    watchdogTerminationContextProcessor SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_watchdogTerminationContextProcessor,
         [[SentryWatchdogTerminationContextProcessor alloc]
@@ -429,4 +431,8 @@ static BOOL isInitialializingDependencyContainer = NO;
 }
 #endif
 
+- (SentryGlobalEventProcessor *)globalEventProcessor SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+{
+    SENTRY_LAZY_INIT(_globalEventProcessor, [[SentryGlobalEventProcessor alloc] init])
+}
 @end

--- a/Sources/Sentry/SentryGlobalEventProcessor.m
+++ b/Sources/Sentry/SentryGlobalEventProcessor.m
@@ -3,15 +3,7 @@
 
 @implementation SentryGlobalEventProcessor
 
-+ (instancetype)shared
-{
-    static SentryGlobalEventProcessor *instance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ instance = [[self alloc] initPrivate]; });
-    return instance;
-}
-
-- (instancetype)initPrivate
+- (instancetype)init
 {
     if (self = [super init]) {
         self.processors = [NSMutableArray new];

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -3,7 +3,6 @@
 #import "SentryBreadcrumb.h"
 #import "SentryEnvelopeItemType.h"
 #import "SentryEvent+Private.h"
-#import "SentryGlobalEventProcessor.h"
 #import "SentryLevelMapper.h"
 #import "SentryLog.h"
 #import "SentryPropagationContext.h"

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -157,7 +157,7 @@ static SentryTouchTracker *_touchTracker;
     [self cleanUp];
 
     [SentrySDK.currentHub registerSessionListener:self];
-    [SentryGlobalEventProcessor.shared
+    [SentryDependencyContainer.sharedInstance.globalEventProcessor
         addEventProcessor:^SentryEvent *_Nullable(SentryEvent *_Nonnull event) {
             if (event.isFatalEvent) {
                 [self resumePreviousSessionReplay:event];

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -24,6 +24,7 @@
 @class SentryFileIOTracker;
 @class SentryScopeContextPersistentStore;
 @class SentryOptions;
+@class SentryGlobalEventProcessor;
 
 @protocol SentryANRTracker;
 @protocol SentryRandom;
@@ -141,6 +142,8 @@ SENTRY_NO_INIT
 @property (nonatomic, strong)
     SentryWatchdogTerminationContextProcessor *watchdogTerminationContextProcessor;
 #endif
+
+@property (nonatomic, strong) SentryGlobalEventProcessor *globalEventProcessor;
 
 @end
 

--- a/Sources/Sentry/include/SentryGlobalEventProcessor.h
+++ b/Sources/Sentry/include/SentryGlobalEventProcessor.h
@@ -7,11 +7,8 @@ typedef SentryEvent *__nullable (^SentryEventProcessor)(SentryEvent *_Nonnull ev
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryGlobalEventProcessor : NSObject
-SENTRY_NO_INIT
 
 @property (nonatomic, strong) NSMutableArray<SentryEventProcessor> *processors;
-
-+ (instancetype)shared;
 
 - (void)addEventProcessor:(SentryEventProcessor)newProcessor;
 

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -149,6 +149,8 @@ final class SentryDependencyContainerTests: XCTestCase {
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().getWatchdogTerminationBreadcrumbProcessor(withMaxBreadcrumbs: 10))
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().watchdogTerminationContextProcessor)
 #endif
+
+                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().globalEventProcessor)
                 }
 
                 expectation.fulfill()

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -45,10 +45,12 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     }
     
     private var uiApplication = TestSentryUIApplication()
-    
+    private var globalEventProcessor = SentryGlobalEventProcessor()
+
     override func setUp() {
         SentryDependencyContainer.sharedInstance().application = uiApplication
         SentryDependencyContainer.sharedInstance().reachability = TestSentryReachability()
+        SentryDependencyContainer.sharedInstance().globalEventProcessor = globalEventProcessor
     }
     
     override func tearDown() {
@@ -76,14 +78,14 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0)
         
         XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 0)
-        XCTAssertEqual(SentryGlobalEventProcessor.shared().processors.count, 0)
+        XCTAssertEqual(globalEventProcessor.processors.count, 0)
     }
     
     func testInstallFullSessionReplay() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0)
         
         XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
-        XCTAssertEqual(SentryGlobalEventProcessor.shared().processors.count, 1)
+        XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
     
     func testInstallNoSwizzlingNoTouchTracker() {
@@ -106,7 +108,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.3)
         startSDK(sessionSampleRate: 0.2, errorSampleRate: 0)
         XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
-        XCTAssertEqual(SentryGlobalEventProcessor.shared().processors.count, 1)
+        XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNil(sut.sessionReplay)
     }
@@ -117,7 +119,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         startSDK(sessionSampleRate: 0.3, errorSampleRate: 0)
         
         XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
-        XCTAssertEqual(SentryGlobalEventProcessor.shared().processors.count, 1)
+        XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNotNil(sut.sessionReplay)
     }
@@ -126,7 +128,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0.1)
         
         XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
-        XCTAssertEqual(SentryGlobalEventProcessor.shared().processors.count, 1)
+        XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
     
     func testWaitForNotificationWithNoWindow() throws {
@@ -229,7 +231,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let crash = Event(error: NSError(domain: "Error", code: 1))
         crash.context = [:]
         crash.isFatalEvent = true
-        SentryGlobalEventProcessor.shared().reportAll(crash)
+        globalEventProcessor.reportAll(crash)
         
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(hub.capturedReplayRecordingVideo.count, 1)
@@ -257,7 +259,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let crash = Event(error: NSError(domain: "Error", code: 1))
         crash.context = [:]
         crash.isFatalEvent = true
-        SentryGlobalEventProcessor.shared().reportAll(crash)
+        globalEventProcessor.reportAll(crash)
         
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(hub.capturedReplayRecordingVideo.count, 1)
@@ -285,7 +287,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         let crash = Event(error: NSError(domain: "Error", code: 1))
         crash.context = [:]
         crash.isFatalEvent = true
-        SentryGlobalEventProcessor.shared().reportAll(crash)
+        globalEventProcessor.reportAll(crash)
         
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(hub.capturedReplayRecordingVideo.count, 0)

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1356,7 +1356,7 @@ class SentryClientTest: XCTestCase {
     }
     
     func testEventDroppedByEventProcessor_RecordsLostEvent() {
-        SentryGlobalEventProcessor.shared().add { _ in return nil }
+        SentryDependencyContainer.sharedInstance().globalEventProcessor.add { _ in return nil }
         
         beforeSendReturnsNil { $0.capture(message: fixture.messageAsString) }
         
@@ -1364,16 +1364,16 @@ class SentryClientTest: XCTestCase {
     }
     
     func testTransactionDroppedByEventProcessor_RecordsLostEvent() {
-        SentryGlobalEventProcessor.shared().add { _ in return nil }
-        
+        SentryDependencyContainer.sharedInstance().globalEventProcessor.add { _ in return nil }
+
         beforeSendReturnsNil { $0.capture(event: fixture.transaction) }
         
         assertLostEventRecorded(category: .transaction, reason: .eventProcessor)
     }
         
     func testRecordEventProcessorDroppingTransaction() {
-        SentryGlobalEventProcessor.shared().add { _ in return nil }
-        
+        SentryDependencyContainer.sharedInstance().globalEventProcessor.add { _ in return nil }
+
         let transaction = Transaction(
             trace: fixture.trace,
             children: [
@@ -1389,7 +1389,7 @@ class SentryClientTest: XCTestCase {
     }
     
     func testRecordEventProcessorDroppingPartiallySpans() {
-        SentryGlobalEventProcessor.shared().add { event in
+        SentryDependencyContainer.sharedInstance().globalEventProcessor.add { event in
             if let transaction = event as? Transaction {
                 transaction.spans = transaction.spans.filter {
                     $0.operation != "child2"
@@ -1487,8 +1487,7 @@ class SentryClientTest: XCTestCase {
     }
     
     func testCombinedPartiallyDroppedSpans() {
-        
-        SentryGlobalEventProcessor.shared().add { event in
+        SentryDependencyContainer.sharedInstance().globalEventProcessor.add { event in
             if let transaction = event as? Transaction {
                 transaction.spans = transaction.spans.filter {
                     $0.operation != "child1"


### PR DESCRIPTION
Moves the singleton managed using `dispatch_once` to the dependency container, so that it gets deallocated on `SentrySDK.close()` correctly and to allow mocking in unit tests.

Related to #5393

#skip-changelog