### PR TITLE
refactor: Add nullability property for screenName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Fix memory leak in SessionReplayIntegration (#5770)
 - Fix reporting of energy used while profiling (#5768)
 
+### Internal
+
+- Add nullability property for `screenName` (#5782)
+
 ## 8.54.0
 
 ### Features

--- a/Sources/Sentry/PrivateSentrySDKOnly.m
+++ b/Sources/Sentry/PrivateSentrySDKOnly.m
@@ -292,7 +292,7 @@ static BOOL _framesTrackingMeasurementHybridSDKMode = NO;
 }
 
 #if SENTRY_UIKIT_AVAILABLE
-+ (void)setCurrentScreen:(NSString *)screenName
++ (void)setCurrentScreen:(NSString *_Nullable)screenName
 {
     [SentrySDKInternal.currentHub
         configureScope:^(SentryScope *scope) { scope.currentScreen = screenName; }];

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -395,7 +395,7 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-- (void)setCurrentScreen:(nullable NSString *)currentScreen
+- (void)setCurrentScreen:(NSString *_Nullable)currentScreen
 {
     _currentScreen = currentScreen;
 

--- a/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
+++ b/Sources/Sentry/include/HybridPublic/PrivateSentrySDKOnly.h
@@ -188,7 +188,7 @@ typedef void (^SentryOnAppStartMeasurementAvailable)(
 /**
  * Allow Hybrids SDKs to set the current Screen.
  */
-+ (void)setCurrentScreen:(NSString *)screenName;
++ (void)setCurrentScreen:(NSString *_Nullable)screenName;
 
 #endif // SENTRY_UIKIT_AVAILABLE
 

--- a/Sources/Sentry/include/SentryScopeObserver.h
+++ b/Sources/Sentry/include/SentryScopeObserver.h
@@ -34,7 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)clear;
 
 @optional
-- (void)setCurrentScreen:(NSString *)currentScreen;
+- (void)setCurrentScreen:(NSString *_Nullable)currentScreen;
 
 @end
 


### PR DESCRIPTION
This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577.

Changes the parameter `screenName` to be nullable, as the method implementation allows it.