### PR TITLE
ci: Crash test app onAppear instead of init

### DIFF
--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
@@ -8,18 +8,20 @@ struct SwiftUICrashTestApp: App {
         SentrySDK.start { options in
             options.dsn = "https://6cc9bae94def43cab8444a99e0031c28@o447951.ingest.sentry.io/5428557"
         }
-
-        let userDefaultsKey = "crash-on-launch"
-        if UserDefaults.standard.bool(forKey: userDefaultsKey) {
-
-            UserDefaults.standard.removeObject(forKey: userDefaultsKey)
-            SentrySDK.crash()
-        }
     }
 
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .onAppear {
+                    let userDefaultsKey = "crash-on-launch"
+                    if UserDefaults.standard.bool(forKey: userDefaultsKey) {
+                        UserDefaults.standard.removeObject(forKey: userDefaultsKey)
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                            SentrySDK.crash()
+                        }
+                    }
+                }
         }
     }
 }


### PR DESCRIPTION
Even though the app has crashes the simulator seems stuck with the app on an intermediary state.

This change attempts to let the app fully launch but crash after a slight delay.

<img width="1179" height="2556" alt="090908_app-did-not-crash" src="https://github.com/user-attachments/assets/002f127d-464e-4e35-b6d5-bf9f675da2eb" />