### PR TITLE
The test testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse tests an

### DIFF
--- a/SentryTestUtils/TestTransport.swift
+++ b/SentryTestUtils/TestTransport.swift
@@ -28,8 +28,4 @@ public class TestTransport: NSObject, Transport {
         flushInvocations.record(timeout)
         return .success
     }
-    
-    public func setStartFlushCallback(_ callback: @escaping () -> Void) {
-        
-    }
 }

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -182,13 +182,6 @@
     }
 }
 
-#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-- (void)setStartFlushCallback:(void (^)(void))callback
-{
-    _startFlushCallback = callback;
-}
-#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-
 - (SentryFlushResult)flush:(NSTimeInterval)timeout
 {
     // Calculate the dispatch time of the flush duration as early as possible to guarantee an exact
@@ -207,11 +200,6 @@
 
         _isFlushing = YES;
         dispatch_group_enter(self.dispatchGroup);
-#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-        if (self.startFlushCallback != nil) {
-            self.startFlushCallback();
-        }
-#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
     }
 
     // We are waiting for the dispatch group below, which we leave in finished sending. As

--- a/Sources/Sentry/SentrySpotlightTransport.m
+++ b/Sources/Sentry/SentrySpotlightTransport.m
@@ -107,14 +107,6 @@ NS_ASSUME_NONNULL_BEGIN
     // Empty on purpose
 }
 
-#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-- (void)setStartFlushCallback:(nonnull void (^)(void))callback
-{
-    // Empty on purpose
-}
-
-#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryTransport.h
+++ b/Sources/Sentry/include/SentryTransport.h
@@ -26,10 +26,6 @@ NS_SWIFT_NAME(Transport)
 
 - (SentryFlushResult)flush:(NSTimeInterval)timeout;
 
-#if defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-- (void)setStartFlushCallback:(void (^)(void))callback;
-#endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
unlikely edge case of calling flush in a tight loop. Instead of investing more time to fix the flaky tests, I think it's acceptable to simply delete the test. We hardly ever change the flush implementation, and it's not worth the effort to keep a test that causes so much maintenance effort.

Fixes GH-5731

#skip-changelog