### PR TITLE
test: dont gate data wipe to only tests

### DIFF
--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -786,11 +786,13 @@ NSString *_Nullable sentryStaticBasePath(void)
     return sentryStaticBasePath;
 }
 
+#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 void
 removeSentryStaticBasePath(void)
 {
     _non_thread_safe_removeFileAtPath(sentryStaticBasePath());
 }
+#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 
 #pragma mark - Profiling
 

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -786,13 +786,11 @@ NSString *_Nullable sentryStaticBasePath(void)
     return sentryStaticBasePath;
 }
 
-#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 void
 removeSentryStaticBasePath(void)
 {
     _non_thread_safe_removeFileAtPath(sentryStaticBasePath());
 }
-#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
 #pragma mark - Profiling
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -143,18 +143,19 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
 {
 #    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
     // we want to allow starting a launch profile from here for UI tests, but not unit tests
-    if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] == nil) {
-        return;
-    }
+//    if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] == nil) {
+//        return;
+//    }
+#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
-    // the ui tests want to wipe the data before each test case runs, to remove any launch config
-    // files that might be present before launching the app initially, however we need to make sure
-    // to remove stale versions of the file before it gets used to potentially start a launch
-    // profile that shouldn't have started, so we check here for this
+    // the samples apps may want to wipe the data like before UI test case runs, or manually during
+    // development, to remove any launch config files that might be present before launching the app
+    // initially, however we need to make sure to remove stale versions of the file before it gets
+    // used to potentially start a launch profile that shouldn't have started, so we check here for
+    // this
     if ([NSProcessInfo.processInfo.arguments containsObject:@"--io.sentry.wipe-data"]) {
         removeSentryStaticBasePath();
     }
-#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
     sentry_startLaunchProfile();
 }
 

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -141,12 +141,11 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
 
 + (void)load
 {
-#    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+#    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
     // we want to allow starting a launch profile from here for UI tests, but not unit tests
-//    if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] == nil) {
-//        return;
-//    }
-#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
+    if (NSProcessInfo.processInfo.environment[@"--io.sentry.ui-test.test-name"] == nil) {
+        return;
+    }
 
     // the samples apps may want to wipe the data like before UI test case runs, or manually during
     // development, to remove any launch config files that might be present before launching the app
@@ -156,6 +155,8 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
     if ([NSProcessInfo.processInfo.arguments containsObject:@"--io.sentry.wipe-data"]) {
         removeSentryStaticBasePath();
     }
+#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
+
     sentry_startLaunchProfile();
 }
 

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -174,9 +174,7 @@ SENTRY_EXTERN void removeAppLaunchProfilingConfigFile(void);
 
 SENTRY_EXTERN NSString *_Nullable sentryStaticBasePath(void);
 
-#    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 SENTRY_EXTERN void removeSentryStaticBasePath(void);
-#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 

--- a/Sources/Sentry/include/SentryFileManager.h
+++ b/Sources/Sentry/include/SentryFileManager.h
@@ -174,7 +174,9 @@ SENTRY_EXTERN void removeAppLaunchProfilingConfigFile(void);
 
 SENTRY_EXTERN NSString *_Nullable sentryStaticBasePath(void);
 
+#    if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 SENTRY_EXTERN void removeSentryStaticBasePath(void);
+#    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 


### PR DESCRIPTION
I needed to be able to do this as part of running a sample app locally, but the way I'd conditionally compiled it out didn't allow that. Also compile this into debug builds.

#skip-changelog