### PR TITLE
feat: Record user for watchdog termination events

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1019,11 +1019,22 @@
 		F45243892DE65968003E8F50 /* ExceptionCatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = F45243872DE65968003E8F50 /* ExceptionCatcher.m */; };
 		F452438A2DE65968003E8F50 /* ExceptionCatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = F45243862DE65968003E8F50 /* ExceptionCatcher.h */; };
 		F452438C2DE65BC0003E8F50 /* SentryUseNSExceptionCallstackWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F452438B2DE65BC0003E8F50 /* SentryUseNSExceptionCallstackWrapper.h */; };
+		F494D2D62E0F316D009B97DD /* SentryScopeUserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2D52E0F316D009B97DD /* SentryScopeUserPersistentStore.swift */; };
+		F494D2D82E0F33CF009B97DD /* SentryUser+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = F494D2D72E0F33C7009B97DD /* SentryUser+Private.h */; };
+		F494D2DA2E0F377C009B97DD /* SentryScopeUserPersistentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2D92E0F3771009B97DD /* SentryScopeUserPersistentStoreTests.swift */; };
+		F494D2F62E0F3A55009B97DD /* SentryWatchdogTerminationUserProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2F52E0F3A4E009B97DD /* SentryWatchdogTerminationUserProcessor.swift */; };
+		F494D2F82E0F3AC9009B97DD /* TestSentryScopeUserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2F72E0F3ABF009B97DD /* TestSentryScopeUserPersistentStore.swift */; };
+		F494D2FA2E0F3B12009B97DD /* SentryWatchdogTerminationUserProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2F92E0F3B12009B97DD /* SentryWatchdogTerminationUserProcessorTests.swift */; };
+		F494D2FC2E12E87E009B97DD /* TestSentryWatchdogTerminationUserProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2FB2E12E87E009B97DD /* TestSentryWatchdogTerminationUserProcessor.swift */; };
+		F494D2FE2E12E8BF009B97DD /* TestSentryWatchdogTerminationUserProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2FD2E12E8BF009B97DD /* TestSentryWatchdogTerminationUserProcessorTests.swift */; };
+		F494D3002E130CE2009B97DD /* SentryScopeBasePersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D2FF2E130CE2009B97DD /* SentryScopeBasePersistentStore.swift */; };
+		F494D3022E131454009B97DD /* SentryScopeBasePersistentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F494D3012E131454009B97DD /* SentryScopeBasePersistentStoreTests.swift */; };
 		F49D41982DEA27AF00D9244E /* SentryUseNSExceptionCallstackWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49D41972DEA27AF00D9244E /* SentryUseNSExceptionCallstackWrapperTests.swift */; };
 		F49D419A2DEA2FB000D9244E /* SentryCrashExceptionApplicationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49D41992DEA2FB000D9244E /* SentryCrashExceptionApplicationTests.swift */; };
 		F49D419C2DEA30C300D9244E /* SentryCrashExceptionApplicationHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F49D419B2DEA30B800D9244E /* SentryCrashExceptionApplicationHelper.h */; };
 		F49D419E2DEA3D0600D9244E /* SentryCrashExceptionApplicationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = F49D419D2DEA3D0300D9244E /* SentryCrashExceptionApplicationHelper.m */; };
 		F4AACD612E01ACE800DDDD1E /* SentryCrashDynamicLinkerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F4AACD602E01ACE800DDDD1E /* SentryCrashDynamicLinkerTests.m */; };
+		F4E3DBC52E135A8D0093CB80 /* SentryWatchdogTerminationBaseProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E3DBC42E135A8D0093CB80 /* SentryWatchdogTerminationBaseProcessor.swift */; };
 		FA034AC82DD3DB4900FE3107 /* SentryIntegrationProtocol.h in Headers */ = {isa = PBXBuildFile; fileRef = FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		FA3734822E0EEA670091EF24 /* SentryScreenshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3734812E0EEA670091EF24 /* SentryScreenshot.swift */; };
 		FA3734842E0F086C0091EF24 /* SentryDependencyContainerSwiftHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3734832E0F07A20091EF24 /* SentryDependencyContainerSwiftHelper.h */; };
@@ -2273,11 +2284,22 @@
 		F45243862DE65968003E8F50 /* ExceptionCatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExceptionCatcher.h; sourceTree = "<group>"; };
 		F45243872DE65968003E8F50 /* ExceptionCatcher.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ExceptionCatcher.m; sourceTree = "<group>"; };
 		F452438B2DE65BC0003E8F50 /* SentryUseNSExceptionCallstackWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUseNSExceptionCallstackWrapper.h; path = include/SentryUseNSExceptionCallstackWrapper.h; sourceTree = "<group>"; };
+		F494D2D52E0F316D009B97DD /* SentryScopeUserPersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScopeUserPersistentStore.swift; sourceTree = "<group>"; };
+		F494D2D72E0F33C7009B97DD /* SentryUser+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryUser+Private.h"; path = "include/SentryUser+Private.h"; sourceTree = "<group>"; };
+		F494D2D92E0F3771009B97DD /* SentryScopeUserPersistentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScopeUserPersistentStoreTests.swift; sourceTree = "<group>"; };
+		F494D2F52E0F3A4E009B97DD /* SentryWatchdogTerminationUserProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryWatchdogTerminationUserProcessor.swift; sourceTree = "<group>"; };
+		F494D2F72E0F3ABF009B97DD /* TestSentryScopeUserPersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryScopeUserPersistentStore.swift; sourceTree = "<group>"; };
+		F494D2F92E0F3B12009B97DD /* SentryWatchdogTerminationUserProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryWatchdogTerminationUserProcessorTests.swift; sourceTree = "<group>"; };
+		F494D2FB2E12E87E009B97DD /* TestSentryWatchdogTerminationUserProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryWatchdogTerminationUserProcessor.swift; sourceTree = "<group>"; };
+		F494D2FD2E12E8BF009B97DD /* TestSentryWatchdogTerminationUserProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSentryWatchdogTerminationUserProcessorTests.swift; sourceTree = "<group>"; };
+		F494D2FF2E130CE2009B97DD /* SentryScopeBasePersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScopeBasePersistentStore.swift; sourceTree = "<group>"; };
+		F494D3012E131454009B97DD /* SentryScopeBasePersistentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScopeBasePersistentStoreTests.swift; sourceTree = "<group>"; };
 		F49D41972DEA27AF00D9244E /* SentryUseNSExceptionCallstackWrapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUseNSExceptionCallstackWrapperTests.swift; sourceTree = "<group>"; };
 		F49D41992DEA2FB000D9244E /* SentryCrashExceptionApplicationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCrashExceptionApplicationTests.swift; sourceTree = "<group>"; };
 		F49D419B2DEA30B800D9244E /* SentryCrashExceptionApplicationHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryCrashExceptionApplicationHelper.h; path = include/SentryCrashExceptionApplicationHelper.h; sourceTree = "<group>"; };
 		F49D419D2DEA3D0300D9244E /* SentryCrashExceptionApplicationHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashExceptionApplicationHelper.m; sourceTree = "<group>"; };
 		F4AACD602E01ACE800DDDD1E /* SentryCrashDynamicLinkerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryCrashDynamicLinkerTests.m; sourceTree = "<group>"; };
+		F4E3DBC42E135A8D0093CB80 /* SentryWatchdogTerminationBaseProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryWatchdogTerminationBaseProcessor.swift; sourceTree = "<group>"; };
 		FA034AC72DD3DB4900FE3107 /* SentryIntegrationProtocol.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryIntegrationProtocol.h; path = Public/SentryIntegrationProtocol.h; sourceTree = "<group>"; };
 		FA3734812E0EEA670091EF24 /* SentryScreenshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryScreenshot.swift; sourceTree = "<group>"; };
 		FA3734832E0F07A20091EF24 /* SentryDependencyContainerSwiftHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDependencyContainerSwiftHelper.h; path = include/SentryDependencyContainerSwiftHelper.h; sourceTree = "<group>"; };
@@ -2564,6 +2586,7 @@
 				639FCF9A1EBC7F9500778193 /* SentryThread.h */,
 				639FCF9B1EBC7F9500778193 /* SentryThread.mm */,
 				639FCFAA1EBC811400778193 /* SentryUser.h */,
+				F494D2D72E0F33C7009B97DD /* SentryUser+Private.h */,
 				639FCFAB1EBC811400778193 /* SentryUser.m */,
 				843FB3212D0CD04D00558F18 /* SentryUserAccess.h */,
 				843FB3222D0CD04D00558F18 /* SentryUserAccess.m */,
