### PR TITLE
ci: Update Codecov configuration to set coverage thresholds for project and patch

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,10 +5,16 @@ codecov:
     wait_for_ci: yes
 
 coverage:
+  status:
+    project:
+      default:
+        threshold: 0.05%
+    patch:
+      default:
+        threshold: 0.05%
   range: 80...100
   precision: 3
   round: down
-  threshold: 0.05 # Allow up to 0.05% coverage decrease before failing the build
 
 ignore:
   - "SentryTestUtilsTests/**"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,10 +8,10 @@ coverage:
   status:
     project:
       default:
-        threshold: 0.05%
+        threshold: 0.05% # Allow up to 0.05% coverage decrease before failing the build
     patch:
       default:
-        threshold: 0.05%
+        threshold: 0.05% # Allow up to 0.05% coverage decrease before failing the build
   range: 80...100
   precision: 3
   round: down


### PR DESCRIPTION
Apparently I misunderstood codecov docs and applied the `threshold` on the root of the settings in #5859

#skip-changelog