### PR TITLE
Fix flaky test

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/UIViewControllerExtension.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/UIViewControllerExtension.swift
@@ -6,7 +6,12 @@ import UIKit
 
 public extension UIViewController {
     func createTransactionObserver(forCallback: @escaping (Span) -> Void) -> SpanObserver? {
-        let result = SpanObserver(callback: forCallback)
+        let result = SpanObserver { span in
+          // This callback may not be on the main queue, but `forCallback` is always called on the main queue.
+          DispatchQueue.main.async {
+            forCallback(span)
+          }
+        }
         if result == nil {
             UIAssert.fail("Transaction was not created")
         }


### PR DESCRIPTION
Fix a flaky test, this is the crash I saw in another test:

```
Thread 8 Crashed::  Dispatch queue: com.apple.NSURLSession-work
0   libsystem_kernel.dylib        	       0x100cb8f30 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x100e73124 pthread_kill + 256
2   libsystem_c.dylib             	       0x1801655c0 abort + 104
3   libMainThreadChecker.dylib    	       0x101c159e4 __ASSERT_API_MUST_BE_CALLED_FROM_MAIN_THREAD_FAILED__ + 980
4   libMainThreadChecker.dylib    	       0x101c1655c checker_c + 460
5   libMainThreadChecker.dylib    	       0x101c154d0 trampoline_c + 72
6   libMainThreadChecker.dylib    	       0x101bd5294 handler_start + 52
7   SentrySampleShared            	       0x101d2d6d0 AssertView.init(frame:) + 344 (AssertView.swift:39)
8   SentrySampleShared            	       0x101d2d750 @objc AssertView.init(frame:) + 56
9   SentrySampleShared            	       0x101d2d4c4 AssertView.init() + 156 (AssertView.swift:35)
10  SentrySampleShared            	       0x101d2d500 @objc AssertView.init() + 20
11  SentrySampleShared            	       0x101d2d420 AssertView.__allocating_init() + 28
12  SentrySampleShared            	       0x101d5d98c UIAssert.().init() + 60 (UIAssert.swift:9)
13  SentrySampleShared            	       0x101d5d6e0 UIAssert.__allocating_init() + 44
14  SentrySampleShared            	       0x101d5d6a0 one-time initialization function for shared + 28 (UIAssert.swift:8)
15  libdispatch.dylib             	       0x180171978 _dispatch_client_callout + 16
16  libdispatch.dylib             	       0x1801731b0 _dispatch_once_callout + 28
17  SentrySampleShared            	       0x101d5d680 UIAssert.shared.unsafeMutableAddressor + 80 (UIAssert.swift:8)
18  SentrySampleShared            	       0x101d5ea2c static UIAssert.isEqual<A>(_:_:_:) + 104 (UIAssert.swift:64)
19  SentrySampleShared            	       0x101d5f21c static UIAssert.checkForViewControllerLifeCycle(_:viewController:stepsToCheck:checkExcess:) + 1384 (UIAssert.swift:98)
20  iOS-Swift                     	       0x100ab5ac8 TableViewController.assertTransaction(span:) + 264 (TableViewController.swift:23)
21  iOS-Swift                     	       0x100ab5884 implicit closure #2 in implicit closure #1 in TableViewController.viewDidLoad() + 88 (TableViewController.swift:13)
22  SentrySampleShared            	       0x101d5b474 thunk for @escaping @callee_guaranteed (@guaranteed SentrySpan) -> () + 24
23  SentrySampleShared            	       0x101d5b444 thunk for @escaping @callee_guaranteed (@in_guaranteed SentrySpan) -> (@out ()) + 56
24  SentrySampleShared            	       0x101d5be08 SpanObserver.observeValue(forKeyPath:of:change:context:) + 588 (SpanObserver.swift:52)
25  SentrySampleShared            	       0x101d5c078 @objc SpanObserver.observeValue(forKeyPath:of:change:context:) + 444
26  Foundation                    	       0x180d65f98 NSKeyValueNotifyObserver + 248
27  Foundation                    	       0x180d68f4c NSKeyValueDidChange + 352
28  Foundation                    	       0x180d68918 -[NSObject(NSKeyValueObservingPrivate) _changeValueForKeys:count:maybeOldValuesDict:maybeNewValuesDict:usingBlock:] + 632
29  Foundation                    	       0x180d69104 -[NSObject(NSKeyValueObservingPrivate) _changeValueForKey:key:key:usingBlock:] + 60
30  Foundation                    	       0x180d6272c _NSSetObjectValueAndNotify + 256
31  Sentry                        	       0x102471988 -[SentrySpan finishWithStatus:] + 280 (SentrySpan.m:267)
32  Sentry                        	       0x102469d38 -[SentryTracer finishTracer:shouldCleanUp:] + 912 (SentryTracer.m:611)
33  Sentry                        	       0x1024697d4 -[SentryTracer finishInternal] + 76 (SentryTracer.m:565)
34  Sentry                        	       0x102469338 -[SentryTracer canBeFinished] + 1140 (SentryTracer.m:541)
35  Sentry                        	       0x102468580 -[SentryTracer spanFinished:] + 564 (SentryTracer.m:415)
36  Sentry                        	       0x102471f80 -[SentrySpan finishWithStatus:] + 1808 (SentrySpan.m:309)
37  Sentry                        	       0x10244aae4 -[SentryNetworkTracker urlSessionTask:setState:] + 1540 (SentryNetworkTracker.m:360)
38  Sentry                        	       0x1023fcadc __57+[SentryNetworkTrackingIntegration swizzleURLSessionTask]_block_invoke_2.38 + 136 (SentryNetworkTrackingIntegration.m:76)
39  CFNetwork                     	       0x1843303d4 0x18430f000 + 136148
40  CFNetwork                     	       0x18439f1b8 0x18430f000 + 590264
41  CFNetwork                     	       0x18439ec78 0x18430f000 + 588920
42  CFNetwork                     	       0x18439ef8c 0x18430f000 + 589708
43  libdispatch.dylib             	       0x1801810bc _dispatch_block_async_invoke2 + 104
44  libdispatch.dylib             	       0x180171978 _dispatch_client_callout + 16
45  libdispatch.dylib             	       0x180179b10 _dispatch_lane_serial_drain + 960
46  libdispatch.dylib             	       0x18017a688 _dispatch_lane_invoke + 388
47  libdispatch.dylib             	       0x180185a84 _dispatch_root_queue_drain_deferred_wlh + 276
48  libdispatch.dylib             	       0x1801850d0 _dispatch_workloop_worker_thread + 448
49  libsystem_pthread.dylib       	       0x100e6f814 _pthread_wqthread + 284
50  libsystem_pthread.dylib       	       0x100e6e5d4 start_wqthread + 8
```

#skip-changelog