### PR TITLE
Update v9 changelog

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -1,4 +1,6 @@
-## 9.0
+# 9.0
+
+## Breaking Changes
 
 ### Fixes
 

--- a/develop-docs/README.md
+++ b/develop-docs/README.md
@@ -286,4 +286,4 @@ Future types conforming to Decodable can be written in Swift from the start and 
 
 ## v9
 
-Work on the v9 SDK is being done behind the compiler flag `SDK_V9`. CI builds the SDK with this flag enabled to ensure it does not break during the course of non-v9 development. This SDK version will focus on quality and be a part of Sentry’s quality quarter initiative. Notably, the minimum supported OS version will be bumped in this release. The changelog for this release is being tracked in CHANGELOG-v9.md.
+Work on the v9 SDK is being done behind the compiler flag `SDK_V9`. CI builds the SDK with this flag enabled to ensure it does not break during the course of non-v9 development. This SDK version will focus on quality and be a part of Sentry’s quality quarter initiative. Notably, the minimum supported OS version will be bumped in this release. The changelog for this release is being tracked in [CHANGELOG-v9.md](../CHANGELOG-v9.md).


### PR DESCRIPTION
Creating a changelog file specific for v9 to keep track of the changes we are making that will eventually be copied into the real changelog.

#skip-changelog