### PR TITLE
Update API stability to handle SPI

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 ./scripts/build-xcframework-local.sh iOSOnly DynamicOnly
 
+# Delete private .swiftinterface files before running swift-api-digester
+# This ensures only public interfaces are analyzed
+find ./Sentry-Dynamic.xcframework -name "*.private.swiftinterface" -type f -delete
+
 xcrun --sdk iphoneos swift-api-digester \
     -dump-sdk \
     -o sdk_api.json \

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -23768,6 +23768,376 @@
         ]
       },
       {
+        "kind": "TypeDecl",
+        "name": "SentryANRType",
+        "printedName": "SentryANRType",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(rawValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Sentry.SentryANRType?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryANRType",
+                    "printedName": "Sentry.SentryANRType",
+                    "usr": "c:@M@Sentry@E@SentryANRType"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:So13SentryANRTypeV8rawValueABSgSi_tcfc",
+            "mangledName": "$sSo13SentryANRTypeV8rawValueABSgSi_tcfc",
+            "moduleName": "Sentry",
+            "implicit": true,
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "rawValue",
+            "printedName": "rawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:So13SentryANRTypeV8rawValueSivp",
+            "mangledName": "$sSo13SentryANRTypeV8rawValueSivp",
+            "moduleName": "Sentry",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:So13SentryANRTypeV8rawValueSivg",
+                "mangledName": "$sSo13SentryANRTypeV8rawValueSivg",
+                "moduleName": "Sentry",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "RawValue",
+            "printedName": "RawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:So13SentryANRTypeV8RawValuea",
+            "mangledName": "$sSo13SentryANRTypeV8RawValuea",
+            "moduleName": "Sentry",
+            "implicit": true
+          },
+          {
+            "kind": "Var",
+            "name": "fatalFullyBlocking",
+            "printedName": "fatalFullyBlocking",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryANRType",
+                    "printedName": "Sentry.SentryANRType",
+                    "usr": "c:@M@Sentry@E@SentryANRType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeFatalFullyBlocking",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fatalNonFullyBlocking",
+            "printedName": "fatalNonFullyBlocking",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryANRType",
+                    "printedName": "Sentry.SentryANRType",
+                    "usr": "c:@M@Sentry@E@SentryANRType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeFatalNonFullyBlocking",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "fullyBlocking",
+            "printedName": "fullyBlocking",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryANRType",
+                    "printedName": "Sentry.SentryANRType",
+                    "usr": "c:@M@Sentry@E@SentryANRType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeFullyBlocking",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "nonFullyBlocking",
+            "printedName": "nonFullyBlocking",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryANRType",
+                    "printedName": "Sentry.SentryANRType",
+                    "usr": "c:@M@Sentry@E@SentryANRType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeNonFullyBlocking",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "unknown",
+            "printedName": "unknown",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryANRType",
+                    "printedName": "Sentry.SentryANRType",
+                    "usr": "c:@M@Sentry@E@SentryANRType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryANRType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryANRType",
+                        "printedName": "Sentry.SentryANRType",
+                        "usr": "c:@M@Sentry@E@SentryANRType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeUnknown",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "c:@M@Sentry@E@SentryANRType",
+        "moduleName": "Sentry",
+        "objc_name": "SentryANRType",
+        "declAttributes": [
+          "SynthesizedProtocol",
+          "ObjC",
+          "SynthesizedProtocol",
+          "Sendable",
+          "Dynamic"
+        ],
+        "enumRawTypeName": "Int",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "RawRepresentable",
+            "printedName": "RawRepresentable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "RawValue",
+                    "printedName": "Sentry.SentryANRType.RawValue",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:SY",
+            "mangledName": "$sSY"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
         "kind": "TypeAlias",
         "name": "SentryBeforeBreadcrumbCallback",
         "printedName": "SentryBeforeBreadcrumbCallback",
@@ -30698,6 +31068,259 @@
                     "kind": "TypeNameAlias",
                     "name": "RawValue",
                     "printedName": "Sentry.SentryReplayQuality.RawValue",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "Int",
+                        "printedName": "Swift.Int",
+                        "usr": "s:Si"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "usr": "s:SY",
+            "mangledName": "$sSY"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Sendable",
+            "printedName": "Sendable",
+            "usr": "s:s8SendableP",
+            "mangledName": "$ss8SendableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Equatable",
+            "printedName": "Equatable",
+            "usr": "s:SQ",
+            "mangledName": "$sSQ"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Hashable",
+            "printedName": "Hashable",
+            "usr": "s:SH",
+            "mangledName": "$sSH"
+          }
+        ]
+      },
+      {
+        "kind": "TypeDecl",
+        "name": "SentryReplayType",
+        "printedName": "SentryReplayType",
+        "children": [
+          {
+            "kind": "Constructor",
+            "name": "init",
+            "printedName": "init(rawValue:)",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Optional",
+                "printedName": "Sentry.SentryReplayType?",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryReplayType",
+                    "printedName": "Sentry.SentryReplayType",
+                    "usr": "c:@M@Sentry@E@SentryReplayType"
+                  }
+                ],
+                "usr": "s:Sq"
+              },
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Constructor",
+            "usr": "s:So16SentryReplayTypeV8rawValueABSgSi_tcfc",
+            "mangledName": "$sSo16SentryReplayTypeV8rawValueABSgSi_tcfc",
+            "moduleName": "Sentry",
+            "implicit": true,
+            "init_kind": "Designated"
+          },
+          {
+            "kind": "Var",
+            "name": "rawValue",
+            "printedName": "rawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "Var",
+            "usr": "s:So16SentryReplayTypeV8rawValueSivp",
+            "mangledName": "$sSo16SentryReplayTypeV8rawValueSivp",
+            "moduleName": "Sentry",
+            "implicit": true,
+            "accessors": [
+              {
+                "kind": "Accessor",
+                "name": "Get",
+                "printedName": "Get()",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Int",
+                    "printedName": "Swift.Int",
+                    "usr": "s:Si"
+                  }
+                ],
+                "declKind": "Accessor",
+                "usr": "s:So16SentryReplayTypeV8rawValueSivg",
+                "mangledName": "$sSo16SentryReplayTypeV8rawValueSivg",
+                "moduleName": "Sentry",
+                "implicit": true,
+                "accessorKind": "get"
+              }
+            ]
+          },
+          {
+            "kind": "TypeAlias",
+            "name": "RawValue",
+            "printedName": "RawValue",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Int",
+                "printedName": "Swift.Int",
+                "usr": "s:Si"
+              }
+            ],
+            "declKind": "TypeAlias",
+            "usr": "s:So16SentryReplayTypeV8RawValuea",
+            "mangledName": "$sSo16SentryReplayTypeV8RawValuea",
+            "moduleName": "Sentry",
+            "implicit": true
+          },
+          {
+            "kind": "Var",
+            "name": "session",
+            "printedName": "session",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryReplayType.Type) -> Sentry.SentryReplayType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryReplayType",
+                    "printedName": "Sentry.SentryReplayType",
+                    "usr": "c:@M@Sentry@E@SentryReplayType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryReplayType@SentryReplayTypeSession",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          },
+          {
+            "kind": "Var",
+            "name": "buffer",
+            "printedName": "buffer",
+            "children": [
+              {
+                "kind": "TypeFunc",
+                "name": "Function",
+                "printedName": "(Sentry.SentryReplayType.Type) -> Sentry.SentryReplayType",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "SentryReplayType",
+                    "printedName": "Sentry.SentryReplayType",
+                    "usr": "c:@M@Sentry@E@SentryReplayType"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "Metatype",
+                    "printedName": "Sentry.SentryReplayType.Type",
+                    "children": [
+                      {
+                        "kind": "TypeNominal",
+                        "name": "SentryReplayType",
+                        "printedName": "Sentry.SentryReplayType",
+                        "usr": "c:@M@Sentry@E@SentryReplayType"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "declKind": "EnumElement",
+            "usr": "c:@M@Sentry@E@SentryReplayType@SentryReplayTypeBuffer",
+            "moduleName": "Sentry",
+            "declAttributes": [
+              "ObjC"
+            ]
+          }
+        ],
+        "declKind": "Enum",
+        "usr": "c:@M@Sentry@E@SentryReplayType",
+        "moduleName": "Sentry",
+        "objc_name": "SentryReplayType",
+        "declAttributes": [
+          "SynthesizedProtocol",
+          "ObjC",
+          "SynthesizedProtocol",
+          "Sendable",
+          "Dynamic"
+        ],
+        "enumRawTypeName": "Int",
+        "conformances": [
+          {
+            "kind": "Conformance",
+            "name": "Copyable",
+            "printedName": "Copyable",
+            "usr": "s:s8CopyableP",
+            "mangledName": "$ss8CopyableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "Escapable",
+            "printedName": "Escapable",
+            "usr": "s:s9EscapableP",
+            "mangledName": "$ss9EscapableP"
+          },
+          {
+            "kind": "Conformance",
+            "name": "RawRepresentable",
+            "printedName": "RawRepresentable",
+            "children": [
+              {
+                "kind": "TypeWitness",
+                "name": "RawValue",
+                "printedName": "RawValue",
+                "children": [
+                  {
+                    "kind": "TypeNameAlias",
+                    "name": "RawValue",
+                    "printedName": "Sentry.SentryReplayType.RawValue",
                     "children": [
                       {
                         "kind": "TypeNominal",
@@ -43179,340 +43802,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "SentryReplayType",
-        "printedName": "SentryReplayType",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "session",
-            "printedName": "session",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryReplayType.Type) -> Sentry.SentryReplayType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryReplayType",
-                    "printedName": "Sentry.SentryReplayType",
-                    "usr": "c:@M@Sentry@E@SentryReplayType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryReplayType",
-                        "printedName": "Sentry.SentryReplayType",
-                        "usr": "c:@M@Sentry@E@SentryReplayType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryReplayType@SentryReplayTypeSession",
-            "mangledName": "$s6Sentry0A10ReplayTypeO7sessionyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "buffer",
-            "printedName": "buffer",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryReplayType.Type) -> Sentry.SentryReplayType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryReplayType",
-                    "printedName": "Sentry.SentryReplayType",
-                    "usr": "c:@M@Sentry@E@SentryReplayType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryReplayType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryReplayType",
-                        "printedName": "Sentry.SentryReplayType",
-                        "usr": "c:@M@Sentry@E@SentryReplayType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryReplayType@SentryReplayTypeBuffer",
-            "mangledName": "$s6Sentry0A10ReplayTypeO6bufferyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(rawValue:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.SentryReplayType?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryReplayType",
-                    "printedName": "Sentry.SentryReplayType",
-                    "usr": "c:@M@Sentry@E@SentryReplayType"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:6Sentry0A10ReplayTypeO8rawValueACSgSi_tcfc",
-            "mangledName": "$s6Sentry0A10ReplayTypeO8rawValueACSgSi_tcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "TypeAlias",
-            "name": "RawValue",
-            "printedName": "RawValue",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "TypeAlias",
-            "usr": "s:6Sentry0A10ReplayTypeO8RawValuea",
-            "mangledName": "$s6Sentry0A10ReplayTypeO8RawValuea",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "rawValue",
-            "printedName": "rawValue",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:6Sentry0A10ReplayTypeO8rawValueSivp",
-            "mangledName": "$s6Sentry0A10ReplayTypeO8rawValueSivp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A10ReplayTypeO8rawValueSivg",
-                "mangledName": "$s6Sentry0A10ReplayTypeO8rawValueSivg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "description",
-            "printedName": "description",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:6Sentry0A10ReplayTypeO11descriptionSSvp",
-            "mangledName": "$s6Sentry0A10ReplayTypeO11descriptionSSvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "isFromExtension": true,
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A10ReplayTypeO11descriptionSSvg",
-                "mangledName": "$s6Sentry0A10ReplayTypeO11descriptionSSvg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "SPIAccessControl"
-                ],
-                "isFromExtension": true,
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Enum",
-        "usr": "c:@M@Sentry@E@SentryReplayType",
-        "mangledName": "$s6Sentry0A10ReplayTypeO",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "enumRawTypeName": "Int",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "RawRepresentable",
-            "printedName": "RawRepresentable",
-            "children": [
-              {
-                "kind": "TypeWitness",
-                "name": "RawValue",
-                "printedName": "RawValue",
-                "children": [
-                  {
-                    "kind": "TypeNameAlias",
-                    "name": "RawValue",
-                    "printedName": "Sentry.SentryReplayType.RawValue",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "usr": "s:SY",
-            "mangledName": "$sSY"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryFeedback",
         "printedName": "SentryFeedback",
         "children": [
@@ -43794,62 +44083,6 @@
             ]
           },
           {
-            "kind": "Var",
-            "name": "eventId",
-            "printedName": "eventId",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryId",
-                "printedName": "Sentry.SentryId",
-                "usr": "c:@M@Sentry@objc(cs)SentryId"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryFeedback(py)eventId",
-            "mangledName": "$s6Sentry0A8FeedbackC7eventIdAA0aD0Cvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryId",
-                    "printedName": "Sentry.SentryId",
-                    "usr": "c:@M@Sentry@objc(cs)SentryId"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryFeedback(im)eventId",
-                "mangledName": "$s6Sentry0A8FeedbackC7eventIdAA0aD0Cvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
             "kind": "Constructor",
             "name": "init",
             "printedName": "init(message:name:email:source:associatedEventId:attachments:)",
@@ -43985,41 +44218,6 @@
               "Dynamic"
             ],
             "isFromExtension": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "attachmentsForEnvelope",
-            "printedName": "attachmentsForEnvelope()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Sentry.Attachment]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Attachment",
-                    "printedName": "Sentry.Attachment",
-                    "usr": "c:objc(cs)SentryAttachment"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@CM@Sentry@objc(cs)SentryFeedback(im)attachmentsForEnvelope",
-            "mangledName": "$s6Sentry0A8FeedbackC22attachmentsForEnvelopeSaySo0A10AttachmentCGyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Dynamic",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "isFromExtension": true,
-            "spi_group_names": [
-              "Private"
-            ],
             "funcSelfKind": "NonMutating"
           }
         ],
@@ -44609,319 +44807,6 @@
             "printedName": "SentrySerializable",
             "usr": "c:objc(pl)SentrySerializable"
           },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryReplayRecording",
-        "printedName": "SentryReplayRecording",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "headerForReplayRecording",
-            "printedName": "headerForReplayRecording()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Dictionary",
-                "printedName": "[Swift.String : Any]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "ProtocolComposition",
-                    "printedName": "Any"
-                  }
-                ],
-                "usr": "s:SD"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayRecording(im)headerForReplayRecording",
-            "mangledName": "$s6Sentry0A15ReplayRecordingC09headerForbC0SDySSypGyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "serialize",
-            "printedName": "serialize()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[[Swift.String : Any]]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Dictionary",
-                    "printedName": "[Swift.String : Any]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "ProtocolComposition",
-                        "printedName": "Any"
-                      }
-                    ],
-                    "usr": "s:SD"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayRecording(im)serialize",
-            "mangledName": "$s6Sentry0A15ReplayRecordingC9serializeSaySDySSypGGyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryReplayRecording",
-        "mangledName": "$s6Sentry0A15ReplayRecordingC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "hasMissingDesignatedInitializers": true,
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryLogSwiftSupport",
-        "printedName": "SentryLogSwiftSupport",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "configure",
-            "printedName": "configure(_:diagnosticLevel:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevel",
-                "printedName": "Sentry.SentryLevel",
-                "usr": "c:@M@Sentry@E@SentryLevel"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryLogSwiftSupport(cm)configure:diagnosticLevel:",
-            "mangledName": "$s6Sentry0A15LogSwiftSupportC9configure_15diagnosticLevelySb_AA0aG0OtFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLogSwiftSupport",
-                "printedName": "Sentry.SentryLogSwiftSupport",
-                "usr": "c:@M@Sentry@objc(cs)SentryLogSwiftSupport"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryLogSwiftSupport(im)init",
-            "mangledName": "$s6Sentry0A15LogSwiftSupportCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryLogSwiftSupport",
-        "mangledName": "$s6Sentry0A15LogSwiftSupportC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -47039,48 +46924,6 @@
         "printedName": "SentryEventDecoder",
         "children": [
           {
-            "kind": "Function",
-            "name": "decodeEvent",
-            "printedName": "decodeEvent(jsonData:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.Event?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Event",
-                    "printedName": "Sentry.Event",
-                    "usr": "c:objc(cs)SentryEvent"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Data",
-                "printedName": "Foundation.Data",
-                "usr": "s:10Foundation4DataV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryEventDecoder(cm)decodeEventWithJsonData:",
-            "mangledName": "$s6Sentry0A12EventDecoderC06decodeB08jsonDataSo0aB0CSg10Foundation0F0V_tFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "decodeEventWithJsonData:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
             "kind": "Constructor",
             "name": "init",
             "printedName": "init()",
@@ -49011,250 +48854,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "SentryDefaultCurrentDateProvider",
-        "printedName": "SentryDefaultCurrentDateProvider",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "date",
-            "printedName": "date()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider(im)date",
-            "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderC4date10Foundation0D0VyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "timezoneOffset",
-            "printedName": "timezoneOffset()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider(im)timezoneOffset",
-            "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderC14timezoneOffsetSiyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "systemTime",
-            "printedName": "systemTime()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UInt64",
-                "printedName": "Swift.UInt64",
-                "usr": "s:s6UInt64V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider(im)systemTime",
-            "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderC10systemTimes6UInt64VyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "systemUptime",
-            "printedName": "systemUptime()",
-            "children": [
-              {
-                "kind": "TypeNameAlias",
-                "name": "TimeInterval",
-                "printedName": "Foundation.TimeInterval",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Double",
-                    "printedName": "Swift.Double",
-                    "usr": "s:Sd"
-                  }
-                ]
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider(im)systemUptime",
-            "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderC12systemUptimeSdyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "getAbsoluteTime",
-            "printedName": "getAbsoluteTime()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UInt64",
-                "printedName": "Swift.UInt64",
-                "usr": "s:s6UInt64V"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider(cm)getAbsoluteTime",
-            "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderC15getAbsoluteTimes6UInt64VyFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryDefaultCurrentDateProvider",
-                "printedName": "Sentry.SentryDefaultCurrentDateProvider",
-                "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider(im)init",
-            "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryDefaultCurrentDateProvider",
-        "mangledName": "$s6Sentry0A26DefaultCurrentDateProviderC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryProfileOptions",
         "printedName": "SentryProfileOptions",
         "children": [
@@ -49816,177 +49415,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "HTTPHeaderSanitizer",
-        "printedName": "HTTPHeaderSanitizer",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "sanitizeHeaders",
-            "printedName": "sanitizeHeaders(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Dictionary",
-                "printedName": "[Swift.String : Swift.String]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:SD"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Dictionary",
-                "printedName": "[Swift.String : Swift.String]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:SD"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)HTTPHeaderSanitizer(cm)sanitizeHeaders:",
-            "mangledName": "$s6Sentry19HTTPHeaderSanitizerC15sanitizeHeadersySDyS2SGAEFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "HTTPHeaderSanitizer",
-                "printedName": "Sentry.HTTPHeaderSanitizer",
-                "usr": "c:@M@Sentry@objc(cs)HTTPHeaderSanitizer"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)HTTPHeaderSanitizer(im)init",
-            "mangledName": "$s6Sentry19HTTPHeaderSanitizerCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)HTTPHeaderSanitizer",
-        "mangledName": "$s6Sentry19HTTPHeaderSanitizerC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryId",
         "printedName": "SentryId",
         "children": [
@@ -50389,788 +49817,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "SentryANRTracker",
-        "printedName": "SentryANRTracker",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "add",
-            "printedName": "add(listener:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryANRTrackerDelegate",
-                "printedName": "any Sentry.SentryANRTrackerDelegate",
-                "usr": "c:@M@Sentry@objc(pl)SentryANRTrackerDelegate"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryANRTracker(im)addListener:",
-            "mangledName": "$s6Sentry0A10ANRTrackerP3add8listeneryAA0aB8Delegate_p_tF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryANRTracker>",
-            "protocolReq": true,
-            "objc_name": "addListener:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "remove",
-            "printedName": "remove(listener:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryANRTrackerDelegate",
-                "printedName": "any Sentry.SentryANRTrackerDelegate",
-                "usr": "c:@M@Sentry@objc(pl)SentryANRTrackerDelegate"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryANRTracker(im)removeListener:",
-            "mangledName": "$s6Sentry0A10ANRTrackerP6remove8listeneryAA0aB8Delegate_p_tF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryANRTracker>",
-            "protocolReq": true,
-            "objc_name": "removeListener:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "clear",
-            "printedName": "clear()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryANRTracker(im)clear",
-            "mangledName": "$s6Sentry0A10ANRTrackerP5clearyyF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryANRTracker>",
-            "protocolReq": true,
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "c:@M@Sentry@objc(pl)SentryANRTracker",
-        "mangledName": "$s6Sentry0A10ANRTrackerP",
-        "moduleName": "Sentry",
-        "genericSig": "<Self : AnyObject>",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryANRTrackerDelegate",
-        "printedName": "SentryANRTrackerDelegate",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "anrDetected",
-            "printedName": "anrDetected(type:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryANRType",
-                "printedName": "Sentry.SentryANRType",
-                "usr": "c:@M@Sentry@E@SentryANRType"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryANRTrackerDelegate(im)anrDetectedWithType:",
-            "mangledName": "$s6Sentry0A18ANRTrackerDelegateP11anrDetected4typeyAA0A7ANRTypeO_tF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryANRTrackerDelegate>",
-            "protocolReq": true,
-            "objc_name": "anrDetectedWithType:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "anrStopped",
-            "printedName": "anrStopped(result:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.SentryANRStoppedResult?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRStoppedResult",
-                    "printedName": "Sentry.SentryANRStoppedResult",
-                    "usr": "c:@M@Sentry@objc(cs)SentryANRStoppedResult"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryANRTrackerDelegate(im)anrStoppedWithResult:",
-            "mangledName": "$s6Sentry0A18ANRTrackerDelegateP10anrStopped6resultyAA0A16ANRStoppedResultCSg_tF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryANRTrackerDelegate>",
-            "protocolReq": true,
-            "objc_name": "anrStoppedWithResult:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "c:@M@Sentry@objc(pl)SentryANRTrackerDelegate",
-        "mangledName": "$s6Sentry0A18ANRTrackerDelegateP",
-        "moduleName": "Sentry",
-        "genericSig": "<Self : AnyObject>",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryANRStoppedResult",
-        "printedName": "SentryANRStoppedResult",
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryANRStoppedResult",
-        "mangledName": "$s6Sentry0A16ANRStoppedResultC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "hasMissingDesignatedInitializers": true,
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryMXManagerDelegate",
-        "printedName": "SentryMXManagerDelegate",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "didReceiveCrashDiagnostic",
-            "printedName": "didReceiveCrashDiagnostic(_:callStackTree:timeStampBegin:timeStampEnd:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "MXCrashDiagnostic",
-                "printedName": "MetricKit.MXCrashDiagnostic",
-                "usr": "c:objc(cs)MXCrashDiagnostic"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXCallStackTree",
-                "printedName": "Sentry.SentryMXCallStackTree",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryMXManagerDelegate(im)didReceiveCrashDiagnostic:callStackTree:timeStampBegin:timeStampEnd:",
-            "mangledName": "$s6Sentry0A17MXManagerDelegateP25didReceiveCrashDiagnostic_13callStackTree14timeStampBegin0kL3EndySo07MXCrashG0C_AA0a6MXCalliJ0C10Foundation4DateVANtF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryMXManagerDelegate>",
-            "protocolReq": true,
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "didReceiveDiskWriteExceptionDiagnostic",
-            "printedName": "didReceiveDiskWriteExceptionDiagnostic(_:callStackTree:timeStampBegin:timeStampEnd:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "MXDiskWriteExceptionDiagnostic",
-                "printedName": "MetricKit.MXDiskWriteExceptionDiagnostic",
-                "usr": "c:objc(cs)MXDiskWriteExceptionDiagnostic"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXCallStackTree",
-                "printedName": "Sentry.SentryMXCallStackTree",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryMXManagerDelegate(im)didReceiveDiskWriteExceptionDiagnostic:callStackTree:timeStampBegin:timeStampEnd:",
-            "mangledName": "$s6Sentry0A17MXManagerDelegateP38didReceiveDiskWriteExceptionDiagnostic_13callStackTree14timeStampBegin0mN3EndySo06MXDiskghI0C_AA0a6MXCallkL0C10Foundation4DateVANtF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryMXManagerDelegate>",
-            "protocolReq": true,
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "didReceiveCpuExceptionDiagnostic",
-            "printedName": "didReceiveCpuExceptionDiagnostic(_:callStackTree:timeStampBegin:timeStampEnd:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "MXCPUExceptionDiagnostic",
-                "printedName": "MetricKit.MXCPUExceptionDiagnostic",
-                "usr": "c:objc(cs)MXCPUExceptionDiagnostic"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXCallStackTree",
-                "printedName": "Sentry.SentryMXCallStackTree",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryMXManagerDelegate(im)didReceiveCpuExceptionDiagnostic:callStackTree:timeStampBegin:timeStampEnd:",
-            "mangledName": "$s6Sentry0A17MXManagerDelegateP32didReceiveCpuExceptionDiagnostic_13callStackTree14timeStampBegin0lM3EndySo014MXCPUExceptionH0C_AA0a6MXCalljK0C10Foundation4DateVANtF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryMXManagerDelegate>",
-            "protocolReq": true,
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "didReceiveHangDiagnostic",
-            "printedName": "didReceiveHangDiagnostic(_:callStackTree:timeStampBegin:timeStampEnd:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "MXHangDiagnostic",
-                "printedName": "MetricKit.MXHangDiagnostic",
-                "usr": "c:objc(cs)MXHangDiagnostic"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXCallStackTree",
-                "printedName": "Sentry.SentryMXCallStackTree",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(pl)SentryMXManagerDelegate(im)didReceiveHangDiagnostic:callStackTree:timeStampBegin:timeStampEnd:",
-            "mangledName": "$s6Sentry0A17MXManagerDelegateP24didReceiveHangDiagnostic_13callStackTree14timeStampBegin0kL3EndySo06MXHangG0C_AA0a6MXCalliJ0C10Foundation4DateVANtF",
-            "moduleName": "Sentry",
-            "genericSig": "<Self where Self : Sentry.SentryMXManagerDelegate>",
-            "protocolReq": true,
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "reqNewWitnessTableEntry": true,
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Protocol",
-        "usr": "c:@M@Sentry@objc(pl)SentryMXManagerDelegate",
-        "mangledName": "$s6Sentry0A17MXManagerDelegateP",
-        "moduleName": "Sentry",
-        "genericSig": "<Self : AnyObject>",
-        "intro_Macosx": "12.0",
-        "intro_iOS": "15.0",
-        "declAttributes": [
-          "Available",
-          "ObjC",
-          "Available",
-          "Available",
-          "Available",
-          "Available",
-          "Available",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryMXManager",
-        "printedName": "SentryMXManager",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(disableCrashDiagnostics:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXManager",
-                "printedName": "Sentry.SentryMXManager",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXManager"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "hasDefaultArg": true,
-                "usr": "s:Sb"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXManager(im)initWithDisableCrashDiagnostics:",
-            "mangledName": "$s6Sentry0A9MXManagerC23disableCrashDiagnosticsACSb_tcfc",
-            "moduleName": "Sentry",
-            "objc_name": "initWithDisableCrashDiagnostics:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "receiveReports",
-            "printedName": "receiveReports()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXManager(im)receiveReports",
-            "mangledName": "$s6Sentry0A9MXManagerC14receiveReportsyyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "pauseReports",
-            "printedName": "pauseReports()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXManager(im)pauseReports",
-            "mangledName": "$s6Sentry0A9MXManagerC12pauseReportsyyF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "didReceive",
-            "printedName": "didReceive(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[MetricKit.MXDiagnosticPayload]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "MXDiagnosticPayload",
-                    "printedName": "MetricKit.MXDiagnosticPayload",
-                    "usr": "c:objc(cs)MXDiagnosticPayload"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXManager(im)didReceiveDiagnosticPayloads:",
-            "mangledName": "$s6Sentry0A9MXManagerC10didReceiveyySaySo19MXDiagnosticPayloadCGF",
-            "moduleName": "Sentry",
-            "objc_name": "didReceiveDiagnosticPayloads:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryMXManager",
-        "mangledName": "$s6Sentry0A9MXManagerC",
-        "moduleName": "Sentry",
-        "intro_Macosx": "12.0",
-        "intro_iOS": "15.0",
-        "declAttributes": [
-          "Available",
-          "ObjCMembers",
-          "Available",
-          "Available",
-          "Available",
-          "Available",
-          "Available",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "MXMetricManagerSubscriber",
-            "printedName": "MXMetricManagerSubscriber",
-            "usr": "c:objc(pl)MXMetricManagerSubscriber"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryRedactViewHelper",
         "printedName": "SentryRedactViewHelper",
         "children": [
@@ -51246,1470 +49892,6 @@
           "ObjectiveC.NSObject"
         ],
         "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryMXCallStackTree",
-        "printedName": "SentryMXCallStackTree",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "callStacks",
-            "printedName": "callStacks",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Sentry.SentryMXCallStack]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryMXCallStack",
-                    "printedName": "Sentry.SentryMXCallStack",
-                    "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree(py)callStacks",
-            "mangledName": "$s6Sentry0A15MXCallStackTreeC10callStacksSayAA0abC0CGvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Sentry.SentryMXCallStack]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryMXCallStack",
-                        "printedName": "Sentry.SentryMXCallStack",
-                        "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree(im)callStacks",
-                "mangledName": "$s6Sentry0A15MXCallStackTreeC10callStacksSayAA0abC0CGvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "callStackPerThread",
-            "printedName": "callStackPerThread",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree(py)callStackPerThread",
-            "mangledName": "$s6Sentry0A15MXCallStackTreeC04callC9PerThreadSbvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree(im)callStackPerThread",
-                "mangledName": "$s6Sentry0A15MXCallStackTreeC04callC9PerThreadSbvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Function",
-            "name": "encode",
-            "printedName": "encode(to:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Encoder",
-                "printedName": "any Swift.Encoder",
-                "usr": "s:s7EncoderP"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:6Sentry0A15MXCallStackTreeC6encode2toys7Encoder_p_tKF",
-            "mangledName": "$s6Sentry0A15MXCallStackTreeC6encode2toys7Encoder_p_tKF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "throwing": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXCallStackTree",
-                "printedName": "Sentry.SentryMXCallStackTree",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Decoder",
-                "printedName": "any Swift.Decoder",
-                "usr": "s:s7DecoderP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:6Sentry0A15MXCallStackTreeC4fromACs7Decoder_p_tKcfc",
-            "mangledName": "$s6Sentry0A15MXCallStackTreeC4fromACs7Decoder_p_tKcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Required",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "throwing": true,
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryMXCallStackTree",
-        "mangledName": "$s6Sentry0A15MXCallStackTreeC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "hasMissingDesignatedInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Decodable",
-            "printedName": "Decodable",
-            "usr": "s:Se",
-            "mangledName": "$sSe"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Encodable",
-            "printedName": "Encodable",
-            "usr": "s:SE",
-            "mangledName": "$sSE"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryMXCallStack",
-        "printedName": "SentryMXCallStack",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "threadAttributed",
-            "printedName": "threadAttributed",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.Bool?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Bool",
-                    "printedName": "Swift.Bool",
-                    "usr": "s:Sb"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:6Sentry0A11MXCallStackC16threadAttributedSbSgvp",
-            "mangledName": "$s6Sentry0A11MXCallStackC16threadAttributedSbSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "HasInitialValue",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.Bool?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
-                        "usr": "s:Sb"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A11MXCallStackC16threadAttributedSbSgvg",
-                "mangledName": "$s6Sentry0A11MXCallStackC16threadAttributedSbSgvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.Bool?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Bool",
-                        "printedName": "Swift.Bool",
-                        "usr": "s:Sb"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A11MXCallStackC16threadAttributedSbSgvs",
-                "mangledName": "$s6Sentry0A11MXCallStackC16threadAttributedSbSgvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "callStackRootFrames",
-            "printedName": "callStackRootFrames",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Sentry.SentryMXFrame]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryMXFrame",
-                    "printedName": "Sentry.SentryMXFrame",
-                    "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack(py)callStackRootFrames",
-            "mangledName": "$s6Sentry0A11MXCallStackC04callC10RootFramesSayAA0A7MXFrameCGvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Sentry.SentryMXFrame]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryMXFrame",
-                        "printedName": "Sentry.SentryMXFrame",
-                        "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack(im)callStackRootFrames",
-                "mangledName": "$s6Sentry0A11MXCallStackC04callC10RootFramesSayAA0A7MXFrameCGvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Sentry.SentryMXFrame]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryMXFrame",
-                        "printedName": "Sentry.SentryMXFrame",
-                        "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack(im)setCallStackRootFrames:",
-                "mangledName": "$s6Sentry0A11MXCallStackC04callC10RootFramesSayAA0A7MXFrameCGvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "flattenedRootFrames",
-            "printedName": "flattenedRootFrames",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Sentry.SentryMXFrame]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryMXFrame",
-                    "printedName": "Sentry.SentryMXFrame",
-                    "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                  }
-                ],
-                "usr": "s:Sa"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack(py)flattenedRootFrames",
-            "mangledName": "$s6Sentry0A11MXCallStackC19flattenedRootFramesSayAA0A7MXFrameCGvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Sentry.SentryMXFrame]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryMXFrame",
-                        "printedName": "Sentry.SentryMXFrame",
-                        "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack(im)flattenedRootFrames",
-                "mangledName": "$s6Sentry0A11MXCallStackC19flattenedRootFramesSayAA0A7MXFrameCGvg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "ObjC",
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Function",
-            "name": "encode",
-            "printedName": "encode(to:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Encoder",
-                "printedName": "any Swift.Encoder",
-                "usr": "s:s7EncoderP"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:6Sentry0A11MXCallStackC6encode2toys7Encoder_p_tKF",
-            "mangledName": "$s6Sentry0A11MXCallStackC6encode2toys7Encoder_p_tKF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "throwing": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXCallStack",
-                "printedName": "Sentry.SentryMXCallStack",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Decoder",
-                "printedName": "any Swift.Decoder",
-                "usr": "s:s7DecoderP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:6Sentry0A11MXCallStackC4fromACs7Decoder_p_tKcfc",
-            "mangledName": "$s6Sentry0A11MXCallStackC4fromACs7Decoder_p_tKcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Required",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "throwing": true,
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryMXCallStack",
-        "mangledName": "$s6Sentry0A11MXCallStackC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "hasMissingDesignatedInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Decodable",
-            "printedName": "Decodable",
-            "usr": "s:Se",
-            "mangledName": "$sSe"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Encodable",
-            "printedName": "Encodable",
-            "usr": "s:SE",
-            "mangledName": "$sSE"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryMXFrame",
-        "printedName": "SentryMXFrame",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "binaryUUID",
-            "printedName": "binaryUUID",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UUID",
-                "printedName": "Foundation.UUID",
-                "usr": "s:10Foundation4UUIDV"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(py)binaryUUID",
-            "mangledName": "$s6Sentry0A7MXFrameC10binaryUUID10Foundation0D0Vvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UUID",
-                    "printedName": "Foundation.UUID",
-                    "usr": "s:10Foundation4UUIDV"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)binaryUUID",
-                "mangledName": "$s6Sentry0A7MXFrameC10binaryUUID10Foundation0D0Vvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UUID",
-                    "printedName": "Foundation.UUID",
-                    "usr": "s:10Foundation4UUIDV"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)setBinaryUUID:",
-                "mangledName": "$s6Sentry0A7MXFrameC10binaryUUID10Foundation0D0Vvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "offsetIntoBinaryTextSegment",
-            "printedName": "offsetIntoBinaryTextSegment",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(py)offsetIntoBinaryTextSegment",
-            "mangledName": "$s6Sentry0A7MXFrameC27offsetIntoBinaryTextSegmentSivp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)offsetIntoBinaryTextSegment",
-                "mangledName": "$s6Sentry0A7MXFrameC27offsetIntoBinaryTextSegmentSivg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)setOffsetIntoBinaryTextSegment:",
-                "mangledName": "$s6Sentry0A7MXFrameC27offsetIntoBinaryTextSegmentSivs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "binaryName",
-            "printedName": "binaryName",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(py)binaryName",
-            "mangledName": "$s6Sentry0A7MXFrameC10binaryNameSSSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "HasInitialValue",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.String?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)binaryName",
-                "mangledName": "$s6Sentry0A7MXFrameC10binaryNameSSSgvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.String?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)setBinaryName:",
-                "mangledName": "$s6Sentry0A7MXFrameC10binaryNameSSSgvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "address",
-            "printedName": "address",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UInt64",
-                "printedName": "Swift.UInt64",
-                "usr": "s:s6UInt64V"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(py)address",
-            "mangledName": "$s6Sentry0A7MXFrameC7addresss6UInt64Vvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UInt64",
-                    "printedName": "Swift.UInt64",
-                    "usr": "s:s6UInt64V"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)address",
-                "mangledName": "$s6Sentry0A7MXFrameC7addresss6UInt64Vvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "UInt64",
-                    "printedName": "Swift.UInt64",
-                    "usr": "s:s6UInt64V"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)setAddress:",
-                "mangledName": "$s6Sentry0A7MXFrameC7addresss6UInt64Vvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "subFrames",
-            "printedName": "subFrames",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "[Sentry.SentryMXFrame]?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Sentry.SentryMXFrame]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryMXFrame",
-                        "printedName": "Sentry.SentryMXFrame",
-                        "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(py)subFrames",
-            "mangledName": "$s6Sentry0A7MXFrameC9subFramesSayACGSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "HasInitialValue",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "[Sentry.SentryMXFrame]?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Sentry.SentryMXFrame]",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMXFrame",
-                            "printedName": "Sentry.SentryMXFrame",
-                            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                          }
-                        ],
-                        "usr": "s:Sa"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)subFrames",
-                "mangledName": "$s6Sentry0A7MXFrameC9subFramesSayACGSgvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "[Sentry.SentryMXFrame]?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Sentry.SentryMXFrame]",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "SentryMXFrame",
-                            "printedName": "Sentry.SentryMXFrame",
-                            "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-                          }
-                        ],
-                        "usr": "s:Sa"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame(im)setSubFrames:",
-                "mangledName": "$s6Sentry0A7MXFrameC9subFramesSayACGSgvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "sampleCount",
-            "printedName": "sampleCount",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.Int?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:6Sentry0A7MXFrameC11sampleCountSiSgvp",
-            "mangledName": "$s6Sentry0A7MXFrameC11sampleCountSiSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "HasInitialValue",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.Int?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A7MXFrameC11sampleCountSiSgvg",
-                "mangledName": "$s6Sentry0A7MXFrameC11sampleCountSiSgvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.Int?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A7MXFrameC11sampleCountSiSgvs",
-                "mangledName": "$s6Sentry0A7MXFrameC11sampleCountSiSgvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Function",
-            "name": "encode",
-            "printedName": "encode(to:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Encoder",
-                "printedName": "any Swift.Encoder",
-                "usr": "s:s7EncoderP"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "s:6Sentry0A7MXFrameC6encode2toys7Encoder_p_tKF",
-            "mangledName": "$s6Sentry0A7MXFrameC6encode2toys7Encoder_p_tKF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "throwing": true,
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryMXFrame",
-                "printedName": "Sentry.SentryMXFrame",
-                "usr": "c:@M@Sentry@objc(cs)SentryMXFrame"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Decoder",
-                "printedName": "any Swift.Decoder",
-                "usr": "s:s7DecoderP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:6Sentry0A7MXFrameC4fromACs7Decoder_p_tKcfc",
-            "mangledName": "$s6Sentry0A7MXFrameC4fromACs7Decoder_p_tKcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Required",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "throwing": true,
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryMXFrame",
-        "mangledName": "$s6Sentry0A7MXFrameC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "hasMissingDesignatedInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Decodable",
-            "printedName": "Decodable",
-            "usr": "s:Se",
-            "mangledName": "$sSe"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Encodable",
-            "printedName": "Encodable",
-            "usr": "s:SE",
-            "mangledName": "$sSE"
-          },
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -53170,403 +50352,6 @@
             ],
             "usr": "s:SY",
             "mangledName": "$sSY"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SwiftDescriptor",
