### PR TITLE
chore(gh): Update GH issue templates for Linear compatibility

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,6 @@
 name: 🐞 Bug Report
 description: Tell us about something that's not working the way we (probably) intend.
-labels: ["Platform: Cocoa", "Type: Bug"]
-type: Bug
+labels: ["Cocoa", "Bug"]
 body:
   - type: dropdown
     id: platform

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,7 +1,6 @@
 name: 💡 Feature Request
 description: Tell us about a problem our SDK could solve but doesn't.
-labels: ["Platform: Cocoa", "Type: Feature Request"]
-type: Feature
+labels: ["Cocoa", "Feature"]
 body:
   - type: textarea
     id: problem

--- a/.github/ISSUE_TEMPLATE/flaky-test.yml
+++ b/.github/ISSUE_TEMPLATE/flaky-test.yml
@@ -1,7 +1,6 @@
 name: Flaky Test
 description: For reporting a flaky test.
-labels: ["Platform: Cocoa", "Type: Flaky Test"]
-type: Task
+labels: ["Cocoa", "Task", "Type: Flaky Test"]
 body:
   - type: input
     id: GitHubActionRunLink

--- a/.github/ISSUE_TEMPLATE/maintainer-blank.yml
+++ b/.github/ISSUE_TEMPLATE/maintainer-blank.yml
@@ -1,6 +1,6 @@
 name: Blank Issue
 description: Blank Issue. Reserved for maintainers.
-labels: ["Platform: Cocoa"]
+labels: ["Cocoa"]
 body:
   - type: textarea
     id: description


### PR DESCRIPTION
replaces usage of GH issue type and platform label to Linear-compatible labels

#skip-changelog