### PR TITLE
chore: Remove dead script references from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,12 +108,6 @@ run-test-server-sync:
 
 .PHONY: run-test-server run-test-server-sync
 
-test-alamofire:
-	./scripts/test-alamofire.sh
-
-test-homekit:
-	./scripts/test-homekit.sh
-
 test-ui-critical:
 	./scripts/test-ui-critical.sh
 


### PR DESCRIPTION
Both scripts don't exist anymore.

#skip-changelog