### PR TITLE
ref(SPM): Create SentrySDKInternal

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -167,7 +167,7 @@ private extension ProfilingViewController {
     }
 
     func optionsConfiguration() {
-        guard let options = SentrySDK.currentHub().getClient()?.options else { return }
+        guard let options = SentrySDKInternal.currentHub().getClient()?.options else { return }
 
         if let sampleRate = options.profilesSampleRate {
             sampleRateField.text = String(format: "%.2f", sampleRate.floatValue)

--- a/Samples/iOS-Swift/iOS-Swift/Tools/SentryExposure.h
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/SentryExposure.h
@@ -1,9 +1,23 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+@class SentryHub;
+
+NS_ASSUME_NONNULL_BEGIN
+
 @interface SentryBreadcrumbTracker : NSObject
 
-+ (NSDictionary *)extractDataFromView:(UIView *)view
-          withAccessibilityIdentifier:(BOOL)includeIdentifier;
++ (nullable NSDictionary *)extractDataFromView:(UIView *)view
+                   withAccessibilityIdentifier:(BOOL)includeIdentifier;
 
 @end
+
+@interface SentrySDKInternal : NSObject
+
++ (nullable NSArray<NSString *> *)relevantViewControllersNames;
+
++ (SentryHub *)currentHub;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Samples/iOS-Swift/iOS-Swift/Tools/TopViewControllerInspector.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/TopViewControllerInspector.swift
@@ -51,7 +51,7 @@ class TopViewControllerInspector: UIView {
     
     @objc
     private func getTopVC() {
-        let names = SentrySDK.relevantViewControllersNames()
+        let names = SentrySDKInternal.relevantViewControllersNames()
         lbl.text = names?.joined(separator: ", ")
     }
     

--- a/Samples/iOS-Swift/iOS-Swift/Tools/iOS-Swift-Bridging-Header.h
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/iOS-Swift-Bridging-Header.h
@@ -3,4 +3,3 @@
 #import "SentryExposure.h"
 #import <Sentry/PrivateSentrySDKOnly.h>
 #import <Sentry/SentryOptions+Private.h>
-#import <Sentry/SentrySDK+Private.h>

--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -493,7 +493,7 @@
 		7BA61CCC247D14E600C130A8 /* SentryThreadInspectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA61CCB247D14E600C130A8 /* SentryThreadInspectorTests.swift */; };
 		7BA61CCF247EB59500C130A8 /* SentryCrashUUIDConversionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA61CCE247EB59500C130A8 /* SentryCrashUUIDConversionTests.swift */; };
 		7BA61EA625F21E660008CAA2 /* SentrySDKLogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA61EA525F21E660008CAA2 /* SentrySDKLogTests.swift */; };
-		7BA840A024A1EC6E00B718AA /* SentrySDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8409F24A1EC6E00B718AA /* SentrySDKTests.swift */; };
+		7BA840A024A1EC6E00B718AA /* SentrySDKInternalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA8409F24A1EC6E00B718AA /* SentrySDKInternalTests.swift */; };
 		7BAF3DB5243C743E008A5414 /* SentryClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */; };
 		7BAF3DB9243C9777008A5414 /* SentryTransport.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BAF3DB8243C9777008A5414 /* SentryTransport.h */; };
 		7BAF3DCE243DCBFE008A5414 /* SentryTransportFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BAF3DCD243DCBFE008A5414 /* SentryTransportFactory.m */; };
@@ -617,7 +617,6 @@
 		7D082B8323C628790029866B /* SentryMeta.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D082B8023C628780029866B /* SentryMeta.m */; };
 		7D0FCFB22379B915004DD83A /* SentryHub.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D0FCFB02379B915004DD83A /* SentryHub.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7D427C62237B1D200046BAC8 /* SentrySDK.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D427C5F237B1D200046BAC8 /* SentrySDK.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7D5C441A237C2E1F00DAB0A3 /* SentrySDK.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D5C4418237C2E1F00DAB0A3 /* SentrySDK.m */; };
 		7D5C441C237C2E1F00DAB0A3 /* SentryHub.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D5C4419237C2E1F00DAB0A3 /* SentryHub.m */; };
 		7D65260E237F649E00113EA2 /* SentryScope.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D65260B237F649E00113EA2 /* SentryScope.m */; };
 		7D7F0A5F23DF3D2C00A4629C /* SentryGlobalEventProcessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7D7F0A5E23DF3D2C00A4629C /* SentryGlobalEventProcessor.h */; };
@@ -1059,6 +1058,10 @@
 		FA3854362E267DA60045A563 /* SentryUser+Serialize.h in Headers */ = {isa = PBXBuildFile; fileRef = FA3854352E267DA20045A563 /* SentryUser+Serialize.h */; };
 		FA3A42722E1C5F9B00A08C39 /* SentryNSNotificationCenterWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3A42712E1C5F9B00A08C39 /* SentryNSNotificationCenterWrapper.swift */; };
 		FA4C32972DF7513F001D7B00 /* SentryExperimentalOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4C32962DF7513F001D7B00 /* SentryExperimentalOptions.swift */; };
+		FA6555142E30181B009917BC /* SentrySDKInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = FA6555132E30181B009917BC /* SentrySDKInternal.h */; };
+		FA6555162E30182B009917BC /* SentrySDKInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = FA6555152E30182B009917BC /* SentrySDKInternal.m */; };
+		FA6555182E301833009917BC /* SentrySDKWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = FA6555172E301833009917BC /* SentrySDKWrapper.m */; };
+		FA65551A2E3018A3009917BC /* SentrySDKTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6555192E30189E009917BC /* SentrySDKTests.swift */; };
 		FA67DCC12DDBD4C800896B02 /* SentrySDKLog+Configure.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCC02DDBD4C800896B02 /* SentrySDKLog+Configure.swift */; };
 		FA67DCF52DDBD4EA00896B02 /* SentryCurrentDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCCA2DDBD4EA00896B02 /* SentryCurrentDateProvider.swift */; };
 		FA67DCF62DDBD4EA00896B02 /* SentryViewRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA67DCE52DDBD4EA00896B02 /* SentryViewRenderer.swift */; };
@@ -1714,7 +1717,7 @@
 		7B8CA85626DD4E6200DD872C /* SentryNetworkTrackerIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNetworkTrackerIntegrationTests.swift; sourceTree = "<group>"; };
 		7B8ECBF926498906005FE2EF /* SentryAppStateManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryAppStateManager.h; path = include/SentryAppStateManager.h; sourceTree = "<group>"; };
 		7B8ECBFB26498958005FE2EF /* SentryAppStateManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAppStateManager.m; sourceTree = "<group>"; };
-		7B9421C4260CA393001F9349 /* SentrySDK+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentrySDK+Tests.h"; sourceTree = "<group>"; };
+		7B9421C4260CA393001F9349 /* SentrySDKInternal+Tests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SentrySDKInternal+Tests.h"; sourceTree = "<group>"; };
 		7B944FAD2469B43700A10721 /* TestHub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestHub.swift; sourceTree = "<group>"; };
 		7B944FAF2469B46000A10721 /* TestClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestClient.swift; sourceTree = "<group>"; };
 		7B96571F26830C9100C66E25 /* SentryScopeSyncC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryScopeSyncC.h; path = include/SentryScopeSyncC.h; sourceTree = "<group>"; };
@@ -1750,7 +1753,7 @@
 		7BA61CCB247D14E600C130A8 /* SentryThreadInspectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryThreadInspectorTests.swift; sourceTree = "<group>"; };
 		7BA61CCE247EB59500C130A8 /* SentryCrashUUIDConversionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryCrashUUIDConversionTests.swift; sourceTree = "<group>"; };
 		7BA61EA525F21E660008CAA2 /* SentrySDKLogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKLogTests.swift; sourceTree = "<group>"; };
-		7BA8409F24A1EC6E00B718AA /* SentrySDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKTests.swift; sourceTree = "<group>"; };
+		7BA8409F24A1EC6E00B718AA /* SentrySDKInternalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKInternalTests.swift; sourceTree = "<group>"; };
 		7BAF3DB4243C743E008A5414 /* SentryClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryClientTests.swift; sourceTree = "<group>"; };
 		7BAF3DB8243C9777008A5414 /* SentryTransport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTransport.h; path = include/SentryTransport.h; sourceTree = "<group>"; };
 		7BAF3DC7243DB90E008A5414 /* TestTransport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTransport.swift; sourceTree = "<group>"; };
@@ -1889,7 +1892,6 @@
 		7D082B8023C628780029866B /* SentryMeta.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryMeta.m; sourceTree = "<group>"; };
 		7D0FCFB02379B915004DD83A /* SentryHub.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryHub.h; path = Public/SentryHub.h; sourceTree = "<group>"; };
 		7D427C5F237B1D200046BAC8 /* SentrySDK.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentrySDK.h; path = Public/SentrySDK.h; sourceTree = "<group>"; };
-		7D5C4418237C2E1F00DAB0A3 /* SentrySDK.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentrySDK.m; sourceTree = "<group>"; };
 		7D5C4419237C2E1F00DAB0A3 /* SentryHub.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryHub.m; sourceTree = "<group>"; };
 		7D65260B237F649E00113EA2 /* SentryScope.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryScope.m; sourceTree = "<group>"; };
 		7D7F0A5E23DF3D2C00A4629C /* SentryGlobalEventProcessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryGlobalEventProcessor.h; path = include/SentryGlobalEventProcessor.h; sourceTree = "<group>"; };
@@ -2391,6 +2393,10 @@
 		FA3854352E267DA20045A563 /* SentryUser+Serialize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryUser+Serialize.h"; path = "include/SentryUser+Serialize.h"; sourceTree = "<group>"; };
 		FA3A42712E1C5F9B00A08C39 /* SentryNSNotificationCenterWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryNSNotificationCenterWrapper.swift; sourceTree = "<group>"; };
 		FA4C32962DF7513F001D7B00 /* SentryExperimentalOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExperimentalOptions.swift; sourceTree = "<group>"; };
+		FA6555132E30181B009917BC /* SentrySDKInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySDKInternal.h; path = include/SentrySDKInternal.h; sourceTree = "<group>"; };
+		FA6555152E30182B009917BC /* SentrySDKInternal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySDKInternal.m; sourceTree = "<group>"; };
+		FA6555172E301833009917BC /* SentrySDKWrapper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySDKWrapper.m; sourceTree = "<group>"; };
+		FA6555192E30189E009917BC /* SentrySDKTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKTests.swift; sourceTree = "<group>"; };
 		FA67DCC02DDBD4C800896B02 /* SentrySDKLog+Configure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SentrySDKLog+Configure.swift"; sourceTree = "<group>"; };
 		FA67DCC22DDBD4EA00896B02 /* Locks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Locks.swift; sourceTree = "<group>"; };
 		FA67DCC32DDBD4EA00896B02 /* NumberExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberExtensions.swift; sourceTree = "<group>"; };
@@ -2977,7 +2983,7 @@
 				84A305592BC9FD1600D84283 /* SentryTraceProfiler+Test.h */,
 				7B569DFE2590EEF600B653FC /* SentryScope+Equality.h */,
 				7B569E052590F04700B653FC /* SentryScope+Properties.h */,
-				7B9421C4260CA393001F9349 /* SentrySDK+Tests.h */,
+				7B9421C4260CA393001F9349 /* SentrySDKInternal+Tests.h */,
 				8431D4572BE175A1009EAEC1 /* SentryContinuousProfiler+Test.h */,
 				639889D21EDF06C100EA7442 /* SentryTests-Bridging-Header.h */,
 				63B819131EC352A7002FDF4C /* SentryInterfacesTests.m */,
@@ -2995,7 +3001,8 @@
 				15D0AC872459EE4D006541C2 /* SentryNSURLRequestTests.swift */,
 				7B0A54552523178700A71716 /* SentryScopeSwiftTests.swift */,
 				D8918B212849FA6D00701F9A /* SentrySDKIntegrationTestsBase.swift */,
-				7BA8409F24A1EC6E00B718AA /* SentrySDKTests.swift */,
+				7BA8409F24A1EC6E00B718AA /* SentrySDKInternalTests.swift */,
+				FA6555192E30189E009917BC /* SentrySDKTests.swift */,
 				FAC62B642E15A40C0003909D /* SentrySDKThreadTests.swift */,
 				7B0002332477F52D0035FEF1 /* SentrySessionTests.swift */,
 				8E70B10025CB8695002B3155 /* SentrySpanIdTests.swift */,
@@ -3060,8 +3067,10 @@
 				7B85DC1C24EFAFCD007D01D2 /* SentryClient+Private.h */,
 				92EC54CD2E1EB54B00A10AC2 /* SentryClient+Logs.h */,
 				7D427C5F237B1D200046BAC8 /* SentrySDK.h */,
-				7D5C4418237C2E1F00DAB0A3 /* SentrySDK.m */,
+				FA6555172E301833009917BC /* SentrySDKWrapper.m */,
 				7B610D5E2512390E00B0B5D9 /* SentrySDK+Private.h */,
+				FA6555132E30181B009917BC /* SentrySDKInternal.h */,
+				FA6555152E30182B009917BC /* SentrySDKInternal.m */,
 				63EED6BC2237923600E02400 /* SentryOptions.h */,
 				63EED6BD2237923600E02400 /* SentryOptions.m */,
 				7BDEAA002632A4580001EA25 /* SentryOptions+Private.h */,
@@ -4984,6 +4993,7 @@
 				7B3398632459C14000BD9C96 /* SentryEnvelopeRateLimit.h in Headers */,
 				6304360A1EC0595B00C4D3FA /* SentryNSDataUtils.h in Headers */,
 				7BF9EF7C2722B90E00B5BBEF /* SentryDefaultObjCRuntimeWrapper.h in Headers */,
+				FA6555142E30181B009917BC /* SentrySDKInternal.h in Headers */,
 				63FE718720DA4C1100CDBAE8 /* SentryCrashReportVersion.h in Headers */,
 				0A56DA5F28ABA01B00C400D5 /* SentryTransactionContext+Private.h in Headers */,
 				8E7C98312693E1CC00E6336C /* SentryTraceHeader.h in Headers */,
@@ -5617,6 +5627,7 @@
 				92ECD73C2E05ACE00063EC10 /* SentryLog.swift in Sources */,
 				F458D1152E1869AD0028273E /* SentryScopePersistentStore+String.swift in Sources */,
 				F458D1172E186DF20028273E /* SentryScopePersistentStore+Fingerprint.swift in Sources */,
+				FA6555182E301833009917BC /* SentrySDKWrapper.m in Sources */,
 				D8CB7417294724CC00A5F964 /* SentryEnvelopeAttachmentHeader.m in Sources */,
 				D84793262788737D00BE8E99 /* SentryByteCountFormatter.m in Sources */,
 				63AA769E1EB9C57A00D153DE /* SentryError.mm in Sources */,
@@ -5739,6 +5750,7 @@
 				FA67DD0A2DDBD4EA00896B02 /* SentryBaggageSerialization.swift in Sources */,
 				FA67DD0B2DDBD4EA00896B02 /* UIViewExtensions.swift in Sources */,
 				FA67DD0C2DDBD4EA00896B02 /* SentryMaskRendererV2.swift in Sources */,
+				FA6555162E30182B009917BC /* SentrySDKInternal.m in Sources */,
 				FA67DD0D2DDBD4EA00896B02 /* SentryUIRedactBuilder.swift in Sources */,
 				FA67DD0E2DDBD4EA00896B02 /* SentryFileContents.swift in Sources */,
 				FA67DD0F2DDBD4EA00896B02 /* SentryViewControllerBreadcrumbTracking.swift in Sources */,
@@ -5811,7 +5823,6 @@
 				7BAF3DCE243DCBFE008A5414 /* SentryTransportFactory.m in Sources */,
 				844EDC70294143B900C86F34 /* SentryNSProcessInfoWrapper.mm in Sources */,
 				F4E3DCCB2E1579240093CB80 /* SentryScopePersistentStore.swift in Sources */,
-				7D5C441A237C2E1F00DAB0A3 /* SentrySDK.m in Sources */,
 				7D65260E237F649E00113EA2 /* SentryScope.m in Sources */,
 				D4EDF9842D0B2A210071E7B3 /* Data+SentryTracing.swift in Sources */,
 				84281C472A57905700EE88F2 /* SentrySample.m in Sources */,
@@ -5964,6 +5975,7 @@
 				D808FB88281AB33C009A2A33 /* SentryUIEventTrackerTests.swift in Sources */,
 				D49480D32DC23E9300A3B6E9 /* SentryReplayTypeTests.swift in Sources */,
 				D8F8F5572B835BC600AC5465 /* SentryMsgPackSerializerTests.m in Sources */,
+				FA65551A2E3018A3009917BC /* SentrySDKTests.swift in Sources */,
 				0A283E79291A67E000EF4126 /* SentryUIDeviceWrapperTests.swift in Sources */,
 				63FE720D20DA66EC00CDBAE8 /* SentryCrashNSErrorUtilTests.m in Sources */,
 				69BEE6F72620729E006DF9DF /* UrlSessionDelegateSpy.swift in Sources */,
@@ -6049,7 +6061,7 @@
 				63FE721B20DA66EC00CDBAE8 /* Container+DeepSearch_Tests.m in Sources */,
 				8EA05EED267C2AB200C82B30 /* SentryNetworkTrackerTests.swift in Sources */,
 				D4E3F35E2D4A877300F79E2B /* SentryNSDictionarySanitize+Tests.m in Sources */,
-				7BA840A024A1EC6E00B718AA /* SentrySDKTests.swift in Sources */,
+				7BA840A024A1EC6E00B718AA /* SentrySDKInternalTests.swift in Sources */,
 				D8AE48BF2C578D540092A2A6 /* SentrySDKLog.swift in Sources */,
 				D8F6A24E288553A800320515 /* SentryPredicateDescriptorTests.swift in Sources */,
 				7B0002322477F0520035FEF1 /* SentrySessionTests.m in Sources */,

--- a/SentryTestUtils/ClearTestState.swift
+++ b/SentryTestUtils/ClearTestState.swift
@@ -23,11 +23,11 @@ class TestCleanup: NSObject {
         assert(Thread.isMainThread, "You must call clearTestState on the main thread.")
         
         SentrySDK.close()
-        SentrySDK.setCurrentHub(nil)
-        SentrySDK.crashedLastRunCalled = false
-        SentrySDK.startInvocations = 0
-        SentrySDK.setDetectedStartUpCrash(false)
-        SentrySDK.setStart(nil)
+        SentrySDKInternal.setCurrentHub(nil)
+        SentrySDKInternal.crashedLastRunCalled = false
+        SentrySDKInternal.startInvocations = 0
+        SentrySDKInternal.setDetectedStartUpCrash(false)
+        SentrySDKInternal.setStart(with: nil)
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false
         SentryNetworkTracker.sharedInstance.disable()
 
@@ -62,7 +62,7 @@ class TestCleanup: NSObject {
 
         #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
         PrivateSentrySDKOnly.onAppStartMeasurementAvailable = nil
-        SentrySDK.setAppStartMeasurement(nil)
+        SentrySDKInternal.setAppStartMeasurement(nil)
         #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
         sentrycrash_scopesync_reset()

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -51,7 +51,7 @@
 #import "SentryPerformanceTracker+Testing.h"
 #import "SentryReachability.h"
 #import "SentrySDK+Private.h"
-#import "SentrySDK+Tests.h"
+#import "SentrySDKInternal+Tests.h"
 #import "SentryScopeSyncC.h"
 #import "SentrySwizzleWrapper.h"
 #import "SentrySystemWrapper.h"

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -40,12 +40,12 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)storeEnvelope:(SentryEnvelope *)envelope
 {
-    [SentrySDK storeEnvelope:envelope];
+    [SentrySDKInternal storeEnvelope:envelope];
 }
 
 + (void)captureEnvelope:(SentryEnvelope *)envelope
 {
-    [SentrySDK captureEnvelope:envelope];
+    [SentrySDKInternal captureEnvelope:envelope];
 }
 
 + (nullable SentryEnvelope *)envelopeWithData:(NSData *)data
@@ -72,13 +72,13 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (nullable SentryAppStartMeasurement *)appStartMeasurement
 {
-    return [SentrySDK getAppStartMeasurement];
+    return [SentrySDKInternal getAppStartMeasurement];
 }
 
 + (nullable NSDictionary<NSString *, id> *)appStartMeasurementWithSpans
 {
 #if SENTRY_HAS_UIKIT
-    SentryAppStartMeasurement *measurement = [SentrySDK getAppStartMeasurement];
+    SentryAppStartMeasurement *measurement = [SentrySDKInternal getAppStartMeasurement];
     if (measurement == nil) {
         return nil;
     }
@@ -142,7 +142,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (SentryOptions *)options
 {
-    SentryOptions *options = [[SentrySDK currentHub] client].options;
+    SentryOptions *options = [[SentrySDKInternal currentHub] client].options;
     if (options != nil) {
         return options;
     }
@@ -203,7 +203,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)setTrace:(SentryId *)traceId spanId:(SentrySpanId *)spanId
 {
-    [SentrySDK.currentHub configureScope:^(SentryScope *scope) {
+    [SentrySDKInternal.currentHub configureScope:^(SentryScope *scope) {
         scope.propagationContext = [[SentryPropagationContext alloc] initWithTraceId:traceId
                                                                               spanId:spanId];
     }];
@@ -227,7 +227,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 
 + (void)discardProfilerForTrace:(SentryId *)traceId;
 {
-    sentry_discardProfilerCorrelatedToTrace(traceId, SentrySDK.currentHub);
+    sentry_discardProfilerCorrelatedToTrace(traceId, SentrySDKInternal.currentHub);
 }
 
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
@@ -294,7 +294,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 #if SENTRY_UIKIT_AVAILABLE
 + (void)setCurrentScreen:(NSString *)screenName
 {
-    [SentrySDK.currentHub
+    [SentrySDKInternal.currentHub
         configureScope:^(SentryScope *scope) { scope.currentScreen = screenName; }];
 }
 #endif // SENTRY_HAS_UIKIT
@@ -331,7 +331,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 + (nullable SentrySessionReplayIntegration *)getReplayIntegration
 {
 
-    NSArray *integrations = [[SentrySDK currentHub] installedIntegrations];
+    NSArray *integrations = [[SentrySDKInternal currentHub] installedIntegrations];
     SentrySessionReplayIntegration *replayIntegration;
     for (id obj in integrations) {
         if ([obj isKindOfClass:[SentrySessionReplayIntegration class]]) {

--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -84,7 +84,7 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
                 screenFrameData
 #    endif // SENTRY_HAS_UIKIT
             );
-        [SentrySDK captureEnvelope:envelope];
+        [SentrySDKInternal captureEnvelope:envelope];
     });
 }
 

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.m
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.m
@@ -316,7 +316,7 @@ SentryEnvelope *_Nullable sentry_continuousProfileChunkEnvelope(
     NSMutableDictionary<NSString *, id> *payload = sentry_serializedContinuousProfileChunk(
         profileID, chunkID, profileState, metricProfilerState,
         [SentryDependencyContainer.sharedInstance.debugImageProvider getDebugImagesFromCache],
-        SentrySDK.currentHub
+        SentrySDKInternal.currentHub
 #    if SENTRY_HAS_UIKIT
         ,
         gpuData

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -125,7 +125,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
         return;
     }
 #endif // SENTRY_HAS_UIKIT
-    SentryThreadInspector *threadInspector = SentrySDK.currentHub.getClient.threadInspector;
+    SentryThreadInspector *threadInspector = SentrySDKInternal.currentHub.getClient.threadInspector;
 
     NSArray<SentryThread *> *threads = [threadInspector getCurrentThreadsWithStackTrace];
 
@@ -179,8 +179,8 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
         // We need to apply the scope now because if the app hang turns into a fatal one,
         // we would lose the scope. Furthermore, we want to know in which state the app was when the
         // app hang started.
-        SentryScope *scope = [SentrySDK currentHub].scope;
-        SentryOptions *options = SentrySDK.options;
+        SentryScope *scope = [SentrySDKInternal currentHub].scope;
+        SentryOptions *options = SentrySDKInternal.options;
         if (scope != nil && options != nil) {
             [scope applyToEvent:event maxBreadcrumb:options.maxBreadcrumbs];
         }
@@ -301,7 +301,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
 
             // We already applied the scope. We use an empty scope to avoid overwriting exising
             // fields on the event.
-            [SentrySDK captureFatalAppHangEvent:event];
+            [SentrySDKInternal captureFatalAppHangEvent:event];
         }
     }];
 }

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -214,10 +214,10 @@ static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 180.0;
                                                    duration:appStartDuration
                                        runtimeInitTimestamp:runtimeInit
                               moduleInitializationTimestamp:sysctl.moduleInitializationTimestamp
-                                          sdkStartTimestamp:SentrySDK.startTimestamp
+                                          sdkStartTimestamp:SentrySDKInternal.startTimestamp
                                 didFinishLaunchingTimestamp:self.didFinishLaunchingTimestamp];
 
-        SentrySDK.appStartMeasurement = appStartMeasurement;
+        SentrySDKInternal.appStartMeasurement = appStartMeasurement;
     };
 
 // With only running this once we know that the process is a new one when the following

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -4,7 +4,7 @@
 #import "SentryFileManager.h"
 #import "SentryLogC.h"
 #import "SentryOptions.h"
-#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
 #import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -88,7 +88,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)addBreadcrumb:(SentryBreadcrumb *)crumb
 {
-    [SentrySDK addBreadcrumb:crumb];
+    [SentrySDKInternal addBreadcrumb:crumb];
 }
 
 @end

--- a/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoSessionTrackingIntegration.m
@@ -2,7 +2,7 @@
 #import "SentryDependencyContainer.h"
 #import "SentryLogC.h"
 #import "SentryOptions.h"
-#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
 #import "SentrySessionTracker.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -877,10 +877,10 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     if (event != nil && isFatalEvent && nil != self.options.onCrashedLastRun
-        && !SentrySDK.crashedLastRunCalled) {
+        && !SentrySDKInternal.crashedLastRunCalled) {
         // We only want to call the callback once. It can occur that multiple crash events are
         // about to be sent.
-        SentrySDK.crashedLastRunCalled = YES;
+        SentrySDKInternal.crashedLastRunCalled = YES;
         self.options.onCrashedLastRun(event);
     }
 

