### PR TITLE
ci: Increase timeouts for 'SentryBinaryImageCacheTests'

### DIFF
--- a/Tests/SentryTests/SentryBinaryImageCacheTests.swift
+++ b/Tests/SentryTests/SentryBinaryImageCacheTests.swift
@@ -197,7 +197,7 @@ class SentryBinaryImageCacheTests: XCTestCase {
             }
         }
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
     
     func testAddingImagesWhileGettingAllOnDifferentThread() {
@@ -224,7 +224,7 @@ class SentryBinaryImageCacheTests: XCTestCase {
             }
         }
         
-        waitForExpectations(timeout: 1)
+        waitForExpectations(timeout: 10)
     }
 }
 


### PR DESCRIPTION
Increases timeout for `SentryBinaryImageCacheTests`

Test failed on main here: https://github.com/getsentry/sentry-cocoa/actions/runs/16808094147/job/47605898902