### PR TITLE
test: explicitly set code coverage to true in all test plans

### DIFF
--- a/Plans/SentrySwiftUI_Base.xctestplan
+++ b/Plans/SentrySwiftUI_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : true,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : true,
     "environmentVariableEntries" : [
       {
         "key" : "TSAN_OPTIONS",

--- a/Plans/SwiftUITestSample_Base.xctestplan
+++ b/Plans/SwiftUITestSample_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : true,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/iOS-ObjectiveC_Base.xctestplan
+++ b/Plans/iOS-ObjectiveC_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : true,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/iOS-Swift6_Base.xctestplan
+++ b/Plans/iOS-Swift6_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : true,
     "uiTestingScreenshotsLifetime" : "keepAlways"
   },
   "testTargets" : [

--- a/Plans/iOS-SwiftUI_Base.xctestplan
+++ b/Plans/iOS-SwiftUI_Base.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
+    "codeCoverage" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:iOS-SwiftUI.xcodeproj",
       "identifier" : "7BB6224826A56C4E00D0E75E",

--- a/Plans/iOS-Swift_Base.xctestplan
+++ b/Plans/iOS-Swift_Base.xctestplan
@@ -9,6 +9,7 @@
     }
   ],
   "defaultOptions" : {
+    "codeCoverage" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:iOS-Swift.xcodeproj",
       "identifier" : "637AFDA5243B02760034958B",

--- a/Plans/iOS13-Swift_Base.xctestplan
+++ b/Plans/iOS13-Swift_Base.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
+    "codeCoverage" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:iOS13-Swift.xcodeproj",
       "identifier" : "D8269A38274C095E00BD5BD5",

--- a/Plans/tvOS-Swift_Base.xctestplan
+++ b/Plans/tvOS-Swift_Base.xctestplan
@@ -9,7 +9,7 @@
     }
   ],
   "defaultOptions" : {
-    "codeCoverage" : false,
+    "codeCoverage" : true,
     "targetForVariableExpansion" : {
       "containerPath" : "container:tvOS-Swift.xcodeproj",
       "identifier" : "7BA61D61247FA32600C130A8",
@@ -21,7 +21,7 @@
     {
       "target" : {
         "containerPath" : "container:tvOS-Swift.xcodeproj",
-        "identifier" : "7B64388526A6C71A000D0F65",
+        "identifier" : "1A9FD4374E53BEB8AC621B3D",
         "name" : "tvOS-Swift-UITests"
       }
     }


### PR DESCRIPTION
I assume this is the default since it wasn't even present in the main SDK's test plan, but for some reason some of these had it set to false. Change those to true and add the explicit directive to all plans.

#skip-changelog