### PR TITLE
fix: Fix XCFramework version including commit sha on release

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -45,6 +45,12 @@ on:
         type: string
         default: "iphoneos,iphonesimulator,macosx,maccatalyst,appletvos,appletvsimulator,watchos,watchsimulator,xros,xrsimulator"
 
+      release-version:
+        description: |-
+          For release workflows, the version to inject into the SDK.
+        required: false
+        type: string
+
 jobs:
   assemble-xcframework-variant:
     name: Assemble ${{inputs.name}}${{inputs.suffix}} XCFramework Variant
@@ -70,11 +76,21 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_USERNAME: ${{ secrets.MATCH_USERNAME }}
 
+      - name: Get version
+        id: get-version
+        run: |
+          if [ -n "${{ inputs.release-version }}" ]; then
+            echo "VERSION=${{ inputs.release-version }}" >> $GITHUB_ENV
+          else
+            echo "VERSION=$(grep MARKETING_VERSION Sources/Configuration/Versioning.xcconfig | cut -d ' ' -f 3)+${{ github.sha }}" >> $GITHUB_ENV
+          fi
+        shell: sh
+
       - name: Compute cache key
         run: |
           sdks_string=${{inputs.sdks}}
           sdks_string_slugified=${sdks_string//,/_}
-          echo "SENTRY_XCFRAMEWORK_CACHE_KEY=${{runner.os}}-xcframework-${{inputs.variant-id}}-$sdks_string_slugified-${{inputs.signed}}-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}" >> $GITHUB_ENV
+          echo "SENTRY_XCFRAMEWORK_CACHE_KEY=${{runner.os}}-xcframework-${{inputs.variant-id}}-$sdks_string_slugified-${{inputs.signed}}-${{env.VERSION}}-${{hashFiles('Sources/**')}}-${{hashFiles('Sentry.xcodeproj/**')}}" >> $GITHUB_ENV
 
       - name: Restore XCFramework cache
         id: cache-xcframework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       configuration-suffix: ${{matrix.variant.configuration-suffix}}
       variant-id: ${{matrix.variant.id}}
       signed: true
+      release-version: ${{ github.event.inputs.version }}
     strategy:
       matrix:
         variant:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 8.53.1
+
+### Fixes
+
+- Fix XCFramework version including commit sha on release.
+
 ## 8.53.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
-## 8.53.1
+## Unreleased
 
 ### Fixes
 
-- Fix XCFramework version including commit sha on release.
+- Fix XCFramework version including commit sha on release. (#5493)
 
 ## 8.53.0
 


### PR DESCRIPTION
Release 8.53.0 job used a cache instead of building from scratch: https://github.com/getsentry/sentry-cocoa/actions/runs/15873193408/job/44760111068
The cache key did not include the version

Fixes: #5492