### PR TITLE
ci: Use iOS 18.5 by default

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -203,7 +203,8 @@ platform :ios do
   lane :ui_critical_tests_ios_swiftui_crash do
     run_ui_tests(
       scheme: "SwiftUITestSampleCrash",
-      result_bundle_name: "ui_critical_tests_ios_swiftui_crash"
+      result_bundle_name: "ui_critical_tests_ios_swiftui_crash",
+      device: "iPhone 16 (18.5)"
     )
   end
 


### PR DESCRIPTION
I just had a CI flake where this simulator crashed when installing the app for the UI test. It was on iOS 18.0, let's bump it up to a newer version that hopefully has less bugs like this

#skip-changelog

