### PR TITLE
ci: Use helper function to run tests in fastlane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,10 +7,10 @@ platform :ios do
 
   ios_swift_infoplist_path = "./Samples/iOS-Swift/iOS-Swift/Info.plist"
   ios_swift_clip_infoplist_path = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
-  configuration = if is_ci then 'TestCI' else 'Test' end
 
   # Helper method to run tests with common configuration
   def run_ui_tests(scheme:, result_bundle_name:, options: {})
+    configuration = if is_ci then 'TestCI' else 'Test' end
     result_bundle_path = "test_results/#{result_bundle_name}.xcresult"
     FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
     

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,7 +9,7 @@ platform :ios do
   ios_swift_clip_infoplist_path = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
 
   # Helper method to run tests with common configuration
-  def run_ui_tests(scheme:, result_bundle_name:, options: {})
+  def run_ui_tests(scheme:, result_bundle_name:, device: nil, address_sanitizer: false)
     configuration = if is_ci then 'TestCI' else 'Test' end
     result_bundle_path = "test_results/#{result_bundle_name}.xcresult"
     FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
@@ -21,7 +21,8 @@ platform :ios do
       xcodebuild_formatter: "xcbeautify --report junit",
       result_bundle: true,
       result_bundle_path: "fastlane/#{result_bundle_path}",
-      **options
+      device: device,
+      address_sanitizer: address_sanitizer
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,22 @@ platform :ios do
   ios_swift_clip_infoplist_path = "./Samples/iOS-Swift/iOS-SwiftClip/Info.plist"
   configuration = if is_ci then 'TestCI' else 'Test' end
 
+  # Helper method to run tests with common configuration
+  def run_ui_tests(scheme:, result_bundle_name:, options: {})
+    result_bundle_path = "test_results/#{result_bundle_name}.xcresult"
+    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
+    
+    run_tests(
+      workspace: "Sentry.xcworkspace",
+      scheme: scheme,
+      configuration: configuration,
+      xcodebuild_formatter: "xcbeautify --report junit",
+      result_bundle: true,
+      result_bundle_path: "fastlane/#{result_bundle_path}",
+      **options
+    )
+  end
+
   lane :prepare_xcframework_signing do
     setup_ci
 
@@ -177,16 +193,9 @@ platform :ios do
   end
 
   lane :ui_critical_tests_ios_swiftui do
-    # FileUtils resolves relative paths to the `fastlane` directory, while lanes resolve relative to root.
-    result_bundle_path = "test_results/ui_critical_tests_ios_swiftui.xcresult"
-    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
-    run_tests(
-      workspace: "Sentry.xcworkspace",
+    run_ui_tests(
       scheme: "SwiftUITestSample",
-      configuration: "Debug",
-      xcodebuild_formatter: "xcbeautify --report junit",
-      result_bundle: true,
-      result_bundle_path: "fastlane/#{result_bundle_path}"
+      result_bundle_name: "ui_critical_tests_ios_swiftui"
     )
   end
 
@@ -212,74 +221,40 @@ platform :ios do
   end
 
   lane :ui_tests_ios_swiftui do
-    # FileUtils resolves relative paths to the `fastlane` directory, while lanes resolve relative to root.
-    result_bundle_path = "test_results/ui_tests_ios_swiftui.xcresult"
-    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
-    run_tests(
-      workspace: "Sentry.xcworkspace",
+    run_ui_tests(
       scheme: "iOS-SwiftUI",
-      configuration: configuration,
-      xcodebuild_formatter: "xcbeautify --report junit",
-      result_bundle: true,
-      result_bundle_path: "fastlane/#{result_bundle_path}"
+      result_bundle_name: "ui_tests_ios_swiftui"
     )
   end
   
   lane :ui_tests_ios_swift6 do |options|
-    # FileUtils resolves relative paths to the `fastlane` directory, while lanes resolve relative to root.
-    result_bundle_path = "test_results/ui_tests_ios_swift6.xcresult"
-    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
-    run_tests(
-      workspace: "Sentry.xcworkspace",
+    run_ui_tests(
       scheme: "iOS-Swift6",
-      configuration: configuration,
-      xcodebuild_formatter: "xcbeautify --report junit",
-      result_bundle: true,
-      result_bundle_path: "fastlane/#{result_bundle_path}"
+      result_bundle_name: "ui_tests_ios_swift6",
+      device: options[:device]
     )
   end
 
   lane :ui_tests_ios_objc do
-    # FileUtils resolves relative paths to the `fastlane` directory, while lanes resolve relative to root.
-    result_bundle_path = "test_results/ui_tests_ios_objc.xcresult"
-    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
-    run_tests(
-      workspace: "Sentry.xcworkspace",
+    run_ui_tests(
       scheme: "iOS-ObjectiveC",
-      configuration: configuration,
-      xcodebuild_formatter: "xcbeautify --report junit",
-      result_bundle: true,
-      result_bundle_path: "fastlane/#{result_bundle_path}"
+      result_bundle_name: "ui_tests_ios_objc"
     )
   end
 
   lane :ui_tests_ios_swift do |options|
-    # FileUtils resolves relative paths to the `fastlane` directory, while lanes resolve relative to root.
-    result_bundle_path = "test_results/ui_tests_ios_swift.xcresult"
-    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
-    run_tests(
-      workspace: "Sentry.xcworkspace",
+    run_ui_tests(
       scheme: "iOS-Swift",
+      result_bundle_name: "ui_tests_ios_swift",
       device: options[:device],
-      address_sanitizer: options[:address_sanitizer],
-      configuration: configuration,
-      xcodebuild_formatter: "xcbeautify --report junit",
-      result_bundle: true,
-      result_bundle_path: "fastlane/#{result_bundle_path}"
+      address_sanitizer: options[:address_sanitizer]
     )
   end
 
   lane :ui_tests_tvos_swift do
-    # FileUtils resolves relative paths to the `fastlane` directory, while lanes resolve relative to root.
-    result_bundle_path = "test_results/ui_tests_tvos_swift.xcresult"
-    FileUtils.rm_r(result_bundle_path) if File.exist?(result_bundle_path)
-    run_tests(
-      workspace: "Sentry.xcworkspace",
+    run_ui_tests(
       scheme: "tvOS-Swift",
-      configuration: configuration,
-      xcodebuild_formatter: "xcbeautify --report junit",
-      result_bundle: true,
-      result_bundle_path: "fastlane/#{result_bundle_path}"
+      result_bundle_name: "ui_tests_tvos_swift"
     )
   end
   


### PR DESCRIPTION
## :scroll: Description

Use a helper function to reduce duplicated code in fastfile.

## :bulb: Motivation and Context

We have lots of tests in the fastfile, with pretty much the same format.
We can make the fastfile easier to read, using a helper function.

## :green_heart: How did you test it?

Run locally.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog