### PR TITLE
ci: Use expectation for test

### DIFF
--- a/Tests/SentryTests/Transaction/SentryTracerTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTracerTests.swift
@@ -1180,19 +1180,18 @@ class SentryTracerTests: XCTestCase {
         SentrySDKInternal.setAppStartMeasurement(fixture.getAppStartMeasurement(type: .warm))
         
         let queue = DispatchQueue(label: "", qos: .background, attributes: [.concurrent, .initiallyInactive] )
-        let group = DispatchGroup()
-        
+        let expectation = expectation(description: "All calls to finish complete")
         let transactions = 5
+        expectation.expectedFulfillmentCount = transactions
         for _ in 0..<transactions {
-            group.enter()
             queue.async {
                 self.fixture.getSut().finish()
-                group.leave()
+                expectation.fulfill()
             }
         }
         
         queue.activate()
-        group.wait()
+        wait(for: [expectation], timeout: 10)
         
         XCTAssertEqual(transactions, fixture.hub.capturedEventsWithScopes.count)
         


### PR DESCRIPTION
This has been failing in tests with this message:

```
Error:     Restarting after unexpected exit, crash, or test timeout in SentryTracerTests.testConcurrentTransactions_OnlyOneGetsMeasurement(); summary will include totals from previous launches.
```

Let's use an expectation so if it times out we get a clear error message

#skip-changelog