### PR TITLE
ci: Bump iOS and tvOS versions to 18.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
             runs-on: macos-15
             platform: "iOS"
             xcode: "16.4"
-            test-destination-os: "18.2"
+            test-destination-os: "18.6"
             device: "iPhone 16"
             scheme: "Sentry"
 
@@ -191,7 +191,7 @@ jobs:
             runs-on: macos-15
             platform: "tvOS"
             xcode: "16.4"
-            test-destination-os: "18.1"
+            test-destination-os: "18.6"
             scheme: "Sentry"
 
     steps:


### PR DESCRIPTION
Bump iOS and tvOS versions used for testing since Github removed older versions on https://github.com/actions/runner-images/pull/12734