### PR TITLE
fix: Remove header not needed in SentryPrivate.h

### DIFF
--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -3,7 +3,6 @@
 #import "NSLocale+Sentry.h"
 #import "SentryCrashExceptionApplicationHelper.h"
 #import "SentryDispatchQueueWrapper.h"
-#import "SentryEnvelope.h"
 #import "SentryNSDataUtils.h"
 #import "SentryRandom.h"
 #import "SentryTime.h"


### PR DESCRIPTION
I accidentally added this file here: https://github.com/getsentry/sentry-cocoa/pull/5457/files#diff-30d12b9d752ae2529667440c152936e6cbc8dbf85a84e0fd8ea08f66a7249a7aR6 but it does not need to be in this header

#skip-changelog