### PR TITLE
Make dispatch queue wrapper public

### DIFF
--- a/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
+++ b/SentryTestUtils/TestSentryDispatchQueueWrapper.swift
@@ -49,11 +49,11 @@ import Foundation
     }
 
     public var dispatchAfterInvocations = Invocations<(interval: TimeInterval, block: () -> Void)>()
-    public override func dispatch(after interval: TimeInterval, block: SentryDispatchBlockWrapper) {
-        dispatchAfterInvocations.record((interval, block.block))
+    public override func dispatch(after interval: TimeInterval, block: @escaping () -> Void) {
+        dispatchAfterInvocations.record((interval, block))
         if blockBeforeMainBlock() {
             if dispatchAfterExecutesBlock {
-                block.block()
+                block()
             }
         }
     }
@@ -62,9 +62,10 @@ import Foundation
         dispatchAfterInvocations.invocations.last?.block()
     }
 
-    public var dispatchCancelInvocations = Invocations<() -> Void>()
-    public override func dispatchCancel(_ block: SentryDispatchBlockWrapper) {
-        dispatchCancelInvocations.record(block.block)
+    public var dispatchCancelInvocations = 0
+    public override var shouldDispatchCancel: Bool {
+        dispatchCancelInvocations += 1
+        return false
     }
 
     public override func dispatchOnce(_ predicate: UnsafeMutablePointer<Int>, block: @escaping () -> Void) {
@@ -72,11 +73,8 @@ import Foundation
     }
     
     public var createDispatchBlockReturnsNULL = false
-    public override func createDispatchBlock(_ block: @escaping () -> Void) -> SentryDispatchBlockWrapper? {
-        if createDispatchBlockReturnsNULL {
-            return nil
-        }
-        return super.createDispatchBlock(block)
+    public override var shouldCreateDispatchBlock: Bool {
+        !createDispatchBlockReturnsNULL
     }
     
 }

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -367,12 +367,12 @@
     }
 
     __weak SentryHttpTransport *weakSelf = self;
-    SentryDispatchBlockWrapper *block = [self.dispatchQueue createDispatchBlock:^{
+    dispatch_block_t block = ^{
         if (weakSelf == nil) {
             return;
         }
         [weakSelf sendAllCachedEnvelopes];
-    }];
+    };
     [self.dispatchQueue dispatchAfter:self.cachedEnvelopeSendDelay block:block];
 }
 

--- a/Sources/Sentry/_SentryDispatchQueueWrapperInternal.m
+++ b/Sources/Sentry/_SentryDispatchQueueWrapperInternal.m
@@ -3,24 +3,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentryDispatchBlockWrapper ()
-
-- (instancetype)initWithBlock:(dispatch_block_t)block;
-
-@end
-
-@implementation SentryDispatchBlockWrapper
-
-- (instancetype)initWithBlock:(dispatch_block_t)block
-{
-    if (self = [super init]) {
-        self.block = block;
-    }
-    return self;
-}
-
-@end
-
 @implementation _SentryDispatchQueueWrapperInternal
 
 - (instancetype)init
@@ -97,34 +79,20 @@ NS_ASSUME_NONNULL_BEGIN
     return YES;
 }
 
-- (void)dispatchAfter:(NSTimeInterval)interval block:(SentryDispatchBlockWrapper *)block
+- (void)dispatchAfter:(NSTimeInterval)interval block:(void (^)(void))block
 {
     dispatch_time_t delta = (int64_t)(interval * NSEC_PER_SEC);
     dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delta);
     dispatch_after(when, _queue, ^{
         @autoreleasepool {
-            block.block();
+            block();
         }
     });
-}
-
-- (void)dispatchCancel:(SentryDispatchBlockWrapper *)block
-{
-    dispatch_block_cancel(block.block);
 }
 
 - (void)dispatchOnce:(dispatch_once_t *)predicate block:(void (^)(void))block
 {
     dispatch_once(predicate, block);
-}
-
-- (nullable SentryDispatchBlockWrapper *)createDispatchBlock:(void (^)(void))block
-{
-    dispatch_block_t dispatch_block = dispatch_block_create(0, block);
-    if (dispatch_block) {
-        return [[SentryDispatchBlockWrapper alloc] initWithBlock:dispatch_block];
-    }
-    return NULL;
 }
 
 @end

