### PR TITLE
test: Use XCTestExpectation in BinaryImageCache

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
@@ -237,7 +237,16 @@ delayAddBinaryImage(void)
     sentrycrashbic_startCache();
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
+    // Guard against underflow when mach_headers_test_cache.count < 5
+    // because otherwise the expectedFulfillmentCount for the test expectation will be negative.
+    if (mach_headers_test_cache.count <= 5) {
+        XCTFail(@"Test requires more than 5 binary images in cache, but only has %lu",
+            (unsigned long)mach_headers_test_cache.count);
+        return;
+    }
+
     NSUInteger taskCount = mach_headers_test_cache.count - 5;
+
     XCTestExpectation *expectation =
         [self expectationWithDescription:@"Add binary images in parallel"];
     expectation.expectedFulfillmentCount = taskCount;

--- a/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
@@ -239,7 +239,7 @@ delayAddBinaryImage(void)
 
     // Guard against underflow when mach_headers_test_cache.count < 5
     // because otherwise the expectedFulfillmentCount for the test expectation will be negative.
-    if (mach_headers_test_cache.count <= 5) {
+    if (mach_headers_test_cache.count < 5) {
         XCTFail(@"Test requires more than 5 binary images in cache, but only has %lu",
             (unsigned long)mach_headers_test_cache.count);
         return;

--- a/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
@@ -239,13 +239,11 @@ delayAddBinaryImage(void)
 
     // Guard against underflow when mach_headers_test_cache.count < 5
     // because otherwise the expectedFulfillmentCount for the test expectation will be negative.
-    if (mach_headers_test_cache.count < 5) {
-        XCTFail(@"Test requires more than 5 binary images in cache, but only has %lu",
-            (unsigned long)mach_headers_test_cache.count);
+    NSInteger taskCount = mach_headers_test_cache.count - 5;
+    if (taskCount <= 0) {
+        XCTFail(@"Expected a positive task count, but got %ld", taskCount);
         return;
     }
-
-    NSUInteger taskCount = mach_headers_test_cache.count - 5;
 
     XCTestExpectation *expectation =
         [self expectationWithDescription:@"Add binary images in parallel"];

--- a/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
+++ b/Tests/SentryTests/SentryCrash/SentryBinaryImageCacheTests.m
@@ -236,16 +236,20 @@ delayAddBinaryImage(void)
 {
     sentrycrashbic_startCache();
     dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-    dispatch_group_t group = dispatch_group_create();
+
+    NSUInteger taskCount = mach_headers_test_cache.count - 5;
+    XCTestExpectation *expectation =
+        [self expectationWithDescription:@"Add binary images in parallel"];
+    expectation.expectedFulfillmentCount = taskCount;
 
     for (NSUInteger i = 5; i < mach_headers_test_cache.count; i++) {
-        dispatch_group_enter(group);
-        dispatch_group_async(group, queue, ^{
+        dispatch_async(queue, ^{
             addBinaryImage([mach_headers_test_cache[i] pointerValue], 0);
-            dispatch_group_leave(group);
+            [expectation fulfill];
         });
     }
-    dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, 5 * NSEC_PER_SEC));
+
+    [self waitForExpectations:@[ expectation ] timeout:5.0];
 
     [self assertBinaryImageCacheLength:(int)mach_headers_test_cache.count];
 }


### PR DESCRIPTION
Replace the dispatch group with a XCTestExpectation to get a failure message when the wait times out.
This contributes to GH-5789  and should fix the flaky test `testRemoveImageAddAgain` because 
from the test log it seems like a bg thread adds an image while the `testRemoveImageAddAgain` 
runs. I couldn't reproduce the flaky test locally. We can reopen GH-5789 if it doesn't.

Fixes GH-5825

#skip-changelog
