### PR TITLE
ci: dry-run releases for non-dispatched workflows (ie PR check runs)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,6 @@ jobs:
       duplication-tests,
       app-metrics,
     ]
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     steps:
       - name: Get auth token
         id: token
@@ -288,3 +287,4 @@ jobs:
           version: ${{ github.event.inputs.version }}
           force: ${{ github.event.inputs.force }}
           merge_target: ${{ github.event.inputs.merge_target }}
+          dry-run: ${{ github.event_name != 'workflow_dispatch' }}


### PR DESCRIPTION
For https://github.com/getsentry/sentry-cocoa/issues/5507, if the dependent PRs are approved, then this can run release dry-runs for PR check runs (and/or nightly builds if we choose to do that in the future).

#skip-changelog