### PR TITLE
test: Add InvocationTests

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -143,6 +143,7 @@
 		62E2119A2DAE99FC007D7262 /* SentryAsyncSafeLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 62E211992DAE99FC007D7262 /* SentryAsyncSafeLog.m */; };
 		62E300942D5202890037AA3F /* SentryExceptionCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E300932D5202830037AA3F /* SentryExceptionCodable.swift */; };
 		62E5325B2DEEC862000B2DD5 /* TestCurrentDateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624729172DE5980500DFEE00 /* TestCurrentDateProviderTests.swift */; };
+		62E75EB92E152953002EC91B /* InvocationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E75EB82E152953002EC91B /* InvocationsTests.swift */; };
 		62EF86A12C626D39004E058B /* SentryANRTrackerV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621AE74E2C626CF70012E730 /* SentryANRTrackerV2Tests.swift */; };
 		62F05D2B2C0DB1F100916E3F /* SentryLogTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */; };
 		62F226B729A37C120038080D /* SentryBooleanSerialization.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F226B629A37C120038080D /* SentryBooleanSerialization.m */; };
@@ -1305,6 +1306,7 @@
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
 		62E211992DAE99FC007D7262 /* SentryAsyncSafeLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAsyncSafeLog.m; sourceTree = "<group>"; };
 		62E300932D5202830037AA3F /* SentryExceptionCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExceptionCodable.swift; sourceTree = "<group>"; };
+		62E75EB82E152953002EC91B /* InvocationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationsTests.swift; sourceTree = "<group>"; };
 		62F05D292C0DB1C800916E3F /* SentryLogTestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryLogTestHelper.h; sourceTree = "<group>"; };
 		62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLogTestHelper.m; sourceTree = "<group>"; };
 		62F226B629A37C120038080D /* SentryBooleanSerialization.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryBooleanSerialization.m; sourceTree = "<group>"; };
@@ -4119,6 +4121,7 @@
 				D44B16712DE464A9006DBDB3 /* TestDispatchFactoryTests.swift */,
 				D4CBA2512DE06D1600581618 /* TestConstantTests.swift */,
 				D43B0E5F2DE7416600EE3759 /* TestFileManagerTests.swift */,
+				62E75EB82E152953002EC91B /* InvocationsTests.swift */,
 			);
 			path = SentryTestUtilsTests;
 			sourceTree = "<group>";
@@ -6029,6 +6032,7 @@
 				D43B0E602DE7416900EE3759 /* TestFileManagerTests.swift in Sources */,
 				D44B16722DE464AD006DBDB3 /* TestDispatchFactoryTests.swift in Sources */,
 				D4EE12D22DE9AC3800385BAF /* TestNSNotificationCenterWrapperTests.swift in Sources */,
