### PR TITLE
fix: Change conditional import of MetricKit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Change conditional import of MetricKit (#5798)
+
 ### Fixes
 
 - Add support for PDFKit views in session replay (#5750)

--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -7,7 +7,6 @@ import Foundation
  */
 #if canImport(MetricKit)
 import MetricKit
-#endif
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
 @available(tvOS, unavailable)
@@ -88,4 +87,5 @@ import MetricKit
     }
 }
 
+#endif
 #endif


### PR DESCRIPTION
## :scroll: Description

The import of MetricKit is wrapped using a `#if canImport(MetricKit)` conditional compiler check. If `MetricKit` is not available, we are still using classes of it, causing compiler issues. This PR changes the conditional compilation move the `#endif` to cover classes using MetricKit.

**We need to verify compilation and SDK usage still works when using the SDK on iOS or macOS without MetricKit available**! I do not think we have a sample project for that.

## :bulb: Motivation and Context

Fixes #5793

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [X] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [X] I updated the docs if needed.
- [X] I updated the wizard if needed.
- [X] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
