### PR TITLE
test: Remove dep container usage in HTTPTransport

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -41,7 +41,7 @@ class SentryHttpTransportTests: XCTestCase {
         @available(*, deprecated, message: "SentryUserFeedback is deprecated in favor of SentryFeedback. There is currently no envelope initializer accepting a SentryFeedback; the envelope is currently built directly in -[SentryClient captureFeedback:withScope:] and sent to -[SentryTransportAdapter sendEvent:traceContext:attachments:additionalEnvelopeItems:].")
         lazy var userFeedbackRequest: URLRequest = {
             let userFeedbackEnvelope = SentryEnvelope(userFeedback: userFeedback)
-            userFeedbackEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+            userFeedbackEnvelope.header.sentAt = currentDateProvider.date()
             return buildRequest(userFeedbackEnvelope)
         }()
         
@@ -55,6 +55,8 @@ class SentryHttpTransportTests: XCTestCase {
             SentryDependencyContainer.sharedInstance().reachability = reachability
             
             currentDateProvider = TestCurrentDateProvider()
+
+            // Event uses the current date provider of the dependency container. Therefore, we need to set it here.
             SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
 
             event = Event()
@@ -64,17 +66,17 @@ class SentryHttpTransportTests: XCTestCase {
             
             eventEnvelope = SentryEnvelope(id: event.eventId, items: [SentryEnvelopeItem(event: event), attachmentEnvelopeItem])
             // We are comparing byte data and the `sentAt` header is also set in the transport, so we also need them here in the expected envelope.
-            eventEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+            eventEnvelope.header.sentAt = currentDateProvider.date()
             eventWithAttachmentRequest = buildRequest(eventEnvelope)
             
             session = SentrySession(releaseName: "2.0.1", distinctId: "some-id")
             sessionEnvelope = SentryEnvelope(id: nil, singleItem: SentryEnvelopeItem(session: session))
-            sessionEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+            sessionEnvelope.header.sentAt = currentDateProvider.date()
             sessionRequest = buildRequest(sessionEnvelope)
 
             let items = [SentryEnvelopeItem(event: event), SentryEnvelopeItem(session: session)]
             eventWithSessionEnvelope = SentryEnvelope(id: event.eventId, items: items)
-            eventWithSessionEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+            eventWithSessionEnvelope.header.sentAt = currentDateProvider.date()
             eventWithSessionRequest = buildRequest(eventWithSessionEnvelope)
 
             options = Options()
@@ -102,7 +104,7 @@ class SentryHttpTransportTests: XCTestCase {
                 SentryEnvelopeItem(clientReport: clientReport)
             ]
             clientReportEnvelope = SentryEnvelope(id: event.eventId, items: clientReportEnvelopeItems)
-            clientReportEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+            clientReportEnvelope.header.sentAt = currentDateProvider.date()
             clientReportRequest = buildRequest(clientReportEnvelope)
         }
         
@@ -261,7 +263,7 @@ class SentryHttpTransportTests: XCTestCase {
             SentryEnvelopeItem(clientReport: clientReport)
         ]
         let envelope = SentryEnvelope(id: fixture.event.eventId, items: envelopeItems)
-        envelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+        envelope.header.sentAt = fixture.currentDateProvider.date()
         let request = SentryHttpTransportTests.buildRequest(envelope)
 
         let actualData = try XCTUnwrap(request.httpBody)
@@ -478,7 +480,7 @@ class SentryHttpTransportTests: XCTestCase {
         assertEnvelopesStored(envelopeCount: 0)
 
         let sessionEnvelope = SentryEnvelope(id: fixture.event.eventId, singleItem: SentryEnvelopeItem(session: fixture.session))
-        sessionEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+        sessionEnvelope.header.sentAt = fixture.currentDateProvider.date()
         let sessionData = try XCTUnwrap(SentrySerialization.data(with: sessionEnvelope))
         let sessionRequest = try! SentryURLRequestFactory.envelopeRequest(with: SentryHttpTransportTests.dsn(), data: sessionData)
 
@@ -569,7 +571,7 @@ class SentryHttpTransportTests: XCTestCase {
             SentryEnvelopeItem(clientReport: clientReport)
         ]
         let clientReportEnvelope = SentryEnvelope(id: fixture.event.eventId, items: clientReportEnvelopeItems)
-        clientReportEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+        clientReportEnvelope.header.sentAt = fixture.currentDateProvider.date()
         let clientReportRequest = SentryHttpTransportTests.buildRequest(clientReportEnvelope)
         
         givenRateLimitResponse(forCategory: "error")
@@ -596,7 +598,7 @@ class SentryHttpTransportTests: XCTestCase {
         let transactionEnvelope = fixture.getTransactionEnvelope()
         
         let clientReportEnvelope = SentryEnvelope(id: transactionEnvelope.header.eventId, items: clientReportEnvelopeItems)
-        clientReportEnvelope.header.sentAt = SentryDependencyContainer.sharedInstance().dateProvider.date()
+        clientReportEnvelope.header.sentAt = fixture.currentDateProvider.date()
         let clientReportRequest = SentryHttpTransportTests.buildRequest(clientReportEnvelope)
         
         givenRateLimitResponse(forCategory: "transaction")


### PR DESCRIPTION
Remove a couple of DependencyContainer usages and use the date provider of the fixture instead, because we want to limit the usage of the DependencyContainer as much as we can during testing, cause it is global state.

Came up while looking at https://github.com/getsentry/sentry-cocoa/issues/5421.

#skip-changelog