### PR TITLE
meta: fix changelog entry for #5223

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Set handled to false for fatal app hangs (#5514)
-- User feedback widget automatically injects into SwiftUI apps correctly (#5223)
+- User feedback widget can now be displayed in SwiftUI apps (#5223)
 - Fix crash when SentryFileManger is nil (#5535)
 
 ### Improvements


### PR DESCRIPTION
I didn't notice that the changelog entry #5223 wasn't scoped down for what the PR wound up actually doing: it only correctly shows the widget when manually calling the display method; automatic injection will be worked on later.