### PR TITLE
fix: Memory leak in SentrySessionReplayIntegration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix Infinite Session Replay Processing Loop (#5765)
+- Fix memory leak in SessionReplayIntegration (#5770)
 
 ## 8.54.0
 

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -159,12 +159,19 @@ static SentryTouchTracker *_touchTracker;
     [self cleanUp];
 
     [SentrySDKInternal.currentHub registerSessionListener:self];
+
+    __weak SentrySessionReplayIntegration *weakSelf = self;
     [SentryDependencyContainer.sharedInstance.globalEventProcessor
         addEventProcessor:^SentryEvent *_Nullable(SentryEvent *_Nonnull event) {
+            if (weakSelf == nil) {
+                SENTRY_LOG_DEBUG(@"WeakSelf is nil. Not doing anything.");
+                return event;
+            }
+
             if (event.isFatalEvent) {
-                [self resumePreviousSessionReplay:event];
+                [weakSelf resumePreviousSessionReplay:event];
             } else {
-                [self.sessionReplay captureReplayForEvent:event];
+                [weakSelf.sessionReplay captureReplayForEvent:event];
             }
             return event;
         }];

--- a/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SessionReplay/SentrySessionReplayIntegrationTests.swift
@@ -668,6 +668,9 @@ class SentrySessionReplayIntegrationTests: XCTestCase {
         XCTAssertLessThan(processingQueue.queue.qos.relativePriority, assetWorkerQueue.queue.qos.relativePriority)
     }
 
+    /// This test ensures to not have memory leaks in the SentrySessionReplayIntegration, such as a strong reference cycle.
+    /// For example, removing the weak reference for accessing self when adding the globalEventProcessor would leak memory and
+    /// this test would start to fail when doing so.
     func testSessionReplayIntegration_DoesNotLeakMemory() throws {
 
         // -- Arrange --


### PR DESCRIPTION


## :scroll: Description

The global event processor used a strong reference to self which lead to strong reference cycle, meaning that the ARC couldn't dealloc SentrySessionReplayIntegration. This also led to having multiple SentrySessionReplayIntegrations running in the tests after running the SentrySessionReplayIntegrationTests, making the tests flaky. This is fixed now by using a weak reference.

## :bulb: Motivation and Context

This came up while investigating https://github.com/getsentry/sentry-cocoa/pull/5747.

## :green_heart: How did you test it?

Unit test. The testSessionReplayIntegration_DoesNotLeakMemory fails without the weak ref.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
