### PR TITLE
Update CI workflows to use default iOS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v5
-      - run: ./scripts/sentry-xcodebuild.sh --platform iOS --os 18.5 --device "iPhone 16" --command build --configuration DebugV9
+      - run: ./scripts/sentry-xcodebuild.sh --platform iOS --os 18.6 --device "iPhone 16" --command build --configuration DebugV9
 
   check-debug-without-UIKit:
     name: Check no UIKit linkage (DebugWithoutUIKit)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
             runs-on: macos-15
             platform: "iOS"
             xcode: "16.4"
-            test-destination-os: "18.5"
+            test-destination-os: "18.6"
             device: "iPhone 16"
             scheme: "Sentry"
 
@@ -191,7 +191,7 @@ jobs:
             runs-on: macos-15
             platform: "tvOS"
             xcode: "16.4"
-            test-destination-os: "18.5"
+            test-destination-os: "18.6"
             scheme: "Sentry"
 
     steps:

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -50,12 +50,12 @@ jobs:
 
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
-          # As of 25th March 2025, the preinstalled iOS simulator version is 18.2 for macOS 15 and Xcode 16.2; see
+          # As of August 2025, the preinstalled iOS simulator version is 18.6 for macOS 15 and Xcode 16.4; see
           # https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md#installed-sdks
           - name: iOS 18
             platform:
               runs-on: macos-15
-              xcode: "16.2"
+              xcode: "16.4"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -50,9 +50,9 @@ jobs:
             target: tvos_swift
     with:
       fastlane_command: ui_tests_${{matrix.target}}
-      xcode_version: 16.2
+      xcode_version: 16.4
       build_with_make: true
-      macos_version: macos-14
+      macos_version: macos-15
       codecov_test_analytics: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -66,7 +66,7 @@ jobs:
       xcode_version: 16.4
       build_with_make: true
       macos_version: macos-15
-      fastlane_command_extra_arguments: device:iPhone 16 (18.5)
+      fastlane_command_extra_arguments: device:iPhone 16 (18.6)
       codecov_test_analytics: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
           - name: iOS 18
             runs-on: macos-15
             xcode: "16.4"
-            device: iPhone 16 (18.5)
+            device: iPhone 16 (18.6)
     with:
       fastlane_command: ui_tests_ios_swift
       fastlane_command_extra_arguments: device:${{matrix.device}}
@@ -106,7 +106,7 @@ jobs:
     uses: ./.github/workflows/ui-tests-common.yml
     with:
       fastlane_command: ui_tests_ios_swift6
-      xcode_version: 16.2
+      xcode_version: 16.4
       build_with_make: true
       macos_version: macos-15
       codecov_test_analytics: true


### PR DESCRIPTION
## :scroll: Description

Updates GitHub Actions CI workflows to use iOS 18.6 and Xcode 16.4, aligning with the latest pre-installed versions available on `macos-15` runners.

## :bulb: Motivation and Context

GitHub Actions runner images have removed older iOS 18.x versions (e.g., 18.0-18.3), leading to CI failures. This PR updates our workflows to utilize the currently available pre-installed iOS 18.6 and Xcode 16.4, ensuring CI stability and faster builds by leveraging pre-installed simulators.

Related GitHub Actions PR: https://github.com/actions/runner-images/pull/12734

## :green_heart: How did you test it?

Verified changes locally and confirmed all relevant workflow files were updated to use the new versions. Final validation will be through CI runs.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
[Slack Thread](https://sentry.slack.com/archives/C040TTUKQT1/p1755112526185669?thread_ts=1755112526.185669&cid=C040TTUKQT1)

<a href="https://cursor.com/background-agent?bcId=bc-4e95f63d-b772-4de2-b2bf-950c79712575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e95f63d-b772-4de2-b2bf-950c79712575">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

