### PR TITLE
ref: Update frame processing logic in SentryVideoFrameProcessor to handle multiple frames when input is ready

### DIFF
--- a/Sources/Swift/Integrations/SessionReplay/SentryVideoFrameProcessor.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryVideoFrameProcessor.swift
@@ -46,46 +46,48 @@ class SentryVideoFrameProcessor {
     }
 
     func processFrames(videoWriterInput: AVAssetWriterInput, onCompletion: @escaping (Result<SentryRenderVideoResult, Error>) -> Void) {
-        SentrySDKLog.debug("[Session Replay] Video writer input is ready, status: \(videoWriter.status)")
-        guard videoWriter.status == .writing else {
-            SentrySDKLog.error("[Session Replay] Video writer is not writing anymore, cancelling the writing session, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
-            videoWriter.inputs.forEach { $0.markAsFinished() }
-            videoWriter.cancelWriting()
-            return onCompletion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
+        while videoWriterInput.isReadyForMoreMediaData {
+            SentrySDKLog.debug("[Session Replay] Video writer input is ready, status: \(videoWriter.status)")
+            guard videoWriter.status == .writing else {
+                SentrySDKLog.error("[Session Replay] Video writer is not writing anymore, cancelling the writing session, reason: \(videoWriter.error?.localizedDescription ?? "Unknown error")")
+                videoWriter.inputs.forEach { $0.markAsFinished() }
+                videoWriter.cancelWriting()
+                return onCompletion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
+            }
+            guard frameIndex < videoFrames.count else {
+                SentrySDKLog.debug("[Session Replay] No more frames available to process, finishing the video")
+                return finishVideo(frameIndex: self.frameIndex, onCompletion: onCompletion)
+            }
+            
+            let frame = videoFrames[frameIndex]
+            defer {
+                // Increment the frame index even if the image could not be appended to the pixel buffer.
+                // This is important to avoid an infinite loop.
+                frameIndex += 1
+            }
+            guard let image = UIImage(contentsOfFile: frame.imagePath) else {
+                return
+            }
+            
+            SentrySDKLog.debug("[Session Replay] Image at index \(frameIndex) is ready, size: \(image.size)")
+            guard lastImageSize == image.size else {
+                SentrySDKLog.debug("[Session Replay] Image size has changed, finishing video")
+                return finishVideo(frameIndex: self.frameIndex, onCompletion: onCompletion)
+            }
+            lastImageSize = image.size
+            
+            let presentTime = SentryOnDemandReplay.calculatePresentationTime(
+                forFrameAtIndex: frameIndex,
+                frameRate: frameRate
+            ).timeValue
+            guard currentPixelBuffer.append(image: image, presentationTime: presentTime) else {
+                SentrySDKLog.error("[Session Replay] Failed to append image to pixel buffer, cancelling the writing session, reason: \(String(describing: videoWriter.error))")
+                videoWriter.inputs.forEach { $0.markAsFinished() }
+                videoWriter.cancelWriting()
+                return onCompletion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
+            }
+            usedFrames.append(frame)
         }
-        guard frameIndex < videoFrames.count else {
-            SentrySDKLog.debug("[Session Replay] No more frames available to process, finishing the video")
-            return finishVideo(frameIndex: self.frameIndex, onCompletion: onCompletion)
-        }
-
-        let frame = videoFrames[frameIndex]
-        defer {
-            // Increment the frame index even if the image could not be appended to the pixel buffer.
-            // This is important to avoid an infinite loop.
-            frameIndex += 1
-        }
-        guard let image = UIImage(contentsOfFile: frame.imagePath) else {
-            return
-        }
-
-        SentrySDKLog.debug("[Session Replay] Image at index \(frameIndex) is ready, size: \(image.size)")
-        guard lastImageSize == image.size else {
-            SentrySDKLog.debug("[Session Replay] Image size has changed, finishing video")
-            return finishVideo(frameIndex: self.frameIndex, onCompletion: onCompletion)
-        }
-        lastImageSize = image.size
-
-        let presentTime = SentryOnDemandReplay.calculatePresentationTime(
-            forFrameAtIndex: frameIndex,
-            frameRate: frameRate
-        ).timeValue
-        guard currentPixelBuffer.append(image: image, presentationTime: presentTime) else {
-            SentrySDKLog.error("[Session Replay] Failed to append image to pixel buffer, cancelling the writing session, reason: \(String(describing: videoWriter.error))")
-            videoWriter.inputs.forEach { $0.markAsFinished() }
-            videoWriter.cancelWriting()
-            return onCompletion(.failure(videoWriter.error ?? SentryOnDemandReplayError.errorRenderingVideo))
-        }
-        usedFrames.append(frame)
     }
 
     // swiftlint:enable function_body_length cyclomatic_complexity

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryVideoFrameProcessorTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryVideoFrameProcessorTests.swift
@@ -197,16 +197,16 @@ class SentryVideoFrameProcessorTests: XCTestCase {
 
     // MARK: - Process Frames Tests
 
-    func testProcessFrames_WhenInputIsReady_ShouldProcessAvailableFrame() {
+    func testProcessFrames_WhenInputIsReady_ShouldProcessAvailableFrames() {
         let sut = fixture.getSut()
         let videoWriterInput = TestAVAssetWriterInput(mediaType: .video, outputSettings: nil)
         videoWriterInput.isReadyForMoreMediaDataOverride = true
 
         sut.processFrames(videoWriterInput: videoWriterInput) { _ in }
 
-        XCTAssertEqual(fixture.currentPixelBuffer.appendInvocations.count, 1)
-        XCTAssertEqual(sut.frameIndex, 1)
-        XCTAssertEqual(sut.usedFrames.count, 1)
+        XCTAssertEqual(fixture.currentPixelBuffer.appendInvocations.count, 3)
+        XCTAssertEqual(sut.frameIndex, 3)
+        XCTAssertEqual(sut.usedFrames.count, 3)
     }
 
     func testProcessFrames_WhenVideoWriterNotWriting_ShouldCancelWriting() {
@@ -240,11 +240,6 @@ class SentryVideoFrameProcessorTests: XCTestCase {
         let completionInvocations = Invocations<Result<SentryRenderVideoResult, any Error>>()
 
         // Process all frames
-        for _ in 0..<sut.videoFrames.count {
-            sut.processFrames(videoWriterInput: videoWriterInput) { completionInvocations.record($0) }
-        }
-
-        // Process again - should finish video
         sut.processFrames(videoWriterInput: videoWriterInput) { completionInvocations.record($0) }
 
         XCTAssertTrue(fixture.videoWriter.finishWritingCalled)


### PR DESCRIPTION
#skip-changelog