### PR TITLE
Deprecate in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Add support for dist and environment fields for termination watch (#5560)
 - Record user for watchdog termination events (#5558)
 - Add support for tags and context fields for termination watch (#5561)
+- Deprecate getStoreEndpoint (#5591)
 
 ## 8.53.1
 


### PR DESCRIPTION
Just realized I should have included this in https://github.com/getsentry/sentry-cocoa/pull/5591 because I ended up adding a new deprecated attribute to a public method in that PR