### PR TITLE
feat: Exclude arm64e slice from Sentry-WithoutUIKitOrAppKit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,12 @@ jobs:
             configuration-suffix: WithoutUIKit
             id: sentry-withoutuikit-dynamic
             excluded-archs: arm64e
+          - scheme: Sentry
+            macho-type: mh_dylib
+            suffix: "-WithoutUIKitOrAppKit"
+            configuration-suffix: WithoutUIKit
+            id: sentry-withoutuikit-dynamic
+            override-name: Sentry-WithoutUIKitOrAppKit-WithARM64e
 
   validate-xcframework:
     name: Validate XCFramework

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,7 @@ jobs:
             suffix: "-WithoutUIKitOrAppKit"
             configuration-suffix: WithoutUIKit
             id: sentry-withoutuikit-dynamic
+            excluded-archs: arm64e
 
   validate-xcframework:
     name: Validate XCFramework

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ Sentry-Dynamic.xcframework*
 Sentry-Dynamic-WithARM64e.xcframework*
 SentrySwiftUI.xcframework*
 Sentry-WithoutUIKitOrAppKit.xcframework*
+Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,22 @@
 
 ## Unreleased
 
+> [!Important]
+> Xcode 26 no longer allows individual frameworks to contain arm64e slices anymore if the main binary doesn't contain them.
+> We have decided to split the Dynamic variant and Sentry-WithoutUIKitOrAppKit of Sentry into two variants:
+>
+> - `Sentry-Dynamic`: Without ARM64e
+> - `Sentry-Dynamic-WithARM64e`: _With_ ARM64e slice
+> - `Sentry-WithoutUIKitOrAppKit`: Without ARM64e
+> - `Sentry-WithoutUIKitOrAppKit-WithARM64e`: _With_ ARM64e slice
+>
+> If your app does not need arm64e, you don't need to make any changes.
+> But if your app _needs arm64e_ please use `Sentry-Dynamic-WithARM64e` or `Sentry-WithoutUIKitOrAppKit-WithARM64e` from 8.55.0 so you don't have issues uploading to the App Store.
+
 ### Features
 
 - Structured Logs: Flush logs on SDK flush/close (#5834)
-- Exclude arm64e slice from Sentry-WithoutUIKitOrAppKit in sync with Sentry-Dynamic
+- Add a new prebuilt framework with ARM64e for WithoutUIKitOrAppKit
 
 ## 8.54.1-alpha.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Structured Logs: Flush logs on SDK flush/close (#5834)
+- Exclude arm64e slice from Sentry-WithoutUIKitOrAppKit in sync with Sentry-Dynamic
 
 ## 8.54.1-alpha.1
 

--- a/scripts/build-xcframework-local.sh
+++ b/scripts/build-xcframework-local.sh
@@ -34,7 +34,7 @@ if [ "$variants" = "SwiftUIOnly" ] || [ "$variants" = "AllVariants" ]; then
 fi
 
 if [ "$variants" = "WithoutUIKitOnly" ] || [ "$variants" = "AllVariants" ]; then
-    ./scripts/build-xcframework-variant.sh "Sentry" "-WithoutUIKitOrAppKit" "mh_dylib" "WithoutUIKit" "$sdks" ""
+    ./scripts/build-xcframework-variant.sh "Sentry" "-WithoutUIKitOrAppKit" "mh_dylib" "WithoutUIKit" "$sdks" "arm64e"
     ./scripts/compress-xcframework.sh "$signed" Sentry-WithoutUIKitOrAppKit
     mv Sentry-WithoutUIKitOrAppKit.xcframework.zip Carthage/Sentry-WithoutUIKitOrAppKit.xcframework.zip
 fi

--- a/scripts/build-xcframework-local.sh
+++ b/scripts/build-xcframework-local.sh
@@ -34,7 +34,13 @@ if [ "$variants" = "SwiftUIOnly" ] || [ "$variants" = "AllVariants" ]; then
 fi
 
 if [ "$variants" = "WithoutUIKitOnly" ] || [ "$variants" = "AllVariants" ]; then
-    ./scripts/build-xcframework-variant.sh "Sentry" "-WithoutUIKitOrAppKit" "mh_dylib" "WithoutUIKit" "$sdks" "arm64e"
+    ./scripts/build-xcframework-variant.sh "Sentry" "-WithoutUIKitOrAppKit" "mh_dylib" "WithoutUIKit" "$sdks" ""
     ./scripts/compress-xcframework.sh "$signed" Sentry-WithoutUIKitOrAppKit
     mv Sentry-WithoutUIKitOrAppKit.xcframework.zip Carthage/Sentry-WithoutUIKitOrAppKit.xcframework.zip
+fi
+
+if [ "$variants" = "WithoutUIKitWithARM64eOnly" ] || [ "$variants" = "AllVariants" ]; then
+    ./scripts/build-xcframework-variant.sh "Sentry" "-WithoutUIKitOrAppKit-WithARM64e" "mh_dylib" "WithoutUIKit" "$sdks" "arm64e"
+    ./scripts/compress-xcframework.sh "$signed" Sentry-WithoutUIKitOrAppKit-WithARM64e
+    mv Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip Carthage/Sentry-WithoutUIKitOrAppKit-WithARM64e.xcframework.zip
 fi


### PR DESCRIPTION
Excludes ARM64e from Sentry-WithoutUIKitOrAppKit and adds a new variant with ARM64e.
Also updates local script to build these new variants.

Fixes: #5876