### PR TITLE
ci: Use xcrun for crash UI test

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -63,5 +63,4 @@ jobs:
 
       - name: Run SwiftUI Crash Test
         run: |
-          cd TestSamples/SwiftUICrashTest
-          ./test-crash-and-relaunch.sh
+          ./TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -58,9 +58,6 @@ jobs:
 
       - run: ./scripts/ci-select-xcode.sh 16.2
 
-      - name: Boot simulator
-        run: ./scripts/ci-boot-simulator.sh "iPhone 16"
-
       - name: Run SwiftUI Crash Test
         run: |
           cd TestSamples/SwiftUICrashTest

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -58,8 +58,8 @@ jobs:
 
       - run: ./scripts/ci-select-xcode.sh 16.2
 
-      # - name: Boot simulator
-      #   run: ./scripts/ci-boot-simulator.sh
+      - name: Boot simulator
+        run: ./scripts/ci-boot-simulator.sh
 
       - name: Run SwiftUI Crash Test
         run: |

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -58,8 +58,8 @@ jobs:
 
       - run: ./scripts/ci-select-xcode.sh 16.2
 
-      - name: Boot simulator
-        run: ./scripts/ci-boot-simulator.sh
+      # - name: Boot simulator
+      #   run: ./scripts/ci-boot-simulator.sh
 
       - name: Run SwiftUI Crash Test
         run: |

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -58,6 +58,9 @@ jobs:
 
       - run: ./scripts/ci-select-xcode.sh 16.2
 
+      - name: Boot simulator
+        run: ./scripts/ci-boot-simulator.sh
+
       - name: Run SwiftUI Crash Test
         run: |
           cd TestSamples/SwiftUICrashTest

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - ci/swiftui-crash-test
 
   pull_request:
     paths:

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - ci/swiftui-crash-test
 
   pull_request:
     paths:
@@ -48,4 +49,19 @@ jobs:
             xcode: "16.2"
         command:
           - fastlane_command: ui_critical_tests_ios_swiftui_envelope
-          - fastlane_command: ui_critical_tests_ios_swiftui_crash
+
+  run-swiftui-crash-test:
+    name: Run SwiftUI Crash Test
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: ./scripts/ci-select-xcode.sh 16.2
+
+      - name: Boot simulator
+        run: ./scripts/ci-boot-simulator.sh "iPhone 16"
+
+      - name: Run SwiftUI Crash Test
+        run: |
+          cd TestSamples/SwiftUICrashTest
+          ./test-crash-and-relaunch.sh

--- a/Sentry.xcworkspace/contents.xcworkspacedata
+++ b/Sentry.xcworkspace/contents.xcworkspacedata
@@ -57,6 +57,9 @@
       location = "container:"
       name = "TestSamples">
       <FileRef
