### PR TITLE
repro: For long SwiftUI TTID spans

### DIFF
--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/LoremIpsumView.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/LoremIpsumView.swift
@@ -8,10 +8,14 @@ struct LoremIpsumView: View {
     @StateObject var viewModel = LoremIpsumViewModel()
     
     var body: some View {
-        SentryTracedView("Lorem Ipsum") {
-            Text(viewModel.text)
-                .padding(16)
-        }
+//        SentryTracedView("Lorem Ipsum") {
+            VStack {
+                checkBody()
+                Text(viewModel.text)
+                    .padding(16)
+            }
+
+//        }
     }
 }
 
@@ -24,6 +28,8 @@ class LoremIpsumViewModel: ObservableObject {
     }
     
     private func fetchLoremIpsum() {
+        checkBody()
+
         let dispatchQueue = DispatchQueue(label: "LoremIpsumViewModel")
         dispatchQueue.async {
             if let path = BundleResourceProvider.loremIpsumTextFilePath {

--- a/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
+++ b/Samples/iOS-SwiftUI/iOS-SwiftUI/SwiftUIApp.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Sentry
 import SentrySampleShared
+import SentrySwiftUI
 import SwiftUI
 
 @main
@@ -9,6 +10,9 @@ struct SwiftUIApp: App {
 
     init() {
         SentrySDKWrapper.shared.startSentry()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+            _ = checkBody()
+        }
     }
 
     var body: some Scene {
@@ -16,6 +20,23 @@ struct SwiftUIApp: App {
             ContentView()
         }
     }
+}
+
+struct MyCustomView: View {
+    var body: some View {
+        SentryTracedView("Hey Phil") {
+            Text("Hey Phil")
+        }
+    }
+}
+
+private let view = MyCustomView()
+
+func checkBody() -> some View {
+    if view.body != nil {
+        print("The body is not nil")
+    }
+    return view
 }
 
 class MyAppDelegate: NSObject, UIApplicationDelegate, ObservableObject {


### PR DESCRIPTION
How to repro the bug https://github.com/getsentry/sentry-cocoa/issues/5688

1. Checkout this branch
2. Open the SwiftUI app
3. Wait for 5 seconds
4. Tap on Lorem Ipsum
5. Wait for around 35 seconds
6. The app should send a Hey Phil transaction similar to https://sentry-sdks.sentry.io/explore/discover/trace/187035e94f3c4f099cdadf87527bf2c3/?dataset=transactions&field=title&field=project&field=user.display&field=timestamp&field=replayId&id=18214&name=&node=span-6dd15feacf0e48a0&project=5428557&query=phil&queryDataset=transaction-like&sort=-timestamp&source=discover&statsPeriod=30d&timestamp=1753868335&topEvents=5&yAxis=count%28%29

<img width="1772" height="920" alt="Screenshot 2025-07-30 at 11 42 42" src="https://github.com/user-attachments/assets/a521f7f3-c7e4-4a70-b9d1-600a8fff7e22" />
