### PR TITLE
ci: Fix Xcode version in CI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - run: ./scripts/ci-select-xcode.sh 16.4
       - run: ./scripts/sentry-xcodebuild.sh --platform iOS --os 18.5 --device "iPhone 16" --command build --configuration DebugV9
 
       - name: Debug Xcode environment

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - run: ./scripts/ci-select-xcode.sh 16.4
+        shell: sh
       - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace
       - run: set -o pipefail && NSUnbufferedIO=YES EXPERIMENTAL_SPM_BUILDS=1 xcodebuild build -scheme SentrySPM -sdk watchos -destination 'generic/platform=watchOS' | tee raw-build-output-spm-watchos.log | xcbeautify
         shell: sh

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -55,6 +55,7 @@ jobs:
           node-version: 18
           cache: "yarn"
           cache-dependency-path: sentry-react-native/yarn.lock
+      - run: ./sentry-cocoa/scripts/ci-select-xcode.sh 16.4
 
       - name: Install SDK JS Dependencies
         working-directory: sentry-react-native

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -51,12 +51,12 @@ jobs:
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
-          # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
+          # As of 14th August 2025, the preinstalled iOS simulator version is 18.5 for macOS 15 and Xcode 16.4; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
           - name: iOS 18
             platform:
               runs-on: macos-15
-              xcode: "16.2"
+              xcode: "16.4"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
Fixed a couple of CI tests which used an Xcode version that was too old to support the installed simulators

#skip-changelog