### PR TITLE
feat(V9): Make span read only in v9

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -14,6 +14,7 @@ Removes Decodable conformances from the public API of model classes (#5691)
 Removes enableTracing property from SentryOptions (#5694)
 Removes `integrations` property from `SentryOptions` (#5749)
 Makes `SentryEventDecodable` internal (#5808)
+The `span` property on `SentryScope` is now readonly (#5866)
 
 ### Fixes
 

--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -33,7 +33,11 @@ NS_SWIFT_NAME(Scope)
  * Returns current Span or Transaction.
  * @return current Span or Transaction or null if transaction has not been set.
  */
+#if SDK_V9
+@property (nullable, nonatomic, readonly, strong) id<SentrySpan> span;
+#else
 @property (nullable, nonatomic, strong) id<SentrySpan> span;
+#endif // SDK_V9
 
 /**
  * The id of current session replay.

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSArray<SentryBreadcrumb *> *)breadcrumbs;
 
+- (void)setSpan:(nullable id<SentrySpan>)span;
+
 /**
  * used to add values in event context.
  */

--- a/sdk_api_V9.json
+++ b/sdk_api_V9.json
@@ -22320,49 +22320,6 @@
                   "Dynamic"
                 ],
                 "accessorKind": "get"
-              },
-              {
-                "kind": "Accessor",
-                "name": "Set",
-                "printedName": "Set()",
-                "children": [
-                  {
-                    "kind": "TypeNameAlias",
-                    "name": "Void",
-                    "printedName": "Swift.Void",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Void",
-                        "printedName": "()"
-                      }
-                    ]
-                  },
-                  {
-                    "kind": "TypeNominal",
-                    "name": "Optional",
-                    "printedName": "(any Sentry.Span)?",
-                    "children": [
-                      {
-                        "kind": "TypeNominal",
-                        "name": "Span",
-                        "printedName": "any Sentry.Span",
-                        "usr": "c:objc(pl)SentrySpan"
-                      }
-                    ],
-                    "usr": "s:Sq"
-                  }
-                ],
-                "declKind": "Accessor",
-                "usr": "c:objc(cs)SentryScope(im)setSpan:",
-                "moduleName": "Sentry",
-                "isOpen": true,
-                "objc_name": "setSpan:",
-                "declAttributes": [
-                  "ObjC",
-                  "Dynamic"
-                ],
-                "accessorKind": "set"
               }
             ]
           },


### PR DESCRIPTION
I suggest we make this readonly in V9. I don't think we want anyone setting it to any new types that conform to the protocol. Also, I want to remove `SentrySerializable` from the public API but this property needs to have the `serialize` function defined. If we want to allow it to be set publicly we will need to keep this function public to make sure anything that it gets set to has a `serialize` function. However, I think we can just make it readonly like this, allowing us to move the `serialize` aspect to a private header.

#skip-changelog