### PR TITLE
fix: Add out of bounds handling for array accessor

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -829,6 +829,7 @@
 		D43B26D62D70964C007747FD /* SentrySpanOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = D43B26D52D709648007747FD /* SentrySpanOperation.m */; };
 		D43B26D82D70A550007747FD /* SentryTraceOrigin.m in Sources */ = {isa = PBXBuildFile; fileRef = D43B26D72D70A54A007747FD /* SentryTraceOrigin.m */; };
 		D43B26DA2D70A612007747FD /* SentrySpanDataKey.m in Sources */ = {isa = PBXBuildFile; fileRef = D43B26D92D70A60E007747FD /* SentrySpanDataKey.m */; };
+		D4411DD52E02B74900EA4987 /* ArrayAccessesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4411DD42E02B74100EA4987 /* ArrayAccessesTests.swift */; };
 		D44B16722DE464AD006DBDB3 /* TestDispatchFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44B16712DE464A9006DBDB3 /* TestDispatchFactoryTests.swift */; };
 		D44DB37F2DDCC8FA00174EF4 /* SentryScopeContextPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44DB37E2DDCC8F200174EF4 /* SentryScopeContextPersistentStore.swift */; };
 		D451ED5D2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D451ED5C2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift */; };
@@ -2054,6 +2055,7 @@
 		D43B26D52D709648007747FD /* SentrySpanOperation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpanOperation.m; sourceTree = "<group>"; };
 		D43B26D72D70A54A007747FD /* SentryTraceOrigin.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTraceOrigin.m; sourceTree = "<group>"; };
 		D43B26D92D70A60E007747FD /* SentrySpanDataKey.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpanDataKey.m; sourceTree = "<group>"; };
+		D4411DD42E02B74100EA4987 /* ArrayAccessesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArrayAccessesTests.swift; sourceTree = "<group>"; };
 		D44B16712DE464A9006DBDB3 /* TestDispatchFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestDispatchFactoryTests.swift; sourceTree = "<group>"; };
 		D44DB37E2DDCC8F200174EF4 /* SentryScopeContextPersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScopeContextPersistentStore.swift; sourceTree = "<group>"; };
 		D451ED5C2D92ECD200C9BEA8 /* SentryOnDemandReplayError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryOnDemandReplayError.swift; sourceTree = "<group>"; };
@@ -4076,6 +4078,7 @@
 			isa = PBXGroup;
 			children = (
 				D43B0E5D2DE7198000EE3759 /* Info.plist */,
+				D4411DD42E02B74100EA4987 /* ArrayAccessesTests.swift */,
 				624729172DE5980500DFEE00 /* TestCurrentDateProviderTests.swift */,
 				D44B16712DE464A9006DBDB3 /* TestDispatchFactoryTests.swift */,
 				D4CBA2512DE06D1600581618 /* TestConstantTests.swift */,
@@ -5968,6 +5971,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D4411DD52E02B74900EA4987 /* ArrayAccessesTests.swift in Sources */,
 				62E5325B2DEEC862000B2DD5 /* TestCurrentDateProviderTests.swift in Sources */,
 				D43B0E602DE7416900EE3759 /* TestFileManagerTests.swift in Sources */,
 				D44B16722DE464AD006DBDB3 /* TestDispatchFactoryTests.swift in Sources */,

