### PR TITLE
feat(v9): Remove deprecated SentryDebugImageProvider in V9

### DIFF
--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -2,6 +2,7 @@
 #import "SentryAppStartMeasurement.h"
 #import "SentryBreadcrumb+Private.h"
 #import "SentryClient.h"
+#import "SentryDebugImageProvider+HybridSDKs.h"
 #import "SentryDebugImageProvider.h"
 #import "SentryExtraContextProvider.h"
 #import "SentryHub+Private.h"
@@ -52,6 +53,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
     return [SentrySerialization envelopeWithData:data];
 }
 
+#if !SDK_V9
 + (NSArray<SentryDebugMeta *> *)getDebugImages
 {
     // maintains previous behavior for the same method call by also trying to gather crash info
@@ -60,12 +62,13 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (NSArray<SentryDebugMeta *> *)getDebugImagesCrashed:(BOOL)isCrash
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return [[SentryDependencyContainer sharedInstance].debugImageProvider
         getDebugImagesCrashed:isCrash];
-#pragma clang diagnostic pop
+#    pragma clang diagnostic pop
 }
+#endif // !SDK_V9
 
 + (nullable SentryAppStartMeasurement *)appStartMeasurement
 {

--- a/Sources/Sentry/Public/SentryDebugImageProvider.h
+++ b/Sources/Sentry/Public/SentryDebugImageProvider.h
@@ -1,4 +1,6 @@
-#import <Foundation/Foundation.h>
+#if !SDK_V9
+
+#    import <Foundation/Foundation.h>
 
 @class SentryDebugMeta;
 @class SentryFrame;
@@ -88,3 +90,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // !SDK_V9

--- a/Sources/Sentry/SentryCrashDefaultBinaryImageProvider.m
+++ b/Sources/Sentry/SentryCrashDefaultBinaryImageProvider.m
@@ -1,7 +1,9 @@
-#import "SentryCrashDefaultBinaryImageProvider.h"
-#import "SentryCrashBinaryImageProvider.h"
-#import "SentryCrashDynamicLinker.h"
-#import <Foundation/Foundation.h>
+#if !SDK_V9
+
+#    import "SentryCrashDefaultBinaryImageProvider.h"
+#    import "SentryCrashBinaryImageProvider.h"
+#    import "SentryCrashDynamicLinker.h"
+#    import <Foundation/Foundation.h>
 
 @implementation SentryCrashDefaultBinaryImageProvider
 
@@ -18,3 +20,5 @@
 }
 
 @end
+
+#endif // !SDK_V9

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -1,6 +1,9 @@
 #import "SentryDebugImageProvider.h"
 #import "SentryBinaryImageCache.h"
-#import "SentryCrashDefaultBinaryImageProvider.h"
+#import "SentryDebugImageProvider+HybridSDKs.h"
+#if !SDK_V9
+#    import "SentryCrashDefaultBinaryImageProvider.h"
+#endif // !SDK_V9
 #import "SentryCrashDynamicLinker.h"
 #import "SentryCrashUUIDConversion.h"
 #import "SentryDebugMeta.h"
@@ -17,7 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryDebugImageProvider ()
 
+#if !SDK_V9
 @property (nonatomic, strong) id<SentryCrashBinaryImageProvider> binaryImageProvider;
+#endif // !SDK_V9
 @property (nonatomic, strong) SentryBinaryImageCache *binaryImageCache;
 
 @end
@@ -26,44 +31,35 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init
 {
+#if SDK_V9
+    self =
+        [self initWithBinaryImageCache:SentryDependencyContainer.sharedInstance.binaryImageCache];
+#else
     SentryCrashDefaultBinaryImageProvider *provider =
         [[SentryCrashDefaultBinaryImageProvider alloc] init];
-
     self = [self
         initWithBinaryImageProvider:provider
                    binaryImageCache:SentryDependencyContainer.sharedInstance.binaryImageCache];
+#endif // SDK_V9
 
     return self;
 }
 
 /** Internal constructor for testing */
+#if SDK_V9
+- (instancetype)initWithBinaryImageCache:(SentryBinaryImageCache *)binaryImageCache
+#else
 - (instancetype)initWithBinaryImageProvider:(id<SentryCrashBinaryImageProvider>)binaryImageProvider
                            binaryImageCache:(SentryBinaryImageCache *)binaryImageCache
+#endif // SDK_V9
 {
     if (self = [super init]) {
+#if !SDK_V9
         self.binaryImageProvider = binaryImageProvider;
+#endif // !SDK_v9
         self.binaryImageCache = binaryImageCache;
     }
     return self;
-}
-
-- (NSArray<SentryDebugMeta *> *)getDebugImagesForAddresses:(NSSet<NSString *> *)addresses
-                                                   isCrash:(BOOL)isCrash
-{
-    NSMutableArray<SentryDebugMeta *> *result = [NSMutableArray array];
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSArray<SentryDebugMeta *> *binaryImages = [self getDebugImagesCrashed:isCrash];
-#pragma clang diagnostic pop
-
-    for (SentryDebugMeta *sourceImage in binaryImages) {
-        if ([addresses containsObject:sourceImage.imageAddress]) {
-            [result addObject:sourceImage];
-        }
-    }
-
-    return result;
 }
 
 - (void)extractDebugImageAddressFromFrames:(NSArray<SentryFrame *> *)frames
