### PR TITLE
feat(feedback): use correct theme setting

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -122,6 +122,7 @@
                     uiForm.useSentryUser = YES;
                 };
                 config.configureTheme = ^(SentryUserFeedbackThemeConfiguration *_Nonnull theme) {
+                    theme.fontFamily = @"ChalkboardSE-Regular";
                     theme.outlineStyle =
                         [[SentryFormElementOutlineStyle alloc] initWithColor:UIColor.purpleColor
                                                                 cornerRadius:10


### PR DESCRIPTION
as found in #5524 after removing the app extension setting hack, the objc sample app was accidentally using the wrong property. this fixes it to use the intended one for this customization 

#skip-changelog