### PR TITLE
test: Fix flaky Tests for SwiftUI

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -50,6 +50,7 @@ jobs:
       xcode_version: 16.2
       build_with_make: true
       macos_version: macos-15
+      fastlane_command_extra_arguments: device:"iPhone 16 (18.5)"
 
   ui-tests-swift:
     name: UI Tests for iOS-Swift Xcode ${{matrix.xcode}} - V5 # Up the version with every change to keep track of flaky tests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -236,10 +236,11 @@ platform :ios do
     )
   end
 
-  lane :ui_tests_ios_swiftui do
+  lane :ui_tests_ios_swiftui do |options|
     run_ui_tests(
       scheme: "iOS-SwiftUI",
-      result_bundle_name: "ui_tests_ios_swiftui"
+      result_bundle_name: "ui_tests_ios_swiftui",
+      device: options[:device]
     )
   end
   


### PR DESCRIPTION
This test flaked: https://github.com/getsentry/sentry-cocoa/actions/runs/15934135003/job/44950002764 

And I saw in the xcresult that the simulator crashed and was iOS 18.0. This PR updates it to 18.5 which we use for most other tests and we've seen to be less flaky

![Screenshot 2025-06-28 at 6 03 02 PM](https://github.com/user-attachments/assets/0ab5a237-7187-4d5d-9907-1ab6d4d7437b)


#skip-changelog