### PR TITLE
Use (intel) large runners for UI tests

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -37,14 +37,14 @@ jobs:
         platform:
           # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
-          - runs-on: macos-13
+          - runs-on: macos-13-large
             xcode: "14.3.1"
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
-          - runs-on: macos-15
+          - runs-on: macos-15-large
             xcode: "16.2"
         command:
           - fastlane_command: ui_critical_tests_ios_swiftui_envelope

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -37,14 +37,14 @@ jobs:
         platform:
           # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
-          - runs-on: macos-13-large
+          - runs-on: macos-13-xlarge
             xcode: "14.3.1"
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
-          - runs-on: macos-15-large
+          - runs-on: macos-15-xlarge
             xcode: "16.2"
         command:
           - fastlane_command: ui_critical_tests_ios_swiftui_envelope

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -39,7 +39,7 @@ jobs:
       fastlane_command: ui_tests_${{matrix.target}}
       xcode_version: 16.2
       build_with_make: true
-      macos_version: macos-14
+      macos_version: macos-15-large
 
   # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:
@@ -49,7 +49,7 @@ jobs:
       fastlane_command: ui_tests_ios_swiftui
       xcode_version: 16.2
       build_with_make: true
-      macos_version: macos-15
+      macos_version: macos-15-large
 
   ui-tests-swift:
     name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}} - V5 # Up the version with every change to keep track of flaky tests
@@ -58,13 +58,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-13
+          - runs-on: macos-13-large
             xcode: "14.3.1"
             device: "iPhone 14 (16.4)"
-          - runs-on: macos-14
+          - runs-on: macos-14-large
             xcode: "15.4"
             device: "iPhone 15 (17.5)"
-          - runs-on: macos-15
+          - runs-on: macos-15-large
             xcode: "16.4"
             device: "iPhone 16 (18.5)"
     with:
@@ -82,7 +82,7 @@ jobs:
       fastlane_command: ui_tests_ios_swift6
       xcode_version: 16.2
       build_with_make: true
-      macos_version: macos-15
+      macos_version: macos-15-large
 
   build-xcframework-variant-slices:
     uses: ./.github/workflows/build-xcframework-variant-slices.yml
@@ -108,5 +108,5 @@ jobs:
     with:
       fastlane_command: duplication_test
       xcode_version: 16.4
-      macos_version: macos-15
+      macos_version: macos-15-large
       needs_xcframework: true

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -39,7 +39,7 @@ jobs:
       fastlane_command: ui_tests_${{matrix.target}}
       xcode_version: 16.2
       build_with_make: true
-      macos_version: macos-15-large
+      macos_version: macos-15-xlarge
 
   # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:
@@ -49,7 +49,7 @@ jobs:
       fastlane_command: ui_tests_ios_swiftui
       xcode_version: 16.2
       build_with_make: true
-      macos_version: macos-15-large
+      macos_version: macos-15-xlarge
 
   ui-tests-swift:
     name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}} - V5 # Up the version with every change to keep track of flaky tests
@@ -58,13 +58,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runs-on: macos-13-large
+          - runs-on: macos-13-xlarge
             xcode: "14.3.1"
             device: "iPhone 14 (16.4)"
-          - runs-on: macos-14-large
+          - runs-on: macos-14-xlarge
             xcode: "15.4"
             device: "iPhone 15 (17.5)"
-          - runs-on: macos-15-large
+          - runs-on: macos-15-xlarge
             xcode: "16.4"
             device: "iPhone 16 (18.5)"
     with:
@@ -82,7 +82,7 @@ jobs:
       fastlane_command: ui_tests_ios_swift6
       xcode_version: 16.2
       build_with_make: true
-      macos_version: macos-15-large
+      macos_version: macos-15-xlarge
 
   build-xcframework-variant-slices:
     uses: ./.github/workflows/build-xcframework-variant-slices.yml
@@ -108,5 +108,5 @@ jobs:
     with:
       fastlane_command: duplication_test
       xcode_version: 16.4
-      macos_version: macos-15-large
+      macos_version: macos-15-xlarge
       needs_xcframework: true


### PR DESCRIPTION
Test using macOS large runners to check stability

`macos-NUM-large` use intel machines
`macos-NUM-xlarge` use M1 machines

#skip-changelog