### PR TITLE
Document main thread requirement for replay methods

### DIFF
--- a/Sources/Sentry/Public/SentryReplayApi.h
+++ b/Sources/Sentry/Public/SentryReplayApi.h
@@ -52,6 +52,8 @@ NS_ASSUME_NONNULL_BEGIN
  * This will only work if the debbuger is attached and it will
  * cause some slow frames.
  *
+ * @note This method must be called from the main thread.
+ *
  * @warning This is an experimental feature and may still have bugs.
  * Do not use this is production.
  */
@@ -67,6 +69,8 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * @param opacity The opacity of the overlay.
  *
+ * @note This method must be called from the main thread.
+ *
  * @warning This is an experimental feature and may still have bugs.
  * Do not use this is production.
  */
@@ -74,6 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Removes the overlay that shows replay masking.
+ *
+ * @note This method must be called from the main thread.
  *
  * @warning This is an experimental feature and may still have bugs.
  * Do not use this is production.


### PR DESCRIPTION
## :scroll: Description

Added documentation to `SentryReplayApi.h` for `showMaskPreview`, `showMaskPreview:(CGFloat)opacity`, and `hideMaskPreview` methods. The documentation now explicitly states that these methods must be called from the main thread.

## :bulb: Motivation and Context

This change addresses an intermittent crash and masking issue reported by a user who was calling `showMaskPreview` from a background thread. Interacting with the UI hierarchy, which these methods do, must occur on the main thread. Adding this note clarifies the usage requirement and helps prevent similar threading-related issues.

## :green_heart: How did you test it?

Verified the documentation was correctly added to the header file by inspecting the changes.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog