### PR TITLE
ref: Workaround for Swift availability bug

### DIFF
--- a/Sources/Sentry/Public/SentryFeedbackAPI.h
+++ b/Sources/Sentry/Public/SentryFeedbackAPI.h
@@ -12,7 +12,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-API_AVAILABLE(ios(13.0))
 @interface SentryFeedbackAPI : NSObject
 
 /**

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -281,7 +281,7 @@ SENTRY_NO_INIT
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
-@property (nonatomic, class, readonly) SentryFeedbackAPI *feedback API_AVAILABLE(ios(13.0));
+@property (nonatomic, class, readonly) SentryFeedbackAPI *feedback;
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -26985,10 +26985,8 @@
         "usr": "c:objc(cs)SentryFeedbackAPI",
         "moduleName": "Sentry",
         "isOpen": true,
-        "intro_iOS": "13.0",
         "objc_name": "SentryFeedbackAPI",
         "declAttributes": [
-          "Available",
           "ObjC",
           "Dynamic"
         ],
@@ -33247,10 +33245,8 @@
             "moduleName": "Sentry",
             "static": true,
             "isOpen": true,
-            "intro_iOS": "13.0",
             "objc_name": "feedback",
             "declAttributes": [
-              "Available",
               "ObjC",
               "Dynamic"
             ],
@@ -33272,11 +33268,9 @@
                 "moduleName": "Sentry",
                 "static": true,
                 "isOpen": true,
-                "intro_iOS": "13.0",
                 "objc_name": "feedback",
                 "declAttributes": [
                   "DiscardableResult",
-                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],

--- a/sdk_api_V9.json
+++ b/sdk_api_V9.json
@@ -26189,10 +26189,8 @@
         "usr": "c:objc(cs)SentryFeedbackAPI",
         "moduleName": "Sentry",
         "isOpen": true,
-        "intro_iOS": "13.0",
         "objc_name": "SentryFeedbackAPI",
         "declAttributes": [
-          "Available",
           "ObjC",
           "Dynamic"
         ],
@@ -32026,10 +32024,8 @@
             "moduleName": "Sentry",
             "static": true,
             "isOpen": true,
-            "intro_iOS": "13.0",
             "objc_name": "feedback",
             "declAttributes": [
-              "Available",
               "ObjC",
               "Dynamic"
             ],
@@ -32051,11 +32047,9 @@
                 "moduleName": "Sentry",
                 "static": true,
                 "isOpen": true,
-                "intro_iOS": "13.0",
                 "objc_name": "feedback",
                 "declAttributes": [
                   "DiscardableResult",
-                  "Available",
                   "ObjC",
                   "Dynamic"
                 ],


### PR DESCRIPTION
Makes this property available on all iOS versions to work around https://github.com/swiftlang/swift/issues/83183

This is not an API breaking change since it just increases the availability. The two functions on SentryFeedbackAPI are still marked unavailable prior to iOS 13 (they were already marked this way before the change)

#skip-changelog