### PR TITLE
ref: Update SentrySDK for duplicates tests

### DIFF
--- a/Tests/DuplicatedSDKTest/DuplicatedSDKTest/DuplicatedSDKTest-Bridging-Header.h
+++ b/Tests/DuplicatedSDKTest/DuplicatedSDKTest/DuplicatedSDKTest-Bridging-Header.h
@@ -1,7 +1,8 @@
 
 #import <Sentry/Sentry.h>
 
-@interface SentrySDK (DuplicatedSDKTest)
+// Added to run integration tests, do not attempt this in your app
+@interface SentrySDKInternal : NSObject
 
 + (SentryHub *)currentHub;
 

--- a/Tests/DuplicatedSDKTest/DuplicatedSDKTest/DuplicatedSDKTestApp.swift
+++ b/Tests/DuplicatedSDKTest/DuplicatedSDKTest/DuplicatedSDKTestApp.swift
@@ -35,7 +35,7 @@ struct ContentView: View {
     }
     
     func checkIntegrations() -> Bool {
-        guard let integrations = SentrySDK.currentHub().installedIntegrations else {
+        guard let integrations = SentrySDKInternal.currentHub().installedIntegrations else {
             return false
         }
         


### PR DESCRIPTION
Fixes duplicated test crashing

#skip-changelog