### PR TITLE
ref: Remove SentryApplication forward declaration

### DIFF
--- a/Sources/Sentry/include/SentryApplication.h
+++ b/Sources/Sentry/include/SentryApplication.h
@@ -1,8 +1,6 @@
 #import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
-@protocol SentryApplication;
-
 #if SENTRY_HAS_UIKIT
 @class UIApplication;
 @class UIScene;


### PR DESCRIPTION
The same header file declares the protocol below, no need to use a forward declaration.

#skip-changelog