### PR TITLE
ref: Replace hardcoded launch arguments with enums to avoid typos or values changed

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -286,7 +286,7 @@ extension SentrySDKWrapper {
     }
 
     func configureFeedback(config: SentryUserFeedbackConfiguration) {
-        guard !args.contains("--io.sentry.feedback.all-defaults") else {
+        guard !args.contains(SentrySDKOverrides.Feedback.allDefaults.rawValue) else {
             config.configureWidget = { widget in
                 widget.layoutUIOffset = self.layoutOffset
             }

--- a/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/BaseUITest.swift
@@ -15,7 +15,7 @@ class BaseUITest: XCTestCase {
         XCUIDevice.shared.orientation = .portrait
         app.launchEnvironment["--io.sentry.scope.sdk-environment"] = "ui-tests"
         app.launchArguments.append(contentsOf: [
-            "--io.sentry.wipe-data"
+            SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue
         ])
         if automaticallyLaunchAndTerminateApp {
             launchApp()

--- a/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/ProfilingUITests.swift
@@ -171,7 +171,7 @@ extension ProfilingUITests {
         case .continuous:
             app.launchArguments.append(SentrySDKOverrides.Profiling.disableUIProfiling.rawValue)
         case .trace:
-            app.launchArguments.append("--io.sentry.disable-ui-profiling")
+            app.launchArguments.append(SentrySDKOverrides.Profiling.disableUIProfiling.rawValue)
             app.launchEnvironment[SentrySDKOverrides.Profiling.sampleRate.rawValue] = "1"
         }
         

--- a/Samples/iOS-Swift/iOS-Swift-UITests/UserFeedbackUITests.swift
+++ b/Samples/iOS-Swift/iOS-Swift-UITests/UserFeedbackUITests.swift
@@ -1,5 +1,6 @@
 //swiftlint:disable file_length
 
+import SentrySampleShared
 import XCTest
 
 class UserFeedbackUITests: BaseUITest {
@@ -15,14 +16,14 @@ class UserFeedbackUITests: BaseUITest {
         super.setUp()
         
         app.launchArguments.append(contentsOf: [
-            "--io.sentry.feedback.no-animations",
-            "--io.sentry.wipe-data",
+            SentrySDKOverrides.Feedback.noAnimations.rawValue,
+            SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue,
             
             // since the goal of these tests is only to exercise the UI of the widget and form, disable other SDK features to avoid any confounding factors that might fail or crash a test case
-            "--io.sentry.disable-everything",
+            SentrySDKOverrides.Special.disableEverything.rawValue,
             
             // write base64-encoded data into the envelope file for attachments instead of raw bytes, specifically for images. this way the entire envelope contents can be more easily passed as a string through the text field in the app to this process for validation.
-            "--io.sentry.other.base64-attachment-data"
+            SentrySDKOverrides.Other.base64AttachmentData.rawValue
         ])
         continueAfterFailure = true
     }
@@ -32,7 +33,7 @@ extension UserFeedbackUITests {
     // MARK: Tests ensuring correct appearance
     
     func testUIElementsWithDefaults() {
-        launchApp(args: ["--io.sentry.feedback.all-defaults"])
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue])
         // widget button text
         XCTAssert(app.otherElements["Report a Bug"].exists)
         
@@ -88,10 +89,10 @@ extension UserFeedbackUITests {
     
     func testPrefilledUserInformation() throws {
         launchApp(args: [
-            "--io.sentry.feedback.all-defaults"
+            SentrySDKOverrides.Feedback.allDefaults.rawValue
         ], env: [
-            "--io.sentry.scope.user.name": "ui test user",
-            "--io.sentry.scope.user.email": "ui-testing@sentry.io"
+            SentrySDKOverrides.Other.userFullName.rawValue: "ui test user",
+            SentrySDKOverrides.Other.userEmail.rawValue: "ui-testing@sentry.io"
         ])
         
         widgetButton.tap()
@@ -101,10 +102,10 @@ extension UserFeedbackUITests {
     
     func testNoPrefilledUserInformation() throws {
         launchApp(args: [
-            "--io.sentry.feedback.dont-use-sentry-user"
+            SentrySDKOverrides.Feedback.noUserInjection.rawValue
         ], env: [
-            "--io.sentry.scope.user.name": "ui test user",
-            "--io.sentry.scope.user.email": "ui-testing@sentry.io"
+            SentrySDKOverrides.Other.userFullName.rawValue: "ui test user",
+            SentrySDKOverrides.Other.userEmail.rawValue: "ui-testing@sentry.io"
         ])
         
         widgetButton.tap()
@@ -117,7 +118,9 @@ extension UserFeedbackUITests {
     // MARK: Tests validating happy path / successful submission
 
     func testSubmitFullyFilledCustomForm() throws {
-        launchApp(args: ["--io.sentry.feedback.dont-use-sentry-user"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.noUserInjection.rawValue
+        ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
         try assertHookMarkersNotExist()
@@ -155,9 +158,9 @@ extension UserFeedbackUITests {
         let testName = "Andrew"
         let testContactEmail = "andrew.mcknight@sentry.io"
         
-        launchApp(args: ["--io.sentry.feedback.all-defaults"], env: [
-            "--io.sentry.scope.user.name": testName,
-            "--io.sentry.scope.user.email": testContactEmail
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
+            SentrySDKOverrides.Other.userFullName.rawValue: testName,
+            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -202,8 +205,8 @@ extension UserFeedbackUITests {
 
     func testSubmitCustomButton() throws {
         launchApp(args: [
-            "--io.sentry.feedback.use-custom-feedback-button",
-            "--io.sentry.feedback.dont-use-sentry-user"
+            SentrySDKOverrides.Feedback.useCustomFeedbackButton.rawValue,
+            SentrySDKOverrides.Feedback.noUserInjection.rawValue
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -243,9 +246,9 @@ extension UserFeedbackUITests {
         let testName = "Andrew"
         let testContactEmail = "andrew.mcknight@sentry.io"
         
-        launchApp(args: ["--io.sentry.feedback.all-defaults"], env: [
-            "--io.sentry.scope.user.name": testName,
-            "--io.sentry.scope.user.email": testContactEmail
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
+            SentrySDKOverrides.Other.userFullName.rawValue: testName,
+            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -272,9 +275,9 @@ extension UserFeedbackUITests {
         let testName = "Andrew"
         let testContactEmail = "andrew.mcknight@sentry.io"
         
-        launchApp(args: ["--io.sentry.feedback.all-defaults"], env: [
-            "--io.sentry.scope.user.name": testName,
-            "--io.sentry.scope.user.email": testContactEmail
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
+            SentrySDKOverrides.Other.userFullName.rawValue: testName,
+            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -309,9 +312,9 @@ extension UserFeedbackUITests {
         let testName = "Andrew"
         let testContactEmail = "andrew.mcknight@sentry.io"
         
-        launchApp(args: ["--io.sentry.feedback.all-defaults"], env: [
-            "--io.sentry.scope.user.name": testName,
-            "--io.sentry.scope.user.email": testContactEmail
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
+            SentrySDKOverrides.Other.userFullName.rawValue: testName,
+            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -341,7 +344,9 @@ extension UserFeedbackUITests {
     // MARK: Tests validating screenshot functionality
     
     func testAddingScreenshots() throws {
-        launchApp(args: ["--io.sentry.feedback.inject-screenshot"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.injectScreenshot.rawValue
+        ])
         XCTAssert(removeScreenshotButton.isHittable)
         
         let testMessage = "UITest user feedback"
@@ -353,7 +358,9 @@ extension UserFeedbackUITests {
     }
     
     func testAddingAndRemovingScreenshots() throws {
-        launchApp(args: ["--io.sentry.feedback.inject-screenshot"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.injectScreenshot.rawValue
+        ])
         XCTAssert(removeScreenshotButton.isHittable)
         removeScreenshotButton.tap()
         XCTAssertFalse(removeScreenshotButton.isHittable)
@@ -369,7 +376,7 @@ extension UserFeedbackUITests {
     // MARK: Tests validating error cases
     
     func testSubmitWithNoFieldsFilledDefault() throws {
-        launchApp(args: ["--io.sentry.feedback.all-defaults"])
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
         try assertHookMarkersNotExist()
@@ -389,7 +396,10 @@ extension UserFeedbackUITests {
     }
     
     func testSubmitWithNoFieldsFilledEmailAndMessageRequired() throws {
-        launchApp(args: ["--io.sentry.feedback.require-email", "--io.sentry.feedback.dont-use-sentry-user"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.requireEmail.rawValue,
+            SentrySDKOverrides.Feedback.noUserInjection.rawValue
+        ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
         try assertHookMarkersNotExist()
@@ -414,9 +424,9 @@ extension UserFeedbackUITests {
     
     func testSubmitWithNoFieldsFilledAllRequired() throws {
         launchApp(args: [
-            "--io.sentry.feedback.require-email",
-            "--io.sentry.feedback.require-name",
-            "--io.sentry.feedback.dont-use-sentry-user"
+            SentrySDKOverrides.Feedback.requireEmail.rawValue,
+            SentrySDKOverrides.Feedback.requireName.rawValue,
+            SentrySDKOverrides.Feedback.noUserInjection.rawValue
         ])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -440,7 +450,7 @@ extension UserFeedbackUITests {
     }
     
     func testSubmitOnlyWithOptionalFieldsFilled() throws {
-        launchApp(args: ["--io.sentry.feedback.all-defaults"])
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue])
 
         try retrieveAppUnderTestApplicationSupportDirectory()
         try assertHookMarkersNotExist()
@@ -462,9 +472,9 @@ extension UserFeedbackUITests {
         let testName = "Andrew"
         let testContactEmail = "andrew.mcknight@sentry.io"
         
-        launchApp(args: ["--io.sentry.feedback.all-defaults"], env: [
-            "--io.sentry.scope.user.name": testName,
-            "--io.sentry.scope.user.email": testContactEmail
+        launchApp(args: [SentrySDKOverrides.Feedback.allDefaults.rawValue], env: [
+            SentrySDKOverrides.Other.userFullName.rawValue: testName,
+            SentrySDKOverrides.Other.userEmail.rawValue: testContactEmail
         ])
         
         try retrieveAppUnderTestApplicationSupportDirectory()
@@ -492,7 +502,9 @@ extension UserFeedbackUITests {
     // MARK: Alternative widget control
 
     func testFormShowsAndDismissesProperlyWithCustomButton() {
-        launchApp(args: ["--io.sentry.feedback.use-custom-feedback-button"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.useCustomFeedbackButton.rawValue
+        ])
 
         customButton.tap()
         cancelButton.tap()
@@ -502,7 +514,9 @@ extension UserFeedbackUITests {
     }
 
     func testNoAutomaticallyInjectedWidgetWithCustomButton() {
-        launchApp(args: ["--io.sentry.feedback.use-custom-feedback-button"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.useCustomFeedbackButton.rawValue
+        ])
 
         XCTAssertFalse(widgetButton.isHittable)
         XCTAssert(customButton.isHittable)
@@ -516,7 +530,9 @@ extension UserFeedbackUITests {
     }
 
     func testManuallyDisplayingWidget() {
-        launchApp(args: ["--io.sentry.feedback.no-auto-inject-widget"])
+        launchApp(args: [
+            SentrySDKOverrides.Feedback.disableAutoInject.rawValue
+        ])
         XCTAssertFalse(widgetButton.isHittable)
         extrasAreaTabBarButton.tap()
         app.buttons["io.sentry.ui-test.button.show-widget"].tap()

--- a/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
+++ b/Samples/iOS-Swift/iOS-Swift/AppDelegate.swift
@@ -18,7 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         print("[iOS-Swift] [debug] launch arguments: \(args)")
         print("[iOS-Swift] [debug] launch environment: \(env)")
 
-        if args.contains("--io.sentry.wipe-data") {
+        if args.contains(SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue) {
             removeAppData()
         }
 

--- a/Samples/macOS-Swift/macOS-Swift-UITests/MacOSSwiftUITests.swift
+++ b/Samples/macOS-Swift/macOS-Swift-UITests/MacOSSwiftUITests.swift
@@ -26,14 +26,14 @@ private extension MacOSSwiftUITests {
         let app = XCUIApplication(bundleIdentifier: appBundleID)
 
         if wipeData {
-            app.launchArguments.append("--io.sentry.wipe-data")
+            app.launchArguments.append(SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue)
         }
 
         try launchAndConfigureSubsequentLaunches(app: app, shouldProfileThisLaunch: false, shouldProfileNextLaunch: shouldProfileLaunches, shouldBeSandboxed: isSandboxed)
         app.terminate()
 
         if wipeData {
-            app.launchArguments.removeAll { $0 == "--io.sentry.wipe-data" }
+            app.launchArguments.removeAll { $0 == SentrySDKOverrides.Special.wipeDataOnLaunch.rawValue }
         }
 
         // second launch to profile a launch if configured


### PR DESCRIPTION
I don't expect any flakiness being fixed with this change but will ensure we don't use strings.

#skip-changelog