### PR TITLE
fix: mac sample searchpaths

### DIFF
--- a/Samples/Shared/Config/Linking.xcconfig
+++ b/Samples/Shared/Config/Linking.xcconfig
@@ -1,1 +1,1 @@
-LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks
+LD_RUNPATH_SEARCH_PATHS = $(inherited) @executable_path/Frameworks @executable_path/../Frameworks


### PR DESCRIPTION
Fixing running the Mac sample app from locations other than Xcode's run action

#skip-changelog