### PR TITLE
ref: Improve test logging

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1063,7 +1063,6 @@
 		FA67DD142DDBD4EA00896B02 /* SentryGraphicsImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCE12DDBD4EA00896B02 /* SentryGraphicsImageRenderer.swift */; };
 		FA67DD152DDBD4EA00896B02 /* UrlSanitized.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCEE2DDBD4EA00896B02 /* UrlSanitized.swift */; };
 		FA67DD162DDBD4EA00896B02 /* SentryViewPhotographer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCE42DDBD4EA00896B02 /* SentryViewPhotographer.swift */; };
-		FA67DD172DDBD4EA00896B02 /* SentryLogOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCEC2DDBD4EA00896B02 /* SentryLogOutput.swift */; };
 		FA67DD182DDBD4EA00896B02 /* UIImageHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCED2DDBD4EA00896B02 /* UIImageHelper.swift */; };
 		FA67DD192DDBD4EA00896B02 /* SwizzleClassNameExclude.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCD52DDBD4EA00896B02 /* SwizzleClassNameExclude.swift */; };
 		FA8A36182DEAA1EB0058D883 /* SentryThread+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = FA8A36172DEAA1EB0058D883 /* SentryThread+Private.h */; };
@@ -2308,7 +2307,6 @@
 		FA67DCE82DDBD4EA00896B02 /* SentryUIRedactBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUIRedactBuilder.swift; sourceTree = "<group>"; };
 		FA67DCEA2DDBD4EA00896B02 /* HTTPHeaderSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPHeaderSanitizer.swift; sourceTree = "<group>"; };
 		FA67DCEB2DDBD4EA00896B02 /* SentryLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLog.swift; sourceTree = "<group>"; };
-		FA67DCEC2DDBD4EA00896B02 /* SentryLogOutput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryLogOutput.swift; sourceTree = "<group>"; };
 		FA67DCED2DDBD4EA00896B02 /* UIImageHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageHelper.swift; sourceTree = "<group>"; };
 		FA67DCEE2DDBD4EA00896B02 /* UrlSanitized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlSanitized.swift; sourceTree = "<group>"; };
 		FA67DCEF2DDBD4EA00896B02 /* URLSessionTaskHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionTaskHelper.swift; sourceTree = "<group>"; };
@@ -4577,7 +4575,6 @@
 				FA67DCE92DDBD4EA00896B02 /* ViewCapture */,
 				FA67DCEA2DDBD4EA00896B02 /* HTTPHeaderSanitizer.swift */,
 				FA67DCEB2DDBD4EA00896B02 /* SentryLog.swift */,
-				FA67DCEC2DDBD4EA00896B02 /* SentryLogOutput.swift */,
 				FA67DCED2DDBD4EA00896B02 /* UIImageHelper.swift */,
 				FA67DCEE2DDBD4EA00896B02 /* UrlSanitized.swift */,
 				FA67DCEF2DDBD4EA00896B02 /* URLSessionTaskHelper.swift */,
@@ -5450,7 +5447,6 @@
 				FA4C32972DF7513F001D7B00 /* SentryExperimentalOptions.swift in Sources */,
 				FA67DD152DDBD4EA00896B02 /* UrlSanitized.swift in Sources */,
 				FA67DD162DDBD4EA00896B02 /* SentryViewPhotographer.swift in Sources */,
-				FA67DD172DDBD4EA00896B02 /* SentryLogOutput.swift in Sources */,
 				FA67DD182DDBD4EA00896B02 /* UIImageHelper.swift in Sources */,
 				FA67DD192DDBD4EA00896B02 /* SwizzleClassNameExclude.swift in Sources */,
 				7B2A70DD27D6083D008B0D15 /* SentryThreadWrapper.m in Sources */,

--- a/Sources/Swift/Core/Tools/SentryLog.swift
+++ b/Sources/Swift/Core/Tools/SentryLog.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+typealias SentryLogOutput = ((String) -> Void)
+
 /// A note on the thread safety:
 /// The methods configure and log don't use synchronization mechanisms, meaning they aren't strictly speaking thread-safe.
 /// Still, you can use log from multiple threads. The problem is that when you call configure while
@@ -20,7 +22,7 @@ import Foundation
      * Threshold log level to always log, regardless of the current configuration
      */
     static let alwaysLevel = SentryLevel.fatal
