### PR TITLE
trigger ui tests to run on sample app shared xcconfig changes

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -18,6 +18,7 @@ on:
       - "Samples/iOS-Swift/**"
       - "Samples/iOS-Swift6/**"
       - "Samples/SentrySampleShared/**"
+      - "Samples/Shared/**"
       - "scripts/build-xcframework-slice.sh"
       - "scripts/assemble-xcframework.sh"
       - ".github/workflows/build-xcframework-variant-slices.yml"


### PR DESCRIPTION
I noticed while proposing #5541 that the UI tests didn't run in CI when they should've upon changing the sample apps' xcconfig files; add this trigger to ensure that happens.

#skip-changelog