### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @philipphofmann @armcknight @philprime @noahsmartin @trevor-e @itaybre @nicohinderling
+* @philipphofmann @armcknight @philprime @noahsmartin @itaybre


### PR DESCRIPTION
@trevor-e and @nicohinderling, I think we can remove you both as code owners so you have fewer GH notifications.
Your activity on this GH repo from both of you is zero or close to zero. I'm not blaming you; it's simply a fact. 

If you would like to remain code owners, please let me know.

#skip-changelog
