### PR TITLE
feat(SPM): Build full SDK with SPM

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,8 +112,9 @@ jobs:
     if: startsWith(github.ref, 'refs/heads/release/') == false
     steps:
       - uses: actions/checkout@v4
-      # Only watchOS is compiling with SPM so far, the rest of the targets need profiling support which is still a work in progress due to the ObjC++ usage
       - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace && EXPERIMENTAL_SPM_BUILDS=1 xcodebuild build -scheme SentrySPM -sdk watchos -destination 'generic/platform=watchOS'
+        shell: sh
+      - run: EXPERIMENTAL_SPM_BUILDS=1 xcodebuild build -scheme SentrySPM -sdk iphoneos -destination 'generic/platform=iphoneos'
         shell: sh
 
   build-v9:

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -798,6 +798,20 @@ sentry_isValidSampleRate(NSNumber *sampleRate)
 #    endif // SENTRY_HAS_UIKIT
 }
 
+#    if SENTRY_TARGET_REPLAY_SUPPORTED
+
+- (BOOL)enableViewRendererV2
+{
+    return self.sessionReplay.enableViewRendererV2;
+}
+
+- (BOOL)enableFastViewRendering
+{
+    return self.sessionReplay.enableFastViewRendering;
+}
+
+#    endif // SENTRY_TARGET_REPLAY_SUPPORTED
+
 - (void)setEnableUserInteractionTracing:(BOOL)enableUserInteractionTracing
 {
 #    if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryOptions+Private.h
+++ b/Sources/Sentry/include/SentryOptions+Private.h
@@ -38,6 +38,14 @@ FOUNDATION_EXPORT NSString *const kSentryDefaultEnvironment;
 @property (nonatomic, nullable, strong) SentryProfileOptions *profiling;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+
+- (BOOL)enableViewRendererV2;
+
+- (BOOL)enableFastViewRendering;
+
+#endif // # SENTRY_TARGET_REPLAY_SUPPORTED
+
 @property (nonatomic, readonly, class) NSArray<Class> *defaultIntegrationClasses;
 
 @property (nonatomic, strong, nullable)

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -22,6 +22,7 @@
 #import "SentryLevelHelper.h"
 #import "SentryMeta.h"
 #import "SentryNSDictionarySanitize.h"
+#import "SentryOptions+Private.h"
 #import "SentryProfiler+Private.h"
 #import "SentryRandom.h"
 #import "SentrySdkInfo.h"

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers @_spi(Private) public class SentryEnabledFeaturesBuilder: NSObject {
@@ -53,11 +54,11 @@ import Foundation
         }
 
 #if (os(iOS) || os(tvOS)) && !SENTRY_NO_UIKIT
-        if options.sessionReplay.enableViewRendererV2 {
+        if options.enableViewRendererV2() {
             // We keep the old name for backwards compatibility of the telemetry data.
             features.append("experimentalViewRenderer")
         }
-        if options.sessionReplay.enableFastViewRendering {
+        if options.enableFastViewRendering() {
             features.append("fastViewRendering")
         }
 #endif // (os(iOS) || os(tvOS)) && !SENTRY_NO_UIKIT


### PR DESCRIPTION
Support building the full SDK with SPM, including all features available on iOS.

This just required fixing one more issue related to `sessionReplay` being defined in Swift but `SentryOptions` in ObjC so it wasn't visible to Swift code in SPM. I'll have a longer term fix for this by making a Swift interface for SentryOptions, but that is blocked by a few other PRs right now so this change is just a smaller patch to get CI building for iOS, ensuring we don't accidentally break anything with the SPM build.

#skip-changelog