### PR TITLE
ci: Add timeout for run-swiftui-crash-test

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -52,6 +52,7 @@ jobs:
   run-swiftui-crash-test:
     name: Run SwiftUI Crash Test
     runs-on: macos-15
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The test ran for 6h in CI. If the test isn't finished after 10 minutes we can cancel the job.

The job took 6 hourse here: https://github.com/getsentry/sentry-cocoa/actions/runs/15985146703/job/45087995982

The next step is to find out why it timed out and fix it.

#skip-changelog