### PR TITLE
test: Use XCTestExpectation for User

### DIFF
--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -157,12 +157,15 @@ class SentryUserTests: XCTestCase {
     
     func testModifyingFromMultipleThreads() throws {
         let queue = DispatchQueue(label: "SentryUserTests", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
-        let group = DispatchGroup()
+        
+        let loopCount = 20
+        let expectation = XCTestExpectation(description: "ModifyingFromMultipleThreads")
+        expectation.expectedFulfillmentCount = loopCount
+        expectation.assertForOverFulfill = true
         
         let user = try XCTUnwrap(TestData.user.copy() as? User)
         
-        for i in 0...20 {
-            group.enter()
+        for i in 0..<loopCount {
             queue.async {
                 
                 // The number is kept small for the CI to not take to long.
@@ -195,11 +198,11 @@ class SentryUserTests: XCTestCase {
                     XCTAssertNotNil([user: user])
                 }
                 
-                group.leave()
+                expectation.fulfill()
             }
         }
         
         queue.activate()
-        group.waitWithTimeout()
+        wait(for: [expectation], timeout: 10.0)
     }
 }


### PR DESCRIPTION
Replace the dispatch group with an XCTestExpectation to get a failure message when the wait times out.

Contributes to GH-5789

#skip-changelog