### PR TITLE
refactor: Add null handling for previous app state

### DIFF
--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -11,6 +11,7 @@
 #    import <PrivateSentrySDKOnly.h>
 #    import <SentryAppState.h>
 #    import <SentryDependencyContainer.h>
+#    import <SentryInternalDefines.h>
 #    import <SentryInternalNotificationNames.h>
 #    import <SentryLogC.h>
 #    import <SentrySDK+Private.h>
@@ -28,7 +29,7 @@ static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 180.0;
 
 @interface SentryAppStartTracker () <SentryFramesTrackerListener>
 
-@property (nonatomic, strong) SentryAppState *previousAppState;
+@property (nonatomic, strong, nullable) SentryAppState *previousAppState;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) SentryAppStateManager *appStateManager;
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;
@@ -258,15 +259,17 @@ static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 180.0;
     if (self.previousAppState == nil) {
         return SentryAppStartTypeCold;
     }
-
+    SentryAppState *_Nonnull previousAppState
+        = SENTRY_UNWRAP_NULLABLE(SentryAppState, self.previousAppState);
     SentryAppState *currentAppState = [self.appStateManager buildCurrentAppState];
 
     // If the release name is different we assume it's an app upgrade
-    if (![currentAppState.releaseName isEqualToString:self.previousAppState.releaseName]) {
+    if (![currentAppState.releaseName
+            isEqualToString:SENTRY_UNWRAP_NULLABLE(NSString, previousAppState.releaseName)]) {
         return SentryAppStartTypeCold;
     }
 
-    NSTimeInterval intervalSincePreviousBootTime = [self.previousAppState.systemBootTimestamp
+    NSTimeInterval intervalSincePreviousBootTime = [previousAppState.systemBootTimestamp
         timeIntervalSinceDate:currentAppState.systemBootTimestamp];
 
     // System rebooted, because the previous boot time is in the past.

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -188,7 +188,7 @@
                                                            .sysctlWrapper.systemBootTimestamp];
 }
 
-- (SentryAppState *)loadPreviousAppState
+- (nullable SentryAppState *)loadPreviousAppState
 {
     return [self.fileManager readPreviousAppState];
 }

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -1,3 +1,4 @@
+#import <SentryInternalDefines.h>
 #import <SentryWatchdogTerminationLogic.h>
 
 #if SENTRY_HAS_UIKIT
@@ -36,21 +37,23 @@
         return NO;
     }
 
-    SentryAppState *previousAppState = [self.appStateManager loadPreviousAppState];
-    SentryAppState *currentAppState = [self.appStateManager buildCurrentAppState];
-
+    SentryAppState *_Nullable nullablePreviousAppState =
+        [self.appStateManager loadPreviousAppState];
     // If there is no previous app state, we can't do anything.
-    if (previousAppState == nil) {
+    if (nullablePreviousAppState == nil) {
         return NO;
     }
+    SentryAppState *_Nonnull previousAppState = (SentryAppState *_Nonnull)nullablePreviousAppState;
 
+    SentryAppState *currentAppState = [self.appStateManager buildCurrentAppState];
     if (self.crashAdapter.isSimulatorBuild) {
         return NO;
     }
 
     // If the release name is different we assume it's an upgrade
     if (currentAppState.releaseName != nil && previousAppState.releaseName != nil
-        && ![currentAppState.releaseName isEqualToString:previousAppState.releaseName]) {
+        && ![SENTRY_UNWRAP_NULLABLE(NSString, currentAppState.releaseName)
+            isEqualToString:SENTRY_UNWRAP_NULLABLE(NSString, previousAppState.releaseName)]) {
         return NO;
     }
 

--- a/Sources/Sentry/include/SentryAppStateManager.h
+++ b/Sources/Sentry/include/SentryAppStateManager.h
@@ -36,7 +36,7 @@ SENTRY_NO_INIT
  */
 - (SentryAppState *)buildCurrentAppState;
 
-- (SentryAppState *)loadPreviousAppState;
+- (nullable SentryAppState *)loadPreviousAppState;
 
 - (void)storeCurrentAppState;
 


### PR DESCRIPTION
This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577.

Changes the `SentryAppStartTracker.previousAppState` and `SentryAppStateManager.loadPreviousAppState` to be nullable with correct null handling. 

#skip-changelog