### PR TITLE
ci: Let simulator dyld cache update before running test

### DIFF
--- a/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
+++ b/TestSamples/SwiftUICrashTest/test-crash-and-relaunch.sh
@@ -121,6 +121,8 @@ xcodebuild -workspace Sentry.xcworkspace \
     CODE_SIGNING_REQUIRED=NO \
     build 2>&1 | tee raw-build.log | xcbeautify
 
+xcrun simctl runtime dyld_shared_cache update iOS18.5
+
 log "Installing app on simulator."
 xcrun simctl install $DEVICE_ID DerivedData/Build/Products/Debug-iphonesimulator/SwiftUICrashTest.app
 


### PR DESCRIPTION
I've heard this can improve CI stability. It maybe be still setting up the shared cache while we try to screenshot it, leading to the timeout

#skip-changelog