### PR TITLE
Update Xcode to 16.4 on CI runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.3
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.3
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - run: make init-ci-build
       - run: make xcode-ci
 
@@ -214,7 +214,7 @@ jobs:
           sed -i '' 's/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_ERROR/#define SENTRY_ASYNC_SAFE_LOG_LEVEL SENTRY_ASYNC_SAFE_LOG_LEVEL_TRACE/' Sources/Sentry/SentryAsyncSafeLog.h
         shell: bash
 
-      - run: ./scripts/ci-select-xcode.sh 16.3
+      - run: ./scripts/ci-select-xcode.sh 16.4
 
       - name: Build for Debug
         run: |

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: ./scripts/ci-select-xcode.sh 16.2
+        run: ./scripts/ci-select-xcode.sh 16.4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - run: make analyze
 
   lint-podspec:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.3
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,7 +98,7 @@ jobs:
           # iOS 18
           - runs-on: macos-15
             platform: "iOS"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "18.2"
             device: "iPhone 16"
             scheme: "Sentry"
@@ -117,7 +117,7 @@ jobs:
           # macOS 15
           - runs-on: macos-15
             platform: "macOS"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "latest"
             scheme: "Sentry"
 
@@ -132,7 +132,7 @@ jobs:
 
           - runs-on: macos-15
             platform: "Catalyst"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "latest"
             scheme: "Sentry"
 
@@ -158,7 +158,7 @@ jobs:
           # tvOS 18
           - runs-on: macos-15
             platform: "tvOS"
-            xcode: "16.2"
+            xcode: "16.4"
             test-destination-os: "18.1"
             scheme: "Sentry"
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - run: ./scripts/ci-select-xcode.sh 16.2
+      - run: ./scripts/ci-select-xcode.sh 16.4
 
       - run: make init-ci-build
       - run: make xcode-ci


### PR DESCRIPTION
```
## :scroll: Description

Updated Xcode version references from 16.2 and 16.3 to 16.4 across multiple GitHub Actions workflow files.

## :bulb: Motivation and Context

This change standardizes and updates the CI runners to use Xcode 16.4, leveraging the latest Swift compiler improvements and SDK features for modern build and test jobs. Older Xcode versions (e.g., 14.3.1, 15.2, 15.4) were intentionally preserved where specific compatibility is required (e.g., iOS 16, XCFramework builds).

## :green_heart: How did you test it?

The changes are to the CI configuration itself. The CI pipelines will run with the updated Xcode version, implicitly verifying the change.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
```

---

[Slack Thread](https://sentry.slack.com/archives/C096RFQ0PHN/p1752673892367739?thread_ts=1752673892.367739&cid=C096RFQ0PHN)