### PR TITLE
ci: Fix codecov token for critical UI tests

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -48,6 +48,8 @@ jobs:
             xcode: "16.2"
         command:
           - fastlane_command: ui_critical_tests_ios_swiftui_envelope
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   run-swiftui-crash-test:
     name: Run SwiftUI Crash Test


### PR DESCRIPTION
`ui-tests-critical.yml` fails on main with
```
[Invalid workflow file: .github/workflows/ui-tests-critical.yml#L27](https://github.com/getsentry/sentry-cocoa/actions/runs/16459714871/workflow)
The workflow is not valid. .github/workflows/ui-tests-critical.yml (Line: 27, Col: 11): Secret CODECOV_TOKEN is required, but not provided while calling.
```

This is fixed now by passing the `CODECOV_TOKEN`.