### PR TITLE
ci: Fix flaky test timeouts

### DIFF
--- a/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentrySpotlightTransportTests.swift
@@ -143,7 +143,7 @@ final class SentrySpotlightTransportTests: XCTestCase {
         
         sut.send(envelope: eventEnvelope)
         
-        requestManager.waitForAllRequests()
+        requestManager.waitForAllRequests(timeout: 1_000)
         
         let logMessages = logOutput.loggedMessages.filter {
             $0.contains("[Sentry] [error]") &&

--- a/Tests/SentryTests/Networking/TestRequestManager.swift
+++ b/Tests/SentryTests/Networking/TestRequestManager.swift
@@ -40,8 +40,8 @@ public class TestRequestManager: NSObject, RequestManager {
         })
     }
     
-    public func waitForAllRequests() {
-        group.waitWithTimeout()
+    public func waitForAllRequests(timeout: Double = 100) {
+        group.waitWithTimeout(timeout: timeout)
     }
     
     func returnResponse(response: HTTPURLResponse?) {

--- a/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryStacktraceBuilderTests.swift
@@ -128,7 +128,7 @@ class SentryStacktraceBuilderTests: XCTestCase {
             XCTAssertGreaterThanOrEqual(filteredFrames, 1, "The Stacktrace must have only one function.")
         }
         
-        var timeout: TimeInterval = 1
+        var timeout: TimeInterval = 5
         #if !os(watchOS) && !os(tvOS)
         // observed the async task taking a long time to finish if TSAN is attached
         if sentry_threadSanitizerIsPresent() {


### PR DESCRIPTION
I saw both of these flaking due to timeouts in https://github.com/getsentry/sentry-cocoa/actions/runs/16342586541/job/46168628617

#skip-changelog