### PR TITLE
feat(spm): Remove swift imports from objc++

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -663,7 +663,7 @@
 		8431F01B29B2852D00D8DC56 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E4A038225F76A7600000D77 /* Logger.swift */; };
 		8431F01C29B2854200D8DC56 /* libSentryTestUtils.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8431F00A29B284F200D8DC56 /* libSentryTestUtils.a */; };
 		84354E1129BF944900CDBB8B /* SentryProfileTimeseries.h in Headers */ = {isa = PBXBuildFile; fileRef = 84354E0F29BF944900CDBB8B /* SentryProfileTimeseries.h */; };
-		84354E1229BF944900CDBB8B /* SentryProfileTimeseries.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84354E1029BF944900CDBB8B /* SentryProfileTimeseries.mm */; };
+		84354E1229BF944900CDBB8B /* SentryProfileTimeseries.m in Sources */ = {isa = PBXBuildFile; fileRef = 84354E1029BF944900CDBB8B /* SentryProfileTimeseries.m */; };
 		843FB3232D0CD04D00558F18 /* SentryUserAccess.m in Sources */ = {isa = PBXBuildFile; fileRef = 843FB3222D0CD04D00558F18 /* SentryUserAccess.m */; };
 		843FB3242D0CD04D00558F18 /* SentryUserAccess.h in Headers */ = {isa = PBXBuildFile; fileRef = 843FB3212D0CD04D00558F18 /* SentryUserAccess.h */; };
 		843FB3432D156B9900558F18 /* SentryFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843FB3412D156B9900558F18 /* SentryFeedbackTests.swift */; };
@@ -676,9 +676,9 @@
 		844EDD6C2949387000C86F34 /* SentryMetricProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 844EDD6B2949387000C86F34 /* SentryMetricProfiler.h */; };
 		8453421228BE855D00C22EEC /* SentrySampleDecision.m in Sources */ = {isa = PBXBuildFile; fileRef = 8453421128BE855D00C22EEC /* SentrySampleDecision.m */; };
 		8453421628BE8A9500C22EEC /* SentrySpanStatus.m in Sources */ = {isa = PBXBuildFile; fileRef = 8453421528BE8A9500C22EEC /* SentrySpanStatus.m */; };
-		8454CF8D293EAF9A006AC140 /* SentryMetricProfiler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */; };
+		8454CF8D293EAF9A006AC140 /* SentryMetricProfiler.m in Sources */ = {isa = PBXBuildFile; fileRef = 8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.m */; };
 		8459FCBE2BD73E820038E9C9 /* SentryProfilerSerialization.h in Headers */ = {isa = PBXBuildFile; fileRef = 8459FCBD2BD73E810038E9C9 /* SentryProfilerSerialization.h */; };
-		8459FCC02BD73EB20038E9C9 /* SentryProfilerSerialization.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8459FCBF2BD73EB20038E9C9 /* SentryProfilerSerialization.mm */; };
+		8459FCC02BD73EB20038E9C9 /* SentryProfilerSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 8459FCBF2BD73EB20038E9C9 /* SentryProfilerSerialization.m */; };
 		845C16D52A622A5B00EC9519 /* SentryTracer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 845C16D42A622A5B00EC9519 /* SentryTracer+Private.h */; };
 		845CEAEF2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEAEE2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift */; };
 		845CEB172D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845CEB162D8A979700B6B325 /* SentryAppStartProfilingConfigurationTests.swift */; };
@@ -700,8 +700,8 @@
 		84A5D75B29D5170700388BFA /* TimeInterval+Sentry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */; };
 		84A7890A2C0E9F6400FF0803 /* SentrySpan+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A789092C0E9F5800FF0803 /* SentrySpan+Private.h */; };
 		84A8891C28DBD28900C51DFD /* SentryDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 84A8891A28DBD28900C51DFD /* SentryDevice.h */; };
-		84A8891D28DBD28900C51DFD /* SentryDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84A8891B28DBD28900C51DFD /* SentryDevice.mm */; };
-		84A8892128DBD8D600C51DFD /* SentryDeviceTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 84A8892028DBD8D600C51DFD /* SentryDeviceTests.mm */; };
+		84A8891D28DBD28900C51DFD /* SentryDevice.m in Sources */ = {isa = PBXBuildFile; fileRef = 84A8891B28DBD28900C51DFD /* SentryDevice.m */; };
+		84A8892128DBD8D600C51DFD /* SentryDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 84A8892028DBD8D600C51DFD /* SentryDeviceTests.m */; };
 		84A903712D39F66F00690CE4 /* SentryUserFeedbackFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A903702D39F66F00690CE4 /* SentryUserFeedbackFormViewModel.swift */; };
 		84AC61D229F7541E009EEF61 /* SentryDispatchSourceWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 84AC61D029F7541E009EEF61 /* SentryDispatchSourceWrapper.h */; };
 		84AC61D329F7541E009EEF61 /* SentryDispatchSourceWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 84AC61D129F7541E009EEF61 /* SentryDispatchSourceWrapper.m */; };
