### PR TITLE
test: Use XCTestExpectation for delay non blocking

### DIFF
--- a/Tests/SentryTests/TestUtils/Async.swift
+++ b/Tests/SentryTests/TestUtils/Async.swift
@@ -1,18 +1,6 @@
 import Foundation
 import XCTest
 
-func delayNonBlocking(timeout: Double = 0.2) {
-    let group = DispatchGroup()
-    group.enter()
-    let queue = DispatchQueue(label: "delay")
-    
-    queue.asyncAfter(deadline: .now() + timeout) {
-        group.leave()
-    }
-    
-    group.wait()
-}
-
 extension DispatchGroup {
     
     /**

--- a/Tests/SentryTests/TestUtils/TestExtensions.swift
+++ b/Tests/SentryTests/TestUtils/TestExtensions.swift
@@ -7,3 +7,20 @@ extension XCTest {
         return try Data(contentsOf: URL(fileURLWithPath: path ?? ""))
     }
 }
+
+extension XCTestCase {
+
+    func delayNonBlocking(timeout: Double = 0.2) {
+        let expectation = XCTestExpectation(description: "Finish Delay")
+        expectation.assertForOverFulfill = true
+
+        let queue = DispatchQueue(label: "delay")
+
+        queue.asyncAfter(deadline: .now() + timeout) {
+            expectation.fulfill()
+        }
+
+        let timeoutWithBuffer = timeout * 1.3
+        self.wait(for: [expectation], timeout: timeoutWithBuffer)
+    }
+}


### PR DESCRIPTION
Ideally, we would remove the method delayNonBlocking, but that requires a few changes to a handful of tests. Instead, we remove the dispatch group wait call, which could hang tests forever in CI. Now tests using delayNonBlocking will fail with an assert instead.

I had to define the method as an extension to XCTestCase to use `XCTestCase.wait`.

Contributes to #5789

#skip-changelog