-        "printedName": "SwiftDescriptor",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "getObjectClassName",
-            "printedName": "getObjectClassName(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "AnyObject",
-                "printedName": "Swift.AnyObject"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SwiftDescriptor(cm)getObjectClassName:",
-            "mangledName": "$s6Sentry15SwiftDescriptorC18getObjectClassNameySSyXlFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "getViewControllerClassName",
-            "printedName": "getViewControllerClassName(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "UIViewController",
-                "printedName": "UIKit.UIViewController",
-                "usr": "c:objc(cs)UIViewController"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SwiftDescriptor(cm)getViewControllerClassName:",
-            "mangledName": "$s6Sentry15SwiftDescriptorC26getViewControllerClassNameySSSo06UIViewF0CFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "getSwiftErrorDescription",
-            "printedName": "getSwiftErrorDescription(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Error",
-                "printedName": "any Swift.Error",
-                "usr": "s:s5ErrorP"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SwiftDescriptor(cm)getSwiftErrorDescription:",
-            "mangledName": "$s6Sentry15SwiftDescriptorC03getB16ErrorDescriptionySSSgs0E0_pFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SwiftDescriptor",
-                "printedName": "Sentry.SwiftDescriptor",
-                "usr": "c:@M@Sentry@objc(cs)SwiftDescriptor"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SwiftDescriptor(im)init",
-            "mangledName": "$s6Sentry15SwiftDescriptorCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SwiftDescriptor",
-        "mangledName": "$s6Sentry15SwiftDescriptorC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryLog",
-        "printedName": "SentryLog",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "log",
-            "printedName": "log(message:andLevel:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevel",
-                "printedName": "Sentry.SentryLevel",
-                "usr": "c:@M@Sentry@E@SentryLevel"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryLog(cm)logWithMessage:andLevel:",
-            "mangledName": "$s6Sentry0A3LogC3log7message8andLevelySS_AA0aF0OtFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "logWithMessage:andLevel:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "willLog",
-            "printedName": "willLog(atLevel:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevel",
-                "printedName": "Sentry.SentryLevel",
-                "usr": "c:@M@Sentry@E@SentryLevel"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryLog(cm)willLogAtLevel:",
-            "mangledName": "$s6Sentry0A3LogC04willB07atLevelSbAA0aE0O_tFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "willLogAtLevel:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLog",
-                "printedName": "Sentry.SentryLog",
-                "usr": "c:@M@Sentry@objc(cs)SentryLog"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryLog(im)init",
-            "mangledName": "$s6Sentry0A3LogCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryLog",
-        "mangledName": "$s6Sentry0A3LogC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
           }
         ]
       },
