### PR TITLE
test(UI): dont launch after activating

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -40,7 +40,6 @@ extension BaseUITest {
         // App prewarming can sometimes cause simulators to get stuck in UI tests, activating them
         // before launching clears any prewarming state.
         app.activate()
-        app.launch()
         waitForExistenceOfMainScreen()
     }
     


### PR DESCRIPTION
Noticed while investigating https://github.com/getsentry/sentry-cocoa/issues/5366 that the UI tests launch twice, once on the call to `activate` and then again on the call to `launch`. This probably slows things down in CI and makes it hard to debug locally.

However, `activate` will always have launched the app, whether it is prewarmed or not. If we need tests for specific app prewarming states, we can craft special pathways for that.

#skip-changelog