### PR TITLE
Structured Logging:  Log `SentrySDK.logger` calls to `SentrySDKLog` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Improvements
 
 - Lazily CharacterSet only once in SentryBaggageSerialization (#5871)
+- Structured Logging: Log `SentrySDK.logger` calls to `SentrySDKLog` (#5991)
 
 ## 8.54.1-alpha.1
 

--- a/Sources/Swift/Protocol/SentryLogLevel.swift
+++ b/Sources/Swift/Protocol/SentryLogLevel.swift
@@ -87,3 +87,21 @@ extension SentryLog {
         try container.encode(value)
     }
 }
+
+@_spi(Private) extension SentryLog.Level {
+    /// Converts the structured log level to the legacy SentryLevel for compatibility with SentrySDKLog
+    @_spi(Private) public func toSentryLevel() -> SentryLevel {
+        switch self {
+        case .trace, .debug:
+            return .debug
+        case .info:
+            return .info
+        case .warn:
+            return .warning
+        case .error:
+            return .error
+        case .fatal:
+            return .fatal
+        }
+    }
+}

--- a/Sources/Swift/Tools/SentryLogger.swift
+++ b/Sources/Swift/Tools/SentryLogger.swift
@@ -216,6 +216,10 @@ public final class SentryLogger: NSObject {
         }
         
         if let processedLog {
+            SentrySDKLog.log(
+                message: "[SentryLogger] \(processedLog.body)",
+                andLevel: processedLog.level.toSentryLevel()
+            )
             batcher.add(processedLog)
         }
     }


### PR DESCRIPTION
## :scroll: Description

<!--- Describe your changes in detail -->

> If debug is set to true in SDK init, calls to the Sentry logger API should also print to the console with the appropriate log level. This will help debugging logging setups.

https://develop.sentry.dev/sdk/telemetry/logs/#other

## :bulb: Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Closes #5948

## :green_heart: How did you test it?

## :pencil: Checklist

Tested with sample app.

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
