### PR TITLE
Add more SPI

### DIFF
--- a/Sources/Swift/Core/Integrations/ANR/SentryANRTrackerV2Delegate.swift
+++ b/Sources/Swift/Core/Integrations/ANR/SentryANRTrackerV2Delegate.swift
@@ -11,10 +11,10 @@ import Foundation
 @objcMembers
 @_spi(Private) public class SentryANRStoppedResult: NSObject {
     
-    let minDuration: TimeInterval
-    let maxDuration: TimeInterval
+    public let minDuration: TimeInterval
+    public let maxDuration: TimeInterval
     
-    init(minDuration: TimeInterval, maxDuration: TimeInterval) {
+    public init(minDuration: TimeInterval, maxDuration: TimeInterval) {
         self.minDuration = minDuration
         self.maxDuration = maxDuration
     }

--- a/Sources/Swift/Core/Integrations/ANR/SentryANRType.swift
+++ b/Sources/Swift/Core/Integrations/ANR/SentryANRType.swift
@@ -37,7 +37,7 @@ import Foundation
     }
     
     @objc
-    static func getFatalExceptionType(nonFatalErrorType: String) -> String {
+    public static func getFatalExceptionType(nonFatalErrorType: String) -> String {
         if nonFatalErrorType == ExceptionType.nonFullyBlocking.rawValue {
             return ExceptionType.fatalNonFullyBlocking.rawValue
         }

--- a/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesDelayResult.swift
+++ b/Sources/Swift/Core/Integrations/FramesTracking/SentryFramesDelayResult.swift
@@ -4,7 +4,7 @@ import Foundation
 @_spi(Private) public class SentryFramesDelayResult: NSObject {
     /// The frames delay for the passed time period. If frame delay can't be calculated this is -1.
     public let delayDuration: CFTimeInterval
-    let framesContributingToDelayCount: UInt
+    public let framesContributingToDelayCount: UInt
 
     init(delayDuration: CFTimeInterval, framesContributingToDelayCount: UInt) {
         self.delayDuration = delayDuration

--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -34,7 +34,7 @@ import MetricKit
         self.disableCrashDiagnostics = disableCrashDiagnostics
     }
 
-    weak var delegate: SentryMXManagerDelegate?
+    public weak var delegate: SentryMXManagerDelegate?
     
     public func receiveReports() {
         let shared = MXMetricManager.shared

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryDefaultViewRenderer.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryDefaultViewRenderer.swift
@@ -5,7 +5,7 @@ import UIKit
 
 @objcMembers
 @_spi(Private) public class SentryDefaultViewRenderer: NSObject, SentryViewRenderer {
-    func render(view: UIView) -> UIImage {
+    public func render(view: UIView) -> UIImage {
         let image = UIGraphicsImageRenderer(size: view.bounds.size).image { _ in
             view.drawHierarchy(in: view.bounds, afterScreenUpdates: false)
         }

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryRedactViewHelper.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryRedactViewHelper.swift
@@ -16,7 +16,7 @@ public class SentryRedactViewHelper: NSObject {
     
     override private init() {}
     
-    static func maskView(_ view: UIView) {
+    @_spi(Private) public static func maskView(_ view: UIView) {
         objc_setAssociatedObject(view, &associatedRedactObjectHandle, true, .OBJC_ASSOCIATION_ASSIGN)
     }
     
@@ -28,7 +28,7 @@ public class SentryRedactViewHelper: NSObject {
         (objc_getAssociatedObject(view, &associatedIgnoreObjectHandle) as? NSNumber)?.boolValue ?? false
     }
     
-    static func unmaskView(_ view: UIView) {
+    @_spi(Private) public static func unmaskView(_ view: UIView) {
         objc_setAssociatedObject(view, &associatedIgnoreObjectHandle, true, .OBJC_ASSOCIATION_ASSIGN)
     }
     

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryViewPhotographer.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryViewPhotographer.swift
@@ -22,7 +22,7 @@ import UIKit
     ///   - enableMaskRendererV2: Flag to enable experimental view renderer.
     /// - Note: The option `enableMaskRendererV2` is an internal flag, which is not part of the public API.
     ///         Therefore, it is not part of the the `redactOptions` parameter, to not further expose it.
-    init(
+    public init(
         renderer: SentryViewRenderer,
         redactOptions: SentryRedactOptions,
         enableMaskRendererV2: Bool
@@ -33,7 +33,7 @@ import UIKit
         super.init()
     }
 
-    func image(view: UIView, onComplete: @escaping ScreenshotCallback) {
+    public func image(view: UIView, onComplete: @escaping ScreenshotCallback) {
         let viewSize = view.bounds.size
         let redactRegions = redactBuilder.redactRegionsFor(view: view)
         // The render method is synchronous and must be called on the main thread.
@@ -50,7 +50,7 @@ import UIKit
         }
     }
 
-    func image(view: UIView) -> UIImage {
+    public func image(view: UIView) -> UIImage {
         let viewSize = view.bounds.size
         let redactRegions = redactBuilder.redactRegionsFor(view: view)
         let renderedScreenshot = renderer.render(view: view)

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryViewRenderer.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryViewRenderer.swift
@@ -3,7 +3,7 @@
 
 import UIKit
 
-@objc protocol SentryViewRenderer {
+@objc @_spi(Private) public protocol SentryViewRenderer {
     func render(view: UIView) -> UIImage
 }
 

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryViewRendererV2.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryViewRendererV2.swift
@@ -7,11 +7,11 @@ import UIKit
 @_spi(Private) public class SentryViewRendererV2: NSObject, SentryViewRenderer {
     let enableFastViewRendering: Bool
 
-    init(enableFastViewRendering: Bool) {
+    public init(enableFastViewRendering: Bool) {
         self.enableFastViewRendering = enableFastViewRendering
     }
 
-    func render(view: UIView) -> UIImage {
+    public func render(view: UIView) -> UIImage {
         let scale = (view as? UIWindow ?? view.window)?.screen.scale ?? 1
         let image = SentryGraphicsImageRenderer(size: view.bounds.size, scale: scale).image { context in
             if enableFastViewRendering {

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryViewScreenshotProvider.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryViewScreenshotProvider.swift
@@ -3,10 +3,10 @@
 import Foundation
 import UIKit
 
-typealias ScreenshotCallback = (_ maskedViewImage: UIImage) -> Void
+@_spi(Private) public typealias ScreenshotCallback = (_ maskedViewImage: UIImage) -> Void
 
 @objc
-protocol SentryViewScreenshotProvider: NSObjectProtocol {
+@_spi(Private) public protocol SentryViewScreenshotProvider: NSObjectProtocol {
     func image(view: UIView, onComplete: @escaping ScreenshotCallback)
 }
 #endif

--- a/Sources/Swift/Helper/SentryDispatchQueueWrapper.swift
+++ b/Sources/Swift/Helper/SentryDispatchQueueWrapper.swift
@@ -20,7 +20,7 @@
     }
 
     @objc(dispatchAsyncWithBlock:)
-    func dispatchAsync(_ block: @escaping () -> Void) {
+    public func dispatchAsync(_ block: @escaping () -> Void) {
         internalWrapper.dispatchAsync(block)
     }
     
@@ -29,16 +29,16 @@
     }
     
     @objc(dispatchAsyncOnMainQueue:)
-    func dispatchAsyncOnMainQueue(block: @escaping () -> Void) {
+    public func dispatchAsyncOnMainQueue(block: @escaping () -> Void) {
         internalWrapper.dispatchAsyncOnMainQueue(block: block)
     }
 
     @objc(dispatchSyncOnMainQueue:)
-    func dispatchSyncOnMainQueue(block: @escaping () -> Void) {
+    public func dispatchSyncOnMainQueue(block: @escaping () -> Void) {
         internalWrapper.dispatchSyncOnMainQueue(block: block)
     }
     
-    func dispatchSyncOnMainQueue(_ block: @escaping () -> Void, timeout: Double) {
+    public func dispatchSyncOnMainQueue(_ block: @escaping () -> Void, timeout: Double) {
         internalWrapper.dispatchSync(onMainQueue: block, timeout: timeout)
     }
 
@@ -50,7 +50,7 @@
         internalWrapper.dispatchCancel(block)
     }
 
-    func dispatchOnce(_ predicate: UnsafeMutablePointer<CLong>, block: @escaping () -> Void) {
+    public func dispatchOnce(_ predicate: UnsafeMutablePointer<CLong>, block: @escaping () -> Void) {
         internalWrapper.dispatchOnce(predicate, block: block)
     }
     

--- a/Sources/Swift/Integrations/SessionReplay/Preview/SentryMaskingPreviewView.swift
+++ b/Sources/Swift/Integrations/SessionReplay/Preview/SentryMaskingPreviewView.swift
@@ -19,7 +19,7 @@ import UIKit
     private var imageView = UIImageView()
     private var idle = true
     
-    var opacity: Float {
+    public var opacity: Float {
         get { return Float(imageView.alpha) }
         set { imageView.alpha = CGFloat(newValue)}
     }

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebBreadcrumbEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebBreadcrumbEvent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class SentryRRWebBreadcrumbEvent: SentryRRWebCustomEvent {
+@_spi(Private) public final class SentryRRWebBreadcrumbEvent: SentryRRWebCustomEvent {
     init(timestamp: Date, category: String, message: String? = nil, level: SentryLevel = .none, data: [String: Any]? = nil) {
         
         var payload: [String: Any] = ["type": "default", "category": category, "level": level.description, "timestamp": timestamp.timeIntervalSince1970 ]

--- a/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/RRWeb/SentryRRWebEvent.swift
@@ -10,7 +10,7 @@ enum SentryRRWebEventType: Int {
 }
 
 @objc(SentryRRWebEvent)
-protocol SentryRRWebEventProtocol: SentrySerializable {
+@_spi(Private) public protocol SentryRRWebEventProtocol: SentrySerializable {
 }
 
 @objcMembers

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -26,12 +26,12 @@ import UIKit
         set { _frames = newValue }
     }
     #endif // SENTRY_TEST || SENTRY_TEST_CI || DEBUG
-    var videoScale: Float = 1
-    var bitRate = 20_000
-    var frameRate = 1
-    var cacheMaxSize = UInt.max
+    public var videoScale: Float = 1
+    public var bitRate = 20_000
+    public var frameRate = 1
+    public var cacheMaxSize = UInt.max
     
-    init(
+    public init(
         outputPath: String,
         processingQueue: SentryDispatchQueueWrapper,
         assetWorkerQueue: SentryDispatchQueueWrapper
@@ -42,7 +42,7 @@ import UIKit
         self.assetWorkerQueue = assetWorkerQueue
     }
         
-    convenience init(
+    public convenience init(
         withContentFrom outputPath: String,
         processingQueue: SentryDispatchQueueWrapper,
         assetWorkerQueue: SentryDispatchQueueWrapper
@@ -142,7 +142,7 @@ import UIKit
         }
     }
 
-    var oldestFrameDate: Date? {
+    public var oldestFrameDate: Date? {
         return _frames.first?.time
     }
 
@@ -157,7 +157,7 @@ import UIKit
         }
     }
 
-    func createVideoWith(beginning: Date, end: Date) -> [SentryVideoInfo] {
+    public func createVideoWith(beginning: Date, end: Date) -> [SentryVideoInfo] {
         SentryLog.debug("[Session Replay] Creating video with beginning: \(beginning), end: \(end)")
         // Note: In previous implementations this method was wrapped by a sync call to the processing queue.
         // As this method is already called from the processing queue, we must remove the sync call.

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -222,7 +222,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Note: See ``SentryReplayOptions.DefaultValues.quality`` for the default value.
      */
-    var replayBitRate: Int {
+    @_spi(Private) public var replayBitRate: Int {
         quality.bitrate
     }
 
@@ -231,7 +231,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Note: The scale is used to reduce the size of the replay.
      */
-    var sizeScale: Float {
+    @_spi(Private) public var sizeScale: Float {
         quality.sizeScale
     }
 
@@ -242,7 +242,7 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
      *
      * - Note: See ``SentryReplayOptions.DefaultValues.frameRate`` for the default value.
      */
-    var frameRate: UInt {
+    @_spi(Private) public var frameRate: UInt {
         didSet {
             if frameRate < 1 {
                 frameRate = 1
@@ -253,12 +253,12 @@ public class SentryReplayOptions: NSObject, SentryRedactOptions {
     /**
      * The maximum duration of replays for error events.
      */
-    var errorReplayDuration: TimeInterval
+    @_spi(Private) public var errorReplayDuration: TimeInterval
 
     /**
      * The maximum duration of the segment of a session replay.
      */
-    var sessionSegmentDuration: TimeInterval
+    @_spi(Private) public var sessionSegmentDuration: TimeInterval
 
     /**
      * The maximum duration of a replay session.

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayRecording.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayRecording.swift
@@ -13,7 +13,7 @@ import Foundation
     let height: Int
     let width: Int
     
-    convenience init(segmentId: Int, video: SentryVideoInfo, extraEvents: [any SentryRRWebEventProtocol]) {
+    public convenience init(segmentId: Int, video: SentryVideoInfo, extraEvents: [any SentryRRWebEventProtocol]) {
         self.init(segmentId: segmentId, size: video.fileSize, start: video.start, duration: video.duration, frameCount: video.frameCount, frameRate: video.frameRate, height: video.height, width: video.width, extraEvents: extraEvents)
     }
     

--- a/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySRDefaultBreadcrumbConverter.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @objc
-protocol SentryReplayBreadcrumbConverter: NSObjectProtocol {
+@_spi(Private) public protocol SentryReplayBreadcrumbConverter: NSObjectProtocol {
     func convert(from breadcrumb: Breadcrumb) -> SentryRRWebEventProtocol?
 }
 
@@ -23,7 +23,7 @@ protocol SentryReplayBreadcrumbConverter: NSObjectProtocol {
      * Any deviation in the information will cause the breadcrumb or the information itself to be discarded
      * in order to avoid unknown behavior in the front-end.
      */
-    func convert(from breadcrumb: Breadcrumb) -> SentryRRWebEventProtocol? {
+    public func convert(from breadcrumb: Breadcrumb) -> SentryRRWebEventProtocol? {
         guard let timestamp = breadcrumb.timestamp else { return nil }
         if breadcrumb.category == "http" {
             return networkSpan(breadcrumb)

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplay.swift
@@ -6,8 +6,8 @@ import UIKit
 // swiftlint:disable type_body_length
 @objcMembers
 @_spi(Private) public class SentrySessionReplay: NSObject {
-    private(set) var isFullSession = false
-    private(set) var sessionReplayId: SentryId?
+    public private(set) var isFullSession = false
+    public private(set) var sessionReplayId: SentryId?
 
     private var urlToCache: URL?
     private var rootView: UIView?
@@ -27,14 +27,14 @@ import UIKit
     private let dateProvider: SentryCurrentDateProvider
     private let touchTracker: SentryTouchTracker?
     private let lock = NSLock()
-    var replayTags: [String: Any]?
+    public var replayTags: [String: Any]?
     
     var isRunning: Bool {
         displayLink.isRunning()
     }
     
-    var screenshotProvider: SentryViewScreenshotProvider
-    var breadcrumbConverter: SentryReplayBreadcrumbConverter
+    public var screenshotProvider: SentryViewScreenshotProvider
+    public var breadcrumbConverter: SentryReplayBreadcrumbConverter
     
     init(
         replayOptions: SentryReplayOptions,
@@ -60,7 +60,7 @@ import UIKit
     
     deinit { displayLink.invalidate() }
 
-    func start(rootView: UIView, fullSession: Bool) {
+    public func start(rootView: UIView, fullSession: Bool) {
         SentryLog.debug("[Session Replay] Starting session replay with full session: \(fullSession)")
         guard !isRunning else { 
             SentryLog.debug("[Session Replay] Session replay is already running, not starting again")
@@ -87,7 +87,7 @@ import UIKit
         delegate?.sessionReplayStarted(replayId: sessionReplayId)
     }
 
-    func pauseSessionMode() {
+    public func pauseSessionMode() {
         SentryLog.debug("[Session Replay] Pausing session mode")
         lock.lock()
         defer { lock.unlock() }
@@ -96,7 +96,7 @@ import UIKit
         self.videoSegmentStart = nil
     }
     
-    func pause() {
+    public func pause() {
         SentryLog.debug("[Session Replay] Pausing session")
         lock.lock()
         defer { lock.unlock() }
@@ -108,7 +108,7 @@ import UIKit
         isSessionPaused = false
     }
 
-    func resume() {
+    public func resume() {
         SentryLog.debug("[Session Replay] Resuming session")
         lock.lock()
         defer { lock.unlock() }
@@ -131,7 +131,7 @@ import UIKit
         displayLink.link(withTarget: self, selector: #selector(newFrame(_:)))
     }
 
-    func captureReplayFor(event: Event) {
+    public func captureReplayFor(event: Event) {
         SentryLog.debug("[Session Replay] Capturing replay for event: \(event)")
         guard isRunning else { 
             SentryLog.debug("[Session Replay] Session replay is not running, not capturing replay")
@@ -153,8 +153,8 @@ import UIKit
     }
 
     @discardableResult
-    func captureReplay() -> Bool {
-        guard isRunning else { 
+    public func captureReplay() -> Bool {
+        guard isRunning else {
             SentryLog.debug("[Session Replay] Session replay is not running, not capturing replay")
             return false 
         }

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayDelegate.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UIKIT
 
 @objc
-protocol SentrySessionReplayDelegate: NSObjectProtocol {
+@_spi(Private) public protocol SentrySessionReplayDelegate: NSObjectProtocol {
     func sessionReplayShouldCaptureReplayForError() -> Bool
     func sessionReplayNewSegment(replayEvent: SentryReplayEvent, replayRecording: SentryReplayRecording, videoUrl: URL)
     func sessionReplayStarted(replayId: SentryId)

--- a/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryTouchTracker.swift
@@ -4,7 +4,7 @@ import Foundation
 import UIKit
 
 @objcMembers
-class SentryTouchTracker: NSObject {
+@_spi(Private) public class SentryTouchTracker: NSObject {
     
     private struct TouchEvent {
         let x: CGFloat
@@ -40,7 +40,7 @@ class SentryTouchTracker: NSObject {
     private let dateProvider: SentryCurrentDateProvider
     private let scale: CGAffineTransform
     
-    init(dateProvider: SentryCurrentDateProvider, scale: Float, dispatchQueue: SentryDispatchQueueWrapper) {
+    public init(dateProvider: SentryCurrentDateProvider, scale: Float, dispatchQueue: SentryDispatchQueueWrapper) {
         self.dateProvider = dateProvider
         self.scale = CGAffineTransform(scaleX: CGFloat(scale), y: CGFloat(scale))
         self.dispatchQueue = dispatchQueue
@@ -53,7 +53,7 @@ class SentryTouchTracker: NSObject {
         self.init(dateProvider: dateProvider, scale: scale, dispatchQueue: SentryDispatchQueueWrapper())
     }
     
-    func trackTouchFrom(event: UIEvent) {
+    public func trackTouchFrom(event: UIEvent) {
         guard let touches = event.allTouches else { return }
         let timestamp = event.timestamp
         

--- a/Sources/Swift/Integrations/SessionReplay/SentryVideoInfo.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryVideoInfo.swift
@@ -3,14 +3,14 @@ import Foundation
 @objcMembers
 @_spi(Private) public class SentryVideoInfo: NSObject {
     
-    let path: URL
+    public let path: URL
     let height: Int
     let width: Int
     let duration: TimeInterval
     let frameCount: Int
     let frameRate: Int
-    let start: Date
-    let end: Date
+    public let start: Date
+    public let end: Date
     let fileSize: Int
     let screens: [String]
     

--- a/Sources/Swift/Persistence/SentryScopeContextPersistentStore.swift
+++ b/Sources/Swift/Persistence/SentryScopeContextPersistentStore.swift
@@ -10,7 +10,7 @@
 
     // MARK: - Context
 
-    func moveCurrentFileToPreviousFile() {
+    public func moveCurrentFileToPreviousFile() {
         SentryLog.debug("Moving context file to previous context file")
         self.fileManager.moveState(contextFileURL.path, toPreviousState: previousContextFileURL.path)
     }


### PR DESCRIPTION
Now that SentryDispatchQueueWrapper a few more of these are unblocked to be public and we can get a bit closer to not requiring the app extension API only flag

#skip-changelog