### PR TITLE
ci: Allow up to 0.05% decrease in coverage before marking the build as failed

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,8 +1,8 @@
 codecov:
   branch: main
-  require_ci_to_pass: true
+  require_ci_to_pass: yes
   notify:
-    wait_for_ci: true
+    wait_for_ci: yes
 
 coverage:
   range: 80...100
@@ -22,5 +22,5 @@ comment:
   # already exists, and a newer commit results in no coverage change for the
   # entire pull, the comment will be deleted.
   require_changes: true
-  require_base: true # must have a base report to post
-  require_head: true # must have a head report to post
+  require_base: yes # must have a base report to post
+  require_head: yes # must have a head report to post

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,13 +1,14 @@
 codecov:
   branch: main
-  require_ci_to_pass: yes
+  require_ci_to_pass: true
   notify:
-    wait_for_ci: yes
+    wait_for_ci: true
 
 coverage:
   range: 80...100
   precision: 3
   round: down
+  threshold: 0.05 # Allow up to 0.05% coverage decrease before failing the build
 
 ignore:
   - "SentryTestUtilsTests/**"
@@ -21,5 +22,5 @@ comment:
   # already exists, and a newer commit results in no coverage change for the
   # entire pull, the comment will be deleted.
   require_changes: true
-  require_base: yes # must have a base report to post
-  require_head: yes # must have a head report to post
+  require_base: true # must have a base report to post
+  require_head: true # must have a head report to post


### PR DESCRIPTION
We have some variance on what code is executed on our tests.
Because of this, the lines covered may change a little bit, with some builds changing by 0.017%.
I believe this is within as margin of error and can be safely ingored

#skip-changelog