### PR TITLE
chore(ci): Add required checks job for lint swiftlint formatting

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -64,3 +64,22 @@ run_api_stability_for_prs: &run_api_stability_for_prs # API-related code
   - "Makefile" # Make commands used for API generation
   - "sdk_api.json"
   - "sdk_api_v9.json"
+
+run_lint_swiftlint_formatting_for_prs: &run_lint_swiftlint_formatting_for_prs # SwiftLint formatting
+  - "Sources/**"
+  - "Tests/**"
+  - "test-server/**"
+  - "Samples/**"
+
+  # GH Actions
+  - ".github/workflows/lint-swiftlint-formatting.yml"
+  - ".github/file-filters.yml"
+
+  # Scripts
+  - "scripts/ci-select-xcode.sh"
+  - "scripts/ci-diagnostics.sh"
+
+  # Other
+  - "Sentry.xcodeproj/**"
+  - "*.podspec"
+  - "Gemfile.lock"

--- a/.github/workflows/lint-swiftlint-formatting.yml
+++ b/.github/workflows/lint-swiftlint-formatting.yml
@@ -14,17 +14,6 @@ on:
       - "scripts/ci-diagnostics.sh"
 
   pull_request:
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "test-server/**"
-      - "Samples/**"
-      - ".github/workflows/lint-swiftlint-formatting.yml"
-      - "scripts/ci-select-xcode.sh"
-      - "scripts/ci-diagnostics.sh"
-      - "Sentry.xcodeproj/**"
-      - "*.podspec"
-      - "Gemfile.lock"
 
 # Concurrency configuration:
 # - We use workflow-specific concurrency groups to prevent multiple lint runs on the same code,
@@ -38,8 +27,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # This job detects if the PR contains changes that require running SwiftLint formatting checks.
+  # If yes, the job will output a flag that will be used by the next job to run the SwiftLint checks.
+  # If no, the job will output a flag that will be used by the next job to skip running the SwiftLint checks.
+  # At the end of this workflow, we run a check that validates that either all SwiftLint checks passed or were
+  # skipped, called lint_swiftlint_formatting-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_lint_swiftlint_formatting_for_prs: ${{ steps.changes.outputs.run_lint_swiftlint_formatting_for_prs }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   lint:
     name: Lint
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_swiftlint_formatting_for_prs == 'true'
+    needs: files-changed
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v5
@@ -51,3 +62,25 @@ jobs:
       - name: Run CI Diagnostics
         if: failure()
         run: ./scripts/ci-diagnostics.sh
+
+  # This check validates that either all SwiftLint formatting checks passed or were skipped, which allows us
+  # to make SwiftLint formatting checks a required check with only running the SwiftLint checks when required.
+  # So, we don't have to run SwiftLint checks, for example, for Changelog or ReadMe changes.
+
+  lint_swiftlint_formatting-required-check:
+    needs:
+      [
+        files-changed,
+        lint,
+      ]
+    name: Lint SwiftLint
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the SwiftLint formatting check jobs has failed." && exit 1


### PR DESCRIPTION
## :scroll: Description

Migrates the `lint-swiftlint-formatting` workflow to use `dorny/paths-filter` for conditional execution on pull requests. This involves:

- Removing `on.pull_request.paths` filtering from the workflow.
- Adding a `files-changed` job to detect relevant changes using a new filter `run_lint_swiftlint_formatting_for_prs` in `.github/file-filters.yml`.
- Making the main `lint` job conditional based on the `files-changed` job's output.
- Introducing a `lint_swiftlint_formatting-required-check` job to serve as a consistent required check for branch protection rules.

## :bulb: Motivation and Context

This change is part of the ongoing effort (see #5951 and #5893) to replace `on.[event].paths` filtering with `dorny/paths-filter` across all workflows. The primary motivation is to enable more efficient conditional execution of CI jobs on pull requests while providing a reliable, always-running "required check" for branch protection rules. This ensures that the SwiftLint formatting check only runs when relevant files are modified, but its overall status (passed or skipped) is always reported.

Fixes #5963

## :green_heart: How did you test it?

The changes are to the CI pipeline itself and will be validated by the CI run of this pull request.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog