### PR TITLE
Armcknight/impr/profile serialization off main thread

### DIFF
--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -157,23 +157,40 @@ final class SentryContinuousProfilerTests: XCTestCase {
         XCTAssertEqual(2, self.fixture.client?.captureEnvelopeInvocations.count)
     }
     
-    func testChunkSerializationAfterBufferInterval() throws {
+    func testChunkSerializationExecutesOnBackgroundThread() throws {
         SentryContinuousProfiler.start()
         XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
         
-        // Advance time by the buffer interval to trigger chunk serialization
+        // Prevent background serialization from executing automatically
+        fixture.dispatchQueueWrapper.dispatchAsyncExecutesBlock = false
+
+        // Memoize how many dispatch asyncs were called during system setup; we'll expect one more for the serialization after simulating the timer elapse below where the serialization should take place
+        let currentAsyncDispatches = fixture.dispatchQueueWrapper.dispatchAsyncCalled
+
+        // Trigger chunk creation by advancing time and firing timer
         fixture.currentDateProvider.advanceBy(interval: 60)
         try fixture.timeoutTimerFactory.check()
         
-        // Check that a chunk was serialized and sent
-        let envelope = try XCTUnwrap(self.fixture.client?.captureEnvelopeInvocations.last)
+        // Validate that no envelope was captured yet (serialization hasn't completed)
+        XCTAssertTrue(fixture.client?.captureEnvelopeInvocations.isEmpty ?? true)
+        
+        // Validate that background work was queued (serialization will be performed on background thread)
+        XCTAssertEqual(fixture.dispatchQueueWrapper.dispatchAsyncCalled, currentAsyncDispatches + 1)
+
+        // Execute the background serialization work
+        fixture.dispatchQueueWrapper.dispatchAsyncExecutesBlock = true
+        fixture.dispatchQueueWrapper.invokeLastDispatchAsync()
+        
+        // Validate that background work completed:
+        // - Envelope was captured with profile chunk
+        let envelope = try XCTUnwrap(fixture.client?.captureEnvelopeInvocations.last)
         let profileItem = try XCTUnwrap(envelope.items.first)
         XCTAssertEqual("profile_chunk", profileItem.header.type)
         
-        // Ensure the profiler is still running
+        // Profiler should still be running after chunk serialization
         XCTAssert(SentryContinuousProfiler.isCurrentlyProfiling())
         
-        // Stop the profiler
+        // Clean up
         SentryContinuousProfiler.stop()
         try assertContinuousProfileStoppage()
     }


### PR DESCRIPTION
It was pointed out that we're performing JSON serialization of continuous profiling chunks on the main thread. Move it off to a background thread similar to how it was done for transaction profiling in https://github.com/getsentry/sentry-cocoa/pull/4377.