### PR TITLE
test: Fix wrong launch arguments in `FeedbackUITests`

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI-UITests/FeedbackUITests.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI-UITests/FeedbackUITests.swift
@@ -1,11 +1,12 @@
+import SentrySampleShared
 import XCTest
 
 final class FeedbackUITests: XCTestCase {
     func testWidgetDisplayInSwiftUIApp() throws {
         let app = XCUIApplication()
         app.launchArguments.append(contentsOf: [
-            "--io.sentry.feedback.all-defaults",
-            "--io.sentry.disable-app-start-profiling"
+            SentrySDKOverrides.Feedback.allDefaults.rawValue,
+            SentrySDKOverrides.Profiling.disableAppStartProfiling.rawValue
         ])
         app.launch()
 


### PR DESCRIPTION
Fixes: #5573

`--io.sentry.disable-app-start-profiling` got renamed but the launch argument still used the old key

#skip-changelog