### PR TITLE
fix: Race condition when closing SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Set handled to false for fatal app hangs (#5514)
 - User feedback widget can now be displayed in SwiftUI apps (#5223)
 - Fix crash when SentryFileManger is nil (#5535)
+- Fix crash when capturing events at the same time `bindClient:` is called from a different thread (#5523)
 
 ### Improvements
 
@@ -14,7 +15,6 @@
 - Improve launch profile configuration management (#5318)
 - Record user for watchdog termination events (#5558)
 - Add support for dist and environment fields for termination watch (#5560)
-- Fix crash when capturing events at the same time `bindClient:nil` is called from a different thread (#5523)
 
 ## 8.53.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Improve launch profile configuration management (#5318)
 - Record user for watchdog termination events (#5558)
 - Add support for dist and environment fields for termination watch (#5560)
+- Fix crash when capturing events at the same time `bindClient:nil` is called from a different thread (#5523)
 
 ## 8.53.1
 

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1085,6 +1085,7 @@
 		FA90FAFD2E070A3B008CAAE8 /* SentryURLRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90FAFC2E070A3B008CAAE8 /* SentryURLRequestFactory.swift */; };
 		FAB359982E05D7E90083D5E3 /* SentryEventSwiftHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */; };
 		FAB3599A2E05D8080083D5E3 /* SentryEventSwiftHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */; };
+		FAC62B652E15A4100003909D /* SentrySDKThreadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC62B642E15A40C0003909D /* SentrySDKThreadTests.swift */; };
 		FAEC270E2DF3526000878871 /* SentryUserFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */; };
 		FAEC273D2DF3933A00878871 /* NSData+Unzip.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEC273C2DF3933200878871 /* NSData+Unzip.m */; };
 /* End PBXBuildFile section */
@@ -2349,6 +2350,7 @@
 		FA90FAFC2E070A3B008CAAE8 /* SentryURLRequestFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryURLRequestFactory.swift; sourceTree = "<group>"; };
 		FAB359972E05D7E90083D5E3 /* SentryEventSwiftHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEventSwiftHelper.h; path = include/SentryEventSwiftHelper.h; sourceTree = "<group>"; };
 		FAB359992E05D8080083D5E3 /* SentryEventSwiftHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryEventSwiftHelper.m; sourceTree = "<group>"; };
+		FAC62B642E15A40C0003909D /* SentrySDKThreadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKThreadTests.swift; sourceTree = "<group>"; };
 		FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUserFeedback.swift; sourceTree = "<group>"; };
 		FAEC273C2DF3933200878871 /* NSData+Unzip.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+Unzip.m"; sourceTree = "<group>"; };
 		FAEC273E2DF393E000878871 /* NSData+Unzip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+Unzip.h"; sourceTree = "<group>"; };
@@ -2897,6 +2899,7 @@
 				7B0A54552523178700A71716 /* SentryScopeSwiftTests.swift */,
 				D8918B212849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift */,
 				7BA8409F24A1EC6E00B718AA /* SentrySDKTests.swift */,
+				FAC62B642E15A40C0003909D /* SentrySDKThreadTests.swift */,
 				7B0002332477F52D0035FEF1 /* SentrySessionTests.swift */,
 				8E70B10025CB8695002B3155 /* SentrySpanIdTests.swift */,
 				8ED3D305264DFE700049393B /* SwiftDescriptorTests.swift */,
@@ -5684,6 +5687,7 @@
 				63FE722420DA66EC00CDBAE8 /* SentryCrashMonitor_NSException_Tests.m in Sources */,
 				7B5AB65D27E48E5200F1D1BA /* TestThreadInspector.swift in Sources */,
 				7BF9EF742722A85B00B5BBEF /* SentryClassRegistrator.m in Sources */,
+				FAC62B652E15A4100003909D /* SentrySDKThreadTests.swift in Sources */,
 				D82915632C85EF0C00A6CDD4 /* SentryViewPhotographerTests.swift in Sources */,
 				D8DBE0CA2C0E093000FAB1FD /* SentryTouchTrackerTests.swift in Sources */,
 				D8F67AF42BE10F9600C9197B /* SentryUIRedactBuilderTests.swift in Sources */,

--- a/Tests/SentryTests/SentrySDKThreadTests.swift
+++ b/Tests/SentryTests/SentrySDKThreadTests.swift
@@ -3,31 +3,32 @@ import XCTest
 
 final class SentrySDKThreadTests: XCTestCase {
     func testRaceWhenBindingClient() {
-        for _ in 0..<10_000 {
-            SentrySDK.start(options: .init())
+
+        let options = Options()
+        let sut = SentryHub(client: SentryClient(options: options), andScope: nil)
+
+        for _ in 0..<100 {
+
             let exp = expectation(description: "wait")
-            let warmupExpectation = expectation(description: "warmup")
-            let warmupCount = 100
-            warmupExpectation.expectedFulfillmentCount = warmupCount
+            exp.expectedFulfillmentCount = 100
+
             let queue = DispatchQueue(label: "com.sentry.test_client", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
-            for i in 0..<1_000 {
-                exp.expectedFulfillmentCount += 1
+
+            for _ in 0..<100 {
                 queue.async {
-                    SentrySDK.currentHub().capture(event: .init())
+                    sut.bindClient(SentryClient(options: options))
+                    sut.capture(message: "Test message")
                     exp.fulfill()
-                    if i < warmupCount {
-                        warmupExpectation.fulfill()
-                    }
                 }
             }
-            exp.expectedFulfillmentCount -= 1
-            
+
             queue.activate()
-            
-            wait(for: [warmupExpectation])
-            SentrySDK.currentHub().bindClient(nil)
-            
-            wait(for: [exp])
+
+            for _ in 0..<100 {
+                sut.bindClient(nil)
+            }
+
+            wait(for: [exp], timeout: 1.0)
         }
     }
 }

--- a/Tests/SentryTests/SentrySDKThreadTests.swift
+++ b/Tests/SentryTests/SentrySDKThreadTests.swift
@@ -1,0 +1,33 @@
+@testable import Sentry
+import XCTest
+
+final class SentrySDKThreadTests: XCTestCase {
+    func testRaceWhenBindingClient() {
+        for _ in 0..<10_000 {
+            SentrySDK.start(options: .init())
+            let exp = expectation(description: "wait")
+            let warmupExpectation = expectation(description: "warmup")
+            let warmupCount = 100
+            warmupExpectation.expectedFulfillmentCount = warmupCount
+            let queue = DispatchQueue(label: "com.sentry.test_client", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+            for i in 0..<1_000 {
+                exp.expectedFulfillmentCount += 1
+                queue.async {
+                    SentrySDK.currentHub().capture(event: .init())
+                    exp.fulfill()
+                    if i < warmupCount {
+                        warmupExpectation.fulfill()
+                    }
+                }
+            }
+            exp.expectedFulfillmentCount -= 1
+            
+            queue.activate()
+            
+            wait(for: [warmupExpectation])
+            SentrySDK.currentHub().bindClient(nil)
+            
+            wait(for: [exp])
+        }
+    }
+}


### PR DESCRIPTION
We have a race condition in the `SentryClient` property of `SentryHub` that is causing flaky unit tests. When the tests are torn down we call `bindClient:nil` (from `[SentrySDK close]`) This sets _client to nil, but the client property can also be accessed by background threads (in particular from `[SentryHub captureReplayEvent]`). This can lead to messaging a dangling pointer. This fix makes the client property atomic, since it is accessed/read from multiple threads.

Fixes https://github.com/getsentry/sentry-cocoa/issues/5506

#skip-changelog