### PR TITLE
tests: Disable spotlight in UI tests

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -33,6 +33,7 @@ extension BaseUITest {
     func newAppSession() -> XCUIApplication {
         let app = XCUIApplication()
         app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
+        app.launchArguments.append("--disable-spotlight")
         return app
     }
     


### PR DESCRIPTION
A lot of the flaky UI tests I'm seeing seem to boil down to this. Basically the UI tests are asserting based on the span found in `currentHub.scope.span`. Spotlight is making network requests in the background to localhost that always fail, but are automatically tracked as spans.  When they fail they call `finishSpan` which eventually calls `finishTracer... shouldCleanup:YES` which then hits this code:

```
    if (shouldCleanUp) {
        id<SentrySpan> _Nullable currentSpan = [_hub.scope span];
        if (currentSpan == self) {
            [_hub.scope setSpan:nil];
        }
    }
```


So in a UI test that asserts the appearing view controller creates a valid span, the test will fail if the spotlight request finishes at just the right moment. This is what was happening in: https://github.com/getsentry/sentry-cocoa/issues/5505


I fixed this by disabling spotlight. I think regardless of these flaky tests we want the UI tests to be as close as possible to a production environment, and spotlight does not run in production so I think it makes sense to disable it here. Currently we default it to on in the test apps when running on a simulator

#skip-changelog