### PR TITLE
fix: remove internal macro SENTRY_UNWRAP_NULLABLE from public header

### DIFF
--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -203,20 +203,3 @@ typedef void (^SentryUserFeedbackConfigurationBlock)(
     SentryUserFeedbackConfiguration *_Nonnull configuration);
 
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
-
-/**
- * `SENTRY_UNWRAP_NULLABLE` is used to unwrap a nullable pointer type to a non-nullable pointer type
- *  It should be used after the pointer has been checked for nullability.
- *
- *  For example:
- *  ```objc
- *  id _Nullable nullablePointer = ...;
- *  if (nullablePointer != nil) {
- *      MyClass *_Nonnull nonNullPointer = SENTRY_UNWRAP_NULLABLE(MyClass, nullablePointer);
- *  }
- *  ```
- *
- *  We use this macro instead of directly casting to be able to find all usages of this
- *  pattern in the codebase.
- */
-#define SENTRY_UNWRAP_NULLABLE(type, nullable_var) (type *_Nonnull)(nullable_var)

--- a/Sources/Sentry/SentryArray.m
+++ b/Sources/Sentry/SentryArray.m
@@ -1,5 +1,6 @@
 #import "SentryArray.h"
 #import "SentryDateUtils.h"
+#import "SentryInternalDefines.h"
 #import "SentryNSDictionarySanitize.h"
 
 @implementation SentryArray

--- a/Sources/Sentry/SentryNSDataUtils.m
+++ b/Sources/Sentry/SentryNSDataUtils.m
@@ -3,6 +3,7 @@
 #endif
 
 #import "SentryError.h"
+#import "SentryInternalDefines.h"
 #import "SentryNSDataUtils.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentyOptionsInternal.m
+++ b/Sources/Sentry/SentyOptionsInternal.m
@@ -5,6 +5,7 @@
 #import "SentryCrashIntegration.h"
 #import "SentryDsn.h"
 #import "SentryFileIOTrackingIntegration.h"
+#import "SentryInternalDefines.h"
 #import "SentryLevelMapper.h"
 #import "SentryNetworkTrackingIntegration.h"
 #import "SentryOptions+Private.h"

--- a/Sources/Sentry/include/SentryInternalDefines.h
+++ b/Sources/Sentry/include/SentryInternalDefines.h
@@ -78,3 +78,20 @@ static NSString *const SentryPlatformName = @"cocoa";
 #define SPAN_DATA_BLOCKED_MAIN_THREAD @"blocked_main_thread"
 #define SPAN_DATA_THREAD_ID @"thread.id"
 #define SPAN_DATA_THREAD_NAME @"thread.name"
+
+/**
+ * `SENTRY_UNWRAP_NULLABLE` is used to unwrap a nullable pointer type to a non-nullable pointer type
+ *  It should be used after the pointer has been checked for nullability.
+ *
+ *  For example:
+ *  ```objc
+ *  id _Nullable nullablePointer = ...;
+ *  if (nullablePointer != nil) {
+ *      MyClass *_Nonnull nonNullPointer = SENTRY_UNWRAP_NULLABLE(MyClass, nullablePointer);
+ *  }
+ *  ```
+ *
+ *  We use this macro instead of directly casting to be able to find all usages of this
+ *  pattern in the codebase.
+ */
+#define SENTRY_UNWRAP_NULLABLE(type, nullable_var) (type *_Nonnull)(nullable_var)


### PR DESCRIPTION
Moves the utility macro introduced in #5737 from the public `SentryDefines.h` to the internal `SentryInternalDefines.h`, as it does not need to be publicly exposed.

#skip-changelog