### PR TITLE
meta: enable library evolution in our podspec hybrid subspec

### DIFF
--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -22,7 +22,8 @@ Pod::Spec.new do |s|
       'CLANG_CXX_LANGUAGE_STANDARD' => 'c++14',
       'CLANG_CXX_LIBRARY' => 'libc++',
       'SWIFT_INCLUDE_PATHS' => '${PODS_TARGET_SRCROOT}/Sources/Sentry/include',
-      'OTHER_CFLAGS' => '$(inherited)'
+      'OTHER_CFLAGS' => '$(inherited)',
+      'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
   }
   s.watchos.pod_target_xcconfig = {
       'OTHER_LDFLAGS' => '$(inherited) -framework WatchKit'
@@ -51,9 +52,5 @@ Pod::Spec.new do |s|
 
       sp.preserve_path = "Sources/Sentry/include/module.modulemap"
       sp.resource_bundles = { "Sentry" => "Sources/Resources/PrivacyInfo.xcprivacy" }
-
-      sp.pod_target_xcconfig = {
-          'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
-      }
   end
 end

--- a/Sentry.podspec
+++ b/Sentry.podspec
@@ -51,5 +51,9 @@ Pod::Spec.new do |s|
 
       sp.preserve_path = "Sources/Sentry/include/module.modulemap"
       sp.resource_bundles = { "Sentry" => "Sources/Resources/PrivacyInfo.xcprivacy" }
+
+      sp.pod_target_xcconfig = {
+          'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
+      }
   end
 end


### PR DESCRIPTION
When I tried updating CI use Xcode 16.4 I started getting these [linter warnings](https://github.com/getsentry/sentry-cocoa/pull/5556/checks) that failed the build from podspec validation:

```
2025-07-02T19:12:48.8538080Z     - WARN  | [Sentry/Core,Sentry/HybridSDK] xcodebuild:  /Users/runner/work/sentry-cocoa/sentry-cocoa/Sources/Swift/Integrations/Performance/IO/Data+SentryTracing.swift:1:22: warning: using '@_implementationOnly' without enabling library evolution for 'Sentry' may lead to instability during execution
```

We do set `BUILD_LIBRARY_FOR_DISTRIBUTION = YES` in our xcconfigs, but those aren't used by cocoapods. Set it in the subspec that's having the issue.