### PR TITLE
fix: Infinite Session Replay Processing Loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - User feedback no longer subject to sample rates or `beforeSend` (#5692)
 - Build error in app extensions (#5682)
 - Fix frame metrics including time while in background (#5681)
+- Fix Infinite Session Replay Processing Loop (#5765)
 
 ## 8.53.2
 

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplay.swift
@@ -224,19 +224,14 @@ import UIKit
     // swiftlint:disable function_body_length cyclomatic_complexity
     private func renderVideo(with videoFrames: [SentryReplayFrame], from: Int, at outputFileURL: URL, completion: @escaping (Result<SentryRenderVideoResult, Error>) -> Void) {
         SentrySDKLog.debug("[Session Replay] Rendering video with \(videoFrames.count) frames, from index: \(from), to output url: \(outputFileURL)")
+
         guard from < videoFrames.count else {
             SentrySDKLog.error("[Session Replay] Failed to render video, reason: index out of bounds")
-            return completion(.success(SentryRenderVideoResult(
-                info: nil,
-                finalFrameIndex: from
-            )))
+            return completion(.failure(SentryOnDemandReplayError.indexOutOfBounds))
         }
         guard let image = UIImage(contentsOfFile: videoFrames[from].imagePath) else {
             SentrySDKLog.error("[Session Replay] Failed to render video, reason: can't read image at path: \(videoFrames[from].imagePath)")
-            return completion(.success(SentryRenderVideoResult(
-                info: nil,
-                finalFrameIndex: from
-            )))
+            return completion(.failure(SentryOnDemandReplayError.cantReadImage))
         }
         
         let videoWidth = image.size.width * CGFloat(videoScale)

--- a/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplayError.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryOnDemandReplayError.swift
@@ -1,6 +1,8 @@
 enum SentryOnDemandReplayError: Error {
     case cantReadVideoSize
     case cantCreatePixelBuffer
+    case cantReadImage
     case errorRenderingVideo
     case cantReadVideoStartTime
+    case indexOutOfBounds
 }

--- a/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentryOnDemandReplayTests.swift
@@ -243,7 +243,40 @@ class SentryOnDemandReplayTests: XCTestCase {
         // -- Assert --
         XCTAssertEqual(videos.count, 0)
     }
-    
+
+    func testCreateVideo_DeleteFrameImages_NoVideoCreated() throws {
+        // -- Arrange --
+        let processingQueue = SentryDispatchQueueWrapper()
+        let workerQueue = SentryDispatchQueueWrapper()
+        let sut = SentryOnDemandReplay(
+            outputPath: outputPath.path,
+            processingQueue: processingQueue,
+            assetWorkerQueue: workerQueue
+        )
+
+        let start = Date(timeIntervalSinceReferenceDate: 0)
+        sut.addFrameAsync(timestamp: start, maskedViewImage: UIImage.add)
+
+        processingQueue.dispatchSync {
+            // Wait for the frame to be added by adding a sync operation to the serial queue
+        }
+        let end = start.addingTimeInterval(10)
+
+        // Delete the image added above so that reading the image at the image path fails,
+        // because it's removed.
+        let fileManager = FileManager.default
+        let contents = try fileManager.contentsOfDirectory(at: outputPath, includingPropertiesForKeys: nil)
+        for fileURL in contents {
+            try fileManager.removeItem(at: fileURL)
+        }
+
+        // -- Act --
+        let result = sut.createVideoWith(beginning: start, end: end)
+
+        // --  Assert --
+        XCTAssertEqual(result.count, 0)
+    }
+
     func testCalculatePresentationTime_withOneFPS_shouldReturnTiming() {
         // -- Arrange --
         let framesPerSecond = 1


### PR DESCRIPTION




## :scroll: Description

Fix an infinite processing loop in SentryOnDemandReplay when not being able to read an image.

## :bulb: Motivation and Context

Fixes GH-5757

## :green_heart: How did you test it?
Unit test

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
