### PR TITLE
fix: Add null-handling for debug meta

### DIFF
--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -509,7 +509,9 @@ NS_ASSUME_NONNULL_BEGIN
         uint64_t imageAddress = mxFrame.address - mxFrame.offsetIntoBinaryTextSegment;
         debugMeta.imageAddress = sentry_formatHexAddressUInt64(imageAddress);
 
-        debugMetas[debugMeta.debugID] = debugMeta;
+        if (nil != debugMeta.debugID) {
+            debugMetas[SENTRY_UNWRAP_NULLABLE(NSString, debugMeta.debugID)] = debugMeta;
+        }
     }
 
     return [debugMetas allValues];

--- a/Sources/Sentry/SentryMetricKitIntegration.m
+++ b/Sources/Sentry/SentryMetricKitIntegration.m
@@ -509,9 +509,7 @@ NS_ASSUME_NONNULL_BEGIN
         uint64_t imageAddress = mxFrame.address - mxFrame.offsetIntoBinaryTextSegment;
         debugMeta.imageAddress = sentry_formatHexAddressUInt64(imageAddress);
 
-        if (nil != debugMeta.debugID) {
-            debugMetas[SENTRY_UNWRAP_NULLABLE(NSString, debugMeta.debugID)] = debugMeta;
-        }
+        debugMetas[binaryUUID] = debugMeta;
     }
 
     return [debugMetas allValues];


### PR DESCRIPTION
_This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577._

Adds explicit null-handling for debug metadata. This is necessary so we do not use `nil` as a key. While this most likely will not cause issues in Objective-C, we should see it as a best practice instead.

#skip-changelog