@@ -1871,7 +1871,7 @@
 		8431EFD929B27B1100D8DC56 /* SentryProfilerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SentryProfilerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8431F00A29B284F200D8DC56 /* libSentryTestUtils.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSentryTestUtils.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		84354E0F29BF944900CDBB8B /* SentryProfileTimeseries.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfileTimeseries.h; path = Sources/Sentry/include/SentryProfileTimeseries.h; sourceTree = SOURCE_ROOT; };
-		84354E1029BF944900CDBB8B /* SentryProfileTimeseries.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryProfileTimeseries.mm; path = Sources/Sentry/SentryProfileTimeseries.mm; sourceTree = SOURCE_ROOT; };
+		84354E1029BF944900CDBB8B /* SentryProfileTimeseries.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SentryProfileTimeseries.m; path = Sources/Sentry/SentryProfileTimeseries.m; sourceTree = SOURCE_ROOT; };
 		843BD6282AD8752300B0098F /* .clang-format */ = {isa = PBXFileReference; lastKnownFileType = text; path = ".clang-format"; sourceTree = "<group>"; };
 		843FB3212D0CD04D00558F18 /* SentryUserAccess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUserAccess.h; path = include/SentryUserAccess.h; sourceTree = "<group>"; };
 		843FB3222D0CD04D00558F18 /* SentryUserAccess.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryUserAccess.m; sourceTree = "<group>"; };
@@ -1911,9 +1911,9 @@
 		8452E77D2DBC43CF0087020B /* Brewfile-ci-build */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Brewfile-ci-build"; sourceTree = "<group>"; };
 		8453421128BE855D00C22EEC /* SentrySampleDecision.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySampleDecision.m; sourceTree = "<group>"; };
 		8453421528BE8A9500C22EEC /* SentrySpanStatus.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpanStatus.m; sourceTree = "<group>"; };
-		8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = SentryMetricProfiler.mm; path = Sources/Sentry/SentryMetricProfiler.mm; sourceTree = SOURCE_ROOT; };
+		8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = SentryMetricProfiler.m; path = Sources/Sentry/SentryMetricProfiler.m; sourceTree = SOURCE_ROOT; };
 		8459FCBD2BD73E810038E9C9 /* SentryProfilerSerialization.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryProfilerSerialization.h; path = Sources/Sentry/include/SentryProfilerSerialization.h; sourceTree = SOURCE_ROOT; };
-		8459FCBF2BD73EB20038E9C9 /* SentryProfilerSerialization.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryProfilerSerialization.mm; sourceTree = "<group>"; };
+		8459FCBF2BD73EB20038E9C9 /* SentryProfilerSerialization.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryProfilerSerialization.m; sourceTree = "<group>"; };
 		8459FCC12BD73EEF0038E9C9 /* SentryProfilerSerialization+Test.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentryProfilerSerialization+Test.h"; sourceTree = "<group>"; };
 		845C16D42A622A5B00EC9519 /* SentryTracer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryTracer+Private.h"; path = "include/SentryTracer+Private.h"; sourceTree = "<group>"; };
 		845CEAEE2D83F79500B6B325 /* SentryProfilingPublicAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryProfilingPublicAPITests.swift; sourceTree = "<group>"; };
@@ -1943,8 +1943,8 @@
 		84A5D75A29D5170700388BFA /* TimeInterval+Sentry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TimeInterval+Sentry.swift"; sourceTree = "<group>"; };
 		84A789092C0E9F5800FF0803 /* SentrySpan+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentrySpan+Private.h"; path = "include/SentrySpan+Private.h"; sourceTree = "<group>"; };
 		84A8891A28DBD28900C51DFD /* SentryDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDevice.h; path = include/SentryDevice.h; sourceTree = "<group>"; };
-		84A8891B28DBD28900C51DFD /* SentryDevice.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryDevice.mm; sourceTree = "<group>"; };
-		84A8892028DBD8D600C51DFD /* SentryDeviceTests.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SentryDeviceTests.mm; sourceTree = "<group>"; };
+		84A8891B28DBD28900C51DFD /* SentryDevice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDevice.m; sourceTree = "<group>"; };
+		84A8892028DBD8D600C51DFD /* SentryDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDeviceTests.m; sourceTree = "<group>"; };
 		84A903702D39F66F00690CE4 /* SentryUserFeedbackFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUserFeedbackFormViewModel.swift; sourceTree = "<group>"; };
 		84AB6AAF2DB2E9BA006D6C83 /* Versioning.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Versioning.xcconfig; sourceTree = "<group>"; };
 		84AC61D029F7541E009EEF61 /* SentryDispatchSourceWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDispatchSourceWrapper.h; path = include/SentryDispatchSourceWrapper.h; sourceTree = "<group>"; };
@@ -2817,7 +2817,7 @@
 				7B18DE3F28D9F748004845C6 /* SentryNSNotificationCenterWrapper.h */,
 				7B18DE4128D9F794004845C6 /* SentryNSNotificationCenterWrapper.m */,
 				84A8891A28DBD28900C51DFD /* SentryDevice.h */,
-				84A8891B28DBD28900C51DFD /* SentryDevice.mm */,
+				84A8891B28DBD28900C51DFD /* SentryDevice.m */,
 				844EDC6D294143B900C86F34 /* SentryNSProcessInfoWrapper.h */,
 				844EDC6E294143B900C86F34 /* SentryNSProcessInfoWrapper.mm */,
 				844EDC74294144DB00C86F34 /* SentrySystemWrapper.h */,
@@ -3468,7 +3468,7 @@
 				D85D3BE9278DF63D001B2889 /* SentryByteCountFormatterTests.swift */,
 				7B2A70DE27D60904008B0D15 /* SentryTestThreadWrapper.swift */,
 				7B18DE4928DA0C8B004845C6 /* SentryNSNotificationCenterWrapperTests.swift */,
-				84A8892028DBD8D600C51DFD /* SentryDeviceTests.mm */,
+				84A8892028DBD8D600C51DFD /* SentryDeviceTests.m */,
 				8431EE5A29ADB8EA00D8DC56 /* SentryTimeTests.m */,
 				62C3168A2B1F865A000D7031 /* SentryTimeSwiftTests.swift */,
 				33042A1629DC2C4300C60085 /* SentryExtraContextProviderTests.swift */,
