### PR TITLE
meta: Add comment explaining why the crash was moved to onAppear

### DIFF
--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
@@ -17,6 +17,8 @@ struct SwiftUICrashTestApp: App {
         WindowGroup {
             ContentView()
                 .onAppear {
+                    // Moved the crash to the onAppear to make sure the app is fully loaded before crashing.
+                    // Previously when the crash was in the init, we found the test to be flaky on CI.
                     let userDefaultsKey = "crash-on-launch"
                     if UserDefaults.standard.bool(forKey: userDefaultsKey) {
                         NSLog("SwiftUICrashTestApp - will crash")

--- a/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
+++ b/TestSamples/SwiftUICrashTest/SwiftUICrashTest/SwiftUICrashTestApp.swift
@@ -17,8 +17,8 @@ struct SwiftUICrashTestApp: App {
         WindowGroup {
             ContentView()
                 .onAppear {
-                    // Moved the crash to the onAppear to make sure the app is fully loaded before crashing.
-                    // Previously when the crash was in the init, we found the test to be flaky on CI.
+                    // Moved the crash from init to onAppear to ensure the app is fully loaded before crashing.
+                    // This prevents test flakiness on CI that occurred when the crash happened during the app launch.
                     let userDefaultsKey = "crash-on-launch"
                     if UserDefaults.standard.bool(forKey: userDefaultsKey) {
                         NSLog("SwiftUICrashTestApp - will crash")


### PR DESCRIPTION
Adds a some more context to the code for testing crash on launch which was changed in #5855

#skip-changelog