### PR TITLE
ci: add a timeout to app collect metrics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
     name: Collect app metrics
     runs-on: macos-15
     needs: assemble-xcframework-variant
+    timeout-minutes: 20
     steps:
       - name: Git checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds a timeout to the collect app metrics jobs