### PR TITLE
refactor: Add full nullability handling to SentryFileManager

### DIFF
--- a/SentryTestUtils/SentryFileManager+Test.h
+++ b/SentryTestUtils/SentryFileManager+Test.h
@@ -8,7 +8,7 @@ NSString *_Nullable sentryGetScopedCachesDirectory(NSString *cachesDirectory);
 NSString *_Nullable sentryBuildScopedCachesDirectoryPath(NSString *cachesDirectory,
     BOOL isSandboxed, NSString *_Nullable bundleIdentifier, NSString *_Nullable lastPathComponent);
 
-SENTRY_EXTERN NSURL *launchProfileConfigFileURL(void);
+SENTRY_EXTERN NSURL *_Nullable launchProfileConfigFileURL(void);
 SENTRY_EXTERN NSURL *_Nullable sentryLaunchConfigFileURL;
 
 @interface SentryFileManager ()

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -203,3 +203,20 @@ typedef void (^SentryUserFeedbackConfigurationBlock)(
     SentryUserFeedbackConfiguration *_Nonnull configuration);
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
+
+/**
+ * `SENTRY_UNWRAP_NULLABLE` is used to unwrap a nullable pointer type to a non-nullable pointer type
+ *  It should be used after the pointer has been checked for nullability.
+ *
+ *  For example:
+ *  ```objc
+ *  id _Nullable nullablePointer = ...;
+ *  if (nullablePointer != nil) {
+ *      MyClass *_Nonnull nonNullPointer = SENTRY_UNWRAP_NULLABLE(MyClass, nullablePointer);
+ *  }
+ *  ```
+ *
+ *  We use this macro instead of directly casting to be able to find all usages of this
+ *  pattern in the codebase.
+ */
+#define SENTRY_UNWRAP_NULLABLE(type, nullable_var) (type *_Nonnull)(nullable_var)

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -161,9 +161,15 @@ _non_thread_safe_removeFileAtPath(NSString *path)
 
     NSString *_Nullable nullableDsnHash = [options.parsedDsn getHash];
     if (nullableDsnHash == nil) {
-        SENTRY_LOG_DEBUG(@"No DSN provided, using base path for envelopes: %@", self.basePath);
+        SENTRY_LOG_FATAL(@"No DSN provided, using base path for envelopes: %@", self.basePath);
     }
-    self.sentryPath = [self.basePath stringByAppendingPathComponent:nullableDsnHash ?: @"default"];
+    // We decided against changing the `sentryPath` and use a null fallback instead, because the
+    // impact of changing the base path can result in critical issues.
+    //
+    // Instead we silence the nullability warning and let `stringByAppendingPathComponent` handle
+    // the null case.
+    self.sentryPath = [self.basePath
+        stringByAppendingPathComponent:SENTRY_UNWRAP_NULLABLE(NSString, nullableDsnHash)];
 
     self.currentSessionFilePath =
         [self.sentryPath stringByAppendingPathComponent:@"session.current"];

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -163,11 +163,14 @@ _non_thread_safe_removeFileAtPath(NSString *path)
     if (nullableDsnHash == nil) {
         SENTRY_LOG_FATAL(@"No DSN provided, using base path for envelopes: %@", self.basePath);
     }
-    // We decided against changing the `sentryPath` and use a null fallback instead, because the
-    // impact of changing the base path can result in critical issues.
+    // We decided against changing the `sentryPath` and use a null fallback instead, because this
+    // has been broken for a long time and the impact of changing the base path can result in
+    // critical issues.
     //
     // Instead we silence the nullability warning and let `stringByAppendingPathComponent` handle
     // the null case.
+    //
+    // Full discussion in https://github.com/getsentry/sentry-cocoa/pull/5737
     self.sentryPath = [self.basePath
         stringByAppendingPathComponent:SENTRY_UNWRAP_NULLABLE(NSString, nullableDsnHash)];
 

