### PR TITLE
fix: Build error on Xcode 14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
 - Add a new prebuilt framework with ARM64e for WithoutUIKitOrAppKit (#5897)
 - Add source context and vars fields to SentryFrame (#5853)
 
+### Fixes
+
+- Fixed a build error in `SentryFeedback.swift` when building with cocoapods on Xcode 14.2 (#5917)
+
 ## 8.54.1-alpha.1
 
 - No documented changes.

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
@@ -49,9 +49,15 @@ extension SentryFeedback: SentrySerializable { }
 extension SentryFeedback {
     #if SDK_V9
     @_spi(Private) public func serialize() -> [String: Any] {
+        return internalSerialize()
+    }
     #else
     public func serialize() -> [String: Any] {
+        return internalSerialize()
+    }
     #endif
+
+    private func internalSerialize() -> [String: Any] {
         let numberOfOptionalItems = (name == nil ? 0 : 1) + (email == nil ? 0 : 1) + (associatedEventId == nil ? 0 : 1)
         var dict = [String: Any](minimumCapacity: 2 + numberOfOptionalItems)
         dict["message"] = message

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
@@ -48,9 +48,10 @@ extension SentryFeedback: SentrySerializable { }
 
 extension SentryFeedback {
     #if SDK_V9
-    @_spi(Private)
-    #endif
+    @_spi(Private) public func serialize() -> [String: Any] {
+    #else
     public func serialize() -> [String: Any] {
+    #endif
         let numberOfOptionalItems = (name == nil ? 0 : 1) + (email == nil ? 0 : 1) + (associatedEventId == nil ? 0 : 1)
         var dict = [String: Any](minimumCapacity: 2 + numberOfOptionalItems)
         dict["message"] = message


### PR DESCRIPTION
Fixes a build error on RN SDK with Xcode 14.2: https://github.com/getsentry/sentry-react-native/actions/runs/16932149646/job/47988490015?pr=5038

Old swift version might have not liked the `@spi` inside the a precompiler flag block

Seems to only happen when building from source or with CocoaPods