--- a/Sources/Sentry/SentryCoreDataTracker.m
+++ b/Sources/Sentry/SentryCoreDataTracker.m
@@ -38,7 +38,7 @@
                             error:(NSError **)error
                       originalImp:(NSArray *(NS_NOESCAPE ^)(NSFetchRequest *, NSError **))original
 {
-    id<SentrySpan> _Nullable currentSpan = [SentrySDK.currentHub.scope span];
+    id<SentrySpan> _Nullable currentSpan = [SentrySDKInternal.currentHub.scope span];
     id<SentrySpan> _Nullable fetchSpan;
     if (currentSpan) {
         NSString *spanDescription = [self descriptionFromRequest:request];
@@ -80,7 +80,7 @@
         __block NSDictionary<NSString *, NSDictionary *> *operations =
             [self groupEntitiesOperations:context];
 
-        id<SentrySpan> _Nullable currentSpan = [SentrySDK.currentHub.scope span];
+        id<SentrySpan> _Nullable currentSpan = [SentrySDKInternal.currentHub.scope span];
         if (currentSpan) {
             NSString *spanDescription = [self descriptionForOperations:operations
                                                              inContext:context];

--- a/Sources/Sentry/SentryCrashExceptionApplicationHelper.m
+++ b/Sources/Sentry/SentryCrashExceptionApplicationHelper.m
@@ -7,7 +7,7 @@
 #    import "SentryCrashExceptionApplicationHelper.h"
 #    import "SentryDependencyContainer.h"
 #    import "SentrySDK+Private.h"
-#    import "SentrySDK.h"
+#    import "SentrySDKInternal.h"
 
 @implementation SentryCrashExceptionApplicationHelper
 
@@ -21,7 +21,7 @@
 
 + (void)_crashOnException:(NSException *)exception
 {
-    [SentrySDK captureCrashOnException:exception];
+    [SentrySDKInternal captureCrashOnException:exception];
 #    if !(SENTRY_TEST || SENTRY_TEST_CI)
     abort();
 #    endif

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -42,7 +42,7 @@ static NSString *const LOCALE_KEY = @"locale";
 void
 sentry_finishAndSaveTransaction(void)
 {
-    SentrySpan *span = SentrySDK.currentHub.scope.span;
+    SentrySpan *span = SentrySDKInternal.currentHub.scope.span;
 
     if (span != nil) {
         SentryTracer *tracer = [span tracer];
@@ -232,7 +232,7 @@ sentry_finishAndSaveTransaction(void)
 {
     // We need to make sure to set always the scope to KSCrash so we have it in
     // case of a crash
-    [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
+    [SentrySDKInternal.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
         NSMutableDictionary<NSString *, id> *userInfo =
             [[NSMutableDictionary alloc] initWithDictionary:[outerScope serialize]];
         // SentryCrashReportConverter.convertReportToEvent needs the release name and
@@ -257,7 +257,7 @@ sentry_finishAndSaveTransaction(void)
 
 - (void)currentLocaleDidChange
 {
-    [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull scope) {
+    [SentrySDKInternal.currentHub configureScope:^(SentryScope *_Nonnull scope) {
         NSMutableDictionary<NSString *, id> *device;
         if (scope.contextDictionary != nil
             && scope.contextDictionary[SENTRY_CONTEXT_DEVICE_KEY] != nil) {

--- a/Sources/Sentry/SentryCrashIntegrationSessionHandler.m
+++ b/Sources/Sentry/SentryCrashIntegrationSessionHandler.m
@@ -39,7 +39,7 @@
 
 - (void)endCurrentSessionIfRequired
 {
-    SentryFileManager *fileManager = [[[SentrySDK currentHub] getClient] fileManager];
+    SentryFileManager *fileManager = [[[SentrySDKInternal currentHub] getClient] fileManager];
 
     if (nil == fileManager) {
         SENTRY_LOG_DEBUG(@"File manager is nil. Cannot end current session.");

--- a/Sources/Sentry/SentryCrashReportSink.m
+++ b/Sources/Sentry/SentryCrashReportSink.m
@@ -11,7 +11,7 @@
 #import "SentryHub.h"
 #import "SentryLogC.h"
 #import "SentrySDK+Private.h"
-#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
 #import "SentryScope+Private.h"
 #import "SentrySwift.h"
 #import "SentryThread.h"
@@ -50,11 +50,11 @@ static const NSTimeInterval SENTRY_APP_START_CRASH_FLUSH_DURATION = 5.0;
         && durationFromCrashStateInitToLastCrash <= SENTRY_APP_START_CRASH_DURATION_THRESHOLD) {
         SENTRY_LOG_WARN(@"Startup crash: detected.");
 
-        [SentrySDK setDetectedStartUpCrash:YES];
+        [SentrySDKInternal setDetectedStartUpCrash:YES];
 
         [self sendReports:reports onCompletion:onCompletion];
 
-        [SentrySDK flush:SENTRY_APP_START_CRASH_FLUSH_DURATION];
+        [SentrySDKInternal flush:SENTRY_APP_START_CRASH_FLUSH_DURATION];
         SENTRY_LOG_DEBUG(@"Startup crash: Finished flushing.");
 
     } else {
@@ -69,7 +69,7 @@ static const NSTimeInterval SENTRY_APP_START_CRASH_FLUSH_DURATION = 5.0;
     for (NSDictionary *report in reports) {
         SentryCrashReportConverter *reportConverter =
             [[SentryCrashReportConverter alloc] initWithReport:report inAppLogic:self.inAppLogic];
-        if (nil != [SentrySDK.currentHub getClient]) {
+        if (nil != [SentrySDKInternal.currentHub getClient]) {
             SentryEvent *event = [reportConverter convertReportToEvent];
             if (nil != event) {
                 [self handleConvertedEvent:event report:report sentReports:sentReports];
@@ -92,7 +92,7 @@ static const NSTimeInterval SENTRY_APP_START_CRASH_FLUSH_DURATION = 5.0;
                  sentReports:(NSMutableArray *)sentReports
 {
     [sentReports addObject:report];
-    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
+    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDKInternal.currentHub.scope];
 
     if (report[SENTRYCRASH_REPORT_ATTACHMENTS_ITEM]) {
         for (NSString *ssPath in report[SENTRYCRASH_REPORT_ATTACHMENTS_ITEM]) {
@@ -100,7 +100,7 @@ static const NSTimeInterval SENTRY_APP_START_CRASH_FLUSH_DURATION = 5.0;
         }
     }
 
-    [SentrySDK captureFatalEvent:event withScope:scope];
+    [SentrySDKInternal captureFatalEvent:event withScope:scope];
 }
 
 @end

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -213,8 +213,8 @@ static BOOL isInitialializingDependencyContainer = NO;
 {
     SENTRY_LAZY_INIT(_fileManager, ({
         NSError *error;
-        SentryFileManager *manager = [[SentryFileManager alloc] initWithOptions:SentrySDK.options
-                                                                          error:&error];
+        SentryFileManager *manager =
+            [[SentryFileManager alloc] initWithOptions:SentrySDKInternal.options error:&error];
         if (manager == nil) {
             SENTRY_LOG_DEBUG(@"Could not create file manager - %@", error);
         }
@@ -225,7 +225,7 @@ static BOOL isInitialializingDependencyContainer = NO;
 - (SentryAppStateManager *)appStateManager SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_appStateManager,
-        [[SentryAppStateManager alloc] initWithOptions:SentrySDK.options
+        [[SentryAppStateManager alloc] initWithOptions:SentrySDKInternal.options
                                           crashWrapper:self.crashWrapper
                                            fileManager:self.fileManager
                                   dispatchQueueWrapper:self.dispatchQueueWrapper
@@ -234,8 +234,8 @@ static BOOL isInitialializingDependencyContainer = NO;
 
 - (SentryThreadInspector *)threadInspector SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
-    SENTRY_LAZY_INIT(
-        _threadInspector, [[SentryThreadInspector alloc] initWithOptions:SentrySDK.options]);
+    SENTRY_LAZY_INIT(_threadInspector,
+        [[SentryThreadInspector alloc] initWithOptions:SentrySDKInternal.options]);
 }
 
 - (SentryFileIOTracker *)fileIOTracker SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
@@ -248,7 +248,7 @@ static BOOL isInitialializingDependencyContainer = NO;
 - (SentryCrash *)crashReporter SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_crashReporter,
-        [[SentryCrash alloc] initWithBasePath:SentrySDK.options.cacheDirectoryPath]);
+        [[SentryCrash alloc] initWithBasePath:SentrySDKInternal.options.cacheDirectoryPath]);
 }
 
 - (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout

--- a/Sources/Sentry/SentryFeedbackAPI.m
+++ b/Sources/Sentry/SentryFeedbackAPI.m
@@ -19,8 +19,8 @@
 - (void)showWidget
 {
     if (@available(iOS 13.0, *)) {
-        SentryUserFeedbackIntegration *feedback =
-            [[SentrySDK currentHub] getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        SentryUserFeedbackIntegration *feedback = [[SentrySDKInternal currentHub]
+            getInstalledIntegration:[SentryUserFeedbackIntegration class]];
         [feedback showWidget];
     } else {
         SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");
@@ -30,8 +30,8 @@
 - (void)hideWidget
 {
     if (@available(iOS 13.0, *)) {
-        SentryUserFeedbackIntegration *feedback =
-            [SentrySDK.currentHub getInstalledIntegration:[SentryUserFeedbackIntegration class]];
+        SentryUserFeedbackIntegration *feedback = [SentrySDKInternal.currentHub
+            getInstalledIntegration:[SentryUserFeedbackIntegration class]];
         [feedback hideWidget];
     } else {
         SENTRY_LOG_WARN(@"Sentry User Feedback is only available on iOS 13 or later.");

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -209,7 +209,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
     }
 
     NSString *spanDescription = [self transactionDescriptionForFile:path fileSize:size];
-    id<SentrySpan> _Nullable currentSpan = [SentrySDK.currentHub.scope span];
+    id<SentrySpan> _Nullable currentSpan = [SentrySDKInternal.currentHub.scope span];
     if (currentSpan == NULL) {
         SENTRY_LOG_DEBUG(@"No transaction bound to scope. Won't track file IO operation.");
         return nil;
@@ -322,7 +322,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
 
 - (BOOL)ignoreFile:(NSString *)path
 {
-    SentryFileManager *fileManager = [SentrySDK.currentHub getClient].fileManager;
+    SentryFileManager *fileManager = [SentrySDKInternal.currentHub getClient].fileManager;
     return fileManager.sentryPath != nil && [path hasPrefix:fileManager.sentryPath];
 }
 

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -842,7 +842,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSMutableArray<NSString *> *)trimmedInstalledIntegrationNames
 {
     NSMutableArray<NSString *> *integrations = [NSMutableArray<NSString *> array];
-    for (NSString *integration in SentrySDK.currentHub.installedIntegrationNames) {
+    for (NSString *integration in SentrySDKInternal.currentHub.installedIntegrationNames) {
         // Every integration starts with "Sentry" and ends with "Integration". To keep the
         // payload of the event small we remove both.
         NSString *withoutSentry = [integration stringByReplacingOccurrencesOfString:@"Sentry"

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -12,7 +12,7 @@
 #import "SentryMeta.h"
 #import "SentryNetworkTrackingIntegration.h"
 #import "SentryOptions+Private.h"
-#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
 #import "SentryScope.h"
 #import "SentrySessionReplayIntegration.h"
 #import "SentrySwift.h"

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
                                                                                  operation:operation
                                                                                     origin:origin];
 
-        id<SentrySpan> span = SentrySDK.currentHub.scope.span;
+        id<SentrySpan> span = SentrySDKInternal.currentHub.scope.span;
 
         BOOL bindToScope = NO;
         if (span == nil) {
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
         SENTRY_LOG_DEBUG(
             @"Starting new transaction for %@ with bindToScope: %d", name, bindToScope);
 
-        newSpan = [SentrySDK.currentHub
+        newSpan = [SentrySDKInternal.currentHub
             startTransactionWithContext:context
                             bindToScope:bindToScope
                   customSamplingContext:@{}

--- a/Sources/Sentry/SentryProfileCollector.mm
+++ b/Sources/Sentry/SentryProfileCollector.mm
@@ -14,7 +14,7 @@
                                                                forTrace:(SentryId *)traceId
 {
     NSMutableDictionary<NSString *, id> *payload = sentry_collectProfileDataHybridSDK(
-        startSystemTime, endSystemTime, traceId, [SentrySDK currentHub]);
+        startSystemTime, endSystemTime, traceId, [SentrySDKInternal currentHub]);
 
     if (payload != nil) {
         payload[@"platform"] = SentryPlatformName;

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -245,9 +245,9 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
     // profiles because it isn't needed for anything else
 
     BOOL autoPerformanceTracingDisabled
-        = ![[[[SentrySDK currentHub] getClient] options] enableAutoPerformanceTracing];
+        = ![[[[SentrySDKInternal currentHub] getClient] options] enableAutoPerformanceTracing];
     BOOL appHangsV2Disabled =
-        [[[[SentrySDK currentHub] getClient] options] isAppHangTrackingV2Disabled];
+        [[[[SentrySDKInternal currentHub] getClient] options] isAppHangTrackingV2Disabled];
 
     if (autoPerformanceTracingDisabled && appHangsV2Disabled) {
         [SentryDependencyContainer.sharedInstance.framesTracker stop];

--- a/Sources/Sentry/SentryReplayApi.m
+++ b/Sources/Sentry/SentryReplayApi.m
@@ -27,7 +27,7 @@
 {
     SENTRY_LOG_INFO(@"[Session Replay] Pausing session");
     SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
     [replayIntegration pause];
 }
@@ -36,7 +36,7 @@
 {
     SENTRY_LOG_INFO(@"[Session Replay] Resuming session");
     SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
     [replayIntegration resume];
 }
@@ -45,7 +45,7 @@
 {
     SENTRY_LOG_INFO(@"[Session Replay] Starting session");
     SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
 
     // Start could be misused and called multiple times, causing it to
@@ -53,15 +53,15 @@
     // Synchronizing it will prevent this problem.
     if (replayIntegration == nil) {
         @synchronized(self) {
-            replayIntegration = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+            replayIntegration = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
                 getInstalledIntegration:SentrySessionReplayIntegration.class];
             if (replayIntegration == nil) {
                 SENTRY_LOG_DEBUG(@"[Session Replay] Initializing replay integration");
-                SentryOptions *currentOptions = SentrySDK.currentHub.client.options;
+                SentryOptions *currentOptions = SentrySDKInternal.currentHub.client.options;
                 replayIntegration =
                     [[SentrySessionReplayIntegration alloc] initForManualUse:currentOptions];
 
-                [SentrySDK.currentHub
+                [SentrySDKInternal.currentHub
                     addInstalledIntegration:replayIntegration
                                        name:NSStringFromClass(SentrySessionReplay.class)];
             }
@@ -74,7 +74,7 @@
 {
     SENTRY_LOG_INFO(@"[Session Replay] Stopping session");
     SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
     [replayIntegration stop];
 }
@@ -89,7 +89,7 @@
 {
     SENTRY_LOG_DEBUG(@"[Session Replay] Showing mask preview with opacity: %f", opacity);
     SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
 
     [replayIntegration showMaskPreview:opacity];
@@ -99,7 +99,7 @@
 {
     SENTRY_LOG_DEBUG(@"[Session Replay] Hiding mask preview");
     SentrySessionReplayIntegration *replayIntegration
-        = (SentrySessionReplayIntegration *)[SentrySDK.currentHub
+        = (SentrySessionReplayIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:SentrySessionReplayIntegration.class];
 
     [replayIntegration hideMaskPreview];

--- a/Sources/Sentry/SentryRequestOperation.m
+++ b/Sources/Sentry/SentryRequestOperation.m
@@ -25,30 +25,30 @@ NS_ASSUME_NONNULL_BEGIN
     self = [super init];
     if (self) {
         self.request = request;
-        self.task = [session dataTaskWithRequest:self.request
-                               completionHandler:^(NSData *_Nullable data,
-                                   NSURLResponse *_Nullable response, NSError *_Nullable error) {
-                                   NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
-                                   NSInteger statusCode = [httpResponse statusCode];
+        self.task = [session
+            dataTaskWithRequest:self.request
+              completionHandler:^(NSData *_Nullable data, NSURLResponse *_Nullable response,
+                  NSError *_Nullable error) {
+                  NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+                  NSInteger statusCode = [httpResponse statusCode];
 
-                                   // We only have these if's here because of performance reasons
-                                   SENTRY_LOG_DEBUG(@"Request status: %ld", (long)statusCode);
-                                   if ([SentrySDK.currentHub getClient].options.debug == YES) {
-                                       SENTRY_LOG_DEBUG(@"Request response: %@",
-                                           [[NSString alloc] initWithData:data
-                                                                 encoding:NSUTF8StringEncoding]);
-                                   }
+                  // We only have these if's here because of performance reasons
+                  SENTRY_LOG_DEBUG(@"Request status: %ld", (long)statusCode);
+                  if ([SentrySDKInternal.currentHub getClient].options.debug == YES) {
+                      SENTRY_LOG_DEBUG(@"Request response: %@",
+                          [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding]);
+                  }
 
-                                   if (nil != error) {
-                                       SENTRY_LOG_ERROR(@"Request failed: %@", error);
-                                   }
+                  if (nil != error) {
+                      SENTRY_LOG_ERROR(@"Request failed: %@", error);
+                  }
 
-                                   if (completionHandler) {
-                                       completionHandler(httpResponse, error);
-                                   }
+                  if (completionHandler) {
+                      completionHandler(httpResponse, error);
+                  }
 
-                                   [self completeOperation];
-                               }];
+                  [self completeOperation];
+              }];
     }
     return self;
 }

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -1,4 +1,4 @@
-#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
 #import "PrivateSentrySDKOnly.h"
 #import "SentryANRTrackingIntegration.h"
 #import "SentryAppStartMeasurement.h"
@@ -48,14 +48,14 @@
 
 NSString *const SENTRY_XCODE_PREVIEW_ENVIRONMENT_KEY = @"XCODE_RUNNING_FOR_PREVIEWS";
 
-@interface SentrySDK ()
+@interface SentrySDKInternal ()
 
 @property (class) SentryHub *currentHub;
 
 @end
 
 NS_ASSUME_NONNULL_BEGIN
-@implementation SentrySDK
+@implementation SentrySDKInternal
 static SentryHub *_Nullable currentHub;
 static NSObject *currentHubLock;
 static SentryLogger *_Nullable currentLogger;
@@ -80,7 +80,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)initialize
 {
-    if (self == [SentrySDK class]) {
+    if (self == [SentrySDKInternal class]) {
         sentrySDKappStartMeasurementLock = [[NSObject alloc] init];
         currentHubLock = [[NSObject alloc] init];
         currentLoggerLock = [[NSObject alloc] init];
@@ -283,12 +283,12 @@ static NSDate *_Nullable startTimestamp = nil;
         // The Hub needs to be initialized with a client so that closing a session
         // can happen.
         SentryHub *hub = [[SentryHub alloc] initWithClient:newClient andScope:scope];
-        [SentrySDK setCurrentHub:hub];
+        [SentrySDKInternal setCurrentHub:hub];
 
         [SentryCrashWrapper.sharedInstance startBinaryImageCache];
         [SentryDependencyContainer.sharedInstance.binaryImageCache start:options.debug];
 
-        [SentrySDK installIntegrations];
+        [SentrySDKInternal installIntegrations];
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
         sentry_sdkInitProfilerTasks(options, hub);
@@ -302,120 +302,121 @@ static NSDate *_Nullable startTimestamp = nil;
 {
     SentryOptions *options = [[SentryOptions alloc] init];
     configureOptions(options);
-    [SentrySDK startWithOptions:options];
+    [SentrySDKInternal startWithOptions:options];
 }
 
 + (void)captureFatalEvent:(SentryEvent *)event
 {
-    [SentrySDK.currentHub captureFatalEvent:event];
+    [SentrySDKInternal.currentHub captureFatalEvent:event];
 }
 
 + (void)captureFatalEvent:(SentryEvent *)event withScope:(SentryScope *)scope
 {
-    [SentrySDK.currentHub captureFatalEvent:event withScope:scope];
+    [SentrySDKInternal.currentHub captureFatalEvent:event withScope:scope];
 }
 
 #if SENTRY_HAS_UIKIT
 
 + (void)captureFatalAppHangEvent:(SentryEvent *)event
 {
-    [SentrySDK.currentHub captureFatalAppHangEvent:event];
+    [SentrySDKInternal.currentHub captureFatalAppHangEvent:event];
 }
 
 #endif // SENTRY_HAS_UIKIT
 
 + (SentryId *)captureEvent:(SentryEvent *)event
 {
-    return [SentrySDK captureEvent:event withScope:SentrySDK.currentHub.scope];
+    return [SentrySDKInternal captureEvent:event withScope:SentrySDKInternal.currentHub.scope];
 }
 
 + (SentryId *)captureEvent:(SentryEvent *)event withScopeBlock:(void (^)(SentryScope *))block
 {
-    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
+    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDKInternal.currentHub.scope];
     block(scope);
-    return [SentrySDK captureEvent:event withScope:scope];
+    return [SentrySDKInternal captureEvent:event withScope:scope];
 }
 
 + (SentryId *)captureEvent:(SentryEvent *)event withScope:(SentryScope *)scope
 {
-    return [SentrySDK.currentHub captureEvent:event withScope:scope];
+    return [SentrySDKInternal.currentHub captureEvent:event withScope:scope];
 }
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name operation:(NSString *)operation
 {
-    return [SentrySDK.currentHub startTransactionWithName:name operation:operation];
+    return [SentrySDKInternal.currentHub startTransactionWithName:name operation:operation];
 }
 
 + (id<SentrySpan>)startTransactionWithName:(NSString *)name
                                  operation:(NSString *)operation
                                bindToScope:(BOOL)bindToScope
 {
-    return [SentrySDK.currentHub startTransactionWithName:name
-                                                operation:operation
-                                              bindToScope:bindToScope];
+    return [SentrySDKInternal.currentHub startTransactionWithName:name
+                                                        operation:operation
+                                                      bindToScope:bindToScope];
 }
 
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
 {
-    return [SentrySDK.currentHub startTransactionWithContext:transactionContext];
+    return [SentrySDKInternal.currentHub startTransactionWithContext:transactionContext];
 }
 
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
 {
-    return [SentrySDK.currentHub startTransactionWithContext:transactionContext
-                                                 bindToScope:bindToScope];
+    return [SentrySDKInternal.currentHub startTransactionWithContext:transactionContext
+                                                         bindToScope:bindToScope];
 }
 
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                                   bindToScope:(BOOL)bindToScope
                         customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
-    return [SentrySDK.currentHub startTransactionWithContext:transactionContext
-                                                 bindToScope:bindToScope
-                                       customSamplingContext:customSamplingContext];
+    return [SentrySDKInternal.currentHub startTransactionWithContext:transactionContext
+                                                         bindToScope:bindToScope
+                                               customSamplingContext:customSamplingContext];
 }
 
 + (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
                         customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
 {
-    return [SentrySDK.currentHub startTransactionWithContext:transactionContext
-                                       customSamplingContext:customSamplingContext];
+    return [SentrySDKInternal.currentHub startTransactionWithContext:transactionContext
+                                               customSamplingContext:customSamplingContext];
 }
 
 + (SentryId *)captureError:(NSError *)error
 {
-    return [SentrySDK captureError:error withScope:SentrySDK.currentHub.scope];
+    return [SentrySDKInternal captureError:error withScope:SentrySDKInternal.currentHub.scope];
 }
 
 + (SentryId *)captureError:(NSError *)error withScopeBlock:(void (^)(SentryScope *_Nonnull))block
 {
-    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
+    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDKInternal.currentHub.scope];
     block(scope);
-    return [SentrySDK captureError:error withScope:scope];
+    return [SentrySDKInternal captureError:error withScope:scope];
 }
 
 + (SentryId *)captureError:(NSError *)error withScope:(SentryScope *)scope
 {
-    return [SentrySDK.currentHub captureError:error withScope:scope];
+    return [SentrySDKInternal.currentHub captureError:error withScope:scope];
 }
 
 + (SentryId *)captureException:(NSException *)exception
 {
-    return [SentrySDK captureException:exception withScope:SentrySDK.currentHub.scope];
+    return [SentrySDKInternal captureException:exception
+                                     withScope:SentrySDKInternal.currentHub.scope];
 }
 
 + (SentryId *)captureException:(NSException *)exception
                 withScopeBlock:(void (^)(SentryScope *))block
 {
-    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
+    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDKInternal.currentHub.scope];
     block(scope);
-    return [SentrySDK captureException:exception withScope:scope];
+    return [SentrySDKInternal captureException:exception withScope:scope];
 }
 
 + (SentryId *)captureException:(NSException *)exception withScope:(SentryScope *)scope
 {
-    return [SentrySDK.currentHub captureException:exception withScope:scope];
+    return [SentrySDKInternal.currentHub captureException:exception withScope:scope];
 }
 
 #if TARGET_OS_OSX
@@ -428,26 +429,27 @@ static NSDate *_Nullable startTimestamp = nil;
                               reason:exception.reason
                             userInfo:exception.userInfo
             callStackReturnAddresses:exception.callStackReturnAddresses];
-    return [SentrySDK captureException:wrappedException withScope:SentrySDK.currentHub.scope];
+    return [SentrySDKInternal captureException:wrappedException
+                                     withScope:SentrySDKInternal.currentHub.scope];
 }
 
 #endif // TARGET_OS_OSX
 
 + (SentryId *)captureMessage:(NSString *)message
 {
-    return [SentrySDK captureMessage:message withScope:SentrySDK.currentHub.scope];
+    return [SentrySDKInternal captureMessage:message withScope:SentrySDKInternal.currentHub.scope];
 }
 
 + (SentryId *)captureMessage:(NSString *)message withScopeBlock:(void (^)(SentryScope *))block
 {
-    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDK.currentHub.scope];
+    SentryScope *scope = [[SentryScope alloc] initWithScope:SentrySDKInternal.currentHub.scope];
     block(scope);
-    return [SentrySDK captureMessage:message withScope:scope];
+    return [SentrySDKInternal captureMessage:message withScope:scope];
 }
 
 + (SentryId *)captureMessage:(NSString *)message withScope:(SentryScope *)scope
 {
-    return [SentrySDK.currentHub captureMessage:message withScope:scope];
+    return [SentrySDKInternal.currentHub captureMessage:message withScope:scope];
 }
 
 /**
@@ -455,7 +457,7 @@ static NSDate *_Nullable startTimestamp = nil;
  */
 + (void)captureEnvelope:(SentryEnvelope *)envelope
 {
-    [SentrySDK.currentHub captureEnvelope:envelope];
+    [SentrySDKInternal.currentHub captureEnvelope:envelope];
 }
 
 /**
@@ -463,19 +465,19 @@ static NSDate *_Nullable startTimestamp = nil;
  */
 + (void)storeEnvelope:(SentryEnvelope *)envelope
 {
-    [SentrySDK.currentHub storeEnvelope:envelope];
+    [SentrySDKInternal.currentHub storeEnvelope:envelope];
 }
 
 #if !SDK_V9
 + (void)captureUserFeedback:(SentryUserFeedback *)userFeedback
 {
-    [SentrySDK.currentHub captureUserFeedback:userFeedback];
+    [SentrySDKInternal.currentHub captureUserFeedback:userFeedback];
 }
 #endif // !SDK_V9
 
 + (void)captureFeedback:(SentryFeedback *)feedback
 {
-    [SentrySDK.currentHub captureFeedback:feedback];
+    [SentrySDKInternal.currentHub captureFeedback:feedback];
 }
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
@@ -492,17 +494,17 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)addBreadcrumb:(SentryBreadcrumb *)crumb
 {
-    [SentrySDK.currentHub addBreadcrumb:crumb];
+    [SentrySDKInternal.currentHub addBreadcrumb:crumb];
 }
 
 + (void)configureScope:(void (^)(SentryScope *scope))callback
 {
-    [SentrySDK.currentHub configureScope:callback];
+    [SentrySDKInternal.currentHub configureScope:callback];
 }
 
 + (void)setUser:(SentryUser *_Nullable)user
 {
-    if (![SentrySDK isEnabled]) {
+    if (![SentrySDKInternal isEnabled]) {
         // We must log with level fatal because only fatal messages get logged even when the SDK
         // isn't started. We've seen multiple times that users try to set the user before starting
         // the SDK, and it confuses them. Ideally, we would do something to store the user and set
@@ -512,7 +514,7 @@ static NSDate *_Nullable startTimestamp = nil;
                          @"the SDK before setting the user.");
     }
 
-    [SentrySDK.currentHub setUser:user];
+    [SentrySDKInternal.currentHub setUser:user];
 }
 
 + (BOOL)crashedLastRun
@@ -532,12 +534,12 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)startSession
 {
-    [SentrySDK.currentHub startSession];
+    [SentrySDKInternal.currentHub startSession];
 }
 
 + (void)endSession
 {
-    [SentrySDK.currentHub endSession];
+    [SentrySDKInternal.currentHub endSession];
 }
 
 /**
@@ -545,13 +547,13 @@ static NSDate *_Nullable startTimestamp = nil;
  */
 + (void)installIntegrations
 {
-    if (nil == [SentrySDK.currentHub getClient]) {
+    if (nil == [SentrySDKInternal.currentHub getClient]) {
         // Gatekeeper
         return;
     }
-    SentryOptions *options = [SentrySDK.currentHub getClient].options;
+    SentryOptions *options = [SentrySDKInternal.currentHub getClient].options;
     NSMutableArray<NSString *> *integrationNames =
-        [SentrySDK.currentHub getClient].options.integrations.mutableCopy;
+        [SentrySDKInternal.currentHub getClient].options.integrations.mutableCopy;
 
     NSArray<Class> *defaultIntegrations = SentryOptions.defaultIntegrationClasses;
 
@@ -580,7 +582,7 @@ static NSDate *_Nullable startTimestamp = nil;
                              @"couldn't find \"%@\" -> skipping.",
                 integrationName);
             continue;
-        } else if ([SentrySDK.currentHub isIntegrationInstalled:integrationClass]) {
+        } else if ([SentrySDKInternal.currentHub isIntegrationInstalled:integrationClass]) {
             SENTRY_LOG_ERROR(
                 @"[SentryHub doInstallIntegrations] already installed \"%@\" -> skipping.",
                 integrationName);
@@ -591,20 +593,21 @@ static NSDate *_Nullable startTimestamp = nil;
 
         if (shouldInstall) {
             SENTRY_LOG_DEBUG(@"Integration installed: %@", integrationName);
-            [SentrySDK.currentHub addInstalledIntegration:integrationInstance name:integrationName];
+            [SentrySDKInternal.currentHub addInstalledIntegration:integrationInstance
+                                                             name:integrationName];
         }
     }
 }
 
 + (void)reportFullyDisplayed
 {
-    [SentrySDK.currentHub reportFullyDisplayed];
+    [SentrySDKInternal.currentHub reportFullyDisplayed];
 }
 
 + (void)pauseAppHangTracking
 {
     SentryANRTrackingIntegration *anrTrackingIntegration
-        = (SentryANRTrackingIntegration *)[SentrySDK.currentHub
+        = (SentryANRTrackingIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:[SentryANRTrackingIntegration class]];
 
     [anrTrackingIntegration pauseAppHangTracking];
@@ -613,7 +616,7 @@ static NSDate *_Nullable startTimestamp = nil;
 + (void)resumeAppHangTracking
 {
     SentryANRTrackingIntegration *anrTrackingIntegration
-        = (SentryANRTrackingIntegration *)[SentrySDK.currentHub
+        = (SentryANRTrackingIntegration *)[SentrySDKInternal.currentHub
             getInstalledIntegration:[SentryANRTrackingIntegration class]];
 
     [anrTrackingIntegration resumeAppHangTracking];
@@ -621,7 +624,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
 + (void)flush:(NSTimeInterval)timeout
 {
-    [SentrySDK.currentHub flush:timeout];
+    [SentrySDKInternal.currentHub flush:timeout];
 }
 
 /**
@@ -637,7 +640,7 @@ static NSDate *_Nullable startTimestamp = nil;
 
     startTimestamp = nil;
 
-    SentryHub *hub = SentrySDK.currentHub;
+    SentryHub *hub = SentrySDKInternal.currentHub;
     [hub removeAllIntegrations];
 
     SENTRY_LOG_DEBUG(@"Uninstalled all integrations.");
@@ -651,7 +654,7 @@ static NSDate *_Nullable startTimestamp = nil;
     [hub close];
     [hub bindClient:nil];
 
-    [SentrySDK setCurrentHub:nil];
+    [SentrySDKInternal setCurrentHub:nil];
 
     @synchronized(currentLoggerLock) {
         currentLogger = nil;

--- a/Sources/Sentry/SentrySDKWrapper.m
+++ b/Sources/Sentry/SentrySDKWrapper.m
@@ -1,0 +1,242 @@
+#import "SentryProfilingConditionals.h"
+#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
+
+@implementation SentrySDK
+
++ (id<SentrySpan>)span
+{
+    return [SentrySDKInternal span];
+}
+
++ (BOOL)isEnabled
+{
+    return [SentrySDKInternal isEnabled];
+}
+
+#if SENTRY_TARGET_REPLAY_SUPPORTED
++ (SentryReplayApi *)replay
+{
+    return [SentrySDKInternal replay];
+}
+#endif // SENTRY_TARGET_REPLAY_SUPPORTED
+
++ (SentryLogger *)logger
+{
+    return [SentrySDKInternal logger];
+}
+
++ (void)startWithOptions:(SentryOptions *)options
+{
+    [SentrySDKInternal startWithOptions:options];
+}
+
++ (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions
+{
+    [SentrySDKInternal startWithConfigureOptions:configureOptions];
+}
+
++ (SentryId *)captureEvent:(SentryEvent *)event
+{
+    return [SentrySDKInternal captureEvent:event];
+}
+
++ (SentryId *)captureEvent:(SentryEvent *)event withScope:(SentryScope *)scope
+{
+    return [SentrySDKInternal captureEvent:event withScope:scope];
+}
+
++ (SentryId *)captureEvent:(SentryEvent *)event withScopeBlock:(void (^)(SentryScope *scope))block
+{
+    return [SentrySDKInternal captureEvent:event withScopeBlock:block];
+}
+
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name operation:(NSString *)operation
+{
+    return [SentrySDKInternal startTransactionWithName:name operation:operation];
+}
+
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope
+{
+    return [SentrySDKInternal startTransactionWithName:name
+                                             operation:operation
+                                           bindToScope:bindToScope];
+}
+
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+{
+    return [SentrySDKInternal startTransactionWithContext:transactionContext];
+}
+
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                                  bindToScope:(BOOL)bindToScope
+{
+    return [SentrySDKInternal startTransactionWithContext:transactionContext
+                                              bindToScope:bindToScope];
+}
+
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                                  bindToScope:(BOOL)bindToScope
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
+{
+    return [SentrySDKInternal startTransactionWithContext:transactionContext
+                                              bindToScope:bindToScope
+                                    customSamplingContext:customSamplingContext];
+}
+
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
+{
+    return [SentrySDKInternal startTransactionWithContext:transactionContext
+                                    customSamplingContext:customSamplingContext];
+}
+
++ (SentryId *)captureError:(NSError *)error
+{
+    return [SentrySDKInternal captureError:error];
+}
+
++ (SentryId *)captureError:(NSError *)error withScope:(SentryScope *)scope
+{
+    return [SentrySDKInternal captureError:error withScope:scope];
+}
+
++ (SentryId *)captureError:(NSError *)error withScopeBlock:(void (^)(SentryScope *scope))block
+{
+    return [SentrySDKInternal captureError:error withScopeBlock:block];
+}
+
++ (SentryId *)captureException:(NSException *)exception
+{
+    return [SentrySDKInternal captureException:exception];
+}
+
++ (SentryId *)captureException:(NSException *)exception withScope:(SentryScope *)scope
+{
+    return [SentrySDKInternal captureException:exception withScope:scope];
+}
+
++ (SentryId *)captureException:(NSException *)exception
+                withScopeBlock:(void (^)(SentryScope *scope))block
+{
+    return [SentrySDKInternal captureException:exception withScopeBlock:block];
+}
+
++ (SentryId *)captureMessage:(NSString *)message
+{
+    return [SentrySDKInternal captureMessage:message];
+}
+
++ (SentryId *)captureMessage:(NSString *)message withScope:(SentryScope *)scope
+{
+    return [SentrySDKInternal captureMessage:message withScope:scope];
+}
+
++ (SentryId *)captureMessage:(NSString *)message withScopeBlock:(void (^)(SentryScope *scope))block
+{
+    return [SentrySDKInternal captureMessage:message withScopeBlock:block];
+}
+
+#if !SDK_V9
+
++ (void)captureUserFeedback:(SentryUserFeedback *)userFeedback
+{
+    [SentrySDKInternal captureUserFeedback:userFeedback];
+}
+
+#endif
+
++ (void)captureFeedback:(SentryFeedback *)feedback
+{
+    [SentrySDKInternal captureFeedback:feedback];
+}
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
++ (SentryFeedbackAPI *)feedback
+{
+    return [SentrySDKInternal feedback];
+}
+#endif
+
++ (void)addBreadcrumb:(SentryBreadcrumb *)crumb
+{
+    [SentrySDKInternal addBreadcrumb:crumb];
+}
+
++ (void)configureScope:(void (^)(SentryScope *scope))callback
+{
+    [SentrySDKInternal configureScope:callback];
+}
+
++ (BOOL)crashedLastRun
+{
+    return [SentrySDKInternal crashedLastRun];
+}
+
++ (BOOL)detectedStartUpCrash
+{
+    return [SentrySDKInternal detectedStartUpCrash];
+}
+
++ (void)setUser:(nullable SentryUser *)user
+{
+    [SentrySDKInternal setUser:user];
+}
+
++ (void)startSession
+{
+    [SentrySDKInternal startSession];
+}
+
++ (void)endSession
+{
+    [SentrySDKInternal endSession];
+}
+
++ (void)crash
+{
+    [SentrySDKInternal crash];
+}
+
++ (void)reportFullyDisplayed
+{
+    [SentrySDKInternal reportFullyDisplayed];
+}
+
++ (void)pauseAppHangTracking
+{
+    [SentrySDKInternal pauseAppHangTracking];
+}
+
++ (void)resumeAppHangTracking
+{
+    [SentrySDKInternal resumeAppHangTracking];
+}
+
++ (void)flush:(NSTimeInterval)timeout
+{
+    [SentrySDKInternal flush:timeout];
+}
+
++ (void)close
+{
+    [SentrySDKInternal close];
+}
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+
++ (void)startProfiler
+{
+    [SentrySDKInternal startProfiler];
+}
+
++ (void)stopProfiler
+{
+    [SentrySDKInternal stopProfiler];
+}
+
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+@end

--- a/Sources/Sentry/SentryScreenshotIntegration.m
+++ b/Sources/Sentry/SentryScreenshotIntegration.m
@@ -39,7 +39,7 @@ saveScreenShot(const char *path)
         return NO;
     }
 
-    SentryClient *client = [SentrySDK.currentHub getClient];
+    SentryClient *client = [SentrySDKInternal.currentHub getClient];
     [client addAttachmentProcessor:self];
 
     sentrycrash_setSaveScreenshots(&saveScreenShot);
@@ -56,7 +56,7 @@ saveScreenShot(const char *path)
 {
     sentrycrash_setSaveScreenshots(NULL);
 
-    SentryClient *client = [SentrySDK.currentHub getClient];
+    SentryClient *client = [SentrySDKInternal.currentHub getClient];
     [client removeAttachmentProcessor:self];
 }
 

--- a/Sources/Sentry/SentrySdkInfo.m
+++ b/Sources/Sentry/SentrySdkInfo.m
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (instancetype)global
 {
-    SentryClient *_Nullable client = [SentrySDK.currentHub getClient];
+    SentryClient *_Nullable client = [SentrySDKInternal.currentHub getClient];
     return [[SentrySdkInfo alloc] initWithOptions:client.options];
 }
 
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma clang diagnostic pop
 
     NSMutableArray<NSString *> *integrations =
-        [SentrySDK.currentHub trimmedInstalledIntegrationNames];
+        [SentrySDKInternal.currentHub trimmedInstalledIntegrationNames];
 
 #if SENTRY_HAS_UIKIT
     if (options.enablePreWarmedAppStartTracing) {

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -158,7 +158,7 @@ static SentryTouchTracker *_touchTracker;
     [self moveCurrentReplay];
     [self cleanUp];
 
-    [SentrySDK.currentHub registerSessionListener:self];
+    [SentrySDKInternal.currentHub registerSessionListener:self];
     [SentryDependencyContainer.sharedInstance.globalEventProcessor
         addEventProcessor:^SentryEvent *_Nullable(SentryEvent *_Nonnull event) {
             if (event.isFatalEvent) {
@@ -295,9 +295,9 @@ static SentryTouchTracker *_touchTracker;
                                                                                   video:video
                                                                             extraEvents:@[]];
 
-    [SentrySDK.currentHub captureReplayEvent:replayEvent
-                             replayRecording:recording
-                                       video:video.path];
+    [SentrySDKInternal.currentHub captureReplayEvent:replayEvent
+                                     replayRecording:recording
+                                               video:video.path];
 
     NSError *error = nil;
     if (![[NSFileManager defaultManager] removeItemAtURL:video.path error:&error]) {
@@ -627,7 +627,7 @@ static SentryTouchTracker *_touchTracker;
 - (void)uninstall
 {
     SENTRY_LOG_DEBUG(@"[Session Replay] Uninstalling");
-    [SentrySDK.currentHub unregisterSessionListener:self];
+    [SentrySDKInternal.currentHub unregisterSessionListener:self];
     _touchTracker = nil;
     [self pause];
 }
@@ -725,9 +725,9 @@ static SentryTouchTracker *_touchTracker;
         return;
     }
 
-    [SentrySDK.currentHub captureReplayEvent:replayEvent
-                             replayRecording:replayRecording
-                                       video:videoUrl];
+    [SentrySDKInternal.currentHub captureReplayEvent:replayEvent
+                                     replayRecording:replayRecording
+                                               video:videoUrl];
 
     sentrySessionReplaySync_updateInfo(
         (unsigned int)replayEvent.segmentId, replayEvent.timestamp.timeIntervalSinceReferenceDate);
@@ -736,21 +736,21 @@ static SentryTouchTracker *_touchTracker;
 - (void)sessionReplayStartedWithReplayId:(SentryId *)replayId
 {
     SENTRY_LOG_DEBUG(@"[Session Replay] Session replay started with replay id: %@", replayId);
-    [SentrySDK.currentHub configureScope:^(
+    [SentrySDKInternal.currentHub configureScope:^(
         SentryScope *_Nonnull scope) { scope.replayId = [replayId sentryIdString]; }];
 }
 
 - (NSArray<SentryBreadcrumb *> *)breadcrumbsForSessionReplay
 {
     __block NSArray<SentryBreadcrumb *> *result;
-    [SentrySDK.currentHub
+    [SentrySDKInternal.currentHub
         configureScope:^(SentryScope *_Nonnull scope) { result = scope.breadcrumbs; }];
     return result;
 }
 
 - (nullable NSString *)currentScreenNameForSessionReplay
 {
-    return SentrySDK.currentHub.scope.currentScreen
+    return SentrySDKInternal.currentHub.scope.currentScreen
         ?: [SentryDependencyContainer.sharedInstance.application relevantViewControllersNames]
                .firstObject;
 }

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -104,7 +104,7 @@
 
 - (void)stop
 {
-    [[SentrySDK currentHub] endSession];
+    [[SentrySDKInternal currentHub] endSession];
 
     [self removeObservers];
 
@@ -145,7 +145,7 @@
  */
 - (void)endCachedSession
 {
-    SentryHub *hub = [SentrySDK currentHub];
+    SentryHub *hub = [SentrySDKInternal currentHub];
     NSDate *_Nullable lastInForeground =
         [[[hub getClient] fileManager] readTimestampLastInForeground];
     if (nil != lastInForeground) {
@@ -184,7 +184,7 @@
         self.wasStartSessionCalled = YES;
     }
 
-    SentryHub *hub = [SentrySDK currentHub];
+    SentryHub *hub = [SentrySDKInternal currentHub];
     self.lastInForeground = [[[hub getClient] fileManager] readTimestampLastInForeground];
 
     if (nil == self.lastInForeground) {
@@ -229,7 +229,7 @@
 - (void)willResignActive
 {
     self.lastInForeground = [self.dateProvider date];
-    SentryHub *hub = [SentrySDK currentHub];
+    SentryHub *hub = [SentrySDKInternal currentHub];
     [[[hub getClient] fileManager] storeTimestampLastInForeground:self.lastInForeground];
     self.wasStartSessionCalled = NO;
 }
@@ -241,7 +241,7 @@
 {
     NSDate *sessionEnded
         = nil == self.lastInForeground ? [self.dateProvider date] : self.lastInForeground;
-    SentryHub *hub = [SentrySDK currentHub];
+    SentryHub *hub = [SentrySDKInternal currentHub];
     [hub endSessionWithTimestamp:sessionEnded];
     [[[hub getClient] fileManager] deleteTimestampLastInForeground];
     self.wasStartSessionCalled = NO;

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -99,7 +99,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    if !SDK_V9
-        _isContinuousProfiling = [SentrySDK.options isContinuousProfilingEnabled];
+        _isContinuousProfiling = [SentrySDKInternal.options isContinuousProfilingEnabled];
         if (_isContinuousProfiling) {
 #    endif // !SDK_V9
             _profileSessionID = SentryContinuousProfiler.currentProfilerID.sentryIdString;

--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -177,7 +177,7 @@
             [SentryDependencyContainer.sharedInstance.framesTracker removeListener:self];
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
             if (sentry_isLaunchProfileCorrelatedToTraces()) {
-                sentry_stopAndDiscardLaunchProfileTracer(SentrySDK.currentHub);
+                sentry_stopAndDiscardLaunchProfileTracer(SentrySDKInternal.currentHub);
             }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
         }
@@ -189,7 +189,7 @@
         [self.fullDisplaySpan finish];
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
         if (sentry_isLaunchProfileCorrelatedToTraces()) {
-            sentry_stopAndDiscardLaunchProfileTracer(SentrySDK.currentHub);
+            sentry_stopAndDiscardLaunchProfileTracer(SentrySDKInternal.currentHub);
         }
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -437,8 +437,8 @@ static BOOL appStartMeasurementRead;
                 _traceContext = [[SentryTraceContext alloc] initWithTracer:self
                                                                      scope:_hub.scope
                                                                    options:_hub.client.options
-                        ?: SentrySDK.options]; // We should remove static classes and always
-                                               // inject dependencies.
+                        ?: SentrySDKInternal.options]; // We should remove static classes and always
+                                                       // inject dependencies.
             }
         }
     }
@@ -812,7 +812,7 @@ static BOOL appStartMeasurementRead;
             return nil;
         }
 
-        measurement = [SentrySDK getAppStartMeasurement];
+        measurement = [SentrySDKInternal getAppStartMeasurement];
         if (measurement == nil) {
             SENTRY_LOG_DEBUG(@"No app start measurement available.");
             return nil;

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -7,7 +7,7 @@
 #    import <SentryHub+Private.h>
 #    import <SentryLogC.h>
 #    import <SentrySDK+Private.h>
-#    import <SentrySDK.h>
+#    import <SentrySDKInternal.h>
 #    import <SentryScope.h>
 #    import <SentrySpanId.h>
 #    import <SentrySpanOperation.h>
@@ -70,7 +70,7 @@ NS_ASSUME_NONNULL_BEGIN
                                              operation:operation
                                                 origin:SentryTraceOriginAutoUiEventTracker];
 
-    id<SentrySpan> _Nullable currentSpan = [SentrySDK.currentHub.scope span];
+    id<SentrySpan> _Nullable currentSpan = [SentrySDKInternal.currentHub.scope span];
     BOOL ongoingScreenLoadTransaction = false;
     BOOL ongoingManualTransaction = false;
     if (currentSpan != nil) {
@@ -92,7 +92,7 @@ NS_ASSUME_NONNULL_BEGIN
         return;
     }
 
-    __block SentryTracer *transaction = [SentrySDK.currentHub
+    __block SentryTracer *transaction = [SentrySDKInternal.currentHub
         startTransactionWithContext:context
                         bindToScope:YES
               customSamplingContext:@{}

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -69,7 +69,7 @@
     if (self = [super init]) {
         self.tracker = tracker;
 
-        SentryOptions *options = [SentrySDK options];
+        SentryOptions *options = [SentrySDKInternal options];
         self.inAppLogic = [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes
                                                             inAppExcludes:options.inAppExcludes];
 
@@ -94,7 +94,7 @@
         return;
     }
 
-    SentryOptions *options = [SentrySDK options];
+    SentryOptions *options = [SentrySDKInternal options];
 
     if ([SentrySwizzleClassNameExclude
             shouldExcludeClassWithClassName:NSStringFromClass([controller class])

--- a/Sources/Sentry/SentryUseNSExceptionCallstackWrapper.m
+++ b/Sources/Sentry/SentryUseNSExceptionCallstackWrapper.m
@@ -58,7 +58,7 @@
 
 - (SentryCrashStackEntryMapper *)buildCrashStackToEntryMapper
 {
-    SentryOptions *options = SentrySDK.options;
+    SentryOptions *options = SentrySDKInternal.options;
 
     SentryInAppLogic *inAppLogic =
         [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes

--- a/Sources/Sentry/SentryUserAccess.m
+++ b/Sources/Sentry/SentryUserAccess.m
@@ -3,4 +3,7 @@
 #import "SentrySDK+Private.h"
 #import "SentryScope+PrivateSwift.h"
 
-SentryUser *_Nullable sentry_getCurrentUser(void) { return SentrySDK.currentHub.scope.userObject; }
+SentryUser *_Nullable sentry_getCurrentUser(void)
+{
+    return SentrySDKInternal.currentHub.scope.userObject;
+}

--- a/Sources/Sentry/SentryViewHierarchyIntegration.m
+++ b/Sources/Sentry/SentryViewHierarchyIntegration.m
@@ -44,7 +44,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
 
     self.options = options;
 
-    SentryClient *client = [SentrySDK.currentHub getClient];
+    SentryClient *client = [SentrySDKInternal.currentHub getClient];
     [client addAttachmentProcessor:self];
 
     sentrycrash_setSaveViewHierarchy(&saveViewHierarchy);
@@ -63,7 +63,7 @@ saveViewHierarchy(const char *reportDirectoryPath)
 {
     sentrycrash_setSaveViewHierarchy(NULL);
 
-    SentryClient *client = [SentrySDK.currentHub getClient];
+    SentryClient *client = [SentrySDKInternal.currentHub getClient];
     [client removeAttachmentProcessor:self];
 }
 

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -104,7 +104,7 @@
 
     // When calling SentrySDK.start twice we would wrongly report a Watchdog Termination. We can
     // only report a Watchdog Termination when the SDK is started the first time.
-    if (SentrySDK.startInvocations != 1) {
+    if (SentrySDKInternal.startInvocations != 1) {
         return NO;
     }
 

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -77,7 +77,7 @@
             // We don't need to update the releaseName of the event to the previous app state as we
             // assume it's not a watchdog termination when the releaseName changed between app
             // starts.
-            [SentrySDK captureFatalEvent:event];
+            [SentrySDKInternal captureFatalEvent:event];
         }
     }];
 #else // !SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -1,7 +1,6 @@
 #import <SentryWatchdogTerminationTrackingIntegration.h>
 
 #if SENTRY_HAS_UIKIT
-
 #    import "SentryScope+Private.h"
 #    import <SentryANRTrackerV1.h>
 #    import <SentryAppState.h>
@@ -60,7 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
         [[SentryDispatchQueueWrapper alloc] initWithName:"io.sentry.watchdog-termination-tracker"
                                               attributes:attributes];
 
-    SentryFileManager *fileManager = [[[SentrySDK currentHub] getClient] fileManager];
+    SentryFileManager *fileManager = [[[SentrySDKInternal currentHub] getClient] fileManager];
     SentryAppStateManager *appStateManager =
         [SentryDependencyContainer sharedInstance].appStateManager;
     SentryCrashWrapper *crashWrapper = [SentryDependencyContainer sharedInstance].crashWrapper;
@@ -97,7 +96,7 @@ NS_ASSUME_NONNULL_BEGIN
         [SentryDependencyContainer.sharedInstance
             getWatchdogTerminationScopeObserverWithOptions:options];
 
-    [SentrySDK.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
+    [SentrySDKInternal.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
         // Add the observer to the scope so that it can be notified when the scope changes.
         [outerScope addObserver:scopeObserver];
 

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -6,13 +6,14 @@
 #endif // SENTRY_HAS_UIKIT
 
 @protocol SentryObjCRuntimeWrapper;
+@class SentryHub;
 
 NS_ASSUME_NONNULL_BEGIN
 
-// Some Swift code needs to access SentryDependencyContainer. To
-// make that possible without requiring all of SentryDependencyContainer
-// to be exposed to Swift this class is exposed to Swift
-// and bridges some functionality from SentryDependencyContainer
+// Some Swift code needs to access Sentry types that we don’t want to completely
+// expose to Swift. This class is exposed to Swift
+// and bridges some functionality from without importing large amounts of the
+// codebase to Swift.
 @interface SentryDependencyContainerSwiftHelper : NSObject
 
 #if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -26,6 +26,7 @@
 #import "SentryOptions+Private.h"
 #import "SentryProfiler+Private.h"
 #import "SentryRandom.h"
+#import "SentrySDKInternal.h"
 #import "SentryScope+PrivateSwift.h"
 #import "SentrySdkInfo.h"
 #import "SentrySerialization.h"

--- a/Sources/Sentry/include/SentrySDK+Private.h
+++ b/Sources/Sentry/include/SentrySDK+Private.h
@@ -4,10 +4,10 @@
 #    import "SentryProfilingConditionals.h"
 #endif
 
-#if __has_include(<Sentry/SentryOptions.h>)
-#    import <Sentry/SentrySDK.h>
+#if __has_include(<Sentry/SentrySDKInternal.h>)
+#    import <Sentry/SentrySDKInternal.h>
 #else
-#    import "SentrySDK.h"
+#    import "SentrySDKInternal.h"
 #endif
 
 @class SentryAppStartMeasurement;
@@ -18,7 +18,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentrySDK ()
+@interface SentrySDKInternal ()
 
 + (void)captureFatalEvent:(SentryEvent *)event;
 

--- a/Sources/Sentry/include/SentrySDKInternal.h
+++ b/Sources/Sentry/include/SentrySDKInternal.h
@@ -1,0 +1,428 @@
+#if __has_include(<Sentry/Sentry.h>)
+#    import <Sentry/SentryDefines.h>
+#elif __has_include(<SentryWithoutUIKit/Sentry.h>)
+#    import <SentryWithoutUIKit/SentryDefines.h>
+#else
+#    import <SentryDefines.h>
+#endif
+#import SENTRY_HEADER(SentryProfilingConditionals)
+
+@protocol SentrySpan;
+
+@class SentryBreadcrumb;
+@class SentryEvent;
+@class SentryFeedback;
+@class SentryFeedbackAPI;
+@class SentryId;
+@class SentryOptions;
+@class SentryReplayApi;
+@class SentryScope;
+@class SentryTransactionContext;
+@class SentryUser;
+@class SentryUserFeedback;
+@class SentryLogger;
+@class UIView;
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * The internal implementation of SentrySDK.
+ * This class is used internally by the Swift wrapper.
+ */
+@interface SentrySDKInternal : NSObject
+SENTRY_NO_INIT
+
+/**
+ * The current active transaction or span bound to the scope.
+ */
+@property (nullable, class, nonatomic, readonly) id<SentrySpan> span;
+
+/**
+ * Indicates whether the SentrySDK is enabled.
+ */
+@property (class, nonatomic, readonly) BOOL isEnabled;
+
+#if SENTRY_TARGET_REPLAY_SUPPORTED
+/**
+ * API to control session replay
+ */
+@property (class, nonatomic, readonly) SentryReplayApi *replay;
+#endif
+
+/**
+ * API to access Sentry logs
+ */
+@property (class, nonatomic, readonly) SentryLogger *logger;
+
+/**
+ * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations. Make sure to
+ * set a valid DSN.
+ *
+ * @discussion Call this method on the main thread. When calling it from a background thread, the
+ * SDK starts on the main thread async.
+ */
++ (void)startWithOptions:(SentryOptions *)options NS_SWIFT_NAME(start(options:));
+
+/**
+ * Inits and configures Sentry (SentryHub, SentryClient) and sets up all integrations. Make sure to
+ * set a valid DSN.
+ *
+ * @discussion Call this method on the main thread. When calling it from a background thread, the
+ * SDK starts on the main thread async.
+ */
++ (void)startWithConfigureOptions:(void (^)(SentryOptions *options))configureOptions
+    NS_SWIFT_NAME(start(configureOptions:));
+
+/**
+ * Captures a manually created event and sends it to Sentry.
+ * @param event The event to send to Sentry.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureEvent:(SentryEvent *)event NS_SWIFT_NAME(capture(event:));
+
+/**
+ * Captures a manually created event and sends it to Sentry. Only the data in this scope object will
+ * be added to the event. The global scope will be ignored.
+ * @param event The event to send to Sentry.
+ * @param scope The scope containing event metadata.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureEvent:(SentryEvent *)event
+                 withScope:(SentryScope *)scope NS_SWIFT_NAME(capture(event:scope:));
+
+/**
+ * Captures a manually created event and sends it to Sentry. Maintains the global scope but mutates
+ * scope data for only this call.
+ * @param event The event to send to Sentry.
+ * @param block The block mutating the scope only for this call.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureEvent:(SentryEvent *)event
+            withScopeBlock:(void (^)(SentryScope *scope))block NS_SWIFT_NAME(capture(event:block:));
+
+/**
+ * Creates a transaction, binds it to the hub and returns the instance.
+ * @param name The transaction name.
+ * @param operation Short code identifying the type of operation the span is measuring.
+ * @return The created transaction.
+ */
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                 operation:(NSString *)operation
+    NS_SWIFT_NAME(startTransaction(name:operation:));
+
+/**
+ * Creates a transaction, binds it to the hub and returns the instance.
+ * @param name The transaction name.
+ * @param operation Short code identifying the type of operation the span is measuring.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
+ * @return The created transaction.
+ */
++ (id<SentrySpan>)startTransactionWithName:(NSString *)name
+                                 operation:(NSString *)operation
+                               bindToScope:(BOOL)bindToScope
+    NS_SWIFT_NAME(startTransaction(name:operation:bindToScope:));
+
+/**
+ * Creates a transaction, binds it to the hub and returns the instance.
+ * @param transactionContext The transaction context.
+ * @return The created transaction.
+ */
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+    NS_SWIFT_NAME(startTransaction(transactionContext:));
+
+/**
+ * Creates a transaction, binds it to the hub and returns the instance.
+ * @param transactionContext The transaction context.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
+ * @return The created transaction.
+ */
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                                  bindToScope:(BOOL)bindToScope
+    NS_SWIFT_NAME(startTransaction(transactionContext:bindToScope:));
+
+/**
+ * Creates a transaction, binds it to the hub and returns the instance.
+ * @param transactionContext The transaction context.
+ * @param bindToScope Indicates whether the SDK should bind the new transaction to the scope.
+ * @param customSamplingContext Additional information about the sampling context.
+ * @return The created transaction.
+ */
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                                  bindToScope:(BOOL)bindToScope
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
+    NS_SWIFT_NAME(startTransaction(transactionContext:bindToScope:customSamplingContext:));
+
+/**
+ * Creates a transaction, binds it to the hub and returns the instance.
+ * @param transactionContext The transaction context.
+ * @param customSamplingContext Additional information about the sampling context.
+ * @return The created transaction.
+ */
++ (id<SentrySpan>)startTransactionWithContext:(SentryTransactionContext *)transactionContext
+                        customSamplingContext:(NSDictionary<NSString *, id> *)customSamplingContext
+    NS_SWIFT_NAME(startTransaction(transactionContext:customSamplingContext:));
+
+/**
+ * Captures an error event and sends it to Sentry.
+ * @param error The error to send to Sentry.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureError:(NSError *)error NS_SWIFT_NAME(capture(error:));
+
+/**
+ * Captures an error event and sends it to Sentry. Only the data in this scope object will be added
+ * to the event. The global scope will be ignored.
+ * @param error The error to send to Sentry.
+ * @param scope The scope containing event metadata.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureError:(NSError *)error
+                 withScope:(SentryScope *)scope NS_SWIFT_NAME(capture(error:scope:));
+
+/**
+ * Captures an error event and sends it to Sentry. Maintains the global scope but mutates scope data
+ * for only this call.
+ * @param error The error to send to Sentry.
+ * @param block The block mutating the scope only for this call.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureError:(NSError *)error
+            withScopeBlock:(void (^)(SentryScope *scope))block NS_SWIFT_NAME(capture(error:block:));
+
+/**
+ * Captures an exception event and sends it to Sentry.
+ * @param exception The exception to send to Sentry.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureException:(NSException *)exception NS_SWIFT_NAME(capture(exception:));
+
+/**
+ * Captures an exception event and sends it to Sentry. Only the data in this scope object will be
+ * added to the event. The global scope will be ignored.
+ * @param exception The exception to send to Sentry.
+ * @param scope The scope containing event metadata.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureException:(NSException *)exception
+                     withScope:(SentryScope *)scope NS_SWIFT_NAME(capture(exception:scope:));
+
+/**
+ * Captures an exception event and sends it to Sentry. Maintains the global scope but mutates scope
+ * data for only this call.
+ * @param exception The exception to send to Sentry.
+ * @param block The block mutating the scope only for this call.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureException:(NSException *)exception
+                withScopeBlock:(void (^)(SentryScope *scope))block
+    NS_SWIFT_NAME(capture(exception:block:));
+
+/**
+ * Captures a message event and sends it to Sentry.
+ * @param message The message to send to Sentry.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureMessage:(NSString *)message NS_SWIFT_NAME(capture(message:));
+
+/**
+ * Captures a message event and sends it to Sentry. Only the data in this scope object will be added
+ * to the event. The global scope will be ignored.
+ * @param message The message to send to Sentry.
+ * @param scope The scope containing event metadata.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureMessage:(NSString *)message
+                   withScope:(SentryScope *)scope NS_SWIFT_NAME(capture(message:scope:));
+
+/**
+ * Captures a message event and sends it to Sentry. Maintains the global scope but mutates scope
+ * data for only this call.
+ * @param message The message to send to Sentry.
+ * @param block The block mutating the scope only for this call.
+ * @return The @c SentryId of the event or @c SentryId.empty if the event is not sent.
+ *
+ */
++ (SentryId *)captureMessage:(NSString *)message
+              withScopeBlock:(void (^)(SentryScope *scope))block
+    NS_SWIFT_NAME(capture(message:block:));
+
+#if !SDK_V9
+/**
+ * Captures user feedback that was manually gathered and sends it to Sentry.
+ * @param userFeedback The user feedback to send to Sentry.
+ * @deprecated Use @c SentrySDK.captureFeedback or use or configure our new managed UX with
+ * @c SentryOptions.configureUserFeedback .
+ */
++ (void)captureUserFeedback:(SentryUserFeedback *)userFeedback
+    NS_SWIFT_NAME(capture(userFeedback:)) DEPRECATED_MSG_ATTRIBUTE(
+        "Use SentrySDK.captureFeedback or use or configure our new managed UX with "
+        "SentryOptions.configureUserFeedback.");
+#endif // !SDK_V9
+
+/**
+ * Captures user feedback that was manually gathered and sends it to Sentry.
+ * @warning This is an experimental feature and may still have bugs.
+ * @param feedback The feedback to send to Sentry.
+ * @note If you'd prefer not to have to build the UI required to gather the feedback from the user,
+ * see @c SentryOptions.configureUserFeedback to customize a fully managed integration. See
+ * https://docs.sentry.io/platforms/apple/user-feedback/ for more information.
+ */
++ (void)captureFeedback:(SentryFeedback *)feedback NS_SWIFT_NAME(capture(feedback:));
+
+#if TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+@property (nonatomic, class, readonly) SentryFeedbackAPI *feedback;
+
+#endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+/**
+ * Adds a Breadcrumb to the current Scope of the current Hub. If the total number of breadcrumbs
+ * exceeds the @c SentryOptions.maxBreadcrumbs  the SDK removes the oldest breadcrumb.
+ * @param crumb The Breadcrumb to add to the current Scope of the current Hub.
+ */
++ (void)addBreadcrumb:(SentryBreadcrumb *)crumb NS_SWIFT_NAME(addBreadcrumb(_:));
+
+/**
+ * Use this method to modify the current Scope of the current Hub. The SDK uses the Scope to attach
+ * contextual data to events.
+ * @param callback The callback for configuring the current Scope of the current Hub.
+ */
++ (void)configureScope:(void (^)(SentryScope *scope))callback;
+
+/**
+ * Checks if the last program execution terminated with a crash.
+ */
+@property (nonatomic, class, readonly) BOOL crashedLastRun;
+
+/**
+ * Checks if the SDK detected a start-up crash during SDK initialization.
+ *
+ * @note The SDK init waits synchronously for up to 5 seconds to flush out events if the app crashes
+ * within 2 seconds after the SDK init.
+ *
+ * @return @c YES if the SDK detected a start-up crash and @c NO if not.
+ */
+@property (nonatomic, class, readonly) BOOL detectedStartUpCrash;
+
+/**
+ * Set user to the current Scope of the current Hub.
+ * @param user The user to set to the current Scope.
+ *
+ * @note You must start the SDK before calling this method, otherwise it doesn't set the user.
+ */
++ (void)setUser:(nullable SentryUser *)user;
+
+/**
+ * Starts a new SentrySession. If there's a running @c SentrySession, it ends it before starting the
+ * new one. You can use this method in combination with endSession to manually track
+ * @c SentrySessions. The SDK uses SentrySession to inform Sentry about release and project
+ * associated project health.
+ */
++ (void)startSession;
+
+/**
+ * Ends the current @c SentrySession. You can use this method in combination with @c startSession to
+ * manually track @c SentrySessions. The SDK uses SentrySession to inform Sentry about release and
+ * project associated project health.
+ */
++ (void)endSession;
+
+/**
+ * This forces a crash, useful to test the @c SentryCrash integration.
+ *
+ * @note The SDK can't report a crash when a debugger is attached. Your application needs to run
+ * without a debugger attached to capture the crash and send it to Sentry the next time you launch
+ * your application.
+ */
++ (void)crash;
+
+/**
+ * Reports to the ongoing UIViewController transaction
+ * that the screen contents are fully loaded and displayed,
+ * which will create a new span.
+ *
+ * For more information see our documentation:
+ * https://docs.sentry.io/platforms/cocoa/performance/instrumentation/automatic-instrumentation/#time-to-full-display
+ */
++ (void)reportFullyDisplayed;
+
+/**
+ * Pauses sending detected app hangs to Sentry.
+ *
+ * @discussion This method doesn't close the detection of app hangs. Instead, the app hang detection
+ * will ignore detected app hangs until you call @c resumeAppHangTracking.
+ */
++ (void)pauseAppHangTracking;
+
+/**
+ * Resumes sending detected app hangs to Sentry.
+ */
++ (void)resumeAppHangTracking;
+
+/**
+ * Waits synchronously for the SDK to flush out all queued and cached items for up to the specified
+ * timeout in seconds. If there is no internet connection, the function returns immediately. The SDK
+ * doesn't dispose the client or the hub.
+ * @param timeout The time to wait for the SDK to complete the flush.
+ */
++ (void)flush:(NSTimeInterval)timeout NS_SWIFT_NAME(flush(timeout:));
+
+/**
+ * Closes the SDK, uninstalls all the integrations, and calls flush with
+ * @c SentryOptions.shutdownTimeInterval .
+ */
++ (void)close;
+
+#if SENTRY_TARGET_PROFILING_SUPPORTED
+/**
+ * Start a new continuous profiling session if one is not already running.
+ * @warning Continuous profiling mode is experimental and may still contain bugs.
+ * @note Unlike transaction-based profiling, continuous profiling does not take into account
+ * @c SentryOptions.profilesSampleRate or @c SentryOptions.profilesSampler . If either of those
+ * options are set, this method does nothing.
+ * @note Taking into account the above note, if @c SentryOptions.configureProfiling is not set,
+ * calls to this method will always start a profile if one is not already running. This includes app
+ * launch profiles configured with @c SentryOptions.enableAppLaunchProfiling .
+ * @note If neither @c SentryOptions.profilesSampleRate nor @c SentryOptions.profilesSampler are
+ * set, and @c SentryOptions.configureProfiling is set, this method does nothing if the profiling
+ * session is not sampled with respect to @c SentryOptions.profileSessionSampleRate , or if it is
+ * sampled but the profiler is already running.
+ * @note If neither @c SentryOptions.profilesSampleRate nor @c SentryOptions.profilesSampler are
+ * set, and @c SentryOptions.configureProfiling is set, this method does nothing if
+ * @c SentryOptions.profileLifecycle is set to @c trace . In this scenario, the profiler is
+ * automatically started and stopped depending on whether there is an active sampled span, so it is
+ * not permitted to manually start profiling.
+ * @note Profiling is automatically disabled if a thread sanitizer is attached.
+ * @seealso https://docs.sentry.io/platforms/apple/guides/ios/profiling/#continuous-profiling
+ */
++ (void)startProfiler;
+
+/**
+ * Stop a continuous profiling session if there is one ongoing.
+ * @warning Continuous profiling mode is experimental and may still contain bugs.
+ * @note Does nothing if @c SentryOptions.profileLifecycle is set to @c trace .
+ * @note Does not immediately stop the profiler. Profiling data is uploaded at regular timed
+ * intervals; when the current interval completes, then the profiler stops and the data gathered
+ * during that last interval is uploaded.
+ * @note If a new call to @c startProfiler that would start the profiler is made before the last
+ * interval completes, the profiler will continue running until another call to stop is made.
+ * @note Profiling is automatically disabled if a thread sanitizer is attached.
+ * @seealso https://docs.sentry.io/platforms/apple/guides/ios/profiling/#continuous-profiling
+ */
++ (void)stopProfiler;
+#endif // SENTRY_TARGET_PROFILING_SUPPORTED
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreview.swift
+++ b/Sources/SentrySwiftUI/Preview/SentryReplayMaskPreview.swift
@@ -19,7 +19,7 @@ struct SentryReplayMaskPreview: ViewModifier {
 @available(iOS 13, macOS 10.15, tvOS 13, *)
 public extension View {
     func sentryReplayPreviewMask(redactOptions: SentryRedactOptions? = nil, opacity: Float = 1) -> some View {
-        let options = redactOptions ?? SentrySDK.options?.sessionReplay ?? PreviewRedactOptions()
+        let options = redactOptions ?? SentrySDKInternal.options?.sessionReplay ?? PreviewRedactOptions()
         return modifier(SentryReplayMaskPreview(redactOptions: options, opacity: opacity))
     }
 }

--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -13,6 +13,10 @@
 #    import "Sentry.h"
 #endif
 
+#if __has_include("SentrySDKInternal.h")
+#    include "SentrySDKInternal.h"
+#endif
+
 #if SENTRY_TEST
 #    import "SentrySpan.h"
 #    import "SentryTracer.h"
@@ -109,8 +113,16 @@ typedef NS_ENUM(NSUInteger, SentrySpanStatus);
 
 @end
 
-@interface SentrySDK ()
+#if __has_include("SentrySDKInternal.h")
+@interface SentrySDKInternal ()
+#else
+@interface SentrySDKInternal : NSObject
+#endif
+
 @property (nonatomic, nullable, readonly, class) SentryOptions *options;
++ (void)setCurrentHub:(nullable SentryHub *)hub;
++ (void)setStartOptions:(nullable SentryOptions *)options NS_SWIFT_NAME(setStart(with:));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -21,7 +21,7 @@ class SentryTraceViewModel {
     init(name: String, nameSource: SentryTransactionNameSource, waitForFullDisplay: Bool?) {
         self.name = name
         self.nameSource = nameSource
-        self.waitForFullDisplay = waitForFullDisplay ?? SentrySDK.options?.enableTimeToFullDisplayTracing ?? false
+        self.waitForFullDisplay = waitForFullDisplay ?? SentrySDKInternal.options?.enableTimeToFullDisplayTracing ?? false
     }
     
     func startSpan() -> SpanId? {

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -111,7 +111,7 @@ extension SentryAppLaunchProfilingTests {
         XCTAssertNotNil(sentry_launchTracer)
 
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         // Ensure frames tracker is running (required for TTD tracker)
         SentryDependencyContainer.sharedInstance().framesTracker = fixture.framesTracker
@@ -145,7 +145,7 @@ extension SentryAppLaunchProfilingTests {
         _sentry_nondeduplicated_startLaunchProfile()
         XCTAssert(try XCTUnwrap(SentryTraceProfiler.getCurrentProfiler()).isRunning())
 
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: false, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: try XCTUnwrap(sentry_launchTracer))
         ttd.reportInitialDisplay()
@@ -230,7 +230,7 @@ extension SentryAppLaunchProfilingTests {
         XCTAssertNil(sentry_launchTracer)
 
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let tracer = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: true, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: tracer)
@@ -251,7 +251,7 @@ extension SentryAppLaunchProfilingTests {
         XCTAssertNil(sentry_launchTracer)
 
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let tracer = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: false, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: tracer)
@@ -525,7 +525,7 @@ extension SentryAppLaunchProfilingTests {
 
         // Act
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let tracer = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: true, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: tracer)
@@ -557,7 +557,7 @@ extension SentryAppLaunchProfilingTests {
 
         // Act
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let tracer = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: true, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: tracer)
@@ -590,7 +590,7 @@ extension SentryAppLaunchProfilingTests {
 
         // Act
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let tracer = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: false, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: tracer)
@@ -621,7 +621,7 @@ extension SentryAppLaunchProfilingTests {
 
         // Act
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let tracer = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: false, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: tracer)

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
@@ -973,7 +973,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Act: simulate TTFD using launch tracer (not a new transaction)
         // Since the launch profiler is trace-based, we use the existing launch tracer
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         // Use the launch tracer for TTFD simulation
         let launchTracer = try XCTUnwrap(sentry_launchTracer)
@@ -1026,7 +1026,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
 
         // Act: simulate TTFD
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         // Use the launch tracer for TTFD simulation
         let launchTracer = try XCTUnwrap(sentry_launchTracer)
@@ -1079,7 +1079,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
 
         // Act: simulate TTFD
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let launchTracer = try XCTUnwrap(sentry_launchTracer)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: true, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: launchTracer)
@@ -1126,7 +1126,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
 
         // Act: simulate TTFD
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         let launchTracer = try XCTUnwrap(sentry_launchTracer)
         let ttd = SentryTimeToDisplayTracker(name: "UIViewController", waitForFullDisplay: true, dispatchQueueWrapper: fixture.dispatchQueueWrapper)
         ttd.start(for: launchTracer)

--- a/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
+++ b/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
@@ -79,7 +79,7 @@ class SentryProfileTestFixture {
         client = TestClient(options: options)
         hub = SentryHub(client: client, andScope: scope)
         hub.bindClient(client)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         options.profilesSampleRate = 1.0
         options.tracesSampleRate = 1.0

--- a/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
+++ b/Tests/SentryProfilerTests/SentryProfilingPublicAPITests.swift
@@ -57,7 +57,7 @@ class SentryProfilingPublicAPITests: XCTestCase {
 
         givenSdkWithHubButNoClient()
 
-        if let autoSessionTracking = SentrySDK.currentHub().installedIntegrations().first(where: { it in
+        if let autoSessionTracking = SentrySDKInternal.currentHub().installedIntegrations().first(where: { it in
             it is SentryAutoSessionTrackingIntegration
         }) as? SentryAutoSessionTrackingIntegration {
             autoSessionTracking.stop()
@@ -669,14 +669,14 @@ extension SentryProfilingPublicAPITests {
 
 private extension SentryProfilingPublicAPITests {
     func givenSdkWithHub() {
-        SentrySDK.setCurrentHub(fixture.hub)
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setStart(with: fixture.options)
         sentry_sdkInitProfilerTasks(fixture.options, fixture.hub)
     }
 
     func givenSdkWithHubButNoClient() {
-        SentrySDK.setCurrentHub(SentryHub(client: nil, andScope: nil))
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setCurrentHub(SentryHub(client: nil, andScope: nil))
+        SentrySDKInternal.setStart(with: fixture.options)
     }
 
     func stopProfiler() throws {

--- a/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryTraceProfilerTests.swift
@@ -336,7 +336,7 @@ class SentryTraceProfilerTests: XCTestCase {
     func testProfilerCleanedUpAfterTransactionDiscarded_WaitForAllChildren_StartTimeModified() throws {
         XCTAssertEqual(SentryTraceProfiler.currentProfiledTracers(), UInt(0))
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         fixture.currentDateProvider.advance(by: 1)
         func performTransaction() throws {
             let sut = try fixture.newTransaction(testingAppLaunchSpans: true, automaticTransaction: true)
@@ -402,7 +402,7 @@ private extension SentryTraceProfilerTests {
         if let uikitParameters = uikitParameters {
             testingAppLaunchSpans = true
             let appStartMeasurement = fixture.getAppStartMeasurement(type: uikitParameters.launchType, preWarmed: uikitParameters.prewarmed)
-            SentrySDK.setAppStartMeasurement(appStartMeasurement)
+            SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         }
 #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
@@ -608,7 +608,7 @@ private extension SentryTraceProfilerTests {
         var startTimestampString = sentry_toIso8601String(latestTransactionTimestamp)
         #if !os(macOS)
         if appStartProfile {
-            let runtimeInitTimestamp = try XCTUnwrap(SentrySDK.getAppStartMeasurement()?.runtimeInitTimestamp)
+            let runtimeInitTimestamp = try XCTUnwrap(SentrySDKInternal.getAppStartMeasurement()?.runtimeInitTimestamp)
             startTimestampString = sentry_toIso8601String(runtimeInitTimestamp)
         }
         #endif // !os(macOS)

--- a/Tests/SentrySwiftUITests/SentryTests-Bridging-Header.h
+++ b/Tests/SentrySwiftUITests/SentryTests-Bridging-Header.h
@@ -1,7 +1,5 @@
 #import "SentryHub+Private.h"
 #import "SentryPerformanceTracker.h"
-#import "SentrySDK+Private.h"
-#import "SentrySDK+Tests.h"
 #import "SentryTracer.h"
 #import "SentryUIViewControllerPerformanceTracker.h"
 
@@ -13,8 +11,4 @@
 
 @interface SentryUIViewControllerPerformanceTracker ()
 @property (nullable, nonatomic, weak) SentryTimeToDisplayTracker *currentTTDTracker;
-@end
-
-@interface SentrySDK ()
-+ (void)setStartOptions:(nullable SentryOptions *)options;
 @end

--- a/Tests/SentrySwiftUITests/SentryTraceViewModelTest.swift
+++ b/Tests/SentrySwiftUITests/SentryTraceViewModelTest.swift
@@ -13,7 +13,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
     
     func testCreateTransaction() throws {
         let option = Options()
-        SentrySDK.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
+        SentrySDKInternal.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
         
         let viewModel = SentryTraceViewModel(name: "TestView", nameSource: .component, waitForFullDisplay: false)
         let spanId = viewModel.startSpan()
@@ -27,7 +27,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
     
     func testRootTransactionStarted() throws {
         let option = Options()
-        SentrySDK.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
+        SentrySDKInternal.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
         
         let viewModel = SentryTraceViewModel(name: "RootTransactionTest", nameSource: .component, waitForFullDisplay: true)
         _ = viewModel.startSpan()
@@ -40,7 +40,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
     
     func testNoRootTransactionForCurrentTransactionRunning() throws {
         let option = Options()
-        SentrySDK.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
+        SentrySDKInternal.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
         
         let testSpan = SentryPerformanceTracker.shared.startSpan(withName: "Test Root", nameSource: .component, operation: "Testing", origin: "Test")
         SentryPerformanceTracker.shared.pushActiveSpan(testSpan)
@@ -58,7 +58,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
        
     func testNoTransactionWhenViewAppeared() {
         let option = Options()
-        SentrySDK.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
+        SentrySDKInternal.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
         
         let viewModel = SentryTraceViewModel(name: "TestView", nameSource: .component, waitForFullDisplay: false)
         viewModel.viewDidAppear()
@@ -69,7 +69,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
     
     func testFinishSpan() throws {
         let option = Options()
-        SentrySDK.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
+        SentrySDKInternal.setCurrentHub(SentryHub(client: SentryClient(options: option), andScope: nil))
         
         let viewModel = SentryTraceViewModel(name: "FinishSpanTest", nameSource: .component, waitForFullDisplay: false)
         let spanId = try XCTUnwrap(viewModel.startSpan())
@@ -97,7 +97,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
     func testUseWaitForFullDisplayFromOptions() throws {
         let option = Options()
         option.enableTimeToFullDisplayTracing = true
-        SentrySDK.setStart(option)
+        SentrySDKInternal.setStart(with: option)
                
         let viewModel = SentryTraceViewModel(name: "FinishSpanTest", nameSource: .component, waitForFullDisplay: nil)
         XCTAssertTrue(viewModel.waitForFullDisplay)
@@ -106,7 +106,7 @@ class SentryTraceViewModelTestCase: XCTestCase {
     func testUseWaitForFullDisplayFromParameter() throws {
         let option = Options()
         option.enableTimeToFullDisplayTracing = true
-        SentrySDK.setStart(option)
+        SentrySDKInternal.setStart(with: option)
                
         let viewModel = SentryTraceViewModel(name: "FinishSpanTest", nameSource: .component, waitForFullDisplay: false)
         XCTAssertFalse(viewModel.waitForFullDisplay)

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -74,7 +74,7 @@ final class SentryDependencyContainerTests: XCTestCase {
 
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
 
         let iterations = 100
 
@@ -166,7 +166,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -183,7 +183,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -203,7 +203,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -227,7 +227,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -247,7 +247,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
 
         let container = SentryDependencyContainer.sharedInstance()
         let dispatchFactory = TestDispatchFactory()
@@ -276,7 +276,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         options2.dsn = SentryDependencyContainerTests.dsn
         options2.sessionTrackingIntervalMillis = 5_000
         
-        SentrySDK.setStart(options1)
+        SentrySDKInternal.setStart(with: options1)
         
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -300,7 +300,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         options2.sessionTrackingIntervalMillis = 5_000
         options2.environment = "test2"
         
-        SentrySDK.setStart(options1)
+        SentrySDKInternal.setStart(with: options1)
         
         let container = SentryDependencyContainer.sharedInstance()
 
@@ -322,7 +322,7 @@ final class SentryDependencyContainerTests: XCTestCase {
         // -- Arrange --
         let options = Options()
         options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
         
         let container = SentryDependencyContainer.sharedInstance()
 

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -495,7 +495,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         setUpThreadInspector()
         Dynamic(sut).anrDetectedWithType(SentryANRType.fullyBlocking)
         
-        SentrySDK.currentHub().client()?.fileManager.storeAppHang(Event())
+        SentrySDKInternal.currentHub().client()?.fileManager.storeAppHang(Event())
 
         // Act
         let result = SentryANRStoppedResult(minDuration: 1.851, maxDuration: 2.249)
@@ -593,13 +593,13 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         
         let abnormalSession = SentrySession(releaseName: "release", distinctId: "distinct")
         abnormalSession.endAbnormal(withTimestamp: fixture.currentDate.date())
-        SentrySDK.currentHub().client()?.fileManager.storeAbnormalSession(abnormalSession)
+        SentrySDKInternal.currentHub().client()?.fileManager.storeAbnormalSession(abnormalSession)
         
         // Act
         givenInitializedTracker(enableV2: true)
         
         // Assert
-        let client = try XCTUnwrap(SentrySDK.currentHub().getClient() as? TestClient)
+        let client = try XCTUnwrap(SentrySDKInternal.currentHub().getClient() as? TestClient)
         
         XCTAssertEqual(1, client.captureFatalEventWithSessionInvocations.count, "Wrong number of `Crashs` captured.")
         let capture = try XCTUnwrap(client.captureFatalEventWithSessionInvocations.first)
@@ -656,7 +656,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         // Arrange
         givenInitializedTracker(enableV2: true)
         let event = Event()
-        SentrySDK.currentHub().client()?.fileManager.storeAppHang(event)
+        SentrySDKInternal.currentHub().client()?.fileManager.storeAppHang(event)
         
         // Act
         givenInitializedTracker(enableV2: true)
@@ -688,7 +688,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker(enableV2: true)
         setUpThreadInspector()
         Dynamic(sut).anrDetectedWithType(SentryANRType.nonFullyBlocking)
-        SentrySDK.currentHub().client()?.fileManager.deleteAppHangEvent()
+        SentrySDKInternal.currentHub().client()?.fileManager.deleteAppHangEvent()
 
         // Act
         let result = SentryANRStoppedResult(minDuration: 1.8, maxDuration: 2.2)
@@ -776,6 +776,6 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             threadInspector.allThreads = []
         }
         
-        SentrySDK.currentHub().getClient()?.threadInspector = threadInspector
+        SentrySDKInternal.currentHub().getClient()?.threadInspector = threadInspector
     }
 }

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryAutoBreadcrumbTrackingIntegrationTests.swift
@@ -70,7 +70,7 @@ class SentryAutoBreadcrumbTrackingIntegrationTests: XCTestCase {
         
         let scope = Scope()
         let hub = SentryHub(client: TestClient(options: Options()), andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let crumb = TestData.crumb
         fixture.systemEventBreadcrumbTracker?.startWithDelegateInvocations.first?.add(crumb)

--- a/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Breadcrumbs/SentryBreadcrumbTrackerTests.swift
@@ -100,7 +100,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let sut = SentryBreadcrumbTracker()
         sut.start(with: delegate)
@@ -167,7 +167,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let tracker = SentryBreadcrumbTracker()
         tracker.start(with: delegate)
@@ -211,7 +211,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let swizzlingWrapper = TestSentrySwizzleWrapper()
         SentryDependencyContainer.sharedInstance().swizzleWrapper = swizzlingWrapper
@@ -240,7 +240,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let swizzlingWrapper = TestSentrySwizzleWrapper()
         SentryDependencyContainer.sharedInstance().swizzleWrapper = swizzlingWrapper
@@ -268,7 +268,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let swizzlingWrapper = TestSentrySwizzleWrapper()
         SentryDependencyContainer.sharedInstance().swizzleWrapper = swizzlingWrapper
@@ -295,7 +295,7 @@ class SentryBreadcrumbTrackerTests: XCTestCase {
         let scope = Scope()
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
 
         let sut = SentryBreadcrumbTracker()
         sut.start(with: delegate)

--- a/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/MetricKit/SentryMetricKitIntegrationTests.swift
@@ -185,7 +185,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
             let mxDelegate = sut as! SentryMXManagerDelegate
             mxDelegate.didReceiveCpuExceptionDiagnostic(TestMXCPUExceptionDiagnostic(), callStackTree: callStackTree, timeStampBegin: timeStampBegin, timeStampEnd: timeStampEnd)
             
-            guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+            guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
                 XCTFail("Hub Client is not a `TestClient`")
                 return
             }
@@ -270,7 +270,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     private func assertNothingCaptured() {
-        guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+        guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }
@@ -279,7 +279,7 @@ final class SentryMetricKitIntegrationTests: SentrySDKIntegrationTestsBase {
     }
     
     private func assertNotPerThread(exceptionType: String, exceptionValue: String, exceptionMechanism: String) throws {
-        guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+        guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -53,7 +53,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
             runtimeInitTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.2)
             moduleInitializationTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.1)
             sdkStartTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.1)
-            SentrySDK.startTimestamp = sdkStartTimestamp
+            SentrySDKInternal.startTimestamp = sdkStartTimestamp
             
             didFinishLaunchingTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(0.2)
         }
@@ -424,11 +424,11 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
      * We assume a class reads the app measurement, sends it with a transaction to Sentry and sets it to nil.
      */
     private func sendAppMeasurement() {
-        SentrySDK.setAppStartMeasurement(nil)
+        SentrySDKInternal.setAppStartMeasurement(nil)
     }
     
     private func assertValidStart(type: SentryAppStartType, expectedDuration: TimeInterval? = nil, preWarmed: Bool = false) {
-        guard let appStartMeasurement = SentrySDK.getAppStartMeasurement() else {
+        guard let appStartMeasurement = SentrySDKInternal.getAppStartMeasurement() else {
             XCTFail("AppStartMeasurement must not be nil")
             return
         }
@@ -454,7 +454,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
     }
     
     private func assertValidHybridStart(type: SentryAppStartType) {
-        guard let appStartMeasurement = SentrySDK.getAppStartMeasurement() else {
+        guard let appStartMeasurement = SentrySDKInternal.getAppStartMeasurement() else {
             XCTFail("AppStartMeasurement must not be nil")
             return
         }
@@ -470,7 +470,7 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
     }
     
     private func assertNoAppStartUp() {
-        XCTAssertNil(SentrySDK.getAppStartMeasurement())
+        XCTAssertNil(SentrySDKInternal.getAppStartMeasurement())
     }
     
     private func advanceTime(bySeconds: TimeInterval) {

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackingIntegrationTests.swift
@@ -31,7 +31,7 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
     override func setUp() {
         super.setUp()
         fixture = Fixture()
-        SentrySDK.setAppStartMeasurement(nil)
+        SentrySDKInternal.setAppStartMeasurement(nil)
         sut = SentryAppStartTrackingIntegration()
     }
 
@@ -39,7 +39,7 @@ class SentryAppStartTrackingIntegrationTests: NotificationCenterTestCase {
         super.tearDown()
         fixture.fileManager.deleteAppState()
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = false
-        SentrySDK.setAppStartMeasurement(nil)
+        SentrySDKInternal.setAppStartMeasurement(nil)
         sut.stop()
         clearTestState()
     }

--- a/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
@@ -59,7 +59,7 @@ class DataSentryTracingIntegrationTests: XCTestCase {
                 }
 
                 // Get the working directory of the SDK, as these files are ignored by default
-                guard let sentryPath = SentrySDK.currentHub().getClient()?.fileManager.sentryPath else {
+                guard let sentryPath = SentrySDKInternal.currentHub().getClient()?.fileManager.sentryPath else {
                     preconditionFailure("Sentry path is nil, but should be configured for test cases.")
                 }
                 let sentryPathUrl = URL(fileURLWithPath: sentryPath)

--- a/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
@@ -53,7 +53,7 @@ class FileManagerSentryTracingIntegrationTests: XCTestCase {
             }
 
             // Get the working directory of the SDK, as the path is using the DSN hash to avoid conflicts
-            let sentryBasePath = try XCTUnwrap(SentrySDK.currentHub().getClient()?.fileManager.basePath, "Sentry base path is nil, but should be configured for test cases.")
+            let sentryBasePath = try XCTUnwrap(SentrySDKInternal.currentHub().getClient()?.fileManager.basePath, "Sentry base path is nil, but should be configured for test cases.")
             let sentryBasePathUrl = URL(fileURLWithPath: sentryBasePath)
 
             // The base path is not unique for the DSN, therefore we need to make it unique
@@ -66,7 +66,7 @@ class FileManagerSentryTracingIntegrationTests: XCTestCase {
             }
 
             // Get the working directory of the SDK, as these files are ignored by default
-            let sentryPath = try XCTUnwrap(SentrySDK.currentHub().getClient()?.fileManager.sentryPath, "Sentry path is nil, but should be configured for test cases.")
+            let sentryPath = try XCTUnwrap(SentrySDKInternal.currentHub().getClient()?.fileManager.sentryPath, "Sentry path is nil, but should be configured for test cases.")
             let sentryPathUrl = URL(fileURLWithPath: sentryPath)
 
             ignoredFileToCreateUrl = sentryPathUrl.appendingPathComponent("test--ignored-file-to-create")

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
@@ -25,7 +25,7 @@ class SentryFileIOTrackerSwiftHelpersTests: XCTestCase {
         SentryDependencyContainer.sharedInstance().dateProvider = mockedDateProvider
 
         hub = SentryHub(client: nil, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
 
         tracker = SentryFileIOTracker(
             threadInspector: TestThreadInspector(options: .noIntegrations()),

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -149,7 +149,7 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         
         wait(for: [expect], timeout: 5)
         
-        let scope = SentrySDK.currentHub().scope
+        let scope = SentrySDKInternal.currentHub().scope
         let breadcrumbs = Dynamic(scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(1, breadcrumbs?.count)
     }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -61,8 +61,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         super.setUp()
         fixture = Fixture()
 
-        SentrySDK.setCurrentHub(fixture.hub)
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setStart(with: fixture.options)
         SentryDependencyContainer.sharedInstance().dateProvider = fixture.dateProvider
     }
 
@@ -148,7 +148,7 @@ class SentryNetworkTrackerTests: XCTestCase {
     }
 
     func testSDKOptionsNil() {
-        SentrySDK.setCurrentHub(nil)
+        SentrySDKInternal.setCurrentHub(nil)
 
         let task = fixture.sentryTask
         let span = spanForTask(task: task)
@@ -911,8 +911,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         _ = try XCTUnwrap(startTransaction() as? SentryTracer)
         sut.urlSessionTaskResume(task)
 
-        let expectedTraceHeader = SentrySDK.currentHub().scope.propagationContext.traceHeader.value()
-        let traceContext = TraceContext(trace: SentrySDK.currentHub().scope.propagationContext.traceId, options: self.fixture.options, userSegment: self.fixture.scope.userObject?.segment, replayId: nil)
+        let expectedTraceHeader = SentrySDKInternal.currentHub().scope.propagationContext.traceHeader.value()
+        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, userSegment: self.fixture.scope.userObject?.segment, replayId: nil)
         let expectedBaggageHeader = traceContext.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["baggage"] ?? "", expectedBaggageHeader)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)
@@ -924,8 +924,8 @@ class SentryNetworkTrackerTests: XCTestCase {
         let task = createDataTask()
         sut.urlSessionTaskResume(task)
 
-        let expectedTraceHeader = SentrySDK.currentHub().scope.propagationContext.traceHeader.value()
-        let traceContext = TraceContext(trace: SentrySDK.currentHub().scope.propagationContext.traceId, options: self.fixture.options, userSegment: self.fixture.scope.userObject?.segment, replayId: nil)
+        let expectedTraceHeader = SentrySDKInternal.currentHub().scope.propagationContext.traceHeader.value()
+        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, userSegment: self.fixture.scope.userObject?.segment, replayId: nil)
         let expectedBaggageHeader = traceContext.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["baggage"] ?? "", expectedBaggageHeader)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)

--- a/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/SentryPerformanceTrackerTests.swift
@@ -32,7 +32,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         super.setUp()
         
         fixture = Fixture()
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
     }
     
     override func tearDown() {
@@ -62,7 +62,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         let spanId = startSpan(tracker: sut)
                 
         let transaction = sut.getSpan(spanId)
-        let scopeSpan = SentrySDK.currentHub().scope.span
+        let scopeSpan = SentrySDKInternal.currentHub().scope.span
         
         XCTAssert(scopeSpan !== transaction)
         XCTAssert(scopeSpan === firstTransaction)
@@ -75,7 +75,7 @@ class SentryPerformanceTrackerTests: XCTestCase {
         let spanId = startSpan(tracker: sut)
                 
         let transaction = sut.getSpan(spanId)
-        let scopeSpan = SentrySDK.currentHub().scope.span
+        let scopeSpan = SentrySDKInternal.currentHub().scope.span
         
         XCTAssert(scopeSpan === transaction)
         XCTAssert(scopeSpan !== firstTransaction)

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryTimeToDisplayTrackerTest.swift
@@ -345,7 +345,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
     
     func testTracerWithAppStartData_notWaitingForFullDisplay() throws {
         let appStartMeasurement = TestData.getAppStartMeasurement(type: .cold, appStartTimestamp: Date(timeIntervalSince1970: 6), runtimeInitSystemTimestamp: 6_000_000_000)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
 
@@ -378,7 +378,7 @@ class SentryTimeToDisplayTrackerTest: XCTestCase {
     
     func testTracerWithAppStartData_waitingForFullDisplay() throws {
         let appStartMeasurement = TestData.getAppStartMeasurement(type: .cold, appStartTimestamp: Date(timeIntervalSince1970: 6), runtimeInitSystemTimestamp: 6_000_000_000)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         fixture.dateProvider.setDate(date: Date(timeIntervalSince1970: 7))
 

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -40,7 +40,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
             $0.attachScreenshot = false
             $0.setIntegrations([SentryScreenshotIntegration.self])
         }
-        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
+        XCTAssertEqual(SentrySDKInternal.currentHub().getClient()?.attachmentProcessors.count, 0)
         XCTAssertFalse(sentrycrash_hasSaveScreenshotCallback())
     }
     
@@ -49,7 +49,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
             $0.attachScreenshot = true
             $0.setIntegrations([SentryScreenshotIntegration.self])
         }
-        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().getClient()?.attachmentProcessors.count, 1)
         XCTAssertTrue(sentrycrash_hasSaveScreenshotCallback())
     }
     
@@ -60,7 +60,7 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         }
         SentrySDK.close()
         
-        XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
+        XCTAssertNil(SentrySDKInternal.currentHub().getClient()?.attachmentProcessors)
         XCTAssertFalse(sentrycrash_hasSaveScreenshotCallback())
     }
     

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -62,7 +62,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         fixture.client.fileManager.deleteAppState()
         fixture.client.fileManager.deleteAppHangEvent()
         
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
     }
     
     override func tearDown() {
@@ -109,7 +109,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     
     func testEndSessionAsCrashed_WithCurrentSession() throws {
         let expectedCrashedSession = givenCrashedSession()
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         
         try advanceTime(bySeconds: 10)
         
@@ -122,11 +122,11 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func testEndSessionAsCrashed_WhenOOM_WithCurrentSession() throws {
         givenOOMAppState()
-        SentrySDK.startInvocations = 1
+        SentrySDKInternal.startInvocations = 1
         
         let expectedCrashedSession = givenCrashedSession()
         
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         try advanceTime(bySeconds: 10)
         
         let sut = fixture.sutWithoutCrash
@@ -210,7 +210,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     
     func testEndSessionAsAbnormal_NoCurrentSession() {
         // Arrange
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         let sentryCrash = fixture.sentryCrash
         sentryCrash.internalCrashedLastLaunch = false
         let sut = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: fixture.dispatchQueueWrapper)
@@ -227,7 +227,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     
     func testEndSessionAsAbnormal_NoAppHangEvent() {
         // Arrange
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         let sentryCrash = fixture.sentryCrash
         sentryCrash.internalCrashedLastLaunch = false
         let sut = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: fixture.dispatchQueueWrapper)
@@ -249,7 +249,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         let fileManager = try DeleteAppHangWhenCheckingExistenceFileManager(options: fixture.options)
         fixture.client.fileManager = fileManager
         
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         let sentryCrash = fixture.sentryCrash
         sentryCrash.internalCrashedLastLaunch = false
         let sut = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: fixture.dispatchQueueWrapper)
@@ -269,7 +269,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     
     func testEndSessionAsAbnormal_AppHangEvent_EndsSessionAsAbnormal() throws {
         // Arrange
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         let sentryCrash = fixture.sentryCrash
         sentryCrash.internalCrashedLastLaunch = false
         let sut = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: fixture.dispatchQueueWrapper)
@@ -300,7 +300,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     func testEndSessionAsAbnormal_AppHangEventAndCrash_EndsSessionAsCrashed() throws {
         // Arrange
         let expectedCrashedSession = givenCrashedSession()
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
         let fileManager = fixture.client.fileManager
         let appHangEvent = Event()
         fileManager.storeAppHang(appHangEvent)
@@ -540,7 +540,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         let client = SentryClient(options: options)
         defer { client?.fileManager.deleteAllEnvelopes() }
         let hub = SentryHub(client: client, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         sut.install(with: options)
@@ -565,13 +565,13 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         let client = SentryClient(options: options)
         defer { client?.fileManager.deleteAllEnvelopes() }
         let hub = SentryHub(client: client, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         sut.install(with: options)
         
         let transaction = SentrySDK.startTransaction(name: "name", operation: "operation", bindToScope: true)
-        SentrySDK.currentHub().scope.span = nil
+        SentrySDKInternal.currentHub().scope.span = nil
         
         sentrycrash_invokeSaveTransaction()
         
@@ -586,14 +586,14 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         let client = SentryClient(options: options)
         defer { client?.fileManager.deleteAllEnvelopes() }
         let hub = SentryHub(client: client, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         sut.install(with: options)
         
         let transaction = SentrySDK.startTransaction(name: "name", operation: "operation", bindToScope: true)
         let span = transaction.startChild(operation: "child")
-        SentrySDK.currentHub().scope.span = span
+        SentrySDKInternal.currentHub().scope.span = span
         
         sentrycrash_invokeSaveTransaction()
         
@@ -630,7 +630,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     private func givenSutWithGlobalHub() -> (SentryCrashIntegration, SentryHub) {
         let sut = fixture.getSut()
         let hub = fixture.hub
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
 
         return (sut, hub)
     }
@@ -641,7 +641,7 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
 #endif
         let sut = fixture.getSut(crashWrapper: SentryCrashWrapper.sharedInstance())
         let hub = fixture.hub
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
 
         return (sut, hub)
     }

--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -101,7 +101,7 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
             let fatalEvent = Event()
             fatalEvent.level = SentryLevel.fatal
             fatalEvent.message = SentryMessage(formatted: "Crash for SentrySessionGeneratorTests")
-            SentrySDK.captureFatalEvent(fatalEvent)
+            SentrySDKInternal.captureFatalEvent(fatalEvent)
         }
         sentryCrash.internalCrashedLastLaunch = false
         
@@ -118,7 +118,7 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
             autoSessionTrackingIntegration.install(with: options)
             goToForeground()
             
-            SentrySDK.captureFatalEvent(TestData.oomEvent)
+            SentrySDKInternal.captureFatalEvent(TestData.oomEvent)
         }
         fileManager.deleteAppState()
         #endif
@@ -141,9 +141,9 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
         SentrySDK.start(options: options)
         
         sentryCrash = TestSentryCrashWrapper.sharedInstance()
-        let client = SentrySDK.currentHub().getClient()
+        let client = SentrySDKInternal.currentHub().getClient()
         let hub = SentryHub(client: client, andScope: nil, andCrashWrapper: self.sentryCrash, andDispatchQueue: SentryDispatchQueueWrapper())
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         crashIntegration = SentryCrashIntegration(crashAdapter: sentryCrash, andDispatchQueueWrapper: TestSentryDispatchQueueWrapper())
         crashIntegration.install(with: options)

--- a/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionTrackerTests.swift
@@ -55,7 +55,7 @@ class SentrySessionTrackerTests: XCTestCase {
         
         func setNewHubToSDK() {
             let hub = SentryHub(client: client, andScope: nil, andCrashWrapper: self.sentryCrash, andDispatchQueue: SentryDispatchQueueWrapper())
-            SentrySDK.setCurrentHub(hub)
+            SentrySDKInternal.setCurrentHub(hub)
         }
     }
     
@@ -858,7 +858,7 @@ class SentrySessionTrackerTests: XCTestCase {
         fixture.fileManager.storeCrashedSession(crashedSession)
         
         startSutInAppDelegate()
-        SentrySDK.captureFatalEvent(Event())
+        SentrySDKInternal.captureFatalEvent(Event())
         
         let session = try XCTUnwrap(fixture.client.captureFatalEventWithSessionInvocations.last?.session)
         assertSession(session: session, started: sessionStartTime, status: SentrySessionStatus.crashed, duration: 5)

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -59,7 +59,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     }
     
     private func getSut() throws -> SentrySessionReplayIntegration {
-        return try XCTUnwrap(SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
+        return try XCTUnwrap(SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration)
     }
     
     private func startSDK(sessionSampleRate: Float, errorSampleRate: Float, enableSwizzling: Bool = true, noIntegrations: Bool = false, configure: ((Options) -> Void)? = nil) {
@@ -71,26 +71,26 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
             $0.cacheDirectoryPath = FileManager.default.temporaryDirectory.path
             configure?($0)
         }
-        SentrySDK.currentHub().startSession()
+        SentrySDKInternal.currentHub().startSession()
     }
     
     func testNoInstall() {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0)
         
-        XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 0)
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 0)
         XCTAssertEqual(globalEventProcessor.processors.count, 0)
     }
     
     func testInstallFullSessionReplay() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0)
         
-        XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
     
     func testInstallNoSwizzlingNoTouchTracker() {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0, enableSwizzling: false)
-        guard let integration = SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
+        guard let integration = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
         else {
             XCTFail("Could not find session replay integration")
             return
@@ -107,7 +107,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     func testInstallFullSessionReplayButDontRunBecauseOfRandom() throws {
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: 0.3)
         startSDK(sessionSampleRate: 0.2, errorSampleRate: 0)
-        XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNil(sut.sessionReplay)
@@ -118,7 +118,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         startSDK(sessionSampleRate: 0.3, errorSampleRate: 0)
         
-        XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
         let sut = try getSut()
         XCTAssertNotNil(sut.sessionReplay)
@@ -127,7 +127,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     func testInstallErrorReplay() {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0.1)
         
-        XCTAssertEqual(SentrySDK.currentHub().trimmedInstalledIntegrationNames().count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames().count, 1)
         XCTAssertEqual(globalEventProcessor.processors.count, 1)
     }
     
@@ -159,7 +159,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         let sut = try getSut()
         XCTAssertNotNil(sut.sessionReplay)
-        SentrySDK.currentHub().endSession()
+        SentrySDKInternal.currentHub().endSession()
         XCTAssertNil(sut.sessionReplay)
     }
     
@@ -177,9 +177,9 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         let sut = try getSut()
         XCTAssertNotNil(sut.sessionReplay)
-        SentrySDK.currentHub().endSession()
+        SentrySDKInternal.currentHub().endSession()
         XCTAssertNil(sut.sessionReplay)
-        SentrySDK.currentHub().startSession()
+        SentrySDKInternal.currentHub().startSession()
         XCTAssertNotNil(sut.sessionReplay)
     }
     
@@ -187,11 +187,11 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         startSDK(sessionSampleRate: 1, errorSampleRate: 0)
         
         let sut = try getSut()
-        SentrySDK.currentHub().startSession()
+        SentrySDKInternal.currentHub().startSession()
         XCTAssertNotNil(sut.sessionReplay)
         let oldSessionReplay = sut.sessionReplay
         XCTAssertTrue(oldSessionReplay?.isRunning ?? false)
-        SentrySDK.currentHub().startSession()
+        SentrySDKInternal.currentHub().startSession()
         XCTAssertFalse(oldSessionReplay?.isRunning ?? true)
     }
     
@@ -205,7 +205,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     func testScreenNameFromSentryScope() throws {
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
         
-        SentrySDK.currentHub().configureScope { scope in
+        SentrySDKInternal.currentHub().configureScope { scope in
             scope.currentScreen = "Scope Screen"
         }
         
@@ -219,10 +219,10 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
         
-        let client = SentryClient(options: try XCTUnwrap(SentrySDK.options))
+        let client = SentryClient(options: try XCTUnwrap(SentrySDKInternal.options))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         let expectation = expectation(description: "Replay to be capture")
         hub.onReplayCapture = {
             expectation.fulfill()
@@ -247,10 +247,10 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
         
-        let client = SentryClient(options: try XCTUnwrap(SentrySDK.options))
+        let client = SentryClient(options: try XCTUnwrap(SentrySDKInternal.options))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         let expectation = expectation(description: "Replay to be capture")
         hub.onReplayCapture = {
             expectation.fulfill()
@@ -273,10 +273,10 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     func testBufferReplayIgnoredBecauseSampleRateForCrash() throws {
         startSDK(sessionSampleRate: 1, errorSampleRate: 1)
         
-        let client = SentryClient(options: try XCTUnwrap(SentrySDK.options))
+        let client = SentryClient(options: try XCTUnwrap(SentrySDKInternal.options))
         let scope = Scope()
         let hub = TestHub(client: client, andScope: scope)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         let expectation = expectation(description: "Replay to be capture")
         expectation.isInverted = true
         hub.onReplayCapture = {
@@ -342,7 +342,7 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
     
     func testStartWithNoSessionReplay() throws {
         startSDK(sessionSampleRate: 0, errorSampleRate: 0, noIntegrations: true)
-        var sut = SentrySDK.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
+        var sut = SentrySDKInternal.currentHub().installedIntegrations().first as? SentrySessionReplayIntegration
         XCTAssertNil(sut)
         SentrySDK.replay.start()
         sut = try getSut()

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -40,7 +40,7 @@ class SentryUIEventTrackerTests: XCTestCase {
         sut = fixture.getSut()
         sut.start()
         
-        SentrySDK.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setCurrentHub(fixture.hub)
     }
     
     override func tearDown() {

--- a/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ViewHierarchy/SentryViewHierarchyIntegrationTests.swift
@@ -40,7 +40,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
             $0.attachViewHierarchy = false
             $0.setIntegrations([SentryViewHierarchyIntegration.self])
         }
-        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 0)
+        XCTAssertEqual(SentrySDKInternal.currentHub().getClient()?.attachmentProcessors.count, 0)
         XCTAssertFalse(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
@@ -49,7 +49,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
             $0.attachViewHierarchy = true
             $0.setIntegrations([SentryViewHierarchyIntegration.self])
         }
-        XCTAssertEqual(SentrySDK.currentHub().getClient()?.attachmentProcessors.count, 1)
+        XCTAssertEqual(SentrySDKInternal.currentHub().getClient()?.attachmentProcessors.count, 1)
         XCTAssertTrue(sentrycrash_hasSaveViewHierarchyCallback())
     }
 
@@ -59,7 +59,7 @@ class SentryViewHierarchyIntegrationTests: XCTestCase {
             $0.setIntegrations([SentryViewHierarchyIntegration.self])
         }
         SentrySDK.close()
-        XCTAssertNil(SentrySDK.currentHub().getClient()?.attachmentProcessors)
+        XCTAssertNil(SentrySDKInternal.currentHub().getClient()?.attachmentProcessors)
         XCTAssertFalse(sentrycrash_hasSaveViewHierarchyCallback())
     }
 

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
@@ -49,7 +49,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
             crashWrapper = TestSentryCrashWrapper.sharedInstance()
             
             let hub = SentryHub(client: client, andScope: nil, andCrashWrapper: crashWrapper, andDispatchQueue: SentryDispatchQueueWrapper())
-            SentrySDK.setCurrentHub(hub)
+            SentrySDKInternal.setCurrentHub(hub)
         }
         
         func getSut() throws -> SentryWatchdogTerminationTracker {
@@ -91,7 +91,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         
         fixture = try Fixture()
         sut = try fixture.getSut()
-        SentrySDK.startInvocations = 1
+        SentrySDKInternal.startInvocations = 1
     }
     
     override func tearDown() {
@@ -244,7 +244,7 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         sut.start()
         goToForeground()
 
-        SentrySDK.startInvocations = 2
+        SentrySDKInternal.startInvocations = 2
         sut.start()
         assertNoOOMSent()
     }

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
@@ -64,7 +64,7 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
             let client = TestClient(options: options)
             scope = Scope()
             hub = SentryHub(client: client, andScope: scope, andCrashWrapper: crashWrapper, andDispatchQueue: dispatchQueueWrapper)
-            SentrySDK.setCurrentHub(hub)
+            SentrySDKInternal.setCurrentHub(hub)
         }
 
         func getSut() -> SentryWatchdogTerminationTrackingIntegration {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1955,7 +1955,7 @@ class SentryClientTest: XCTestCase {
         let sut = fixture.getSut()
         
         let hub = SentryHub(client: sut, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         func addIntegrations(amount: Int) {
             let emptyIntegration = EmptyIntegration()

--- a/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashInstallationReporterTests.swift
@@ -86,7 +86,7 @@ class SentryCrashInstallationReporterTests: XCTestCase {
         
         testClient = TestClient(options: options)
         let hub = SentryHub(client: testClient, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         
         sut = SentryCrashInstallationReporter(inAppLogic: SentryInAppLogic(inAppIncludes: [], inAppExcludes: []), crashWrapper: TestSentryCrashWrapper.sharedInstance(), dispatchQueue: TestSentryDispatchQueueWrapper())
         sut.install(options.cacheDirectoryPath)

--- a/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryCrashReportSinkTests.swift
@@ -32,7 +32,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
     }
     
     func testFilterReports_CopyHubScope() {
-        SentrySDK.currentHub().scope.setEnvironment("testFilterReports_CopyHubScope")
+        SentrySDKInternal.currentHub().scope.setEnvironment("testFilterReports_CopyHubScope")
         
         let expect = expectation(description: "Callback Called")
         
@@ -122,7 +122,7 @@ class SentryCrashReportSinkTests: SentrySDKIntegrationTestsBase {
     }
     
     private func getTestClient() -> TestClient {
-        let client = SentrySDK.currentHub().getClient() as? TestClient
+        let client = SentrySDKInternal.currentHub().getClient() as? TestClient
         
         if client == nil {
             XCTFail("Hub Client is not a `TestClient`")

--- a/Tests/SentryTests/SentryCrashExceptionApplicationTests.swift
+++ b/Tests/SentryTests/SentryCrashExceptionApplicationTests.swift
@@ -18,14 +18,14 @@ class SentryCrashExceptionApplicationHelperTests: XCTestCase {
         // Arrange
         let client = TestClient(options: Options())
         let hub = TestHub(client: client, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setCurrentHub(hub)
         let exception = NSException(name: NSExceptionName("TestException"), reason: "Test Reason", userInfo: nil)
         
         // Act
         SentryCrashExceptionApplicationHelper._crash(on: exception)
         
         // Assert
-        let testClient = try XCTUnwrap(SentrySDK.currentHub().getClient() as? TestClient)
+        let testClient = try XCTUnwrap(SentrySDKInternal.currentHub().getClient() as? TestClient)
         XCTAssertEqual(1, testClient.captureExceptionWithScopeInvocations.count)
         XCTAssertEqual(exception.name, testClient.captureExceptionWithScopeInvocations.first?.exception.name)
         XCTAssertEqual(exception.reason, testClient.captureExceptionWithScopeInvocations.first?.exception.reason)

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1,7 +1,7 @@
 #import "SentryOptions.h"
 #import "SentryError.h"
 #import "SentryOptions+HybridSDKs.h"
-#import "SentrySDK.h"
+#import "SentrySDKInternal.h"
 #import "SentrySpan.h"
 #import "SentryTests-Swift.h"
 #import <XCTest/XCTest.h>

--- a/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
+++ b/Tests/SentryTests/SentrySDKIntegrationTestsBase.swift
@@ -30,12 +30,12 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
         let client = TestClient(options: options ?? self.options)
         let hub = SentryHub(client: client, andScope: scope, andCrashWrapper: TestSentryCrashWrapper.sharedInstance(), andDispatchQueue: SentryDispatchQueueWrapper())
         
-        SentrySDK.setStart(self.options)
-        SentrySDK.setCurrentHub(hub)
+        SentrySDKInternal.setStart(with: self.options)
+        SentrySDKInternal.setCurrentHub(hub)
     }
     
     func assertNoEventCaptured() {
-        guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+        guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }
@@ -43,7 +43,7 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
     }
     
     func assertEventWithScopeCaptured(_ callback: (Event?, Scope?, [SentryEnvelopeItem]?) throws -> Void) throws {
-        guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+        guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }
@@ -54,7 +54,7 @@ class SentrySDKIntegrationTestsBase: XCTestCase {
     }
     
     func assertFatalEventWithScope(_ callback: (Event?, Scope?) throws -> Void) rethrows {
-        guard let client = SentrySDK.currentHub().getClient() as? TestClient else {
+        guard let client = SentrySDKInternal.currentHub().getClient() as? TestClient else {
             XCTFail("Hub Client is not a `TestClient`")
             return
         }

--- a/Tests/SentryTests/SentrySDKInternal+Tests.h
+++ b/Tests/SentryTests/SentrySDKInternal+Tests.h
@@ -1,16 +1,15 @@
 #import "SentryDefines.h"
-#import "SentrySDK.h"
 
 @class SentryEnvelope;
 @class SentryHub;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SentrySDK ()
+@interface SentrySDKInternal ()
 
 + (void)setCurrentHub:(nullable SentryHub *)hub;
 
-+ (void)setStartOptions:(nullable SentryOptions *)options;
++ (void)setStartOptions:(nullable SentryOptions *)options NS_SWIFT_NAME(setStart(with:));
 
 + (void)captureEnvelope:(SentryEnvelope *)envelope;
 

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -1,0 +1,1063 @@
+@_spi(Private) @testable import Sentry
+@_spi(Private) import SentryTestUtils
+import XCTest
+
+// swiftlint:disable file_length
+class SentrySDKInternalTests: XCTestCase {
+
+    private static let dsnAsString = TestConstants.dsnAsString(username: "SentrySDKTests")
+
+    private class Fixture {
+    
+        let options: Options = {
+            let options = Options.noIntegrations()
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.releaseName = "1.0.0"
+            return options
+        }()
+
+        let event: Event
+        let scope: Scope
+        let client: TestClient
+        let hub: SentryHub
+        let error: Error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Object does not exist"])
+        let exception = NSException(name: NSExceptionName("My Custom exeption"), reason: "User clicked the button", userInfo: nil)
+        @available(*, deprecated, message: "SentryUserFeedback is deprecated in favor of SentryFeedback.")
+        let userFeedback: UserFeedback
+        let feedback: SentryFeedback
+        let currentDate = TestCurrentDateProvider()
+        
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        let dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
+        let observer: SentryWatchdogTerminationScopeObserver
+        let scopePersistentStore: TestSentryScopePersistentStore
+#endif //  os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+        let scopeBlock: (Scope) -> Void = { scope in
+            scope.setTag(value: "tag", key: "tag")
+        }
+
+        var scopeWithBlockApplied: Scope {
+            let scope = self.scope
+            scopeBlock(scope)
+            return scope
+        }
+
+        let message = "message"
+        let operation = "ui.load"
+        let transactionName = "Load Main Screen"
+
+        @available(*, deprecated, message: "This is marked deprecated as a workaround until we can remove SentryUserFeedback in favor of SentryFeedback. When SentryUserFeedback is removed, this deprecation annotation can be removed.")
+        init() {
+            SentryDependencyContainer.sharedInstance().dateProvider = currentDate
+
+            event = Event()
+            event.message = SentryMessage(formatted: message)
+
+            scope = Scope()
+            scope.setTag(value: "value", key: "key")
+
+            client = TestClient(options: options)!
+            hub = SentryHub(client: client, andScope: scope, andCrashWrapper: TestSentryCrashWrapper.sharedInstance(), andDispatchQueue: SentryDispatchQueueWrapper())
+
+            userFeedback = UserFeedback(eventId: SentryId())
+            userFeedback.comments = "Again really?"
+            userFeedback.email = "tim@apple.com"
+            userFeedback.name = "Tim Apple"
+
+            feedback = SentryFeedback(message: "Again really?", name: "Tim Apple", email: "tim@apple.com")
+            
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+            options.dsn = SentrySDKInternalTests.dsnAsString
+
+            let fileManager = try! TestFileManager(options: options)
+            let breadcrumbProcessor = SentryWatchdogTerminationBreadcrumbProcessor(maxBreadcrumbs: 10, fileManager: fileManager)
+            scopePersistentStore = try! XCTUnwrap(TestSentryScopePersistentStore(fileManager: fileManager))
+            let attributesProcessor = SentryWatchdogTerminationAttributesProcessor(
+                withDispatchQueueWrapper: dispatchQueueWrapper,
+                scopePersistentStore: scopePersistentStore
+            )
+            observer = SentryWatchdogTerminationScopeObserver(breadcrumbProcessor: breadcrumbProcessor, attributesProcessor: attributesProcessor)
+#endif //  os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+        }
+    }
+
+    private var fixture: Fixture!
+
+    @available(*, deprecated, message: "This is marked deprecated as a workaround (for the workaround deprecating the Fixture.init method) until we can remove SentryUserFeedback in favor of SentryFeedback. When SentryUserFeedback is removed, this deprecation annotation can be removed.")
+    override func setUp() {
+        super.setUp()
+        fixture = Fixture()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        givenSdkWithHubButNoClient()
+
+        if let autoSessionTracking = SentrySDKInternal.currentHub().installedIntegrations().first(where: { it in
+            it is SentryAutoSessionTrackingIntegration
+        }) as? SentryAutoSessionTrackingIntegration {
+            autoSessionTracking.stop()
+        }
+
+        clearTestState()
+    }
+
+    func testDetectedStartUpCrash() {
+        SentrySDKInternal.setDetectedStartUpCrash(true)
+        XCTAssertEqual(SentrySDK.detectedStartUpCrash, true)
+
+        SentrySDKInternal.setDetectedStartUpCrash(false)
+        XCTAssertFalse(SentrySDK.detectedStartUpCrash)
+    }
+
+    func testCaptureFatalEvent() {
+        let hub = TestHub(client: nil, andScope: nil)
+        SentrySDKInternal.setCurrentHub(hub)
+
+        let event = fixture.event
+        SentrySDKInternal.captureFatalEvent(event)
+    
+        XCTAssertEqual(1, hub.sentFatalEvents.count)
+        XCTAssertEqual(event.message, hub.sentFatalEvents.first?.message)
+        XCTAssertEqual(event.eventId, hub.sentFatalEvents.first?.eventId)
+    }
+
+    func testCaptureEnvelope() {
+        givenSdkWithHub()
+
+        let envelope = SentryEnvelope(event: TestData.event)
+        SentrySDKInternal.capture(envelope)
+
+        XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
+        XCTAssertEqual(envelope.header.eventId, fixture.client.captureEnvelopeInvocations.first?.header.eventId)
+    }
+
+    func testStoreEnvelope() {
+        givenSdkWithHub()
+
+        let envelope = SentryEnvelope(event: TestData.event)
+        SentrySDKInternal.store(envelope)
+
+        XCTAssertEqual(1, fixture.client.storedEnvelopeInvocations.count)
+        XCTAssertEqual(envelope.header.eventId, fixture.client.storedEnvelopeInvocations.first?.header.eventId)
+    }
+
+    /// This is to prevent https://github.com/getsentry/sentry-cocoa/issues/4280
+    /// With 8.33.0, writing an envelope could fail in the middle of the process, which the envelope
+    /// payload below simulates. The JSON stems from writing an envelope to disk with vast data
+    /// that leads to an OOM termination on v 8.33.0.
+    /// Running this test on v 8.33.0 leads to a crash.
+    func testStartSDK_WithCorruptedEnvelope() throws {
+
+        let fileManager = try SentryFileManager(options: fixture.options)
+
+        let corruptedEnvelopeData = Data("""
+                       {"event_id":"1990b5bc31904b7395fd07feb72daf1c","sdk":{"name":"sentry.cocoa","version":"8.33.0"}}
+                       {"type":"test","length":50}
+                       """.utf8)
+
+        try corruptedEnvelopeData.write(to: URL(fileURLWithPath: "\(fileManager.envelopesPath)/corrupted-envelope.json"))
+
+        SentrySDK.start(options: fixture.options)
+
+        fileManager.deleteAllEnvelopes()
+    }
+
+    func testStoreEnvelope_WhenNoClient_NoCrash() {
+        SentrySDKInternal.store(SentryEnvelope(event: TestData.event))
+
+        XCTAssertEqual(0, fixture.client.storedEnvelopeInvocations.count)
+    }
+
+    @available(*, deprecated, message: "-[SentrySDK captureUserFeedback:] is deprecated. -[SentrySDK captureFeedback:] is the new way. This test case can be removed in favor of testCaptureFeedback when -[SentrySDK captureUserFeedback:] is removed.")
+    func testCaptureUserFeedback() {
+        givenSdkWithHub()
+
+        SentrySDK.capture(userFeedback: fixture.userFeedback)
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureUserFeedbackInvocations.count)
+        if let actual = client.captureUserFeedbackInvocations.first {
+            let expected = fixture.userFeedback
+            XCTAssertEqual(expected.eventId, actual.eventId)
+            XCTAssertEqual(expected.name, actual.name)
+            XCTAssertEqual(expected.email, actual.email)
+            XCTAssertEqual(expected.comments, actual.comments)
+        }
+    }
+
+    func testCaptureFeedback() {
+        givenSdkWithHub()
+
+        SentrySDK.capture(feedback: fixture.feedback)
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureFeedbackInvocations.count)
+        if let actual = client.captureFeedbackInvocations.first {
+            let expected = fixture.feedback
+            XCTAssertEqual(expected.eventId, actual.0.eventId)
+            XCTAssertEqual(expected.name, actual.0.name)
+            XCTAssertEqual(expected.email, actual.0.email)
+            XCTAssertEqual(expected.message, actual.0.message)
+        }
+    }
+    
+    func testStartSession() {
+        givenSdkWithHub()
+
+        SentrySDK.startSession()
+
+        XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
+
+        let actual = fixture.client.captureSessionInvocations.first
+        let expected = SentrySession(releaseName: fixture.options.releaseName ?? "", distinctId: "some-id")
+
+        XCTAssertEqual(expected.flagInit, actual?.flagInit)
+        XCTAssertEqual(expected.errors, actual?.errors)
+        XCTAssertEqual(expected.sequence, actual?.sequence)
+        XCTAssertEqual(expected.releaseName, actual?.releaseName)
+        XCTAssertEqual(SentryDependencyContainer.sharedInstance().dateProvider.date(), actual?.started)
+        XCTAssertEqual(SentrySessionStatus.ok, actual?.status)
+        XCTAssertNil(actual?.timestamp)
+        XCTAssertNil(actual?.duration)
+    }
+
+    func testEndSession() throws {
+        givenSdkWithHub()
+
+        SentrySDK.startSession()
+        advanceTime(bySeconds: 1)
+        SentrySDK.endSession()
+
+        XCTAssertEqual(2, fixture.client.captureSessionInvocations.count)
+
+        let actual = try XCTUnwrap(fixture.client.captureSessionInvocations.invocations.last)
+
+        XCTAssertNil(actual.flagInit)
+        XCTAssertEqual(0, actual.errors)
+        XCTAssertEqual(2, actual.sequence)
+        XCTAssertEqual(SentrySessionStatus.exited, actual.status)
+        XCTAssertEqual(fixture.options.releaseName ?? "", actual.releaseName)
+        XCTAssertEqual(1, actual.duration)
+        XCTAssertEqual(SentryDependencyContainer.sharedInstance().dateProvider.date(), actual.timestamp)
+    }
+
+    func testSetUser_SetsUserToScopeOfHub() {
+        givenSdkWithHub()
+
+        let user = TestData.user
+        SentrySDK.setUser(user)
+
+        let actualScope = SentrySDKInternal.currentHub().scope
+        let event = actualScope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
+        XCTAssertEqual(event?.user, user)
+    }
+
+    func testSetUserBeforeStartingSDK_LogsFatalMessage() throws {
+        // Arrange
+        let oldOutput = SentrySDKLog.getLogOutput()
+
+        defer {
+            SentrySDKLog.setOutput(oldOutput)
+        }
+
+        let logOutput = TestLogOutput()
+        SentrySDKLog.setLogOutput(logOutput)
+
+        // Act
+        SentrySDK.setUser(nil)
+    
+        // Assert
+        let actualLogMessage = try XCTUnwrap(logOutput.loggedMessages.first)
+        let expectedLogMessage = "The SDK is disabled, so setUser doesn't work. Please ensure to start the SDK before setting the user."
+
+        XCTAssertTrue(actualLogMessage.contains(expectedLogMessage), "Expected log message to contain '\(expectedLogMessage)', but got '\(actualLogMessage)'")
+    }
+
+    func testSetUserAFterStartingSDK_DoesNotLogFatalMessage() {
+        // Arrange
+        let oldOutput = SentrySDKLog.getLogOutput()
+
+        defer {
+            SentrySDKLog.setOutput(oldOutput)
+        }
+
+        let logOutput = TestLogOutput()
+        SentrySDKLog.setLogOutput(logOutput)
+
+        givenSdkWithHub()
+
+        let user = TestData.user
+
+        // Act
+        SentrySDK.setUser(user)
+
+        //Assert
+        XCTAssertEqual(0, logOutput.loggedMessages.count, "Expected no log messages, but got \(logOutput.loggedMessages.count)")
+    }
+
+    func testStartTransaction() throws {
+        givenSdkWithHub()
+
+        let operation = "ui.load"
+        let name = "Load Main Screen"
+        let transaction = SentrySDK.startTransaction(name: name, operation: operation)
+
+        XCTAssertEqual(operation, transaction.operation)
+        let tracer = try XCTUnwrap(transaction as? SentryTracer)
+        XCTAssertEqual(name, tracer.traceContext?.transaction)
+
+        XCTAssertNil(SentrySDK.span)
+    }
+
+    func testStartTransaction_WithBindToScope() throws {
+        givenSdkWithHub()
+
+        let transaction = SentrySDK.startTransaction(name: fixture.transactionName, operation: fixture.operation, bindToScope: true)
+
+        XCTAssertEqual(fixture.operation, transaction.operation)
+        let tracer = try XCTUnwrap(transaction as? SentryTracer)
+        XCTAssertEqual(fixture.transactionName, tracer.traceContext?.transaction)
+        XCTAssertEqual(.custom, tracer.transactionContext.nameSource)
+
+        let newSpan = SentrySDK.span
+
+        XCTAssert(transaction === newSpan)
+    }
+
+    func testInstallIntegrations() throws {
+        let options = Options()
+        options.dsn = "mine"
+        options.integrations = ["SentryTestIntegration", "SentryTestIntegration", "IDontExist"]
+
+        SentrySDK.start(options: options)
+
+        assertIntegrationsInstalled(integrations: ["SentryTestIntegration"])
+        let integration = SentrySDKInternal.currentHub().installedIntegrations().first
+        if let testIntegration = integration as? SentryTestIntegration {
+            XCTAssertEqual(options.dsn, testIntegration.options.dsn)
+            XCTAssertEqual(options.integrations, testIntegration.options.integrations)
+        }
+    }
+
+#if SENTRY_HAS_UIKIT
+    func testSetAppStartMeasurement_CallsPrivateSDKCallback() {
+        let appStartMeasurement = TestData.getAppStartMeasurement(type: .warm)
+
+        var callbackCalled = false
+        PrivateSentrySDKOnly.onAppStartMeasurementAvailable = { measurement in
+            XCTAssertEqual(appStartMeasurement, measurement)
+            callbackCalled = true
+        }
+
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
+        XCTAssertTrue(callbackCalled)
+    }
+
+    func testSetAppStartMeasurement_NoCallback_CallbackNotCalled() {
+        let appStartMeasurement = TestData.getAppStartMeasurement(type: .warm)
+
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
+
+        XCTAssertEqual(SentrySDKInternal.getAppStartMeasurement(), appStartMeasurement)
+    }
+#endif // SENTRY_HAS_UIKIT
+
+    func testSDKStartInvocations() {
+        XCTAssertEqual(0, SentrySDKInternal.startInvocations)
+
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        XCTAssertEqual(1, SentrySDKInternal.startInvocations)
+    }
+
+    func testSDKStartTimestamp() {
+        let currentDateProvider = TestCurrentDateProvider()
+        SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
+
+        XCTAssertNil(SentrySDKInternal.startTimestamp)
+
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        XCTAssertEqual(SentrySDKInternal.startTimestamp, currentDateProvider.date())
+
+        SentrySDK.close()
+        XCTAssertNil(SentrySDKInternal.startTimestamp)
+    }
+
+    func testIsEnabled() {
+        XCTAssertFalse(SentrySDK.isEnabled)
+
+        SentrySDK.capture(message: "message")
+        XCTAssertFalse(SentrySDK.isEnabled)
+
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+        XCTAssertTrue(SentrySDK.isEnabled)
+
+        SentrySDK.close()
+        XCTAssertFalse(SentrySDK.isEnabled)
+
+        SentrySDK.capture(message: "message")
+        XCTAssertFalse(SentrySDK.isEnabled)
+
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+        XCTAssertTrue(SentrySDK.isEnabled)
+    }
+
+    func testClose_ResetsDependencyContainer() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        let first = SentryDependencyContainer.sharedInstance()
+
+        SentrySDK.close()
+
+        let second = SentryDependencyContainer.sharedInstance()
+
+        XCTAssertNotEqual(first, second)
+    }
+
+    func testClose_ClearsIntegrations() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.swiftAsyncStacktraces = true
+            options.setIntegrations([SentrySwiftAsyncIntegration.self])
+        }
+
+        let hub = SentrySDKInternal.currentHub()
+        XCTAssertEqual(1, hub.installedIntegrations().count)
+        SentrySDK.close()
+        XCTAssertEqual(0, hub.installedIntegrations().count)
+        assertIntegrationsInstalled(integrations: [])
+    }
+
+#if SENTRY_HAS_UIKIT
+    func testClose_StopsAppStateManager() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKTests.dsnAsString
+            options.tracesSampleRate = 1
+            options.removeAllIntegrations()
+        }
+
+        let appStateManager = SentryDependencyContainer.sharedInstance().appStateManager
+        XCTAssertEqual(appStateManager.startCount, 1)
+
+        SentrySDK.start { options in
+            options.dsn = SentrySDKTests.dsnAsString
+            options.tracesSampleRate = 1
+            options.removeAllIntegrations()
+        }
+
+        XCTAssertEqual(appStateManager.startCount, 2)
+
+        SentrySDK.close()
+
+        XCTAssertEqual(appStateManager.startCount, 0)
+
+        let stateAfterStop = fixture.fileManager.readAppState()
+        XCTAssertFalse(stateAfterStop!.isSDKRunning)
+    }
+#endif
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    func testReportFullyDisplayed() {
+        fixture.options.enableTimeToFullDisplayTracing = true
+
+        let testTTDTracker = TestTimeToDisplayTracker(waitForFullDisplay: true)
+        let performanceTracker = Dynamic(SentryDependencyContainer.sharedInstance().uiViewControllerPerformanceTracker)
+        performanceTracker.currentTTDTracker = testTTDTracker
+
+        // Start SDK after setting up the tracker to ensure we're changing the tracker during it's initialization,
+        // because some initialization logic happens on a BG thread and we would end up in a race condition.
+        SentrySDK.start(options: fixture.options)
+
+        SentrySDK.reportFullyDisplayed()
+
+        XCTAssertTrue(testTTDTracker.registerFullDisplayCalled)
+    }
+#endif
+
+#if os(iOS)
+    func testSentryUIDeviceWrapperStarted() {
+        let deviceWrapper = TestSentryUIDeviceWrapper()
+        SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
+        SentrySDK.start(options: fixture.options)
+        XCTAssertTrue(deviceWrapper.started)
+    }
+
+    func testSentryUIDeviceWrapperStopped() {
+        let deviceWrapper = TestSentryUIDeviceWrapper()
+        SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
+        SentrySDK.start(options: fixture.options)
+        SentrySDK.close()
+        XCTAssertFalse(deviceWrapper.started)
+    }
+
+    /// Ensure to start the UIDeviceWrapper before initializing the hub, so enrich scope sets the correct OS version.
+    func testStartSDK_ScopeContextContainsOSVersion() throws {
+        let expectation = expectation(description: "MainThreadTestIntegration install called")
+        MainThreadTestIntegration.expectation = expectation
+
+        DispatchQueue.global(qos: .default).async {
+            SentrySDK.start { options in
+                options.integrations = [ NSStringFromClass(MainThreadTestIntegration.self) ]
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let os = try XCTUnwrap (SentrySDKInternal.currentHub().scope.contextDictionary["os"] as? [String: Any])
+#if !targetEnvironment(macCatalyst)
+        XCTAssertEqual(UIDevice.current.systemVersion, os["version"] as? String)
+#endif
+    }
+#endif
+
+    func testResumeAndPauseAppHangTracking() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.setIntegrations([SentryANRTrackingIntegration.self])
+        }
+
+        let client = fixture.client
+        SentrySDKInternal.currentHub().bindClient(client)
+
+        let anrTrackingIntegration = SentrySDKInternal.currentHub().getInstalledIntegration(SentryANRTrackingIntegration.self)
+
+        SentrySDK.pauseAppHangTracking()
+        Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
+        XCTAssertEqual(0, client.captureEventWithScopeInvocations.count)
+
+        SentrySDK.resumeAppHangTracking()
+        Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
+
+        if SentryDependencyContainer.sharedInstance().crashWrapper.isBeingTraced() {
+            XCTAssertEqual(0, client.captureEventWithScopeInvocations.count)
+        } else {
+            XCTAssertEqual(1, client.captureEventWithScopeInvocations.count)
+        }
+    }
+
+    func testResumeAndPauseAppHangTracking_ANRTrackingNotInstalled() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        let client = fixture.client
+        SentrySDKInternal.currentHub().bindClient(client)
+
+        // Both invocations do nothing
+        SentrySDK.pauseAppHangTracking()
+        SentrySDK.resumeAppHangTracking()
+    }
+
+    func testClose_SetsClientToNil() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        SentrySDK.close()
+
+        XCTAssertNil(SentrySDKInternal.currentHub().client())
+    }
+
+    func testClose_ClosesClient() {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        let client = SentrySDKInternal.currentHub().client()
+        SentrySDK.close()
+
+        XCTAssertFalse(client?.isEnabled ?? true)
+    }
+
+    func testClose_CallsFlushCorrectlyOnTransport() throws {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        let transport = TestTransport()
+        let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
+        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
+        SentrySDKInternal.currentHub().bindClient(client)
+        SentrySDK.close()
+
+        XCTAssertEqual(Options().shutdownTimeInterval, transport.flushInvocations.first)
+    }
+    
+    func testLogger_ReturnsSameInstanceOnMultipleCalls() {
+        givenSdkWithHub()
+        
+        let logger1 = SentrySDK.logger
+        let logger2 = SentrySDK.logger
+        
+        XCTAssertIdentical(logger1, logger2)
+    }
+
+    func testClose_ResetsLogger() {
+        givenSdkWithHub()
+        
+        // Get logger instance
+        let logger1 = SentrySDK.logger
+        XCTAssertNotNil(logger1)
+        
+        // Close SDK
+        SentrySDK.close()
+        
+        // Start SDK again
+        givenSdkWithHub()
+        
+        // Get logger instance again
+        let logger2 = SentrySDK.logger
+        XCTAssertNotNil(logger2)
+        
+        // Should be a different instance
+        XCTAssertNotIdentical(logger1, logger2)
+    }
+
+    func testLogger_WithLogsEnabled_CapturesLog() {
+        fixture.client.options.experimental.enableLogs = true
+        givenSdkWithHub()
+        
+        SentrySDK.logger.error(String(repeating: "S", count: 1_024 * 1_024))
+        
+        let expectation = self.expectation(description: "Wait for async add.")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 0.5)
+        
+        XCTAssertEqual(fixture.client.captureLogsDataInvocations.count, 1)
+    }
+
+    func testLogger_WithNoClient_DoesNotCaptureLog() {
+        fixture.client.options.experimental.enableLogs = true
+        let hubWithoutClient = SentryHub(client: nil, andScope: nil)
+        SentrySDKInternal.setCurrentHub(hubWithoutClient)
+        
+        SentrySDK.logger.error(String(repeating: "S", count: 1_024 * 1_024))
+        
+        let expectation = self.expectation(description: "Wait for async add.")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 0.5)
+        
+        XCTAssertEqual(fixture.client.captureLogsDataInvocations.count, 0)
+    }
+    
+    func testLogger_WithLogsDisabled_DoesNotCaptureLog() {
+        fixture.client.options.experimental.enableLogs = false
+        givenSdkWithHub()
+        
+        SentrySDK.logger.error("foo")
+        XCTAssertEqual(fixture.client.captureLogsDataInvocations.count, 0)
+    }
+    
+    func testFlush_CallsFlushCorrectlyOnTransport() throws {
+        SentrySDK.start { options in
+            options.dsn = SentrySDKInternalTests.dsnAsString
+            options.removeAllIntegrations()
+        }
+
+        let transport = TestTransport()
+        let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
+        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
+        SentrySDKInternal.currentHub().bindClient(client)
+
+        let flushTimeout = 10.0
+        SentrySDK.flush(timeout: flushTimeout)
+
+        XCTAssertEqual(flushTimeout, transport.flushInvocations.first)
+    }
+
+    func testStartOnTheMainThread() throws {
+        let expectation = expectation(description: "MainThreadTestIntegration install called")
+        MainThreadTestIntegration.expectation = expectation
+
+        print("[Sentry] [TEST] [\(#file):\(#line) Dispatching to nonmain queue.")
+        DispatchQueue.global(qos: .background).async {
+            print("[Sentry] [TEST] [\(#file):\(#line) About to start SDK from nonmain queue.")
+            SentrySDK.start { options in
+                print("[Sentry] [TEST] [\(#file):\(#line) configuring options.")
+                options.integrations = [ NSStringFromClass(MainThreadTestIntegration.self) ]
+            }
+        }
+
+        wait(for: [expectation], timeout: 1.0)
+
+        let mainThreadIntegration = try XCTUnwrap(SentrySDKInternal.currentHub().installedIntegrations().first as? MainThreadTestIntegration)
+        XCTAssert(mainThreadIntegration.installedInTheMainThread, "SDK is not being initialized in the main thread")
+
+    }
+
+#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+    func testSetAppStartMeasurementConcurrently() {
+        let runtimeInitSystemTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date()
+
+        func setAppStartMeasurement(_ queue: DispatchQueue, _ i: Int) {
+            group.enter()
+            queue.async {
+                let appStartTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(TimeInterval(i))
+                let appStartMeasurement = TestData.getAppStartMeasurement(
+                    type: .warm,
+                    appStartTimestamp: appStartTimestamp,
+                    runtimeInitSystemTimestamp: UInt64(runtimeInitSystemTimestamp.timeIntervalSince1970)
+                )
+                SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
+                group.leave()
+            }
+        }
+
+        func createQueue() -> DispatchQueue {
+            return DispatchQueue(label: "SentrySDKTests", qos: .userInteractive, attributes: [.initiallyInactive])
+        }
+
+        let queue1 = createQueue()
+        let queue2 = createQueue()
+        let group = DispatchGroup()
+
+        let amount = 100
+
+        for i in 0...amount {
+            setAppStartMeasurement(queue1, i)
+            setAppStartMeasurement(queue2, i)
+        }
+
+        queue1.activate()
+        queue2.activate()
+        group.waitWithTimeout(timeout: 100)
+
+        let timestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(TimeInterval(amount))
+        XCTAssertEqual(timestamp, SentrySDKInternal.getAppStartMeasurement()?.appStartTimestamp)
+    }
+
+    func testMovesBreadcrumbsToPreviousBreadcrumbs() throws {
+        let options = Options()
+        options.dsn = SentrySDKInternalTests.dsnAsString
+
+        let fileManager = try TestFileManager(options: options)
+        let breadcrumbProcessor = SentryWatchdogTerminationBreadcrumbProcessor(maxBreadcrumbs: 10, fileManager: fileManager)
+        let dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
+        let scopePersistentStore = try XCTUnwrap(TestSentryScopePersistentStore(fileManager: fileManager))
+        let attributesProcessor = SentryWatchdogTerminationAttributesProcessor(
+            withDispatchQueueWrapper: dispatchQueueWrapper,
+            scopePersistentStore: scopePersistentStore
+        )
+        let observer = SentryWatchdogTerminationScopeObserver(breadcrumbProcessor: breadcrumbProcessor, attributesProcessor: attributesProcessor)
+        let serializedBreadcrumb = TestData.crumb.serialize()
+
+        for _ in 0..<3 {
+            observer.addSerializedBreadcrumb(serializedBreadcrumb)
+        }
+
+        SentrySDK.start(options: options)
+
+        let result = fileManager.readPreviousBreadcrumbs()
+        XCTAssertEqual(result.count, 3)
+    }
+
+    func testStartWithOptions_shouldMoveCurrentContextFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setContext([
+            "a": ["b": "c"]
+        ])
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setContext completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Delete the previous context file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        // Sanity-check for the pre-condition
+        let previousContext = fixture.scopePersistentStore.readPreviousContextFromDisk()
+        XCTAssertNil(previousContext)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousContextFromDisk())
+        XCTAssertEqual(result.count, 1)
+        let value = try XCTUnwrap(result["a"] as? [String: String])
+        XCTAssertEqual(value["b"], "c")
+    }
+    
+    func testStartWithOptions_shouldMoveCurrentUserFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setUser(User(userId: "user1234"))
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setUser completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Delete the previous context file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        // Sanity-check for the pre-condition
+        let previousUser = fixture.scopePersistentStore.readPreviousUserFromDisk()
+        XCTAssertNil(previousUser)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousUserFromDisk())
+        XCTAssertEqual(result.userId, "user1234")
+    }
+    
+    func testStartWithOptions_shouldMoveCurrentDistFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setDist("dist-string")
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setDist completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        // Delete the previous context file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        // Sanity-check for the pre-condition
+        let previousUser = fixture.scopePersistentStore.readPreviousDistFromDisk()
+        XCTAssertNil(previousUser)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousDistFromDisk())
+        XCTAssertEqual(result, "dist-string")
+    }
+
+    func testStartWithOptions_shouldMoveCurrentEnvironmentFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setEnvironment("prod-string")
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setEnvironment completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        // Delete the previous context file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        // Sanity-check for the pre-condition
+        let previousUser = fixture.scopePersistentStore.readPreviousEnvironmentFromDisk()
+        XCTAssertNil(previousUser)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousEnvironmentFromDisk())
+        XCTAssertEqual(result, "prod-string")
+    }
+
+    func testStartWithOptions_shouldMoveCurrentExtraFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setExtras(["extra1": "value1", "extra2": "value2"])
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setExtras completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+        // Delete the previous context file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        
+        // Sanity-check for the pre-condition
+        let previousExtras = fixture.scopePersistentStore.readPreviousExtrasFromDisk()
+        XCTAssertNil(previousExtras)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousExtrasFromDisk())
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result["extra1"] as? String, "value1")
+        XCTAssertEqual(result["extra2"] as? String, "value2")
+    }
+
+    func testStartWithOptions_shouldMoveCurrentFingerprintFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setFingerprint(["fingerprint1", "fingerprint2"])
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setFingerprint completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Delete the previous fingerprint file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        // Sanity-check for the pre-condition
+        let previousFingerprint = fixture.scopePersistentStore.readPreviousFingerprintFromDisk()
+        XCTAssertNil(previousFingerprint)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousFingerprintFromDisk())
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result[0], "fingerprint1")
+        XCTAssertEqual(result[1], "fingerprint2")
+    }
+    
+    func testStartWithOptions_shouldMoveCurrentTagsFileToPreviousFile() throws {
+        // -- Arrange --
+        fixture.observer.setTags(["tag1": "value1", "tag2": "value2"])
+
+        // Wait for the observer to complete
+        let expectation = XCTestExpectation(description: "setTags completes")
+        fixture.dispatchQueueWrapper.dispatchAsync {
+            // Dispatching a block on the same queue will be run after the context processor.
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1.0)
+
+        // Delete the previous tags file if it exists
+        fixture.scopePersistentStore.deleteAllPreviousState()
+        // Sanity-check for the pre-condition
+        let previousTags = fixture.scopePersistentStore.readPreviousTagsFromDisk()
+        XCTAssertNil(previousTags)
+
+        // -- Act --
+        SentrySDK.start(options: fixture.options)
+
+        // -- Assert --
+        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousTagsFromDisk())
+        XCTAssertEqual(result.count, 2)
+        XCTAssertEqual(result["tag1"], "value1")
+        XCTAssertEqual(result["tag2"], "value2")
+    }
+#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+    
+#if os(macOS)
+    func testCaptureCrashOnException() {
+        givenSdkWithHub()
+        
+        SentrySDKInternal.captureCrashOn(exception: fixture.exception)
+
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)
+        XCTAssertNotEqual(fixture.exception, client.captureExceptionWithScopeInvocations.first?.exception)
+        XCTAssertEqual(fixture.exception.name, client.captureExceptionWithScopeInvocations.first?.exception.name)
+        XCTAssertEqual(fixture.exception.reason, client.captureExceptionWithScopeInvocations.first?.exception.reason)
+        XCTAssertEqual(fixture.scope, client.captureExceptionWithScopeInvocations.first?.scope)
+    }
+#endif // os(macOS)
+}
+
+private extension SentrySDKInternalTests {
+    func givenSdkWithHub() {
+        SentrySDKInternal.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setStart(with: fixture.options)
+    }
+
+    func givenSdkWithHubButNoClient() {
+        SentrySDKInternal.setCurrentHub(SentryHub(client: nil, andScope: nil))
+        SentrySDKInternal.setStart(with: fixture.options)
+    }
+    
+    func assertIntegrationsInstalled(integrations: [String]) {
+        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
+        integrations.forEach { integration in
+            if let integrationClass = NSClassFromString(integration) {
+                XCTAssertTrue(SentrySDKInternal.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")
+            } else {
+                XCTFail("Integration \(integration) not installed.")
+            }
+        }
+    }
+
+    private func advanceTime(bySeconds: TimeInterval) {
+        fixture.currentDate.setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))
+    }
+}
+
+/// Tests in this class aren't part of SentrySDKTests because we need would need to undo a bunch of operations
+/// that are done in the setup.
+class SentrySDKWithSetupTests: XCTestCase {
+
+    func testAccessingHubAndOptions_NoDeadlock() {
+        let concurrentQueue = DispatchQueue(label: "concurrent", attributes: .concurrent)
+
+        let expectation = expectation(description: "no deadlock")
+        expectation.expectedFulfillmentCount = 20
+
+        SentrySDKInternal.setStart(with: Options())
+
+        for _ in 0..<10 {
+            concurrentQueue.async {
+                SentrySDKInternal.currentHub().capture(message: "mess")
+                SentrySDKInternal.setCurrentHub(nil)
+
+                expectation.fulfill()
+            }
+
+            concurrentQueue.async {
+                let hub = SentryHub(client: nil, andScope: nil)
+                XCTAssertNotNil(hub)
+
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5.0)
+    }
+}
+
+public class MainThreadTestIntegration: NSObject, SentryIntegrationProtocol {
+
+    static var expectation: XCTestExpectation?
+
+    public var installedInTheMainThread = false
+
+    public func install(with options: Options) -> Bool {
+        print("[Sentry] [TEST] [\(#file):\(#line) starting install.")
+        installedInTheMainThread = Thread.isMainThread
+        MainThreadTestIntegration.expectation?.fulfill()
+        MainThreadTestIntegration.expectation = nil
+        return true
+    }
+
+    public func uninstall() {
+    }
+}
+// swiftlint:enable file_length

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -2,11 +2,10 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
-// swiftlint:disable file_length
 class SentrySDKTests: XCTestCase {
-
+    
     private static let dsnAsString = TestConstants.dsnAsString(username: "SentrySDKTests")
-
+    
     private class Fixture {
     
         let options: Options = {
@@ -89,13 +88,13 @@ class SentrySDKTests: XCTestCase {
         super.setUp()
         fixture = Fixture()
     }
-
+    
     override func tearDown() {
         super.tearDown()
 
         givenSdkWithHubButNoClient()
 
-        if let autoSessionTracking = SentrySDK.currentHub().installedIntegrations().first(where: { it in
+        if let autoSessionTracking = SentrySDKInternal.currentHub().installedIntegrations().first(where: { it in
             it is SentryAutoSessionTrackingIntegration
         }) as? SentryAutoSessionTrackingIntegration {
             autoSessionTracking.stop()
@@ -113,10 +112,10 @@ class SentrySDKTests: XCTestCase {
         }
 
         SentrySDK.addBreadcrumb(Breadcrumb(level: SentryLevel.warning, category: "test"))
-        let breadcrumbs = Dynamic(SentrySDK.currentHub().scope).breadcrumbArray as [Breadcrumb]?
+        let breadcrumbs = Dynamic(SentrySDKInternal.currentHub().scope).breadcrumbArray as [Breadcrumb]?
         XCTAssertEqual(0, breadcrumbs?.count)
     }
-
+    
     func testStartWithConfigureOptions() {
         SentrySDK.start { options in
             options.dsn = SentrySDKTests.dsnAsString
@@ -125,7 +124,7 @@ class SentrySDKTests: XCTestCase {
             options.attachStacktrace = true
         }
 
-        let hub = SentrySDK.currentHub()
+        let hub = SentrySDKInternal.currentHub()
         XCTAssertNotNil(hub)
         XCTAssertNotNil(hub.installedIntegrations)
         XCTAssertNotNil(hub.getClient()?.options)
@@ -170,7 +169,7 @@ class SentrySDKTests: XCTestCase {
             options.removeAllIntegrations()
         }
 
-        let options = SentrySDK.currentHub().getClient()?.options
+        let options = SentrySDKInternal.currentHub().getClient()?.options
         XCTAssertNotNil(options, "Options should not be nil")
         XCTAssertNil(options?.parsedDsn)
         XCTAssertTrue(options?.enabled ?? false)
@@ -183,7 +182,7 @@ class SentrySDKTests: XCTestCase {
             options.removeAllIntegrations()
         }
 
-        let options = SentrySDK.currentHub().getClient()?.options
+        let options = SentrySDKInternal.currentHub().getClient()?.options
         XCTAssertNotNil(options, "Options should not be nil")
         XCTAssertTrue(options?.enabled ?? false)
         XCTAssertNil(options?.parsedDsn)
@@ -217,8 +216,8 @@ class SentrySDKTests: XCTestCase {
             }
             options.removeAllIntegrations()
         }
-        XCTAssertEqual("me", SentrySDK.currentHub().scope.userObject?.userId)
-        XCTAssertIdentical(scope, SentrySDK.currentHub().scope)
+        XCTAssertEqual("me", SentrySDKInternal.currentHub().scope.userObject?.userId)
+        XCTAssertIdentical(scope, SentrySDKInternal.currentHub().scope)
     }
 
     func testDontStartInsideXcodePreview() {
@@ -238,25 +237,25 @@ class SentrySDKTests: XCTestCase {
     func testDetectedStartUpCrash_DefaultValue() {
         XCTAssertFalse(SentrySDK.detectedStartUpCrash)
     }
+    
+    func testInstallIntegrations_NoIntegrations() {
+        SentrySDK.start { options in
+            options.removeAllIntegrations()
+        }
 
-    func testDetectedStartUpCrash() {
-        SentrySDK.setDetectedStartUpCrash(true)
-        XCTAssertEqual(SentrySDK.detectedStartUpCrash, true)
-
-        SentrySDK.setDetectedStartUpCrash(false)
-        XCTAssertFalse(SentrySDK.detectedStartUpCrash)
+        assertIntegrationsInstalled(integrations: [])
     }
 
-    func testCaptureFatalEvent() {
-        let hub = TestHub(client: nil, andScope: nil)
-        SentrySDK.setCurrentHub(hub)
+    func testGlobalOptions() {
+        SentrySDK.start(options: fixture.options)
+        XCTAssertEqual(SentrySDKInternal.options, fixture.options)
+    }
 
-        let event = fixture.event
-        SentrySDK.captureFatalEvent(event)
-    
-        XCTAssertEqual(1, hub.sentFatalEvents.count)
-        XCTAssertEqual(event.message, hub.sentFatalEvents.first?.message)
-        XCTAssertEqual(event.eventId, hub.sentFatalEvents.first?.eventId)
+    func testGlobalOptionsForPreview() {
+        startprocessInfoWrapperForPreview()
+
+        SentrySDK.start(options: fixture.options)
+        XCTAssertEqual(SentrySDKInternal.options, fixture.options)
     }
 
     func testCaptureEvent() {
@@ -373,1000 +372,66 @@ class SentrySDKTests: XCTestCase {
 
         assertHubScopeNotChanged()
     }
-
-    func testCaptureEnvelope() {
-        givenSdkWithHub()
-
-        let envelope = SentryEnvelope(event: TestData.event)
-        SentrySDK.capture(envelope)
-
-        XCTAssertEqual(1, fixture.client.captureEnvelopeInvocations.count)
-        XCTAssertEqual(envelope.header.eventId, fixture.client.captureEnvelopeInvocations.first?.header.eventId)
-    }
-
-    func testStoreEnvelope() {
-        givenSdkWithHub()
-
-        let envelope = SentryEnvelope(event: TestData.event)
-        SentrySDK.store(envelope)
-
-        XCTAssertEqual(1, fixture.client.storedEnvelopeInvocations.count)
-        XCTAssertEqual(envelope.header.eventId, fixture.client.storedEnvelopeInvocations.first?.header.eventId)
-    }
-
-    /// This is to prevent https://github.com/getsentry/sentry-cocoa/issues/4280
-    /// With 8.33.0, writing an envelope could fail in the middle of the process, which the envelope
-    /// payload below simulates. The JSON stems from writing an envelope to disk with vast data
-    /// that leads to an OOM termination on v 8.33.0.
-    /// Running this test on v 8.33.0 leads to a crash.
-    func testStartSDK_WithCorruptedEnvelope() throws {
-
-        let fileManager = try SentryFileManager(options: fixture.options)
-
-        let corruptedEnvelopeData = Data("""
-                       {"event_id":"1990b5bc31904b7395fd07feb72daf1c","sdk":{"name":"sentry.cocoa","version":"8.33.0"}}
-                       {"type":"test","length":50}
-                       """.utf8)
-
-        try corruptedEnvelopeData.write(to: URL(fileURLWithPath: "\(fileManager.envelopesPath)/corrupted-envelope.json"))
-
-        SentrySDK.start(options: fixture.options)
-
-        fileManager.deleteAllEnvelopes()
-    }
-
-    func testStoreEnvelope_WhenNoClient_NoCrash() {
-        SentrySDK.store(SentryEnvelope(event: TestData.event))
-
-        XCTAssertEqual(0, fixture.client.storedEnvelopeInvocations.count)
-    }
-
-    @available(*, deprecated, message: "-[SentrySDK captureUserFeedback:] is deprecated. -[SentrySDK captureFeedback:] is the new way. This test case can be removed in favor of testCaptureFeedback when -[SentrySDK captureUserFeedback:] is removed.")
-    func testCaptureUserFeedback() {
-        givenSdkWithHub()
-
-        SentrySDK.capture(userFeedback: fixture.userFeedback)
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureUserFeedbackInvocations.count)
-        if let actual = client.captureUserFeedbackInvocations.first {
-            let expected = fixture.userFeedback
-            XCTAssertEqual(expected.eventId, actual.eventId)
-            XCTAssertEqual(expected.name, actual.name)
-            XCTAssertEqual(expected.email, actual.email)
-            XCTAssertEqual(expected.comments, actual.comments)
-        }
-    }
-
-    func testCaptureFeedback() {
-        givenSdkWithHub()
-
-        SentrySDK.capture(feedback: fixture.feedback)
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureFeedbackInvocations.count)
-        if let actual = client.captureFeedbackInvocations.first {
-            let expected = fixture.feedback
-            XCTAssertEqual(expected.eventId, actual.0.eventId)
-            XCTAssertEqual(expected.name, actual.0.name)
-            XCTAssertEqual(expected.email, actual.0.email)
-            XCTAssertEqual(expected.message, actual.0.message)
-        }
-    }
-
-    func testSetUser_SetsUserToScopeOfHub() {
-        givenSdkWithHub()
-
-        let user = TestData.user
-        SentrySDK.setUser(user)
-
-        let actualScope = SentrySDK.currentHub().scope
-        let event = actualScope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
-        XCTAssertEqual(event?.user, user)
-    }
-
-    func testSetUserBeforeStartingSDK_LogsFatalMessage() throws {
-        // Arrange
-        let oldOutput = SentrySDKLog.getLogOutput()
-
-        defer {
-            SentrySDKLog.setOutput(oldOutput)
-        }
-
-        let logOutput = TestLogOutput()
-        SentrySDKLog.setLogOutput(logOutput)
-
-        // Act
-        SentrySDK.setUser(nil)
-    
-        // Assert
-        let actualLogMessage = try XCTUnwrap(logOutput.loggedMessages.first)
-        let expectedLogMessage = "The SDK is disabled, so setUser doesn't work. Please ensure to start the SDK before setting the user."
-
-        XCTAssertTrue(actualLogMessage.contains(expectedLogMessage), "Expected log message to contain '\(expectedLogMessage)', but got '\(actualLogMessage)'")
-    }
-
-    func testSetUserAFterStartingSDK_DoesNotLogFatalMessage() {
-        // Arrange
-        let oldOutput = SentrySDKLog.getLogOutput()
-
-        defer {
-            SentrySDKLog.setOutput(oldOutput)
-        }
-
-        let logOutput = TestLogOutput()
-        SentrySDKLog.setLogOutput(logOutput)
-
-        givenSdkWithHub()
-
-        let user = TestData.user
-
-        // Act
-        SentrySDK.setUser(user)
-
-        //Assert
-        XCTAssertEqual(0, logOutput.loggedMessages.count, "Expected no log messages, but got \(logOutput.loggedMessages.count)")
-    }
-
-    func testStartTransaction() throws {
-        givenSdkWithHub()
-
-        let operation = "ui.load"
-        let name = "Load Main Screen"
-        let transaction = SentrySDK.startTransaction(name: name, operation: operation)
-
-        XCTAssertEqual(operation, transaction.operation)
-        let tracer = try XCTUnwrap(transaction as? SentryTracer)
-        XCTAssertEqual(name, tracer.traceContext?.transaction)
-
-        XCTAssertNil(SentrySDK.span)
-    }
-
-    func testStartTransaction_WithBindToScope() throws {
-        givenSdkWithHub()
-
-        let transaction = SentrySDK.startTransaction(name: fixture.transactionName, operation: fixture.operation, bindToScope: true)
-
-        XCTAssertEqual(fixture.operation, transaction.operation)
-        let tracer = try XCTUnwrap(transaction as? SentryTracer)
-        XCTAssertEqual(fixture.transactionName, tracer.traceContext?.transaction)
-        XCTAssertEqual(.custom, tracer.transactionContext.nameSource)
-
-        let newSpan = SentrySDK.span
-
-        XCTAssert(transaction === newSpan)
-    }
-
-    func testInstallIntegrations() throws {
-        let options = Options()
-        options.dsn = "mine"
-        options.integrations = ["SentryTestIntegration", "SentryTestIntegration", "IDontExist"]
-
-        SentrySDK.start(options: options)
-
-        assertIntegrationsInstalled(integrations: ["SentryTestIntegration"])
-        let integration = SentrySDK.currentHub().installedIntegrations().first
-        if let testIntegration = integration as? SentryTestIntegration {
-            XCTAssertEqual(options.dsn, testIntegration.options.dsn)
-            XCTAssertEqual(options.integrations, testIntegration.options.integrations)
-        }
-    }
-
-    func testInstallIntegrations_NoIntegrations() {
-        SentrySDK.start { options in
-            options.removeAllIntegrations()
-        }
-
-        assertIntegrationsInstalled(integrations: [])
-    }
-
-    func testStartSession() {
-        givenSdkWithHub()
-
-        SentrySDK.startSession()
-
-        XCTAssertEqual(1, fixture.client.captureSessionInvocations.count)
-
-        let actual = fixture.client.captureSessionInvocations.first
-        let expected = SentrySession(releaseName: fixture.options.releaseName ?? "", distinctId: "some-id")
-
-        XCTAssertEqual(expected.flagInit, actual?.flagInit)
-        XCTAssertEqual(expected.errors, actual?.errors)
-        XCTAssertEqual(expected.sequence, actual?.sequence)
-        XCTAssertEqual(expected.releaseName, actual?.releaseName)
-        XCTAssertEqual(SentryDependencyContainer.sharedInstance().dateProvider.date(), actual?.started)
-        XCTAssertEqual(SentrySessionStatus.ok, actual?.status)
-        XCTAssertNil(actual?.timestamp)
-        XCTAssertNil(actual?.duration)
-    }
-
-    func testEndSession() throws {
-        givenSdkWithHub()
-
-        SentrySDK.startSession()
-        advanceTime(bySeconds: 1)
-        SentrySDK.endSession()
-
-        XCTAssertEqual(2, fixture.client.captureSessionInvocations.count)
-
-        let actual = try XCTUnwrap(fixture.client.captureSessionInvocations.invocations.last)
-
-        XCTAssertNil(actual.flagInit)
-        XCTAssertEqual(0, actual.errors)
-        XCTAssertEqual(2, actual.sequence)
-        XCTAssertEqual(SentrySessionStatus.exited, actual.status)
-        XCTAssertEqual(fixture.options.releaseName ?? "", actual.releaseName)
-        XCTAssertEqual(1, actual.duration)
-        XCTAssertEqual(SentryDependencyContainer.sharedInstance().dateProvider.date(), actual.timestamp)
-    }
-
-    func testGlobalOptions() {
-        SentrySDK.start(options: fixture.options)
-        XCTAssertEqual(SentrySDK.options, fixture.options)
-    }
-
-    func testGlobalOptionsForPreview() {
-        startprocessInfoWrapperForPreview()
-
-        SentrySDK.start(options: fixture.options)
-        XCTAssertEqual(SentrySDK.options, fixture.options)
-    }
-
-#if SENTRY_HAS_UIKIT
-    func testSetAppStartMeasurement_CallsPrivateSDKCallback() {
-        let appStartMeasurement = TestData.getAppStartMeasurement(type: .warm)
-
-        var callbackCalled = false
-        PrivateSentrySDKOnly.onAppStartMeasurementAvailable = { measurement in
-            XCTAssertEqual(appStartMeasurement, measurement)
-            callbackCalled = true
-        }
-
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
-        XCTAssertTrue(callbackCalled)
-    }
-
-    func testSetAppStartMeasurement_NoCallback_CallbackNotCalled() {
-        let appStartMeasurement = TestData.getAppStartMeasurement(type: .warm)
-
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
-
-        XCTAssertEqual(SentrySDK.getAppStartMeasurement(), appStartMeasurement)
-    }
-#endif // SENTRY_HAS_UIKIT
-
-    func testSDKStartInvocations() {
-        XCTAssertEqual(0, SentrySDK.startInvocations)
-
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        XCTAssertEqual(1, SentrySDK.startInvocations)
-    }
-
-    func testSDKStartTimestamp() {
-        let currentDateProvider = TestCurrentDateProvider()
-        SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
-
-        XCTAssertNil(SentrySDK.startTimestamp)
-
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        XCTAssertEqual(SentrySDK.startTimestamp, currentDateProvider.date())
-
-        SentrySDK.close()
-        XCTAssertNil(SentrySDK.startTimestamp)
-    }
-
-    func testIsEnabled() {
-        XCTAssertFalse(SentrySDK.isEnabled)
-
-        SentrySDK.capture(message: "message")
-        XCTAssertFalse(SentrySDK.isEnabled)
-
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-        XCTAssertTrue(SentrySDK.isEnabled)
-
-        SentrySDK.close()
-        XCTAssertFalse(SentrySDK.isEnabled)
-
-        SentrySDK.capture(message: "message")
-        XCTAssertFalse(SentrySDK.isEnabled)
-
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-        XCTAssertTrue(SentrySDK.isEnabled)
-    }
-
-    func testClose_ResetsDependencyContainer() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        let first = SentryDependencyContainer.sharedInstance()
-
-        SentrySDK.close()
-
-        let second = SentryDependencyContainer.sharedInstance()
-
-        XCTAssertNotEqual(first, second)
-    }
-
-    func testClose_ClearsIntegrations() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.swiftAsyncStacktraces = true
-            options.setIntegrations([SentrySwiftAsyncIntegration.self])
-        }
-
-        let hub = SentrySDK.currentHub()
-        XCTAssertEqual(1, hub.installedIntegrations().count)
-        SentrySDK.close()
-        XCTAssertEqual(0, hub.installedIntegrations().count)
-        assertIntegrationsInstalled(integrations: [])
-    }
-
-#if SENTRY_HAS_UIKIT
-    func testClose_StopsAppStateManager() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.tracesSampleRate = 1
-            options.removeAllIntegrations()
-        }
-
-        let appStateManager = SentryDependencyContainer.sharedInstance().appStateManager
-        XCTAssertEqual(appStateManager.startCount, 1)
-
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.tracesSampleRate = 1
-            options.removeAllIntegrations()
-        }
-
-        XCTAssertEqual(appStateManager.startCount, 2)
-
-        SentrySDK.close()
-
-        XCTAssertEqual(appStateManager.startCount, 0)
-
-        let stateAfterStop = fixture.fileManager.readAppState()
-        XCTAssertFalse(stateAfterStop!.isSDKRunning)
-    }
-#endif
-
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-    func testReportFullyDisplayed() {
-        fixture.options.enableTimeToFullDisplayTracing = true
-
-        let testTTDTracker = TestTimeToDisplayTracker(waitForFullDisplay: true)
-        let performanceTracker = Dynamic(SentryDependencyContainer.sharedInstance().uiViewControllerPerformanceTracker)
-        performanceTracker.currentTTDTracker = testTTDTracker
-
-        // Start SDK after setting up the tracker to ensure we're changing the tracker during it's initialization,
-        // because some initialization logic happens on a BG thread and we would end up in a race condition.
-        SentrySDK.start(options: fixture.options)
-
-        SentrySDK.reportFullyDisplayed()
-
-        XCTAssertTrue(testTTDTracker.registerFullDisplayCalled)
-    }
-#endif
-
-#if os(iOS)
-    func testSentryUIDeviceWrapperStarted() {
-        let deviceWrapper = TestSentryUIDeviceWrapper()
-        SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
-        SentrySDK.start(options: fixture.options)
-        XCTAssertTrue(deviceWrapper.started)
-    }
-
-    func testSentryUIDeviceWrapperStopped() {
-        let deviceWrapper = TestSentryUIDeviceWrapper()
-        SentryDependencyContainer.sharedInstance().uiDeviceWrapper = deviceWrapper
-        SentrySDK.start(options: fixture.options)
-        SentrySDK.close()
-        XCTAssertFalse(deviceWrapper.started)
-    }
-
-    /// Ensure to start the UIDeviceWrapper before initializing the hub, so enrich scope sets the correct OS version.
-    func testStartSDK_ScopeContextContainsOSVersion() throws {
-        let expectation = expectation(description: "MainThreadTestIntegration install called")
-        MainThreadTestIntegration.expectation = expectation
-
-        DispatchQueue.global(qos: .default).async {
-            SentrySDK.start { options in
-                options.integrations = [ NSStringFromClass(MainThreadTestIntegration.self) ]
-            }
-        }
-
-        wait(for: [expectation], timeout: 1.0)
-
-        let os = try XCTUnwrap (SentrySDK.currentHub().scope.contextDictionary["os"] as? [String: Any])
-#if !targetEnvironment(macCatalyst)
-        XCTAssertEqual(UIDevice.current.systemVersion, os["version"] as? String)
-#endif
-    }
-#endif
-
-    func testResumeAndPauseAppHangTracking() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.setIntegrations([SentryANRTrackingIntegration.self])
-        }
-
-        let client = fixture.client
-        SentrySDK.currentHub().bindClient(client)
-
-        let anrTrackingIntegration = SentrySDK.currentHub().getInstalledIntegration(SentryANRTrackingIntegration.self)
-
-        SentrySDK.pauseAppHangTracking()
-        Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
-        XCTAssertEqual(0, client.captureEventWithScopeInvocations.count)
-
-        SentrySDK.resumeAppHangTracking()
-        Dynamic(anrTrackingIntegration).anrDetectedWithType(SentryANRType.unknown)
-
-        if SentryDependencyContainer.sharedInstance().crashWrapper.isBeingTraced() {
-            XCTAssertEqual(0, client.captureEventWithScopeInvocations.count)
-        } else {
-            XCTAssertEqual(1, client.captureEventWithScopeInvocations.count)
-        }
-    }
-
-    func testResumeAndPauseAppHangTracking_ANRTrackingNotInstalled() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        let client = fixture.client
-        SentrySDK.currentHub().bindClient(client)
-
-        // Both invocations do nothing
-        SentrySDK.pauseAppHangTracking()
-        SentrySDK.resumeAppHangTracking()
-    }
-
-    func testClose_SetsClientToNil() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        SentrySDK.close()
-
-        XCTAssertNil(SentrySDK.currentHub().client())
-    }
-
-    func testClose_ClosesClient() {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        let client = SentrySDK.currentHub().client()
-        SentrySDK.close()
-
-        XCTAssertFalse(client?.isEnabled ?? true)
-    }
-
-    func testClose_CallsFlushCorrectlyOnTransport() throws {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        let transport = TestTransport()
-        let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
-        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
-        SentrySDK.currentHub().bindClient(client)
-        SentrySDK.close()
-
-        XCTAssertEqual(Options().shutdownTimeInterval, transport.flushInvocations.first)
-    }
-    
-    func testLogger_ReturnsSameInstanceOnMultipleCalls() {
-        givenSdkWithHub()
-        
-        let logger1 = SentrySDK.logger
-        let logger2 = SentrySDK.logger
-        
-        XCTAssertIdentical(logger1, logger2)
-    }
-
-    func testClose_ResetsLogger() {
-        givenSdkWithHub()
-        
-        // Get logger instance
-        let logger1 = SentrySDK.logger
-        XCTAssertNotNil(logger1)
-        
-        // Close SDK
-        SentrySDK.close()
-        
-        // Start SDK again
-        givenSdkWithHub()
-        
-        // Get logger instance again
-        let logger2 = SentrySDK.logger
-        XCTAssertNotNil(logger2)
-        
-        // Should be a different instance
-        XCTAssertNotIdentical(logger1, logger2)
-    }
-
-    func testLogger_WithLogsEnabled_CapturesLog() {
-        fixture.client.options.experimental.enableLogs = true
-        givenSdkWithHub()
-        
-        SentrySDK.logger.error(String(repeating: "S", count: 1_024 * 1_024))
-        
-        let expectation = self.expectation(description: "Wait for async add.")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.5)
-        
-        XCTAssertEqual(fixture.client.captureLogsDataInvocations.count, 1)
-    }
-
-    func testLogger_WithNoClient_DoesNotCaptureLog() {
-        fixture.client.options.experimental.enableLogs = true
-        let hubWithoutClient = SentryHub(client: nil, andScope: nil)
-        SentrySDK.setCurrentHub(hubWithoutClient)
-        
-        SentrySDK.logger.error(String(repeating: "S", count: 1_024 * 1_024))
-        
-        let expectation = self.expectation(description: "Wait for async add.")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: 0.5)
-        
-        XCTAssertEqual(fixture.client.captureLogsDataInvocations.count, 0)
-    }
-    
-    func testLogger_WithLogsDisabled_DoesNotCaptureLog() {
-        fixture.client.options.experimental.enableLogs = false
-        givenSdkWithHub()
-        
-        SentrySDK.logger.error("foo")
-        XCTAssertEqual(fixture.client.captureLogsDataInvocations.count, 0)
-    }
-    
-    func testFlush_CallsFlushCorrectlyOnTransport() throws {
-        SentrySDK.start { options in
-            options.dsn = SentrySDKTests.dsnAsString
-            options.removeAllIntegrations()
-        }
-
-        let transport = TestTransport()
-        let client = SentryClient(options: fixture.options, fileManager: try TestFileManager(options: fixture.options), deleteOldEnvelopeItems: false)
-        Dynamic(client).transportAdapter = TestTransportAdapter(transports: [transport], options: fixture.options)
-        SentrySDK.currentHub().bindClient(client)
-
-        let flushTimeout = 10.0
-        SentrySDK.flush(timeout: flushTimeout)
-
-        XCTAssertEqual(flushTimeout, transport.flushInvocations.first)
-    }
-
-    func testStartOnTheMainThread() throws {
-        let expectation = expectation(description: "MainThreadTestIntegration install called")
-        MainThreadTestIntegration.expectation = expectation
-
-        print("[Sentry] [TEST] [\(#file):\(#line) Dispatching to nonmain queue.")
-        DispatchQueue.global(qos: .background).async {
-            print("[Sentry] [TEST] [\(#file):\(#line) About to start SDK from nonmain queue.")
-            SentrySDK.start { options in
-                print("[Sentry] [TEST] [\(#file):\(#line) configuring options.")
-                options.integrations = [ NSStringFromClass(MainThreadTestIntegration.self) ]
-            }
-        }
-
-        wait(for: [expectation], timeout: 1.0)
-
-        let mainThreadIntegration = try XCTUnwrap(SentrySDK.currentHub().installedIntegrations().first as? MainThreadTestIntegration)
-        XCTAssert(mainThreadIntegration.installedInTheMainThread, "SDK is not being initialized in the main thread")
-
-    }
-
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-
-    func testSetAppStartMeasurementConcurrently() {
-        let runtimeInitSystemTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date()
-
-        func setAppStartMeasurement(_ queue: DispatchQueue, _ i: Int) {
-            group.enter()
-            queue.async {
-                let appStartTimestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(TimeInterval(i))
-                let appStartMeasurement = TestData.getAppStartMeasurement(
-                    type: .warm,
-                    appStartTimestamp: appStartTimestamp,
-                    runtimeInitSystemTimestamp: UInt64(runtimeInitSystemTimestamp.timeIntervalSince1970)
-                )
-                SentrySDK.setAppStartMeasurement(appStartMeasurement)
-                group.leave()
-            }
-        }
-
-        func createQueue() -> DispatchQueue {
-            return DispatchQueue(label: "SentrySDKTests", qos: .userInteractive, attributes: [.initiallyInactive])
-        }
-
-        let queue1 = createQueue()
-        let queue2 = createQueue()
-        let group = DispatchGroup()
-
-        let amount = 100
-
-        for i in 0...amount {
-            setAppStartMeasurement(queue1, i)
-            setAppStartMeasurement(queue2, i)
-        }
-
-        queue1.activate()
-        queue2.activate()
-        group.waitWithTimeout(timeout: 100)
-
-        let timestamp = SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(TimeInterval(amount))
-        XCTAssertEqual(timestamp, SentrySDK.getAppStartMeasurement()?.appStartTimestamp)
-    }
-
-    func testMovesBreadcrumbsToPreviousBreadcrumbs() throws {
-        let options = Options()
-        options.dsn = SentrySDKTests.dsnAsString
-
-        let fileManager = try TestFileManager(options: options)
-        let breadcrumbProcessor = SentryWatchdogTerminationBreadcrumbProcessor(maxBreadcrumbs: 10, fileManager: fileManager)
-        let dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
-        let scopePersistentStore = try XCTUnwrap(TestSentryScopePersistentStore(fileManager: fileManager))
-        let attributesProcessor = SentryWatchdogTerminationAttributesProcessor(
-            withDispatchQueueWrapper: dispatchQueueWrapper,
-            scopePersistentStore: scopePersistentStore
-        )
-        let observer = SentryWatchdogTerminationScopeObserver(breadcrumbProcessor: breadcrumbProcessor, attributesProcessor: attributesProcessor)
-        let serializedBreadcrumb = TestData.crumb.serialize()
-
-        for _ in 0..<3 {
-            observer.addSerializedBreadcrumb(serializedBreadcrumb)
-        }
-
-        SentrySDK.start(options: options)
-
-        let result = fileManager.readPreviousBreadcrumbs()
-        XCTAssertEqual(result.count, 3)
-    }
-
-    func testStartWithOptions_shouldMoveCurrentContextFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setContext([
-            "a": ["b": "c"]
-        ])
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setContext completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-
-        // Delete the previous context file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        // Sanity-check for the pre-condition
-        let previousContext = fixture.scopePersistentStore.readPreviousContextFromDisk()
-        XCTAssertNil(previousContext)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousContextFromDisk())
-        XCTAssertEqual(result.count, 1)
-        let value = try XCTUnwrap(result["a"] as? [String: String])
-        XCTAssertEqual(value["b"], "c")
-    }
-    
-    func testStartWithOptions_shouldMoveCurrentUserFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setUser(User(userId: "user1234"))
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setUser completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-
-        // Delete the previous context file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        // Sanity-check for the pre-condition
-        let previousUser = fixture.scopePersistentStore.readPreviousUserFromDisk()
-        XCTAssertNil(previousUser)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousUserFromDisk())
-        XCTAssertEqual(result.userId, "user1234")
-    }
-    
-    func testStartWithOptions_shouldMoveCurrentDistFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setDist("dist-string")
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setDist completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-        // Delete the previous context file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        // Sanity-check for the pre-condition
-        let previousUser = fixture.scopePersistentStore.readPreviousDistFromDisk()
-        XCTAssertNil(previousUser)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousDistFromDisk())
-        XCTAssertEqual(result, "dist-string")
-    }
-
-    func testStartWithOptions_shouldMoveCurrentEnvironmentFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setEnvironment("prod-string")
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setEnvironment completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-        // Delete the previous context file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        // Sanity-check for the pre-condition
-        let previousUser = fixture.scopePersistentStore.readPreviousEnvironmentFromDisk()
-        XCTAssertNil(previousUser)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousEnvironmentFromDisk())
-        XCTAssertEqual(result, "prod-string")
-    }
-
-    func testStartWithOptions_shouldMoveCurrentExtraFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setExtras(["extra1": "value1", "extra2": "value2"])
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setExtras completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-        // Delete the previous context file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        
-        // Sanity-check for the pre-condition
-        let previousExtras = fixture.scopePersistentStore.readPreviousExtrasFromDisk()
-        XCTAssertNil(previousExtras)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousExtrasFromDisk())
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result["extra1"] as? String, "value1")
-        XCTAssertEqual(result["extra2"] as? String, "value2")
-    }
-
-    func testStartWithOptions_shouldMoveCurrentFingerprintFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setFingerprint(["fingerprint1", "fingerprint2"])
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setFingerprint completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-
-        // Delete the previous fingerprint file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        // Sanity-check for the pre-condition
-        let previousFingerprint = fixture.scopePersistentStore.readPreviousFingerprintFromDisk()
-        XCTAssertNil(previousFingerprint)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousFingerprintFromDisk())
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result[0], "fingerprint1")
-        XCTAssertEqual(result[1], "fingerprint2")
-    }
-    
-    func testStartWithOptions_shouldMoveCurrentTagsFileToPreviousFile() throws {
-        // -- Arrange --
-        fixture.observer.setTags(["tag1": "value1", "tag2": "value2"])
-
-        // Wait for the observer to complete
-        let expectation = XCTestExpectation(description: "setTags completes")
-        fixture.dispatchQueueWrapper.dispatchAsync {
-            // Dispatching a block on the same queue will be run after the context processor.
-            expectation.fulfill()
-        }
-        wait(for: [expectation], timeout: 1.0)
-
-        // Delete the previous tags file if it exists
-        fixture.scopePersistentStore.deleteAllPreviousState()
-        // Sanity-check for the pre-condition
-        let previousTags = fixture.scopePersistentStore.readPreviousTagsFromDisk()
-        XCTAssertNil(previousTags)
-
-        // -- Act --
-        SentrySDK.start(options: fixture.options)
-
-        // -- Assert --
-        let result = try XCTUnwrap(fixture.scopePersistentStore.readPreviousTagsFromDisk())
-        XCTAssertEqual(result.count, 2)
-        XCTAssertEqual(result["tag1"], "value1")
-        XCTAssertEqual(result["tag2"], "value2")
-    }
-#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-    
-#if os(macOS)
-    func testCaptureCrashOnException() {
-        givenSdkWithHub()
-        
-        SentrySDK.captureCrashOn(exception: fixture.exception)
-
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)
-        XCTAssertNotEqual(fixture.exception, client.captureExceptionWithScopeInvocations.first?.exception)
-        XCTAssertEqual(fixture.exception.name, client.captureExceptionWithScopeInvocations.first?.exception.name)
-        XCTAssertEqual(fixture.exception.reason, client.captureExceptionWithScopeInvocations.first?.exception.reason)
-        XCTAssertEqual(fixture.scope, client.captureExceptionWithScopeInvocations.first?.scope)
-    }
-#endif // os(macOS)
 }
 
-private extension SentrySDKTests {
-    func givenSdkWithHub() {
-        SentrySDK.setCurrentHub(fixture.hub)
-        SentrySDK.setStart(fixture.options)
-    }
-
-    func givenSdkWithHubButNoClient() {
-        SentrySDK.setCurrentHub(SentryHub(client: nil, andScope: nil))
-        SentrySDK.setStart(fixture.options)
+extension SentrySDKTests {
+    private func assertEventCaptured(expectedScope: Scope) {
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureEventWithScopeInvocations.count)
+        XCTAssertEqual(fixture.event, client.captureEventWithScopeInvocations.first?.event)
+        XCTAssertEqual(expectedScope, client.captureEventWithScopeInvocations.first?.scope)
     }
     
-    func assertIntegrationsInstalled(integrations: [String]) {
-        XCTAssertEqual(integrations.count, SentrySDK.currentHub().installedIntegrations().count)
+    private func assertErrorCaptured(expectedScope: Scope) {
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureErrorWithScopeInvocations.count)
+        XCTAssertEqual(fixture.error.localizedDescription, client.captureErrorWithScopeInvocations.first?.error.localizedDescription)
+        XCTAssertEqual(expectedScope, client.captureErrorWithScopeInvocations.first?.scope)
+    }
+    
+    private func assertExceptionCaptured(expectedScope: Scope) {
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)
+        XCTAssertEqual(fixture.exception, client.captureExceptionWithScopeInvocations.first?.exception)
+        XCTAssertEqual(expectedScope, client.captureExceptionWithScopeInvocations.first?.scope)
+    }
+    
+    private func assertMessageCaptured(expectedScope: Scope) {
+        let client = fixture.client
+        XCTAssertEqual(1, client.captureMessageWithScopeInvocations.count)
+        XCTAssertEqual(fixture.message, client.captureMessageWithScopeInvocations.first?.message)
+        XCTAssertEqual(expectedScope, client.captureMessageWithScopeInvocations.first?.scope)
+    }
+    
+    private func assertHubScopeNotChanged() {
+        let hubScope = SentrySDKInternal.currentHub().scope
+        XCTAssertEqual(fixture.scope, hubScope)
+    }
+    
+    private func startprocessInfoWrapperForPreview() {
+        let testProcessInfoWrapper = TestSentryNSProcessInfoWrapper()
+        testProcessInfoWrapper.overrides.environment = ["XCODE_RUNNING_FOR_PREVIEWS": "1"]
+        SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
+    }
+    
+    private func assertIntegrationsInstalled(integrations: [String]) {
+        XCTAssertEqual(integrations.count, SentrySDKInternal.currentHub().installedIntegrations().count)
         integrations.forEach { integration in
             if let integrationClass = NSClassFromString(integration) {
-                XCTAssertTrue(SentrySDK.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")
+                XCTAssertTrue(SentrySDKInternal.currentHub().isIntegrationInstalled(integrationClass), "\(integration) not installed")
             } else {
                 XCTFail("Integration \(integration) not installed.")
             }
         }
     }
 
-    func assertEventCaptured(expectedScope: Scope) {
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureEventWithScopeInvocations.count)
-        XCTAssertEqual(fixture.event, client.captureEventWithScopeInvocations.first?.event)
-        XCTAssertEqual(expectedScope, client.captureEventWithScopeInvocations.first?.scope)
+    private func givenSdkWithHubButNoClient() {
+        SentrySDKInternal.setCurrentHub(SentryHub(client: nil, andScope: nil))
+        SentrySDKInternal.setStart(with: fixture.options)
     }
 
-    func assertErrorCaptured(expectedScope: Scope) {
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureErrorWithScopeInvocations.count)
-        XCTAssertEqual(fixture.error.localizedDescription, client.captureErrorWithScopeInvocations.first?.error.localizedDescription)
-        XCTAssertEqual(expectedScope, client.captureErrorWithScopeInvocations.first?.scope)
-    }
-
-    func assertExceptionCaptured(expectedScope: Scope) {
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureExceptionWithScopeInvocations.count)
-        XCTAssertEqual(fixture.exception, client.captureExceptionWithScopeInvocations.first?.exception)
-        XCTAssertEqual(expectedScope, client.captureExceptionWithScopeInvocations.first?.scope)
-    }
-
-    func assertMessageCaptured(expectedScope: Scope) {
-        let client = fixture.client
-        XCTAssertEqual(1, client.captureMessageWithScopeInvocations.count)
-        XCTAssertEqual(fixture.message, client.captureMessageWithScopeInvocations.first?.message)
-        XCTAssertEqual(expectedScope, client.captureMessageWithScopeInvocations.first?.scope)
-    }
-
-    func assertHubScopeNotChanged() {
-        let hubScope = SentrySDK.currentHub().scope
-        XCTAssertEqual(fixture.scope, hubScope)
-    }
-
-    func advanceTime(bySeconds: TimeInterval) {
-        fixture.currentDate.setDate(date: SentryDependencyContainer.sharedInstance().dateProvider.date().addingTimeInterval(bySeconds))
-    }
-
-    func startprocessInfoWrapperForPreview() {
-        let testProcessInfoWrapper = TestSentryNSProcessInfoWrapper()
-        testProcessInfoWrapper.overrides.environment = ["XCODE_RUNNING_FOR_PREVIEWS": "1"]
-        SentryDependencyContainer.sharedInstance().processInfoWrapper = testProcessInfoWrapper
+    private func givenSdkWithHub() {
+        SentrySDKInternal.setCurrentHub(fixture.hub)
+        SentrySDKInternal.setStart(with: fixture.options)
     }
 }
-
-/// Tests in this class aren't part of SentrySDKTests because we need would need to undo a bunch of operations
-/// that are done in the setup.
-class SentrySDKWithSetupTests: XCTestCase {
-
-    func testAccessingHubAndOptions_NoDeadlock() {
-        let concurrentQueue = DispatchQueue(label: "concurrent", attributes: .concurrent)
-
-        let expectation = expectation(description: "no deadlock")
-        expectation.expectedFulfillmentCount = 20
-
-        SentrySDK.setStart(Options())
-
-        for _ in 0..<10 {
-            concurrentQueue.async {
-                SentrySDK.currentHub().capture(message: "mess")
-                SentrySDK.setCurrentHub(nil)
-
-                expectation.fulfill()
-            }
-
-            concurrentQueue.async {
-                let hub = SentryHub(client: nil, andScope: nil)
-                XCTAssertNotNil(hub)
-
-                expectation.fulfill()
-            }
-        }
-
-        wait(for: [expectation], timeout: 5.0)
-    }
-}
-
-public class MainThreadTestIntegration: NSObject, SentryIntegrationProtocol {
-
-    static var expectation: XCTestExpectation?
-
-    public var installedInTheMainThread = false
-
-    public func install(with options: Options) -> Bool {
-        print("[Sentry] [TEST] [\(#file):\(#line) starting install.")
-        installedInTheMainThread = Thread.isMainThread
-        MainThreadTestIntegration.expectation?.fulfill()
-        MainThreadTestIntegration.expectation = nil
-        return true
-    }
-
-    public func uninstall() {
-    }
-}
-// swiftlint:enable file_length

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -175,7 +175,7 @@
 #import "SentryReachability.h"
 #import "SentryRetryAfterHeaderParser.h"
 #import "SentrySDK+Private.h"
-#import "SentrySDK+Tests.h"
+#import "SentrySDKInternal+Tests.h"
 #import "SentrySampleDecision+Private.h"
 #import "SentryScope+Private.h"
 #import "SentryScopeObserver.h"

--- a/Tests/SentryTests/SentryTests.m
+++ b/Tests/SentryTests/SentryTests.m
@@ -28,7 +28,7 @@
 
 - (void)setUp
 {
-    [SentrySDK.currentHub bindClient:nil];
+    [SentrySDKInternal.currentHub bindClient:nil];
 }
 
 - (void)testSharedClient
@@ -40,10 +40,10 @@
 
     SentryClient *client = [[SentryClient alloc] initWithOptions:options];
     XCTAssertNil(error);
-    XCTAssertNil([SentrySDK.currentHub getClient]);
-    [SentrySDK.currentHub bindClient:client];
-    XCTAssertNotNil([SentrySDK.currentHub getClient]);
-    [SentrySDK.currentHub bindClient:nil];
+    XCTAssertNil([SentrySDKInternal.currentHub getClient]);
+    [SentrySDKInternal.currentHub bindClient:client];
+    XCTAssertNotNil([SentrySDKInternal.currentHub getClient]);
+    [SentrySDKInternal.currentHub bindClient:nil];
 }
 
 - (void)testSDKDefaultHub
@@ -51,8 +51,8 @@
     [SentrySDK startWithConfigureOptions:^(SentryOptions *_Nonnull options) {
         options.dsn = @"https://username:password@app.getsentry.com/12345";
     }];
-    XCTAssertNotNil([SentrySDK.currentHub getClient]);
-    [SentrySDK.currentHub bindClient:nil];
+    XCTAssertNotNil([SentrySDKInternal.currentHub getClient]);
+    [SentrySDKInternal.currentHub bindClient:nil];
 }
 
 - (void)testSDKBreadCrumbAdd

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -69,7 +69,7 @@ class SentrySpanTests: XCTestCase {
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     func testSpanDoesNotIncludeTraceProfilerID() throws {
         fixture.options.profilesSampleRate = 1
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let span = fixture.getSut()
         let continuousProfileObservations = fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -85,7 +85,7 @@ class SentrySpanTests: XCTestCase {
     func testSpanDoesNotSubscribeToNotificationsIfAlreadyCapturedContinuousProfileID() {
         fixture.options.profilesSampleRate = nil
         SentryContinuousProfiler.start()
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let _ = fixture.getSut()
         let continuousProfileObservations = fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -95,7 +95,7 @@ class SentrySpanTests: XCTestCase {
     
     func testSpanDoesNotSubscribeToNotificationsIfContinuousProfilingDisabled() {
         fixture.options.profilesSampleRate = 1
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let _ = fixture.getSut()
         let continuousProfileObservations = fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -105,7 +105,7 @@ class SentrySpanTests: XCTestCase {
     
     func testSpanDoesSubscribeToNotificationsIfNotAlreadyCapturedContinuousProfileID() {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let _ = fixture.getSut()
         let continuousProfileObservations = fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -121,7 +121,7 @@ class SentrySpanTests: XCTestCase {
     /// ```
     func test_spanStart_profileStart_spanEnd_profileEnd_spanIncludesProfileID() throws {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let span = fixture.getSut()
         XCTAssertEqual(fixture.notificationCenter.addObserverWithObjectInvocations.invocations.filter {
             $0.name?.rawValue == kSentryNotificationContinuousProfileStarted
@@ -143,7 +143,7 @@ class SentrySpanTests: XCTestCase {
     /// ```
     func test_spanStart_profileStart_profileEnd_spanEnd_spanIncludesProfileID() throws {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let span = fixture.getSut()
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
@@ -163,7 +163,7 @@ class SentrySpanTests: XCTestCase {
     /// ```
     func test_profileStart_spanStart_profileEnd_spanEnd_spanIncludesProfileID() throws {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
@@ -183,7 +183,7 @@ class SentrySpanTests: XCTestCase {
     /// ```
     func test_profileStart_spanStart_spanEnd_profileEnd_spanIncludesProfileID() throws {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
         let span = fixture.getSut()
@@ -202,7 +202,7 @@ class SentrySpanTests: XCTestCase {
     /// ```
     func test_spanStart_profileStart_profileEnd_profileStart_profileEnd_spanEnd_spanIncludesSameProfileID() throws {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         let span = fixture.getSut()
         SentryContinuousProfiler.start()
         let profileId1 = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)
@@ -225,7 +225,7 @@ class SentrySpanTests: XCTestCase {
     /// ```
     func test_spanStart_spanEnd_profileStart_profileEnd_spanDoesNotIncludeProfileID() {
         fixture.options.profilesSampleRate = nil
-        SentrySDK.setStart(fixture.options)
+        SentrySDKInternal.setStart(with: fixture.options)
         SentryContinuousProfiler.start()
         SentryContinuousProfiler.stop()
         let span = fixture.getSut()

--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -464,7 +464,7 @@ class SentryTracerTests: XCTestCase {
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func testFinish_WaitForAllChildren_StartTimeModified_NoTransactionCaptured() {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         advanceTime(bySeconds: 1)
         
         let sut = fixture.getSut()
@@ -690,7 +690,7 @@ class SentryTracerTests: XCTestCase {
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
     func testAddColdAppStartMeasurement_PutOnNextAutoUITransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         whenFinishingAutoUITransaction(startTimestamp: 5)
 
@@ -752,7 +752,7 @@ class SentryTracerTests: XCTestCase {
 
     func testAddPreWarmedAppStartMeasurement_PutOnNextAutoUITransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold, preWarmed: true)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         whenFinishingAutoUITransaction(startTimestamp: 5)
 
@@ -764,7 +764,7 @@ class SentryTracerTests: XCTestCase {
 
     func testAddWarmAppStartMeasurement_PutOnNextAutoUITransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         advanceTime(bySeconds: -(fixture.appStartDuration + 4))
 
@@ -784,7 +784,7 @@ class SentryTracerTests: XCTestCase {
 
         let sut = fixture.getSut()
         advanceTime(bySeconds: 1)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         sut.finish()
         
         XCTAssertEqual(self.fixture.hub.capturedEventsWithScopes.count, 1)
@@ -794,7 +794,7 @@ class SentryTracerTests: XCTestCase {
     
     func testAddAppStartMeasurement_PutOnFirstFinishedAutoUITransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         advanceTime(bySeconds: 0.5)
 
@@ -827,7 +827,7 @@ class SentryTracerTests: XCTestCase {
     }
     
     func testAddUnknownAppStartMeasurement_NotPutOnNextTransaction() throws {
-        SentrySDK.setAppStartMeasurement(SentryAppStartMeasurement(
+        SentrySDKInternal.setAppStartMeasurement(SentryAppStartMeasurement(
             type: SentryAppStartType.unknown,
             isPreWarmed: false,
             appStartTimestamp: fixture.currentDateProvider.date(),
@@ -846,7 +846,7 @@ class SentryTracerTests: XCTestCase {
     
     func testPreWarmedColdAppStart_AddsStartTypeToContext() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold, preWarmed: true)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         whenFinishingAutoUITransaction(startTimestamp: 5)
 
@@ -855,7 +855,7 @@ class SentryTracerTests: XCTestCase {
 
     func testColdAppStart_AddsStartTypeToContext() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold, preWarmed: false)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         whenFinishingAutoUITransaction(startTimestamp: 5)
 
@@ -864,7 +864,7 @@ class SentryTracerTests: XCTestCase {
 
     func testPreWarmedWarmAppStart_AddsStartTypeToContext() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm, preWarmed: true)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         whenFinishingAutoUITransaction(startTimestamp: 5)
 
@@ -873,7 +873,7 @@ class SentryTracerTests: XCTestCase {
 
     func testPreWarmedWarmAppStart_DoesntAddStartTypeToContext() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .unknown, preWarmed: true)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         whenFinishingAutoUITransaction(startTimestamp: 5)
 
@@ -882,12 +882,12 @@ class SentryTracerTests: XCTestCase {
 
     func testAddWarmAppStartMeasurement_NotPutOnNonAutoUITransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         let sut = try XCTUnwrap(fixture.hub.startTransaction(transactionContext: TransactionContext(name: "custom", operation: "custom")) as? SentryTracer)
         sut.finish()
         
-        XCTAssertNotNil(SentrySDK.getAppStartMeasurement())
+        XCTAssertNotNil(SentrySDKInternal.getAppStartMeasurement())
         
         XCTAssertEqual(1, fixture.hub.capturedEventsWithScopes.count)
         let serializedTransaction = try XCTUnwrap(fixture.hub.capturedEventsWithScopes.first).event.serialize()
@@ -902,7 +902,7 @@ class SentryTracerTests: XCTestCase {
     
     func testAddWarmAppStartMeasurement_TooOldTransaction_NotPutOnTransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         advanceTime(bySeconds: fixture.appStartDuration + 5.01)
 
@@ -915,7 +915,7 @@ class SentryTracerTests: XCTestCase {
     
     func testAddWarmAppStartMeasurement_TooYoungTransaction_NotPutOnTransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         
         advanceTime(bySeconds: -(fixture.appStartDuration + 4.01))
 
@@ -928,7 +928,7 @@ class SentryTracerTests: XCTestCase {
     
     func testAppStartMeasurementHybridSDKModeEnabled_NotPutOnTransaction() throws {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .warm)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
         PrivateSentrySDKOnly.appStartMeasurementHybridSDKMode = true
         
         let sut = fixture.getSut()
@@ -939,7 +939,7 @@ class SentryTracerTests: XCTestCase {
     
     func testAppStartTransaction_AddsDebugMeta() {
         let appStartMeasurement = fixture.getAppStartMeasurement(type: .cold)
-        SentrySDK.setAppStartMeasurement(appStartMeasurement)
+        SentrySDKInternal.setAppStartMeasurement(appStartMeasurement)
 
         whenFinishingAutoUITransaction(startTimestamp: 5)
         
@@ -1177,7 +1177,7 @@ class SentryTracerTests: XCTestCase {
     #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
     func testConcurrentTransactions_OnlyOneGetsMeasurement() {
-        SentrySDK.setAppStartMeasurement(fixture.getAppStartMeasurement(type: .warm))
+        SentrySDKInternal.setAppStartMeasurement(fixture.getAppStartMeasurement(type: .warm))
         
         let queue = DispatchQueue(label: "", qos: .background, attributes: [.concurrent, .initiallyInactive] )
         let group = DispatchGroup()
@@ -1296,7 +1296,7 @@ class SentryTracerTests: XCTestCase {
         let expectedDelay = displayLink.slowestSlowFrameDuration + displayLink.fastestFrozenFrameDuration - expectedFrameDuration * 2 as NSNumber
         
         XCTAssertEqual(framesDelay.doubleValue, expectedDelay.doubleValue, accuracy: 0.0001)
-        XCTAssertNil(SentrySDK.getAppStartMeasurement())
+        XCTAssertNil(SentrySDKInternal.getAppStartMeasurement())
     }
     
     func testFramesDelay_WhenBeingZero() throws {

--- a/Tests/SentryTests/Transaction/SentryTransactionTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionTests.swift
@@ -210,7 +210,7 @@ class SentryTransactionTests: XCTestCase {
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
     func testTransactionWithContinuousProfile() throws {
         let options = Options()
-        SentrySDK.setStart(options)
+        SentrySDKInternal.setStart(with: options)
         let transaction = fixture.getTransaction()
         SentryContinuousProfiler.start()
         let profileId = try XCTUnwrap(SentryContinuousProfiler.profiler()?.profilerId.sentryIdString)


### PR DESCRIPTION
This renamed SentrySDK to SentrySDKInternal, and then creates a new copy of SentrySDK.h that isn't renamed. The implementation of this new SentrySDK is just a wrapper on SentrySDKInternal.

The reason for this change is to prepare to implement SentrySDK in Swift, which can be done with very little changes by having the swift version just call the ObjC version (SentrySDKInternal). I'll do this in another PR (draft here https://github.com/getsentry/sentry-cocoa/pull/5653) I just wanted the routine renaming in 100 files to be done separate from the actual language conversion so it can be more carefully reviewed.

This is done for supporting the SPM API

#skip-changelog