### PR TITLE
test: restart the SDK when changing the DSN

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/DSNDisplayViewController.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/DSNDisplayViewController.swift
@@ -77,6 +77,8 @@ class DSNDisplayViewController: UIViewController {
                 DispatchQueue.main.async {
                     self.updateDSNLabel()
                 }
+
+                SentrySDKWrapper.shared.startSentry()
             }
         } else {
             showToast(in: self, type: .warning, message: "Invalid DSN, reverting to the default.")
@@ -92,6 +94,8 @@ class DSNDisplayViewController: UIViewController {
                 DispatchQueue.main.async {
                     self.updateDSNLabel()
                 }
+
+                SentrySDKWrapper.shared.startSentry()
             }
         }
     }
@@ -119,6 +123,8 @@ class DSNDisplayViewController: UIViewController {
                 DispatchQueue.main.async {
                     showToast(in: self, type: .success, message: "DSN reset to default!")
                 }
+
+                SentrySDKWrapper.shared.startSentry()
             } catch {
                 SentrySDK.capture(error: error)
                 DispatchQueue.main.async {


### PR DESCRIPTION
For the time being, this branch serves as a test bed for https://github.com/getsentry/sentry-cocoa/issues/5655

This originally came out of a facility I was building for sales engineering: https://github.com/sentry-demos/ios/pull/115. I noticed the crash so reproduced here as I was going to add the SDK restart logic for our debug menu anyways.

#skip-changelog