### PR TITLE
ci: Add full screen capture in addition to simulator as backup

### DIFF
--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -68,6 +68,9 @@ take_simulator_screenshot() {
     # Start screenshot command in background
     xcrun simctl io booted screenshot "$screenshot_name" &
     screenshot_pid=$!
+
+    # take a screenshot of the whole screen
+    screencapture -x "${screenshot_name}_full_screen.png"
     
     # Wait for 10 seconds or until process completes
     start_time=$(date +%s)

--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -57,6 +57,7 @@ take_simulator_screenshot() {
     # Generate timestamp-based filename with custom name
     timestamp=$(date '+%H%M%S')
     screenshot_name="$SCREENSHOTS_DIR/${timestamp}_${name}.png"
+    full_screen_screenshot_name="$SCREENSHOTS_DIR/${timestamp}_${name}_full_screen.png"
 
     log "Taking screenshot with name: $screenshot_name"
     
@@ -70,7 +71,7 @@ take_simulator_screenshot() {
     screenshot_pid=$!
 
     # take a screenshot of the whole screen
-    screencapture -x "${screenshot_name}_full_screen.png"
+    screencapture -x "$full_screen_screenshot_name"
     
     # Wait for 10 seconds or until process completes
     start_time=$(date +%s)


### PR DESCRIPTION
Some jobs fail to capture screenshots ([example](https://github.com/getsentry/sentry-cocoa/actions/runs/16675184003/job/47200028195))
Taking a screenshot should help here

#skip-changelog