### PR TITLE
ref: Don't use functions for notification names

### DIFF
--- a/SentryTestUtils/TestNSNotificationCenterWrapper.swift
+++ b/SentryTestUtils/TestNSNotificationCenterWrapper.swift
@@ -1,6 +1,12 @@
 import Foundation
 import Sentry
 
+#if canImport(UIKit)
+public typealias CrossPlatformApplication = UIApplication
+#else
+public typealias CrossPlatformApplication = NSApplication
+#endif
+
 @objcMembers public class TestNSNotificationCenterWrapper: SentryNSNotificationCenterWrapper {
     private enum Observer {
         case observer(WeakReference<NSObject>, Selector, NSNotification.Name)

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -50,24 +50,21 @@
 - (void)start
 {
     if (self.startCount == 0) {
-        [self.notificationCenterWrapper
-            addObserver:self
-               selector:@selector(didBecomeActive)
-                   name:SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName];
+        [self.notificationCenterWrapper addObserver:self
+                                           selector:@selector(didBecomeActive)
+                                               name:SentryDidBecomeActiveNotification];
 
         [self.notificationCenterWrapper addObserver:self
                                            selector:@selector(didBecomeActive)
                                                name:SentryHybridSdkDidBecomeActiveNotificationName];
 
-        [self.notificationCenterWrapper
-            addObserver:self
-               selector:@selector(willResignActive)
-                   name:SentryNSNotificationCenterWrapper.willResignActiveNotificationName];
+        [self.notificationCenterWrapper addObserver:self
+                                           selector:@selector(willResignActive)
+                                               name:SentryWillResignActiveNotification];
 
-        [self.notificationCenterWrapper
-            addObserver:self
-               selector:@selector(willTerminate)
-                   name:SentryNSNotificationCenterWrapper.willTerminateNotificationName];
+        [self.notificationCenterWrapper addObserver:self
+                                           selector:@selector(willTerminate)
+                                               name:SentryWillTerminateNotification];
 
         [self storeCurrentAppState];
     }
@@ -99,21 +96,16 @@
     if (self.startCount == 0) {
         // Remove the observers with the most specific detail possible, see
         // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
-        [self.notificationCenterWrapper
-            removeObserver:self
-                      name:SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName];
+        [self.notificationCenterWrapper removeObserver:self name:SentryDidBecomeActiveNotification];
 
         [self.notificationCenterWrapper
             removeObserver:self
                       name:SentryHybridSdkDidBecomeActiveNotificationName];
 
-        [self.notificationCenterWrapper
-            removeObserver:self
-                      name:SentryNSNotificationCenterWrapper.willResignActiveNotificationName];
+        [self.notificationCenterWrapper removeObserver:self
+                                                  name:SentryWillResignActiveNotification];
 
-        [self.notificationCenterWrapper
-            removeObserver:self
-                      name:SentryNSNotificationCenterWrapper.willTerminateNotificationName];
+        [self.notificationCenterWrapper removeObserver:self name:SentryWillTerminateNotification];
     }
 }
 

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -136,15 +136,13 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
     _isStarted = YES;
 
-    [self.notificationCenter
-        addObserver:self
-           selector:@selector(didBecomeActive)
-               name:SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName];
+    [self.notificationCenter addObserver:self
+                                selector:@selector(didBecomeActive)
+                                    name:SentryDidBecomeActiveNotification];
 
-    [self.notificationCenter
-        addObserver:self
-           selector:@selector(willResignActive)
-               name:SentryNSNotificationCenterWrapper.willResignActiveNotificationName];
+    [self.notificationCenter addObserver:self
+                                selector:@selector(willResignActive)
+                                    name:SentryWillResignActiveNotification];
 
     [self unpause];
 }
@@ -336,12 +334,8 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 
     // Remove the observers with the most specific detail possible, see
     // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
-    [self.notificationCenter
-        removeObserver:self
-                  name:SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName];
-    [self.notificationCenter
-        removeObserver:self
-                  name:SentryNSNotificationCenterWrapper.willResignActiveNotificationName];
+    [self.notificationCenter removeObserver:self name:SentryDidBecomeActiveNotification];
+    [self.notificationCenter removeObserver:self name:SentryWillResignActiveNotification];
 
     @synchronized(self.listeners) {
         [self.listeners removeAllObjects];

--- a/Sources/Sentry/SentryNSNotificationCenterWrapper.m
+++ b/Sources/Sentry/SentryNSNotificationCenterWrapper.m
@@ -14,44 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryNSNotificationCenterWrapper
 
-#if SENTRY_HAS_UIKIT
-+ (NSNotificationName)didBecomeActiveNotificationName
-{
-    return UIApplicationDidBecomeActiveNotification;
-}
-
-+ (NSNotificationName)willResignActiveNotificationName
-{
-    return UIApplicationWillResignActiveNotification;
-}
-
-+ (NSNotificationName)willTerminateNotificationName
-{
-    return UIApplicationWillTerminateNotification;
-}
-
-+ (NSNotificationName)didEnterBackgroundNotificationName
-{
-    return UIApplicationDidEnterBackgroundNotification;
-}
-
-#elif SENTRY_TARGET_MACOS_HAS_UI
-+ (NSNotificationName)didBecomeActiveNotificationName
-{
-    return NSApplicationDidBecomeActiveNotification;
-}
-
-+ (NSNotificationName)willResignActiveNotificationName
-{
-    return NSApplicationWillResignActiveNotification;
-}
-
-+ (NSNotificationName)willTerminateNotificationName
-{
-    return NSApplicationWillTerminateNotification;
-}
-#endif
-
 - (void)addObserver:(NSObject *)observer
            selector:(SEL)aSelector
                name:(NSNotificationName)aName

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -72,23 +72,20 @@
     // ending the cached session.
     [self endCachedSession];
 
-    [self.notificationCenter
-        addObserver:self
-           selector:@selector(didBecomeActive)
-               name:SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName];
+    [self.notificationCenter addObserver:self
+                                selector:@selector(didBecomeActive)
+                                    name:SentryDidBecomeActiveNotification];
 
     [self.notificationCenter addObserver:self
                                 selector:@selector(didBecomeActive)
                                     name:SentryHybridSdkDidBecomeActiveNotificationName];
-    [self.notificationCenter
-        addObserver:self
-           selector:@selector(willResignActive)
-               name:SentryNSNotificationCenterWrapper.willResignActiveNotificationName];
+    [self.notificationCenter addObserver:self
+                                selector:@selector(willResignActive)
+                                    name:SentryWillResignActiveNotification];
 
-    [self.notificationCenter
-        addObserver:self
-           selector:@selector(willTerminate)
-               name:SentryNSNotificationCenterWrapper.willTerminateNotificationName];
+    [self.notificationCenter addObserver:self
+                                selector:@selector(willTerminate)
+                                    name:SentryWillTerminateNotification];
 
     // Edge case: When starting the SDK after the app did become active, we need to call
     //            didBecomeActive manually to start the session. This is the case when
@@ -117,17 +114,11 @@
 #if SENTRY_HAS_UIKIT || SENTRY_TARGET_MACOS_HAS_UI
     // Remove the observers with the most specific detail possible, see
     // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver
-    [self.notificationCenter
-        removeObserver:self
-                  name:SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName];
+    [self.notificationCenter removeObserver:self name:SentryDidBecomeActiveNotification];
     [self.notificationCenter removeObserver:self
                                        name:SentryHybridSdkDidBecomeActiveNotificationName];
-    [self.notificationCenter
-        removeObserver:self
-                  name:SentryNSNotificationCenterWrapper.willResignActiveNotificationName];
-    [self.notificationCenter
-        removeObserver:self
-                  name:SentryNSNotificationCenterWrapper.willTerminateNotificationName];
+    [self.notificationCenter removeObserver:self name:SentryWillResignActiveNotification];
+    [self.notificationCenter removeObserver:self name:SentryWillTerminateNotification];
 #endif
 }
 

--- a/Sources/Sentry/include/SentryNSNotificationCenterWrapper.h
+++ b/Sources/Sentry/include/SentryNSNotificationCenterWrapper.h
@@ -1,5 +1,15 @@
 #import "SentryDefines.h"
 
+#if SENTRY_HAS_UIKIT
+#    define SentryDidBecomeActiveNotification UIApplicationDidBecomeActiveNotification
+#    define SentryWillResignActiveNotification UIApplicationWillResignActiveNotification
+#    define SentryWillTerminateNotification UIApplicationWillTerminateNotification
+#elif SENTRY_TARGET_MACOS_HAS_UI
+#    define SentryDidBecomeActiveNotification NSApplicationDidBecomeActiveNotification
+#    define SentryWillResignActiveNotification NSApplicationWillResignActiveNotification
+#    define SentryWillTerminateNotification NSApplicationWillTerminateNotification
+#endif
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -11,18 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @c NSNotificationCenter.
  */
 @interface SentryNSNotificationCenterWrapper : NSObject
-
-#if SENTRY_HAS_UIKIT || SENTRY_TARGET_MACOS_HAS_UI
-@property (nonatomic, readonly, copy, class) NSNotificationName didBecomeActiveNotificationName;
-@property (nonatomic, readonly, copy, class) NSNotificationName willResignActiveNotificationName;
-@property (nonatomic, readonly, copy, class) NSNotificationName willTerminateNotificationName;
-#endif
-
-#if SENTRY_HAS_UIKIT
-// macOS apps can not enter the background, therefore this notification
-// is not available there.
-@property (nonatomic, readonly, copy, class) NSNotificationName didEnterBackgroundNotificationName;
-#endif
 
 - (void)addObserver:(NSObject *)observer
            selector:(SEL)aSelector

--- a/Tests/SentryTests/Helper/SentryNSNotificationCenterWrapperTests.swift
+++ b/Tests/SentryTests/Helper/SentryNSNotificationCenterWrapperTests.swift
@@ -8,8 +8,8 @@ class SentryNSNotificationCenterWrapperTests: XCTestCase {
     private var didBecomeActiveExpectation: XCTestExpectation!
     private var willResignActiveExpectation: XCTestExpectation!
     
-    private let didBecomeActiveNotification = SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName
-    private let willResignActiveNotification = SentryNSNotificationCenterWrapper.willResignActiveNotificationName
+    private let didBecomeActiveNotification = CrossPlatformApplication.didBecomeActiveNotification
+    private let willResignActiveNotification = CrossPlatformApplication.willResignActiveNotification
     
     override func setUp() {
         super.setUp()

--- a/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/FramesTracking/SentryFramesTrackerTests.swift
@@ -683,7 +683,7 @@ class SentryFramesTrackerTests: XCTestCase {
         let sut = fixture.sut
         sut.start()
         
-        fixture.notificationCenter.post(Notification(name: SentryNSNotificationCenterWrapper.willResignActiveNotificationName))
+        fixture.notificationCenter.post(Notification(name: CrossPlatformApplication.willResignActiveNotification))
         
         XCTAssertFalse(sut.isRunning)
     }
@@ -699,9 +699,9 @@ class SentryFramesTrackerTests: XCTestCase {
         }
         sut.add(listener)
         
-        fixture.notificationCenter.post(Notification(name: SentryNSNotificationCenterWrapper.willResignActiveNotificationName))
+        fixture.notificationCenter.post(Notification(name: CrossPlatformApplication.willResignActiveNotification))
         
-        fixture.notificationCenter.post(Notification(name: SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName))
+        fixture.notificationCenter.post(Notification(name: CrossPlatformApplication.didBecomeActiveNotification))
         
         // Ensure to keep listeners when moving to background
         fixture.displayLinkWrapper.normalFrame()

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -608,7 +608,7 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.notificationCenter
             .post(
                 Notification(
-                    name: SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName,
+                    name: CrossPlatformApplication.didBecomeActiveNotification,
                     object: nil,
                     userInfo: nil
                 )
@@ -624,7 +624,7 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.notificationCenter
            .post(
                Notification(
-                   name: SentryNSNotificationCenterWrapper.didEnterBackgroundNotificationName,
+                  name: UIApplication.didEnterBackgroundNotification,
                    object: nil,
                    userInfo: nil
                )
@@ -652,7 +652,7 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.notificationCenter
             .post(
                 Notification(
-                    name: SentryNSNotificationCenterWrapper.willResignActiveNotificationName,
+                    name: CrossPlatformApplication.willResignActiveNotification,
                     object: nil,
                     userInfo: nil
                 )
@@ -669,7 +669,7 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.notificationCenter
             .post(
                 Notification(
-                    name: SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName,
+                    name: CrossPlatformApplication.didBecomeActiveNotification,
                     object: nil,
                     userInfo: nil
                 )
@@ -699,7 +699,7 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.notificationCenter
             .post(
                 Notification(
-                    name: SentryNSNotificationCenterWrapper.willTerminateNotificationName,
+                    name: CrossPlatformApplication.willTerminateNotification,
                     object: nil,
                     userInfo: nil
                 )
@@ -868,10 +868,10 @@ class SentrySessionTrackerTests: XCTestCase {
         XCTAssertEqual(4, notificationNames.count)
         
         XCTAssertEqual([
-            SentryNSNotificationCenterWrapper.didBecomeActiveNotificationName,
+            CrossPlatformApplication.didBecomeActiveNotification,
             NSNotification.Name(rawValue: SentryHybridSdkDidBecomeActiveNotificationName),
-            SentryNSNotificationCenterWrapper.willResignActiveNotificationName,
-            SentryNSNotificationCenterWrapper.willTerminateNotificationName
+            CrossPlatformApplication.willResignActiveNotification,
+            CrossPlatformApplication.willTerminateNotification
         ], notificationNames)
     }
 


### PR DESCRIPTION
While looking at moving NotificationCenterWrapper to swift I noticed this separate cleanup opportunity. This moves the functions that bridged iOS/Mac notifications into a typedef, which is less lines of code (making it safer by reducing the chance for typos) and also more performant (less app size, fewer objc method dispatch)

It works even better in Swift (currently only used by tests) where you can just define a single typedef and get all the notifications bridged without having to write another line for each notification name

The main change is in `SentryNSNotificationCenterWrapper.h` the rest of the changes are just updating the callsites.

#skip-changelog