### PR TITLE
chore(ci): Add required checks job for lint dprint

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -64,3 +64,14 @@ run_api_stability_for_prs: &run_api_stability_for_prs # API-related code
   - "Makefile" # Make commands used for API generation
   - "sdk_api.json"
   - "sdk_api_v9.json"
+
+run_lint_dprint_for_prs: &run_lint_dprint_for_prs # dprint-related files
+  - "**/*.yml"
+  - "**/*.yaml"
+  - "**/*.json"
+  - "**/*.md"
+  - ".github/workflows/lint-dprint-formatting.yml"
+  - "dprint.json"
+
+  # GH Actions
+  - ".github/file-filters.yml"

--- a/.github/workflows/lint-dprint-formatting.yml
+++ b/.github/workflows/lint-dprint-formatting.yml
@@ -8,22 +8,8 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "**/*.json"
-      - "**/*.md"
-      - ".github/workflows/lint-dprint-formatting.yml"
-      - "dprint.json"
 
   pull_request:
-    paths:
-      - "**/*.yml"
-      - "**/*.yaml"
-      - "**/*.json"
-      - "**/*.md"
-      - ".github/workflows/lint-dprint-formatting.yml"
-      - "dprint.json"
 
 # Concurrency configuration:
 # - We use workflow-specific concurrency groups to prevent multiple lint runs on the same code,
@@ -37,9 +23,55 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # This job detects if the PR contains changes that require running dprint linting.
+  # If yes, the job will output a flag that will be used by the next job to run the dprint linting.
+  # If no, the job will output a flag that will be used by the next job to skip running the dprint linting.
+  # At the end of this workflow, we run a check that validates that either all dprint linting passed or were
+  # skipped, called lint-dprint-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_lint_dprint_for_prs: ${{ steps.changes.outputs.run_lint_dprint_for_prs }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   lint:
     name: Lint
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_dprint_for_prs == 'true'
+    needs: files-changed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: dprint/check@v2.3
+
+  # Combined check that will be used as the required check in the branch protection rule.
+  # This job will pass if any jobs it depends on were either successful or skipped,
+  # and fail if any jobs it depends on failed or were cancelled.
+  # to make lint dprint a required check with only running the lint dprint when required.
+  # So, we don't have to run lint dprint, for example, for changes that don't affect the files dprint checks.
+
+  lint-dprint-required-check:
+    needs:
+      [
+        files-changed,
+        lint,
+      ]
+    name: Lint dprint
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the lint dprint jobs has failed." && exit 1


### PR DESCRIPTION
## :scroll: Description

This PR migrates the `Lint dprint` workflow (`lint-dprint-formatting.yml`) to use `dorny/paths-filter` for conditional execution based on file changes. It removes the `on.pull_request.paths` and `on.push.paths` filters from the workflow and introduces a `files-changed` job to detect relevant modifications. Additionally, a `lint-dprint-required-check` job is added to serve as a reliable required check for branch protection rules.

## :bulb: Motivation and Context

This change is part of a larger effort to migrate all workflows using `on.[event].paths` filtering to a `files-changed` job using `dorny/paths-filter`. This approach improves efficiency by only running the linting process when relevant files are modified in a pull request, while still providing a consistent required check for branch protection.

Fixes #5960

## :green_heart: How did you test it?

The changes are to the CI/CD workflow itself. The functionality will be verified by observing the behavior of the `Lint dprint` workflow on subsequent pull requests and pushes to `main`, ensuring it runs conditionally and the required check job functions as expected.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0fdc070-30b5-40f0-9787-78f755fe1fa9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0fdc070-30b5-40f0-9787-78f755fe1fa9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

#skip-changelog