### PR TITLE
test: Remove infinity response delay

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportTests.swift
@@ -947,11 +947,12 @@ class SentryHttpTransportTests: XCTestCase {
         let sut = fixture.getSut(dispatchQueueWrapper: SentryDispatchQueueWrapper())
         givenCachedEvents(amount: 1)
 
-        fixture.requestManager.responseDelay = .infinity
+        fixture.requestManager.waitForResponseDispatchGroup = true
+        fixture.requestManager.responseDispatchGroup.enter()
 
         XCTAssertEqual(sut.flush(0.0), .timedOut, "Flush should time out.")
 
-        fixture.requestManager.responseDelay = 0.0
+        self.fixture.requestManager.responseDispatchGroup.leave()
 
         XCTAssertEqual(sut.flush(self.fixture.flushTimeout), .success, "Flush should not time out.")
     }


### PR DESCRIPTION
Remove infinity response delay for the HTTPTransportTest, so we avoid having one item on the dispatch queue that would run forever. Instead, we can use the waitForResponseDispatchGroup.

#skip-changelog