### PR TITLE
Example of using enable unhandled cpp in objc

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -81,6 +81,7 @@
 
         options.experimental.enableFileManagerSwizzling
             = ![args containsObject:@"--disable-filemanager-swizzling"];
+        options.experimental.enableUnhandledCPPExceptionsV2 = true;
 
         options.initialScope = ^(SentryScope *scope) {
             [scope setTagValue:@"" forKey:@""];


### PR DESCRIPTION
Not meant to be merged, just demonstrating this works

#skip-changelog