### PR TITLE
ci: Add unit tests required check

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -16,19 +16,26 @@ high_risk_code: &high_risk_code
   - "Sources/Sentry/SentrySerialization.m"
   - "Sources/Sentry/SentrySerialization.h"
 
-run_unit_tests_for_prs: &run_unit_tests_for_prs
+run_unit_tests_for_prs: &run_unit_tests_for_prs # Code
   - "Sources/**"
   - "Tests/**"
   - "SentryTestUtils/**"
   - "SentryTestUtilsDynamic/**"
-  - "test-server/**"
+
+  # GH Actions
   - ".github/workflows/test.yml"
-  - "fastlane/**"
-  - "scripts/tests-with-thread-sanitizer.sh"
+  - ".github/file-filters.yml"
+
+  # Scripts
   - "scripts/ci-select-xcode.sh"
   - "scripts/sentry-xcodebuild.sh"
-  - ".codecov.yml"
+  - "scripts/tests-with-thread-sanitizer.sh"
+
+  # Other
+  - "test-server/**"
   - "Sentry.xcodeproj"
   - "**/*.xctestplan"
-  - "Makefile" # Make commands used for CI build setup
+  - "fastlane/**"
+  - ".codecov.yml"
   - "Brewfile*" # Dependency installation affects test environment
+  - "Makefile" # Make commands used for CI build setup

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -15,3 +15,20 @@ high_risk_code: &high_risk_code
   - "Sources/Sentry/SentryFileManager.m"
   - "Sources/Sentry/SentrySerialization.m"
   - "Sources/Sentry/SentrySerialization.h"
+
+run_unit_tests_for_prs: &run_unit_tests_for_prs
+  - "Sources/**"
+  - "Tests/**"
+  - "SentryTestUtils/**"
+  - "SentryTestUtilsDynamic/**"
+  - "test-server/**"
+  - ".github/workflows/test.yml"
+  - "fastlane/**"
+  - "scripts/tests-with-thread-sanitizer.sh"
+  - "scripts/ci-select-xcode.sh"
+  - "scripts/sentry-xcodebuild.sh"
+  - ".codecov.yml"
+  - "Sentry.xcodeproj"
+  - "**/*.xctestplan"
+  - "Makefile" # Make commands used for CI build setup
+  - "Brewfile*" # Dependency installation affects test environment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,22 +6,6 @@ on:
       - release/**
 
   pull_request:
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "SentryTestUtils/**"
-      - "SentryTestUtilsDynamic/**" # Dynamic test utilities used by tests
-      - "test-server/**"
-      - ".github/workflows/test.yml"
-      - "fastlane/**"
-      - "scripts/tests-with-thread-sanitizer.sh"
-      - "scripts/ci-select-xcode.sh"
-      - "scripts/sentry-xcodebuild.sh"
-      - ".codecov.yml"
-      - "Sentry.xcodeproj"
-      - "**/*.xctestplan"
-      - "Makefile" # Make commands used for CI build setup
-      - "Brewfile*" # Dependency installation affects test environment
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value
 concurrency:
@@ -29,8 +13,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # This job detects if the PR contains changes that require running unit tests.
+  # If yes, the job will output a flag that will be used by the next job to run the unit tests.
+  # If no, the job will output a flag that will be used by the next job to skip running the unit tests.
+  # At the end of this workflow, we run a check that validates that either all unit tests passed or were
+  # called unit-tests-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_unit_tests_for_prs: ${{ steps.changes.outputs.run_unit_tests_for_prs }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
   build-test-server:
     name: Build test server
+    if: needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
+    needs: files-changed
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
@@ -300,3 +305,25 @@ jobs:
           verbose: true
           name: sentry-cocoa-unit-tests
           flags: unittests-${{ matrix.platform }}-${{ matrix.xcode }}-${{ matrix.test-destination-os }}, unittests
+
+  # This check validates that either all unit tests passed or were skipped, which allows us
+  # to make unit tests a required check with only running the unit tests when required.
+  # So, we don't have to run unit tests, for example, for Changelog or ReadMe changes.
+
+  unit-tests-required-check:
+    needs:
+      [
+        build-test-server,
+        unit-tests,
+      ]
+    name: Unit Tests
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the unit test jobs has failed." && exit 1

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -396,12 +396,6 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.capture(message: fixture.message, block: fixture.scopeBlock)
 
         assertHubScopeNotChanged()
-        
-        // Intentionally fail about 30% of the time to simulate flakiness for CI experiments
-        if Int.random(in: 0..<100) < 30 {
-            XCTFail("Injected random failure (30%) for flakiness testing")
-        }
-        
     }
 }
 

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -396,6 +396,12 @@ class SentrySDKTests: XCTestCase {
         SentrySDK.capture(message: fixture.message, block: fixture.scopeBlock)
 
         assertHubScopeNotChanged()
+        
+        // Intentionally fail about 30% of the time to simulate flakiness for CI experiments
+        if Int.random(in: 0..<100) < 30 {
+            XCTFail("Injected random failure (30%) for flakiness testing")
+        }
+        
     }
 }
 


### PR DESCRIPTION
Use dorny path filters to have one single job failing or succeeding when the unit tests passed or were skipped so we can enable unit tests as required checks for PRs.

Fixes GH-5868

PR with only a Changelog entry let's the job unit test pass https://github.com/getsentry/sentry-cocoa/pull/5891.

<img width="1678" height="862" alt="Screenshot 2025-08-12 at 13 19 31" src="https://github.com/user-attachments/assets/036eec58-4e50-451a-889f-ae5a8efa0bdf" />


When cancelling unit tests jobs fail

https://github.com/getsentry/sentry-cocoa/actions/runs/16907162839/job/47899511411

<img width="2226" height="930" alt="Screenshot 2025-08-12 at 13 21 18" src="https://github.com/user-attachments/assets/1b556fab-d37f-47e4-af83-f152b9e9f3d3" />


When a few unit tests fail also the main unit test job fails

<img width="1926" height="994" alt="Screenshot 2025-08-12 at 14 46 52" src="https://github.com/user-attachments/assets/cf52bbab-1b53-47db-b734-4bf2edb7cf81" />

#skip-changelog
