### PR TITLE
test: fix objc sample app build errors from deprecation warnings

### DIFF
--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -52,20 +52,29 @@
         }
 
         if (env[@"--io.sentry.profiling.profilesSampleRate"] != nil) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             options.profilesSampleRate =
                 @([env[@"--io.sentry.profiling.profilesSampleRate"] floatValue]);
+#pragma clang diagnostic pop
         }
 
         if (env[@"--io.sentry.profilesSamplerValue"] != nil) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             options.profilesSampler
                 = ^NSNumber *_Nullable(SentrySamplingContext *_Nonnull samplingContext)
             {
                 return @([env[@"--io.sentry.profilesSamplerValue"] floatValue]);
             };
+#pragma clang diagnostic pop
         }
 
         if (![args containsObject:@"--io.sentry.profiling.disable-app-start-profiling"]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
             options.enableAppLaunchProfiling = YES;
+#pragma clang diagnostic pop
         }
 
         SentryHttpStatusCodeRange *httpStatusCodeRange =

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/ViewController.m
@@ -75,11 +75,17 @@
 #if SDK_V9
     NSLog(@"SDK V9 does not support user feedback.");
 #else
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentryUserFeedback *userFeedback = [[SentryUserFeedback alloc] initWithEventId:eventId];
+#    pragma clang diagnostic pop
     userFeedback.comments = @"It broke on iOS-ObjectiveC. I don't know why, but this happens.";
     userFeedback.email = @"john@me.com";
     userFeedback.name = @"John Me";
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [SentrySDK captureUserFeedback:userFeedback];
+#    pragma clang diagnostic pop
 #endif // SDK_V9
 }
 


### PR DESCRIPTION
Noticed these were failing the objc sample app build so the ui tests couldn't run there: https://github.com/getsentry/sentry-cocoa/actions/runs/16359229447/job/46223970689?pr=5658#step:12:741

#skip-changelog