### PR TITLE
fix: Delete undefined SentryMetricsAPI

### DIFF
--- a/Sources/Sentry/Public/SentryHub.h
+++ b/Sources/Sentry/Public/SentryHub.h
@@ -12,7 +12,6 @@
 @class SentryEvent;
 @class SentryFeedback;
 @class SentryId;
-@class SentryMetricsAPI;
 @class SentryScope;
 @class SentryTransactionContext;
 @class SentryUser;
@@ -24,8 +23,6 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithClient:(SentryClient *_Nullable)client
                       andScope:(SentryScope *_Nullable)scope;
-
-@property (nonatomic, readonly) SentryMetricsAPI *metrics;
 
 /**
  * Starts a new SentrySession. If there's a running SentrySession, it ends it before starting the

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -13,7 +13,6 @@
 @class SentryFeedback;
 @class SentryFeedbackAPI;
 @class SentryId;
-@class SentryMetricsAPI;
 @class SentryOptions;
 @class SentryReplayApi;
 @class SentryScope;
@@ -41,8 +40,6 @@ SENTRY_NO_INIT
  * Indicates whether the SentrySDK is enabled.
  */
 @property (class, nonatomic, readonly) BOOL isEnabled;
-
-@property (class, nonatomic, readonly) SentryMetricsAPI *metrics;
 
 #if SENTRY_TARGET_REPLAY_SUPPORTED
 /**

--- a/Sources/Sentry/SentrySDK.m
+++ b/Sources/Sentry/SentrySDK.m
@@ -159,11 +159,6 @@ static NSDate *_Nullable startTimestamp = nil;
     return currentHub != nil && [currentHub getClient] != nil;
 }
 
-+ (SentryMetricsAPI *)metrics
-{
-    return currentHub.metrics;
-}
-
 + (BOOL)crashedLastRunCalled
 {
     return crashedLastRunCalled;


### PR DESCRIPTION
This type was only forward declared and never used, we can delete it

#skip-changelog