### PR TITLE
fix(ci): Add files-changed to needs of unit-tests-required-check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -319,6 +319,7 @@ jobs:
   unit-tests-required-check:
     needs:
       [
+        files-changed,
         build-test-server,
         unit-tests,
       ]


### PR DESCRIPTION
During review of #5893 the Cursor Review Bot and Sentry Seer mentioned [reported](https://github.com/getsentry/sentry-cocoa/pull/5893#discussion_r2269955609) the following issue:

The `api-stability-required-check` job only depends on `api-stability`, not `files-changed`. If the `files-changed` job fails, the `api-stability` job will be skipped. Since `api-stability-required-check` only checks for 'failure' or 'cancelled' results, it incorrectly passes, allowing the workflow to complete without validating if API stability checks were needed. This could lead to undetected API changes. The `api-stability-required-check` job should depend on both `files-changed` and `api-stability`.

The same applies ot the `unit-tests-required-check`, therefore I am adding the `files-changed` to the list of needs.

#skip-changelog