@@ -3624,6 +3647,8 @@
 				D434DB0B2DE09CE700DD6F82 /* TestSentryWatchdogTerminationBreadcrumbProcessorTests.swift */,
 				D452FE722DDC8DB700AFF56F /* TestSentryWatchdogTerminationContextProcessor.swift */,
 				D434DB0F2DE09D0300DD6F82 /* TestSentryWatchdogTerminationContextProcessorTests.swift */,
+				F494D2FB2E12E87E009B97DD /* TestSentryWatchdogTerminationUserProcessor.swift */,
+				F494D2FD2E12E8BF009B97DD /* TestSentryWatchdogTerminationUserProcessorTests.swift */,
 			);
 			path = WatchdogTerminations;
 			sourceTree = "<group>";
@@ -4016,7 +4041,9 @@
 		D44DB3802DDCCF1700174EF4 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				F494D2FF2E130CE2009B97DD /* SentryScopeBasePersistentStore.swift */,
 				D44DB37E2DDCC8F200174EF4 /* SentryScopeContextPersistentStore.swift */,
+				F494D2D52E0F316D009B97DD /* SentryScopeUserPersistentStore.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -4041,7 +4068,9 @@
 		D452FCBD2DDB6FC200AFF56F /* Processors */ = {
 			isa = PBXGroup;
 			children = (
+				F4E3DBC42E135A8D0093CB80 /* SentryWatchdogTerminationBaseProcessor.swift */,
 				D452FCBE2DDB6FCA00AFF56F /* SentryWatchdogTerminationContextProcessor.swift */,
+				F494D2F52E0F3A4E009B97DD /* SentryWatchdogTerminationUserProcessor.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -4051,6 +4080,7 @@
 			children = (
 				D452FE702DDC8C4400AFF56F /* SentryWatchdogTerminationBreadcrumbProcessorTests.swift */,
 				D452FE6C2DDC873900AFF56F /* SentryWatchdogTerminationContextProcessorTests.swift */,
+				F494D2F92E0F3B12009B97DD /* SentryWatchdogTerminationUserProcessorTests.swift */,
 			);
 			path = Processors;
 			sourceTree = "<group>";
@@ -4078,8 +4108,11 @@
 		D480F9D72DE47A40009A0594 /* Persistence */ = {
 			isa = PBXGroup;
 			children = (
+				F494D3012E131454009B97DD /* SentryScopeBasePersistentStoreTests.swift */,
+				F494D2D92E0F3771009B97DD /* SentryScopeUserPersistentStoreTests.swift */,
 				D480F9DA2DE47AEB009A0594 /* SentryScopeContextPersistentStoreTests.swift */,
 				D480F9D82DE47A48009A0594 /* TestSentryScopeContextPersistentStore.swift */,
+				F494D2F72E0F3ABF009B97DD /* TestSentryScopeUserPersistentStore.swift */,
 			);
 			path = Persistence;
 			sourceTree = "<group>";
@@ -4898,6 +4931,7 @@
 				638DC9A01EBC6B6400A66E41 /* SentryRequestOperation.h in Headers */,
 				7B7A599526B692540060A676 /* SentryScreenFrames.h in Headers */,
 				6344DDB01EC308E400D9160D /* SentryCrashInstallationReporter.h in Headers */,
+				F494D2D82E0F33CF009B97DD /* SentryUser+Private.h in Headers */,
 				8E25C95725F836EE00DC215B /* SentryRandom.h in Headers */,
 				7B5CAF7527F5A67C00ED0DB6 /* SentryNSURLRequestBuilder.h in Headers */,
 				63FE70ED20DA4C1000CDBAE8 /* SentryCrashMonitor_NSException.h in Headers */,
@@ -5581,6 +5615,7 @@
 				63FE710F20DA4C1000CDBAE8 /* SentryCrashNSErrorUtil.m in Sources */,
 				8ECC674925C23A20000E2BF6 /* SentrySpanId.m in Sources */,
 				6344DDB51EC309E000D9160D /* SentryCrashReportSink.m in Sources */,
+				F494D2F62E0F3A55009B97DD /* SentryWatchdogTerminationUserProcessor.swift in Sources */,
 				D43B26D62D70964C007747FD /* SentrySpanOperation.m in Sources */,
 				8EAE9806261E87120073B6B3 /* SentryUIViewControllerPerformanceTracker.m in Sources */,
 				D81988C72BEC18E20020E36C /* SentryRRWebVideoEvent.swift in Sources */,
@@ -5592,6 +5627,7 @@
 				7BC9A20428F4166D001E7C4C /* SentryMeasurementValue.m in Sources */,
 				D859696B27BECD8F0036A46E /* SentryCoreDataTrackingIntegration.m in Sources */,
 				7BD86EC7264A641D005439DB /* SentrySysctl.m in Sources */,
+				F4E3DBC52E135A8D0093CB80 /* SentryWatchdogTerminationBaseProcessor.swift in Sources */,
 				84281C432A578E5600EE88F2 /* SentryProfilerState.mm in Sources */,
 				D859697327BECDD20036A46E /* SentryCoreDataSwizzling.m in Sources */,
 				639889BD1EDED18400EA7442 /* SentrySwizzle.m in Sources */,
@@ -5612,6 +5648,7 @@
 				8482FA9C2DD7C397000E9283 /* SentryFeedbackAPI.m in Sources */,
 				7BC9A20628F41781001E7C4C /* SentryMeasurementUnit.m in Sources */,
 				63FE71A020DA4C1100CDBAE8 /* SentryCrashInstallation.m in Sources */,
+				F494D2D62E0F316D009B97DD /* SentryScopeUserPersistentStore.swift in Sources */,
 				63FE713520DA4C1100CDBAE8 /* SentryCrashMemory.c in Sources */,
 				629194A92D51F976000F7C6B /* SentryDebugMetaCodable.swift in Sources */,
 				63FE714520DA4C1100CDBAE8 /* SentryCrashObjC.c in Sources */,
@@ -5624,6 +5661,7 @@
 				620379DD2AFE1432005AC0C1 /* SentryBuildAppStartSpans.m in Sources */,
 				6292585F2DAFA8290049388F /* SentryCrashMach-O.c in Sources */,
 				7B77BE3727EC8460003C9020 /* SentryDiscardReasonMapper.m in Sources */,
+				F494D3002E130CE2009B97DD /* SentryScopeBasePersistentStore.swift in Sources */,
 				63FE712520DA4C1000CDBAE8 /* SentryCrashSignalInfo.c in Sources */,
 				63FE70F320DA4C1000CDBAE8 /* SentryCrashMonitor_Signal.c in Sources */,
 				D859696F27BECDA20036A46E /* SentryCoreDataTracker.m in Sources */,
@@ -5650,6 +5688,7 @@
 				7B5AB65D27E48E5200F1D1BA /* TestThreadInspector.swift in Sources */,
 				7BF9EF742722A85B00B5BBEF /* SentryClassRegistrator.m in Sources */,
 				D82915632C85EF0C00A6CDD4 /* SentryViewPhotographerTests.swift in Sources */,
+				F494D2FE2E12E8BF009B97DD /* TestSentryWatchdogTerminationUserProcessorTests.swift in Sources */,
 				D8DBE0CA2C0E093000FAB1FD /* SentryTouchTrackerTests.swift in Sources */,
 				D8F67AF42BE10F9600C9197B /* SentryUIRedactBuilderTests.swift in Sources */,
 				63B819141EC352A7002FDF4C /* SentryInterfacesTests.m in Sources */,
@@ -5668,6 +5707,7 @@
 				7BE3C78724472E9800A38442 /* TestRequestManager.swift in Sources */,
 				7BD4E8E627FD84480086C410 /* TestFileManagerDelegate.swift in Sources */,
 				63FE722220DA66EC00CDBAE8 /* SentryCrashJSONCodec_Tests.m in Sources */,
+				F494D2DA2E0F377C009B97DD /* SentryScopeUserPersistentStoreTests.swift in Sources */,
 				7B0A5452252311CE00A71716 /* SentryBreadcrumbTests.swift in Sources */,
 				7BE3C7752445C82300A38442 /* SentryCurrentDateTests.swift in Sources */,
 				7B3398672459C4AE00BD9C96 /* SentryEnvelopeRateLimitTests.swift in Sources */,
@@ -5694,6 +5734,7 @@
 				D8FFE50C2703DBB400607131 /* SwizzlingCallTests.swift in Sources */,
 				7BFAA6E7297AA16A00E7E02E /* SentryCrashMonitor_CppException_Tests.mm in Sources */,
 				9286059929A50BAB00F96038 /* SentryGeoTests.swift in Sources */,
+				F494D2FA2E0F3B12009B97DD /* SentryWatchdogTerminationUserProcessorTests.swift in Sources */,
 				621655662DB12A8900810504 /* SentryCrashMach-OTests.m in Sources */,
 				D8B76B0828081461000A58C4 /* TestSentryScreenShot.swift in Sources */,
 				A8AFFCD22907DA7600967CD7 /* SentryHttpStatusCodeRangeTests.swift in Sources */,
@@ -5710,6 +5751,7 @@
 				D8137D54272B53070082656C /* TestSentrySpan.m in Sources */,
 				7BECF432261463E600D9826E /* SentryMechanismMetaTests.swift in Sources */,
 				7BE8E8462593313500C4DA1F /* SentryAttachment+Equality.m in Sources */,
+				F494D3022E131454009B97DD /* SentryScopeBasePersistentStoreTests.swift in Sources */,
 				D80694C72B7CD22B00B820E6 /* SentryReplayRecordingTests.swift in Sources */,
 				63FE721F20DA66EC00CDBAE8 /* SentryCrashSignalInfo_Tests.m in Sources */,
 				D452FE712DDC8C4400AFF56F /* SentryWatchdogTerminationBreadcrumbProcessorTests.swift in Sources */,
@@ -5825,6 +5867,7 @@
 				0A2D7BBA29152CBF008727AF /* SentryWatchdogTerminationScopeObserverTests.swift in Sources */,
 				7BD4BD4B27EB2DC20071F4FF /* SentryDiscardedEventTests.swift in Sources */,
 				63FE721A20DA66EC00CDBAE8 /* SentryCrashSysCtl_Tests.m in Sources */,
+				F494D2F82E0F3AC9009B97DD /* TestSentryScopeUserPersistentStore.swift in Sources */,
 				7B88F30424BC8E6500ADF90A /* SentrySerializationTests.swift in Sources */,
 				843FB3432D156B9900558F18 /* SentryFeedbackTests.swift in Sources */,
 				623E16C32D6C57C000CF1625 /* SentryANRTypeTests.swift in Sources */,
@@ -5904,6 +5947,7 @@
 				D452FE6D2DDC873A00AFF56F /* SentryWatchdogTerminationContextProcessorTests.swift in Sources */,
 				7BAF3DD2243DD05C008A5414 /* SentryTransportInitializerTests.swift in Sources */,
 				7B68D93625FF5F1A0082D139 /* SentryAppState+Equality.m in Sources */,
+				F494D2FC2E12E87E009B97DD /* TestSentryWatchdogTerminationUserProcessor.swift in Sources */,
 				7B5CAF7E27F5AD3500ED0DB6 /* TestNSURLRequestBuilder.m in Sources */,
 				D467125E2DCCFF2500D4074A /* SentryReplayOptionsObjcTests.m in Sources */,
 				7BF69E072987D1FE002EBCA4 /* SentryCrashDoctorTests.swift in Sources */,

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -397,6 +397,13 @@ static BOOL isInitialializingDependencyContainer = NO;
         [[SentryScopeContextPersistentStore alloc] initWithFileManager:self.fileManager]);
 }
 