@@ -3792,9 +3792,9 @@
 				03F84D2C27DD4191008FE43F /* SentryMachLogging.cpp */,
 				03F84D1B27DD414C008FE43F /* SentryMachLogging.hpp */,
 				844EDD6B2949387000C86F34 /* SentryMetricProfiler.h */,
-				8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.mm */,
+				8454CF8B293EAF9A006AC140 /* SentryMetricProfiler.m */,
 				8459FCBD2BD73E810038E9C9 /* SentryProfilerSerialization.h */,
-				8459FCBF2BD73EB20038E9C9 /* SentryProfilerSerialization.mm */,
+				8459FCBF2BD73EB20038E9C9 /* SentryProfilerSerialization.m */,
 				8459FCC12BD73EEF0038E9C9 /* SentryProfilerSerialization+Test.h */,
 				84AF45A429A7FFA500FBB177 /* SentryProfiledTracerConcurrency.h */,
 				84AF45A529A7FFA500FBB177 /* SentryProfiledTracerConcurrency.mm */,
@@ -3811,7 +3811,7 @@
 				84281C422A578E5600EE88F2 /* SentryProfilerState.mm */,
 				84281C642A57D36100EE88F2 /* SentryProfilerState+ObjCpp.h */,
 				84354E0F29BF944900CDBB8B /* SentryProfileTimeseries.h */,
-				84354E1029BF944900CDBB8B /* SentryProfileTimeseries.mm */,
+				84354E1029BF944900CDBB8B /* SentryProfileTimeseries.m */,
 				03BCC38D27E2A377003232C7 /* SentryProfilingConditionals.h */,
 				84281C442A57905700EE88F2 /* SentrySample.h */,
 				84281C452A57905700EE88F2 /* SentrySample.m */,
@@ -5369,7 +5369,7 @@
 				7BF9EF782722B35D00B5BBEF /* SentrySubClassFinder.m in Sources */,
 				84CFA4CD2C9E0CA3008DA5F4 /* SentryUserFeedbackIntegration.m in Sources */,
 				7BCFA71627D0BB50008C662C /* SentryANRTrackerV1.m in Sources */,
-				8459FCC02BD73EB20038E9C9 /* SentryProfilerSerialization.mm in Sources */,
+				8459FCC02BD73EB20038E9C9 /* SentryProfilerSerialization.m in Sources */,
 				63EED6C02237923600E02400 /* SentryOptions.m in Sources */,
 				620078722D38F00D0022CB67 /* SentryGeoCodable.swift in Sources */,
 				D8CB741B2947286500A5F964 /* SentryEnvelopeItemHeader.m in Sources */,
@@ -5408,7 +5408,7 @@
 				33042A0D29DAF79A00C60085 /* SentryExtraContextProvider.m in Sources */,
 				7BA61CAD247BAA0B00C130A8 /* SentryDebugImageProvider.m in Sources */,
 				63FE70E720DA4C1000CDBAE8 /* SentryCrashMonitor.c in Sources */,
-				84354E1229BF944900CDBB8B /* SentryProfileTimeseries.mm in Sources */,
+				84354E1229BF944900CDBB8B /* SentryProfileTimeseries.m in Sources */,
 				7D5C441C237C2E1F00DAB0A3 /* SentryHub.m in Sources */,
 				84E13B842CBF1D91003B52EC /* SentryUserFeedbackWidgetButtonMegaphoneIconView.swift in Sources */,
 				63FE715920DA4C1100CDBAE8 /* SentryCrashCPU_x86_32.c in Sources */,
@@ -5448,7 +5448,7 @@
 				6360850E1ED2AFE100E8599E /* SentryBreadcrumb.m in Sources */,
 				D82859432C3E753C009A28AA /* SentrySessionReplaySyncC.c in Sources */,
 				D833D57C2D10784800961E7A /* SentryRRWebOptionsEvent.swift in Sources */,
-				84A8891D28DBD28900C51DFD /* SentryDevice.mm in Sources */,
+				84A8891D28DBD28900C51DFD /* SentryDevice.m in Sources */,
 				7B56D73324616D9500B842DA /* SentryConcurrentRateLimitsDictionary.m in Sources */,
 				8ECC674825C23A20000E2BF6 /* SentryTransaction.m in Sources */,
 				0A80E433291017C300095219 /* SentryWatchdogTerminationScopeObserver.m in Sources */,
@@ -5579,7 +5579,7 @@
 				D88B30A92D48D8C3008DE513 /* SentryMaskingPreviewView.swift in Sources */,
 				849B8F992C6E906900148E1F /* SentryUserFeedbackFormConfiguration.swift in Sources */,
 				8E8C57A225EEFC07001CEEFA /* SentrySampling.m in Sources */,
-				8454CF8D293EAF9A006AC140 /* SentryMetricProfiler.mm in Sources */,
+				8454CF8D293EAF9A006AC140 /* SentryMetricProfiler.m in Sources */,
 				63FE714120DA4C1100CDBAE8 /* SentryCrashDate.c in Sources */,
 				D43B26DA2D70A612007747FD /* SentrySpanDataKey.m in Sources */,
 				63FE70DB20DA4C1000CDBAE8 /* SentryCrashMonitor_System.m in Sources */,
@@ -5731,7 +5731,7 @@
 				D8B76B0828081461000A58C4 /* TestSentryScreenShot.swift in Sources */,
 				A8AFFCD22907DA7600967CD7 /* SentryHttpStatusCodeRangeTests.swift in Sources */,
 				7BE2C7F8257000A4003B66C7 /* SentryTestIntegration.m in Sources */,
