### PR TITLE
Fix v9 typo

### DIFF
--- a/Sources/Sentry/Public/SentryDsn.h
+++ b/Sources/Sentry/Public/SentryDsn.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)getHash;
 
-#if !SDK_v9
+#if !SDK_V9
 - (NSURL *)getStoreEndpoint DEPRECATED_MSG_ATTRIBUTE("This endpoint is no longer used");
 #endif // !SDK_V9
 - (NSURL *)getEnvelopeEndpoint;

--- a/Sources/Sentry/SentryDataCategoryMapper.m
+++ b/Sources/Sentry/SentryDataCategoryMapper.m
@@ -13,7 +13,7 @@ NSString *const kSentryDataCategoryNameTransaction = @"transaction";
 NSString *const kSentryDataCategoryNameAttachment = @"attachment";
 #if !SDK_V9
 NSString *const kSentryDataCategoryNameUserFeedback = @"user_report";
-#endif // !SSDK_v9
+#endif // !SDK_V9
 NSString *const kSentryDataCategoryNameProfile = @"profile";
 NSString *const kSentryDataCategoryNameProfileChunk = @"profile_chunk_ui";
 NSString *const kSentryDataCategoryNameReplay = @"replay";

--- a/Sources/Sentry/SentryDebugImageProvider.m
+++ b/Sources/Sentry/SentryDebugImageProvider.m
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
 #if !SDK_V9
         self.binaryImageProvider = binaryImageProvider;
-#endif // !SDK_v9
+#endif // !SDK_V9
         self.binaryImageCache = binaryImageCache;
     }
     return self;

--- a/Sources/Sentry/SentryDsn.m
+++ b/Sources/Sentry/SentryDsn.m
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
     return output;
 }
 
-#if !SDK_v9
+#if !SDK_V9
 - (NSURL *)getStoreEndpoint
 {
     if (nil == _storeEndpoint) {
@@ -51,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return _storeEndpoint;
 }
-#endif // !SDK_v9
+#endif // !SDK_V9
 
 - (NSURL *)getEnvelopeEndpoint
 {

--- a/sdk_api_V9.json
+++ b/sdk_api_V9.json
@@ -24165,32 +24165,6 @@
           },
           {
             "kind": "Function",
-            "name": "getStoreEndpoint",
-            "printedName": "getStoreEndpoint()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "URL",
-                "printedName": "Foundation.URL",
-                "usr": "s:10Foundation3URLV"
-              }
-            ],
-            "declKind": "Func",
-            "usr": "c:objc(cs)SentryDsn(im)getStoreEndpoint",
-            "moduleName": "Sentry",
-            "deprecated": true,
-            "isOpen": true,
-            "objc_name": "getStoreEndpoint",
-            "declAttributes": [
-              "DiscardableResult",
-              "Available",
-              "ObjC",
-              "Dynamic"
-            ],
-            "funcSelfKind": "NonMutating"
-          },
-          {
-            "kind": "Function",
             "name": "getEnvelopeEndpoint",
             "printedName": "getEnvelopeEndpoint()",
             "children": [


### PR DESCRIPTION
Fix typo in V9 check. At the time this code was added we didn't have the API stability check so this was missed, now that we have the check we can confirm the API is removed because the sdk_api_v9.json file updated

#skip-changelog