+- (SentryScopeUserPersistentStore *)
+    scopeUserPersistentStore SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+{
+    SENTRY_LAZY_INIT(_scopeUserPersistentStore,
+        [[SentryScopeUserPersistentStore alloc] initWithFileManager:self.fileManager]);
+}
+
 - (SentryDebugImageProvider *)debugImageProvider SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     // SentryDebugImageProvider is public, so we can't initialize the dependency in
@@ -416,7 +423,8 @@ static BOOL isInitialializingDependencyContainer = NO;
         initWithBreadcrumbProcessor:
             [self
                 getWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs:options.maxBreadcrumbs]
-                   contextProcessor:self.watchdogTerminationContextProcessor];
+                   contextProcessor:self.watchdogTerminationContextProcessor
+                      userProcessor:self.watchdogTerminationUserProcessor];
 }
 
 - (SentryWatchdogTerminationBreadcrumbProcessor *)
@@ -429,16 +437,28 @@ static BOOL isInitialializingDependencyContainer = NO;
                    fileManager:self.fileManager];
 }
 
-- (SentryWatchdogTerminationContextProcessor *)
+- (SentryWatchdogTerminationContextProcessorWrapper *)
     watchdogTerminationContextProcessor SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_watchdogTerminationContextProcessor,
-        [[SentryWatchdogTerminationContextProcessor alloc]
+        [[SentryWatchdogTerminationContextProcessorWrapper alloc]
             initWithDispatchQueueWrapper:
                 [self.dispatchFactory
                     createUtilityQueue:"io.sentry.watchdog-termination-tracking.context-processor"
                       relativePriority:0]
                        scopeContextStore:self.scopeContextPersistentStore])
+}
+
+- (SentryWatchdogTerminationUserProcessorWrapper *)
+    watchdogTerminationUserProcessor SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+{
+    SENTRY_LAZY_INIT(_watchdogTerminationUserProcessor,
+        [[SentryWatchdogTerminationUserProcessorWrapper alloc]
+            initWithDispatchQueueWrapper:
+                [self.dispatchFactory
+                    createUtilityQueue:"io.sentry.watchdog-termination-tracking.user-processor"
+                      relativePriority:0]
+                          scopeUserStore:self.scopeUserPersistentStore])
 }
 #endif
 

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -242,6 +242,8 @@ static NSDate *_Nullable startTimestamp = nil;
     [newClient.fileManager moveBreadcrumbsToPreviousBreadcrumbs];
     [SentryDependencyContainer.sharedInstance
             .scopeContextPersistentStore moveCurrentFileToPreviousFile];
+    [SentryDependencyContainer.sharedInstance
+            .scopeUserPersistentStore moveCurrentFileToPreviousFile];
 
     SentryScope *scope
         = options.initialScope([[SentryScope alloc] initWithMaxBreadcrumbs:options.maxBreadcrumbs]);

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -24,26 +24,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (atomic, strong) NSMutableDictionary<NSString *, NSString *> *tagDictionary;
 
-/**
- * Set global extra -> these will be sent with every event
- */
-@property (atomic, strong) NSMutableDictionary<NSString *, id> *extraDictionary;
-
-/**
- * This distribution of the application.
- */
-@property (atomic, copy) NSString *_Nullable distString;
-
-/**
- * Set the fingerprint of an event to determine the grouping
- */
-@property (atomic, strong) NSMutableArray<NSString *> *fingerprintArray;
-
-/**
- * SentryLevel of the event
- */
-@property (atomic) enum SentryLevel levelEnum;
-
 @property (atomic) NSUInteger maxBreadcrumbs;
 @property (atomic) NSUInteger currentBreadcrumbIndex;
 

--- a/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
+++ b/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
@@ -11,7 +11,8 @@
 @interface SentryWatchdogTerminationScopeObserver ()
 
 @property (nonatomic, strong) SentryWatchdogTerminationBreadcrumbProcessor *breadcrumbProcessor;
-@property (nonatomic, strong) SentryWatchdogTerminationContextProcessor *contextProcessor;
+@property (nonatomic, strong) SentryWatchdogTerminationContextProcessorWrapper *contextProcessor;
+@property (nonatomic, strong) SentryWatchdogTerminationUserProcessorWrapper *userProcessor;
 
 @end
 
@@ -19,11 +20,13 @@
 
 - (instancetype)
     initWithBreadcrumbProcessor:(SentryWatchdogTerminationBreadcrumbProcessor *)breadcrumbProcessor
