### PR TITLE
ci: Add timeout to RN integration test and disable parallelization

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -30,6 +30,8 @@ jobs:
   test-react-native:
     name: React Native Installation
     runs-on: macos-15
+    # This job can take a while to run, so we set a timeout.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
         with:
@@ -66,6 +68,10 @@ jobs:
 
       - name: Add Sentry/HybridSDK Dependency to RNSentryCocoaTester/Podfile
         run: sed -i '' -e "s/RNSentry.podspec'/RNSentry.podspec'\\n  pod 'Sentry\/HybridSDK', :path => '..\/..\/..\/..\/sentry-cocoa'/" sentry-react-native/packages/core/RNSentryCocoaTester/Podfile
+
+      - name: Disable test parallelization
+        working-directory: sentry-react-native/packages/core/RNSentryCocoaTester
+        run: sed -i '' "s/parallelizable = \"YES\"/parallelizable = \"NO\"/" RNSentryCocoaTester.xcodeproj/xcshareddata/xcschemes/RNSentryCocoaTester.xcscheme
 
       - name: Install App Pods
         working-directory: sentry-react-native/packages/core/RNSentryCocoaTester


### PR DESCRIPTION
Jobs are running for 3 hours so this PR aims to:
- Limit the time a job may be running
- Disable parallelization so CI doesn't need to create a new simulator clone for each run.

Example of long running job: https://github.com/getsentry/sentry-cocoa/actions/runs/16990934529/job/48169903804