-				84A8892128DBD8D600C51DFD /* SentryDeviceTests.mm in Sources */,
+				84A8892128DBD8D600C51DFD /* SentryDeviceTests.m in Sources */,
 				7BC6EBF4255C044A0059822A /* SentryEventTests.swift in Sources */,
 				63FE721920DA66EC00CDBAE8 /* SentryCrashReportStore_Tests.m in Sources */,
 				7B6D98EB24C6E84F005502FA /* SentryCrashInstallationReporterTests.swift in Sources */,

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -7,7 +7,6 @@
 #    import "SentryLogC.h"
 #    import "SentryOptions+Private.h"
 #    import "SentryProfiler+Private.h"
-#    import "SentrySwift.h"
 #    include <mutex>
 
 #    import "SentryDependencyContainer.h"

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.m
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.m
@@ -39,8 +39,6 @@ NSString *const kSentryProfilerSerializationKeyFrameRates = @"screen_frame_rates
 
 #    pragma mark - Private
 
-namespace {
-
 /**
  * Given an array of samples with absolute timestamps, return the serialized JSON mapping with
  * their data, with timestamps normalized relative to the provided transaction's start time.
@@ -49,7 +47,7 @@ NSArray<NSDictionary *> *
 _sentry_serializedTraceProfileSamplesWithRelativeTimestamps(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime)
 {
-    const auto result = [NSMutableArray<NSDictionary *> array];
+    NSMutableArray<NSDictionary *> *result = [NSMutableArray<NSDictionary *> array];
     [samples enumerateObjectsUsingBlock:^(
         SentrySample *_Nonnull sample, NSUInteger idx, BOOL *_Nonnull stop) {
         // This shouldn't happen as we would've filtered out any such samples, but we should still
@@ -58,8 +56,8 @@ _sentry_serializedTraceProfileSamplesWithRelativeTimestamps(
             SENTRY_LOG_WARN(@"Filtering sample as it came before start time to begin slicing.");
             return;
         }
-        const auto dict = [NSMutableDictionary dictionary];
-        const auto durationNs = getDurationNs(startSystemTime, sample.absoluteTimestamp);
+        NSMutableDictionary *dict = [NSMutableDictionary dictionary];
+        uint64_t durationNs = getDurationNs(startSystemTime, sample.absoluteTimestamp);
         dict[@"elapsed_since_start_ns"] = sentry_stringForUInt64(durationNs);
 
         dict[@"thread_id"] = sentry_stringForUInt64(sample.threadID);
@@ -81,10 +79,10 @@ _sentry_serializedTraceProfileSamplesWithRelativeTimestamps(
 NSArray<NSDictionary *> *
 _sentry_serializedContinuousProfileSamples(NSArray<SentrySample *> *samples)
 {
-    const auto result = [NSMutableArray<NSDictionary *> array];
+    NSMutableArray<NSDictionary *> *result = [NSMutableArray<NSDictionary *> array];
     [samples enumerateObjectsUsingBlock:^(
         SentrySample *_Nonnull sample, NSUInteger idx, BOOL *_Nonnull stop) {
-        const auto dict = [NSMutableDictionary dictionary];
+        NSMutableDictionary *dict = [NSMutableDictionary dictionary];
         dict[@"timestamp"] = @(sample.absoluteNSDateInterval);
         dict[@"thread_id"] = sentry_stringForUInt64(sample.threadID);
         dict[@"stack_id"] = sample.stackIndex;
@@ -95,8 +93,6 @@ _sentry_serializedContinuousProfileSamples(NSArray<SentrySample *> *samples)
     }];
     return result;
 }
-
-} // namespace
 
 #    pragma mark - Exported for tests
 
@@ -136,21 +132,23 @@ sentry_serializedTraceProfileData(
     }
 
     // slice the profile data to only include the samples/metrics within the transaction
-    const auto slicedSamples = sentry_slicedProfileSamples(samples, startSystemTime, endSystemTime);
+    NSArray<SentrySample *> *slicedSamples
+        = sentry_slicedProfileSamples(samples, startSystemTime, endSystemTime);
     if (slicedSamples.count < 2) {
         SENTRY_LOG_DEBUG(@"Not enough samples in profile during the transaction");
         [hub.getClient recordLostEvent:kSentryDataCategoryProfile
                                 reason:kSentryDiscardReasonEventProcessor];
         return nil;
     }
-    const auto payload = [NSMutableDictionary<NSString *, id> dictionary];
+    NSMutableDictionary<NSString *, id> *payload = [NSMutableDictionary<NSString *, id> dictionary];
     NSMutableDictionary<NSString *, id> *const profile = [profileData[@"profile"] mutableCopy];
     profile[@"samples"] = _sentry_serializedTraceProfileSamplesWithRelativeTimestamps(
         slicedSamples, startSystemTime);
     payload[@"profile"] = profile;
 
     payload[@"version"] = @"1";
-    const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
+    NSMutableArray<NSDictionary<NSString *, id> *> *debugImages =
+        [NSMutableArray<NSDictionary<NSString *, id> *> new];
     for (SentryDebugMeta *debugImage in debugMeta) {
         [debugImages addObject:[debugImage serialize]];
     }
@@ -164,7 +162,7 @@ sentry_serializedTraceProfileData(
         @"build_number" : sentry_getOSBuildNumber()
     };
 
-    const auto isEmulated = sentry_isSimulatorBuild();
+    bool isEmulated = sentry_isSimulatorBuild();
     payload[@"device"] = @{
         @"architecture" : sentry_getCPUArchitecture(),
         @"is_emulator" : @(isEmulated),
@@ -179,20 +177,21 @@ sentry_serializedTraceProfileData(
     payload[@"release"] = hub.getClient.options.releaseName;
 
     // add the gathered metrics
-    auto metrics = serializedMetrics;
+    NSDictionary<NSString *, id> *metrics = serializedMetrics;
 
 #    if SENTRY_HAS_UIKIT
-    const auto mutableMetrics =
+    NSMutableDictionary<NSString *, id> *mutableMetrics =
         [NSMutableDictionary<NSString *, id> dictionaryWithDictionary:metrics];
-    const auto slowFrames = sentry_sliceTraceProfileGPUData(gpuData.slowFrameTimestamps,
-        startSystemTime, endSystemTime, /*useMostRecentFrameRate */ NO);
+    NSArray<SentrySerializedMetricEntry *> *slowFrames
+        = sentry_sliceTraceProfileGPUData(gpuData.slowFrameTimestamps, startSystemTime,
+            endSystemTime, /*useMostRecentFrameRate */ NO);
     if (slowFrames.count > 0) {
         mutableMetrics[kSentryProfilerSerializationKeySlowFrameRenders] =
             @ { @"unit" : @"nanosecond", @"values" : slowFrames };
     }
 
