### PR TITLE
ref: SessionTracker remove observers

### DIFF
--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)stop
 {
     if (nil != self.tracker) {
-        [self.tracker stopWithGracefully:YES];
+        [self.tracker stop];
     }
 }
 

--- a/Sources/Sentry/include/SentrySessionTracker.h
+++ b/Sources/Sentry/include/SentrySessionTracker.h
@@ -23,7 +23,11 @@ SENTRY_NO_INIT
              notificationCenter:(SentryNSNotificationCenterWrapper *)notificationCenter;
 
 - (void)start;
-- (void)stopWithGracefully:(BOOL)gracefully;
+- (void)stop;
+
+/** Only used for testing */
+- (void)removeObservers;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -557,7 +557,10 @@ class SentrySessionTrackerTests: XCTestCase {
     }
 
     private func abnormalStopSut() {
+
+        // We remove the observers, to ensure future notifications are not handled.
         sut.removeObservers()
+
         #if os(iOS) || targetEnvironment(macCatalyst) || os(tvOS)
         // When the app stops, the app state is `inactive`.
         // This can be observed by viewing the application state in `UIAppDelegate.applicationDidEnterBackground`.

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -551,13 +551,13 @@ class SentrySessionTrackerTests: XCTestCase {
     }
 
     private func stopSut() {
-        sut.stop(withGracefully: true)
+        sut.stop()
         // After stopping the session tracker, we need to set a new hub to the SDK.
         fixture.setNewHubToSDK()
     }
 
     private func abnormalStopSut() {
-        sut.stop(withGracefully: false)
+        sut.removeObservers()
         #if os(iOS) || targetEnvironment(macCatalyst) || os(tvOS)
         // When the app stops, the app state is `inactive`.
         // This can be observed by viewing the application state in `UIAppDelegate.applicationDidEnterBackground`.
@@ -572,7 +572,7 @@ class SentrySessionTrackerTests: XCTestCase {
     }
 
     private func crashSut() {
-        sut.stop(withGracefully: false)
+        sut.removeObservers()
         #if os(iOS) || targetEnvironment(macCatalyst) || os(tvOS)
         // When the app stops, the app state is `inactive`.
         //
@@ -709,7 +709,7 @@ class SentrySessionTrackerTests: XCTestCase {
     }
     
     private func launchBackgroundTaskAppNotRunning() {
-        sut.stop(withGracefully: false)
+        sut.removeObservers()
 
         fixture.setNewHubToSDK()
         sut = fixture.getSut()


### PR DESCRIPTION
Replace stop(gracefully) with removeObservers.

This PR is based on https://github.com/getsentry/sentry-cocoa/pull/5121#discussion_r2161035116.

#skip-changelog