### PR TITLE
ref: Cleanup SentryEvent V9 public API

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -9,10 +9,11 @@ Removes deprecated useSpan function (#5591)
 Removes deprecated SentryDebugImageProvider class (#5598)
 Makes app hang tracking V2 the default and removes the option to enable/disable it (#5615)
 Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)
-Removes public SentrySerializable conformance from many public models (#5636)
+Removes public SentrySerializable conformance from many public models (#5636, #5797)
 Removes Decodable conformances from the public API of model classes (#5691)
 Removes enableTracing property from SentryOptions (#5694)
 Removes `integrations` property from `SentryOptions` (#5749)
+Makes `SentryEventDecodable` internal (#5797)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -22,7 +22,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryUser;
 
 NS_SWIFT_NAME(Event)
-@interface SentryEvent : NSObject <SentrySerializable>
+@interface SentryEvent : NSObject
+#if !SDK_V9
+                         <SentrySerializable>
+#endif // !SDK_V9
 
 /**
  * This will be set by the initializer.

--- a/Sources/Sentry/SentryEnvelope.m
+++ b/Sources/Sentry/SentryEnvelope.m
@@ -5,6 +5,7 @@
 #import "SentryEnvelopeAttachmentHeader.h"
 #import "SentryEnvelopeItemHeader.h"
 #import "SentryEnvelopeItemType.h"
+#import "SentryEvent+Private.h"
 #import "SentryEvent.h"
 #import "SentryLogC.h"
 #import "SentryMessage.h"

--- a/Sources/Sentry/SentryFileManager.m
+++ b/Sources/Sentry/SentryFileManager.m
@@ -7,6 +7,7 @@
 #import "SentryEnvelope.h"
 #import "SentryEnvelopeItemHeader.h"
 #import "SentryError.h"
+#import "SentryEvent+Private.h"
 #import "SentryEvent.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"

--- a/Sources/Sentry/SentryTransaction.m
+++ b/Sources/Sentry/SentryTransaction.m
@@ -1,5 +1,6 @@
 #import "SentryTransaction.h"
 #import "SentryEnvelopeItemType.h"
+#import "SentryEvent+Private.h"
 #import "SentryMeasurementValue.h"
 #import "SentryNSDictionarySanitize.h"
 #import "SentryProfilingConditionals.h"

--- a/Sources/Sentry/include/SentryEvent+Private.h
+++ b/Sources/Sentry/include/SentryEvent+Private.h
@@ -4,6 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface SentryEvent ()
+#if SDK_V9
+    <SentrySerializable>
+#endif // SDK_V9
 
 /**
  * This indicates whether this event is a result of a fatal app termination, such as a crash,

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -18,6 +18,7 @@
 #import "SentryDateUtils.h"
 #import "SentryDependencyContainerSwiftHelper.h"
 #import "SentryDisplayLinkWrapper.h"
+#import "SentryEvent+Private.h"
 #import "SentryFileIOTracker.h"
 #import "SentryFileManager.h"
 #import "SentryLevelHelper.h"

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayEvent.swift
@@ -36,6 +36,9 @@ import Foundation
         fatalError("init() has not been implemented")
     }
     
+    #if SDK_V9
+    @_implementationOnly
+    #endif
     public override func serialize() -> [String: Any] {
         var result = super.serialize()
         result["urls"] = urls

--- a/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
@@ -18,39 +18,9 @@ import Foundation
  * overridden. Therefore, we add the Decodable implementation not on the Event, but to a subclass of
  * the event.
  */
+#if !SDK_V9
 @objc(SentryEventDecodable)
 open class SentryEventDecodable: Event, Decodable {
-    
-    private enum CodingKeys: String, CodingKey {
-        case eventId = "event_id"
-        case message
-        // Leaving out error on purpose, it's not serialized.
-        case timestamp
-        case startTimestamp = "start_timestamp"
-        case level
-        case platform
-        case logger
-        case serverName = "server_name"
-        case releaseName = "release"
-        case dist
-        case environment
-        case transaction
-        case type
-        case tags
-        case extra
-        case sdk
-        case modules
-        case fingerprint
-        case user
-        case context = "contexts"
-        case threads
-        case exception
-        case stacktrace
-        case debugMeta = "debug_meta"
-        case breadcrumbs
-        case request
-    }
-    
     required convenience public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         
@@ -111,5 +81,102 @@ open class SentryEventDecodable: Event, Decodable {
         
         self.breadcrumbs = try container.decodeIfPresent([BreadcrumbDecodable].self, forKey: .breadcrumbs)
         self.request = try container.decodeIfPresent(SentryRequestDecodable.self, forKey: .request)
+    }
+}
+#else
+final class SentryEventDecodable: Event, Decodable {
+    required convenience public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        self.init()
+
+        let eventIdAsString = try container.decode(String.self, forKey: .eventId)
+        SentryEventSwiftHelper.setEventIdString(eventIdAsString, event: self)
+        self.message = try container.decodeIfPresent(SentryMessageDecodable.self, forKey: .message)
+        self.timestamp = try container.decode(Date.self, forKey: .timestamp)
+        self.startTimestamp = try container.decodeIfPresent(Date.self, forKey: .startTimestamp)
+
+        if let rawLevel = try container.decodeIfPresent(String.self, forKey: .level) {
+            let level = SentryLevelHelper.levelForName(rawLevel)
+            SentryLevelBridge.setBreadcrumbLevelOn(self, level: level.rawValue)
+        } else {
+            SentryLevelBridge.setBreadcrumbLevelOn(self, level:
+            SentryLevel.none.rawValue)
+        }
+
+        self.platform = try container.decode(String.self, forKey: .platform)
+        self.logger = try container.decodeIfPresent(String.self, forKey: .logger)
+        self.serverName = try container.decodeIfPresent(String.self, forKey: .serverName)
+        self.releaseName = try container.decodeIfPresent(String.self, forKey: .releaseName)
+        self.dist = try container.decodeIfPresent(String.self, forKey: .dist)
+        self.environment = try container.decodeIfPresent(String.self, forKey: .environment)
+        self.transaction = try container.decodeIfPresent(String.self, forKey: .transaction)
+        self.type = try container.decodeIfPresent(String.self, forKey: .type)
+        self.tags = try container.decodeIfPresent([String: String].self, forKey: .tags)
+
+        self.extra = decodeArbitraryData {
+            try container.decodeIfPresent([String: ArbitraryData].self, forKey: .extra)
+        }
+        self.sdk = decodeArbitraryData {
+            try container.decodeIfPresent([String: ArbitraryData].self, forKey: .sdk)
+        }
+
+        self.modules = try container.decodeIfPresent([String: String].self, forKey: .modules)
+        self.fingerprint = try container.decodeIfPresent([String].self, forKey: .fingerprint)
+        self.user = try container.decodeIfPresent(UserDecodable.self, forKey: .user)
+        
+        self.context = decodeArbitraryData {
+            try container.decodeIfPresent([String: [String: ArbitraryData]].self, forKey: .context)
+        }
+
+        if let rawThreads = try container.decodeIfPresent([String: [SentryThreadDecodable]].self, forKey: .threads) {
+            self.threads = rawThreads["values"]
+        }
+            
+        if let rawExceptions = try container.decodeIfPresent([String: [ExceptionDecodable]].self, forKey: .exception) {
+            self.exceptions = rawExceptions["values"]
+        }
+        
+        self.stacktrace = try container.decodeIfPresent(SentryStacktraceDecodable.self, forKey: .stacktrace)
+        
+        if let rawDebugMeta = try container.decodeIfPresent([String: [DebugMetaDecodable]].self, forKey: .debugMeta) {
+            self.debugMeta = rawDebugMeta["images"]
+        }
+        
+        self.breadcrumbs = try container.decodeIfPresent([BreadcrumbDecodable].self, forKey: .breadcrumbs)
+        self.request = try container.decodeIfPresent(SentryRequestDecodable.self, forKey: .request)
+    }
+}
+#endif
+
+extension SentryEventDecodable {
+    private enum CodingKeys: String, CodingKey {
+        case eventId = "event_id"
+        case message
+        // Leaving out error on purpose, it's not serialized.
+        case timestamp
+        case startTimestamp = "start_timestamp"
+        case level
+        case platform
+        case logger
+        case serverName = "server_name"
+        case releaseName = "release"
+        case dist
+        case environment
+        case transaction
+        case type
+        case tags
+        case extra
+        case sdk
+        case modules
+        case fingerprint
+        case user
+        case context = "contexts"
+        case threads
+        case exception
+        case stacktrace
+        case debugMeta = "debug_meta"
+        case breadcrumbs
+        case request
     }
 }

--- a/sdk_api_V9.json
+++ b/sdk_api_V9.json
@@ -7174,7 +7174,6 @@
             "objc_name": "init",
             "declAttributes": [
               "Override",
-              "Required",
               "ObjC",
               "Dynamic"
             ],
@@ -7252,12 +7251,6 @@
           "ObjectiveC.NSObject"
         ],
         "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "SentrySerializable",
-            "printedName": "SentrySerializable",
-            "usr": "c:objc(pl)SentrySerializable"
-          },
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -39462,150 +39455,6 @@
           "ObjectiveC.NSObject"
         ],
         "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryEventDecodable",
-        "printedName": "SentryEventDecodable",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(from:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecodable",
-                "printedName": "Sentry.SentryEventDecodable",
-                "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Decoder",
-                "printedName": "any Swift.Decoder",
-                "usr": "s:s7DecoderP"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "s:6Sentry0A14EventDecodableC4fromACs7Decoder_p_tKcfc",
-            "mangledName": "$s6Sentry0A14EventDecodableC4fromACs7Decoder_p_tKcfc",
-            "moduleName": "Sentry",
-            "declAttributes": [
-              "Required"
-            ],
-            "throwing": true,
-            "init_kind": "Convenience"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecodable",
-                "printedName": "Sentry.SentryEventDecodable",
-                "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable(im)init",
-            "mangledName": "$s6Sentry0A14EventDecodableCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "Required"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryEventDecodable",
-        "mangledName": "$s6Sentry0A14EventDecodableC",
-        "moduleName": "Sentry",
-        "isOpen": true,
-        "objc_name": "SentryEventDecodable",
-        "declAttributes": [
-          "ObjC"
-        ],
-        "superclassUsr": "c:objc(cs)SentryEvent",
-        "superclassNames": [
-          "Sentry.Event",
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
-          {
-            "kind": "Conformance",
-            "name": "Decodable",
-            "printedName": "Decodable",
-            "usr": "s:Se",
-            "mangledName": "$sSe"
-          },
-          {
-            "kind": "Conformance",
-            "name": "SentrySerializable",
-            "printedName": "SentrySerializable",
-            "usr": "c:objc(pl)SentrySerializable"
-          },
           {
             "kind": "Conformance",
             "name": "Copyable",


### PR DESCRIPTION
This removes the public conformance to `SentrySerializable` from SDK V9, and removes `SentryEventDecodable` from the public API entirely in V9

#skip-changelog