### PR TITLE
meta: log complete raw envelope contents in debug

### DIFF
--- a/Sources/Sentry/SentryEvent.m
+++ b/Sources/Sentry/SentryEvent.m
@@ -84,7 +84,6 @@ NS_ASSUME_NONNULL_BEGIN
     // before
     [serializedData setValue:sentry_sanitize(self.extra) forKey:@"extra"];
     [serializedData setValue:self.tags forKey:@"tags"];
-    SENTRY_LOG_DEBUG(@"Serialized event: %@", serializedData);
 
     return serializedData;
 }

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -356,6 +356,10 @@
     // We must set sentAt as close as possible to the transmission of the envelope to Sentry.
     rateLimitedEnvelope.header.sentAt = [self.dateProvider date];
 
+#if DEBUG
+    SENTRY_LOG_DEBUG(@"%@", rateLimitedEnvelope.debugDescription);
+#endif // DEBUG
+
     NSError *requestError = nil;
     NSURLRequest *request = [self.requestBuilder createEnvelopeRequest:rateLimitedEnvelope
                                                                    dsn:self.options.parsedDsn


### PR DESCRIPTION
I had a need to debug the complete raw contents of an envelope. AFAICT we logged a few things like headers, but not the envelope in its entirety. It produces large output so I also constrained it to just DEBUG builds. In the future it'd be nice to be able to selectively enable/disable this type of logging like I proposed in https://github.com/getsentry/sentry-cocoa/issues/4020

#skip-changelog