### PR TITLE
test: Fix flaky non file url for data tracing

### DIFF
--- a/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
@@ -93,8 +93,10 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         }
 
         var nonFileUrl: URL {
-            // URL to a file that is not a file but should exist at all times
-            URL(string: "https://raw.githubusercontent.com/getsentry/sentry-cocoa/refs/heads/main/.gitignore")!
+            // Use a non-file scheme that doesn't hit the network.
+            // We use a data: URL to reliably return bytes without external dependencies,
+            // ensuring this test verifies "non-file URL should not trace" deterministically.
+            URL(string: "data:text/plain;base64,SGVsbG8=")!
         }
 
         func tearDown() throws {

--- a/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
@@ -121,8 +121,10 @@ class FileManagerSentryTracingIntegrationTests: XCTestCase {
         var invalidPathToCreate: String { invalidDestPath }
 
         var nonFileUrl: URL {
-            // URL to a file that is not a file but should exist at all times
-            URL(string: "https://raw.githubusercontent.com/getsentry/sentry-cocoa/refs/heads/main/.gitignore")!
+            // Use a non-file scheme that doesn't hit the network.
+            // We use a data: URL to reliably return bytes without external dependencies,
+            // ensuring this test verifies "non-file URL should not trace" deterministically.
+            URL(string: "data:text/plain;base64,SGVsbG8=")!
         }
 
         var ignoredFileToCreatePath: String {


### PR DESCRIPTION
The web request to the .gitignore file on GitHub sometimes failed in CI. We can test the same approach with a data URL to avoid flakiness.

The test `testInitContentsOfWithSentryTracing_nonFileUrl_shouldNotTraceManually` using `nonFileUrl` failed here https://github.com/getsentry/sentry-cocoa/actions/runs/16823204267/job/47654500560

```
swift:226: error: -[SentryTests.DataSentryTracingIntegrationTests testInitContentsOfWithSentryTracing_nonFileUrl_shouldNotTraceManually] : failed: caught error: "Error Domain=NSCocoaErrorDomain Code=256 "The file “.gitignore” couldn’t be opened." UserInfo={NSURL=https://raw.githubusercontent.com/getsentry/sentry-cocoa/refs/heads/main/.gitignore}"
```

I double checked the URL and it works fine. Maybe our CI hits some rate limiting or something similar. Therefore, we use a local data URL

#skip-changelog