--- a/Sources/Sentry/include/_SentryDispatchQueueWrapperInternal.h
+++ b/Sources/Sentry/include/_SentryDispatchQueueWrapperInternal.h
@@ -2,14 +2,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-// dispatch_block_t is not compatible with Swift, this wraps it
-// so we can pass dispatch blocks through the Swift interface.
-@interface SentryDispatchBlockWrapper : NSObject
-
-@property dispatch_block_t block;
-
-@end
-
 /**
  * A wrapper around DispatchQueue functions for testability.
  * This should not be used directly, instead the  Swift version in
@@ -35,13 +27,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)dispatchSyncOnMainQueue:(void (^)(void))block timeout:(NSTimeInterval)timeout;
 
-- (void)dispatchAfter:(NSTimeInterval)interval block:(SentryDispatchBlockWrapper *)block;
-
-- (void)dispatchCancel:(SentryDispatchBlockWrapper *)block;
+- (void)dispatchAfter:(NSTimeInterval)interval block:(void (^)(void))block;
 
 - (void)dispatchOnce:(dispatch_once_t *)predicate block:(void (^)(void))block;
-
-- (nullable SentryDispatchBlockWrapper *)createDispatchBlock:(void (^)(void))block;
 
 @end
 

--- a/Sources/Swift/Helper/SentryDispatchQueueWrapper.swift
+++ b/Sources/Swift/Helper/SentryDispatchQueueWrapper.swift
@@ -42,19 +42,24 @@
         internalWrapper.dispatchSync(onMainQueue: block, timeout: timeout)
     }
 
-    func dispatch(after interval: TimeInterval, block: SentryDispatchBlockWrapper) {
+    public func dispatch(after interval: TimeInterval, block: @escaping () -> Void) {
         internalWrapper.dispatch(after: interval, block: block)
-    }
-
-    func dispatchCancel(_ block: SentryDispatchBlockWrapper) {
-        internalWrapper.dispatchCancel(block)
     }
 
     public func dispatchOnce(_ predicate: UnsafeMutablePointer<CLong>, block: @escaping () -> Void) {
         internalWrapper.dispatchOnce(predicate, block: block)
     }
+
+    // The ObjC version of this code wrapped `dispatch_cancel` and `dispatch_block_create`
+    // However dispatch_block is not accessible in Swift. Unit tests rely on stubbing out
+    // the creation and cancelation of dispatch blocks, so these two variables allow
+    // unit tests to still do that, while moving the creation of the `dispatch_block_t`
+    // to the ObjC callers. Once these callers migrate to Swift we can remove this entirely.
+    public var shouldDispatchCancel: Bool {
+        return true
+    }
     
-    func createDispatchBlock(_ block: @escaping () -> Void) -> SentryDispatchBlockWrapper? {
-        internalWrapper.createDispatchBlock(block)
+    public var shouldCreateDispatchBlock: Bool {
+        return true
     }
 }

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -295,7 +295,7 @@ class SentryUIEventTrackerTests: XCTestCase {
     
     private func assertResetsTimeout(_ firstTransaction: SentryTracer, _ secondTransaction: SentryTracer) {
         XCTAssertTrue(firstTransaction === secondTransaction)
-        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations.count)
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations)
         XCTAssertEqual(3, fixture.dispatchQueue.dispatchAfterInvocations.count, "Expected 3 dispatchAfter invocations. One for the initial timeout, one for the reset and one for the deadline timeout.")
     }
     

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -275,7 +275,7 @@ class SentryTracerTests: XCTestCase {
         
         XCTAssertNil(weakSut, "sut was not deallocated")
 
-        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations.count, "Expected one cancel invocation for the deadline timeout.")
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations, "Expected one cancel invocation for the deadline timeout.")
     }
     
     func testDeadlineTimeout_FiresAfterTracerDeallocated() throws {
@@ -351,7 +351,7 @@ class SentryTracerTests: XCTestCase {
         let sut = fixture.getSut()
         sut.finish()
         
-        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations.count, "Excpected one cancel invocation for the deadline timeout.")
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations, "Excpected one cancel invocation for the deadline timeout.")
     }
     
     func testDeadlineTimer_MultipleSpansFinishedInParallel() {
@@ -518,7 +518,7 @@ class SentryTracerTests: XCTestCase {
         sut.startChild(operation: fixture.transactionOperation)
         
         XCTAssertEqual(2, fixture.dispatchQueue.dispatchAfterInvocations.count, "Expected two dispatchAfter invocations one for the idle timeout and one for the deadline timer.")
-        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations.count, "Expected one cancel invocation for the idle timeout.")
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations, "Expected one cancel invocation for the idle timeout.")
     }
     
     func testIdleTimeoutWithRealDispatchQueue_SpanAdded_IdleTimeoutCancelled() {
@@ -559,18 +559,18 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(2, fixture.dispatchQueue.dispatchAfterInvocations.count)
         
         let child = sut.startChild(operation: fixture.transactionOperation)
-        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations.count)
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations)
         
         child.finish()
         XCTAssertEqual(3, fixture.dispatchQueue.dispatchAfterInvocations.count)
 
         // The grandchild is a NoOp span
         let grandChild = child.startChild(operation: fixture.transactionOperation)
-        XCTAssertEqual(3, fixture.dispatchQueue.dispatchCancelInvocations.count)
+        XCTAssertEqual(3, fixture.dispatchQueue.dispatchCancelInvocations)
         
         grandChild.finish()
         XCTAssertEqual(4, fixture.dispatchQueue.dispatchAfterInvocations.count)
-        XCTAssertEqual(4, fixture.dispatchQueue.dispatchCancelInvocations.count)
+        XCTAssertEqual(4, fixture.dispatchQueue.dispatchCancelInvocations)
         
         fixture.dispatchQueue.invokeLastDispatchAfter()
         
@@ -675,7 +675,7 @@ class SentryTracerTests: XCTestCase {
         XCTAssertEqual(2, fixture.dispatchQueue.dispatchAfterInvocations.count)
         
         sut.finish()
-        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations.count)
+        XCTAssertEqual(1, fixture.dispatchQueue.dispatchCancelInvocations)
         XCTAssertEqual(2, fixture.dispatchQueue.dispatchAfterInvocations.count)
         
         XCTAssertFalse(sut.isFinished)
@@ -1382,7 +1382,7 @@ class SentryTracerTests: XCTestCase {
         
         sut.finishForCrash()
         
-        XCTAssertEqual(0, fixture.dispatchQueue.dispatchCancelInvocations.count, "Expected no cancel invocation for the deadline timeout.")
+        XCTAssertEqual(0, fixture.dispatchQueue.dispatchCancelInvocations, "Expected no cancel invocation for the deadline timeout.")
     }
 
     func testFinishForCrash_DoesNotCallFinishCallback() throws {


### PR DESCRIPTION
This allows further work on https://github.com/getsentry/sentry-cocoa/issues/5371 by making three DispatchQueueWrapper methods `public`. These I had previously not made public because they used an internal type due to `dispatch_queue_t` not being available in Swift. This slight refactor preserves the functionality while making all the methods public.

#skip-changelog