### PR TITLE
ci: Run Cocoapods integration test on iOS 18.5

### DIFF
--- a/Samples/iOS-Cocoapods-Swift6/fastlane/Fastfile
+++ b/Samples/iOS-Cocoapods-Swift6/fastlane/Fastfile
@@ -8,14 +8,16 @@ platform :ios do
     run_tests(
       workspace: "iOS-Cocoapods-Swift6.xcworkspace",
       scheme: "App",
-      build_for_testing: true
+      build_for_testing: true,
+      destination: "platform=iOS Simulator,name=iPhone 16,OS=18.5"
     )
     run_tests(
       workspace: "iOS-Cocoapods-Swift6.xcworkspace", 
       scheme: "App",
       test_without_building: true,
       result_bundle: true,
-      result_bundle_path: "fastlane/test_results/results.xcresult"
+      result_bundle_path: "fastlane/test_results/results.xcresult",
+      destination: "platform=iOS Simulator,name=iPhone 16,OS=18.5"
     )
   end
 end


### PR DESCRIPTION
iOS18.2 simulators sometimes crash like here: https://github.com/getsentry/sentry-cocoa/actions/runs/16647631298/job/47112011249
This PR selects iOS18.5 to run the integration test and avoid this issues

#skip-changelog