### PR TITLE
ci: Open Simulator GUI on CI

### DIFF
--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -59,6 +59,8 @@ head -n1)
 
 echo "Booting simulator $SIMULATOR - iOS $IOS_VERSION: $UDID"
 xcrun simctl boot "$UDID"
+
+# We use `open -a Simulator` because there's no lower-level CLI like `simctl` to display the simulator UI available.
 open -a Simulator
 
 # Wait for the simulator to boot

--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -59,6 +59,7 @@ head -n1)
 
 echo "Booting simulator $SIMULATOR - iOS $IOS_VERSION: $UDID"
 xcrun simctl boot "$UDID"
+open -a Simulator
 
 # Wait for the simulator to boot
 # We need to wait for the simulator to boot to avoid the test to fail due to timeout (because the simulator is not booted yet)


### PR DESCRIPTION
After reviewing screenshots on https://github.com/getsentry/sentry-cocoa/actions/runs/16805606320/job/47597097673, I see that the simulator is launched in background.

Having it in the foreground will help the screenshots to capture relevant data.