### PR TITLE
chore: Increase maximum binary diff size in metrics check

### DIFF
--- a/Tests/Perf/metrics-test.yml
+++ b/Tests/Perf/metrics-test.yml
@@ -11,4 +11,4 @@ startupTimeTest:
 
 binarySizeTest:
   diffMin: 200 KiB
-  diffMax: 890 KiB
+  diffMax: 925 KiB


### PR DESCRIPTION
#skip-changelog

## :scroll: Description

Bumps diffMax, as it's the only thing blocking #5668, and we discussed we should do this sepratley.

https://github.com/getsentry/sentry-cocoa/pull/5678?notification_referrer_id=NT_kwDOADzMRbMxNzczNjA4MTE2MDozOTg0NDUz#discussion_r2256906830
