### PR TITLE
Fix typos in obj c comments

### DIFF
--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -188,7 +188,7 @@
     self.lastInForeground = [[[hub getClient] fileManager] readTimestampLastInForeground];
 
     if (nil == self.lastInForeground) {
-        // Cause we don't want to track sessions if the app is in the background we need to wait
+        // Because we don't want to track sessions if the app is in the background we need to wait
         // until the app is in the foreground to start a session.
         SENTRY_LOG_DEBUG(@"App was in the foreground for the first time. Starting a new session.");
         [hub startSession];

--- a/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
+++ b/Sources/Sentry/SentryUIViewControllerPerformanceTracker.m
@@ -183,7 +183,7 @@
         [self.tracker getSpan:SENTRY_UNWRAP_NULLABLE(SentrySpanId, spanId)];
 
     if (![vcSpan isKindOfClass:[SentryTracer self]]) {
-        // Since TTID and TTFD are meant to the whole screen
+        // Since TTID and TTFD are meant for the whole screen
         // we will not track child view controllers
         return;
     }
@@ -416,7 +416,7 @@
         // (https://developer.apple.com/documentation/uikit/uiviewcontroller/1621510-viewwillappear),
         // viewWillAppear should be called for before the UIViewController is added to the view
         // hierarchy. There are some edge cases, though, when this doesn't happen, and we saw
-        // customers' transactions also proofing this. Therefore, we must also report the
+        // customers' transactions also proving this. Therefore, we must also report the
         // initial display here, as the customers' transactions had spans for
         // `viewWillLayoutSubviews`.
         [self reportInitialDisplayForController:controller];

--- a/Sources/Sentry/SentryUIViewControllerSwizzling.m
+++ b/Sources/Sentry/SentryUIViewControllerSwizzling.m
@@ -188,7 +188,7 @@
 
     [self.imagesActedOnSubclassesOfUIViewControllers addObject:imageName];
 
-    // Swizzle all custom UIViewControllers. Cause loading all classes can take a few milliseconds,
+    // Swizzle all custom UIViewControllers. Because loading all classes can take a few milliseconds,
     // the SubClassFinder does this on a background thread, which should be fine because the SDK
     // swizzles the root view controller and its children above. After finding all subclasses of the
     // UIViewController, we swizzles them on the main thread. Swizzling the UIViewControllers on a
@@ -336,7 +336,7 @@
         return;
     }
 
-    // This are the five main functions related to UI creation in a view controller.
+    // These are the five main functions related to UI creation in a view controller.
     // We are swizzling it to track anything that happens inside one of this functions.
     [self swizzleViewLayoutSubViews:class];
     [self swizzleLoadView:class];

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -74,7 +74,7 @@
     }
 
     // Restarting the app in development is a termination we can't catch and would falsely
-    // report watchdog termiations.
+    // report watchdog terminations.
     if (previousAppState.isDebugging) {
         return NO;
     }

--- a/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
+++ b/Sources/SentryCrash/Reporting/Filters/SentryCrashReportFilterBasic.m
@@ -86,7 +86,7 @@
             }
             if (![entry conformsToProtocol:@protocol(SentryCrashReportFilter)]) {
                 SENTRY_LOG_ERROR(@"Not a filter: %@", entry);
-                // Cause next key entry to fail as well.
+                // Causes next key entry to fail as well.
                 return;
             } else {
                 [filters addObject:entry];


### PR DESCRIPTION
## :scroll: Description

Fixed several obvious typos in Objective-C comment blocks across various `.m` files.

## :bulb: Motivation and Context

This change improves the overall code quality and readability by correcting grammatical errors and misspellings in comments. It ensures that the documentation within the code is accurate and professional.

## :green_heart: How did you test it?

A systematic scan of all `.m` files was performed, prioritizing files with a higher number of comments. Each identified typo was manually reviewed for context and corrected. A broader scan was then conducted to catch any remaining issues.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
[Slack Thread](https://sentry.slack.com/archives/C095WL15DDY/p1756264224747369?thread_ts=1756264224.747369&cid=C095WL15DDY)

<a href="https://cursor.com/background-agent?bcId=bc-b55defa8-cf60-46ab-a244-5cb0c3db0ba9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b55defa8-cf60-46ab-a244-5cb0c3db0ba9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