--- a/Sources/Sentry/SentryNSDataUtils.m
+++ b/Sources/Sentry/SentryNSDataUtils.m
@@ -63,7 +63,7 @@ NSData *_Nullable sentry_nullTerminated(NSData *_Nullable data)
     if (data == nil) {
         return nil;
     }
-    NSMutableData *mutable = [NSMutableData dataWithData:(NSData *_Nonnull)data];
+    NSMutableData *mutable = [NSMutableData dataWithData:SENTRY_UNWRAP_NULLABLE(NSData, data)];
     [mutable appendBytes:"\0" length:1];
     return mutable;
 }

--- a/Sources/Sentry/SentryNSDataUtils.m
+++ b/Sources/Sentry/SentryNSDataUtils.m
@@ -63,7 +63,7 @@ NSData *_Nullable sentry_nullTerminated(NSData *_Nullable data)
     if (data == nil) {
         return nil;
     }
-    NSMutableData *mutable = [NSMutableData dataWithData:data];
+    NSMutableData *mutable = [NSMutableData dataWithData:(NSData *_Nonnull)data];
     [mutable appendBytes:"\0" length:1];
     return mutable;
 }

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
@@ -33,7 +33,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -65,7 +65,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -101,7 +101,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -133,7 +133,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -171,7 +171,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -208,7 +208,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -247,7 +247,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -282,7 +282,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -320,7 +320,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -356,7 +356,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -399,7 +399,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -431,7 +431,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -467,7 +467,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -504,7 +504,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -538,7 +538,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -577,7 +577,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -623,7 +623,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -660,7 +660,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -702,7 +702,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -743,7 +743,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -784,7 +784,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -822,7 +822,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -865,7 +865,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -907,7 +907,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: false
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -949,7 +949,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration (continuous V1)
@@ -998,7 +998,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1052,7 +1052,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1102,7 +1102,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1147,7 +1147,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1181,7 +1181,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1220,7 +1220,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1258,7 +1258,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyContinuousProfiling: true,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1296,7 +1296,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1333,7 +1333,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1375,7 +1375,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1416,7 +1416,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1456,7 +1456,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1500,7 +1500,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1549,7 +1549,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration
@@ -1597,7 +1597,7 @@ extension SentryAppStartProfilingConfigurationChangeTests {
             kSentryLaunchProfileConfigKeyTracesSampleRand: 0.5,
             kSentryLaunchProfileConfigKeyWaitForFullDisplay: true
         ]
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         // new options simulating current launch configuration

--- a/Tests/SentryProfilerTests/SentryApplaunchProfilingMalformedConfigFileTests.swift
+++ b/Tests/SentryProfilerTests/SentryApplaunchProfilingMalformedConfigFileTests.swift
@@ -15,7 +15,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
 
     func testMalformedConfigFile_CorruptedPlist_DoesNotStartProfilingAndRemovesFile() throws {
         // Create a corrupted plist file that can't be parsed
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         let corruptedData = Data("this is not a valid plist file {[}".utf8)
         try corruptedData.write(to: configURL)
 
@@ -41,7 +41,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -65,7 +65,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyProfilesSampleRate
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -89,7 +89,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyProfilesSampleRand
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -113,7 +113,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyProfilesSampleRate
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -137,7 +137,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyProfilesSampleRand
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -161,7 +161,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyTracesSampleRate
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -185,7 +185,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyTracesSampleRand
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -204,7 +204,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
         // Create an empty but valid plist file
         let configDict: [String: Any] = [:]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())
@@ -230,7 +230,7 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
             // Missing: kSentryLaunchProfileConfigKeyTracesSampleRate
         ]
 
-        let configURL = launchProfileConfigFileURL()
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
         try (configDict as NSDictionary).write(to: configURL)
 
         XCTAssertTrue(appLaunchProfileConfigFileExists())

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -1200,9 +1200,10 @@ extension SentryFileManagerTests {
             kSentryLaunchProfileConfigKeyProfilesSampleRate: expectedProfilesSampleRate,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: expectedProfilesSampleRand
         ])
