### PR TITLE
chore: Rename low priority -> utility

### DIFF
--- a/SentryTestUtils/TestDispatchFactory.swift
+++ b/SentryTestUtils/TestDispatchFactory.swift
@@ -5,7 +5,7 @@ public class TestDispatchFactory: SentryDispatchFactory {
     public var vendedSourceHandler: ((TestDispatchSourceWrapper) -> Void)?
     public var vendedQueueHandler: ((TestSentryDispatchQueueWrapper) -> Void)?
 
-    public var createLowPriorityQueueInvocations = Invocations<(name: String, relativePriority: Int32)>()
+    public var createUtilityQueueInvocations = Invocations<(name: String, relativePriority: Int32)>()
 
     public override func queue(withName name: UnsafePointer<CChar>, attributes: __OS_dispatch_queue_attr) -> SentryDispatchQueueWrapper {
         let queue = TestSentryDispatchQueueWrapper(name: name, attributes: attributes)
@@ -13,8 +13,8 @@ public class TestDispatchFactory: SentryDispatchFactory {
         return queue
     }
 
-    public override func createLowPriorityQueue(_ name: UnsafePointer<CChar>, relativePriority: Int32) -> SentryDispatchQueueWrapper {
-        createLowPriorityQueueInvocations.record((String(cString: name), relativePriority))
+    public override func createUtilityQueue(_ name: UnsafePointer<CChar>, relativePriority: Int32) -> SentryDispatchQueueWrapper {
+        createUtilityQueueInvocations.record((String(cString: name), relativePriority))
         // Due to the absense of `dispatch_queue_attr_make_with_qos_class` in Swift, we do not pass any attributes.
         // This will not affect the tests as they do not need an actual low priority queue.
         return TestSentryDispatchQueueWrapper(name: name, attributes: nil)

--- a/SentryTestUtilsTests/TestDispatchFactoryTests.swift
+++ b/SentryTestUtilsTests/TestDispatchFactoryTests.swift
@@ -27,15 +27,15 @@ class TestDispatchFactoryTests: XCTestCase {
         // Due to the absense of `dispatch_queue_attr_make_with_qos_class` in Swift, this method is not tested.
     }
 
-    func testCreateLowPriorityQueue_shouldReturnDispatchQueueWithLowPriority() {
+    func testCreateUtilityQueue_shouldReturnDispatchQueueWithLowPriority() {
         // -- Arrange --
-        let queueName = "testLowPriorityQueue"
+        let queueName = "testUtilityQueue"
         let relativePriority: Int32 = -15
 
         let expectedQueueWrapper = TestSentryDispatchQueueWrapper(name: queueName, attributes: nil)
 
         // -- Act --
-        let queueWrapper = sut.createLowPriorityQueue(queueName, relativePriority: relativePriority)
+        let queueWrapper = sut.createUtilityQueue(queueName, relativePriority: relativePriority)
 
         // -- Assert --
         XCTAssertEqual(queueWrapper.queue.label, expectedQueueWrapper.queue.label)
@@ -43,19 +43,19 @@ class TestDispatchFactoryTests: XCTestCase {
         XCTAssertEqual(queueWrapper.queue.qos.relativePriority, expectedQueueWrapper.queue.qos.relativePriority)
     }
 
-    func testCreateLowPriorityQueue_shouldRecordInvocation() throws {
+    func testCreateUtilityQueue_shouldRecordInvocation() throws {
         // -- Act --
-        let _ = sut.createLowPriorityQueue("queue-1", relativePriority: -5)
-        let _ = sut.createLowPriorityQueue("queue-2", relativePriority: -10)
+        let _ = sut.createUtilityQueue("queue-1", relativePriority: -5)
+        let _ = sut.createUtilityQueue("queue-2", relativePriority: -10)
 
         // -- Assert --
-        XCTAssertEqual(sut.createLowPriorityQueueInvocations.count, 2)
+        XCTAssertEqual(sut.createUtilityQueueInvocations.count, 2)
 
-        let firstInvocation = try XCTUnwrap(sut.createLowPriorityQueueInvocations.invocations.element(at: 0))
+        let firstInvocation = try XCTUnwrap(sut.createUtilityQueueInvocations.invocations.element(at: 0))
         XCTAssertEqual(firstInvocation.name, "queue-1")
         XCTAssertEqual(firstInvocation.relativePriority, -5)
 
-        let secondInvocation = try XCTUnwrap(sut.createLowPriorityQueueInvocations.invocations.element(at: 1))
+        let secondInvocation = try XCTUnwrap(sut.createUtilityQueueInvocations.invocations.element(at: 1))
         XCTAssertEqual(secondInvocation.name, "queue-2")
         XCTAssertEqual(secondInvocation.relativePriority, -10)
     }

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -434,9 +434,9 @@ static BOOL isInitialializingDependencyContainer = NO;
     SENTRY_LAZY_INIT(_watchdogTerminationContextProcessor,
         [[SentryWatchdogTerminationContextProcessor alloc]
             initWithDispatchQueueWrapper:
-                [self.dispatchFactory createLowPriorityQueue:
-                        "io.sentry.watchdog-termination-tracking.context-processor"
-                                            relativePriority:0]
+                [self.dispatchFactory
+                    createUtilityQueue:"io.sentry.watchdog-termination-tracking.context-processor"
+                      relativePriority:0]
                        scopeContextStore:self.scopeContextPersistentStore])
 }
 #endif

--- a/Sources/Sentry/SentryDispatchFactory.m
+++ b/Sources/Sentry/SentryDispatchFactory.m
@@ -11,14 +11,11 @@
     return [[SentryDispatchQueueWrapper alloc] initWithName:name attributes:attributes];
 }
 
-- (SentryDispatchQueueWrapper *)createLowPriorityQueue:(const char *)name
-                                      relativePriority:(int)relativePriority
+- (SentryDispatchQueueWrapper *)createUtilityQueue:(const char *)name
+                                  relativePriority:(int)relativePriority
 {
     SENTRY_CASSERT(relativePriority <= 0 && relativePriority >= QOS_MIN_RELATIVE_PRIORITY,
         @"Relative priority must be between 0 and %d", QOS_MIN_RELATIVE_PRIORITY);
-    // The QOS_CLASS_UTILITY is defined in `qos.h` and used by the `DISPATCH_QUEUE_PRIORITY_LOW`,
-    // therefore it can be considered it a low priority queue
-    // Reference: https://developer.apple.com/documentation/dispatch/dispatch_queue_priority_low
     dispatch_queue_attr_t attributes = dispatch_queue_attr_make_with_qos_class(
         DISPATCH_QUEUE_SERIAL, QOS_CLASS_UTILITY, relativePriority);
     return [[SentryDispatchQueueWrapper alloc] initWithName:name attributes:attributes];

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -142,14 +142,14 @@ static SentryTouchTracker *_touchTracker;
     // The asset worker queue is used to work on video and frames data.
     // Use a relative priority of -1 to make it lower than the default background priority.
     _replayAssetWorkerQueue =
-        [dispatchQueueProvider createLowPriorityQueue:"io.sentry.session-replay.asset-worker"
-                                     relativePriority:-1];
+        [dispatchQueueProvider createUtilityQueue:"io.sentry.session-replay.asset-worker"
+                                 relativePriority:-1];
     // The dispatch queue is used to asynchronously wait for the asset worker queue to finish its
     // work. To avoid a deadlock, the priority of the processing queue must be lower than the asset
     // worker queue. Use a relative priority of -2 to make it lower than the asset worker queue.
     _replayProcessingQueue =
-        [dispatchQueueProvider createLowPriorityQueue:"io.sentry.session-replay.processing"
-                                     relativePriority:-2];
+        [dispatchQueueProvider createUtilityQueue:"io.sentry.session-replay.processing"
+                                 relativePriority:-2];
 
     // The asset worker queue is used to work on video and frames data.
 

--- a/Sources/Sentry/include/SentryDispatchQueueProviderProtocol.h
+++ b/Sources/Sentry/include/SentryDispatchQueueProviderProtocol.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
                                    attributes:(dispatch_queue_attr_t)attributes;
 
 /**
- * Creates a low priority queue with the given name and relative priority, wrapped in a @c
+ * Creates a utility QoS queue with the given name and relative priority, wrapped in a @c
  * SentryDispatchQueueWrapper.
  *
  * @note This method is only a factory method and does not keep a reference to the created queue.
@@ -25,8 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
  * quality-of-service.
  * @return Unretained reference to the created queue.
  */
-- (SentryDispatchQueueWrapper *)createLowPriorityQueue:(const char *)name
-                                      relativePriority:(int)relativePriority;
+- (SentryDispatchQueueWrapper *)createUtilityQueue:(const char *)name
+                                  relativePriority:(int)relativePriority;
 
 @end
 

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -258,7 +258,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         let _ = container.watchdogTerminationContextProcessor
 
         // -- Assert --
-        let dispatchFactoryInvocation = try XCTUnwrap(dispatchFactory.createLowPriorityQueueInvocations.first)
+        let dispatchFactoryInvocation = try XCTUnwrap(dispatchFactory.createUtilityQueueInvocations.first)
         XCTAssertEqual(dispatchFactoryInvocation.name, "io.sentry.watchdog-termination-tracking.context-processor")
         XCTAssertEqual(dispatchFactoryInvocation.relativePriority, 0)
 #else

--- a/Tests/SentryTests/Networking/SentryDispatchFactoryTests.m
+++ b/Tests/SentryTests/Networking/SentryDispatchFactoryTests.m
@@ -43,7 +43,7 @@
 }
 
 - (void)
-    testCreateLowPriorityQueueWithNameAndRelativePriority_shouldReturnQueueWithNameAndRelativePrioritySet
+    testCreateUtilityQueueWithNameAndRelativePriority_shouldReturnQueueWithNameAndRelativePrioritySet
 {
     // Note: We are not testing the functionality of the queue itself, just the creation of it,
     // making sure the factory sets the name and attributes correctly.
@@ -53,8 +53,8 @@
     int relativePriority = -5;
 
     // -- Act --
-    SentryDispatchQueueWrapper *wrappedQueue = [self.sut createLowPriorityQueue:queueName
-                                                               relativePriority:relativePriority];
+    SentryDispatchQueueWrapper *wrappedQueue = [self.sut createUtilityQueue:queueName
+                                                           relativePriority:relativePriority];
 
     // -- Assert --
     const char *actualName = dispatch_queue_get_label(wrappedQueue.queue);


### PR DESCRIPTION
Following up from this comment: https://github.com/getsentry/sentry-cocoa/pull/5459#discussion_r2161850327

We should use the name utility since that's what QoS classes use, "low priority" is a term for deprecated dispatch queue priorities and we should move everything to being named based on the QoS class instead

#skip-changelog