### PR TITLE
ci: Fix flaky flush test

### DIFF
--- a/Tests/SentryTests/Networking/SentryHttpTransportFlushIntegrationTests.swift
+++ b/Tests/SentryTests/Networking/SentryHttpTransportFlushIntegrationTests.swift
@@ -96,11 +96,13 @@ final class SentryHttpTransportFlushIntegrationTests: XCTestCase {
         waitForEnvelopeToBeStored(dispatchQueueWrapper)
         requestManager.returnResponse(response: HTTPURLResponse())
 
-        let flushTimeout = 0.1
+        // This must be long enough that all the threads we start below get to run
+        // while the first call to flush is still blocking
+        let flushTimeout = 10.0
         requestManager.waitForResponseDispatchGroup = true
         requestManager.responseDispatchGroup.enter()
 
-        let allFlushCallsGroup = DispatchGroup()
+        let initialFlushCallGroup = DispatchGroup()
         let ensureFlushingGroup = DispatchGroup()
         let ensureFlushingQueue = DispatchQueue(label: "First flushing")
 
@@ -108,12 +110,11 @@ final class SentryHttpTransportFlushIntegrationTests: XCTestCase {
             ensureFlushingGroup.leave()
         }
 
-        allFlushCallsGroup.enter()
+        initialFlushCallGroup.enter()
         ensureFlushingGroup.enter()
         ensureFlushingQueue.async {
-            XCTAssertEqual(.timedOut, sut.flush(flushTimeout))
-            requestManager.responseDispatchGroup.leave()
-            allFlushCallsGroup.leave()
+            XCTAssertEqual(.success, sut.flush(flushTimeout), "Initial call to flush should succeed")
+            initialFlushCallGroup.leave()
         }
 
         // Ensure transport is flushing.
@@ -122,20 +123,24 @@ final class SentryHttpTransportFlushIntegrationTests: XCTestCase {
         // Now the transport should also have left the synchronized block, and the
         // flush should return immediately.
 
+        let parallelFlushCallsGroup = DispatchGroup()
         let initiallyInactiveQueue = DispatchQueue(label: "testFlush_CalledMultipleTimes_ImmediatelyReturnsFalse", qos: .userInitiated, attributes: [.concurrent, .initiallyInactive])
         for _ in 0..<2 {
-            allFlushCallsGroup.enter()
+            parallelFlushCallsGroup.enter()
             initiallyInactiveQueue.async {
                 for _ in 0..<10 {
-                    XCTAssertEqual(.alreadyFlushing, sut.flush(flushTimeout), "Flush should have returned immediately")
+                    let result = sut.flush(flushTimeout)
+                    XCTAssertEqual(.alreadyFlushing, result, "Flush should have returned immediately")
                 }
 
-                allFlushCallsGroup.leave()
+                parallelFlushCallsGroup.leave()
             }
         }
 
         initiallyInactiveQueue.activate()
-        allFlushCallsGroup.waitWithTimeout()
+        parallelFlushCallsGroup.waitWithTimeout()
+        requestManager.responseDispatchGroup.leave()
+        initialFlushCallGroup.waitWithTimeout()
     }
 
     // We use the test name as part of the DSN to ensure that each test runs in isolation.


### PR DESCRIPTION
Fixed this flaky test. It had two flakes:

1. All messages could be sent before we even called flush, fixed that by moving the waitForResponseDispatchGroup = true further up.
2. The flush call could have timed out before the following concurrent calls to flush got scheduled. Fixed this by making the responseDispatchGroup only exit after all the other calls have been made. I changed the original call to expect success not timeout because otherwise the timeout would have to be very large due to it needing to block long enough for these other calls to flush to finish, and I didn't want to make this test take a long time. What that first call returned wasn't important to the test, what is important is that subsequent calls return `alreadyFlushing` which is still what is tested

#skip-changelog