### PR TITLE
fix: mark feedback API as unavailable to app extensions

### DIFF
--- a/Sources/Sentry/Public/SentryFeedbackAPI.h
+++ b/Sources/Sentry/Public/SentryFeedbackAPI.h
@@ -12,6 +12,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+API_UNAVAILABLE(iOSApplicationExtension)
 @interface SentryFeedbackAPI : NSObject
 
 /**

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -812,7 +812,8 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
  * @note User feedback widget is only available for iOS 13 or later.
  */
 @property (nonatomic, copy, nullable)
-    SentryUserFeedbackConfigurationBlock configureUserFeedback API_AVAILABLE(ios(13.0));
+    SentryUserFeedbackConfigurationBlock configureUserFeedback API_AVAILABLE(ios(13.0))
+        API_UNAVAILABLE(iOSApplicationExtension);
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/Public/SentrySDK.h
+++ b/Sources/Sentry/Public/SentrySDK.h
@@ -281,7 +281,8 @@ SENTRY_NO_INIT
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
 
-@property (nonatomic, class, readonly) SentryFeedbackAPI *feedback;
+@property (nonatomic, class, readonly)
+    SentryFeedbackAPI *feedback API_UNAVAILABLE(iOSApplicationExtension);
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -78,8 +78,10 @@ NSString *const kSentryDefaultEnvironment = @"production";
         [SentrySwiftAsyncIntegration class], nil];
 
 #if TARGET_OS_IOS && SENTRY_HAS_UIKIT
-    if (@available(iOS 13.0, *)) {
-        [defaultIntegrations addObject:[SentryUserFeedbackIntegration class]];
+    if (@available(iOSApplicationExtension 13.0, *)) {
+        if (@available(iOS 13.0, *)) {
+            [defaultIntegrations addObject:NSClassFromString(@"SentryUserFeedbackIntegration")];
+        }
     }
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
 

--- a/Sources/Sentry/include/SentryUserFeedbackIntegration.h
+++ b/Sources/Sentry/include/SentryUserFeedbackIntegration.h
@@ -7,6 +7,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 API_AVAILABLE(ios(13.0))
+API_UNAVAILABLE(iOSApplicationExtension)
 @interface SentryUserFeedbackIntegration : SentryBaseIntegration
 - (void)showWidget;
 - (void)hideWidget;

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackIntegrationDriver.swift
@@ -13,6 +13,7 @@ import UIKit
  * - note: The default method to show the feedback form is via a floating widget placed in the bottom trailing corner of the screen. See the configuration classes for alternative options.
  */
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 @objcMembers
 @_spi(Private) public class SentryUserFeedbackIntegrationDriver: NSObject {
     let configuration: SentryUserFeedbackConfiguration
@@ -85,6 +86,7 @@ import UIKit
 
 // MARK: SentryUserFeedbackFormDelegate
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
     func finished(with feedback: SentryFeedback?) {
         if let feedback = feedback {
@@ -100,6 +102,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackFormDelegate {
 
 // MARK: SentryUserFeedbackWidgetDelegate
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate {
     func showForm() {
         showForm(screenshot: nil)
@@ -108,6 +111,7 @@ extension SentryUserFeedbackIntegrationDriver: SentryUserFeedbackWidgetDelegate 
 
 // MARK: UIAdaptivePresentationControllerDelegate
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerDelegate {
     public func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         widget?.rootVC.setWidget(visible: true, animated: configuration.animations)
@@ -118,6 +122,7 @@ extension SentryUserFeedbackIntegrationDriver: UIAdaptivePresentationControllerD
 
 // MARK: Private
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 private extension SentryUserFeedbackIntegrationDriver {
     func showForm(screenshot: UIImage?) {
         let form = SentryUserFeedbackFormController(config: configuration, delegate: self, screenshot: screenshot)

--- a/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryUserFeedbackWidget.swift
@@ -11,6 +11,7 @@ protocol SentryUserFeedbackWidgetDelegate: NSObjectProtocol {
 }
 
 @available(iOS 13.0, *)
+@available(iOSApplicationExtension, unavailable)
 final class SentryUserFeedbackWidget {
     private lazy var button = {
         let button = SentryUserFeedbackWidgetButtonView(config: config, target: self, selector: #selector(showForm))


### PR DESCRIPTION
For https://github.com/getsentry/sentry-cocoa/issues/5648, fix compilation in extensions where we use UIApplication API, which is unavailable in certain extension contexts.