### PR TITLE
ci: Fix flush timeout test

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportFlushIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportFlushIntegrationTests.swift
@@ -65,12 +65,12 @@ final class SentryHttpTransportFlushIntegrationTests: XCTestCase {
     func testFlushTimesOut_RequestManagerNeverFinishes_FlushingWorksNextTime() throws {
         let (sut, requestManager, _) = try getSut()
 
+        requestManager.waitForResponseDispatchGroup = true
+        requestManager.responseDispatchGroup.enter()
+
         requestManager.returnResponse(response: nil)
         sut.send(envelope: SentryEnvelope(event: Event()))
         requestManager.returnResponse(response: HTTPURLResponse())
-
-        requestManager.waitForResponseDispatchGroup = true
-        requestManager.responseDispatchGroup.enter()
 
         XCTAssertEqual(sut.flush(0.0), .timedOut, "Flush should time out.")
 


### PR DESCRIPTION
This test was flaky because the event could have been sent before we made the request manager blocking, leading to there not being a timeout. I just moved enabling blocking to before we send the event

#skip-changelog