### PR TITLE
fix: check correct variables for profiles/traces rand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Fix building with Xcode 26 (#5386)
 - Fix usage of `@available` to be `iOS` instead of `iOSApplicationExtension` (#5361)
+- Robustness against corrupt launch profile configuration files (#5447)
 
 ### Improvements
 

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -271,7 +271,7 @@ _sentry_nondeduplicated_startLaunchProfile(void)
     profileOptions.sessionSampleRate = profilesRate.floatValue;
 
     NSNumber *profilesRand = launchConfig[kSentryLaunchProfileConfigKeyProfilesSampleRand];
-    if (profilesRate == nil) {
+    if (profilesRand == nil) {
         SENTRY_LOG_DEBUG(@"Received a nil configured launch profile sample rand, will not "
                          @"start trace profiler for launch.");
         return;
@@ -285,7 +285,7 @@ _sentry_nondeduplicated_startLaunchProfile(void)
     }
 
     NSNumber *tracesRand = launchConfig[kSentryLaunchProfileConfigKeyTracesSampleRand];
-    if (tracesRate == nil) {
+    if (tracesRand == nil) {
         SENTRY_LOG_DEBUG(@"Received a nil configured launch trace sample rand, will not start "
                          @"trace profiler for launch.");
         return;


### PR DESCRIPTION
I noticed while adding more edge case tests to #5318 that these checks were copypasta'd and not checking the correct variable contents, first introduced in https://github.com/getsentry/sentry-cocoa/pull/4751