### PR TITLE
test: Fix flaky thread inspector tests

### DIFF
--- a/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
+++ b/Tests/SentryTests/SentryCrash/SentryThreadInspectorTests.swift
@@ -61,6 +61,15 @@ class SentryThreadInspectorTests: XCTestCase {
             queue.async {
                 let threads = sut.getCurrentThreadsWithStackTrace()
 
+                if threads.count == 0 {
+                    // If there are more than 70 threads getCurrentThreadsWithStackTrace
+                    // returns an empty list because it can't handle so many threads.
+                    // This is a known limitation SentryThreadInspector and should be
+                    // addressed in https://github.com/getsentry/sentry-cocoa/issues/2825.
+                    // We see this sometimes happening in CI.
+                    return
+                }
+
                 var threadsWithStackTraceFrames = 0
 
                 for thread in threads {
@@ -110,6 +119,15 @@ class SentryThreadInspectorTests: XCTestCase {
             
             queue.async {
                 let threads = sut.getCurrentThreadsWithStackTrace()
+
+                if threads.count == 0 {
+                    // If there are more than 70 threads getCurrentThreadsWithStackTrace
+                    // returns an empty list because it can't handle so many threads.
+                    // This is a known limitation SentryThreadInspector and should be
+                    // addressed in https://github.com/getsentry/sentry-cocoa/issues/2825.
+                    // We see this sometimes happening in CI.
+                    return
+                }
 
                 var threadsWithStackTraceFrames = 0
 


### PR DESCRIPTION
Consider edge case when getting threads returns an empty list. This can happen when there are more than 70 threads in CI and is a known limitation. We don't need to let the tests flake for this.

The test flaked here https://github.com/getsentry/sentry-cocoa/actions/runs/16804748963/job/47594270995

```
testGetCurrentThreadsWithStacktrace_WithoutSymbolication, XCTAssertGreaterThan failed: ("nan") is not greater than ("0.6") - More than 60% of threads should have stacktrace frames, but got nan%
```

#skip-changelog