### PR TITLE
Remove unnecessary dependency property

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -368,12 +368,6 @@ static BOOL isInitialializingDependencyContainer = NO;
     SENTRY_LAZY_INIT(_dispatchFactory, [[SentryDispatchFactory alloc] init]);
 }
 
-- (id<SentryDispatchQueueProviderProtocol>)dispatchQueueProvider SENTRY_DISABLE_THREAD_SANITIZER(
-    "double-checked lock produce false alarms")
-{
-    SENTRY_LAZY_INIT(_dispatchQueueProvider, [[SentryDispatchFactory alloc] init]);
-}
-
 - (SentryNSTimerFactory *)timerFactory SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_timerFactory, [[SentryNSTimerFactory alloc] init]);

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -5,6 +5,7 @@
 #    import "SentryClient+Private.h"
 #    import "SentryCrashWrapper.h"
 #    import "SentryDependencyContainer.h"
+#    import "SentryDispatchFactory.h"
 #    import "SentryDispatchQueueProviderProtocol.h"
 #    import "SentryDisplayLinkWrapper.h"
 #    import "SentryEvent+Private.h"
@@ -139,7 +140,7 @@ static SentryTouchTracker *_touchTracker;
     // We use the dispatch queue provider as a factory to create the queues, but store the queues
     // directly in this instance, so they get deallocated when the integration is deallocated.
     id<SentryDispatchQueueProviderProtocol> dispatchQueueProvider
-        = SentryDependencyContainer.sharedInstance.dispatchQueueProvider;
+        = SentryDependencyContainer.sharedInstance.dispatchFactory;
 
     // The asset worker queue is used to work on video and frames data.
     // Use a relative priority of -1 to make it lower than the default background priority.

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -122,7 +122,6 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentrySystemWrapper *systemWrapper;
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 @property (nonatomic, strong) SentryDispatchFactory *dispatchFactory;
-@property (nonatomic, strong) id<SentryDispatchQueueProviderProtocol> dispatchQueueProvider;
 @property (nonatomic, strong) SentryNSTimerFactory *timerFactory;
 
 @property (nonatomic, strong) SentrySwizzleWrapper *swizzleWrapper;

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -129,7 +129,6 @@ final class SentryDependencyContainerTests: XCTestCase {
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().systemWrapper)
 #endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().dispatchFactory)
-                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().dispatchQueueProvider)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().timerFactory)
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)


### PR DESCRIPTION
This property was redundant, and only had one use. Updated it to the new property 

#skip-changelog