### PR TITLE
fix: Add null-handling for timestamp in breadcrumb serialization

### DIFF
--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -1,6 +1,7 @@
 #import "SentryBreadcrumb.h"
 #import "SentryBreadcrumb+Private.h"
 #import "SentryDateUtils.h"
+#import "SentryInternalDefines.h"
 #import "SentryLevelMapper.h"
 #import "SentryNSDictionarySanitize.h"
 #import "SentrySwift.h"
@@ -59,7 +60,11 @@
     NSMutableDictionary *serializedData = [NSMutableDictionary new];
 
     [serializedData setValue:nameForSentryLevel(self.level) forKey:@"level"];
-    [serializedData setValue:sentry_toIso8601String(self.timestamp) forKey:@"timestamp"];
+    if (self.timestamp != nil) {
+        [serializedData
+            setValue:sentry_toIso8601String(SENTRY_UNWRAP_NULLABLE(NSDate, self.timestamp))
+              forKey:@"timestamp"];
+    }
     [serializedData setValue:self.category forKey:@"category"];
     [serializedData setValue:self.type forKey:@"type"];
     [serializedData setValue:self.origin forKey:@"origin"];


### PR DESCRIPTION
_This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577._

The method `sentry_toIso8601String` expects a non-null value (soft-failing because Objective-C is quite lenient).

#skip-changelog