### PR TITLE
ci: fix artifact key name after moving to other workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ on:
       - "scripts/assemble-xcframework.sh"
       - ".github/workflows/build-xcframework-variant-slices.yml"
       - ".github/workflows/assemble-xcframework-variant.yml"
+      - ".github/workflows/ui-tests-common.yml"
       - Samples/macOS-SPM-CommandLine/**
       - Samples/SPM-Dynamic/**
 

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ inputs.needs_xcframework }}
         uses: actions/download-artifact@v4
         with:
-          name: xcframework-${{github.sha}}-sentry-static-uitests
+          name: xcframework-${{github.sha}}-sentry-static
           path: Carthage/
 
       - name: Unzip XCFramework


### PR DESCRIPTION
Forgot to update this after making the changes in #5448 

#skip-changelog