### PR TITLE
test: Use XCTestExpectation for concurrent modifications

### DIFF
--- a/Tests/SentryTests/TestUtils/TestConncurrentModifications.swift
+++ b/Tests/SentryTests/TestUtils/TestConncurrentModifications.swift
@@ -1,26 +1,33 @@
-import Foundation
 @_spi(Private) import Sentry
 @_spi(Private) import SentryTestUtils
+import XCTest
 
-func testConcurrentModifications(asyncWorkItems: Int = 5, writeLoopCount: Int = 1_000, writeWork: @escaping (Int) -> Void, readWork: @escaping () -> Void = {}) {
-    
-    let queue = DispatchQueue(label: "testConcurrentModifications", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
-    let group = DispatchGroup()
-    
-    for _ in 0..<asyncWorkItems {
-        group.enter()
-        queue.async {
-            
-            for i in 0...writeLoopCount {
-                writeWork(i)
+extension XCTestCase {
+
+    func testConcurrentModifications(asyncWorkItems: Int = 5, writeLoopCount: Int = 1_000, writeWork: @escaping (Int) -> Void, readWork: @escaping () -> Void = {}) {
+
+        let queue = DispatchQueue(label: "testConcurrentModifications", qos: .userInteractive, attributes: [.concurrent, .initiallyInactive])
+
+        let expectation = XCTestExpectation(description: "ConcurrentModifications")
+        expectation.expectedFulfillmentCount = asyncWorkItems
+        expectation.assertForOverFulfill = true
+
+        for _ in 0..<asyncWorkItems {
+
+            queue.async {
+
+                for i in 0...writeLoopCount {
+                    writeWork(i)
+                }
+
+                readWork()
+
+                expectation.fulfill()
             }
-            
-            readWork()
-            
-            group.leave()
         }
+
+        queue.activate()
+
+        self.wait(for: [expectation], timeout: 10)
     }
-    
-    queue.activate()
-    group.waitWithTimeout(timeout: 500)
 }


### PR DESCRIPTION
Replace the dispatch group with an XCTestExpectation to get a failure message when the wait times out. To make this work, this PR changes the method to an extension so it can call XCTestCase.wait. Furthermore, this PR reduces the timeout from 500s to 10s, because 500s is way too high and risks slowing down CI.

Contributes to GH-5789

#skip-changelog