### PR TITLE
test: reorganize networking feature flags and add another one

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -42,6 +42,7 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case .other: return SentrySDKOverrides.Other.allCases
         case .tracing: return SentrySDKOverrides.Tracing.allCases
         case .profiling: return SentrySDKOverrides.Profiling.allCases
+        case .networking: return SentrySDKOverrides.Networking.allCases
         }
     }
 
@@ -77,7 +78,6 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case disableSessionTracking             = "--io.sentry.performance.disable-automatic-session-tracking"
         case disableFileIOTracing               = "--io.sentry.performance.disable-file-io-tracing"
         case disableUIVCTracing                 = "--io.sentry.performance.disable-uiviewcontroller-tracing"
-        case disableNetworkTracing              = "--io.sentry.performance.disable-network-tracking"
         case disableCoreDataTracing             = "--io.sentry.performance.disable-core-data-tracing"
         case disableANRTracking                 = "--io.sentry.performance.disable-anr-tracking"
         case disableWatchdogTracking            = "--io.sentry.performance.disable-watchdog-tracking"
@@ -100,6 +100,13 @@ public enum SentrySDKOverrides: String, CaseIterable {
     }
     case sessionReplay = "Session Replay"
 
+    public enum Networking: String, SentrySDKOverride {
+        case disableBreadcrumbs            = "--io.sentry.networking.disable-breadcrumbs"
+        case disablePerformanceTracking    = "--io.sentry.networking.disable-tracking"
+        case disableFailedRequestTracking  = "--io.sentry.networking.disable-failed-request-tracking"
+    }
+    case networking = "Networking"
+
     public enum Other: String, SentrySDKOverride {
         case disableAttachScreenshot        = "--io.sentry.other.disable-attach-screenshot"
         case disableAttachViewHierarchy     = "--io.sentry.other.disable-attach-view-hierarchy"
@@ -110,7 +117,6 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case disableMetricKit               = "--io.sentry.other.disable-metrickit-integration"
         case disableMetricKitRawPayloads    = "--io.sentry.other.disable-metrickit-raw-payloads"
         case disableBreadcrumbs             = "--io.sentry.other.disable-automatic-breadcrumbs"
-        case disableNetworkBreadcrumbs      = "--io.sentry.other.disable-network-breadcrumbs"
         case disableSwizzling               = "--io.sentry.other.disable-swizzling"
         case disableCrashHandling           = "--io.sentry.other.disable-crash-handler"
         case disableSpotlight               = "--io.sentry.other.disable-spotlight"
@@ -259,10 +265,18 @@ extension SentrySDKOverrides.Tracing {
     }
 }
 
