### PR TITLE
chore: Fix pre-commit path matching for YAML

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,7 @@ repos:
       - id: format-yaml
         name: Format YAML
         description: "Format YAML"
-        files: ^.*\.{yaml,yml}$
+        files: ^.*\.(yaml|yml)$
         types_or: [yaml]
         entry: dprint
         language: system


### PR DESCRIPTION
While working on #5838 I noticed that the YAML files in the `.github/workflows` path were not linted/formatted on commit, but then fails in the CI.

It turns out the multi-extension matching needs to be parentheses not curly-brackets because the pattern is a Python regex ([docs](https://pre-commit.com/#regular-expressions)) and can be evaluated like this:

```shell
$ python3 -c "import re; print(re.match(r'^.*\.{yaml,yml}$', '.github/workflows/benchmarking.yml'))"
None

$ python3 -c "import re; print(re.match(r'^.*\.(yaml|yml)$', '.github/workflows/benchmarking.yml'))"
<re.Match object; span=(0, 34), match='.github/workflows/benchmarking.yml'>
```
 
#skip-changelog