### PR TITLE
test: Fix flaky SentryThreadInspectorTests

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -86,6 +86,8 @@ class SentryThreadInspectorTests: XCTestCase {
 
                 // During testing we usually have around 90% to 100%
                 // We choose a bit lower threshold to avoid flaky tests in CI
+                // Especially during the test when launching multiple threads for the concurrent DispatchQueue
+                // it can occur that more than one thread have no stacktrace frames yet, because they just started.
                 XCTAssertGreaterThan(percantageWithStacktraceFrames, 0.6, "More than 60% of threads should have stacktrace frames, but got \(percantageWithStacktraceFrames * 100)%")
 
                 expect.fulfill()
@@ -134,6 +136,8 @@ class SentryThreadInspectorTests: XCTestCase {
 
                 // During testing we usually have around 90% to 100%
                 // We choose a bit lower threshold to avoid flaky tests in CI
+                // Especially during the test when launching multiple threads for the concurrent DispatchQueue
+                // it can occur that more than one thread have no stacktrace frames yet, because they just started.
                 XCTAssertGreaterThan(percantageWithStacktraceFrames, 0.6, "More than 60% of threads should have stacktrace frames, but got \(percantageWithStacktraceFrames * 100)%")
 
                 expect.fulfill()


### PR DESCRIPTION
Change the assertion approach of
testGetCurrentThreadsWithStacktrace_WithSymbolication and testGetCurrentThreadsWithStacktrace_WithoutSymbolication to validate the percentage of threads having a stracktrace, which is more robust than the previous method which failed if more than one thread had no stacktrace frames. Especially during the test when launching multiple threads for the concurrent DispatchQueue it can occur that more than one thread have no stacktrace frames yet, because they just started.

The tests failed here https://github.com/getsentry/sentry-cocoa/actions/runs/16760984375/job/47456025143

#skip-changelog