+         location = "group:TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:TestSamples/SwiftUITestSample/SwiftUITestSample.xcodeproj">
       </FileRef>
    </Group>

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj/project.pbxproj
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -320,6 +321,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj/project.pbxproj
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj/project.pbxproj
@@ -1,0 +1,360 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		627AB7D12E0E6C2F00BCBB1B /* Sentry.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 627AB7D02E0E6C2F00BCBB1B /* Sentry.framework */; };
+		627AB7D22E0E6C2F00BCBB1B /* Sentry.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 627AB7D02E0E6C2F00BCBB1B /* Sentry.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		627AB7D32E0E6C2F00BCBB1B /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				627AB7D22E0E6C2F00BCBB1B /* Sentry.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		627AB7C12E0E6BE600BCBB1B /* SwiftUICrashTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftUICrashTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		627AB7D02E0E6C2F00BCBB1B /* Sentry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Sentry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		627AB7C32E0E6BE600BCBB1B /* SwiftUICrashTest */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = SwiftUICrashTest;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		627AB7BE2E0E6BE600BCBB1B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				627AB7D12E0E6C2F00BCBB1B /* Sentry.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		627AB7B82E0E6BE600BCBB1B = {
+			isa = PBXGroup;
+			children = (
+				627AB7C32E0E6BE600BCBB1B /* SwiftUICrashTest */,
+				627AB7CF2E0E6C2F00BCBB1B /* Frameworks */,
+				627AB7C22E0E6BE600BCBB1B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		627AB7C22E0E6BE600BCBB1B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				627AB7C12E0E6BE600BCBB1B /* SwiftUICrashTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		627AB7CF2E0E6C2F00BCBB1B /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				627AB7D02E0E6C2F00BCBB1B /* Sentry.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		627AB7C02E0E6BE600BCBB1B /* SwiftUICrashTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 627AB7CC2E0E6BE800BCBB1B /* Build configuration list for PBXNativeTarget "SwiftUICrashTest" */;
+			buildPhases = (
+				627AB7BD2E0E6BE600BCBB1B /* Sources */,
+				627AB7BE2E0E6BE600BCBB1B /* Frameworks */,
+				627AB7BF2E0E6BE600BCBB1B /* Resources */,
+				627AB7D32E0E6C2F00BCBB1B /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				627AB7C32E0E6BE600BCBB1B /* SwiftUICrashTest */,
+			);
+			name = SwiftUICrashTest;
+			packageProductDependencies = (
+			);
+			productName = SwiftUICrashTest;
+			productReference = 627AB7C12E0E6BE600BCBB1B /* SwiftUICrashTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		627AB7B92E0E6BE600BCBB1B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1640;
+				LastUpgradeCheck = 1640;
+				TargetAttributes = {
+					627AB7C02E0E6BE600BCBB1B = {
+						CreatedOnToolsVersion = 16.4;
+					};
+				};
+			};
+			buildConfigurationList = 627AB7BC2E0E6BE600BCBB1B /* Build configuration list for PBXProject "SwiftUICrashTest" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 627AB7B82E0E6BE600BCBB1B;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 627AB7C22E0E6BE600BCBB1B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				627AB7C02E0E6BE600BCBB1B /* SwiftUICrashTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		627AB7BF2E0E6BE600BCBB1B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		627AB7BD2E0E6BE600BCBB1B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		627AB7CA2E0E6BE800BCBB1B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 97JCY7859U;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		627AB7CB2E0E6BE800BCBB1B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = 97JCY7859U;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.5;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		627AB7CD2E0E6BE800BCBB1B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 97JCY7859U;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.sentry.SwiftUICrashTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		627AB7CE2E0E6BE800BCBB1B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 97JCY7859U;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = io.sentry.sentry.SwiftUICrashTest;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		627AB7BC2E0E6BE600BCBB1B /* Build configuration list for PBXProject "SwiftUICrashTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				627AB7CA2E0E6BE800BCBB1B /* Debug */,
+				627AB7CB2E0E6BE800BCBB1B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		627AB7CC2E0E6BE800BCBB1B /* Build configuration list for PBXNativeTarget "SwiftUICrashTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				627AB7CD2E0E6BE800BCBB1B /* Debug */,
+				627AB7CE2E0E6BE800BCBB1B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 627AB7B92E0E6BE600BCBB1B /* Project object */;
+}

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors": [
+    {
+      "idiom": "universal"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images": [
+    {
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    },
+    {
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "dark"
+        }
+      ],
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    },
+    {
+      "appearances": [
+        {
+          "appearance": "luminosity",
+          "value": "tinted"
+        }
+      ],
+      "idiom": "universal",
+      "platform": "ios",
+      "size": "1024x1024"
+    }
+  ],
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/Assets.xcassets/Contents.json
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info": {
+    "author": "xcode",
+    "version": 1
+  }
+}

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/ContentView.swift
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/ContentView.swift
@@ -1,0 +1,18 @@
+import Sentry
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        VStack {
+            Image(systemName: "globe")
+                .imageScale(.large)
+                .foregroundStyle(.tint)
+            Text("Hello, world!")
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
@@ -1,0 +1,25 @@
+import Sentry
+import SwiftUI
+
+@main
+struct SwiftUICrashTestApp: App {
+
+    init() {
+        SentrySDK.start { options in
+            options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
+        }
+
+        let userDefaultsKey = "crash-on-launch"
+        if UserDefaults.standard.bool(forKey: userDefaultsKey) {
+
+            UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+            SentrySDK.crash()
+        }
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+BUNDLE_ID="io.sentry.sentry.SwiftUICrashTest"
+USER_DEFAULT_KEY="crash-on-launch"
+DEVICE_ID="booted"
+
+echo "Starting crash test and relaunch test."
+echo "This test crashes the app and validates that it can relaunch after a crash without crashing again."
+
+
+echo "🔨 Building SwiftUI Crash Test app for simulator 🔨"
+xcodebuild -project SwiftUICrashTest.xcodeproj -scheme SwiftUICrashTest -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build
+
+echo "Installing app on simulator..."
+xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app
+
+echo "Terminating app if running..."
+xcrun simctl terminate $DEVICE_ID $BUNDLE_ID 2>/dev/null || true
+
+# Phase 1: Let the app crash
+
+echo "Setting crash flag..."
+xcrun simctl spawn $DEVICE_ID defaults write $BUNDLE_ID $USER_DEFAULT_KEY -bool true
+
+echo "Launching app with expected crash."
+xcrun simctl launch $DEVICE_ID $BUNDLE_ID > /dev/null 2>&1 &
+
+# Check every 100ms for 5 seconds if the app is still running.
+for i in {1..50}; do
+    if xcrun simctl listapps $DEVICE_ID | grep "$BUNDLE_ID" | grep -q "Running"; then
+        sleep 0.1
+    else
+        echo "✅ App crashed as expected after $(echo "scale=1; $i * 0.1" | bc) seconds."
+        break
+    fi
+    
+    if [ "$i" -eq 50 ]; then
+        echo "❌ App is still running after 5 seconds but it should have crashed instead."
+        exit 1
+    fi
+done
+
+# Phase 2: Test normal operation
+
+echo "Removing crash flag..."
+xcrun simctl spawn $DEVICE_ID defaults delete $BUNDLE_ID $USER_DEFAULT_KEY 2>/dev/null || true
+
+echo "Relaunching app after crash."
+xcrun simctl launch $DEVICE_ID $BUNDLE_ID > /dev/null 2>&1
+
+sleep 5
+
+# Check if app is still running
+
+if xcrun simctl spawn booted launchctl list | grep "$BUNDLE_ID"; then
+    echo "✅ App is still running"
+else
+    echo "❌ App is not running"
+    exit 1
+fi
+
+echo "Terminating app..."
+xcrun simctl terminate $DEVICE_ID $BUNDLE_ID 2>/dev/null || true
+
+echo "✅ Test completed successfully!" 
+exit 0

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Launches the SwiftUI Crash Test app and validates that it crashes and relaunches correctly.
 # This test run requires one booted simulator to work. So make sure to boot one simulator before running this script.
 
@@ -13,7 +15,7 @@ echo "This test crashes the app and validates that it can relaunch after a crash
 
 echo "🔨 Building SwiftUI Crash Test app for simulator 🔨"
 
-xcodebuild -workspace Sentry.xcworkspace  -scheme SwiftUICrashTest -destination "platform=iOS Simulator,name=iPhone 16" -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO build
+xcodebuild -workspace Sentry.xcworkspace -scheme SwiftUICrashTest -destination "platform=iOS Simulator,name=iPhone 16" -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO build
 
 echo "Installing app on simulator..."
 xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -12,7 +12,8 @@ echo "This test crashes the app and validates that it can relaunch after a crash
 
 
 echo "🔨 Building SwiftUI Crash Test app for simulator 🔨"
-xcodebuild -project ./TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj -scheme SwiftUICrashTest -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build
+
+xcodebuild -workspace Sentry.xcworkspace  -scheme SwiftUICrashTest -destination "platform=iOS Simulator,name=iPhone 16" -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO build
 
 echo "Installing app on simulator..."
 xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Launches the SwiftUI Crash Test app and validates that it crashes and relaunches correctly.
+# This test run requires one booted simulator to work. So make sure to boot one simulator before running this script.
+
 BUNDLE_ID="io.sentry.sentry.SwiftUICrashTest"
 USER_DEFAULT_KEY="crash-on-launch"
 DEVICE_ID="booted"
@@ -9,7 +12,7 @@ echo "This test crashes the app and validates that it can relaunch after a crash
 
 
 echo "🔨 Building SwiftUI Crash Test app for simulator 🔨"
-xcodebuild -project SwiftUICrashTest.xcodeproj -scheme SwiftUICrashTest -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build
+xcodebuild -project ./TestSamples/SwiftUICrashTest/SwiftUICrashTest.xcodeproj -scheme SwiftUICrashTest -destination 'platform=iOS Simulator,name=iPhone 16' -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= build
 
 echo "Installing app on simulator..."
 xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -15,7 +15,13 @@ echo "This test crashes the app and validates that it can relaunch after a crash
 
 echo "🔨 Building SwiftUI Crash Test app for simulator 🔨"
 
-xcodebuild -workspace Sentry.xcworkspace -scheme SwiftUICrashTest -destination "platform=iOS Simulator,name=iPhone 16" -derivedDataPath DerivedData -configuration Debug CODE_SIGNING_REQUIRED=NO build
+xcodebuild -workspace Sentry.xcworkspace \
+    -scheme SwiftUICrashTest \
+    -destination "platform=iOS Simulator,name=iPhone 16" \
+    -derivedDataPath DerivedData \
+    -configuration Debug \
+    CODE_SIGNING_REQUIRED=NO \
+    build 2>&1 | tee raw-build.log | xcbeautify
 
 echo "Installing app on simulator..."
 xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -23,15 +23,15 @@ xcodebuild -workspace Sentry.xcworkspace \
     CODE_SIGNING_REQUIRED=NO \
     build 2>&1 | tee raw-build.log | xcbeautify
 
-echo "Installing app on simulator..."
+echo "Installing app on simulator."
 xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app
 
-echo "Terminating app if running..."
+echo "Terminating app if running."
 xcrun simctl terminate $DEVICE_ID $BUNDLE_ID 2>/dev/null || true
 
 # Phase 1: Let the app crash
 
-echo "Setting crash flag..."
+echo "Setting crash flag."
 xcrun simctl spawn $DEVICE_ID defaults write $BUNDLE_ID $USER_DEFAULT_KEY -bool true
 
 echo "Launching app with expected crash."
@@ -60,9 +60,8 @@ xcrun simctl spawn $DEVICE_ID defaults delete $BUNDLE_ID $USER_DEFAULT_KEY 2>/de
 echo "Relaunching app after crash."
 xcrun simctl launch $DEVICE_ID $BUNDLE_ID > /dev/null 2>&1
 
+echo "Waiting for 5 seconds to check if the app is still running."
 sleep 5
-
-# Check if app is still running
 
 if xcrun simctl spawn booted launchctl list | grep "$BUNDLE_ID"; then
     echo "✅ App is still running"
@@ -71,8 +70,8 @@ else
     exit 1
 fi
 
-echo "Terminating app..."
+echo "Terminating app."
 xcrun simctl terminate $DEVICE_ID $BUNDLE_ID 2>/dev/null || true
 
-echo "✅ Test completed successfully!" 
+echo "✅ Test completed successfully." 
 exit 0


### PR DESCRIPTION
XCTest isn't built for crashing during tests. Instead of using XCTest to press a button and let a test app crash, we now use UserDefaults to tell the test app to crash during launch. We then simply launch the app again and wait to see if it keeps running. This is basically the same as the `testCrash` of the SwiftUITestSample without using XCTests.

The plan is to also replace the `ui_critical_tests_ios_swiftui_envelope` with this approach if this looks acceptable.

I still need to use Xcodegen for the test project.