### PR TITLE
fix: Add null-handling and type-checking to modify context in client

### DIFF
--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -19,6 +19,7 @@
 #import "SentryHub.h"
 #import "SentryInAppLogic.h"
 #import "SentryInstallation.h"
+#import "SentryInternalDefines.h"
 #import "SentryLogC.h"
 #import "SentryMechanism.h"
 #import "SentryMechanismMeta.h"
@@ -1089,10 +1090,14 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
         return;
     }
 
-    NSMutableDictionary *context = [[NSMutableDictionary alloc] initWithDictionary:event.context];
-    NSMutableDictionary *dict = event.context[key] == nil
-        ? [[NSMutableDictionary alloc] init]
-        : [[NSMutableDictionary alloc] initWithDictionary:context[key]];
+    NSMutableDictionary *context = [[NSMutableDictionary alloc]
+        initWithDictionary:SENTRY_UNWRAP_NULLABLE(NSDictionary, event.context)];
+    NSMutableDictionary *dict
+        = event.context[key] != nil && [event.context[key] isKindOfClass:[NSDictionary class]]
+        ? [[NSMutableDictionary alloc]
+              initWithDictionary:SENTRY_UNWRAP_NULLABLE(NSDictionary, context[key])]
+        : [NSMutableDictionary dictionary];
+
     block(dict);
     context[key] = dict;
     event.context = context;


### PR DESCRIPTION
_This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577._

Adds full type-checking of the context value and silencing of the nullability-warning

#skip-changelog