### PR TITLE
meta: claude init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Best Practices
+
+- Before forming a commit, ensure compilation succeeds for all platforms: iOS, macOS, tvOS, watchOS and visionOS. This should hold for:
+  - the SDK framework targets
+  - the sample apps
+  - the test targets for the SDK framework and sample apps
+- Before submitting a branch for a PR, ensure there are no new issues being introduced for:
+  - static analysis
+  - runtime analysis, using thread, address and undefined behavior sanitizers
+  - cross platform dependencies:
+    - React Native
+    - Flutter
+    - .Net
+    - Unity
+- While preparing changes, ensure that relevant documentation is added/updated in:
+  - headerdocs and inline comments
+  - readmes and maintainer markdown docs
+  - our docs repo and web app onboarding
+  - our cli and integration wizard
+
+## Helpful Commands
+
+- run static analysis: `make analyze`
+- run unit tests: `make run-test-server && make test`
+- run important UI tests: `make test-ui-critical`
+- build the XCFramework deliverables: `make build-xcframework`
+- lint pod deliverable: make `pod-lint`
+
+## Resources & Documentation
+
+- **Main Documentation**: [docs.sentry.io/platforms/apple](https://docs.sentry.io/platforms/apple/)
+  - **Docs Repo**: [sentry-docs](https://github.com/getsentry/sentry-docs)
+- **SDK Developer Documentation**: [develop.sentry.dev/sdk/](https://develop.sentry.dev/sdk/)
+
+### `sentry-cocoa` Maintainer Documentation
+
+- **README**: @README.md
+- **Contributing**: @CONTRIBUTING.md
+- **Developer README**: @develop-docs/README.md
+- **Sample App collection README**: @Samples/README.md
+
+## Related Code & Repositories
+
+- [sentry-cli](https://github.com/getsentry/sentry-cli): uploading dSYMs for symbolicating stack traces gathered via the SDK
+- [sentry-wizard](https://github.com/getsentry/sentry-wizard): automatically injecting SDK initialization code
+- [sentry-cocoa onboarding](https://github.com/getsentry/sentry/blob/master/static/app/utils/gettingStartedDocs/apple.tsx): the web app's onboarding instructions for `sentry-cocoa`
+- [sentry-unity](https://github.com/getsentry/sentry-unity): the Sentry Unity SDK, which depends on sentry-cocoa
+- [sentry-dart](https://github.com/getsentry/sentry-dart): the Sentry Dart SDK, which depends on sentry-cocoa
+- [sentry-react-native](https://github.com/getsentry/sentry-react-native): the Sentry React Native SDK, which depends on sentry-cocoa
+- [sentry-dotnet](https://github.com/getsentry/sentry-dotnet): the Sentry .NET SDK, which depends on sentry-cocoa

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Helpful Commands
 
+- format code: `make format`
 - run static analysis: `make analyze`
 - run unit tests: `make run-test-server && make test`
 - run important UI tests: `make test-ui-critical`

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -1952,6 +1952,7 @@
 		84A8891A28DBD28900C51DFD /* SentryDevice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDevice.h; path = include/SentryDevice.h; sourceTree = "<group>"; };
 		84A8891B28DBD28900C51DFD /* SentryDevice.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDevice.m; sourceTree = "<group>"; };
 		84A8892028DBD8D600C51DFD /* SentryDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDeviceTests.m; sourceTree = "<group>"; };
+		84A899342E218C5F009A551E /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
 		84A903702D39F66F00690CE4 /* SentryUserFeedbackFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUserFeedbackFormViewModel.swift; sourceTree = "<group>"; };
 		84AB6AAF2DB2E9BA006D6C83 /* Versioning.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Versioning.xcconfig; sourceTree = "<group>"; };
 		84AC61D029F7541E009EEF61 /* SentryDispatchSourceWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDispatchSourceWrapper.h; path = include/SentryDispatchSourceWrapper.h; sourceTree = "<group>"; };
@@ -4401,6 +4402,7 @@
 		D878C6C22BC8066D0039D6A3 /* Docs */ = {
 			isa = PBXGroup;
 			children = (
+				84A899342E218C5F009A551E /* CLAUDE.md */,
 				844DA81028246D5000E6B62E /* CONTRIBUTING.md */,
 				844DA80E28246D5000E6B62E /* LICENSE.md */,
 				840B7EF02BBF2B5F008B8120 /* MIGRATION.md */,


### PR DESCRIPTION
I've started using Claude Code, and wanted to introduce a CLAUDE.md into our repo to help with it.

For future reference, we have a couple other repos at Sentry that already have a CLAUDE.md file: 
- https://github.com/getsentry/sentry-javascript/blob/develop/CLAUDE.md
- https://github.com/getsentry/getsentry/blob/master/CLAUDE.md
- https://github.com/getsentry/sentry-mcp/blob/main/CLAUDE.md
- https://github.com/getsentry/vanguard/blob/main/CLAUDE.md

And there is also a general collection of rules at https://github.com/steipete/agent-rules. 

And then there are the anthropic docs: https://www.anthropic.com/engineering/claude-code-best-practices and https://docs.anthropic.com/en/docs/claude-code/memory were two I read while going through this.

Keeping those in mind, let's iterate on this going forward, step by step.

#skip-changelog