+				62E75EB92E152953002EC91B /* InvocationsTests.swift in Sources */,
 				D4CBA2532DE06D1600581618 /* TestConstantTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SentryTestUtilsTests/InvocationsTests.swift
+++ b/SentryTestUtilsTests/InvocationsTests.swift
@@ -1,0 +1,211 @@
+@_spi(Private) import SentryTestUtils
+import XCTest
+
+final class InvocationsTests: XCTestCase {
+
+    func testInitialStateIsEmpty() throws {
+        // Arrange & Act
+        let sut = Invocations<String>()
+        
+        // Assert
+        XCTAssertTrue(sut.isEmpty)
+        XCTAssertEqual(sut.count, 0)
+        XCTAssertTrue(sut.invocations.isEmpty)
+        XCTAssertNil(sut.first)
+        XCTAssertNil(sut.last)
+    }
+    
+    func testRecordSingleInvocation() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        let testValue = "test"
+        
+        // Act
+        sut.record(testValue)
+        
+        // Assert
+        XCTAssertFalse(sut.isEmpty)
+        XCTAssertEqual(sut.count, 1)
+        XCTAssertEqual(sut.invocations.count, 1)
+        XCTAssertEqual(sut.first, testValue)
+        XCTAssertEqual(sut.last, testValue)
+        XCTAssertEqual(sut.invocations[0], testValue)
+    }
+    
+    func testRecordMultipleInvocations() throws {
+        // Arrange
+        let sut = Invocations<Int>()
+        let values = [1, 2, 3]
+        
+        // Act
+        for value in values {
+            sut.record(value)
+        }
+        
+        // Assert
+        XCTAssertFalse(sut.isEmpty)
+        XCTAssertEqual(sut.count, 3)
+        XCTAssertEqual(sut.invocations, values)
+        XCTAssertEqual(sut.first, 1)
+        XCTAssertEqual(sut.last, 3)
+    }
+    
+    func testGetWithValidIndex() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        let values = ["first", "second", "third"]
+        values.forEach { sut.record($0) }
+        
+        // Act
+        let result = sut.get(1)
+        
+        // Assert
+        XCTAssertEqual(result, "second")
+    }
+    
+    func testGetWithInvalidIndex() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        sut.record("test")
+        
+        // Act
+        let result = sut.get(5)
+        
+        // Assert
+        XCTAssertNil(result)
+    }
+    
+    func testGetWithNegativeIndex() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        sut.record("test")
+        
+        // Act
+        let result = sut.get(-1)
+        
+        // Assert
+        XCTAssertNil(result)
+    }
+    
+    func testGetFromEmptyInvocations() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        
+        // Act
+        let result = sut.get(0)
+        
+        // Assert
+        XCTAssertNil(result)
+    }
+    
+    func testRemoveAllFromEmptyInvocations() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        
+        // Act
+        sut.removeAll()
+        
+        // Assert
+        XCTAssertTrue(sut.isEmpty)
+        XCTAssertEqual(sut.count, 0)
+        XCTAssertTrue(sut.invocations.isEmpty)
+    }
+    
+    func testRemoveAllFromPopulatedInvocations() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        sut.record("test1")
+        sut.record("test2")
+        
+        // Act
+        sut.removeAll()
+        
+        // Assert
+        XCTAssertTrue(sut.isEmpty)
+        XCTAssertEqual(sut.count, 0)
+        XCTAssertTrue(sut.invocations.isEmpty)
+        XCTAssertNil(sut.first)
+        XCTAssertNil(sut.last)
+    }
+    
+    func testFirstAndLastWithSingleInvocation() throws {
+        // Arrange
+        let sut = Invocations<String>()
+        let testValue = "single"
+        
+        // Act
+        sut.record(testValue)
+        
+        // Assert
+        XCTAssertEqual(sut.first, testValue)
+        XCTAssertEqual(sut.last, testValue)
+        XCTAssertEqual(sut.first, sut.last)
+    }
+
+    func testFromMultipleThreads() throws {
+
+        // Arrange
+        let sut = Invocations<Int>()
+
+        let dispatchQueue = DispatchQueue(label: "InvocationsTests", attributes: [.concurrent, .initiallyInactive])
+
+        let expectation = self.expectation(description: "testFromMultipleThreads")
+        expectation.expectedFulfillmentCount = 1_000
+
+        // Act
+        for i in 0..<1_000 {
+           dispatchQueue.async {
+               sut.record(i)
+
+               XCTAssertTrue(sut.invocations.contains(i))
+               XCTAssertNotNil(sut.invocations)
+               XCTAssertNotNil(sut.count)
+               XCTAssertNotNil(sut.first)
+               XCTAssertNotNil(sut.last)
+               XCTAssertFalse(sut.isEmpty)
+
+               expectation.fulfill()
+           }
+        }
+
+        dispatchQueue.activate()
+        wait(for: [expectation], timeout: 5.0)
+
+        // Assert
+        XCTAssertEqual(sut.invocations.count, 1_000)
+    }
+
+    func testRemoveAllAfterAddingRecords() throws {
+
+        // Arrange
+        let sut = Invocations<Void>()
+
+        let dispatchQueue = DispatchQueue(label: "InvocationsTests", attributes: [.concurrent, .initiallyInactive])
+
+        let expectation = self.expectation(description: "testFromMultipleThreads")
+        expectation.expectedFulfillmentCount = 1_000
+
+        // Act
+        for _ in 0..<1_000 {
+           dispatchQueue.async {
+               // Act
+               for _ in 0..<10 {
+                   sut.record(Void())
+               }
+
+               sut.removeAll()
+
+               expectation.fulfill()
+           }
+        }
+
+        dispatchQueue.activate()
+
+        wait(for: [expectation], timeout: 5.0)
+
+        // Assert
+        XCTAssertTrue(sut.invocations.isEmpty)
+
+    }
+
+}

--- a/SentryTestUtilsTests/InvocationsTests.swift
+++ b/SentryTestUtilsTests/InvocationsTests.swift
@@ -205,7 +205,5 @@ final class InvocationsTests: XCTestCase {
 
         // Assert
         XCTAssertTrue(sut.invocations.isEmpty)
-
     }
-
 }


### PR DESCRIPTION
Add tests for the test util class Invocations. We need to ensure our test code works correctly for a deterministic test suite.

This came up while investigating https://github.com/getsentry/sentry-cocoa/issues/5421.

#skip-changelog