### PR TITLE
fix: Remove unnecessary function

### DIFF
--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -173,11 +173,6 @@ NS_SWIFT_NAME(Scope)
         "now considered unsafe and deprecated. Use `span` instead.");
 #endif // !SDK_V9
 
-/**
- * Returns the current span.
- */
-- (id<SentrySpan> _Nullable)span;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This function wasn't doing anything because there was already an `@property ... span` defined above. Confirmed that it wasn't doing anything because the API stability check didn't trigger any changes by removing it

#skip-changelog