### PR TITLE
fix: Remove unnecessary metric kit check

### DIFF
--- a/Sources/Swift/Core/MetricKit/SentryMXManager.swift
+++ b/Sources/Swift/Core/MetricKit/SentryMXManager.swift
@@ -2,12 +2,7 @@ import Foundation
 
 #if os(iOS) || os(macOS)
 
-/**
- * We need to check if MetricKit is available for compatibility on iOS 12 and below. As there are no compiler directives for iOS versions we use canImport.
- */
-#if canImport(MetricKit)
 import MetricKit
-#endif
 
 @available(iOS 15.0, macOS 12.0, macCatalyst 15.0, *)
 @available(tvOS, unavailable)


### PR DESCRIPTION
As an alternative to https://github.com/getsentry/sentry-cocoa/pull/5798 I think we should just remove this conditional check because the whole file is already wrapped in `#if os(iOS) || os(macOS)`. MetricKit can only not be imported on watchOS (according to the [docs](https://developer.apple.com/documentation/metrickit)) so this check was redundant

#skip-changelog