### PR TITLE
Fix sentry unwrap nullable macro type mismatch

### DIFF
--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -130,14 +130,12 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
             const auto profileIsContinuousV2 = configurationFromLaunch.profileOptions != nil;
             const auto v2LifecycleIsManual = profileIsContinuousV2
                 && !sentry_isTraceLifecycle(
-                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)
-                        .profileOptions);
+                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch.profileOptions));
 
 #    if SENTRY_HAS_UIKIT
             const auto v2LifecycleIsTrace = profileIsContinuousV2
                 && sentry_isTraceLifecycle(
-                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)
-                        .profileOptions);
+                    SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch.profileOptions));
             const auto profileIsCorrelatedToTrace = !profileIsContinuousV2 || v2LifecycleIsTrace;
             if (profileIsCorrelatedToTrace && configurationFromLaunch.waitForFullDisplay) {
                 SENTRY_LOG_DEBUG(


### PR DESCRIPTION
## :scroll: Description

Corrected the application of the `SENTRY_UNWRAP_NULLABLE` macro in `SentryProfiler.mm` to directly unwrap `configurationFromLaunch.profileOptions`.

## :bulb: Motivation and Context

The `SENTRY_UNWRAP_NULLABLE` macro was incorrectly attempting to unwrap `configurationFromLaunch` (type `SentryProfileConfiguration *`) as `SentryProfileOptions`, then accessing `.profileOptions` on the result. This type mismatch could lead to compilation errors or runtime crashes. The change ensures the macro unwraps `configurationFromLaunch.profileOptions` (type `SentryProfileOptions *`) directly, resolving the issue.

## :green_heart: How did you test it?

Verified that no other instances of the incorrect `SENTRY_UNWRAP_NULLABLE(SentryProfileOptions, configurationFromLaunch)` remained and that other related usages were already correct.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-8b7e1aac-f550-483b-bd15-8dae0898d4d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8b7e1aac-f550-483b-bd15-8dae0898d4d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

