### PR TITLE
chore: Minor wording fixes for CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,14 @@
 ## Unreleased
 
 > [!Important]
-> Xcode 26 is not allowing individual frameworks to contain arm64e slices anymore if the main binary doesn't contain it.
+> Xcode 26 no longer allows individual frameworks to contain arm64e slices anymore if the main binary doesn't contain them.
 > We have decided to split the Dynamic variant of Sentry into two variants:
 >
 > - `Sentry-Dynamic`: Without arm64e
 > - `Sentry-Dynamic-WithARM64e`: _With_ ARM64e slice
 >
-> If your app does not need arm64e, you don't need to do any changes.
-> But if your app _needs arm64e_ please use `Sentry-Dynamic-WithARM64e` from 8.55.0 so you don't have issues uploading to the AppStore.
+> If your app does not need arm64e, you don't need to make any changes.
+> But if your app _needs arm64e_ please use `Sentry-Dynamic-WithARM64e` from 8.55.0 so you don't have issues uploading to the App Store.
 
 ### Features
 


### PR DESCRIPTION
Do a couple of wording fixes for the last changelog entry.

I did these fixes mostly to see which CI jobs will run if we're only touching the changelog to see if making unit tests required checks will block this PR.

#skip-changelog