### PR TITLE
ci: SwiftUI Crash Test Increase Timeouts

### DIFF
--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -100,7 +100,9 @@ xcrun simctl spawn $DEVICE_ID defaults write $BUNDLE_ID $USER_DEFAULT_KEY -bool 
 log "Launching app with expected crash."
 xcrun simctl launch $DEVICE_ID $BUNDLE_ID
 
-# Check every 100ms for 5 seconds if the app is still running.
+log "Starting to check if app crashed as expected."
+
+# Check for 20 seconds if the app is still running.
 start_time=$(date +%s)
 while true; do
     if is_app_running; then
@@ -113,10 +115,11 @@ while true; do
     current_time=$(date +%s)
     elapsed=$((current_time - start_time))
     
-    if [ $elapsed -ge 5 ]; then
-        log "❌ App is still running after 5 seconds but it should have crashed instead."
+    if [ $elapsed -ge 20 ]; then
+        log "❌ App is still running after 20 seconds but it should have crashed instead."
         exit 1
     fi
+
 done
 
 take_simulator_screenshot "after-crash"
@@ -134,7 +137,9 @@ xcrun simctl launch $DEVICE_ID $BUNDLE_ID &
 
 take_simulator_screenshot "after-crash-check"
 
-# Check for 5 seconds if the app is running.
+log "Starting to check if app is running."
+
+# Check for 20 seconds if the app is still running.
 start_time=$(date +%s)
 while true; do
     if is_app_running; then
@@ -146,7 +151,7 @@ while true; do
     current_time=$(date +%s)
     elapsed=$((current_time - start_time))
     
-    if [ $elapsed -ge 5 ]; then
+    if [ $elapsed -ge 20 ]; then
         log "✅ Completed checking if app is still running."
         break
     fi


### PR DESCRIPTION
Increase the timeout to 20 seconds to check if the app has crashed and if it's still running. Also add more log messages.

Fixes GH-5705

#skip-changelog