### PR TITLE
feat(v9): Mark deprecated APIs as deprecated

### DIFF
--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -164,9 +164,12 @@ sentry_shouldProfileNextLaunch(SentryOptions *options)
         return sentry_launchShouldHaveContinuousProfilingV2(options);
     }
 
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([options isContinuousProfilingEnabled]) {
         return (SentryLaunchProfileConfig) { options.enableAppLaunchProfiling, nil, nil };
     }
+#    pragma clang diagnostic pop
 
     return sentry_launchShouldHaveTransactionProfiling(options);
 }

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -543,7 +543,9 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @c SentryProfileOptions.startOnAppStart and @c SentryProfileOptions.lifecycle .
  * @note Profiling is automatically disabled if a thread sanitizer is attached.
  */
-@property (nonatomic, assign) BOOL enableAppLaunchProfiling;
+@property (nonatomic, assign) BOOL enableAppLaunchProfiling DEPRECATED_MSG_ATTRIBUTE(
+    "This property is deprecated and will be removed in a future version of the SDK. See "
+    "SentryProfileOptions.startOnAppStart and SentryProfileOptions.lifecycle");
 
 /**
  * @note Profiling is not supported on watchOS or tvOS.
@@ -570,7 +572,9 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @warning This property is deprecated and will be removed in a future version of the SDK. See
  * @c  SentryProfileOptions.sessionSampleRate.
  */
-@property (nullable, nonatomic, strong) NSNumber *profilesSampleRate;
+@property (nullable, nonatomic, strong) NSNumber *profilesSampleRate DEPRECATED_MSG_ATTRIBUTE(
+    "This property is deprecated and will be removed in a future version of the SDK. See "
+    "SentryProfileOptions.sessionSampleRate");
 
 /**
  * @note Profiling is not supported on watchOS or tvOS.
@@ -584,7 +588,11 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @warning This property is deprecated and will be removed in a future version of the SDK. See
  * @c SentryProfileOptions.sessionSampleRate .
  */
-@property (nullable, nonatomic) SentryTracesSamplerCallback profilesSampler NS_SWIFT_SENDABLE;
+@property (nullable, nonatomic)
+    SentryTracesSamplerCallback profilesSampler NS_SWIFT_SENDABLE DEPRECATED_MSG_ATTRIBUTE(
+        "This property is deprecated and will be removed in a future version of the SDK. See "
+        "SentryProfileOptions.sessionSampleRate");
+;
 
 /**
  * If profiling should be enabled or not.
@@ -597,7 +605,8 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @note Profiling is automatically disabled if a thread sanitizer is attached.
  * @warning This property is deprecated and will be removed in a future version of the SDK.
  */