--- a/SentryTestUtils/ArrayAccesses.swift
+++ b/SentryTestUtils/ArrayAccesses.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public extension Array {
     func element(at index: Int) -> Self.Element? {
-        guard count >= index else {
+        guard index >= 0, index < count else {
             return nil
         }
         return self[index]

--- a/SentryTestUtilsTests/ArrayAccessesTests.swift
+++ b/SentryTestUtilsTests/ArrayAccessesTests.swift
@@ -103,16 +103,16 @@ class ArrayAccessesTests: XCTestCase {
         XCTAssertNil(array.element(at: -1))
     }
     
-    func testElementAtIndex_optionalArray_returnsCorrectElement() {
+    func testElementAtIndex_optionalArray_returnsCorrectElement() throws {
         // -- Arrange --
         let array: [String?] = ["hello", nil, "world"]
         
         // -- Act --
         XCTAssertEqual(array.element(at: 0), "hello")
-        XCTAssertNil(array.element(at: 1))
+        XCTAssertNil(try XCTUnwrap(array.element(at: 1))) // The element should be accessible, but the value is nil
         XCTAssertEqual(array.element(at: 2), "world")
-        XCTAssertNil(array.element(at: 3))
-        XCTAssertNil(array.element(at: -1))
+        XCTAssertTrue(array.element(at: 3) == nil)
+        XCTAssertTrue(array.element(at: -1) == nil)
     }
     
     func testElementAtIndex_customStructArray_returnsCorrectElement() {

--- a/SentryTestUtilsTests/ArrayAccessesTests.swift
+++ b/SentryTestUtilsTests/ArrayAccessesTests.swift
@@ -1,0 +1,145 @@
+import SentryTestUtils
+import XCTest
+
+class ArrayAccessesTests: XCTestCase {
+    func testElementAtIndex_emptyArrayWithNegativeIndex_returnsNil() {
+        // -- Arrange --
+        let array = [Int]()
+
+        // -- Act --
+        XCTAssertNil(array.element(at: -1))
+    }
+
+    func testElementAtIndex_emptyArrayWithIndexZero_returnsNil() {
+        // -- Arrange --
+        let array = [Int]()
+
+        // -- Act --
+        XCTAssertNil(array.element(at: 0))
+    }
+
+    func testElementAtIndex_emptyArrayWithPositiveIndex_returnsNil() {
+        // -- Arrange --
+        let array = [Int]()
+
+        // -- Act --
+        XCTAssertNil(array.element(at: 1))
+    }
+
+    func testElementAtIndex_negativeIndex_returnsNil() {
+        // -- Arrange --
+        let array = [1, 2, 3]
+
+        // -- Act --
+        XCTAssertNil(array.element(at: -1))
+    }
+
+    func testElementAtIndex_indexBelowCount_returnsElement() {
+        // -- Arrange --
+        let array = [1, 2, 3]
+
+        // -- Act --
+        XCTAssertEqual(array.element(at: 0), 1)
+        XCTAssertEqual(array.element(at: 1), 2)
+        XCTAssertEqual(array.element(at: 2), 3)
+    }
+
+    func testElementAtIndex_indexEqualCount_returnsNil() {
+        // -- Arrange --
+        let array = [1, 2, 3]
+
+        // -- Act --
+        XCTAssertNil(array.element(at: array.count))
+    }
+
+    func testElementAtIndex_indexAboveCount_returnsNil() {
+        // -- Arrange --
+        let array = [1, 2, 3]
+        
+        // -- Act --
+        XCTAssertNil(array.element(at: array.count + 1))
+    }
+    
+    // MARK: - Edge Cases
+    
+    func testElementAtIndex_singleElementArray_returnsCorrectElement() {
+        // -- Arrange --
+        let array = [42]
+        
+        // -- Act --
+        XCTAssertEqual(array.element(at: 0), 42)
+        XCTAssertNil(array.element(at: 1))
+        XCTAssertNil(array.element(at: -1))
+    }
+    
+    func testElementAtIndex_veryLargeIndex_returnsNil() {
+        // -- Arrange --
+        let array = [1, 2, 3]
+        
+        // -- Act --
+        XCTAssertNil(array.element(at: Int.max))
+        XCTAssertNil(array.element(at: 1_000_000))
+    }
+    
+    func testElementAtIndex_intMinIndex_returnsNil() {
+        // -- Arrange --
+        let array = [1, 2, 3]
+        
+        // -- Act --
+        XCTAssertNil(array.element(at: Int.min))
+    }
+    
+    // MARK: - Different Data Types
+    
+    func testElementAtIndex_stringArray_returnsCorrectElement() {
+        // -- Arrange --
+        let array = ["hello", "world", "test"]
+        
+        // -- Act --
+        XCTAssertEqual(array.element(at: 0), "hello")
+        XCTAssertEqual(array.element(at: 1), "world")
+        XCTAssertEqual(array.element(at: 2), "test")
+        XCTAssertNil(array.element(at: 3))
+        XCTAssertNil(array.element(at: -1))
+    }
+    
+    func testElementAtIndex_optionalArray_returnsCorrectElement() {
+        // -- Arrange --
+        let array: [String?] = ["hello", nil, "world"]
+        
+        // -- Act --
+        XCTAssertEqual(array.element(at: 0), "hello")
+        XCTAssertNil(array.element(at: 1))
+        XCTAssertEqual(array.element(at: 2), "world")
+        XCTAssertNil(array.element(at: 3))
+        XCTAssertNil(array.element(at: -1))
+    }
+    
+    func testElementAtIndex_customStructArray_returnsCorrectElement() {
+        // -- Arrange --
+        struct TestStruct: Equatable {
+            let value: Int
+        }
+        
+        let array = [TestStruct(value: 1), TestStruct(value: 2)]
+        
+        // -- Act --
+        XCTAssertEqual(array.element(at: 0)?.value, 1)
+        XCTAssertEqual(array.element(at: 1)?.value, 2)
+        XCTAssertNil(array.element(at: 2))
+        XCTAssertNil(array.element(at: -1))
+    }
+    
+    // MARK: - Boundary Tests
+    
+    func testElementAtIndex_boundaryIndices_returnsCorrectResults() {
+        // -- Arrange --
+        let array = Array(0..<100) // Array with 100 elements
+        
+        // -- Act --
+        XCTAssertEqual(array.element(at: 0), 0)
+        XCTAssertEqual(array.element(at: 99), 99)
+        XCTAssertNil(array.element(at: 100))
+        XCTAssertNil(array.element(at: -1))
+    }
+}


### PR DESCRIPTION
The current implementation of `Array.element(at index: Int)` does not handle out of bounds indicies for negative and positive numbers.

This PR adds correct handling and tests to verify the behaviour.

#skip-changelog