-               contextProcessor:(SentryWatchdogTerminationContextProcessor *)contextProcessor;
+               contextProcessor:(SentryWatchdogTerminationContextProcessorWrapper *)contextProcessor
+                  userProcessor:(SentryWatchdogTerminationUserProcessorWrapper *)userProcessor
 {
     if (self = [super init]) {
         self.breadcrumbProcessor = breadcrumbProcessor;
         self.contextProcessor = contextProcessor;
+        self.userProcessor = userProcessor;
     }
 
     return self;
@@ -35,6 +38,7 @@
 {
     [self.breadcrumbProcessor clear];
     [self.contextProcessor clear];
+    [self.userProcessor clear];
 }
 
 - (void)addSerializedBreadcrumb:(NSDictionary *)crumb
@@ -84,7 +88,7 @@
 
 - (void)setUser:(nullable SentryUser *)user
 {
-    // Left blank on purpose
+    [self.userProcessor setUser:user];
 }
 
 - (void)setTraceContext:(nullable NSDictionary<NSString *, id> *)traceContext

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -23,6 +23,7 @@
 @property (nonatomic, strong) SentryAppStateManager *appStateManager;
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryScopeContextPersistentStore *scopeContextStore;
+@property (nonatomic, strong) SentryScopeUserPersistentStore *scopeUserStore;
 
 @end
 
@@ -34,6 +35,7 @@
            dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                     fileManager:(SentryFileManager *)fileManager
               scopeContextStore:(SentryScopeContextPersistentStore *)scopeContextStore
+                 scopeUserStore:(SentryScopeUserPersistentStore *)scopeUserStore
 {
     if (self = [super init]) {
         self.options = options;
@@ -42,6 +44,7 @@
         self.dispatchQueue = dispatchQueueWrapper;
         self.fileManager = fileManager;
         self.scopeContextStore = scopeContextStore;
+        self.scopeUserStore = scopeUserStore;
     }
     return self;
 }
@@ -57,6 +60,10 @@
 
             [self addBreadcrumbsToEvent:event];
             [self addContextToEvent:event];
+            event.user = [self.scopeUserStore readPreviousUserFromDisk];
+            // We intentionally skip reading level from the scope because all watchdog terminations
+            // are fatal
+            // TODO: Itay - Should we add trace context here?
 
             SentryException *exception =
                 [[SentryException alloc] initWithValue:SentryWatchdogTerminationExceptionValue

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -12,6 +12,7 @@
 #    import <SentryHub.h>
 #    import <SentryNSProcessInfoWrapper.h>
 #    import <SentryOptions+Private.h>
+#    import <SentryPropagationContext.h>
 #    import <SentrySDK+Private.h>
 #    import <SentrySwift.h>
 #    import <SentryWatchdogTerminationBreadcrumbProcessor.h>
@@ -68,13 +69,16 @@ NS_ASSUME_NONNULL_BEGIN
                                                 appStateManager:appStateManager];
     SentryScopeContextPersistentStore *scopeContextStore =
         [SentryDependencyContainer.sharedInstance scopeContextPersistentStore];
+    SentryScopeUserPersistentStore *scopeUserStore =
+        [SentryDependencyContainer.sharedInstance scopeUserPersistentStore];
 
     self.tracker = [[SentryWatchdogTerminationTracker alloc] initWithOptions:options
                                                     watchdogTerminationLogic:logic
                                                              appStateManager:appStateManager
                                                         dispatchQueueWrapper:dispatchQueueWrapper
                                                                  fileManager:fileManager
-                                                           scopeContextStore:scopeContextStore];
+                                                           scopeContextStore:scopeContextStore
+                                                              scopeUserStore:scopeUserStore];
 
     [self.tracker start];
 
@@ -96,6 +100,14 @@ NS_ASSUME_NONNULL_BEGIN
         // Sync the current context to the observer to capture context modifications that happened
         // before installation.
         [scopeObserver setContext:outerScope.contextDictionary];
+        [scopeObserver setUser:outerScope.userObject];
+        [scopeObserver setTags:outerScope.tags];
+        [scopeObserver setLevel:outerScope.levelEnum];
+        [scopeObserver setExtras:outerScope.extraDictionary];
+        [scopeObserver setDist:outerScope.distString];
+        [scopeObserver setFingerprint:outerScope.fingerprintArray];
+        [scopeObserver setEnvironment:outerScope.environmentString];
+        [scopeObserver setTraceContext:[outerScope.propagationContext traceContextForEvent]];
     }];
 
     return YES;

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -23,6 +23,7 @@
 @class SentryThreadInspector;
 @class SentryFileIOTracker;
 @class SentryScopeContextPersistentStore;
+@class SentryScopeUserPersistentStore;
 @class SentryOptions;
 @class SentrySessionTracker;
 @class SentryGlobalEventProcessor;
@@ -45,8 +46,9 @@
 @class SentryViewHierarchyProvider;
 @class SentryUIViewControllerPerformanceTracker;
 @class SentryWatchdogTerminationScopeObserver;
-@class SentryWatchdogTerminationContextProcessor;
 @class SentryWatchdogTerminationBreadcrumbProcessor;
+@class SentryWatchdogTerminationContextProcessorWrapper;
+@class SentryWatchdogTerminationUserProcessorWrapper;
 #endif // SENTRY_UIKIT_AVAILABLE
 
 #if SENTRY_HAS_UIKIT
@@ -110,6 +112,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryFileIOTracker *fileIOTracker;
 @property (nonatomic, strong) SentryCrash *crashReporter;
 @property (nonatomic, strong) SentryScopeContextPersistentStore *scopeContextPersistentStore;
