### PR TITLE
fix: Stacktrace symbolication of fatal app hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix building with Xcode 26 (#5386)
 - Fix usage of `@available` to be `iOS` instead of `iOSApplicationExtension` (#5361)
+- Fix stacktrace symbolication of fatal app hangs (#5438)
 
 ### Improvements
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -2,6 +2,7 @@
 #import "SentryClient+Private.h"
 #import "SentryCrashMachineContext.h"
 #import "SentryCrashWrapper.h"
+#import "SentryDebugImageProvider+HybridSDKs.h"
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchQueueWrapper.h"
 #import "SentryEvent.h"
@@ -36,6 +37,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
+@property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 @property (atomic, assign) BOOL reportAppHangs;
 @property (atomic, assign) BOOL enableReportNonFullyBlockingAppHangs;
 
@@ -61,6 +63,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
     self.fileManager = SentryDependencyContainer.sharedInstance.fileManager;
     self.dispatchQueueWrapper = SentryDependencyContainer.sharedInstance.dispatchQueueWrapper;
     self.crashWrapper = SentryDependencyContainer.sharedInstance.crashWrapper;
+    self.debugImageProvider = SentryDependencyContainer.sharedInstance.debugImageProvider;
     [self.tracker addListener:self];
     self.options = options;
     self.reportAppHangs = YES;
@@ -147,6 +150,12 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
 
     event.exceptions = @[ sentryException ];
     event.threads = threads;
+
+    // When storing the app hang event to disk, it could turn into a fatal one, and then we can't
+    // recover the debug images. The client would also attach the debug images when directly
+    // capturing the app hang event. Still, we attach them already now to ensure all app hang events
+    // have debug images cause it's easy to mess this up in the future.
+    event.debugMeta = [self.debugImageProvider getDebugImagesFromCacheForThreads:event.threads];
 
 #if SENTRY_HAS_UIKIT
     // We only measure app hang duration for V2.

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -10,12 +10,15 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         let options: Options
         
         let currentDate = TestCurrentDateProvider()
-                
+        let debugImageProvider = TestDebugImageProvider()
+
         init() {
             options = Options()
             options.dsn = SentryANRTrackingIntegrationTests.dsn
             options.enableAppHangTracking = true
             options.appHangTimeoutInterval = 4.5
+
+            debugImageProvider.debugImages = [TestData.debugImage]
         }
     }
     
@@ -28,8 +31,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
     
     override func setUp() {
         super.setUp()
-        SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
         fixture = Fixture()
+
+        SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
+        SentryDependencyContainer.sharedInstance().debugImageProvider = fixture.debugImageProvider
     }
     
     override func tearDown() {
@@ -122,6 +127,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             }.count
             
             XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+
+            XCTAssertEqual(event?.debugMeta?.count, 1)
+            let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
+            XCTAssertEqual(eventDebugImage.uuid, TestData.debugImage.uuid)
         }
     }
     
@@ -159,6 +168,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             }.count
 
             XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+
+            XCTAssertEqual(event?.debugMeta?.count, 1)
+            let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
+            XCTAssertEqual(eventDebugImage.uuid, TestData.debugImage.uuid)
         }
     }
 
@@ -197,6 +210,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             }.count
 
             XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+
+            XCTAssertEqual(event?.debugMeta?.count, 1)
+            let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
+            XCTAssertEqual(eventDebugImage.uuid, TestData.debugImage.uuid)
         }
     }
     
@@ -235,6 +252,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             }.count
 
             XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+
+            XCTAssertEqual(event?.debugMeta?.count, 1)
+            let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
+            XCTAssertEqual(eventDebugImage.uuid, TestData.debugImage.uuid)
         }
     }
     
@@ -391,7 +412,11 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             }.count
             
             XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
-            
+
+            XCTAssertEqual(event?.debugMeta?.count, 1)
+            let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
+            XCTAssertEqual(eventDebugImage.uuid, TestData.debugImage.uuid)
+
             let tags = try XCTUnwrap(event?.tags)
             XCTAssertEqual(1, tags.count)
             XCTAssertEqual("value", tags["key"])
@@ -445,6 +470,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             }.count
 
             XCTAssertTrue(threadsWithFrames > 1, "Not enough threads with frames")
+
+            XCTAssertEqual(event?.debugMeta?.count, 1)
+            let eventDebugImage = try XCTUnwrap(event?.debugMeta?.first)
+            XCTAssertEqual(eventDebugImage.uuid, TestData.debugImage.uuid)
 
             let tags = try XCTUnwrap(event?.tags)
             XCTAssertEqual(1, tags.count)


### PR DESCRIPTION
## :scroll: Description

Add debug images for all app hang events directly in the ANRTrackingIntegration to ensure all app hang events have debug images attached, which is required for symbolication.

## :bulb: Motivation and Context

Fixes GH-5433

## :green_heart: How did you test it?

Unit tests and with TestFlight

Fatal app hang event before the fix from the iOS-Swift sample app via TestFlight

https://sentry-sdks.sentry.io/issues/6690874496/events/da915f043c0741959b04d9ce9ba42943/?project=5428557
![Screenshot 2025-06-20 at 08 52 39](https://github.com/user-attachments/assets/1d66c14a-abdd-4797-9b47-4e9c97343949)

With the fix

https://sentry-sdks.sentry.io/issues/6695548079/events/934bb93490554023905e9570cc78c75a/?project=5428557
![Screenshot 2025-06-20 at 08 59 41](https://github.com/user-attachments/assets/d773c28d-268a-4638-9d84-a8b38bfeb699)


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
