### PR TITLE
fix: user feedback events should not be sampled or subject to `beforeSend`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@
 
 - Fix video replay crashes due to video writer inputs not marked as finished on cancellation (#5608)
 - Fix wrong flush timeout (#5565). When flush timed out before the SDK finished sending data, it always blocked the full flush timeout the next time being called. This is fixed now.
-
 - Launch profiling now respects original configured options if they change on the next launch (#5417)
+- User feedback no longer subject to sample rates or `beforeSend` (#5692)
 
 ## 8.53.2
 

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKOverrides.swift
@@ -1,3 +1,5 @@
+//swiftlint:disable file_length
+
 import Foundation
 
 public enum OverrideType {
@@ -39,6 +41,7 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case .feedback: return SentrySDKOverrides.Feedback.allCases
         case .performance: return SentrySDKOverrides.Performance.allCases
         case .sessionReplay: return SentrySDKOverrides.SessionReplay.allCases
+        case .events: return SentrySDKOverrides.Events.allCases
         case .other: return SentrySDKOverrides.Other.allCases
         case .tracing: return SentrySDKOverrides.Tracing.allCases
         case .profiling: return SentrySDKOverrides.Profiling.allCases
@@ -70,6 +73,12 @@ public enum SentrySDKOverrides: String, CaseIterable {
         case noShakeGesture             = "--io.sentry.feedback.no-shake-gesture"
     }
     case feedback = "Feedback"
+
+    public enum Events: String, SentrySDKOverride {
+        case sampleRate = "--io.sentry.events.sampleRate"
+        case rejectAll = "--io.sentry.events.reject-all"
+    }
+    case events = "Events"
 
     public enum Performance: String, SentrySDKOverride {
         case disableTimeToFullDisplayTracing    = "--io.sentry.performance.disable-time-to-full-display-tracing"
@@ -110,7 +119,6 @@ public enum SentrySDKOverrides: String, CaseIterable {
     public enum Other: String, SentrySDKOverride {
         case disableAttachScreenshot        = "--io.sentry.other.disable-attach-screenshot"
         case disableAttachViewHierarchy     = "--io.sentry.other.disable-attach-view-hierarchy"
-        case rejectAllEvents                = "--io.sentry.other.reject-all-events"
         case rejectAllSpans                 = "--io.sentry.other.reject-all-spans"
         case rejectScreenshots              = "--io.sentry.other.reject-screenshots-in-before-capture-screenshot"
         case rejectViewHierarchy            = "--io.sentry.other.reject-view-hierarchy-in-before-capture-view-hierarchy"
@@ -273,10 +281,20 @@ extension SentrySDKOverrides.Networking {
     }
 }
 
+extension SentrySDKOverrides.Events {
+    public var overrideType: OverrideType {
+        switch self {
+        case .rejectAll: return .boolean
+        case .sampleRate: return .float
+        }
+    }
+
+}
+
 extension SentrySDKOverrides.Other {
     public var overrideType: OverrideType {
         switch self {
-        case .disableAttachScreenshot, .disableAttachViewHierarchy, .rejectScreenshots, .rejectViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .rejectAllSpans, .rejectAllEvents, .base64AttachmentData, .disableHttpTransport: return .boolean
+        case .disableAttachScreenshot, .disableAttachViewHierarchy, .rejectScreenshots, .rejectViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .rejectAllSpans, .base64AttachmentData, .disableHttpTransport: return .boolean
         case .username, .userFullName, .userEmail, .userID, .environment: return .string
         }
     }
@@ -348,10 +366,14 @@ extension SentrySDKOverrides.Networking {
     public var ignoresDisableEverything: Bool { return false }
 }
 
+extension SentrySDKOverrides.Events {
+    public var ignoresDisableEverything: Bool { return false }
+}
+
 extension SentrySDKOverrides.Other {
     public var ignoresDisableEverything: Bool {
         switch self {
-        case .rejectScreenshots, .rejectViewHierarchy, .rejectAllSpans, .rejectAllEvents, .username, .userFullName, .userEmail, .userID, .environment, .base64AttachmentData: return true
+        case .rejectScreenshots, .rejectViewHierarchy, .rejectAllSpans, .username, .userFullName, .userEmail, .userID, .environment, .base64AttachmentData: return true
         case .disableAttachScreenshot, .disableAttachViewHierarchy, .disableMetricKit, .disableMetricKitRawPayloads, .disableBreadcrumbs, .disableSwizzling, .disableCrashHandling, .disableSpotlight, .disableFileManagerSwizzling, .disableHttpTransport: return false
         }
     }
@@ -390,3 +412,5 @@ extension SentrySDKOverrides.Special {
         }
     }
 }
+
+//swiftlint:enable file_length

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -33,8 +33,11 @@ public struct SentrySDKWrapper {
 
     func configureSentryOptions(options: Options) {
         options.dsn = dsn
+        if let sampleRate = SentrySDKOverrides.Events.sampleRate.floatValue {
+            options.sampleRate = NSNumber(value: sampleRate)
+        }
         options.beforeSend = {
-            guard !SentrySDKOverrides.Other.rejectAllEvents.boolValue else { return nil }
+            guard !SentrySDKOverrides.Events.rejectAll.boolValue else { return nil }
             return $0
         }
         options.beforeSendSpan = {
@@ -141,7 +144,9 @@ public struct SentrySDKWrapper {
             return breadcrumb
         }
 
-        options.initialScope = configureInitialScope(scope:)
+        options.initialScope = { scope in
+            configureInitialScope(scope: scope, options: options)
+        }
 
 #if !os(macOS) && !os(tvOS) && !os(watchOS) && !os(visionOS)
         if #available(iOS 13.0, *) {
@@ -154,7 +159,7 @@ public struct SentrySDKWrapper {
         options.experimental.enableUnhandledCPPExceptionsV2 = true
     }
 
-    func configureInitialScope(scope: Scope) -> Scope {
+    func configureInitialScope(scope: Scope, options: Options) -> Scope {
         if let environmentOverride = SentrySDKOverrides.Other.environment.stringValue {
             scope.setEnvironment(environmentOverride)
         } else if isBenchmarking {
@@ -186,6 +191,9 @@ public struct SentrySDKWrapper {
         }
         let data = Data("hello".utf8)
         scope.addAttachment(Attachment(data: data, filename: "log.txt"))
+
+        scope.setTag(value: options.sampleRate?.stringValue ?? "0", key: "sample-rate")
+
         return scope
     }
 

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -193,6 +193,7 @@ public struct SentrySDKWrapper {
         scope.addAttachment(Attachment(data: data, filename: "log.txt"))
 
         scope.setTag(value: options.sampleRate?.stringValue ?? "0", key: "sample-rate")
+        scope.setTag(value: SentrySDKOverrides.Events.rejectAll.boolValue ? "true" : "false", key: "beforeSend-reject-all")
 
         return scope
     }

--- a/Samples/Shared/feature-flags.yml
+++ b/Samples/Shared/feature-flags.yml
@@ -62,16 +62,23 @@ schemeTemplates:
         "--io.sentry.performance.disable-ui-tracing": false
         "--io.sentry.other.disable-filemanager-swizzling": false
 
+        # events
+        "--io.sentry.events.reject-all": false
+
         # other
         "--io.sentry.other.base64-attachment-data": false
         "--io.sentry.other.disable-http-transport": false
         "--io.sentry.other.disable-spotlight": false
         "--io.sentry.other.reject-screenshots-in-before-capture-screenshot": false
         "--io.sentry.other.reject-view-hierarchy-in-before-capture-view-hierarchy": false
-        "--io.sentry.other.reject-all-events": false
         "--io.sentry.other.reject-all-spans": false
 
       environmentVariables:
+        # events
+        - variable: "--io.sentry.events.sampleRate"
+          value:
+          isEnabled: false
+
         # session replay
         - variable: "--io.sentry.session-replay.sessionReplaySampleRate"
           value:

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -700,7 +700,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         = event.type == nil || ![event.type isEqualToString:SentryEnvelopeItemTypeFeedback];
 
     // Transactions and replays have their own sampleRate
-    if (eventIsNotATransaction && eventIsNotReplay && [self isSampled:self.options.sampleRate]) {
+    if (eventIsNotATransaction && eventIsNotReplay && eventIsNotUserFeedback &&
+        [self isSampled:self.options.sampleRate]) {
         SENTRY_LOG_DEBUG(@"Event got sampled, will not send the event");
         [self recordLostEvent:kSentryDataCategoryError reason:kSentryDiscardReasonSampleRate];
         return nil;
@@ -857,7 +858,7 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         }
     }
 
-    if (event != nil && nil != self.options.beforeSend) {
+    if (eventIsNotUserFeedback && event != nil && nil != self.options.beforeSend) {
         event = self.options.beforeSend(event);
         if (event == nil) {
             [self recordLost:eventIsNotATransaction reason:kSentryDiscardReasonBeforeSend];

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -226,11 +226,8 @@ class SentryFeedbackTests: XCTestCase {
         // Verify that the feedback was captured and sent despite the 0.0 sample rate
         let lastSentEventArguments = try XCTUnwrap(transportAdapter.sendEventWithTraceStateInvocations.last)
         let capturedFeedback = try XCTUnwrap(lastSentEventArguments.event)
-        print(capturedFeedback)
-//
-//        XCTAssertEqual(capturedFeedback.message, "Test feedback message")
-//        XCTAssertEqual(capturedFeedback.name, "Test User")
-//        XCTAssertEqual(capturedFeedback.email, "test@example.com")
+
+        XCTAssertEqual(capturedFeedback.type, SentryEnvelopeItemTypeFeedback)
     }
     
     func testFeedbackNotSubjectToBeforeSendFiltering() throws {
@@ -267,7 +264,8 @@ class SentryFeedbackTests: XCTestCase {
         // Verify that the feedback was captured and sent despite beforeSend returning nil
         let lastSentEventArguments = try XCTUnwrap(transportAdapter.sendEventWithTraceStateInvocations.last)
         let capturedFeedback = try XCTUnwrap(lastSentEventArguments.event)
-        print(capturedFeedback)
+
+        XCTAssertEqual(capturedFeedback.type, SentryEnvelopeItemTypeFeedback)
     }
     
     func testFeedbackWithSamplingAndBeforeSendFilteringCombined() throws {
@@ -312,7 +310,8 @@ class SentryFeedbackTests: XCTestCase {
         // Verify that the feedback was captured and sent despite both sampling and beforeSend filtering
         let lastSentEventArguments = try XCTUnwrap(transportAdapter.sendEventWithTraceStateInvocations.last)
         let capturedFeedback = try XCTUnwrap(lastSentEventArguments.event)
-        print(capturedFeedback)
+
+        XCTAssertEqual(capturedFeedback.type, SentryEnvelopeItemTypeFeedback)
     }
 }
 

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -190,6 +190,130 @@ class SentryFeedbackTests: XCTestCase {
 
         }
     }
+    
+    func testFeedbackNotSubjectToSampling() throws {
+        let options = Options()
+        options.dsn = TestConstants.dsnAsString(username: "SentryFeedbackTests")
+        options.sampleRate = 0.0 // Sample rate that would normally filter out all events
+
+        let transport = TestTransport()
+        let transportAdapter = TestTransportAdapter(transports: [transport], options: options)
+
+        let client = SentryClient(
+            options: options,
+            transportAdapter: transportAdapter,
+            fileManager: try XCTUnwrap(SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())),
+            deleteOldEnvelopeItems: false,
+            threadInspector: TestThreadInspector.instance,
+            debugImageProvider: TestDebugImageProvider(),
+            random: TestRandom(value: 1.0),
+            locale: Locale(identifier: "en_US"),
+            timezone: try XCTUnwrap(TimeZone(identifier: "Europe/Vienna"))
+        )
+        let hub = TestHub(client: client, andScope: nil)
+
+        SentrySDKInternal.setCurrentHub(hub)
+        
+        let feedback = SentryFeedback(
+            message: "Test feedback message",
+            name: "Test User",
+            email: "test@example.com",
+            source: .widget
+        )
+
+        SentrySDK.capture(feedback: feedback)
+        
+        // Verify that the feedback was captured and sent despite the 0.0 sample rate
+        let lastSentEventArguments = try XCTUnwrap(transportAdapter.sendEventWithTraceStateInvocations.last)
+        let capturedFeedback = try XCTUnwrap(lastSentEventArguments.event)
+        print(capturedFeedback)
+//
+//        XCTAssertEqual(capturedFeedback.message, "Test feedback message")
+//        XCTAssertEqual(capturedFeedback.name, "Test User")
+//        XCTAssertEqual(capturedFeedback.email, "test@example.com")
+    }
+    
+    func testFeedbackNotSubjectToBeforeSendFiltering() throws {
+        let options = Options()
+        options.dsn = TestConstants.dsnAsString(username: "SentryFeedbackTests")
+        options.beforeSend = { _ in return nil } // beforeSend that filters out all events
+
+        let transport = TestTransport()
+        let transportAdapter = TestTransportAdapter(transports: [transport], options: options)
+
+        let client = SentryClient(
+            options: options,
+            transportAdapter: transportAdapter,
+            fileManager: try XCTUnwrap(SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())),
+            deleteOldEnvelopeItems: false,
+            threadInspector: TestThreadInspector.instance,
+            debugImageProvider: TestDebugImageProvider(),
+            random: TestRandom(value: 1.0),
+            locale: Locale(identifier: "en_US"),
+            timezone: try XCTUnwrap(TimeZone(identifier: "Europe/Vienna"))
+        )
+        let hub = TestHub(client: client, andScope: nil)
+        SentrySDKInternal.setCurrentHub(hub)
+        
+        let feedback = SentryFeedback(
+            message: "Test feedback message",
+            name: "Test User", 
+            email: "test@example.com",
+            source: .widget
+        )
+
+        SentrySDK.capture(feedback: feedback)
+        
+        // Verify that the feedback was captured and sent despite beforeSend returning nil
+        let lastSentEventArguments = try XCTUnwrap(transportAdapter.sendEventWithTraceStateInvocations.last)
+        let capturedFeedback = try XCTUnwrap(lastSentEventArguments.event)
+        print(capturedFeedback)
+    }
+    
+    func testFeedbackWithSamplingAndBeforeSendFilteringCombined() throws {
+        let options = Options()
+        options.dsn = TestConstants.dsnAsString(username: "SentryFeedbackTests")
+        options.sampleRate = 0.5 // Partial sampling
+        options.beforeSend = { _ in return nil } // beforeSend that filters out all events
+
+        let transport = TestTransport()
+        let transportAdapter = TestTransportAdapter(transports: [transport], options: options)
+
+        let client = SentryClient(
+            options: options,
+            transportAdapter: transportAdapter,
+            fileManager: try XCTUnwrap(SentryFileManager(options: options, dispatchQueueWrapper: TestSentryDispatchQueueWrapper())),
+            deleteOldEnvelopeItems: false,
+            threadInspector: TestThreadInspector.instance,
+            debugImageProvider: TestDebugImageProvider(),
+            random: TestRandom(value: 1.0),
+            locale: Locale(identifier: "en_US"),
+            timezone: try XCTUnwrap(TimeZone(identifier: "Europe/Vienna"))
+        )
+        let hub = TestHub(client: client, andScope: nil)
+        SentrySDKInternal.setCurrentHub(hub)
+
+        struct UserInfo {
+            var email: String?
+        }
+        
+        let userInfo = UserInfo(email: nil)
+        let emailString = String(userInfo.email ?? "newanonymous@example.com")
+        
+        let feedback = SentryFeedback(
+            message: "messageString",
+            name: "nameString",
+            email: emailString,
+            source: .widget
+        )
+
+        SentrySDK.capture(feedback: feedback)
+        
+        // Verify that the feedback was captured and sent despite both sampling and beforeSend filtering
+        let lastSentEventArguments = try XCTUnwrap(transportAdapter.sendEventWithTraceStateInvocations.last)
+        let capturedFeedback = try XCTUnwrap(lastSentEventArguments.event)
+        print(capturedFeedback)
+    }
 }
 
 #endif // os(iOS) && !SENTRY_NO_UIKIT


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-cocoa/issues/5159#issuecomment-3070392706

Added unit tests that failed before the fix and passed afterwards. Also added a new SDK override for configuring the events sample rate (and reorganized that and the preexisting override to reject events in `beforeSend` under a new `Events` override enum), and set that as a tag on the scope, and verified that with both overrides configured to reproduce the setup, the user feedback was still received: https://sentry-sdks.sentry.io/issues/feedback/?feedbackSlug=sentry-cocoa%3A6765771740&mailbox=unresolved&project=5428557&referrer=feedback_list_page&statsPeriod=1h
<img width="3624" height="2274" alt="image" src="https://github.com/user-attachments/assets/292326e2-3064-4c36-9c3a-1147c09c1f34" />
