### PR TITLE
test(UI): always wipe all data on disk before starting a new UI test

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -29,6 +29,9 @@ extension BaseUITest {
     func newAppSession() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
+        app.launchArguments.append(contentsOf: [
+            "--io.sentry.wipe-data"
+        ])
         return app
     }
     

--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -12,6 +12,9 @@ class BaseUITest: XCTestCase {
         continueAfterFailure = false
         XCUIDevice.shared.orientation = .portrait
         app.launchEnvironment["--io.sentry.sdk-environment"] = "ui-tests"
+        app.launchArguments.append(contentsOf: [
+            "--io.sentry.wipe-data"
+        ])
         if automaticallyLaunchAndTerminateApp {
             launchApp()
         }
@@ -29,9 +32,6 @@ extension BaseUITest {
     func newAppSession() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
-        app.launchArguments.append(contentsOf: [
-            "--io.sentry.wipe-data"
-        ])
         return app
     }
     

--- a/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
@@ -5,14 +5,6 @@ import XCTest
 class ProfilingUITests: BaseUITest {
     override var automaticallyLaunchAndTerminateApp: Bool { false }
     
-    override func setUp() {
-        super.setUp()
-
-        app.launchArguments.append(contentsOf: [
-            "--io.sentry.wipe-data" // make sure there are no previous configuration files or profile files written
-        ])
-    }
-    
     func testAppLaunchesWithTraceProfiler() throws {
         guard #available(iOS 16, *) else {
             throw XCTSkip("Only run for latest iOS version we test; we've had issues with prior versions in SauceLabs")


### PR DESCRIPTION
The profile UI tests all wind up removing launch config files before they end. But if they abnormally exited before being able to do so, then another UI test would wind up running a launch profile.

This change makes sure there is no on-disk data leakage between UI tests in any way, whether that be launch profiles, envelopes, etc.

Noticed this while investigating https://github.com/getsentry/sentry-cocoa/issues/5366, but this doesn't fix the root problem of imbalanced bookkeeping mentioned there.

#skip-changelog