### PR TITLE
ci: Use iOS18.5 since 18.6 seems to be unavailable sometimes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
-      - run: ./scripts/sentry-xcodebuild.sh --platform iOS --os latest --device "iPhone 16" --command build --configuration DebugV9
+      - run: ./scripts/sentry-xcodebuild.sh --platform iOS --os 18.5 --device "iPhone 16" --command build --configuration DebugV9
 
   check-debug-without-UIKit:
     name: Check no UIKit linkage (DebugWithoutUIKit)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
             runs-on: macos-15
             platform: "iOS"
             xcode: "16.4"
-            test-destination-os: "18.6"
+            test-destination-os: "18.5"
             device: "iPhone 16"
             scheme: "Sentry"
 


### PR DESCRIPTION
Releases are blocked because tests fails when iOS18.6 is not found.

#skip-changelog