### PR TITLE
test: Initialize Dyld address before running tests for BinaryImageCache

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
@@ -1,5 +1,6 @@
 #import "SentryBinaryImageCache+Private.h"
 #import "SentryCrashBinaryImageCache.h"
+#import "SentryCrashDynamicLinker+Test.h"
 #import "SentryCrashWrapper.h"
 #import "SentryDependencyContainer.h"
 #import <XCTest/XCTest.h>
@@ -85,6 +86,7 @@ delayAddBinaryImage(void)
     mach_headers_test_cache = [NSMutableArray array];
 
     // Manually include dyld
+    sentrycrashdl_initialize();
     [mach_headers_test_cache addObject:[NSValue valueWithPointer:sentryDyldHeader]];
     _dyld_register_func_for_add_image(&cacheMachHeaders);
 }
@@ -102,6 +104,7 @@ delayAddBinaryImage(void)
 
 - (void)tearDown
 {
+    sentrycrashdl_clearDyld();
     sentry_resetFuncForAddRemoveImage();
     sentrycrashbic_stopCache();
     sentry_setFuncForBeforeAdd(NULL);


### PR DESCRIPTION
Fixes `SentryCrashBinaryImageCacheTests` sometimes failing due to dyld address being NULL.

#skip-changelog