### PR TITLE
docs(feedback): add a warning to autoInject property about SwiftUI

### DIFF
--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
@@ -11,6 +11,7 @@ public class SentryUserFeedbackWidgetConfiguration: NSObject {
     /**
      * Automatically inject the widget button into the application UI.
      * - note: Default: `true`
+     * - warning: Does not currently work for SwiftUI apps. See https://docs.sentry.io/platforms/apple/user-feedback/#swiftui
      */
     public var autoInject: Bool = true
     


### PR DESCRIPTION
Should've gone in with #5223. Requires https://github.com/getsentry/sentry-docs/pull/14227 to be merged first.

#skip-changelog