@@ -74,6 +70,27 @@ NS_ASSUME_NONNULL_BEGIN
             [set addObject:frame.imageAddress];
         }
     }
+}
+
+#if !SDK_V9
+
+- (NSArray<SentryDebugMeta *> *)getDebugImagesForAddresses:(NSSet<NSString *> *)addresses
+                                                   isCrash:(BOOL)isCrash
+{
+    NSMutableArray<SentryDebugMeta *> *result = [NSMutableArray array];
+
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    NSArray<SentryDebugMeta *> *binaryImages = [self getDebugImagesCrashed:isCrash];
+#    pragma clang diagnostic pop
+
+    for (SentryDebugMeta *sourceImage in binaryImages) {
+        if ([addresses containsObject:sourceImage.imageAddress]) {
+            [result addObject:sourceImage];
+        }
+    }
+
+    return result;
 }
 
 - (NSArray<SentryDebugMeta *> *)getDebugImagesForFrames:(NSArray<SentryFrame *> *)frames
@@ -108,24 +125,27 @@ NS_ASSUME_NONNULL_BEGIN
     return [self getDebugImagesForAddresses:imageAddresses isCrash:isCrash];
 }
 
-- (NSArray<SentryDebugMeta *> *)getDebugImagesFromCacheForFrames:(NSArray<SentryFrame *> *)frames
+- (NSArray<SentryDebugMeta *> *)getDebugImages
 {
-    NSMutableSet<NSString *> *imageAddresses = [[NSMutableSet alloc] init];
-    [self extractDebugImageAddressFromFrames:frames intoSet:imageAddresses];
-
-    return [self getDebugImagesForImageAddressesFromCache:imageAddresses];
+    // maintains previous behavior for the same method call by also trying to gather crash info
+    return [self getDebugImagesCrashed:YES];
 }
 
-- (NSArray<SentryDebugMeta *> *)getDebugImagesFromCacheForThreads:(NSArray<SentryThread *> *)threads
+- (NSArray<SentryDebugMeta *> *)getDebugImagesCrashed:(BOOL)isCrash
 {
-    NSMutableSet<NSString *> *imageAddresses = [[NSMutableSet alloc] init];
+    NSMutableArray<SentryDebugMeta *> *debugMetaArray = [NSMutableArray new];
 
-    for (SentryThread *thread in threads) {
-        [self extractDebugImageAddressFromFrames:thread.stacktrace.frames intoSet:imageAddresses];
+    NSInteger imageCount = [self.binaryImageProvider getImageCount];
+    for (NSInteger i = 0; i < imageCount; i++) {
+        SentryCrashBinaryImage image = [self.binaryImageProvider getBinaryImage:i isCrash:isCrash];
+        SentryDebugMeta *debugMeta = [self fillDebugMetaFrom:image];
+        [debugMetaArray addObject:debugMeta];
     }
 
-    return [self getDebugImagesForImageAddressesFromCache:imageAddresses];
+    return debugMetaArray;
 }
+
+#endif // !SDK_V9
 
 - (NSArray<SentryDebugMeta *> *)getDebugImagesForImageAddressesFromCache:
     (NSSet<NSString *> *)imageAddresses
@@ -145,10 +165,23 @@ NS_ASSUME_NONNULL_BEGIN
     return result;
 }
 
-- (NSArray<SentryDebugMeta *> *)getDebugImages
+- (NSArray<SentryDebugMeta *> *)getDebugImagesFromCacheForFrames:(NSArray<SentryFrame *> *)frames
 {
-    // maintains previous behavior for the same method call by also trying to gather crash info
-    return [self getDebugImagesCrashed:YES];
+    NSMutableSet<NSString *> *imageAddresses = [[NSMutableSet alloc] init];
+    [self extractDebugImageAddressFromFrames:frames intoSet:imageAddresses];
+
+    return [self getDebugImagesForImageAddressesFromCache:imageAddresses];
+}
+
+- (NSArray<SentryDebugMeta *> *)getDebugImagesFromCacheForThreads:(NSArray<SentryThread *> *)threads
+{
+    NSMutableSet<NSString *> *imageAddresses = [[NSMutableSet alloc] init];
+
+    for (SentryThread *thread in threads) {
+        [self extractDebugImageAddressFromFrames:thread.stacktrace.frames intoSet:imageAddresses];
+    }
+
+    return [self getDebugImagesForImageAddressesFromCache:imageAddresses];
 }
 
 - (NSArray<SentryDebugMeta *> *)getDebugImagesFromCache
@@ -160,20 +193,6 @@ NS_ASSUME_NONNULL_BEGIN
         [result addObject:[self fillDebugMetaFromBinaryImageInfo:info]];
     }
     return result;
