### PR TITLE
test: Remove background QoS usages

### DIFF
--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -3,6 +3,13 @@ parent_config: ../.swiftlint.yml
 enabled_rules:
   - test_case_accessibility
 
+custom_rules:
+  avoid_background_qos_for_dispatch_queue:
+    name: "Avoid background QoS for dispatch queues in tests"
+    regex: 'qos:\s*\.background'
+    message: "Avoid background QoS for dispatch queues in tests, as in CI, work on dispatch queues with background QoS can take a long time to run and lead to flaky tests."
+    severity: error
+
 disabled_rules:
   - force_cast
   - force_try

--- a/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
+++ b/Tests/SentryTests/Networking/RateLimits/SentryConcurrentRateLimitsDictionaryTests.swift
@@ -33,8 +33,8 @@ class SentryConcurrentRateLimitsDictionaryTests: XCTestCase {
     }
 
     func testConcurrentReadWrite() {
-        let queue1 = DispatchQueue(label: "SentryConcurrentRateLimitsStorageTests1", qos: .background, attributes: [.concurrent, .initiallyInactive])
-        let queue2 = DispatchQueue(label: "SentryConcurrentRateLimitsStorageTests2", qos: .utility, attributes: [.concurrent, .initiallyInactive])
+        let queue1 = DispatchQueue(label: "SentryConcurrentRateLimitsStorageTests1", attributes: [.concurrent, .initiallyInactive])
+        let queue2 = DispatchQueue(label: "SentryConcurrentRateLimitsStorageTests2", attributes: [.concurrent, .initiallyInactive])
         
         let group = DispatchGroup()
         

--- a/Tests/SentryTests/TestUtils/Async.swift
+++ b/Tests/SentryTests/TestUtils/Async.swift
@@ -4,7 +4,7 @@ import XCTest
 func delayNonBlocking(timeout: Double = 0.2) {
     let group = DispatchGroup()
     group.enter()
-    let queue = DispatchQueue(label: "delay", qos: .background, attributes: [])
+    let queue = DispatchQueue(label: "delay")
     
     queue.asyncAfter(deadline: .now() + timeout) {
         group.leave()


### PR DESCRIPTION
Remove usages of DispatchQueues with qos .background as these can cause flaky tests. Also add a linter to check for such usages in unit tests.

#skip-changelog