### PR TITLE
ci: Allow bash to take snapshots on private windows

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -65,6 +65,9 @@ jobs:
       - run: make init-ci-build
       - run: make xcode-ci
 
+      - name: Enable screenshots permissions
+        run: ./scripts/ci-enable-permissions.sh
+
       - name: Boot simulator
         run: ./scripts/ci-boot-simulator.sh
 

--- a/scripts/ci-enable-permissions.sh
+++ b/scripts/ci-enable-permissions.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+defaults write ~/Library/Group\ Containers/group.com.apple.replayd/ScreenCaptureApprovals.plist "/bin/bash" -date "3024-09-23 12:00:00 +0000"


### PR DESCRIPTION
After reviewing screenshots on https://github.com/getsentry/sentry-cocoa/actions/runs/16805606320/job/47597097673, I see that the screenshots sometimes fail with this message:

<img width="1024" height="768" alt="132223_app-did-not-crash_full_screen" src="https://github.com/user-attachments/assets/f046575e-f3e2-41ed-9366-d60afcb34871" />

Having this should help capture more helpful screenshots.