### PR TITLE
ci: separate slather step

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,6 +254,9 @@ jobs:
           path: |
             ~/Library/Logs/DiagnosticReports/**
 
+      - name: Gather code coverage information
+        run: slather coverage --configuration TestCI --scheme Sentry
+
       # We can upload all coverage reports, because codecov merges them.
       # See https://docs.codecov.io/docs/merging-reports
       # Checkout .codecov.yml to see the config of Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -254,7 +254,7 @@ jobs:
           path: |
             ~/Library/Logs/DiagnosticReports/**
 
-      - name: Gather code coverage information
+      - name: Gather code coverage information via slather
         run: slather coverage --configuration TestCI --scheme Sentry
 
       # We can upload all coverage reports, because codecov merges them.

--- a/scripts/sentry-xcodebuild.sh
+++ b/scripts/sentry-xcodebuild.sh
@@ -167,6 +167,5 @@ if [ $RUN_TEST_WITHOUT_BUILDING == true ]; then
         -destination "$DESTINATION" \
         test-without-building 2>&1 |
         tee raw-test-output.log |
-        xcbeautify --report junit &&
-        slather coverage --configuration "$CONFIGURATION" --scheme "$TEST_SCHEME"
+        xcbeautify --report junit
 fi


### PR DESCRIPTION
I noticed that sometimes unit test jobs still report failures even though no tests fail, with the script exiting nonzero. See https://github.com/getsentry/sentry-cocoa/actions/runs/16505144160/job/46673775222

I thought maybe this is actually an error coming from slather. Separate that into its own step so we can isolate potential failures.

#skip-changelog