### PR TITLE
chore(ci): Add required checks job for test-cross-plattform

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -64,3 +64,13 @@ run_api_stability_for_prs: &run_api_stability_for_prs # API-related code
   - "Makefile" # Make commands used for API generation
   - "sdk_api.json"
   - "sdk_api_v9.json"
+
+run_test_cross_platform_for_prs: &run_test_cross_platform_for_prs # Cross-platform testing code
+  - ".github/workflows/test-cross-platform.yml"
+  - "Sources/**"
+  - "Sentry.podspec"
+  - "SentrySwiftUI.podspec"
+  - "Package*.swift"
+  - "Makefile" # Make commands used for cross-platform setup
+  - "Brewfile*" # Dependency installation affects cross-platform testing
+  - "scripts/ci-diagnostics.sh"

--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -5,15 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    paths:
-      - ".github/workflows/test-cross-platform.yml"
-      - "Sources/**"
-      - "Sentry.podspec"
-      - "SentrySwiftUI.podspec"
-      - "Package*.swift"
-      - "Makefile" # Make commands used for cross-platform setup
-      - "Brewfile*" # Dependency installation affects cross-platform testing
-      - "scripts/ci-diagnostics.sh"
 
 # Concurrency configuration:
 # - We use workflow-specific concurrency groups to prevent multiple cross-platform tests,
@@ -27,8 +18,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # This job detects if the PR contains changes that require running cross-platform tests.
+  # If yes, the job will output a flag that will be used by the next job to run the cross-platform tests.
+  # If no, the job will output a flag that will be used by the next job to skip running the cross-platform tests.
+  # At the end of this workflow, we run a check that validates that either all cross-platform tests passed or were
+  # skipped, called test_cross_platform-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_test_cross_platform_for_prs: ${{ steps.changes.outputs.run_test_cross_platform_for_prs }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   test-react-native:
     name: React Native Installation
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_test_cross_platform_for_prs == 'true'
+    needs: files-changed
     runs-on: macos-15
     # This job can take a while to run, so we set a timeout.
     timeout-minutes: 30
@@ -94,3 +107,25 @@ jobs:
       - name: Run CI Diagnostics
         if: failure()
         run: ./scripts/ci-diagnostics.sh
+
+  # This check validates that either all cross-platform tests passed or were skipped, which allows us
+  # to make cross-platform tests a required check with only running the cross-platform tests when required.
+  # So, we don't have to run cross-platform tests, for example, for Changelog or ReadMe changes.
+
+  test_cross_platform-required-check:
+    needs:
+      [
+        files-changed,
+        test-react-native,
+      ]
+    name: Test Cross Platform
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the cross-platform test jobs has failed." && exit 1


### PR DESCRIPTION
## :scroll: Description

This PR migrates the `test-cross-platform.yml` workflow to use `dorny/paths-filter` for conditional execution on pull requests and introduces a `test_cross_platform-required-check` job.

Specifically, it:
- Adds a `run_test_cross_platform_for_prs` filter to `.github/file-filters.yml`.
- Removes the `paths` filter from `on.pull_request` in `test-cross-platform.yml`.
- Adds a `files-changed` job to detect relevant file modifications.
- Makes the `test-react-native` job conditional based on the `files-changed` output.
- Adds a `test_cross_platform-required-check` job that always runs to provide a reliable required status check.

## :bulb: Motivation and Context

This change is required as part of the migration effort to move all workflows using `on.[event].paths` filtering to a `files-changed` job using `dorny/paths-filter`. (See #5951 for full context).

The goal is to:
- Optimize CI by running expensive cross-platform tests only when relevant files are changed in a PR.
- Provide a reliable required check (`test_cross_platform-required-check`) that can be used in branch protection rules, ensuring that the overall status of cross-platform tests (passed or skipped) is always reported.
- Follows the pattern established in #5893 for `tests.yml` and `api-stability.yml`.

Fixes #5967

## :green_heart: How did you test it?

The implementation follows the established pattern from `api-stability.yml` and `auto-update-tools.yml` workflows. The `if: always()` condition on the `test_cross_platform-required-check` job ensures it will always run and report the status of its dependent jobs, whether they passed, failed, or were skipped.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog