### PR TITLE
ci: Fix flaky test timeout

### DIFF
--- a/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
+++ b/Tests/SentryTests/SentryViewHierarchyProviderTests.swift
@@ -196,7 +196,7 @@ class SentryViewHierarchyProviderTests: XCTestCase {
             let _ = sut.appViewHierarchyFromMainThread()
         }
 
-        wait(for: [ex], timeout: 1)
+        wait(for: [ex], timeout: 5)
     }
 
     func test_appViewHierarchy_usesMainThread() {
@@ -211,7 +211,7 @@ class SentryViewHierarchyProviderTests: XCTestCase {
             ex.fulfill()
         }
 
-        wait(for: [ex], timeout: 1)
+        wait(for: [ex], timeout: 5)
         XCTAssertTrue(fixture.uiApplication.calledOnMainThread, "appViewHierarchy is not using the main thread to get UI windows")
     }
 


### PR DESCRIPTION
This one just flaked on me here: https://github.com/getsentry/sentry-cocoa/actions/runs/16498789244/job/46651405693?pr=5710

#skip-changelog