+extension SentrySDKOverrides.Networking {
+    public var overrideType: OverrideType {
+        switch self {
+        case .disableBreadcrumbs, .disablePerformanceTracking, .disableFailedRequestTracking: return .boolean
+        }
+    }
+}
+
 extension SentrySDKOverrides.Other {
     public var overrideType: OverrideType {
         switch self {
-        case .disableAttachScreenshot, .disableAttachViewHierarchy, .rejectScreenshots, .rejectViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableNetworkBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .rejectAllSpans, .rejectAllEvents, .base64AttachmentData, .disableHttpTransport: return .boolean
+        case .disableAttachScreenshot, .disableAttachViewHierarchy, .rejectScreenshots, .rejectViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .rejectAllSpans, .rejectAllEvents, .base64AttachmentData, .disableHttpTransport: return .boolean
         case .username, .userFullName, .userEmail, .userID, .environment: return .string
         }
     }
@@ -271,7 +285,7 @@ extension SentrySDKOverrides.Other {
 extension SentrySDKOverrides.Performance {
     public var overrideType: OverrideType {
         switch self {
-        case .disableTimeToFullDisplayTracing, .disablePerformanceV2, .disableAppHangTrackingV2, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableNetworkTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .disablePerformanceTracing: return .boolean
+        case .disableTimeToFullDisplayTracing, .disablePerformanceV2, .disableAppHangTrackingV2, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .disablePerformanceTracing: return .boolean
         case .sessionTrackingIntervalMillis: return .string
         }
     }
@@ -330,11 +344,15 @@ extension SentrySDKOverrides.Tracing {
     }
 }
 
+extension SentrySDKOverrides.Networking {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
 extension SentrySDKOverrides.Other {
     public var ignoresDisableEverything: Bool {
         switch self {
         case .rejectScreenshots, .rejectViewHierarchy, .rejectAllSpans, .rejectAllEvents, .username, .userFullName, .userEmail, .userID, .environment, .base64AttachmentData: return true
-        case .disableAttachScreenshot, .disableAttachViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableNetworkBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .disableHttpTransport: return false
+        case .disableAttachScreenshot, .disableAttachViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .disableHttpTransport: return false
         }
     }
 }
@@ -342,7 +360,7 @@ extension SentrySDKOverrides.Other {
 extension SentrySDKOverrides.Performance {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .disableTimeToFullDisplayTracing, .disablePerformanceV2, .disableAppHangTrackingV2, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableNetworkTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .disablePerformanceTracing: return false
+        case .disableTimeToFullDisplayTracing, .disablePerformanceV2, .disableAppHangTrackingV2, .disableSessionTracking, .disableFileIOTracing, .disableUIVCTracing, .disableCoreDataTracing, .disableANRTracking, .disableWatchdogTracking, .disableUITracing, .disablePrewarmedAppStartTracing, .disablePerformanceTracing: return false
         case .sessionTrackingIntervalMillis: return true
         }
     }

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -114,11 +114,13 @@ public struct SentrySDKWrapper {
         options.enableAutoPerformanceTracing = !isBenchmarking && !SentrySDKOverrides.Performance.disablePerformanceTracing.boolValue
         options.enableTracing = !isBenchmarking && !SentrySDKOverrides.Tracing.disableTracing.boolValue
 
+        options.enableNetworkTracking = !SentrySDKOverrides.Networking.disablePerformanceTracking.boolValue
+        options.enableCaptureFailedRequests = !SentrySDKOverrides.Networking.disableFailedRequestTracking.boolValue
+        options.enableNetworkBreadcrumbs = !SentrySDKOverrides.Networking.disableBreadcrumbs.boolValue
+
         options.enableFileIOTracing = !SentrySDKOverrides.Performance.disableFileIOTracing.boolValue
         options.enableAutoBreadcrumbTracking = !SentrySDKOverrides.Other.disableBreadcrumbs.boolValue
-        options.enableNetworkTracking = !SentrySDKOverrides.Performance.disableNetworkTracing.boolValue
         options.enableCoreDataTracing = !SentrySDKOverrides.Performance.disableCoreDataTracing.boolValue
-        options.enableNetworkBreadcrumbs = !SentrySDKOverrides.Other.disableNetworkBreadcrumbs.boolValue
         options.enableSwizzling = !SentrySDKOverrides.Other.disableSwizzling.boolValue
         options.enableCrashHandler = !SentrySDKOverrides.Other.disableCrashHandling.boolValue
         options.enablePersistingTracesWhenCrashing = true

--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -35,6 +35,11 @@ schemeTemplates:
         "--io.sentry.profiling.disable-app-start-profiling": false
         "--io.sentry.profiling.continuous-profiler-immediate-stop": false
 
+        # networking
+        "--io.sentry.networking.disable-breadcrumbs": false
+        "--io.sentry.networking.disable-tracking": false
+        "--io.sentry.networking.disable-failed-request-tracking": false
+
         # performance
         "--io.sentry.performance.disable-app-hang-tracking-v2": false
         "--io.sentry.performance.disable-time-to-full-display-tracing": false
@@ -49,9 +54,7 @@ schemeTemplates:
         "--io.sentry.tracing.disable-tracing": false
         "--io.sentry.other.disable-crash-handler": false
         "--io.sentry.other.disable-swizzling": false
-        "--io.sentry.other.disable-network-breadcrumbs": false
         "--io.sentry.performance.disable-core-data-tracing": false
-        "--io.sentry.performance.disable-network-tracking": false
         "--io.sentry.performance.disable-uiviewcontroller-tracing": false
         "--io.sentry.other.disable-automatic-breadcrumbs": false
         "--io.sentry.performance.disable-anr-tracking": false


### PR DESCRIPTION
I needed to disable stuff for a test and noticed I had never provided a feature flag and override enum case for SentryOptions.enableCaptureFailedRequests, so i added that and reorganized the networking options under their own enum

#skip-changelog