### PR TITLE
fix: Remove private import from sample app

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -1,7 +1,6 @@
 #import "AppDelegate.h"
 @import CoreData;
 @import Sentry;
-#import <Sentry/SentryOptions+Private.h>
 
 @import SentrySampleShared;
 


### PR DESCRIPTION
This doesn't seem to be used

#skip-changelog