### PR TITLE
feat: Mark exceptions as fatal for macOS

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -215,14 +215,22 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     event.exceptions = @[ sentryException ];
 
+    SentryMechanism *mechanism = [[SentryMechanism alloc] initWithType:@"NSException"];
+    mechanism.desc = exception.reason;
+    mechanism.data = sentry_sanitize(exception.userInfo);
+
 #if TARGET_OS_OSX
     // When a exception class is SentryUseNSExceptionCallstackWrapper, we should use the thread from
     // it
     if ([exception isKindOfClass:[SentryUseNSExceptionCallstackWrapper class]]) {
         event.threads = [(SentryUseNSExceptionCallstackWrapper *)exception buildThreads];
+        event.level = kSentryLevelFatal;
+
+        // Only exceptions through `_crashOnExceptions` are guaranteed to be unhandled
+        mechanism.handled = @(NO);
     }
 #endif
-
+    sentryException.mechanism = mechanism;
     [self setUserInfo:exception.userInfo withEvent:event];
     return event;
 }

--- a/Sources/Sentry/SentryCrashExceptionApplicationHelper.m
+++ b/Sources/Sentry/SentryCrashExceptionApplicationHelper.m
@@ -8,6 +8,8 @@
 #    import "SentryDependencyContainer.h"
 #    import "SentrySDK+Private.h"
 #    import "SentrySDK.h"
+#    import "SentryScope.h"
+#    import "SentrySwift.h"
 
 @implementation SentryCrashExceptionApplicationHelper
 
@@ -21,9 +23,11 @@
 
 + (void)_crashOnException:(NSException *)exception
 {
-    [SentrySDK captureCrashOnException:exception];
+    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
+    [scope setLevel:kSentryLevelFatal];
+    [SentrySDK captureCrashOnException:exception withScope:scope];
 #    if !(SENTRY_TEST || SENTRY_TEST_CI)
-    abort();
+//    abort();
 #    endif
 }
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -398,7 +398,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
 #if TARGET_OS_OSX
 
-+ (SentryId *)captureCrashOnException:(NSException *)exception
++ (SentryId *)captureCrashOnException:(NSException *)exception withScope:(SentryScope *)scope
 {
     SentryUseNSExceptionCallstackWrapper *wrappedException =
         [[SentryUseNSExceptionCallstackWrapper alloc]
@@ -406,7 +406,7 @@ static NSDate *_Nullable startTimestamp = nil;
                               reason:exception.reason
                             userInfo:exception.userInfo
             callStackReturnAddresses:exception.callStackReturnAddresses];
-    return [SentrySDK captureException:wrappedException withScope:SentrySDK.currentHub.scope];
+    return [SentrySDK captureException:wrappedException withScope:scope];
 }
 
 #endif // TARGET_OS_OSX

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -67,7 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  */
 + (SentryId *)captureCrashOnException:(NSException *)exception
-    NS_SWIFT_NAME(captureCrashOn(exception:));
+                            withScope:(SentryScope *)scope
+    NS_SWIFT_NAME(captureCrashOn(exception:withScope:));
 
 #endif // TARGET_OS_OSX
 

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -1006,7 +1006,7 @@ class SentrySDKTests: XCTestCase {
     func testCaptureCrashOnException() {
         givenSdkWithHub()
         
-        SentrySDK.captureCrashOn(exception: fixture.exception)
+        SentrySDK.captureCrashOn(exception: fixture.exception, withScope: fixture.scope)
 
         let client = fixture.client
         XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)


### PR DESCRIPTION
## :scroll: Description

Mark exception events as crashed
Partially fixes: #5336
Still needs to mark sessions as crashed

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.