### PR TITLE
ref: Inject dependencies for ViewHierarchyProvider

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -289,7 +289,9 @@ static BOOL isInitialializingDependencyContainer = NO;
 {
 #    if SENTRY_HAS_UIKIT
 
-    SENTRY_LAZY_INIT(_viewHierarchyProvider, [[SentryViewHierarchyProvider alloc] init]);
+    SENTRY_LAZY_INIT(_viewHierarchyProvider,
+        [[SentryViewHierarchyProvider alloc] initWithDispatchQueueWrapper:self.dispatchQueueWrapper
+                                                      sentryUIApplication:self.application]);
 #    else
     SENTRY_LOG_DEBUG(
         @"SentryDependencyContainer.viewHierarchyProvider only works with UIKit "

--- a/Sources/Sentry/SentryViewHierarchyProvider.m
+++ b/Sources/Sentry/SentryViewHierarchyProvider.m
@@ -4,7 +4,6 @@
 
 #    import "SentryCrashFileUtils.h"
 #    import "SentryCrashJSONCodec.h"
-#    import "SentryDependencyContainer.h"
 #    import "SentryDispatchQueueWrapper.h"
 #    import "SentryLog.h"
 #    import "SentrySwift.h"
@@ -27,19 +26,29 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
     return SentryCrashJSON_OK;
 }
 
+@interface SentryViewHierarchyProvider ()
+
+@property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
+@property (nonatomic, strong) SentryUIApplication *sentryUIApplication;
+
+@end
+
 @implementation SentryViewHierarchyProvider
 
-- (instancetype)init
+- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
+                         sentryUIApplication:(SentryUIApplication *)sentryUIApplication
 {
     if (self = [super init]) {
         self.reportAccessibilityIdentifier = YES;
+        self.dispatchQueueWrapper = dispatchQueueWrapper;
+        self.sentryUIApplication = sentryUIApplication;
     }
     return self;
 }
 
 - (BOOL)saveViewHierarchy:(NSString *)filePath
 {
-    NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
+    NSArray<UIWindow *> *windows = [self.sentryUIApplication windows];
 
     const char *path = [filePath UTF8String];
     int fd = open(path, O_RDWR | O_CREAT | O_TRUNC, 0644);
@@ -62,8 +71,7 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
 
     SENTRY_LOG_INFO(@"Starting to fetch the view hierarchy from the main thread.");
 
-    [[SentryDependencyContainer sharedInstance].dispatchQueueWrapper
-        dispatchSyncOnMainQueue:fetchViewHierarchy];
+    [self.dispatchQueueWrapper dispatchSyncOnMainQueue:fetchViewHierarchy];
 
     SENTRY_LOG_INFO(@"Finished fetching the view hierarchy from the main thread.");
 
@@ -73,7 +81,7 @@ writeJSONDataToMemory(const char *const data, const int length, void *const user
 - (NSData *)appViewHierarchy
 {
     NSMutableData *result = [[NSMutableData alloc] init];
-    NSArray<UIWindow *> *windows = [SentryDependencyContainer.sharedInstance.application windows];
+    NSArray<UIWindow *> *windows = [self.sentryUIApplication windows];
 
     if (![self processViewHierarchy:windows
                         addFunction:writeJSONDataToMemory

--- a/Sources/Sentry/include/SentryViewHierarchyProvider.h
+++ b/Sources/Sentry/include/SentryViewHierarchyProvider.h
@@ -4,7 +4,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class SentryDispatchQueueWrapper;
+@class SentryUIApplication;
+
 @interface SentryViewHierarchyProvider : NSObject
+
+- (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
+                         sentryUIApplication:(SentryUIApplication *)sentryUIApplication;
 
 /**
  * Whether we should add `accessibilityIdentifier` to the view hierarchy.

--- a/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
@@ -7,7 +7,7 @@ class SentryViewHierarchyProviderTests: XCTestCase {
         let uiApplication = TestSentryUIApplication()
 
         var sut: SentryViewHierarchyProvider {
-            return SentryViewHierarchyProvider()
+            return SentryViewHierarchyProvider(dispatchQueueWrapper: SentryDispatchQueueWrapper(), sentryUIApplication: uiApplication)
         }
     }
 
@@ -17,7 +17,6 @@ class SentryViewHierarchyProviderTests: XCTestCase {
         super.setUp()
 
         fixture = Fixture()
-        SentryDependencyContainer.sharedInstance().application = fixture.uiApplication
     }
 
     override func setUpWithError() throws {
@@ -33,11 +32,6 @@ class SentryViewHierarchyProviderTests: XCTestCase {
         guard #available(iOS 13, *) else {
             throw XCTSkip("Skipping for iOS < 13")
         }
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        SentryDependencyContainer.reset()
     }
 
     func test_Multiple_Window() {
@@ -175,7 +169,7 @@ class SentryViewHierarchyProviderTests: XCTestCase {
     }
 
     func test_invalidSerialization() {
-        let sut = TestSentryViewHierarchyProvider()
+        let sut = TestSentryViewHierarchyProvider(dispatchQueueWrapper: SentryDispatchQueueWrapper(), sentryUIApplication: fixture.uiApplication)
         sut.viewHierarchyResult = -1
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         window.accessibilityIdentifier = "WindowId"
@@ -186,7 +180,7 @@ class SentryViewHierarchyProviderTests: XCTestCase {
     }
 
     func test_appViewHierarchyFromBackgroundTest() {
-        let sut = TestSentryViewHierarchyProvider()
+        let sut = TestSentryViewHierarchyProvider(dispatchQueueWrapper: SentryDispatchQueueWrapper(), sentryUIApplication: fixture.uiApplication)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         fixture.uiApplication.windows = [window]
 
@@ -205,7 +199,7 @@ class SentryViewHierarchyProviderTests: XCTestCase {
     }
 
     func test_appViewHierarchy_usesMainThread() {
-        let sut = TestSentryViewHierarchyProvider()
+        let sut = TestSentryViewHierarchyProvider(dispatchQueueWrapper: SentryDispatchQueueWrapper(), sentryUIApplication: fixture.uiApplication)
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 10, height: 10))
         fixture.uiApplication.windows = [window]
 


### PR DESCRIPTION
Instead of retrieving the dependencies in the
SentryViewHierarchyProvider via the SentryDependencyContainer, clearly specify them in the initializer, which is better for testability and readability. Another benefit is that the
SentryViewHierarchyProviderTests don't need to call SentryDependencyContainer.reset.

This came up while investigating `test_appViewHierarchy_usesMainThread` being flaky on MacCatalyst. This PR minimizes potential side effects of SentryDependencyContainer.reset.

Smoke test that ViewHierarchy still works: https://sentry-sdks.sentry.io/issues/6607086585/events/1623c22620294553a448e152fac70848/?project=5428557

![Screenshot 2025-06-23 at 10 09 16](https://github.com/user-attachments/assets/c4817827-8722-4e40-89f5-d95ce37ca7a9)


#skip-changelog