@@ -54383,776 +51168,6 @@
       },
       {
         "kind": "TypeDecl",
-        "name": "SentryLevelHelper",
-        "printedName": "SentryLevelHelper",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "nameForLevel",
-            "printedName": "nameForLevel(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevel",
-                "printedName": "Sentry.SentryLevel",
-                "usr": "c:@M@Sentry@E@SentryLevel"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryLevelHelper(cm)nameForLevel:",
-            "mangledName": "$s6Sentry0A11LevelHelperC07nameForB0ySSAA0aB0OFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "levelForName",
-            "printedName": "levelForName(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevel",
-                "printedName": "Sentry.SentryLevel",
-                "usr": "c:@M@Sentry@E@SentryLevel"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryLevelHelper(cm)levelForName:",
-            "mangledName": "$s6Sentry0A11LevelHelperC12levelForNameyAA0aB0OSSFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryLevelHelper",
-                "printedName": "Sentry.SentryLevelHelper",
-                "usr": "c:@M@Sentry@objc(cs)SentryLevelHelper"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryLevelHelper(im)init",
-            "mangledName": "$s6Sentry0A11LevelHelperCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryLevelHelper",
-        "mangledName": "$s6Sentry0A11LevelHelperC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "URLSessionTaskHelper",
-        "printedName": "URLSessionTaskHelper",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "getGraphQLOperationName",
-            "printedName": "getGraphQLOperationName(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Foundation.URLSessionTask?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "URLSessionTask",
-                    "printedName": "Foundation.URLSessionTask",
-                    "usr": "c:objc(cs)NSURLSessionTask"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)URLSessionTaskHelper(cm)getGraphQLOperationNameFrom:",
-            "mangledName": "$s6Sentry20URLSessionTaskHelperC23getGraphQLOperationName4fromSSSgSo012NSURLSessionC0CSg_tFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "getGraphQLOperationNameFrom:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "URLSessionTaskHelper",
-                "printedName": "Sentry.URLSessionTaskHelper",
-                "usr": "c:@M@Sentry@objc(cs)URLSessionTaskHelper"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)URLSessionTaskHelper(im)init",
-            "mangledName": "$s6Sentry20URLSessionTaskHelperCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)URLSessionTaskHelper",
-        "mangledName": "$s6Sentry20URLSessionTaskHelperC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryBaggageSerialization",
-        "printedName": "SentryBaggageSerialization",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "encodeDictionary",
-            "printedName": "encodeDictionary(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Dictionary",
-                "printedName": "[Swift.String : Swift.String]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:SD"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryBaggageSerialization(cm)encodeDictionary:",
-            "mangledName": "$s6Sentry0A20BaggageSerializationC16encodeDictionaryySSSDyS2SGFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "decode",
-            "printedName": "decode(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Dictionary",
-                "printedName": "[Swift.String : Swift.String]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:SD"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryBaggageSerialization(cm)decode:",
-            "mangledName": "$s6Sentry0A20BaggageSerializationC6decodeySDyS2SGSSFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryBaggageSerialization",
-                "printedName": "Sentry.SentryBaggageSerialization",
-                "usr": "c:@M@Sentry@objc(cs)SentryBaggageSerialization"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryBaggageSerialization(im)init",
-            "mangledName": "$s6Sentry0A20BaggageSerializationCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryBaggageSerialization",
-        "mangledName": "$s6Sentry0A20BaggageSerializationC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryFileContents",
-        "printedName": "SentryFileContents",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "path",
-            "printedName": "path",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryFileContents(py)path",
-            "mangledName": "$s6Sentry0A12FileContentsC4pathSSvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryFileContents(im)path",
-                "mangledName": "$s6Sentry0A12FileContentsC4pathSSvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "contents",
-            "printedName": "contents",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Data",
-                "printedName": "Foundation.Data",
-                "usr": "s:10Foundation4DataV"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryFileContents(py)contents",
-            "mangledName": "$s6Sentry0A12FileContentsC8contents10Foundation4DataVvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Data",
-                    "printedName": "Foundation.Data",
-                    "usr": "s:10Foundation4DataV"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryFileContents(im)contents",
-                "mangledName": "$s6Sentry0A12FileContentsC8contents10Foundation4DataVvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(path:contents:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryFileContents",
-                "printedName": "Sentry.SentryFileContents",
-                "usr": "c:@M@Sentry@objc(cs)SentryFileContents"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Data",
-                "printedName": "Foundation.Data",
-                "usr": "s:10Foundation4DataV"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryFileContents(im)initWithPath:contents:",
-            "mangledName": "$s6Sentry0A12FileContentsC4path8contentsACSS_10Foundation4DataVtcfc",
-            "moduleName": "Sentry",
-            "objc_name": "initWithPath:contents:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryFileContents",
-        "mangledName": "$s6Sentry0A12FileContentsC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
         "name": "SentryUIViewControllerDescriptor",
         "printedName": "SentryUIViewControllerDescriptor",
         "children": [
@@ -55232,591 +51247,6 @@
             "name": "NSObjectProtocol",
             "printedName": "NSObjectProtocol",
             "usr": "c:objc(pl)NSObject"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryANRType",
-        "printedName": "SentryANRType",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "fatalFullyBlocking",
-            "printedName": "fatalFullyBlocking",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRType",
-                    "printedName": "Sentry.SentryANRType",
-                    "usr": "c:@M@Sentry@E@SentryANRType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeFatalFullyBlocking",
-            "mangledName": "$s6Sentry0A7ANRTypeO18fatalFullyBlockingyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "fatalNonFullyBlocking",
-            "printedName": "fatalNonFullyBlocking",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRType",
-                    "printedName": "Sentry.SentryANRType",
-                    "usr": "c:@M@Sentry@E@SentryANRType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeFatalNonFullyBlocking",
-            "mangledName": "$s6Sentry0A7ANRTypeO21fatalNonFullyBlockingyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "fullyBlocking",
-            "printedName": "fullyBlocking",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRType",
-                    "printedName": "Sentry.SentryANRType",
-                    "usr": "c:@M@Sentry@E@SentryANRType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeFullyBlocking",
-            "mangledName": "$s6Sentry0A7ANRTypeO13fullyBlockingyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "nonFullyBlocking",
-            "printedName": "nonFullyBlocking",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRType",
-                    "printedName": "Sentry.SentryANRType",
-                    "usr": "c:@M@Sentry@E@SentryANRType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeNonFullyBlocking",
-            "mangledName": "$s6Sentry0A7ANRTypeO16nonFullyBlockingyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "unknown",
-            "printedName": "unknown",
-            "children": [
-              {
-                "kind": "TypeFunc",
-                "name": "Function",
-                "printedName": "(Sentry.SentryANRType.Type) -> Sentry.SentryANRType",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRType",
-                    "printedName": "Sentry.SentryANRType",
-                    "usr": "c:@M@Sentry@E@SentryANRType"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Metatype",
-                    "printedName": "Sentry.SentryANRType.Type",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "SentryANRType",
-                        "printedName": "Sentry.SentryANRType",
-                        "usr": "c:@M@Sentry@E@SentryANRType"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "declKind": "EnumElement",
-            "usr": "c:@M@Sentry@E@SentryANRType@SentryANRTypeUnknown",
-            "mangledName": "$s6Sentry0A7ANRTypeO7unknownyA2CmF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl",
-              "ObjC"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(rawValue:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.SentryANRType?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryANRType",
-                    "printedName": "Sentry.SentryANRType",
-                    "usr": "c:@M@Sentry@E@SentryANRType"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:6Sentry0A7ANRTypeO8rawValueACSgSi_tcfc",
-            "mangledName": "$s6Sentry0A7ANRTypeO8rawValueACSgSi_tcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "TypeAlias",
-            "name": "RawValue",
-            "printedName": "RawValue",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "TypeAlias",
-            "usr": "s:6Sentry0A7ANRTypeO8RawValuea",
-            "mangledName": "$s6Sentry0A7ANRTypeO8RawValuea",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "rawValue",
-            "printedName": "rawValue",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "s:6Sentry0A7ANRTypeO8rawValueSivp",
-            "mangledName": "$s6Sentry0A7ANRTypeO8rawValueSivp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "s:6Sentry0A7ANRTypeO8rawValueSivg",
-                "mangledName": "$s6Sentry0A7ANRTypeO8rawValueSivg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Enum",
-        "usr": "c:@M@Sentry@E@SentryANRType",
-        "mangledName": "$s6Sentry0A7ANRTypeO",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "enumRawTypeName": "Int",
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "RawRepresentable",
-            "printedName": "RawRepresentable",
-            "children": [
-              {
-                "kind": "TypeWitness",
-                "name": "RawValue",
-                "printedName": "RawValue",
-                "children": [
-                  {
-                    "kind": "TypeNameAlias",
-                    "name": "RawValue",
-                    "printedName": "Sentry.SentryANRType.RawValue",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Int",
-                        "printedName": "Swift.Int",
-                        "usr": "s:Si"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "usr": "s:SY",
-            "mangledName": "$sSY"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryAppHangTypeMapper",
-        "printedName": "SentryAppHangTypeMapper",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "getExceptionType",
-            "printedName": "getExceptionType(anrType:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryANRType",
-                "printedName": "Sentry.SentryANRType",
-                "usr": "c:@M@Sentry@E@SentryANRType"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryAppHangTypeMapper(cm)getExceptionTypeWithAnrType:",
-            "mangledName": "$s6Sentry0A17AppHangTypeMapperC012getExceptionD003anrD0SSAA0A7ANRTypeO_tFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "getExceptionTypeWithAnrType:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
-            "name": "isExceptionTypeAppHang",
-            "printedName": "isExceptionTypeAppHang(exceptionType:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Bool",
-                "printedName": "Swift.Bool",
-                "usr": "s:Sb"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryAppHangTypeMapper(cm)isExceptionTypeAppHangWithExceptionType:",
-            "mangledName": "$s6Sentry0A17AppHangTypeMapperC011isExceptiondbC009exceptionD0SbSS_tFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "isExceptionTypeAppHangWithExceptionType:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryAppHangTypeMapper",
-                "printedName": "Sentry.SentryAppHangTypeMapper",
-                "usr": "c:@M@Sentry@objc(cs)SentryAppHangTypeMapper"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryAppHangTypeMapper(im)init",
-            "mangledName": "$s6Sentry0A17AppHangTypeMapperCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryAppHangTypeMapper",
-        "mangledName": "$s6Sentry0A17AppHangTypeMapperC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
           }
         ]
       },
@@ -56045,57 +51475,6 @@
             ]
           },
           {
-            "kind": "Function",
-            "name": "validateOptions",
-            "printedName": "validateOptions(_:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Void",
-                "printedName": "()"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "[Swift.String : Any]?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Dictionary",
-                    "printedName": "[Swift.String : Any]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      },
-                      {
-                        "kind": "TypeNominal",
-                        "name": "ProtocolComposition",
-                        "printedName": "Any"
-                      }
-                    ],
-                    "usr": "s:SD"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryExperimentalOptions(im)validateOptions:",
-            "mangledName": "$s6Sentry0A19ExperimentalOptionsC08validateC0yySDySSypGSgF",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
             "kind": "Constructor",
             "name": "init",
             "printedName": "init()",
@@ -56131,402 +51510,6 @@
         ],
         "superclassUsr": "c:objc(cs)NSObject",
         "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "UrlSanitized",
-        "printedName": "UrlSanitized",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "query",
-            "printedName": "query",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)UrlSanitized(py)query",
-            "mangledName": "$s6Sentry12UrlSanitizedC5querySSSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.String?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)UrlSanitized(im)query",
-                "mangledName": "$s6Sentry12UrlSanitizedC5querySSSgvg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "ObjC",
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "queryItems",
-            "printedName": "queryItems",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "[Foundation.URLQueryItem]?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Foundation.URLQueryItem]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "URLQueryItem",
-                        "printedName": "Foundation.URLQueryItem",
-                        "usr": "s:10Foundation12URLQueryItemV"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)UrlSanitized(py)queryItems",
-            "mangledName": "$s6Sentry12UrlSanitizedC10queryItemsSay10Foundation12URLQueryItemVGSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "[Foundation.URLQueryItem]?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Foundation.URLQueryItem]",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "URLQueryItem",
-                            "printedName": "Foundation.URLQueryItem",
-                            "usr": "s:10Foundation12URLQueryItemV"
-                          }
-                        ],
-                        "usr": "s:Sa"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)UrlSanitized(im)queryItems",
-                "mangledName": "$s6Sentry12UrlSanitizedC10queryItemsSay10Foundation12URLQueryItemVGSgvg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "ObjC",
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "fragment",
-            "printedName": "fragment",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)UrlSanitized(py)fragment",
-            "mangledName": "$s6Sentry12UrlSanitizedC8fragmentSSSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.String?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)UrlSanitized(im)fragment",
-                "mangledName": "$s6Sentry12UrlSanitizedC8fragmentSSSgvg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "ObjC",
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(URL:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "UrlSanitized",
-                "printedName": "Sentry.UrlSanitized",
-                "usr": "c:@M@Sentry@objc(cs)UrlSanitized"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "URL",
-                "printedName": "Foundation.URL",
-                "usr": "s:10Foundation3URLV"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)UrlSanitized(im)initWithURL:",
-            "mangledName": "$s6Sentry12UrlSanitizedC3URLAC10FoundationADV_tcfc",
-            "moduleName": "Sentry",
-            "objc_name": "initWithURL:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Var",
-            "name": "sanitizedUrl",
-            "printedName": "sanitizedUrl",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Swift.String?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)UrlSanitized(py)sanitizedUrl",
-            "mangledName": "$s6Sentry12UrlSanitizedC09sanitizedB0SSSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "Swift.String?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)UrlSanitized(im)sanitizedUrl",
-                "mangledName": "$s6Sentry12UrlSanitizedC09sanitizedB0SSSgvg",
-                "moduleName": "Sentry",
-                "declAttributes": [
-                  "ObjC",
-                  "SPIAccessControl"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)UrlSanitized",
-        "mangledName": "$s6Sentry12UrlSanitizedC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
         "superclassNames": [
           "ObjectiveC.NSObject"
         ],
