### PR TITLE
ci: cache unit test builds

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -106,12 +106,6 @@ jobs:
         run: ./scripts/compress-xcframework.sh ${{inputs.signed && '--sign' || '--not-signed'}} ${{inputs.name}}${{inputs.suffix}}
         shell: bash
 
-      - name: Cache XCFramework
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{inputs.name}}${{inputs.suffix}}.xcframework.zip
-
       - name: Upload XCFramework
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -85,15 +85,11 @@ jobs:
           fi
         shell: sh
 
-      - name: Compute cache key
-        run: |
-          echo "SENTRY_XCFRAMEWORK_CACHE_KEY=${{ runner.os }}-xcframework-${{inputs.variant-id}}-slice-${{matrix.sdk}}-${{ env.VERSION }}-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}" >> $GITHUB_ENV
-
       - name: Restore xcarchive cache
         id: cache-xcarchive
         uses: actions/cache@v4
         with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
+          key: ${{ runner.os }}-xcframework-${{inputs.variant-id}}-slice-${{matrix.sdk}}-${{ env.VERSION }}-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}
           path: ${{inputs.name}}${{inputs.suffix}}.xcarchive.zip
 
       - name: Bump version
@@ -121,13 +117,6 @@ jobs:
         run: |
           ditto -c -k -X --rsrc --keepParent ${{github.workspace}}/Carthage/archive/${{inputs.name}}${{inputs.suffix}}/${{matrix.sdk}}.xcarchive ${{inputs.name}}${{inputs.suffix}}.xcarchive.zip
         shell: bash
-
-      - name: Cache xcarchive
-        if: steps.cache-xcarchive.outputs.cache-hit != 'true'
-        uses: actions/cache@v4
-        with:
-          key: ${{env.SENTRY_XCFRAMEWORK_CACHE_KEY}}
-          path: ${{inputs.name}}${{inputs.suffix}}.xcarchive.zip
 
       - name: Upload xcarchive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,9 +183,17 @@ jobs:
       - name: Install Slather
         run: gem install slather
 
+      - name: Restore test build cache
+        id: test-build-cache
+        uses: actions/cache@v4
+        with:
+          key: ${{matrix.scheme}}-${{matrix.runs-on}}-${{matrix.platform}}-${{matrix.test-destination-os}}-xcode-${{matrix.xcode}}-${{hashFiles('Tests/**', 'Sentry.xcodeproj/**', 'Tests/Configuration/**', 'Sentry/Configuration/DeploymentTargets.xcconfig')}}
+          path: uikit-check-build
+
       # We split building and running tests in two steps so we know how long running the tests takes.
       - name: Build tests
         id: build_tests
+        if: steps.test-build-cache.outputs.cache-hit != 'true'
         run: |
           ./scripts/sentry-xcodebuild.sh \
             --platform ${{matrix.platform}} \
@@ -194,7 +202,8 @@ jobs:
             --command build-for-testing \
             --device "${{matrix.device}}" \
             --configuration TestCI \
-            --scheme ${{matrix.scheme}}
+            --scheme ${{matrix.scheme}} \
+            --derived-data unit-test-build
 
       - name: Run tests
         # We call a script with the platform so the destination
@@ -209,7 +218,8 @@ jobs:
             --command test-without-building \
             --device "${{matrix.device}}" \
             --configuration TestCI \
-            --scheme ${{matrix.scheme}}
+            --scheme ${{matrix.scheme}} \
+            --derived-data unit-test-build
 
       - name: Publish Test Report
         uses: mikepenz/action-junit-report@a83fd2b5d58d4fc702e690c1ea688d702d28d281 # v5.6.1


### PR DESCRIPTION
This takes a little over a minute per run, but tests don't always change, so it's wasted time/compute. Instead, cache the build product so it can be reused.

I also realized i was misapplying the cache action in other recent changes, so removed the unnecessary second calls to it.

#skip-changelog