### PR TITLE
fix: Remove unused function declaration

### DIFF
--- a/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
+++ b/Sources/Sentry/include/SentryProfiledTracerConcurrency.h
@@ -25,9 +25,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_EXTERN_C_BEGIN
 
-void sentry_captureTransactionWithProfile(SentryHub *hub, SentryDispatchQueueWrapper *dispatchQueue,
-    SentryTransaction *transaction, NSDate *startTimestamp);
-
 /**
  * @Returns An ID to use as a unique, unchanging ID for the tracer that started the profiler. It's
  * different from the profiler's internal ID.


### PR DESCRIPTION
This seems to be unused and unimplemented

#skip-changelog