### PR TITLE
test: Fix flaky launch UI test

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/TransactionsViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/TransactionsViewController.swift
@@ -25,6 +25,11 @@ class TransactionsViewController: UIViewController {
     }
     
     private func periodicallyDoWork() {
+      // This creates spans on background queues when doing things like reading files
+      // The background spans can interfere with UI tests that assert certain active spans
+      // (using SentryScope.span) because if this span is running the active span does not
+      // get overwritten (bindToScope = 0)
+      guard ProcessInfo.processInfo.environment["--io.sentry.ui-test.test-name"] == nil else { return }
 
         self.timer = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { _ in
             self.dispatchQueue.async {


### PR DESCRIPTION
From looking at some of these flaky test logs I noticed the active span sometimes gets set by file io operations right before/during the view lifecycle of the VC being tested. That causes the span to be nil when we check it. This should fix background file io overwriting the current span in UI tests

This should fix https://github.com/getsentry/sentry-cocoa/issues/5505

#skip-changelog