### PR TITLE
test: selectively activate, always launch ui tests

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -39,16 +39,17 @@ extension BaseUITest {
             app.launchEnvironment[k] = v
         }
 
-        // App prewarming can sometimes cause simulators to get stuck in UI tests, activating them
-        // before launching clears any prewarming state.
-        app.activate()
-
         // Calling activate() and then launch() effectively launches the app twice, interfering with
-        // local debugging. Check for attached debuggers first.
+        // local debugging. Only call activate if there isn't a debugger attached, which is a decent
+        // proxy for whether this is running in CI.
         if !isDebugging() {
-            app.launch()
+            // App prewarming can sometimes cause simulators to get stuck in UI tests, activating them
+            // before launching clears any prewarming state.
+            app.activate()
         }
-        
+
+        app.launch()
+
         waitForExistenceOfMainScreen()
     }
     


### PR DESCRIPTION
It seems I got this backwards in #5437, because my local UI test runs didn't work correctly until I switched these.

#skip-changelog