### PR TITLE
ci: Bump Xcode & set device used for `ui_tests_ios_swift6`

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -107,7 +107,7 @@ jobs:
     with:
       fastlane_command: ui_tests_ios_swift6
       fastlane_command_extra_arguments: device:iPhone 16 (18.5)
-      xcode_version: 16.2
+      xcode_version: 16.4
       build_with_make: true
       macos_version: macos-15
       codecov_test_analytics: true

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -106,6 +106,7 @@ jobs:
     uses: ./.github/workflows/ui-tests-common.yml
     with:
       fastlane_command: ui_tests_ios_swift6
+      fastlane_command_extra_arguments: device:iPhone 16 (18.5)
       xcode_version: 16.2
       build_with_make: true
       macos_version: macos-15


### PR DESCRIPTION
Bump Xcode used to 16.4 and manually set iPhone 16 and iOS 18.5 device for `ui_tests_ios_swift6`.

Fixes: #5975

#skip-changelog