### PR TITLE
ci: Fix location of VC inspector being behind another button

### DIFF
--- a/Samples/iOS-Swift/iOS-Swift/Tools/TopViewControllerInspector.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Tools/TopViewControllerInspector.swift
@@ -62,7 +62,7 @@ class TopViewControllerInspector: UIView {
     override func layoutSubviews() {
         let screenBounds = UIScreen.main.bounds
         
-        btn.frame = CGRect(x: screenBounds.width - 160, y: screenBounds.height - 160, width: 140, height: 44)
+        btn.frame = CGRect(x: screenBounds.width - 160, y: screenBounds.height - 200, width: 140, height: 44)
         lbl.frame = CGRect(x: 20, y: btn.frame.origin.y, width: screenBounds.width - 200, height: 44)
     }
     


### PR DESCRIPTION
Moves the `Top VC Name` button 40px up so it is visible and tappable during UI Tests.

Fixes: #5972

<img width="557" height="310" alt="image" src="https://github.com/user-attachments/assets/98b507f3-41a2-4837-b144-19a06d3a143e" />