### PR TITLE
test: Data race in testReportFullyDisplayed

### DIFF
--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -732,6 +732,8 @@ class SentrySDKTests: XCTestCase {
         let performanceTracker = Dynamic(SentryDependencyContainer.sharedInstance().uiViewControllerPerformanceTracker)
         performanceTracker.currentTTDTracker = testTTDTracker
 
+        // Start SDK after setting up the tracker to ensure we're changing the tracker during it's initialization,
+        // because some initialization logic happens on a BG thread and we would end up in a race condition.
         SentrySDK.start(options: fixture.options)
 
         SentrySDK.reportFullyDisplayed()


### PR DESCRIPTION
Setting a new TestTimeToDisplayTracker to the SentryDependencyContainer directly after starting the SDK led to a data race in sentry_sdkInitProfilerTasks, because sentry_sdkInitProfilerTasks accesses the TimeToDisplayTracker on a BG thread. This is fixed now by setting the TestTimeToDisplayTracker to the SentryDependencyContainer before starting the SDK.

Running the `testReportFullyDisplayed` repeatedly with the thread sanitizer on led to the following data race 

```
==================
WARNING: ThreadSanitizer: data race (pid=47792)
  Read of size 1 at 0x00030aa799f8 by thread T350:
    #0 -[SentryUIViewControllerPerformanceTracker alwaysWaitForFullDisplay] <null> (Sentry:arm64+0x18c298)
    #1 __sentry_sdkInitProfilerTasks_block_invoke <null> (Sentry:arm64+0x12fca8)
    #2 __53-[SentryDispatchQueueWrapper dispatchAsyncWithBlock:]_block_invoke <null> (Sentry:arm64+0x144bc)
    #3 __tsan::invoke_and_release_block(void*) <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x7f97c)
    #4 _dispatch_client_callout <null> (libdispatch.dylib:arm64+0x1c274)

  Previous write of size 1 at 0x00030aa799f8 by main thread (mutexes: write M0):
    #0 -[SentryUIViewControllerPerformanceTracker initWithTracker:dispatchQueueWrapper:] <null> (Sentry:arm64+0x1860bc)
    #1 -[SentryDependencyContainer uiViewControllerPerformanceTracker] <null> (Sentry:arm64+0x178bc8)
    #2 SentryTests.SentrySDKTests.testReportFullyDisplayed() -> () <null> (SentryTests:arm64+0x783388)
    #3 @objc SentryTests.SentrySDKTests.testReportFullyDisplayed() -> () <null> (SentryTests:arm64+0x783728)
    #4 __invoking___ <null> (CoreFoundation:arm64+0x13a20c)

  Location is heap block of size 80 at 0x00030aa799f0 allocated by main thread:
    #0 calloc <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x5ed24)
    #1 _malloc_type_calloc_outlined <null> (libsystem_malloc.dylib:arm64+0xf308)
    #2 SentryTests.SentrySDKTests.testReportFullyDisplayed() -> () <null> (SentryTests:arm64+0x783388)
    #3 @objc SentryTests.SentrySDKTests.testReportFullyDisplayed() -> () <null> (SentryTests:arm64+0x783728)
    #4 __invoking___ <null> (CoreFoundation:arm64+0x13a20c)

  Mutex M0 (0x000109f0eb60) created at:
    #0 objc_sync_enter <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x7d384)
    #1 -[SentryDependencyContainer crashReporter] <null> (Sentry:arm64+0x178094)
    #2 __32-[SentryCrashWrapper systemInfo]_block_invoke <null> (Sentry:arm64+0x4e73c)
    #3 dispatch_once <null> (libclang_rt.tsan_iossim_dynamic.dylib:arm64+0x80988)
    #4 -[SentryCrashWrapper systemInfo] <null> (Sentry:arm64+0x4e660)
    #5 -[SentryCrashWrapper enrichScope:] <null> (Sentry:arm64+0x4ec28)
    #6 -[SentryHub initWithClient:andScope:andCrashWrapper:andDispatchQueue:] <null> (Sentry:arm64+0xaf850)
    #7 -[SentryHub initWithClient:andScope:] <null> (Sentry:arm64+0xaf2cc)
    #8 __30+[SentrySDK startWithOptions:]_block_invoke <null> (Sentry:arm64+0x1427a8)
    #9 -[SentryDispatchQueueWrapper dispatchAsyncOnMainQueue:] <null> (Sentry:arm64+0x14638)
    #10 +[SentrySDK startWithOptions:] <null> (Sentry:arm64+0x1424e0)
    #11 +[SentrySDK startWithConfigureOptions:] <null> (Sentry:arm64+0x142ba8)
    #12 SentryTests.DataSentryTracingIntegrationTests.(Fixture in _F9C28CBE30EAC9BE15107FEF3A455A1A).getSut(testName: Swift.String, isSDKEnabled: Swift.Bool, isEnabled: Swift.Bool) throws -> Foundation.Data <null> (SentryTests:arm64+0xb4f298)
    #13 SentryTests.DataSentryTracingIntegrationTests.testInitContentsOfWithSentryTracing_fileIsIgnored_shouldNotTraceManually() throws -> () <null> (SentryTests:arm64+0xb5f9f4)
    #14 @objc SentryTests.DataSentryTracingIntegrationTests.testInitContentsOfWithSentryTracing_fileIsIgnored_shouldNotTraceManually() throws -> () <null> (SentryTests:arm64+0xb609bc)
    #15 __invoking___ <null> (CoreFoundation:arm64+0x13a20c)

  Thread T350 (tid=446262, running) is a GCD worker thread

SUMMARY: ThreadSanitizer: data race (/Users/philipp.hofmann/Library/Developer/Xcode/DerivedData/Sentry-bahizrqpvqbrnycjvclkuwoibtgv/Build/Products/Test-iphonesimulator/Sentry.framework/Sentry:arm64+0x18c298) in -[SentryUIViewControllerPerformanceTracker alwaysWaitForFullDisplay]+0x40
==================
```

With this fix now, the data race is gone.

This is a follow up on https://github.com/getsentry/sentry-cocoa/pull/5300.