@@ -60543,645 +55526,6 @@
           "ObjCMembers",
           "Available",
           "ObjC"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryReplayEvent",
-        "printedName": "SentryReplayEvent",
-        "children": [
-          {
-            "kind": "Var",
-            "name": "replayStartTimestamp",
-            "printedName": "replayStartTimestamp",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(py)replayStartTimestamp",
-            "mangledName": "$s6Sentry0A11ReplayEventC20replayStartTimestamp10Foundation4DateVvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Date",
-                    "printedName": "Foundation.Date",
-                    "usr": "s:10Foundation4DateV"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)replayStartTimestamp",
-                "mangledName": "$s6Sentry0A11ReplayEventC20replayStartTimestamp10Foundation4DateVvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "replayType",
-            "printedName": "replayType",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryReplayType",
-                "printedName": "Sentry.SentryReplayType",
-                "usr": "c:@M@Sentry@E@SentryReplayType"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(py)replayType",
-            "mangledName": "$s6Sentry0A11ReplayEventC10replayTypeAA0abE0Ovp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SentryReplayType",
-                    "printedName": "Sentry.SentryReplayType",
-                    "usr": "c:@M@Sentry@E@SentryReplayType"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)replayType",
-                "mangledName": "$s6Sentry0A11ReplayEventC10replayTypeAA0abE0Ovg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "segmentId",
-            "printedName": "segmentId",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(py)segmentId",
-            "mangledName": "$s6Sentry0A11ReplayEventC9segmentIdSivp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "isLet": true,
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Int",
-                    "printedName": "Swift.Int",
-                    "usr": "s:Si"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)segmentId",
-                "mangledName": "$s6Sentry0A11ReplayEventC9segmentIdSivg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "Final",
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              }
-            ]
-          },
-          {
-            "kind": "Var",
-            "name": "urls",
-            "printedName": "urls",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "[Swift.String]?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Array",
-                    "printedName": "[Swift.String]",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "String",
-                        "printedName": "Swift.String",
-                        "usr": "s:SS"
-                      }
-                    ],
-                    "usr": "s:Sa"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Var",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(py)urls",
-            "mangledName": "$s6Sentry0A11ReplayEventC4urlsSaySSGSgvp",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "HasInitialValue",
-              "ObjC",
-              "SPIAccessControl",
-              "HasStorage"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "hasStorage": true,
-            "accessors": [
-              {
-                "kind": "Accessor",
-                "name": "Get",
-                "printedName": "Get()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "[Swift.String]?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.String]",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "usr": "s:Sa"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)urls",
-                "mangledName": "$s6Sentry0A11ReplayEventC4urlsSaySSGSgvg",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Void",
-                    "printedName": "()"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "[Swift.String]?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Array",
-                        "printedName": "[Swift.String]",
-                        "children": [
-                          {
-                            "kind": "TypeNominal",
-                            "name": "String",
-                            "printedName": "Swift.String",
-                            "usr": "s:SS"
-                          }
-                        ],
-                        "usr": "s:Sa"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)setUrls:",
-                "mangledName": "$s6Sentry0A11ReplayEventC4urlsSaySSGSgvs",
-                "moduleName": "Sentry",
-                "implicit": true,
-                "declAttributes": [
-                  "ObjC"
-                ],
-                "spi_group_names": [
-                  "Private"
-                ],
-                "accessorKind": "set"
-              }
-            ]
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(eventId:replayStartTimestamp:replayType:segmentId:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryReplayEvent",
-                "printedName": "Sentry.SentryReplayEvent",
-                "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryId",
-                "printedName": "Sentry.SentryId",
-                "usr": "c:@M@Sentry@objc(cs)SentryId"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Date",
-                "printedName": "Foundation.Date",
-                "usr": "s:10Foundation4DateV"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryReplayType",
-                "printedName": "Sentry.SentryReplayType",
-                "usr": "c:@M@Sentry@E@SentryReplayType"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Int",
-                "printedName": "Swift.Int",
-                "usr": "s:Si"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)initWithEventId:replayStartTimestamp:replayType:segmentId:",
-            "mangledName": "$s6Sentry0A11ReplayEventC7eventId20replayStartTimestamp0F4Type07segmentE0AcA0aE0C_10Foundation4DateVAA0abI0OSitcfc",
-            "moduleName": "Sentry",
-            "objc_name": "initWithEventId:replayStartTimestamp:replayType:segmentId:",
-            "declAttributes": [
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Function",
-            "name": "serialize",
-            "printedName": "serialize()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Dictionary",
-                "printedName": "[Swift.String : Any]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "ProtocolComposition",
-                    "printedName": "Any"
-                  }
-                ],
-                "usr": "s:SD"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent(im)serialize",
-            "mangledName": "$s6Sentry0A11ReplayEventC9serializeSDySSypGyF",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "serialize",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryReplayEvent",
-        "mangledName": "$s6Sentry0A11ReplayEventC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
-        ],
-        "superclassUsr": "c:objc(cs)SentryEvent",
-        "superclassNames": [
-          "Sentry.Event",
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "SentrySerializable",
-            "printedName": "SentrySerializable",
-            "usr": "c:objc(pl)SentrySerializable"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryEnabledFeaturesBuilder",
-        "printedName": "SentryEnabledFeaturesBuilder",
-        "children": [
-          {
-            "kind": "Function",
-            "name": "getEnabledFeatures",
-            "printedName": "getEnabledFeatures(options:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "Array",
-                "printedName": "[Swift.String]",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "String",
-                    "printedName": "Swift.String",
-                    "usr": "s:SS"
-                  }
-                ],
-                "usr": "s:Sa"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.Options?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Options",
-                    "printedName": "Sentry.Options",
-                    "usr": "c:objc(cs)SentryOptions"
-                  }
-                ],
-                "usr": "s:Sq"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:@M@Sentry@objc(cs)SentryEnabledFeaturesBuilder(cm)getEnabledFeaturesWithOptions:",
-            "mangledName": "$s6Sentry0A22EnabledFeaturesBuilderC03getbC07optionsSaySSGSo0A7OptionsCSg_tFZ",
-            "moduleName": "Sentry",
-            "static": true,
-            "objc_name": "getEnabledFeaturesWithOptions:",
-            "declAttributes": [
-              "Final",
-              "ObjC",
-              "SPIAccessControl"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEnabledFeaturesBuilder",
-                "printedName": "Sentry.SentryEnabledFeaturesBuilder",
-                "usr": "c:@M@Sentry@objc(cs)SentryEnabledFeaturesBuilder"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryEnabledFeaturesBuilder(im)init",
-            "mangledName": "$s6Sentry0A22EnabledFeaturesBuilderCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "SPIAccessControl",
-              "Override"
-            ],
-            "spi_group_names": [
-              "Private"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryEnabledFeaturesBuilder",
-        "mangledName": "$s6Sentry0A22EnabledFeaturesBuilderC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC",
-          "SPIAccessControl"
-        ],
-        "spi_group_names": [
-          "Private"
         ],
         "superclassUsr": "c:objc(cs)NSObject",
         "inheritsConvenienceInitializers": true,


### PR DESCRIPTION
Update the API stability check to handle SPI, we use SPI to expose Swift to Objective-C and it is not part of the public API, so we can exclude it from the stability check to avoid unnecessary churn.

#skip-changelog