### PR TITLE
ref: Remove `SentryDefaultObjCRuntimeWrapper` singleton pattern and use `SentryDependencyContainer`

### DIFF
--- a/Sources/Sentry/SentryDefaultObjCRuntimeWrapper.m
+++ b/Sources/Sentry/SentryDefaultObjCRuntimeWrapper.m
@@ -3,14 +3,6 @@
 
 @implementation SentryDefaultObjCRuntimeWrapper
 
-+ (instancetype)sharedInstance
-{
-    static SentryDefaultObjCRuntimeWrapper *instance = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{ instance = [[self alloc] init]; });
-    return instance;
-}
-
 - (const char **)copyClassNamesForImage:(const char *)image amount:(unsigned int *)outCount
 {
     return objc_copyClassNamesForImage(image, outCount);

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -2,6 +2,7 @@
 
 #import "SentryApplication.h"
 #import "SentryBinaryImageCache.h"
+#import "SentryDefaultObjCRuntimeWrapper.h"
 #import "SentryDispatchFactory.h"
 #import "SentryDisplayLinkWrapper.h"
 #import "SentryExtraContextProvider.h"
@@ -450,5 +451,10 @@ static BOOL isInitialializingDependencyContainer = NO;
                                              application:self.application
                                             dateProvider:self.dateProvider
                                       notificationCenter:self.notificationCenterWrapper];
+}
+
+- (id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+{
+    SENTRY_LAZY_INIT(_objcRuntimeWrapper, [[SentryDefaultObjCRuntimeWrapper alloc] init]);
 }
 @end

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -19,4 +19,9 @@
     [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchSyncOnMainQueue:block];
 }
 
++ (id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper
+{
+    return SentryDependencyContainer.sharedInstance.objcRuntimeWrapper;
+}
+
 @end

--- a/Sources/Sentry/SentryPerformanceTrackingIntegration.m
+++ b/Sources/Sentry/SentryPerformanceTrackingIntegration.m
@@ -2,7 +2,6 @@
 
 #if SENTRY_HAS_UIKIT
 
-#    import "SentryDefaultObjCRuntimeWrapper.h"
 #    import "SentryDependencyContainer.h"
 #    import "SentryLogC.h"
 #    import "SentryNSProcessInfoWrapper.h"
@@ -34,13 +33,13 @@
 
     SentrySubClassFinder *subClassFinder = [[SentrySubClassFinder alloc]
            initWithDispatchQueue:dispatchQueue
-              objcRuntimeWrapper:[SentryDefaultObjCRuntimeWrapper sharedInstance]
+              objcRuntimeWrapper:[SentryDependencyContainer.sharedInstance objcRuntimeWrapper]
         swizzleClassNameExcludes:options.swizzleClassNameExcludes];
 
     self.swizzling = [[SentryUIViewControllerSwizzling alloc]
            initWithOptions:options
              dispatchQueue:dispatchQueue
-        objcRuntimeWrapper:[SentryDefaultObjCRuntimeWrapper sharedInstance]
+        objcRuntimeWrapper:[SentryDependencyContainer.sharedInstance objcRuntimeWrapper]
             subClassFinder:subClassFinder
         processInfoWrapper:[SentryDependencyContainer.sharedInstance processInfoWrapper]
           binaryImageCache:[SentryDependencyContainer.sharedInstance binaryImageCache]];

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -33,6 +33,7 @@
 @protocol SentryApplication;
 @protocol SentryDispatchQueueProviderProtocol;
 @protocol SentryNSNotificationCenterWrapper;
+@protocol SentryObjCRuntimeWrapper;
 
 #if SENTRY_HAS_METRIC_KIT
 @class SentryMXManager;
@@ -135,6 +136,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentryMXManager *metricKitManager API_AVAILABLE(
     ios(15.0), macos(12.0), macCatalyst(15.0)) API_UNAVAILABLE(tvos, watchos);
 #endif // SENTRY_HAS_METRIC_KIT
+@property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
 
 #if SENTRY_HAS_UIKIT
 - (SentryWatchdogTerminationScopeObserver *)getWatchdogTerminationScopeObserverWithOptions:

--- a/Sources/Sentry/include/SentryDefaultObjCRuntimeWrapper.h
+++ b/Sources/Sentry/include/SentryDefaultObjCRuntimeWrapper.h
@@ -5,8 +5,5 @@
  * A wrapper around the objc runtime functions for testability.
  */
 @interface SentryDefaultObjCRuntimeWrapper : NSObject <SentryObjCRuntimeWrapper>
-SENTRY_NO_INIT
-
-+ (instancetype)sharedInstance;
 
 @end

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -5,6 +5,8 @@
 #    import <UIKit/UIKit.h>
 #endif // SENTRY_HAS_UIKIT
 
+@protocol SentryObjCRuntimeWrapper;
+
 NS_ASSUME_NONNULL_BEGIN
 
 // Some Swift code needs to access SentryDependencyContainer. To
@@ -20,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 #endif // SENTRY_HAS_UIKIT
 
 + (void)dispatchSyncOnMainQueue:(void (^)(void))block;
++ (id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper;
 
 @end
 

--- a/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
+++ b/Tests/SentryTests/Helper/SentryTestObjCRuntimeWrapper.m
@@ -1,10 +1,11 @@
 #import "SentryTestObjCRuntimeWrapper.h"
-#import "SentryDefaultObjCRuntimeWrapper.h"
+#import "SentryDependencyContainer.h"
+#import "SentryObjCRuntimeWrapper.h"
 #import <objc/runtime.h>
 
 @interface SentryTestObjCRuntimeWrapper ()
 
-@property (nonatomic, strong) SentryDefaultObjCRuntimeWrapper *objcRuntimeWrapper;
+@property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
 
 @end
 
@@ -13,7 +14,7 @@
 - (instancetype)init
 {
     if (self = [super init]) {
-        self.objcRuntimeWrapper = [SentryDefaultObjCRuntimeWrapper sharedInstance];
+        self.objcRuntimeWrapper = [[SentryDependencyContainer sharedInstance] objcRuntimeWrapper];
     }
 
     return self;

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -32,7 +32,7 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         }
         
         var sutWithDefaultObjCRuntimeWrapper: SentryUIViewControllerSwizzling {
-            return SentryUIViewControllerSwizzling(options: options, dispatchQueue: dispatchQueue, objcRuntimeWrapper: SentryDefaultObjCRuntimeWrapper.sharedInstance(), subClassFinder: subClassFinder, processInfoWrapper: processInfoWrapper, binaryImageCache: binaryImageCache)
+            return SentryUIViewControllerSwizzling(options: options, dispatchQueue: dispatchQueue, objcRuntimeWrapper: SentryDependencyContainerSwiftHelper.objcRuntimeWrapper(), subClassFinder: subClassFinder, processInfoWrapper: processInfoWrapper, binaryImageCache: binaryImageCache)
         }
         
         var testableSut: TestSentryUIViewControllerSwizzling {


### PR DESCRIPTION
Implementing this change here so I don't add more files changed in #5298

#skip-changelog