+@property (nonatomic, strong) SentryScopeUserPersistentStore *scopeUserPersistentStore;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 
 - (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout;
@@ -142,7 +145,9 @@ SENTRY_NO_INIT
 - (SentryWatchdogTerminationBreadcrumbProcessor *)
     getWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs:(NSInteger)maxBreadcrumbs;
 @property (nonatomic, strong)
-    SentryWatchdogTerminationContextProcessor *watchdogTerminationContextProcessor;
+    SentryWatchdogTerminationContextProcessorWrapper *watchdogTerminationContextProcessor;
+@property (nonatomic, strong)
+    SentryWatchdogTerminationUserProcessorWrapper *watchdogTerminationUserProcessor;
 #endif
 
 @property (nonatomic, strong) SentryGlobalEventProcessor *globalEventProcessor;

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -5,6 +5,7 @@
 #import "SentryEventSwiftHelper.h"
 #import "SentryNSDataUtils.h"
 #import "SentryRandom.h"
+#import "SentryScope+Private.h"
 #import "SentryTime.h"
 #import "SentryUserAccess.h"
 #import "_SentryDispatchQueueWrapperInternal.h"

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -21,6 +21,26 @@ NS_ASSUME_NONNULL_BEGIN
 @property (atomic, strong) SentryUser *_Nullable userObject;
 
 /**
+ * SentryLevel of the event
+ */
+@property (atomic) enum SentryLevel levelEnum;
+
+/**
+ * Set global extra -> these will be sent with every event
+ */
+@property (atomic, strong) NSMutableDictionary<NSString *, id> *extraDictionary;
+
+/**
+ * This distribution of the application.
+ */
+@property (atomic, copy) NSString *_Nullable distString;
+
+/**
+ * Set the fingerprint of an event to determine the grouping
+ */
+@property (atomic, strong) NSMutableArray<NSString *> *fingerprintArray;
+
+/**
  * The propagation context has a setter, requiring it to be nonatomic
  */
 @property (nonatomic, strong) SentryPropagationContext *propagationContext;

--- a/Sources/Sentry/include/SentryUser+Private.h
+++ b/Sources/Sentry/include/SentryUser+Private.h
@@ -1,0 +1,5 @@
+#import "SentryUser.h"
+
+@interface SentryUser ()
+- (instancetype)initWithDictionary:(NSDictionary *)dictionary;
+@end

--- a/Sources/Sentry/include/SentryWatchdogTerminationScopeObserver.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationScopeObserver.h
@@ -5,7 +5,8 @@
 #    import "SentryScopeObserver.h"
 
 @class SentryWatchdogTerminationBreadcrumbProcessor;
-@class SentryWatchdogTerminationContextProcessor;
+@class SentryWatchdogTerminationContextProcessorWrapper;
+@class SentryWatchdogTerminationUserProcessorWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,7 +21,8 @@ SENTRY_NO_INIT
 
 - (instancetype)
     initWithBreadcrumbProcessor:(SentryWatchdogTerminationBreadcrumbProcessor *)breadcrumbProcessor
-               contextProcessor:(SentryWatchdogTerminationContextProcessor *)contextProcessor;
+               contextProcessor:(SentryWatchdogTerminationContextProcessorWrapper *)contextProcessor
+                  userProcessor:(SentryWatchdogTerminationUserProcessorWrapper *)userProcessor;
 
 @end
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
@@ -6,6 +6,7 @@
 @class SentryOptions;
 @class SentryWatchdogTerminationLogic;
 @class SentryScopeContextPersistentStore;
+@class SentryScopeUserPersistentStore;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -28,7 +29,8 @@ SENTRY_NO_INIT
                 appStateManager:(SentryAppStateManager *)appStateManager
            dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                     fileManager:(SentryFileManager *)fileManager
-              scopeContextStore:(SentryScopeContextPersistentStore *)scopeContextStore;
+              scopeContextStore:(SentryScopeContextPersistentStore *)scopeContextStore
+                 scopeUserStore:(SentryScopeUserPersistentStore *)scopeUserStore;
 
 - (void)start;
 - (void)stop;

--- a/Sources/Swift/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBaseProcessor.swift
+++ b/Sources/Swift/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationBaseProcessor.swift
@@ -1,0 +1,45 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+class SentryWatchdogTerminationBaseProcessor<T>: NSObject {
+    
+    private let dispatchQueueWrapper: SentryDispatchQueueWrapper
+    private let store: SentryScopeBasePersistentStore
+    private let dataTypeName: String
+    
+    init(
+        withDispatchQueueWrapper dispatchQueueWrapper: SentryDispatchQueueWrapper,
+        store: SentryScopeBasePersistentStore,
+        dataTypeName: String
+    ) {
+        self.dispatchQueueWrapper = dispatchQueueWrapper
+        self.store = store
+        self.dataTypeName = dataTypeName
+        
+        super.init()
+        
+        clear()
+    }
+    
+    func setData(_ data: T?, writeAction: @escaping (T) -> Void) {
+        SentrySDKLog.debug("Setting \(dataTypeName) in background queue: \(String(describing: data))")
+        let name = dataTypeName
+        dispatchQueueWrapper.dispatchAsync { [weak self] in
+            guard let strongSelf = self else {
+                SentrySDKLog.debug("Can not set \(name), reason: reference to \(name) processor is nil")
+                return
+            }
+            guard let data = data else {
+                SentrySDKLog.debug("\(strongSelf.dataTypeName) is nil, deleting active file.")
+                strongSelf.store.deleteStateOnDisk()
+                return
+            }
+            writeAction(data)
+        }
+    }
+    
+    public func clear() {
+        SentrySDKLog.debug("Deleting \(dataTypeName) file in persistent store")
+        store.deleteStateOnDisk()
+    }
+}

--- a/Sources/Swift/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationContextProcessor.swift
+++ b/Sources/Swift/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationContextProcessor.swift
@@ -1,42 +1,47 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-@objcMembers
-@_spi(Private) public class SentryWatchdogTerminationContextProcessor: NSObject {
+class SentryWatchdogTerminationContextProcessor: SentryWatchdogTerminationBaseProcessor<[String: [String: Any]]> {
 
-    private let dispatchQueueWrapper: SentryDispatchQueueWrapper
     private let scopeContextStore: SentryScopeContextPersistentStore
 
     public init(
         withDispatchQueueWrapper dispatchQueueWrapper: SentryDispatchQueueWrapper,
         scopeContextStore: SentryScopeContextPersistentStore
     ) {
-        self.dispatchQueueWrapper = dispatchQueueWrapper
         self.scopeContextStore = scopeContextStore
-
-        super.init()
-
-        clear()
+        super.init(
+            withDispatchQueueWrapper: dispatchQueueWrapper,
+            store: scopeContextStore,
+            dataTypeName: "context"
+        )
     }
 
     public func setContext(_ context: [String: [String: Any]]?) {
-        SentrySDKLog.debug("Setting context in background queue: \(context ?? [:])")
-        dispatchQueueWrapper.dispatchAsync { [weak self] in
-            guard let strongSelf = self else {
-                SentrySDKLog.debug("Can not set context, reason: reference to context processor is nil")
-                return
-            }
-            guard let context = context else {
-                SentrySDKLog.debug("Context is nil, deleting active file.")
-                strongSelf.scopeContextStore.deleteContextOnDisk()
-                return
-            }
-            strongSelf.scopeContextStore.writeContextToDisk(context: context)
+        setData(context) { [weak self] data in
+            self?.scopeContextStore.writeContextToDisk(context: data)
         }
     }
+}
+
+// Wrapper to expose the processor to Objective-C
+// This is needed because Objective-C has issues with generic types
+@objcMembers
+public class SentryWatchdogTerminationContextProcessorWrapper: NSObject {
+    private let processor: SentryWatchdogTerminationContextProcessor
     
+    init(
+        withDispatchQueueWrapper dispatchQueueWrapper: SentryDispatchQueueWrapper,
+        scopeContextStore: SentryScopeContextPersistentStore
+    ) {
+        self.processor = SentryWatchdogTerminationContextProcessor(withDispatchQueueWrapper: dispatchQueueWrapper, scopeContextStore: scopeContextStore)
+    }
+
+    public func setContext(_ context: [String: [String: Any]]?) {
+        processor.setContext(context)
+    }
+
     public func clear() {
-        SentrySDKLog.debug("Deleting context file in persistent store")
-        scopeContextStore.deleteContextOnDisk()
+        processor.clear()
     }
 }

--- a/Sources/Swift/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationUserProcessor.swift
+++ b/Sources/Swift/Integrations/WatchdogTerminations/Processors/SentryWatchdogTerminationUserProcessor.swift
@@ -1,0 +1,47 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+class SentryWatchdogTerminationUserProcessor: SentryWatchdogTerminationBaseProcessor<User> {
+
+    private let scopeUserStore: SentryScopeUserPersistentStore
+
+    init(
+        withDispatchQueueWrapper dispatchQueueWrapper: SentryDispatchQueueWrapper,
+        scopeUserStore: SentryScopeUserPersistentStore
+    ) {
+        self.scopeUserStore = scopeUserStore
+        super.init(
+            withDispatchQueueWrapper: dispatchQueueWrapper,
+            store: scopeUserStore,
+            dataTypeName: "user"
+        )
+    }
+
+    public func setUser(_ user: User?) {
+        setData(user) { [weak self] data in
+            self?.scopeUserStore.writeUserToDisk(user: data)
+        }
+    }
+}
+
+// Wrapper to expose the processor to Objective-C
+// This is needed because Objective-C has issues with generic types
+@objcMembers
+public class SentryWatchdogTerminationUserProcessorWrapper: NSObject {
+    private let processor: SentryWatchdogTerminationUserProcessor
+    
+    init(
+        withDispatchQueueWrapper dispatchQueueWrapper: SentryDispatchQueueWrapper,
+        scopeUserStore: SentryScopeUserPersistentStore
+    ) {
+        self.processor = SentryWatchdogTerminationUserProcessor(withDispatchQueueWrapper: dispatchQueueWrapper, scopeUserStore: scopeUserStore)
+    }
+
+    public func setUser(_ user: User?) {
+        processor.setUser(user)
+    }
+
+    public func clear() {
+        processor.clear()
+    }
+}

--- a/Sources/Swift/Persistence/SentryScopeBasePersistentStore.swift
+++ b/Sources/Swift/Persistence/SentryScopeBasePersistentStore.swift
@@ -1,0 +1,67 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+@objcMembers
+@_spi(Private) public class SentryScopeBasePersistentStore: NSObject {
+    private let fileManager: SentryFileManagerProtocol
+    private let fileName: String
+
+    init(fileManager: SentryFileManagerProtocol, fileName: String) {
+        self.fileManager = fileManager
+        self.fileName = fileName
+    }
+
+    // MARK: - State Manipulation
+
+    public func moveCurrentFileToPreviousFile() {
+        SentrySDKLog.debug("Moving \(fileName) file to previous \(fileName) file")
+        self.fileManager.moveState(currentFileURL.path, toPreviousState: previousFileURL.path)
+    }
+
+    public func readPreviousStateFromDisk() -> Data? {
+        SentrySDKLog.debug("Reading previous \(fileName) file at path: \(previousFileURL.path)")
+        do {
+            return try fileManager.readData(fromPath: previousFileURL.path)
+        } catch {
+            SentrySDKLog.error("Failed to read previous \(fileName) file at path: \(previousFileURL.path), reason: \(error)")
+            return nil
+        }
+    }
+
+    func writeStateToDisk(data: Data) {
+        SentrySDKLog.debug("Writing \(fileName) to disk at path: \(currentFileURL.path)")
+        fileManager.write(data, toPath: currentFileURL.path)
+    }
+
+    func deleteStateOnDisk() {
+        SentrySDKLog.debug("Deleting \(fileName) file at path: \(currentFileURL.path)")
+        fileManager.removeFile(atPath: currentFileURL.path)
+    }
+
+    func deletePreviousStateOnDisk() {
+        SentrySDKLog.debug("Deleting \(fileName) file at path: \(previousFileURL.path)")
+        fileManager.removeFile(atPath: previousFileURL.path)
+    }
+
+    // MARK: - Helpers
+
+    /**
+     * Path to a state file holding the latest state observed from the scope.
+     *
+     * This path is used to keep a persistent copy of the scope state on disk, to be available after
+     * restart of the app.
+     */
+    var currentFileURL: URL {
+        return fileManager.getSentryPathAsURL().appendingPathComponent("\(self.fileName).state")
+    }
+
+    /**
+     * Path to the previous state file holding the latest state observed from the scope.
+     *
+     * This file is overwritten at SDK start and kept as a copy of the last state file until the next
+     * SDK start.
+     */
+    var previousFileURL: URL {
+        return fileManager.getSentryPathAsURL().appendingPathComponent("previous.\(self.fileName).state")
+    }
+}

--- a/Sources/Swift/Persistence/SentryScopeUserPersistentStore.swift
+++ b/Sources/Swift/Persistence/SentryScopeUserPersistentStore.swift
@@ -1,0 +1,57 @@
+@_implementationOnly import _SentryPrivate
+import Foundation
+
+@objcMembers
+@_spi(Private) public class SentryScopeUserPersistentStore: SentryScopeBasePersistentStore {
+    init(fileManager: SentryFileManagerProtocol) {
+        super.init(fileManager: fileManager, fileName: "user")
+    }
+
+    // MARK: - User
+
+    public func readPreviousUserFromDisk() -> User? {
+        guard let data = super.readPreviousStateFromDisk() else {
+            return nil
+        }
+        return decodeUser(from: data)
+    }
+
+    func writeUserToDisk(user: User) {
+        guard let data = encode(user: user) else {
+            return
+        }
+        super.writeStateToDisk(data: data)
+    }
+    
+    func deleteUserOnDisk() {
+        super.deleteStateOnDisk()
+    }
+
+    func deletePreviousUserOnDisk() {
+        super.deletePreviousStateOnDisk()
+    }
+
+    // MARK: - Encoding
+
+    private func encode(user: User) -> Data? {
+        guard let sanitizedUser = sentry_sanitize(user.serialize()) else {
+            SentrySDKLog.error("Failed to sanitize user, reason: user is not valid json: \(user)")
+            return nil
+        }
+        guard let data = SentrySerialization.data(withJSONObject: sanitizedUser) else {
+            SentrySDKLog.error("Failed to serialize user, reason: user is not valid json: \(user)")
+            return nil
+        }
+        return data
+    }
+
+    private func decodeUser(from data: Data) -> User? {
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(UserDecodable.self, from: data)
+        } catch {
+            SentrySDKLog.error("Failed to decode user, reason: \(error)")
+            return nil
+        }
+    }
+}

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -118,6 +118,7 @@ final class SentryDependencyContainerTests: XCTestCase {
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().fileIOTracker)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().crashReporter)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().scopeContextPersistentStore)
+                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().scopeUserPersistentStore)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().debugImageProvider)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().getANRTracker(2.0))
 
