### PR TITLE
test: Increase timeout for ANRTrackerV2 tests

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -5,7 +5,7 @@ import XCTest
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class SentryANRTrackerV2Tests: XCTestCase {
     
-    private let waitTimeout: TimeInterval = 5.0
+    private let waitTimeout: TimeInterval = 10.0
     private var timeoutInterval: TimeInterval = 2
         
     private func getSut() throws -> (SentryANRTracker, TestCurrentDateProvider, TestDisplayLinkWrapper, TestSentryCrashWrapper, SentryTestThreadWrapper, SentryFramesTracker) {


### PR DESCRIPTION
Increase timeout from 5 to 10 seconds, because when CI is slow the tests fail sometimes with 5 seconds.

Fixes GH-5831