### PR TITLE
refactor: Add null-handling to profiler

### DIFF
--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -179,8 +179,11 @@ sentry_discardProfilerCorrelatedToTrace(SentryId *internalTraceId, SentryHub *hu
     } else if (internalTraceId != nil) {
 #    if !SDK_V9
         SentryClient *_Nullable client = hub.getClient;
-        if (nil != client
-            && sentry_isContinuousProfilingEnabled(SENTRY_UNWRAP_NULLABLE(SentryClient, client))) {
+        if (client == nil) {
+            SENTRY_LOG_ERROR(@"No client found, skipping cleanup.");
+            return;
+        }
+        if (sentry_isContinuousProfilingEnabled(SENTRY_UNWRAP_NULLABLE(SentryClient, client))) {
             SENTRY_LOG_ERROR(@"Tracers are not tracked with continuous profiling V1.");
             return;
         }

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -130,14 +130,12 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
             const auto profileIsContinuousV2 = configurationFromLaunch.profileOptions != nil;
             const auto v2LifecycleIsManual = profileIsContinuousV2
                 && !sentry_isTraceLifecycle(
-                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)
-                        .profileOptions);
+                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch.profileOptions));
 
 #    if SENTRY_HAS_UIKIT
             const auto v2LifecycleIsTrace = profileIsContinuousV2
                 && sentry_isTraceLifecycle(
-                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)
-                        .profileOptions);
+                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch.profileOptions));
             const auto profileIsCorrelatedToTrace = !profileIsContinuousV2 || v2LifecycleIsTrace;
             if (profileIsCorrelatedToTrace && configurationFromLaunch.waitForFullDisplay) {
                 SENTRY_LOG_DEBUG(

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -129,13 +129,13 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
 
             const auto profileIsContinuousV2 = configurationFromLaunch.profileOptions != nil;
             const auto v2LifecycleIsManual = profileIsContinuousV2
-                && !sentry_isTraceLifecycle(
-                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch.profileOptions));
+                && !sentry_isTraceLifecycle(SENTRY_UNWRAP_NULLABLE(
+                    SentryProfileOptions, configurationFromLaunch.profileOptions));
 
 #    if SENTRY_HAS_UIKIT
             const auto v2LifecycleIsTrace = profileIsContinuousV2
-                && sentry_isTraceLifecycle(
-                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch.profileOptions));
+                && sentry_isTraceLifecycle(SENTRY_UNWRAP_NULLABLE(
+                    SentryProfileOptions, configurationFromLaunch.profileOptions));
             const auto profileIsCorrelatedToTrace = !profileIsContinuousV2 || v2LifecycleIsTrace;
             if (profileIsCorrelatedToTrace && configurationFromLaunch.waitForFullDisplay) {
                 SENTRY_LOG_DEBUG(

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -85,10 +85,11 @@ sentry_configureContinuousProfiling(SentryOptions *options)
         return;
     }
 
-    options.profiling = sentry_getSentryProfileOptions();
-    options.configureProfiling(options.profiling);
+    SentryProfileOptions *_Nonnull profilingOptions = sentry_getSentryProfileOptions();
+    options.profiling = profilingOptions;
+    options.configureProfiling(profilingOptions);
 
-    if (sentry_isTraceLifecycle(options.profiling) && !options.isTracingEnabled) {
+    if (sentry_isTraceLifecycle(profilingOptions) && !options.isTracingEnabled) {
         SENTRY_LOG_WARN(
             @"Tracing must be enabled in order to configure profiling with trace lifecycle.");
         return;
@@ -101,16 +102,16 @@ sentry_configureContinuousProfiling(SentryOptions *options)
     // the profile session sample rate henceforth
     if (sentry_profileConfiguration == nil) {
         sentry_profileConfiguration =
-            [[SentryProfileConfiguration alloc] initWithProfileOptions:options.profiling];
+            [[SentryProfileConfiguration alloc] initWithProfileOptions:profilingOptions];
     }
 
     sentry_reevaluateSessionSampleRate();
 
     SENTRY_LOG_DEBUG(@"Configured profiling options: <%@: {\n  lifecycle: %@\n  sessionSampleRate: "
                      @"%.2f\n  profileAppStarts: %@\n}",
-        options.profiling, sentry_isTraceLifecycle(options.profiling) ? @"trace" : @"manual",
-        sentry_sessionSampleRate(options.profiling),
-        sentry_profileAppStarts(options.profiling) ? @"YES" : @"NO");
+        options.profiling, sentry_isTraceLifecycle(profilingOptions) ? @"trace" : @"manual",
+        sentry_sessionSampleRate(profilingOptions),
+        sentry_profileAppStarts(profilingOptions) ? @"YES" : @"NO");
 }
 
 void
@@ -128,11 +129,15 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
 
             const auto profileIsContinuousV2 = configurationFromLaunch.profileOptions != nil;
             const auto v2LifecycleIsManual = profileIsContinuousV2
-                && !sentry_isTraceLifecycle(configurationFromLaunch.profileOptions);
+                && !sentry_isTraceLifecycle(
+                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)
+                        .profileOptions);
 
 #    if SENTRY_HAS_UIKIT
             const auto v2LifecycleIsTrace = profileIsContinuousV2
-                && sentry_isTraceLifecycle(configurationFromLaunch.profileOptions);
+                && sentry_isTraceLifecycle(
+                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)
+                        .profileOptions);
             const auto profileIsCorrelatedToTrace = !profileIsContinuousV2 || v2LifecycleIsTrace;
             if (profileIsCorrelatedToTrace && configurationFromLaunch.waitForFullDisplay) {
                 SENTRY_LOG_DEBUG(


### PR DESCRIPTION
This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577.

Resolves warnings in SentryProfiledTracerConcurrency.mm and SentryProfiler.mm

#skip-changelog