### PR TITLE
ci: Assert a UIWindowScene is available on sceneDidBecomeActive

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
@@ -34,6 +34,10 @@ class MySceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
     var initializedSentry = false
     func sceneDidBecomeActive(_ scene: UIScene) {
         guard !initializedSentry else { return }
+        guard UIApplication.shared.connectedScenes.first as? UIWindowScene != nil else {
+            preconditionFailure("The test app should always have a UIWindowScene at this point")
+        }
+
         SampleAppDebugMenu.shared.display()
         SentrySDK.feedback.showWidget()
         initializedSentry = true


### PR DESCRIPTION
Sometimes I see a UI test fail to find the feedback button in the SwiftUI sample app. One codepath I saw that would not present the button is if there isn't a connected UIWindowScene. Adding this assertion so if this is the reason it fails it fails early so we can tell this is happening