### PR TITLE
fix: Set handled to false for fatal app hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Set handled to false for fatal app hangs (#5514)
+
 ## 8.53.1
 
 ### Fixes

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -264,6 +264,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
             event.level = kSentryLevelFatal;
 
             SentryException *exception = event.exceptions.firstObject;
+            exception.mechanism.handled = @(NO);
 
             NSString *exceptionType = exception.type;
             NSString *fatalExceptionType =

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -522,9 +522,10 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         // Assert
         try assertFatalEventWithScope { event, _ in
             XCTAssertEqual(event?.level, SentryLevel.fatal)
-            
+
             let ex = try XCTUnwrap(event?.exceptions?.first)
-            
+            XCTAssertEqual(ex.mechanism?.handled, false)
+
             XCTAssertEqual(ex.type, "Fatal App Hang Non Fully Blocked")
             XCTAssertEqual(ex.value, "The user or the OS watchdog terminated your app while it blocked the main thread for at least 4500 ms.")
             
@@ -559,6 +560,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             XCTAssertEqual(event?.level, SentryLevel.fatal)
 
             let ex = try XCTUnwrap(event?.exceptions?.first)
+            XCTAssertEqual(ex.mechanism?.handled, false)
 
             XCTAssertEqual(ex.type, "Fatal App Hang Non Fully Blocked")
             XCTAssertEqual(ex.value, "The user or the OS watchdog terminated your app while it blocked the main thread for at least 4500 ms.")


### PR DESCRIPTION



## :scroll: Description

Fatal app hangs didn't have `mechanism.handled = false`, which should be the case because it's an unhandled error.

## :bulb: Motivation and Context

A customer brought this up.

## :green_heart: How did you test it?

Unit tests and triggering a fatal app hang via simulator: https://sentry-sdks.sentry.io/issues/6675226860/events/e75fd272f1604537b5a8b3d9e6e7b99f/?project=5428557

![Screenshot 2025-06-27 at 14 24 50](https://github.com/user-attachments/assets/2d7a5b4d-9cad-4e70-ab5d-9c8e778e8ad5)


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
