### PR TITLE
fix: Add null-handling for static cache path in async logger

### DIFF
--- a/Sources/Sentry/SentryAsyncLog.m
+++ b/Sources/Sentry/SentryAsyncLog.m
@@ -2,6 +2,7 @@
 #import "SentryAsyncSafeLog.h"
 #import "SentryFileManager.h"
 #import "SentryInternalCDefines.h"
+#import "SentryInternalDefines.h"
 #import "SentryLogC.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -10,11 +11,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (void)initializeAsyncLogFile
 {
-    const char *asyncLogPath =
-        [[sentryStaticCachesPath() stringByAppendingPathComponent:@"async.log"] UTF8String];
+    NSString *_Nullable nullableStaticCachesPath = sentryStaticCachesPath();
+    if (nullableStaticCachesPath == nil) {
+        SENTRY_LOG_ERROR(@"Failed to get static caches path for async log file.");
+        return;
+    }
+    NSString *_Nonnull cachesPath = SENTRY_UNWRAP_NULLABLE(NSString, nullableStaticCachesPath);
 
-    NSError *error;
-    if (!createDirectoryIfNotExists(sentryStaticCachesPath(), &error)) {
+    const char *asyncLogPath =
+        [[cachesPath stringByAppendingPathComponent:@"async.log"] UTF8String];
+
+    NSError *_Nullable error;
+    if (!createDirectoryIfNotExists(cachesPath, &error)) {
         SENTRY_LOG_ERROR(@"Failed to initialize directory for async log file: %@", error);
         return;
     }


### PR DESCRIPTION
This PR is derived from https://github.com/getsentry/sentry-cocoa/pull/5572 in an effort to make the large amount of changes easier to review for https://github.com/getsentry/sentry-cocoa/issues/5577.

The async logger relies on a nullable static caches path, so we need to unwrap it before we check for existence. As we are already logging an error and exiting the method, when directory creation fails, I use the same approach when the cache directory is not defined.

#skip-changelog