### PR TITLE
ci: remove condition that would prevent xcframework slice builds for …

### DIFF
--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -91,7 +91,6 @@ jobs:
           make bump-version TO=${{ env.VERSION }}
 
       - name: Build ${{inputs.name}}${{inputs.suffix}} XCFramework slice for ${{matrix.sdk}}
-        if: startsWith(github.ref, 'refs/heads/release/') == false
         run: ./scripts/build-xcframework-slice.sh ${{matrix.sdk}} ${{inputs.name}} "${{inputs.suffix}}" "${{inputs.macho-type}}" "${{inputs.configuration-suffix}}"
         shell: bash
 


### PR DESCRIPTION
Noticed while working on https://github.com/getsentry/sentry-cocoa/pull/5449 that this condition would prevent actually building the xcframework for release. 

#skip-changelog