### PR TITLE
ci: Disable tests parallelization for cocoapods integration test

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,6 +15,7 @@ on:
       - "*.podspec"
       - "fastlane/**"
       - "Gemfile.lock"
+      - "Plans/iOS-Cocoapods-Swift6_Base.xctestplan"
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:

--- a/Plans/iOS-Cocoapods-Swift6_Base.xctestplan
+++ b/Plans/iOS-Cocoapods-Swift6_Base.xctestplan
@@ -17,11 +17,10 @@
   },
   "testTargets" : [
     {
-      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:iOS-Cocoapods-Swift6.xcodeproj",
         "identifier" : "D4DC1E792D6F0FAD00F562AA",
-        "name" : "iOS-Cocoapods-Swift6-UITests"
+        "name" : "UITests"
       }
     }
   ],


### PR DESCRIPTION
Disable test parallelization for Cocoapods Integration test since there is a single test to be ran and doing so will avoid using clone of simulators: 
```
[09:04:10]: ▸ Testing started
[09:07:37]: ▸ Test Suite UITestsLaunchTests started on 'Clone 1 of iPhone 16 - UITests-Runner (5805)'
```

#skip-changelog