### PR TITLE
test: dont use BYOB feedback by default in sample apps

### DIFF
--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -16,7 +16,7 @@ schemeTemplates:
         "--io.sentry.session-replay.disable-mask-all-images": false
 
         # user feedback
-        "--io.sentry.feedback.use-custom-feedback-button": true
+        "--io.sentry.feedback.use-custom-feedback-button": false
         "--io.sentry.feedback.dont-use-sentry-user": false
         "--io.sentry.feedback.require-name": false
         "--io.sentry.feedback.require-email": false


### PR DESCRIPTION
Somehow, I must've committed this to be enabled by default in the repository, but that was not my intention. I want to see the custom-themed automatically-injected widget by default in the sample apps.

#skip-changelog