### PR TITLE
fix: Add date provider to SentryHttpTransport constructor

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -102,6 +102,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 {
     NSArray<id<SentryTransport>> *transports =
         [SentryTransportFactory initTransports:options
+                                  dateProvider:SentryDependencyContainer.sharedInstance.dateProvider
                              sentryFileManager:fileManager
                                     rateLimits:SentryDependencyContainer.sharedInstance.rateLimits];
 

--- a/Sources/Sentry/SentryTransportFactory.m
+++ b/Sources/Sentry/SentryTransportFactory.m
@@ -23,6 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation SentryTransportFactory
 
 + (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
+                                    dateProvider:(id<SentryCurrentDateProvider>)dateProvider
                                sentryFileManager:(SentryFileManager *)sentryFileManager
                                       rateLimits:(id<SentryRateLimits>)rateLimits
 {
@@ -55,6 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     SentryHttpTransport *httpTransport =
         [[SentryHttpTransport alloc] initWithOptions:options
                              cachedEnvelopeSendDelay:0.1
+                                        dateProvider:dateProvider
                                          fileManager:sentryFileManager
                                       requestManager:requestManager
                                       requestBuilder:requestBuilder

--- a/Sources/Sentry/include/SentryHttpTransport.h
+++ b/Sources/Sentry/include/SentryHttpTransport.h
@@ -8,6 +8,7 @@
 @class SentryDispatchQueueWrapper;
 @class SentryNSURLRequestBuilder;
 @class SentryOptions;
+@protocol SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,6 +18,7 @@ SENTRY_NO_INIT
 
 - (id)initWithOptions:(SentryOptions *)options
     cachedEnvelopeSendDelay:(NSTimeInterval)cachedEnvelopeSendDelay
+               dateProvider:(id<SentryCurrentDateProvider>)dateProvider
                 fileManager:(SentryFileManager *)fileManager
              requestManager:(id<SentryRequestManager>)requestManager
              requestBuilder:(SentryNSURLRequestBuilder *)requestBuilder

--- a/Sources/Sentry/include/SentryTransportFactory.h
+++ b/Sources/Sentry/include/SentryTransportFactory.h
@@ -11,6 +11,7 @@ NS_SWIFT_NAME(TransportInitializer)
 @interface SentryTransportFactory : NSObject
 
 + (NSArray<id<SentryTransport>> *)initTransports:(SentryOptions *)options
+                                    dateProvider:(id<SentryCurrentDateProvider>)dateProvider
                                sentryFileManager:(SentryFileManager *)sentryFileManager
                                       rateLimits:(id<SentryRateLimits>)rateLimits;
 

--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -138,6 +138,7 @@ class SentryHttpTransportTests: XCTestCase {
             return SentryHttpTransport(
                 options: options,
                 cachedEnvelopeSendDelay: 0.0,
+                dateProvider: currentDateProvider,
                 fileManager: fileManager ?? self.fileManager,
                 requestManager: requestManager,
                 requestBuilder: requestBuilder,

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -19,7 +19,12 @@ class SentryTransportFactoryTests: XCTestCase {
         options.urlSessionDelegate = urlSessionDelegateSpy
         
         let fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
-        let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager, rateLimits: rateLimiting())
+        let transports = TransportInitializer.initTransports(
+            options,
+            dateProvider: SentryDependencyContainer.sharedInstance().dateProvider,
+            sentryFileManager: fileManager,
+            rateLimits: rateLimiting()
+        )
         let httpTransport = transports.first
         let requestManager = try XCTUnwrap(Dynamic(httpTransport).requestManager.asObject as? SentryQueueableRequestManager)
         
@@ -44,7 +49,12 @@ class SentryTransportFactoryTests: XCTestCase {
         options.urlSession = sessionConfiguration
         
         let fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
-        let transports = TransportInitializer.initTransports(options, sentryFileManager: fileManager, rateLimits: rateLimiting())
+        let transports = TransportInitializer.initTransports(
+            options,
+            dateProvider: SentryDependencyContainer.sharedInstance().dateProvider,
+            sentryFileManager: fileManager,
+            rateLimits: rateLimiting()
+        )
                 
         let httpTransport = transports.first
         let requestManager = try XCTUnwrap(Dynamic(httpTransport).requestManager.asObject as? SentryQueueableRequestManager)
@@ -60,7 +70,12 @@ class SentryTransportFactoryTests: XCTestCase {
     func testShouldReturnTwoTransports_WhenSpotlightEnabled() throws {
         let options = Options()
         options.enableSpotlight = true
-        let transports = TransportInitializer.initTransports(options, sentryFileManager: try SentryFileManager(options: options), rateLimits: rateLimiting())
+        let transports = TransportInitializer.initTransports(
+            options,
+            dateProvider: SentryDependencyContainer.sharedInstance().dateProvider,
+            sentryFileManager: try SentryFileManager(options: options),
+            rateLimits: rateLimiting()
+        )
         
         XCTAssert(transports.contains {
             $0.isKind(of: SentrySpotlightTransport.self)

--- a/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportInitializerTests.swift
@@ -7,18 +7,27 @@ class SentryTransportInitializerTests: XCTestCase {
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentryTransportInitializerTests")
     
     private var fileManager: SentryFileManager!
-    
+    private var dateProvider: TestCurrentDateProvider!
+    private var rateLimits: (any RateLimits)!
+
     override func setUp() {
         super.setUp()
         let options = Options()
         options.dsn = SentryTransportInitializerTests.dsnAsString
         fileManager = try! SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())
+        dateProvider = TestCurrentDateProvider()
+        rateLimits = SentryDependencyContainer.sharedInstance().rateLimits
     }
 
     func testDefault() throws {
         let options = try Options(dict: ["dsn": SentryTransportInitializerTests.dsnAsString])
     
-        let result = TransportInitializer.initTransports(options, sentryFileManager: fileManager, rateLimits: SentryDependencyContainer.sharedInstance().rateLimits)
+        let result = TransportInitializer.initTransports(
+            options,
+            dateProvider: dateProvider,
+            sentryFileManager: fileManager,
+            rateLimits: rateLimits
+        )
         XCTAssertEqual(result.count, 1)
         
         let firstTransport = result.first


### PR DESCRIPTION
This PR fixes a deadlock in SentryHttpTransport by injecting a date provider instead of accessing it via the `SentryDependencyContainer.sharedInstance`.

Tests were experiencing deadlocks due to a circular dependency between `SentryDependencyContainer` and `SentryReachability`:

**Deadlock Scenario:**
- **Thread 1 (main)**: Holds `sentryDependencyContainerInstanceLock` during `reset()` → trying to acquire `sentry_reachability_observers` lock in `removeAllObservers`
- **Thread 112/132 (reachability callbacks)**: Hold `sentry_reachability_observers` lock → trying to acquire `sentryDependencyContainerInstanceLock` via `SentryDependencyContainer.sharedInstance.dateProvider`

```
Thread 1 Queue : com.apple.main-thread (serial)
#0	0x00000001010e1ae0 in __ulock_wait2 ()
#1	0x0000000100c6539c in _os_unfair_lock_lock_slow ()
#2	0x00000001800898ec in objc_sync_enter ()
#3	0x0000000120f3d988 in -[SentryReachability removeAllObservers] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryReachability.m:233
#4	0x0000000120f956e0 in +[SentryDependencyContainer reset] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryDependencyContainer.m:135
#5	0x0000000120f75484 in +[SentrySDK close] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentrySDK.m:639
#6	0x0000000123285dc8 in static TestCleanup.clearTestState() at /Volumes/Developer/getsentry/sentry-cocoa/SentryTestUtils/ClearTestState.swift:25
#7	0x0000000123285c98 in clearTestState() at /Volumes/Developer/getsentry/sentry-cocoa/SentryTestUtils/ClearTestState.swift:5
#8	0x0000000122c6c630 in SentryHubTests.tearDown() at /Volumes/Developer/getsentry/sentry-cocoa/Tests/SentryTests/SentryHubTests.swift:88
#9	0x0000000122c6c66c in @objc SentryHubTests.tearDown() ()
#10	0x00000001012fdb18 in __86-[XCTestCase _performTearDownSequenceWithSelector:permittingControlFlowInterruptions:]_block_invoke_2 ()
#11	0x00000001012fddb4 in __79-[XCTestCase _performFailableTearDownBlock:permittingControlFlowInterruptions:]_block_invoke ()
#12	0x00000001012e91fc in -[XCTestCase(XCTIssueHandling) _caughtUnhandledDeveloperExceptionPermittingControlFlowInterruptions:caughtInterruptionException:whileExecutingBlock:] ()
#13	0x00000001012fdba0 in -[XCTestCase _performFailableTearDownBlock:permittingControlFlowInterruptions:] ()
#14	0x00000001012fd7dc in __86-[XCTestCase _performTearDownSequenceWithSelector:permittingControlFlowInterruptions:]_block_invoke ()
```
```
Thread 112 Queue : io.sentry.cocoa.connectivity (serial)
#0	0x00000001010e1ae0 in __ulock_wait2 ()
#1	0x0000000100c6539c in _os_unfair_lock_lock_slow ()
#2	0x00000001800898ec in objc_sync_enter ()
#3	0x0000000120f95530 in +[SentryDependencyContainer sharedInstance] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryDependencyContainer.m:115
#4	0x0000000120f3aa00 in -[SentryHttpTransport sendAllCachedEnvelopes] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryHttpTransport.m:339
#5	0x0000000120f38f30 in -[SentryHttpTransport connectivityChanged:typeDescription:] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryHttpTransport.m:110
#6	0x0000000120f3cf98 in SentryConnectivityCallback at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryReachability.m:121
#7	0x0000000120f3d1c8 in SentryConnectivityActualCallback at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryReachability.m:145
#8	0x00000001807db684 in reachPerformAndUnlock ()
#9	0x00000001807dbfec in ____SCNetworkReachabilityRestartResolver_block_invoke_2 ()
#10	0x0000000187e734e8 in invocation function for block in nw_resolver_update_client(NWConcrete_nw_resolver*, void () block_pointer) ()
#11	0x000000018017c788 in _dispatch_call_block_and_release ()
#12	0x0000000180197278 in _dispatch_client_callout ()
#13	0x0000000180185ad0 in _dispatch_lane_serial_drain ()
#14	0x0000000180186590 in _dispatch_lane_invoke ()
#15	0x0000000180191380 in _dispatch_root_queue_drain_deferred_wlh ()
#16	0x00000001801909f4 in _dispatch_workloop_worker_thread ()
#17	0x0000000100c06bcc in _pthread_wqthread ()
```
```
Thread 132 Queue : io.sentry.default (serial)
#0	0x00000001010e1ae0 in __ulock_wait2 ()
#1	0x0000000100c6539c in _os_unfair_lock_lock_slow ()
#2	0x00000001800898ec in objc_sync_enter ()
#3	0x0000000120f95530 in +[SentryDependencyContainer sharedInstance] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryDependencyContainer.m:115
#4	0x0000000120fbef2c in -[SentryFileManager deleteOldEnvelopesFromPath:] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryFileManager.m:964
#5	0x0000000120fbee1c in -[SentryFileManager deleteOldEnvelopesFromAllSentryPaths] at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryFileManager.m:957
#6	0x0000000120fba350 in __43-[SentryFileManager deleteOldEnvelopeItems]_block_invoke at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryFileManager.m:292
#7	0x0000000120eb1198 in __53-[SentryDispatchQueueWrapper dispatchAsyncWithBlock:]_block_invoke at /Volumes/Developer/getsentry/sentry-cocoa/Sources/Sentry/SentryDispatchQueueWrapper.m:31
#8	0x000000018017c788 in _dispatch_call_block_and_release ()
#9	0x0000000180197278 in _dispatch_client_callout ()
#10	0x0000000180185ad0 in _dispatch_lane_serial_drain ()
#11	0x0000000180186590 in _dispatch_lane_invoke ()
#12	0x0000000180191380 in _dispatch_root_queue_drain_deferred_wlh ()
#13	0x00000001801909f4 in _dispatch_workloop_worker_thread ()
#14	0x0000000100c06bcc in _pthread_wqthread ()
```

## Solution

Implemented dependency injection to eliminate `SentryHttpTransport`'s dependency on the global `SentryDependencyContainer.sharedInstance`, breaking the circular dependency.

## Testing

- ✅ All existing tests pass

#skip-changelog