@@ -176,6 +177,22 @@ final class SentryDependencyContainerTests: XCTestCase {
 
         // -- Assert --
         XCTAssertIdentical(scopeContextStore1, scopeContextStore2)
+    }
+    
+    func testScopeUserStore_shouldReturnSameInstance() throws {
+        // -- Arrange --
+        let options = Options()
+        options.dsn = SentryDependencyContainerTests.dsn
+        SentrySDK.setStart(options)
+
+        let container = SentryDependencyContainer.sharedInstance()
+
+        // -- Act --
+        let scopeUserStore1 = container.scopeUserPersistentStore
+        let scopeUserStore2 = container.scopeUserPersistentStore
+
+        // -- Assert --
+        XCTAssertIdentical(scopeUserStore1, scopeUserStore2)
     }
 
     func testGetWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs_shouldReturnNewInstancePerCall() throws {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
@@ -24,7 +24,8 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         let dispatchQueue = TestSentryDispatchQueueWrapper()
 
         let breadcrumbProcessor: SentryWatchdogTerminationBreadcrumbProcessor
-        let contextProcessor: SentryWatchdogTerminationContextProcessor
+        let contextProcessor: SentryWatchdogTerminationContextProcessorWrapper
+        let userProcessor: SentryWatchdogTerminationUserProcessorWrapper
 
         init() {
             SentryDependencyContainer.sharedInstance().sysctlWrapper = sysctl
@@ -38,9 +39,13 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
             breadcrumbProcessor = SentryWatchdogTerminationBreadcrumbProcessor(maxBreadcrumbs: Int(options.maxBreadcrumbs), fileManager: fileManager)
             let backgroundQueueWrapper = TestSentryDispatchQueueWrapper()
             let scopeContextStore = SentryScopeContextPersistentStore(fileManager: fileManager)
-            contextProcessor = SentryWatchdogTerminationContextProcessor(
+            contextProcessor = SentryWatchdogTerminationContextProcessorWrapper(
                 withDispatchQueueWrapper: backgroundQueueWrapper,
                 scopeContextStore: scopeContextStore
+            )
+            userProcessor = SentryWatchdogTerminationUserProcessorWrapper(
+                withDispatchQueueWrapper: backgroundQueueWrapper,
+                scopeUserStore: SentryScopeUserPersistentStore(fileManager: fileManager)
             )
 
             client = TestClient(options: options)
@@ -71,13 +76,17 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
             let scopePersistentStore = SentryScopeContextPersistentStore(
                 fileManager: fileManager
             )
+            let scopeUserPersistentStore = SentryScopeUserPersistentStore(
+                fileManager: fileManager
+            )
             return SentryWatchdogTerminationTracker(
                 options: options,
                 watchdogTerminationLogic: logic,
                 appStateManager: appStateManager,
                 dispatchQueueWrapper: dispatchQueue,
                 fileManager: fileManager,
-                scopeContextStore: scopePersistentStore
+                scopeContextStore: scopePersistentStore,
+                scopeUserStore: scopeUserPersistentStore
             )
         }
     }
@@ -288,7 +297,8 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         let breadcrumb = TestData.crumb
         let sentryWatchdogTerminationScopeObserver = SentryWatchdogTerminationScopeObserver(
             breadcrumbProcessor: fixture.breadcrumbProcessor,
-            contextProcessor: fixture.contextProcessor
+            contextProcessor: fixture.contextProcessor,
+            userProcessor: fixture.userProcessor
         )
 
         for _ in 0..<3 {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
@@ -14,6 +14,8 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         let fileManager: SentryFileManager
         let processInfoWrapper: TestSentryNSProcessInfoWrapper
         let watchdogTerminationContextProcessor: TestSentryWatchdogTerminationContextProcessor
+        let watchdogTerminationUserProcessor: TestSentryWatchdogTerminationUserProcessor
+
         let hub: SentryHub
         let scope: Scope
         let appStateManager: SentryAppStateManager
@@ -60,6 +62,13 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
                 scopeContextStore: scopeContextPersistentStore
             )
             container.watchdogTerminationContextProcessor = watchdogTerminationContextProcessor
+            
+            let scopeUserPersistentStore = TestSentryScopeUserPersistentStore(fileManager: fileManager)
+            watchdogTerminationUserProcessor = TestSentryWatchdogTerminationUserProcessor(
+                withDispatchQueueWrapper: dispatchQueueWrapper,
+                scopeUserStore: scopeUserPersistentStore
+            )
+            container.watchdogTerminationUserProcessor = watchdogTerminationUserProcessor
 
             let client = TestClient(options: options)
             scope = Scope()
@@ -200,6 +209,47 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         XCTAssertEqual(fixture.watchdogTerminationContextProcessor.setContextInvocations.count, 1)
         let invocation = try XCTUnwrap(fixture.watchdogTerminationContextProcessor.setContextInvocations.first)
         XCTAssertEqual(invocation as? [String: [String: String]]?, ["foo": ["key": "value"]])
+    }
+    
+    func testInstallWithOptions_shouldStoreUserInfo() throws {
+        // -- Arrange --
+        let sut = fixture.getSut()
+
+        // Check pre-condition
+        XCTAssertEqual(fixture.watchdogTerminationUserProcessor.setUserInvocations.count, 0)
+
+        // -- Act --
+        sut.install(with: fixture.options)
+        XCTAssertEqual(fixture.watchdogTerminationUserProcessor.setUserInvocations.count, 1)
+        fixture.scope.setUser(User(userId: "exampleUserId"))
+
+        // -- Assert --
+        // As the instance of the scope observer is dynamically created by the dependency container,
+        // we extend the tested scope by expecting the scope observer to forward the context to the
+        // context processor and assert that it was called.
+        XCTAssertEqual(fixture.watchdogTerminationUserProcessor.setUserInvocations.count, 2)
+        let invocation = try XCTUnwrap(fixture.watchdogTerminationUserProcessor.setUserInvocations.last)
+        XCTAssertEqual(invocation?.userId, "exampleUserId")
+    }
+
+    func testInstallWithOptions_shouldSetCurrentUserOnScopeObserver() throws {
+        // -- Arrange --
+        let sut = fixture.getSut()
+        fixture.scope.userObject = User(userId: "outerUser")
+
+        // Check pre-condition
+        XCTAssertEqual(fixture.watchdogTerminationUserProcessor.setUserInvocations.count, 0)
+
+        // -- Act --
+        sut.install(with: fixture.options)
+
+        // -- Assert --
+        // As the instance of the scope observer is dynamically created by the dependency container,
+        // we extend the tested scope by expecting the scope observer to forward the context to the
+        // context processor and assert that it was called.
+        XCTAssertEqual(fixture.watchdogTerminationUserProcessor.setUserInvocations.count, 1)
+        let invocation = try XCTUnwrap(fixture.watchdogTerminationUserProcessor.setUserInvocations.first)
+        XCTAssertEqual(invocation?.userId, "outerUser")
     }
 
     func testANRDetected_UpdatesAppStateToTrue() throws {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationUserProcessor.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationUserProcessor.swift
@@ -4,12 +4,12 @@
 // Note: This file should ideally live in SentryTestUtils, but this would lead to circular imports.
 // When refactoring the project structure, consider moving this to SentryTestUtils.
 
-class TestSentryWatchdogTerminationContextProcessor: SentryWatchdogTerminationContextProcessorWrapper {
-    var setContextInvocations = Invocations<[String: [String: Any]]?>()
+class TestSentryWatchdogTerminationUserProcessor: SentryWatchdogTerminationUserProcessorWrapper {
+    var setUserInvocations = Invocations<User?>()
     var clearInvocations = Invocations<Void>()
 
-    override func setContext(_ context: [String: [String: Any]]?) {
-        setContextInvocations.record(context)
+    override func setUser(_ user: User?) {
+        setUserInvocations.record(user)
     }
 
     override func clear() {

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationUserProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/TestSentryWatchdogTerminationUserProcessorTests.swift
@@ -1,0 +1,83 @@
+@_spi(Private) @testable import Sentry
+@_spi(Private) import SentryTestUtils
+import XCTest
+
+// This test is used to verify the functionality of the mock of TestSentryWatchdogTerminationUserProcessor.
+//
+// It ensures that the mock works as expected and can be used in tests suites.
+//
+// Note: This file should ideally live in SentryTestUtilsTests, but this would lead to circular imports.
+// When refactoring the project structure, consider moving this to SentryTestUtilsTests.
+
+class TestSentryWatchdogTerminationUserProcessorTests: XCTestCase {
+
+    private static let dsn = TestConstants.dsnForTestCase(type: TestSentryWatchdogTerminationUserProcessorTests.self)
+
+    private class Fixture {
+
+        let dispatchQueueWrapper: SentryDispatchQueueWrapper
+        let fileManager: SentryFileManager
+        let scopeUserStore: SentryScopeUserPersistentStore
+
+        init() throws {
+            let options = Options()
+            options.dsn = TestSentryWatchdogTerminationUserProcessorTests.dsn
+            fileManager = try TestFileManager(options: options)
+
+            dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
+            scopeUserStore = SentryScopeUserPersistentStore(fileManager: fileManager)
+        }
+
+        func getSut() -> TestSentryWatchdogTerminationUserProcessor {
+            return TestSentryWatchdogTerminationUserProcessor(
+                withDispatchQueueWrapper: dispatchQueueWrapper,
+                scopeUserStore: scopeUserStore
+            )
+        }
+    }
+
+    private var fixture: Fixture!
+    private var sut: TestSentryWatchdogTerminationUserProcessor!
+
+    override func setUpWithError() throws {
+        super.setUp()
+
+        fixture = try Fixture()
+        sut = fixture.getSut()
+    }
+
+    func testSetUser_shouldRecordInvocations() throws {
+        // -- Arrange --
+        // Clean the invocations to ensure a clean state
+        sut.setUserInvocations.removeAll()
+        XCTAssertEqual(sut.setUserInvocations.count, 0)
+
+        // -- Act --
+        sut.setUser(User(userId: "1"))
+        sut.setUser(User(userId: "2"))
+        sut.setUser(nil)
+
+        // -- Assert --
+        XCTAssertEqual(sut.setUserInvocations.count, 3)
+        XCTAssertEqual((sut.setUserInvocations.invocations.element(at: 0) as? User)?.userId, "1")
+        XCTAssertEqual((sut.setUserInvocations.invocations.element(at: 1) as? User)?.userId, "2")
+        // Use unwrap because the return type of element(at:) is double-wrapped optional [String: [String: String]]??
+        let thirdInvocation = try XCTUnwrap(sut.setUserInvocations.invocations.element(at: 2))
+        XCTAssertNil(thirdInvocation)
+    }
+
+    func testClear_shouldRecordInvocations() throws {
+        // -- Arrange --
+        // Clean the invocations to ensure a clean state
+        sut.clearInvocations.removeAll()
+        XCTAssertEqual(sut.clearInvocations.count, 0)
+
+        // -- Act --
+        sut.clear()
+        sut.clear()
+        sut.clear()
+
+        // -- Assert --
+        XCTAssertEqual(sut.clearInvocations.count, 3)
+    }
+}

--- a/Tests/SentryTests/Persistence/SentryScopeBasePersistentStoreTests.swift
+++ b/Tests/SentryTests/Persistence/SentryScopeBasePersistentStoreTests.swift
@@ -1,0 +1,368 @@
+@_spi(Private) @testable import Sentry
+@_spi(Private) import SentryTestUtils
+import XCTest
+
+class SentryScopeBasePersistentStoreTests: XCTestCase {
+    private static let dsn = TestConstants.dsnForTestCase(type: SentryScopeBasePersistentStoreTests.self)
+
+    private class Fixture {
+        let fileManager: TestFileManager
+        let fileName: String
+
+        init() throws {
+            let options = Options()
+            options.dsn = SentryScopeBasePersistentStoreTests.dsn
+            fileManager = try TestFileManager(options: options)
+            fileName = "test"
+        }
+
+        func getSut() -> SentryScopeBasePersistentStore {
+            return SentryScopeBasePersistentStore(fileManager: fileManager, fileName: fileName)
+        }
+    }
+
+    private var fixture: Fixture!
+    private var sut: SentryScopeBasePersistentStore!
+
+    override func setUpWithError() throws {
+        super.setUp()
+
+        fixture = try Fixture()
+        sut = fixture.getSut()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        fixture.fileManager.deleteAllFolders()
+    }
+
+    // MARK: - Initialization Tests
+
+    func testInit_withValidParameters_shouldCreateInstance() {
+        // -- Act & Assert --
+        XCTAssertNotNil(sut)
+    }
+
+    func testInit_withDifferentFileName_shouldCreateInstance() {
+        // -- Arrange --
+        let customFileName = "custom"
+        
+        // -- Act --
+        let customSut = SentryScopeBasePersistentStore(fileManager: fixture.fileManager, fileName: customFileName)
+        
+        // -- Assert --
+        XCTAssertNotNil(customSut)
+    }
+
+    // MARK: - File URL Tests
+
+    func testCurrentFileURL_shouldReturnCorrectPath() {
+        // -- Arrange --
+        let expectedURL = URL(fileURLWithPath: fixture.fileManager.sentryPath)
+            .appendingPathComponent("\(fixture.fileName).state")
+
+        // -- Act & Assert --
+        XCTAssertEqual(sut.currentFileURL, expectedURL)
+    }
+
+    func testPreviousFileURL_shouldReturnCorrectPath() {
+        // -- Arrange --
+        let expectedURL = URL(fileURLWithPath: fixture.fileManager.sentryPath)
+            .appendingPathComponent("previous.\(fixture.fileName).state")
+
+        // -- Act & Assert --
+        XCTAssertEqual(sut.previousFileURL, expectedURL)
+    }
+
+    func testFileURLs_withDifferentFileName_shouldReturnDifferentPaths() {
+        // -- Arrange --
+        let customFileName = "custom"
+        let customSut = SentryScopeBasePersistentStore(fileManager: fixture.fileManager, fileName: customFileName)
+        
+        let expectedCurrentURL = URL(fileURLWithPath: fixture.fileManager.sentryPath)
+            .appendingPathComponent("\(customFileName).state")
+        let expectedPreviousURL = URL(fileURLWithPath: fixture.fileManager.sentryPath)
+            .appendingPathComponent("previous.\(customFileName).state")
+
+        // -- Act & Assert --
+        XCTAssertEqual(customSut.currentFileURL, expectedCurrentURL)
+        XCTAssertEqual(customSut.previousFileURL, expectedPreviousURL)
+    }
+
+    // MARK: - Move Current File to Previous File Tests
+
+    func testMoveCurrentFileToPreviousFile_whenCurrentFileExists_shouldMoveFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data = Data("<TEST DATA>".utf8)
+
+        // Clean up any existing files
+        if fm.fileExists(atPath: sut.previousFileURL.path) {
+            try fm.removeItem(at: sut.previousFileURL)
+        }
+        if fm.fileExists(atPath: sut.currentFileURL.path) {
+            try fm.removeItem(at: sut.currentFileURL)
+        }
+        
+        // Create current file
+        fm.createFile(atPath: sut.currentFileURL.path, contents: data)
+
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act --
+        sut.moveCurrentFileToPreviousFile()
+
+        // -- Assert --
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        let previousFileData = try Data(contentsOf: sut.previousFileURL)
+        XCTAssertEqual(previousFileData, data)
+    }
+
+    func testMoveCurrentFileToPreviousFile_whenCurrentFileNotExists_shouldNotThrow() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        
+        // Clean up any existing files
+        if fm.fileExists(atPath: sut.previousFileURL.path) {
+            try fm.removeItem(at: sut.previousFileURL)
+        }
+        if fm.fileExists(atPath: sut.currentFileURL.path) {
+            try fm.removeItem(at: sut.currentFileURL)
+        }
+        
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act & Assert --
+        XCTAssertNoThrow(sut.moveCurrentFileToPreviousFile())
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+    }
+
+    func testMoveCurrentFileToPreviousFile_whenPreviousFileExists_shouldOverwritePreviousFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let oldData = Data("<OLD DATA>".utf8)
+        let newData = Data("<NEW DATA>".utf8)
+
+        // Create both files
+        fm.createFile(atPath: sut.previousFileURL.path, contents: oldData)
+        fm.createFile(atPath: sut.currentFileURL.path, contents: newData)
+
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act --
+        sut.moveCurrentFileToPreviousFile()
+
+        // -- Assert --
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        let previousFileData = try Data(contentsOf: sut.previousFileURL)
+        XCTAssertEqual(previousFileData, newData)
+        XCTAssertNotEqual(previousFileData, oldData)
+    }
+
+    // MARK: - Read Previous State Tests
+
+    func testReadPreviousStateFromDisk_whenPreviousFileExists_shouldReturnData() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data = Data("<TEST DATA>".utf8)
+        
+        fm.createFile(atPath: sut.previousFileURL.path, contents: data)
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act --
+        let result = sut.readPreviousStateFromDisk()
+
+        // -- Assert --
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result, data)
+    }
+
+    func testReadPreviousStateFromDisk_whenPreviousFileNotExists_shouldReturnNil() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        
+        if fm.fileExists(atPath: sut.previousFileURL.path) {
+            try fm.removeItem(at: sut.previousFileURL)
+        }
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act --
+        let result = sut.readPreviousStateFromDisk()
+
+        // -- Assert --
+        XCTAssertNil(result)
+    }
+
+    // MARK: - Write State Tests
+
+    func testWriteStateToDisk_whenValidData_shouldWriteToCurrentFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data = Data("<TEST DATA>".utf8)
+        
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+
+        // -- Act --
+        sut.writeStateToDisk(data: data)
+
+        // -- Assert --
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        
+        let writtenData = try Data(contentsOf: sut.currentFileURL)
+        XCTAssertEqual(writtenData, data)
+    }
+
+    func testWriteStateToDisk_whenFileExists_shouldOverwriteFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let oldData = Data("<OLD DATA>".utf8)
+        let newData = Data("<NEW DATA>".utf8)
+        
+        fm.createFile(atPath: sut.currentFileURL.path, contents: oldData)
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+
+        // -- Act --
+        sut.writeStateToDisk(data: newData)
+
+        // -- Assert --
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        
+        let writtenData = try Data(contentsOf: sut.currentFileURL)
+        XCTAssertEqual(writtenData, newData)
+        XCTAssertNotEqual(writtenData, oldData)
+    }
+
+    func testWriteStateToDisk_withEmptyData_shouldWriteEmptyFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data = Data()
+        
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+
+        // -- Act --
+        sut.writeStateToDisk(data: data)
+
+        // -- Assert --
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        
+        let writtenData = try Data(contentsOf: sut.currentFileURL)
+        XCTAssertEqual(writtenData, data)
+        XCTAssertTrue(writtenData.isEmpty)
+    }
+
+    // MARK: - Delete State Tests
+
+    func testDeleteStateOnDisk_whenCurrentFileExists_shouldDeleteFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data = Data("<TEST DATA>".utf8)
+        
+        fm.createFile(atPath: sut.currentFileURL.path, contents: data)
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+
+        // -- Act --
+        sut.deleteStateOnDisk()
+
+        // -- Assert --
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+    }
+
+    func testDeleteStateOnDisk_whenCurrentFileNotExists_shouldNotThrow() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        
+        if fm.fileExists(atPath: sut.currentFileURL.path) {
+            try fm.removeItem(at: sut.currentFileURL)
+        }
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+
+        // -- Act & Assert --
+        XCTAssertNoThrow(sut.deleteStateOnDisk())
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+    }
+
+    func testDeletePreviousStateOnDisk_whenPreviousFileExists_shouldDeleteFile() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data = Data("<TEST DATA>".utf8)
+        
+        fm.createFile(atPath: sut.previousFileURL.path, contents: data)
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act --
+        sut.deletePreviousStateOnDisk()
+
+        // -- Assert --
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+    }
+
+    func testDeletePreviousStateOnDisk_whenPreviousFileNotExists_shouldNotThrow() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        
+        if fm.fileExists(atPath: sut.previousFileURL.path) {
+            try fm.removeItem(at: sut.previousFileURL)
+        }
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+
+        // -- Act & Assert --
+        XCTAssertNoThrow(sut.deletePreviousStateOnDisk())
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+    }
+
+    // MARK: - Integration Tests
+
+    func testFullWorkflow_shouldWorkCorrectly() throws {
+        // -- Arrange --
+        let fm = FileManager.default
+        let data1 = Data("<DATA 1>".utf8)
+        let data2 = Data("<DATA 2>".utf8)
+        
+        // Clean up any existing files
+        if fm.fileExists(atPath: sut.previousFileURL.path) {
+            try fm.removeItem(at: sut.previousFileURL)
+        }
+        if fm.fileExists(atPath: sut.currentFileURL.path) {
+            try fm.removeItem(at: sut.currentFileURL)
+        }
+
+        // -- Act & Assert --
+        
+        // Step 1: Write initial data
+        sut.writeStateToDisk(data: data1)
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+        
+        // Step 2: Move current to previous
+        sut.moveCurrentFileToPreviousFile()
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+        
+        // Step 3: Read previous data
+        let readData = sut.readPreviousStateFromDisk()
+        XCTAssertEqual(readData, data1)
+        
+        // Step 4: Write new data
+        sut.writeStateToDisk(data: data2)
+        XCTAssertTrue(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+        
+        // Step 5: Delete current file
+        sut.deleteStateOnDisk()
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertTrue(fm.fileExists(atPath: sut.previousFileURL.path))
+        
+        // Step 6: Delete previous file
+        sut.deletePreviousStateOnDisk()
+        XCTAssertFalse(fm.fileExists(atPath: sut.currentFileURL.path))
+        XCTAssertFalse(fm.fileExists(atPath: sut.previousFileURL.path))
+    }
+} 

--- a/Tests/SentryTests/Persistence/TestSentryScopeUserPersistentStore.swift
+++ b/Tests/SentryTests/Persistence/TestSentryScopeUserPersistentStore.swift
@@ -1,0 +1,17 @@
+@_spi(Private) @testable import Sentry
+import SentryTestUtils
+
+class TestSentryScopeUserPersistentStore: SentryScopeUserPersistentStore {
+    let moveCurrentFileToPreviousFileInvocations = Invocations<Void>()
+    let writeContextToDiskInvocations = Invocations<User>()
+
+    override func moveCurrentFileToPreviousFile() {
+        moveCurrentFileToPreviousFileInvocations.record(())
+        super.moveCurrentFileToPreviousFile()
+    }
+
+    override func writeUserToDisk(user: User) {
+        writeContextToDiskInvocations.record(user)
+        super.writeUserToDisk(user: user)
+    }
+}


### PR DESCRIPTION
## :scroll: Description

Changes:
- Record user for watchdog termination events
- Added Base Scope and Processor

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
