### PR TITLE
chore: logging timestamp tweaks

### DIFF
--- a/Sources/Swift/Core/Tools/SentryLog.swift
+++ b/Sources/Swift/Core/Tools/SentryLog.swift
@@ -34,7 +34,7 @@ typealias SentryLogOutput = ((String) -> Void)
     public static func log(message: String, andLevel level: SentryLevel) {
         guard willLog(atLevel: level) else { return }
         
-        // We use the timeIntervalSinceReferenceDate because date format is
+        // We use the time interval because date format is
         // expensive and we only care about the time difference between the
         // log messages. We don't use system uptime because of privacy concerns
         // see: NSPrivacyAccessedAPICategorySystemBootTime.

--- a/Sources/Swift/Core/Tools/SentryLog.swift
+++ b/Sources/Swift/Core/Tools/SentryLog.swift
@@ -39,7 +39,7 @@ typealias SentryLogOutput = ((String) -> Void)
         // log messages. We don't use system uptime because of privacy concerns
         // see: NSPrivacyAccessedAPICategorySystemBootTime.
         let time = self.dateProvider.date().timeIntervalSince1970
-        logOutput("[Sentry] [\(level)] [timeIntervalSince1970:\(time)] \(message)")
+        logOutput("[Sentry] [\(level)] [\(time)] \(message)")
     }
 
     /**


### PR DESCRIPTION
Recently noticed the comment drifted from the implementation per https://github.com/getsentry/sentry-cocoa/pull/4781#discussion_r1938967646

Also, having this long prefix add a decent bit of noise, so I propose removing it. We know what that number is.

#skip-changelog