### PR TITLE
Fix prewarmed swiftui tests

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI-UITests/LaunchUITests.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI-UITests/LaunchUITests.swift
@@ -1,3 +1,4 @@
+import SentrySampleUITestShared
 import XCTest
 
 class LaunchUITests: XCTestCase {
@@ -8,8 +9,7 @@ class LaunchUITests: XCTestCase {
     }
 
     func testTransactionSpan() {
-        let app = XCUIApplication()
-        app.launch()
+        let app = newAppSession()
         
         let transactionName = app.staticTexts["TRANSACTION_NAME"]
         let transactionId = app.staticTexts["TRANSACTION_ID"]
@@ -28,8 +28,7 @@ class LaunchUITests: XCTestCase {
     }
 
     func testNoNewTransactionForSecondCallToBody() {
-        let app = XCUIApplication()
-        app.launch()
+        let app = newAppSession()
 
         app.buttons["Form Screen"].tap()
 
@@ -40,10 +39,32 @@ class LaunchUITests: XCTestCase {
     }
     
     func testTTID_TTFD() {
-        let app = XCUIApplication()
-        app.launch()
+        let app = newAppSession()
+        app.safelyLaunch()
         app.buttons["Show TTD"].tap()
         
         XCTAssertEqual(app.staticTexts["TTDInfo"].label, "TTID and TTFD found")
     }
+  
+  func newAppSession() -> XCUIApplication {
+      let app = XCUIApplication()
+      app.launchEnvironment["--io.sentry.ui-test.test-name"] = name
+      app.launchArguments.append("--disable-spotlight")
+      return app
+  }
+}
+
+extension XCUIApplication {
+  public func safelyLaunch() {
+    // Calling activate() and then launch() effectively launches the app twice, interfering with
+    // local debugging. Only call activate if there isn't a debugger attached, which is a decent
+    // proxy for whether this is running in CI.
+    if !isDebugging() {
+      // App prewarming can sometimes cause simulators to get stuck in UI tests, activating them
+      // before launching clears any prewarming state.
+      activate()
+    }
+    
+    launch()
+  }
 }

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI.yml
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI.yml
@@ -49,6 +49,8 @@ targets:
   iOS-SwiftUI-UITests:
     type: bundle.ui-testing
     platform: auto
+    dependencies:
+      - target: SentrySampleShared/SentrySampleUITestShared
     sources:
       - iOS-SwiftUI-UITests
     configFiles:


### PR DESCRIPTION
These tests flaked on me, and I noticed they didn't have our fixes for prewarmed app launches since those were in "SentrySwift" and these tests are for "SentrySwiftUI". I tried to move them to SentrySampleUITestShared, but it looks like that framework can't import XCTest so I just copied it here 

#skip-changelog