### PR TITLE
ci: Remove move file step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,6 @@ jobs:
         with:
           pattern: xcframework-${{github.sha}}-sentry-swiftui
           path: Carthage/
-      - run: find Carthage -name "*.zip" -print0 | xargs -t0I @ mv @ Carthage
       - run: ./scripts/ci-select-xcode.sh 15.4
       - run: make build-xcframework-sample
       - name: Run CI Diagnostics


### PR DESCRIPTION
Previously with download artifact v4 files were downloaded to:
`./Carthage/artifact_id/file.zip`

But with v5 they are stored in
`./Carthage/file.zip`

Fixes #5970