### PR TITLE
test: Increase timeout to 5 seconds for ANRV1

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -9,7 +9,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
     private var fixture: Fixture!
     private var anrDetectedExpectation: XCTestExpectation!
     private var anrStoppedExpectation: XCTestExpectation!
-    private let waitTimeout: TimeInterval = 2.0
+    private let waitTimeout: TimeInterval = 5.0
     private var lastANRStoppedResult: SentryANRStoppedResult?
     
     private class Fixture {


### PR DESCRIPTION
A waitTimeout of 2 seconds is usually not enough. Let's increase it to 5 seconds.

Failed here on main https://github.com/getsentry/sentry-cocoa/actions/runs/16913124095/job/47921390079

#skip-changelog