### PR TITLE
fix: Add null-handling for default rate limits

### DIFF
--- a/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
+++ b/Sources/Sentry/SentryConcurrentRateLimitsDictionary.m
@@ -24,7 +24,7 @@
     }
 }
 
-- (NSDate *)getRateLimitForCategory:(SentryDataCategory)category
+- (nullable NSDate *)getRateLimitForCategory:(SentryDataCategory)category
 {
     @synchronized(self.rateLimits) {
         return self.rateLimits[@(category)];

--- a/Sources/Sentry/SentryDefaultRateLimits.m
+++ b/Sources/Sentry/SentryDefaultRateLimits.m
@@ -38,8 +38,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (BOOL)isRateLimitActive:(SentryDataCategory)category
 {
-    NSDate *categoryDate = [self.rateLimits getRateLimitForCategory:category];
-    NSDate *allCategoriesDate = [self.rateLimits getRateLimitForCategory:kSentryDataCategoryAll];
+    NSDate *_Nullable categoryDate = [self.rateLimits getRateLimitForCategory:category];
+    NSDate *_Nullable allCategoriesDate =
+        [self.rateLimits getRateLimitForCategory:kSentryDataCategoryAll];
 
     BOOL isActiveForCategory = [self.dateUtil isInFuture:categoryDate];
     BOOL isActiveForCategories = [self.dateUtil isInFuture:allCategoriesDate];

--- a/Sources/Sentry/include/SentryConcurrentRateLimitsDictionary.h
+++ b/Sources/Sentry/include/SentryConcurrentRateLimitsDictionary.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addRateLimit:(SentryDataCategory)category validUntil:(NSDate *)date;
 
 /** Returns the date until the rate limit is active. */
-- (NSDate *)getRateLimitForCategory:(SentryDataCategory)category;
+- (nullable NSDate *)getRateLimitForCategory:(SentryDataCategory)category;
 
 @end
 


### PR DESCRIPTION
_This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577._

Adds null-handling for rate limits per category.

#skip-changelog