-    const auto frozenFrames = sentry_sliceTraceProfileGPUData(gpuData.frozenFrameTimestamps,
-        startSystemTime, endSystemTime,
+    NSArray<SentrySerializedMetricEntry *> *frozenFrames = sentry_sliceTraceProfileGPUData(
+        gpuData.frozenFrameTimestamps, startSystemTime, endSystemTime,
         /*useMostRecentFrameRate */ NO);
     if (frozenFrames.count > 0) {
         mutableMetrics[kSentryProfilerSerializationKeyFrozenFrameRenders] =
@@ -200,8 +199,8 @@ sentry_serializedTraceProfileData(
     }
 
     if (slowFrames.count > 0 || frozenFrames.count > 0) {
-        const auto frameRates = sentry_sliceTraceProfileGPUData(gpuData.frameRateTimestamps,
-            startSystemTime, endSystemTime,
+        NSArray<SentrySerializedMetricEntry *> *frameRates = sentry_sliceTraceProfileGPUData(
+            gpuData.frameRateTimestamps, startSystemTime, endSystemTime,
             /*useMostRecentFrameRate */ YES);
         if (frameRates.count > 0) {
             mutableMetrics[kSentryProfilerSerializationKeyFrameRates] =
@@ -236,14 +235,15 @@ sentry_serializedContinuousProfileChunk(SentryId *profileID, SentryId *chunkID,
     // profiling session, to count the number of total samples sent so far, to decide whether or not
     // a 1-sample chunk is acceptable.
 
-    const auto payload = [NSMutableDictionary<NSString *, id> dictionary];
+    NSMutableDictionary<NSString *, id> *payload = [NSMutableDictionary<NSString *, id> dictionary];
     NSMutableDictionary<NSString *, id> *const profile = [profileData[@"profile"] mutableCopy];
     profile[@"samples"] = _sentry_serializedContinuousProfileSamples(samples);
 
     payload[@"profile"] = profile;
 
     payload[@"version"] = @"2";
-    const auto debugImages = [NSMutableArray<NSDictionary<NSString *, id> *> new];
+    NSMutableArray<NSDictionary<NSString *, id> *> *debugImages =
+        [NSMutableArray<NSDictionary<NSString *, id> *> new];
     for (SentryDebugMeta *debugImage in debugMeta) {
         [debugImages addObject:[debugImage serialize]];
     }
@@ -257,26 +257,26 @@ sentry_serializedContinuousProfileChunk(SentryId *profileID, SentryId *chunkID,
     payload[@"release"] = hub.getClient.options.releaseName;
     payload[@"platform"] = SentryPlatformName;
 
-    const auto clientInfo = [NSMutableDictionary dictionary];
+    NSMutableDictionary *clientInfo = [NSMutableDictionary dictionary];
     clientInfo[@"name"] = SentryMeta.sdkName;
     clientInfo[@"version"] = SentryMeta.versionString;
     payload[@"client_sdk"] = clientInfo;
 
     // add the gathered metrics
-    auto metrics = serializedMetrics;
+    NSDictionary<NSString *, id> *metrics = serializedMetrics;
 
 #    if SENTRY_HAS_UIKIT
-    const auto mutableMetrics =
+    NSMutableDictionary<NSString *, id> *mutableMetrics =
         [NSMutableDictionary<NSString *, id> dictionaryWithDictionary:metrics];
     if (gpuData.slowFrameTimestamps.count > 0) {
-        const auto values = [NSMutableDictionary dictionary];
+        NSMutableDictionary *values = [NSMutableDictionary dictionary];
         values[@"unit"] = @"nanosecond";
         values[@"values"] = gpuData.slowFrameTimestamps;
         mutableMetrics[kSentryProfilerSerializationKeySlowFrameRenders] = values;
     }
 
     if (gpuData.frozenFrameTimestamps.count > 0) {
-        const auto values = [NSMutableDictionary dictionary];
+        NSMutableDictionary *values = [NSMutableDictionary dictionary];
         values[@"unit"] = @"nanosecond";
         values[@"values"] = gpuData.frozenFrameTimestamps;
         mutableMetrics[kSentryProfilerSerializationKeyFrozenFrameRenders] = values;
@@ -284,7 +284,7 @@ sentry_serializedContinuousProfileChunk(SentryId *profileID, SentryId *chunkID,
 
     if (gpuData.slowFrameTimestamps.count > 0 || gpuData.frozenFrameTimestamps.count > 0) {
         if (gpuData.frameRateTimestamps.count > 0) {
-            const auto values = [NSMutableDictionary dictionary];
+            NSMutableDictionary *values = [NSMutableDictionary dictionary];
             values[@"unit"] = @"hz";
             values[@"values"] = gpuData.frameRateTimestamps;
             mutableMetrics[kSentryProfilerSerializationKeyFrameRates] = values;
@@ -310,8 +310,8 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
 #    endif // SENTRY_HAS_UIKIT
 )
 {
-    const auto chunkID = [[SentryId alloc] init];
-    const auto payload = sentry_serializedContinuousProfileChunk(
+    SentryId *chunkID = [[SentryId alloc] init];
+    NSMutableDictionary<NSString *, id> *payload = sentry_serializedContinuousProfileChunk(
         profileID, chunkID, profileState, metricProfilerState,
         [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesFromCache],
         SentrySDK.currentHub
@@ -326,7 +326,7 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
         return nil;
     }
 
-    const auto JSONData = [SentrySerialization dataWithJSONObject:payload];
+    NSData *JSONData = [SentrySerialization dataWithJSONObject:payload];
     if (JSONData == nil) {
         SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON.");
         return nil;
@@ -343,11 +343,12 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
     }
 #    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
-    const auto header =
+    SentryEnvelopeItemHeader *header =
         [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfileChunk
                                                 length:JSONData.length];
     header.platform = @"cocoa";
-    const auto envelopeItem = [[SentryEnvelopeItem alloc] initWithHeader:header data:JSONData];
+    SentryEnvelopeItem *envelopeItem = [[SentryEnvelopeItem alloc] initWithHeader:header
+                                                                             data:JSONData];
 
     return [[SentryEnvelope alloc] initWithId:chunkID singleItem:envelopeItem];
 }
@@ -356,9 +357,9 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(SentryHub *hub,
     SentryProfiler *profiler, NSDictionary<NSString *, id> *profilingData,
     SentryTransaction *transaction, NSDate *startTimestamp)
 {
-    const auto images =
+    NSArray<SentryDebugMeta *> *images =
         [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesFromCache];
-    const auto payload = sentry_serializedTraceProfileData(
+    NSMutableDictionary<NSString *, id> *payload = sentry_serializedTraceProfileData(
         profilingData, transaction.startSystemTime, transaction.endSystemTime,
         sentry_profilerTruncationReasonName(profiler.truncationReason),
         [profiler.metricProfiler serializeTraceProfileMetricsBetween:transaction.startSystemTime
@@ -384,7 +385,7 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(SentryHub *hub,
     };
     payload[@"timestamp"] = sentry_toIso8601String(startTimestamp);
 
-    const auto JSONData = [SentrySerialization dataWithJSONObject:payload];
+    NSData *JSONData = [SentrySerialization dataWithJSONObject:payload];
     if (JSONData == nil) {
         SENTRY_LOG_DEBUG(@"Failed to encode profile to JSON.");
         return nil;
@@ -394,15 +395,16 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(SentryHub *hub,
     sentry_writeProfileFile(JSONData, false /*continuous*/);
 #    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI)
 
-    const auto header = [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
-                                                                length:JSONData.length];
+    SentryEnvelopeItemHeader *header =
+        [[SentryEnvelopeItemHeader alloc] initWithType:SentryEnvelopeItemTypeProfile
+                                                length:JSONData.length];
     return [[SentryEnvelopeItem alloc] initWithHeader:header data:JSONData];
 }
 
 NSMutableDictionary<NSString *, id> *_Nullable sentry_collectProfileDataHybridSDK(
     uint64_t startSystemTime, uint64_t endSystemTime, SentryId *traceId, SentryHub *hub)
 {
-    const auto profiler = sentry_profilerForFinishedTracer(traceId);
+    SentryProfiler *profiler = sentry_profilerForFinishedTracer(traceId);
     if (!profiler) {
         return nil;
     }

--- a/Sources/Sentry/SentryDevice.m
+++ b/Sources/Sentry/SentryDevice.m
@@ -24,7 +24,6 @@
 #    import <UIKit/UIKit.h>
 #endif // SENTRY_HAS_UIKIT
 
-namespace {
 /**
  * @brief Get an iOS hardware model name, or for mac devices, either the hardware model name or CPU
  * architecture of the device, depending on the option provided.
@@ -64,7 +63,7 @@ getHardwareDescription(int type)
         return @"";
     }
 
-    const auto nameNSString = [NSString stringWithUTF8String:name];
+    NSString *nameNSString = [NSString stringWithUTF8String:name];
 
     NSString *argName;
     switch (type) {
@@ -132,7 +131,6 @@ getCPUType(NSNumber *_Nullable subtype)
         return @"arm64_32";
     }
 }
-} // namespace
 
 NSString *
 sentry_getCPUArchitecture(void)
@@ -187,7 +185,7 @@ sentry_getOSVersion(void)
 #elif SENTRY_HAS_UIKIT
     return [UIDevice currentDevice].systemVersion;
 #else
-    const auto version = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSOperatingSystemVersion version = [[NSProcessInfo processInfo] operatingSystemVersion];
     return [NSString stringWithFormat:@"%ld.%ld.%ld", (long)version.majorVersion,
         (long)version.minorVersion, (long)version.patchVersion];
 #endif // SENTRY_HAS_UIKIT
@@ -198,14 +196,14 @@ sentry_getDeviceModel(void)
 {
 #if TARGET_OS_SIMULATOR
     // iPhone/iPad, Watch and TV simulators
-    const auto simulatedDeviceModelName = sentry_getSimulatorDeviceModel();
+    NSString *simulatedDeviceModelName = sentry_getSimulatorDeviceModel();
     SENTRY_LOG_DEBUG(@"Got simulated device model name %@ (running on %@)",
         simulatedDeviceModelName, getHardwareDescription(HW_MODEL));
     return simulatedDeviceModelName;
 #else
 #    if defined(HW_PRODUCT)
     if (@available(iOS 14, macOS 11, *)) {
-        const auto model = getHardwareDescription(HW_PRODUCT);
+        NSString *model = getHardwareDescription(HW_PRODUCT);
         if (model.length > 0) {
             SENTRY_LOG_DEBUG(@"Model name using HW_PRODUCT: %@", model);
             return model;

--- a/Sources/Sentry/SentryMetricProfiler.m
+++ b/Sources/Sentry/SentryMetricProfiler.m
@@ -40,7 +40,6 @@ NSString *const kSentryMetricProfilerSerializationUnitNanoJoules = @"nanojoule";
 // backtrace profiler's resolution.
 static uint64_t frequencyHz = 10;
 
-namespace {
 /**
  * @return a dictionary containing all the metric values recorded during the transaction, or @c nil
  * if there were no metrics recorded during the transaction.
@@ -49,7 +48,8 @@ SentrySerializedMetricEntry *_Nullable serializeTraceProfileMetricValuesWithNorm
     NSArray<SentryMetricReading *> *absoluteTimestampValues, NSString *unit,
     uint64_t startSystemTime, uint64_t endSystemTime)
 {
-    const auto *timestampNormalizedValues = [NSMutableArray<SentrySerializedMetricReading *> array];
+    NSMutableArray<SentrySerializedMetricReading *> *timestampNormalizedValues =
+        [NSMutableArray<SentrySerializedMetricReading *> array];
     [absoluteTimestampValues enumerateObjectsUsingBlock:^(
         SentryMetricReading *_Nonnull reading, NSUInteger idx, BOOL *_Nonnull stop) {
         // if the metric reading wasn't recorded until the transaction ended, don't include it
@@ -62,8 +62,8 @@ SentrySerializedMetricEntry *_Nullable serializeTraceProfileMetricValuesWithNorm
             return;
         }
 
-        const auto value = [NSMutableDictionary dictionary];
-        const auto relativeTimestamp
+        NSMutableDictionary *value = [NSMutableDictionary dictionary];
+        uint64_t relativeTimestamp
             = getDurationNs(startSystemTime, reading.absoluteSystemTimestamp);
         value[@"elapsed_since_start_ns"] = sentry_stringForUInt64(relativeTimestamp);
         value[@"value"] = reading.value;
@@ -85,17 +85,17 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
     if (readings.count == 0) {
         return nil;
     }
-    const auto *serializedValues = [NSMutableArray<SentrySerializedMetricReading *> array];
+    NSMutableArray<SentrySerializedMetricReading *> *serializedValues =
+        [NSMutableArray<SentrySerializedMetricReading *> array];
     [readings enumerateObjectsUsingBlock:^(
         SentryMetricReading *_Nonnull reading, NSUInteger idx, BOOL *_Nonnull stop) {
-        const auto value = [NSMutableDictionary dictionary];
+        NSMutableDictionary *value = [NSMutableDictionary dictionary];
         value[@"timestamp"] = @(reading.absoluteNSDateInterval);
         value[@"value"] = reading.value;
         [serializedValues addObject:value];
     }];
     return @ { @"unit" : unit, @"values" : serializedValues };
 }
-} // namespace
 
 @implementation SentryMetricProfiler {
     SentryDispatchSourceWrapper *_dispatchSource;
@@ -156,7 +156,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
         cpuUsage = [NSArray<SentryMetricReading *> arrayWithArray:_cpuUsage];
     }
 
-    const auto dict = [NSMutableDictionary<NSString *, id> dictionary];
+    NSMutableDictionary<NSString *, id> *dict = [NSMutableDictionary<NSString *, id> dictionary];
     if (memoryFootprint.count > 0) {
         dict[kSentryMetricProfilerSerializationKeyMemoryFootprint]
             = serializeTraceProfileMetricValuesWithNormalizedTime(memoryFootprint,
@@ -188,7 +188,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
         cpuUsage = [NSArray<SentryMetricReading *> arrayWithArray:_cpuUsage];
     }
 
-    const auto dict = [NSMutableDictionary<NSString *, id> dictionary];
+    NSMutableDictionary<NSString *, id> *dict = [NSMutableDictionary<NSString *, id> dictionary];
     if (memoryFootprint.count > 0) {
         dict[kSentryMetricProfilerSerializationKeyMemoryFootprint]
             = serializeContinuousProfileMetricReadings(
@@ -227,9 +227,9 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 
 - (void)registerSampler
 {
-    __weak auto weakSelf = self;
-    const auto intervalNs = (uint64_t)1e9 / frequencyHz;
-    const auto leewayNs = intervalNs / 2;
+    __weak typeof(self) weakSelf = self;
+    uint64_t intervalNs = (uint64_t)1e9 / frequencyHz;
+    uint64_t leewayNs = intervalNs / 2;
     _dispatchSource = [SentryDependencyContainer.sharedInstance.dispatchFactory
         sourceWithInterval:intervalNs
                     leeway:leewayNs
@@ -242,7 +242,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 - (void)recordMemoryFootprint
 {
     NSError *error;
-    const auto footprintBytes =
+    SentryRAMBytes footprintBytes =
         [SentryDependencyContainer.sharedInstance.systemWrapper memoryFootprintBytes:&error];
 
     if (error) {
@@ -258,7 +258,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 - (void)recordCPUsage
 {
     NSError *error;
-    const auto result =
+    NSNumber *result =
         [SentryDependencyContainer.sharedInstance.systemWrapper cpuUsageWithError:&error];
 
     if (error) {
@@ -278,7 +278,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 - (void)recordEnergyUsageEstimate
 {
     NSError *error;
-    const auto reading =
+    NSNumber *reading =
         [SentryDependencyContainer.sharedInstance.systemWrapper cpuEnergyUsageWithError:&error];
     if (error) {
         SENTRY_LOG_ERROR(@"Failed to read CPU energy usage: %@", error);
@@ -290,7 +290,7 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
         return;
     }
 
-    const auto value = reading.unsignedIntegerValue - previousEnergyReading.unsignedIntegerValue;
+    NSUInteger value = reading.unsignedIntegerValue - previousEnergyReading.unsignedIntegerValue;
     previousEnergyReading = reading;
 
     @synchronized(self) {
@@ -300,9 +300,10 @@ SentrySerializedMetricEntry *_Nullable serializeContinuousProfileMetricReadings(
 
 - (SentryMetricReading *)metricReadingForValue:(NSNumber *)value
 {
-    const auto reading = [[SentryMetricReading alloc] init];
+    SentryMetricReading *reading = [[SentryMetricReading alloc] init];
     reading.value = value;
-    const auto dateProvider = SentryDependencyContainer.sharedInstance.dateProvider;
+    id<SentryCurrentDateProvider> dateProvider
+        = SentryDependencyContainer.sharedInstance.dateProvider;
     reading.absoluteSystemTimestamp = dateProvider.systemTime;
     reading.absoluteNSDateInterval = dateProvider.date.timeIntervalSince1970;
     return reading;

--- a/Sources/Sentry/include/SentryProfileTimeseries.h
+++ b/Sources/Sentry/include/SentryProfileTimeseries.h
@@ -15,6 +15,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#    if defined(__cplusplus)
+extern "C" {
+#    endif
+
 NSArray<SentrySample *> *_Nullable sentry_slicedProfileSamples(
     NSArray<SentrySample *> *samples, uint64_t startSystemTime, uint64_t endSystemTime);
 
@@ -40,6 +44,10 @@ NSArray<NSDictionary<NSString *, NSNumber *> *> *sentry_sliceContinuousProfileGP
     BOOL useMostRecentFrameRate);
 
 #    endif // SENTRY_HAS_UIKIT
+
+#    if defined(__cplusplus)
+}
+#    endif
 
 NS_ASSUME_NONNULL_END
 

--- a/Sources/Sentry/include/SentryProfilerSerialization.h
+++ b/Sources/Sentry/include/SentryProfilerSerialization.h
@@ -14,6 +14,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#    if defined(__cplusplus)
+extern "C" {
+#    endif
+
 SENTRY_EXTERN SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(SentryHub *hub,
     SentryProfiler *profiler, NSDictionary<NSString *, id> *profilingData,
     SentryTransaction *transaction, NSDate *startTimestamp);
@@ -29,6 +33,10 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
 /** Alternative affordance for use by PrivateSentrySDKOnly for hybrid SDKs. */
 NSMutableDictionary<NSString *, id> *_Nullable sentry_collectProfileDataHybridSDK(
     uint64_t startSystemTime, uint64_t endSystemTime, SentryId *traceId, SentryHub *hub);
+
+#    if defined(__cplusplus)
+}
+#    endif
 
 NS_ASSUME_NONNULL_END
 

--- a/Tests/SentryTests/Helper/SentryDeviceTests.m
+++ b/Tests/SentryTests/Helper/SentryDeviceTests.m
@@ -8,8 +8,8 @@
     XCTAssert([parentString containsString:childString], @"Expected %@ to contain %@",             \
         parentString, childString)
 #define SENTRY_ASSERT_PREFIX(reportedVersion, ...)                                                 \
-    const auto acceptableVersions = @[ __VA_ARGS__ ];                                              \
-    auto foundPrefix = NO;                                                                         \
+    NSArray<NSString *> *acceptableVersions = @[ __VA_ARGS__ ];                                    \
+    BOOL foundPrefix = NO;                                                                         \
     for (NSString * prefix in acceptableVersions) {                                                \
         if ([osVersion hasPrefix:prefix]) {                                                        \
             foundPrefix = YES;                                                                     \
@@ -32,7 +32,7 @@
 
 - (void)testCPUArchitecture
 {
-    const auto arch = sentry_getCPUArchitecture();
+    NSString *arch = sentry_getCPUArchitecture();
 #if TARGET_OS_OSX
 #    if TARGET_CPU_X86_64
     // I observed this branch still being taken when running unit tests for macOS in Xcode 13.4.1 on
@@ -86,7 +86,7 @@
 
 - (void)testOSVersion
 {
-    const auto osVersion = sentry_getOSVersion();
+    NSString *osVersion = sentry_getOSVersion();
     XCTAssertNotEqual(osVersion.length, 0U);
 #if TARGET_OS_OSX
     SENTRY_ASSERT_PREFIX(osVersion, @"10.", @"11.", @"12.", @"13.", @"14.", @"15.");
@@ -103,7 +103,7 @@
 
 - (void)testOSName
 {
-    const auto osName = sentry_getOSName();
+    NSString *osName = sentry_getOSName();
 #if TARGET_OS_OSX
     SENTRY_ASSERT_EQUAL(osName, @"macOS");
 #elif TARGET_OS_MACCATALYST
@@ -132,7 +132,7 @@
 
 - (void)testDeviceModel
 {
-    const auto modelName = sentry_getDeviceModel();
+    NSString *modelName = sentry_getDeviceModel();
     XCTAssertNotEqual(modelName.length, 0U);
 #if TARGET_OS_OSX || TARGET_OS_MACCATALYST
     NSString *VMware = @"VMware";
@@ -183,7 +183,7 @@
 #if !TARGET_OS_SIMULATOR
     XCTSkip(@"Should only run on simulators.");
 #else
-    const auto modelName = sentry_getSimulatorDeviceModel();
+    NSString *modelName = sentry_getSimulatorDeviceModel();
     XCTAssertNotEqual(modelName.length, 0U);
 #    if TARGET_OS_IOS
     // We must test this branch in iOS-Swift-UITests since it must run on device, which SentryTests


### PR DESCRIPTION
SPM doesn't support mixing Swift and ObjectiveC++, this PR converts some ObjectiveC++ that imported SentrySwift into regular ObjectiveC

#skip-changelog