-@property (nonatomic, assign, readonly) BOOL isProfilingEnabled;
+@property (nonatomic, assign, readonly) BOOL isProfilingEnabled DEPRECATED_MSG_ATTRIBUTE(
+    "This property is deprecated and will be removed in a future version of the SDK");
 
 /**
  * @brief Whether to enable the sampling profiler.

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -153,7 +153,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.tracesSampleRate = nil;
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         _enableProfiling = NO;
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
         self.profilesSampleRate = SENTRY_INITIAL_PROFILES_SAMPLE_RATE;
+#    pragma clang diagnostic pop
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
         self.enableCoreDataTracing = YES;
         _enableSwizzling = YES;
@@ -538,12 +541,18 @@ NSString *const kSentryDefaultEnvironment = @"production";
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
     if ([options[@"profilesSampleRate"] isKindOfClass:[NSNumber class]]) {
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
         self.profilesSampleRate = options[@"profilesSampleRate"];
+#    pragma clang diagnostic pop
     }
 
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     if ([self isBlock:options[@"profilesSampler"]]) {
         self.profilesSampler = options[@"profilesSampler"];
     }
+#    pragma clang diagnostic pop
 
     [self setBool:options[@"enableProfiling"]
             block:^(BOOL value) { self->_enableProfiling = value; }];

--- a/Sources/Sentry/SentrySampling.m
+++ b/Sources/Sentry/SentrySampling.m
@@ -108,15 +108,18 @@ sentry_sampleTraceProfile(SentrySamplingContext *context,
                                                  forSampleRate:@1.0
                                                 withSampleRand:@1.0];
     }
-#    pragma clang diagnostic pop
 
     NSNumber *callbackRate = _sentry_samplerCallbackRate(
         options.profilesSampler, context, SENTRY_DEFAULT_PROFILES_SAMPLE_RATE);
+#    pragma clang diagnostic pop
     if (callbackRate != nil) {
         return _sentry_calcSample(callbackRate);
     }
 
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     return _sentry_calcSampleFromNumericalRate(options.profilesSampleRate);
+#    pragma clang diagnostic pop
 }
 
 SentrySamplerDecision *

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -22,8 +22,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithOptions:(SentryOptions *_Nullable)options
 {
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSArray<NSString *> *features =
         [SentryEnabledFeaturesBuilder getEnabledFeaturesWithOptions:options];
+#pragma clang diagnostic pop
 
     NSMutableArray<NSString *> *integrations =
         [SentrySDK.currentHub trimmedInstalledIntegrationNames];

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -3,6 +3,7 @@ import Foundation
 @objcMembers @_spi(Private) public class SentryEnabledFeaturesBuilder: NSObject {
 
     // swiftlint:disable cyclomatic_complexity function_body_length
+    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     public static func getEnabledFeatures(options: Options?) -> [String] {
         guard let options = options else {
             return []

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -2,6 +2,7 @@
 import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+@available(*, deprecated, message: "App launch profiling is deprecated in favor of continuous profiling.")
 final class SentryAppLaunchProfilingTests: XCTestCase {
     private var fixture: SentryProfileTestFixture!
 
@@ -17,6 +18,7 @@ final class SentryAppLaunchProfilingTests: XCTestCase {
 }
 
 // MARK: transaction based profiling
+@available(*, deprecated, message: "App launch profiling is deprecated in favor of continuous profiling.")
 extension SentryAppLaunchProfilingTests {
     // test that the launch trace instance is nil after stopping the launch
     // profiler
@@ -95,6 +97,7 @@ extension SentryAppLaunchProfilingTests {
 
 // MARK: transaction based profiling iOS-only
 #if !os(macOS)
+@available(*, deprecated, message: "App launch profiling is deprecated in favor of continuous profiling.")
 extension SentryAppLaunchProfilingTests {
     // test that if a launch trace profiler is running and SentryTimeToDisplayTracker reports the app had its initial frame drawn and isn't waiting for full drawing, that the profile is stopped
     func testLaunchTraceProfileStoppedOnInitialDisplayWithoutWaitingForFullDisplay() throws {
@@ -145,6 +148,7 @@ extension SentryAppLaunchProfilingTests {
 #endif // !os(macOS)
 
 // MARK: continuous profiling v1
+@available(*, deprecated, message: "Continuos profiling V1 is deprecated.")
 extension SentryAppLaunchProfilingTests {
     // test continuous launch profiling configuration
     func testContinuousLaunchProfileV1Configuration() throws {
@@ -205,6 +209,7 @@ extension SentryAppLaunchProfilingTests {
 
 // MARK: continuous profiling v1 iOS-only
 #if !os(macOS)
+@available(*, deprecated, message: "Continuos profiling V1 is deprecated.")
 extension SentryAppLaunchProfilingTests {
     // test that if a launch continuous profiler is running and SentryTimeToDisplayTracker reports the app is fully drawn, that the profiler continues running
     func testLaunchContinuousProfileV1NotStoppedOnFullyDisplayed() throws {
@@ -250,6 +255,7 @@ extension SentryAppLaunchProfilingTests {
 #endif // !os(macOS)
 
 // MARK: continuous profiling v2
+@available(*, deprecated, message: "This is only deprecated because SentryAppLaunchProfilingTests is deprecated. Once trace based and continuous profiling v1 is removed this deprecation can be removed.")
 extension SentryAppLaunchProfilingTests {
     func testContinuousLaunchProfileV2TraceLifecycleConfiguration() throws {
         // Arrange
@@ -488,6 +494,7 @@ extension SentryAppLaunchProfilingTests {
 
 // MARK: continuous profiling v2 iOS-only
 #if !os(macOS)
+@available(*, deprecated, message: "This is only deprecated because SentryAppLaunchProfilingTests is deprecated. Once trace based and continuous profiling v1 is removed this deprecation can be removed.")
 extension SentryAppLaunchProfilingTests {
     func testLaunchContinuousProfileV2TraceLifecycleNotStoppedOnFullyDisplayed() throws {
         // Arrange

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
@@ -28,6 +28,7 @@ final class SentryAppStartProfilingConfigurationTests: XCTestCase {
     }
 }
 
+@available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
 extension SentryAppStartProfilingConfigurationTests {
     func testValidCombinations() {
         for config in SentryAppStartProfilingConfigurationTests.validConfigurations {
@@ -61,6 +62,7 @@ extension SentryAppStartProfilingConfigurationTests {
 }
 
 private extension SentryAppStartProfilingConfigurationTests {
+    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     private func performTest(expectedOptions: LaunchProfileOptions, shouldProfileLaunch: Bool) {
         let actualOptions = Options()
         actualOptions.enableAppLaunchProfiling = expectedOptions.enableAppLaunchProfiling

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
 
+@available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
 final class SentryContinuousProfilerTests: XCTestCase {
     private var fixture: SentryProfileTestFixture!
     
@@ -206,6 +207,7 @@ final class SentryContinuousProfilerTests: XCTestCase {
     }
 }
 
+@available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
 private extension SentryContinuousProfilerTests {
     func addMockSamples(mockAddresses: [NSNumber]) throws {
         let mockThreadMetadata = SentryProfileTestFixture.ThreadMetadata(id: 1, priority: 2, name: "main")

--- a/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
+++ b/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
@@ -39,6 +39,7 @@ class SentryProfileTestFixture {
     lazy var framesTracker = TestFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: currentDateProvider, dispatchQueueWrapper: dispatchQueueWrapper, notificationCenter: notificationCenter, keepDelayedFramesDuration: 0)
 #endif // !os(macOS)
     
+    @available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
     init() {
         SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueueWrapper
         SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -63,6 +63,7 @@ class SentryProfilingPublicAPITests: XCTestCase {
 }
 
 // MARK: transaction profiling
+@available(*, deprecated, message: "Transaction profiling is deprecated")
 extension SentryProfilingPublicAPITests {
     func testSentryOptionsReportsProfilingCorrelatedToTraces_NonnilSampleRate() {
         // Arrange
@@ -98,6 +99,7 @@ extension SentryProfilingPublicAPITests {
 }
 
 // MARK: continuous profiling v1
+@available(*, deprecated, message: "Continuous profiling v1 is deprecated")
 extension SentryProfilingPublicAPITests {
     func testSentryOptionsReportsContinuousProfilingEnabled() {
         // Arrange
@@ -203,6 +205,7 @@ extension SentryProfilingPublicAPITests {
 }
 
 // MARK: continuous profiling v2
+@available(*, deprecated, message: "This is only deprecated because profilesSampleRate is deprecated. Once that is removed this attribute can be removed.")
 extension SentryProfilingPublicAPITests {
     func testSentryOptionsReportsContinuousProfilingV2Enabled() {
         // Arrange

--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -4,6 +4,7 @@ import _SentryPrivate
 import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
+@available(*, deprecated, message: "This is only marked deprecated because SentryProfileTestFixture is marked as deprecated.")
 class SentryTraceProfilerTests: XCTestCase {
 
     private var fixture: SentryProfileTestFixture!
@@ -360,6 +361,7 @@ class SentryTraceProfilerTests: XCTestCase {
 #endif // !os(macOS)
 }
 
+@available(*, deprecated, message: "This is only marked deprecated because SentryProfileTestFixture is marked as deprecated.")
 private extension SentryTraceProfilerTests {
     func getLatestProfileData() throws -> Data {
         let envelope = try XCTUnwrap(self.fixture.client?.captureEventWithScopeInvocations.last)

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -1,6 +1,7 @@
 @_spi(Private) @testable import Sentry
 import XCTest
 
+@available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
 final class SentryEnabledFeaturesBuilderTests: XCTestCase {
 
     func testDefaultFeatures() throws {

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -736,9 +736,9 @@
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     XCTAssertEqual(NO, options.enableProfiling);
-#    pragma clang diagnostic pop
     XCTAssertNil(options.profilesSampleRate);
     XCTAssertNil(options.profilesSampler);
+#    pragma clang diagnostic pop
     XCTAssertTrue([options isContinuousProfilingEnabled]);
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -1155,6 +1155,8 @@
     [self testBooleanField:@"enableProfiling" defaultValue:NO];
 }
 
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testProfilesSampleRate
 {
     SentryOptions *options = [self getValidOptions:@{ @"profilesSampleRate" : @0.1 }];
@@ -1344,6 +1346,7 @@
     XCTAssertNil(options.profilesSampler);
     XCTAssertTrue([options isContinuousProfilingEnabled]);
 }
+#    pragma clang diagnostic pop
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
@@ -1426,11 +1429,14 @@
 }
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testEnableAppLaunchProfilingDefaultValue
 {
     SentryOptions *options = [self getValidOptions:@{}];
     XCTAssertFalse(options.enableAppLaunchProfiling);
 }
+#    pragma clang diagnostic pop
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
 - (SentryOptions *)getValidOptions:(NSDictionary<NSString *, id> *)dict

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -2,6 +2,7 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
+@available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
 class SentrySpanTests: XCTestCase {
     private var logOutput: TestLogOutput!
     private var fixture: Fixture!

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -19649,9 +19649,11 @@
             "declKind": "Var",
             "usr": "c:objc(cs)SentryOptions(py)enableAppLaunchProfiling",
             "moduleName": "Sentry",
+            "deprecated": true,
             "isOpen": true,
             "objc_name": "enableAppLaunchProfiling",
             "declAttributes": [
+              "Available",
               "ObjC",
               "Dynamic"
             ],
@@ -19671,10 +19673,12 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)enableAppLaunchProfiling",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "enableAppLaunchProfiling",
                 "declAttributes": [
                   "DiscardableResult",
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],
@@ -19707,9 +19711,11 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)setEnableAppLaunchProfiling:",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "setEnableAppLaunchProfiling:",
                 "declAttributes": [
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],
@@ -19740,9 +19746,11 @@
             "declKind": "Var",
             "usr": "c:objc(cs)SentryOptions(py)profilesSampleRate",
             "moduleName": "Sentry",
+            "deprecated": true,
             "isOpen": true,
             "objc_name": "profilesSampleRate",
             "declAttributes": [
+              "Available",
               "ObjC",
               "Dynamic"
             ],
@@ -19770,10 +19778,12 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)profilesSampleRate",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "profilesSampleRate",
                 "declAttributes": [
                   "DiscardableResult",
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],
@@ -19814,9 +19824,11 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)setProfilesSampleRate:",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "setProfilesSampleRate:",
                 "declAttributes": [
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],
@@ -19868,9 +19880,11 @@
             "declKind": "Var",
             "usr": "c:objc(cs)SentryOptions(py)profilesSampler",
             "moduleName": "Sentry",
+            "deprecated": true,
             "isOpen": true,
             "objc_name": "profilesSampler",
             "declAttributes": [
+              "Available",
               "ObjC",
               "Dynamic"
             ],
@@ -19919,10 +19933,12 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)profilesSampler",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "profilesSampler",
                 "declAttributes": [
                   "DiscardableResult",
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],
@@ -19984,9 +20000,11 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)setProfilesSampler:",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "setProfilesSampler:",
                 "declAttributes": [
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],
@@ -20009,9 +20027,11 @@
             "declKind": "Var",
             "usr": "c:objc(cs)SentryOptions(py)isProfilingEnabled",
             "moduleName": "Sentry",
+            "deprecated": true,
             "isOpen": true,
             "objc_name": "isProfilingEnabled",
             "declAttributes": [
+              "Available",
               "ObjC",
               "Dynamic"
             ],
@@ -20031,10 +20051,12 @@
                 "declKind": "Accessor",
                 "usr": "c:objc(cs)SentryOptions(im)isProfilingEnabled",
                 "moduleName": "Sentry",
+                "deprecated": true,
                 "isOpen": true,
                 "objc_name": "isProfilingEnabled",
                 "declAttributes": [
                   "DiscardableResult",
+                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],


### PR DESCRIPTION
These are all deprecated but were not using the deprecated attribute

#skip-changelog