-        
-        let config = NSDictionary(contentsOf: launchProfileConfigFileURL())
-        
+
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
+        let config = NSDictionary(contentsOf: configURL)
+
         let actualTracesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRate] as? NSNumber).doubleValue
         let actualTracesSampleRand = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRand] as? NSNumber).doubleValue
         let actualProfilesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyProfilesSampleRate] as? NSNumber).doubleValue
@@ -1232,8 +1233,9 @@ extension SentryFileManagerTests {
         ])
         
         // -- Assert --
-        let config = NSDictionary(contentsOf: launchProfileConfigFileURL())
-        
+        let configURL = try XCTUnwrap(launchProfileConfigFileURL())
+        let config = NSDictionary(contentsOf: configURL)
+
         let actualTracesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRate] as? NSNumber).doubleValue
         let actualTracesSampleRand = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyTracesSampleRand] as? NSNumber).doubleValue
         let actualProfilesSampleRate = try XCTUnwrap(config?[kSentryLaunchProfileConfigKeyProfilesSampleRate] as? NSNumber).doubleValue
@@ -1246,17 +1248,17 @@ extension SentryFileManagerTests {
     
     func testRemoveAppLaunchProfilingConfigFile() throws {
         try ensureAppLaunchProfileConfig(exists: true)
-        XCTAssertNotNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
+        XCTAssertNotNil(NSDictionary(contentsOf: try XCTUnwrap(launchProfileConfigFileURL())))
         removeAppLaunchProfilingConfigFile()
-        XCTAssertNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
+        XCTAssertNil(NSDictionary(contentsOf: try XCTUnwrap(launchProfileConfigFileURL())))
     }
     
     // if there's not a file when we expect one, just make sure we don't crash
     func testRemoveAppLaunchProfilingConfigFile_noFileExists() throws {
         try ensureAppLaunchProfileConfig(exists: false)
-        XCTAssertNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
+        XCTAssertNil(NSDictionary(contentsOf: try XCTUnwrap(launchProfileConfigFileURL())))
         removeAppLaunchProfilingConfigFile()
-        XCTAssertNil(NSDictionary(contentsOf: launchProfileConfigFileURL()))
+        XCTAssertNil(NSDictionary(contentsOf: try XCTUnwrap(launchProfileConfigFileURL())))
     }
     
     func testCheckForLaunchProfilingConfigFile_URLDoesNotExist() {
@@ -1270,7 +1272,7 @@ extension SentryFileManagerTests {
         XCTAssertFalse(appLaunchProfileConfigFileExists())
         
         // set the original value back so other tests don't crash
-        sentryLaunchConfigFileURL = (originalURL as NSURL)
+        sentryLaunchConfigFileURL = (originalURL as? NSURL)
     }
 
     func testSentryGetScopedCachesDirectory_targetIsNotMacOS_shouldReturnSamePath() throws {
@@ -1383,7 +1385,7 @@ extension SentryFileManagerTests {
 // MARK: Private profiling tests
 private extension SentryFileManagerTests {
     func ensureAppLaunchProfileConfig(exists: Bool = true, tracesSampleRate: Double = 1, tracesSampleRand: Double = 1.0, profilesSampleRate: Double = 1, profilesSampleRand: Double = 1.0) throws {
-        let url = launchProfileConfigFileURL()
+        let url = try XCTUnwrap(launchProfileConfigFileURL())
         
         if exists {
             let dict = [


### PR DESCRIPTION
_This PR is derived from #5572 in an effort to make the large amount of changes easier to review for #5577._

**Should be merged after #5736**

Fixes nullability handling in the `SentryFileManager`.

Most notably this PR adds a new macro `SENTRY_UNWRAP_NULLABLE` which is just a convenience macro for force-casting a nullable to non-null pointer. I introduced it, so we can easily find all locations where we force-cast.

#skip-changelog