### PR TITLE
ci: update from xcode 16.2 to 16.4

### DIFF
--- a/.github/workflows/assemble-xcframework-variant.yml
+++ b/.github/workflows/assemble-xcframework-variant.yml
@@ -55,7 +55,7 @@ jobs:
   assemble-xcframework-variant:
     name: Assemble ${{inputs.name}}${{inputs.suffix}} XCFramework Variant
 
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-xcframework-variant-slices.yml
+++ b/.github/workflows/build-xcframework-variant-slices.yml
@@ -56,8 +56,7 @@ jobs:
   build-xcframework-variant-slices:
     name: ${{matrix.sdk}}
 
-    # We must compile this on an arm64 runner, cause it's required for visionOS. macos-14 uses arm64.
-    # To see the available runners see https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories.
+    # can't update to macos-15 until the issues requiring us to use Xcode 15.2 are resolved as described below
     runs-on: macos-14
 
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: ./scripts/ci-select-xcode.sh 16.2
+        run: ./scripts/ci-select-xcode.sh 16.4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
 
   xcode-analyze:
     name: Xcode Analyze
-    runs-on: macos-14
+    runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
       - run: ./scripts/ci-select-xcode.sh 16.4
@@ -48,7 +48,7 @@ jobs:
 
   lint-podspec:
     name: pod lint ${{ matrix.podspec}} ${{ matrix.library_type }} ${{ matrix.platform}}
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: false
       matrix:
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 15.4
+      - run: ./scripts/ci-select-xcode.sh 16.4
       # We need to update the spec-repo, because it can happen that it is not up to date and then the lint fails.
       - run: pod repo update
       - name: Validate Podspec
@@ -66,11 +66,11 @@ jobs:
 
   lint-hybrid-sdk-podspec:
     name: pod lint Sentry/HybridSDK
-    runs-on: macos-14
+    runs-on: macos-15
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 15.4
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - run: pod repo update
       - name: Validate HybridPod Podspec
         run: pod lib lint ./Tests/HybridSDKTest/HybridPod.podspec --allow-warnings --verbose --platforms=ios "--include-podspecs={Sentry.podspec}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - run: make analyze
 
   lint-podspec:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           # iOS 18
           - runs-on: macos-15
             platform: "iOS"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "18.2"
             device: "iPhone 16"
             scheme: "Sentry"
@@ -117,7 +117,7 @@ jobs:
           # macOS 15
           - runs-on: macos-15
             platform: "macOS"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "latest"
             scheme: "Sentry"
 
@@ -132,7 +132,7 @@ jobs:
 
           - runs-on: macos-15
             platform: "Catalyst"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "latest"
             scheme: "Sentry"
 
@@ -158,7 +158,7 @@ jobs:
           # tvOS 18
           - runs-on: macos-15
             platform: "tvOS"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "18.1"
             scheme: "Sentry"
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -35,17 +35,13 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          # As of 25th March 2025, the preinstalled iOS simulator version is 16.4 for macOS 13 and Xcode 14.3.1; see
-          # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#installed-sdks
           - runs-on: macos-13
             xcode: "14.3.1"
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
-          # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
-          # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
           - runs-on: macos-15
-            xcode: "16.2"
+            xcode: "16.4"
         command:
           - fastlane_command: ui_critical_tests_ios_swiftui_envelope
 
@@ -56,7 +52,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.4
 
       - run: make init-ci-build
       - run: make xcode-ci

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -38,7 +38,7 @@ jobs:
         target: ["ios_objc", "tvos_swift"]
     with:
       fastlane_command: ui_tests_${{matrix.target}}
-      xcode_version: 16.2
+      xcode_version: 16.4
       build_with_make: true
       macos_version: macos-14
 
@@ -82,6 +82,6 @@ jobs:
     uses: ./.github/workflows/ui-tests-common.yml
     with:
       fastlane_command: ui_tests_ios_swift6
-      xcode_version: 16.2
+      xcode_version: 16.4
       build_with_make: true
       macos_version: macos-15

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -40,7 +40,7 @@ jobs:
       fastlane_command: ui_tests_${{matrix.target}}
       xcode_version: 16.4
       build_with_make: true
-      macos_version: macos-14
+      macos_version: macos-15
 
   # SwiftUI only supports iOS 14+ so we run it in a separate matrix here
   ui-tests-swift-ui:

--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -12,7 +12,7 @@
 set -euo pipefail
 
 # Parse named arguments
-XCODE_VERSION="16.2" # Default value
+XCODE_VERSION="16.4" # Default value
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -38,7 +38,7 @@ case "$XCODE_VERSION" in
     "15.4")
         SIMULATOR="iPhone 15"
         ;;
-    "16.2")
+    "16.4")
         SIMULATOR="iPhone 16"
         ;;
     *)


### PR DESCRIPTION
I encountered an [error](https://github.com/getsentry/sentry-cocoa/actions/runs/16031579582/job/45233349395?pr=5318#step:8:69) on a check run:
```
xcodebuild: error: Unable to find a device matching the provided destination specifier
```

and thought maybe this is why. generally we should be on the latest version anyways. ideally we could centralize this in something like `//.xcode-version` which we could `cat` out into CI steps, but i'll tackle that separately.

#skip-changelog