-    private static var logOutput = SentryLogOutput()
+    private static var logOutput: ((String) -> Void) = { print($0) }
     private static var dateProvider: SentryCurrentDateProvider = SentryDefaultCurrentDateProvider()
 
     static func _configure(_ isDebug: Bool, diagnosticLevel: SentryLevel) {
@@ -37,7 +39,7 @@ import Foundation
         // log messages. We don't use system uptime because of privacy concerns
         // see: NSPrivacyAccessedAPICategorySystemBootTime.
         let time = self.dateProvider.date().timeIntervalSince1970
-        logOutput.log("[Sentry] [\(level)] [timeIntervalSince1970:\(time)] \(message)")
+        logOutput("[Sentry] [\(level)] [timeIntervalSince1970:\(time)] \(message)")
     }
 
     /**
@@ -57,7 +59,7 @@ import Foundation
  
     #if SENTRY_TEST || SENTRY_TEST_CI
     
-    static func setOutput(_ output: SentryLogOutput) {
+    static func setOutput(_ output: @escaping SentryLogOutput) {
         logOutput = output
     }
     

--- a/Sources/Swift/Core/Tools/SentryLogOutput.swift
+++ b/Sources/Swift/Core/Tools/SentryLogOutput.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-class SentryLogOutput {
-    func log(_ message: String) {
-        print(message)
-    }
-}

--- a/Tests/SentryTests/Helper/SentryLog.swift
+++ b/Tests/SentryTests/Helper/SentryLog.swift
@@ -6,9 +6,11 @@ extension Sentry.SentryLog {
         SentryLogSwiftSupport.configure(isDebug, diagnosticLevel: diagnosticLevel)
     }
     
-    static func setLogOutput(_ output: SentryLogOutput) {
+    static func setLogOutput(_ output: TestLogOutput) {
         #if SENTRY_TEST || SENTRY_TEST_CI
-        SentryLog.setOutput(output)
+        SentryLog.setOutput { string in
+            output.log(string)
+        }
         #endif
     }
     
@@ -16,7 +18,7 @@ extension Sentry.SentryLog {
         #if SENTRY_TEST || SENTRY_TEST_CI
         return SentryLog.getOutput()
         #else
-        SentryLogOutput()
+        { print($0) }
         #endif
     }
     

--- a/Tests/SentryTests/Helper/SentryLogTests.swift
+++ b/Tests/SentryTests/Helper/SentryLogTests.swift
@@ -24,7 +24,7 @@ class SentryLogTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         SentryLogSwiftSupport.configure(oldDebug, diagnosticLevel: oldLevel)
-        SentryLog.setLogOutput(oldOutput)
+        SentryLog.setOutput(oldOutput)
         SentryLog.setCurrentDateProvider(SentryDefaultCurrentDateProvider())
     }
 

--- a/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryBaseIntegrationTests.swift
@@ -26,7 +26,7 @@ class SentryBaseIntegrationTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         SentryLogSwiftSupport.configure(oldDebug, diagnosticLevel: oldLevel)
-        SentryLog.setLogOutput(oldOutput)
+        SentryLog.setOutput(oldOutput)
     }
 
     func testIntegrationName() {

--- a/Tests/SentryTests/SentryCrash/SentryCrashStackCursorSelfThreadTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashStackCursorSelfThreadTests.swift
@@ -9,7 +9,7 @@ final class SentryCrashStackCursorSelfThreadTests: XCTestCase {
         let oldOutput = SentryLog.getLogOutput()
 
         defer {
-            SentryLog.setLogOutput(oldOutput)
+            SentryLog.setOutput(oldOutput)
             SentryLogSwiftSupport.configure(oldDebug, diagnosticLevel: oldLevel)
         }
 

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -449,7 +449,7 @@ class SentrySDKTests: XCTestCase {
         let oldOutput = SentryLog.getLogOutput()
 
         defer {
-            SentryLog.setLogOutput(oldOutput)
+            SentryLog.setOutput(oldOutput)
         }
 
         let logOutput = TestLogOutput()
@@ -470,7 +470,7 @@ class SentrySDKTests: XCTestCase {
         let oldOutput = SentryLog.getLogOutput()
 
         defer {
-            SentryLog.setLogOutput(oldOutput)
+            SentryLog.setOutput(oldOutput)
         }
 
         let logOutput = TestLogOutput()

--- a/Tests/SentryTests/TestLogOutput.swift
+++ b/Tests/SentryTests/TestLogOutput.swift
@@ -2,23 +2,23 @@ import Foundation
 @testable import Sentry
 import XCTest
 
-class TestLogOutput: SentryLogOutput {
+final class TestLogOutput {
     
     private let queue = DispatchQueue(label: "TestLogOutput", attributes: .concurrent)
     
     private var _loggedMessages: [String] = []
     
-    var callSuperWhenLogging = true
-    
+    var logsToConsole: Bool = true
+
     var loggedMessages: [String] {
         queue.sync {
             return _loggedMessages
         }
     }
     
-    override func log(_ message: String) {
-        if callSuperWhenLogging {
-            super.log(message)
+    func log(_ message: String) {
+        if logsToConsole {
+            print(message)
         }
         queue.async(flags: .barrier) {
             self._loggedMessages.append(message)
@@ -30,7 +30,7 @@ class TestLogOutPutTests: XCTestCase {
     
     func testLoggingFromMulitpleThreads() {
         let sut = TestLogOutput()
-        sut.callSuperWhenLogging = false
+        sut.logsToConsole = false
         testConcurrentModifications(writeWork: { i in
             sut.log("Some message \(i)")
         }, readWork: {


### PR DESCRIPTION
I noticed this was a class acting as a closure, updated it to simplify the code a bit and improve performance by avoiding objc runtime/classes.

#skip-changelog