-}
-
-- (NSArray<SentryDebugMeta *> *)getDebugImagesCrashed:(BOOL)isCrash
-{
-    NSMutableArray<SentryDebugMeta *> *debugMetaArray = [NSMutableArray new];
-
-    NSInteger imageCount = [self.binaryImageProvider getImageCount];
-    for (NSInteger i = 0; i < imageCount; i++) {
-        SentryCrashBinaryImage image = [self.binaryImageProvider getBinaryImage:i isCrash:isCrash];
-        SentryDebugMeta *debugMeta = [self fillDebugMetaFrom:image];
-        [debugMetaArray addObject:debugMeta];
-    }
-
-    return debugMetaArray;
 }
 
 - (SentryDebugMeta *)fillDebugMetaFrom:(SentryCrashBinaryImage)image

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -21,9 +21,8 @@
 #import "SentryUIDeviceWrapper.h"
 #import <SentryAppStateManager.h>
 #import <SentryCrash.h>
-#import <SentryCrashDefaultBinaryImageProvider.h>
 #import <SentryCrashWrapper.h>
-#import <SentryDebugImageProvider.h>
+#import <SentryDebugImageProvider+HybridSDKs.h>
 #import <SentryDefaultRateLimits.h>
 #import <SentryDependencyContainer.h>
 #import <SentryGlobalEventProcessor.h>

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -56,6 +56,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  */
 + (nullable SentryEnvelope *)envelopeWithData:(NSData *)data;
 
+#if !SDK_V9
 /**
  * Returns the current list of debug images. Be aware that the @c SentryDebugMeta is actually
  * describing a debug image.
@@ -73,6 +74,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
  * crash, each image's data section crash info is also included.
  */
 + (NSArray<SentryDebugMeta *> *)getDebugImagesCrashed:(BOOL)isCrash;
+#endif // !SDK_V9
 
 /**
  * Override SDK information.

--- a/Sources/Sentry/include/HybridPublic/SentryDebugImageProvider+HybridSDKs.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDebugImageProvider+HybridSDKs.h
@@ -4,13 +4,21 @@
 #    import "SentryDebugImageProvider.h"
 #endif
 
+#import <Foundation/Foundation.h>
+
 @class SentryDebugMeta;
 @class SentryThread;
 @class SentryFrame;
 
 NS_ASSUME_NONNULL_BEGIN
 
+#if SDK_V9
+@interface SentryDebugImageProvider : NSObject
+#else
 @interface SentryDebugImageProvider ()
+#endif
+
+- (instancetype)init;
 
 /**
  * Returns a list of debug images that are being referenced by the given frames.

--- a/Sources/Sentry/include/SentryCrashBinaryImageProvider.h
+++ b/Sources/Sentry/include/SentryCrashBinaryImageProvider.h
@@ -1,5 +1,7 @@
-#import "SentryCrashDynamicLinker.h"
-#import <Foundation/Foundation.h>
+#if !SDK_V9
+
+#    import "SentryCrashDynamicLinker.h"
+#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -21,3 +23,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // !SDK_V9

--- a/Sources/Sentry/include/SentryCrashDefaultBinaryImageProvider.h
+++ b/Sources/Sentry/include/SentryCrashDefaultBinaryImageProvider.h
@@ -1,5 +1,6 @@
-#import "SentryCrashBinaryImageProvider.h"
-#import <Foundation/Foundation.h>
+#if !SDK_V9
+#    import "SentryCrashBinaryImageProvider.h"
+#    import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -8,3 +9,5 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
+
+#endif // !SDK_V9

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
@@ -480,6 +480,7 @@ getCrashInfo(const struct mach_header *header, SentryCrashBinaryImage *buffer)
     }
 }
 
+#if !SDK_V9
 int
 sentrycrashdl_imageCount(void)
 {
@@ -497,6 +498,7 @@ sentrycrashdl_getBinaryImage(int index, SentryCrashBinaryImage *buffer, bool isC
     const char *imageName = _dyld_get_image_name((unsigned)index);
     return sentrycrashdl_getBinaryImageForHeader((const void *)header, imageName, buffer, isCrash);
 }
+#endif // !SDK_V9
 
 void
 sentrycrashdl_getCrashInfo(uint64_t address, SentryCrashBinaryImage *buffer)

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.h
@@ -63,6 +63,7 @@ typedef struct {
     uintptr_t size;
 } SentrySegmentAddress;
 
+#if !SDK_V9
 /** Get the number of loaded binary images.
  */
 int sentrycrashdl_imageCount(void);
@@ -76,6 +77,7 @@ int sentrycrashdl_imageCount(void);
  * @return True if the image was successfully queried.
  */
 bool sentrycrashdl_getBinaryImage(int index, SentryCrashBinaryImage *buffer, bool isCrash);
+#endif // !SDK_V9
 
 /** Get information about a binary image based on mach_header.
  *


### PR DESCRIPTION
Moves SentryDebugImageProvider to be an internal class for v9, visible only to the hybrid SDK. The only methods on this class that are currently public are deprecated and now removed behind the V9 flag.

#skip-changelog