### PR TITLE
chore(ci): Add required checks job for lint cocoapods specs

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -64,3 +64,27 @@ run_api_stability_for_prs: &run_api_stability_for_prs # API-related code
   - "Makefile" # Make commands used for API generation
   - "sdk_api.json"
   - "sdk_api_v9.json"
+
+run_lint_cocoapods_Specs_for_prs: &run_lint_cocoapods_Specs_for_prs # CocoaPods specs linting
+  - "Sources/**"
+  - "Tests/**"
+  - "test-server/**"
+  - "Samples/**"
+
+  # GH Actions
+  - ".github/workflows/lint-cocoapods-specs.yml"
+  - ".github/file-filters.yml"
+
+  # Scripts
+  - "scripts/ci-select-xcode.sh"
+  - "scripts/ci-diagnostics.sh"
+
+  # Project files
+  - "Sentry.xcodeproj/**"
+  - "*.podspec"
+  - "Gemfile.lock"
+
+  # Other
+  - "Makefile" # Make commands used for linting setup
+  - "Brewfile*" # Tools installation affects linting environment
+  - ".swiftlint.yml"

--- a/.github/workflows/lint-cocoapods-specs.yml
+++ b/.github/workflows/lint-cocoapods-specs.yml
@@ -30,15 +30,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # This job detects if the PR contains changes that require running CocoaPods specs linting.
-  # If yes, the job will output a flag that will be used by the next jobs to run the linting.
-  # If no, the job will output a flag that will be used by the next jobs to skip running the linting.
-  # At the end of this workflow, we run a check that validates that either all linting jobs passed or were
-  # skipped, called lint_cocoapods_Specs-required-check.
   files-changed:
     name: Detect File Changes
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
       run_lint_cocoapods_Specs_for_prs: ${{ steps.changes.outputs.run_lint_cocoapods_Specs_for_prs }}
     steps:
@@ -52,6 +46,7 @@ jobs:
 
   lint-podspec:
     name: ${{ matrix.podspec}} ${{ matrix.library_type }} ${{ matrix.platform}}
+    # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_cocoapods_Specs_for_prs == 'true'
     needs: files-changed
     runs-on: macos-14
@@ -75,6 +70,7 @@ jobs:
 
   lint-hybrid-sdk-podspec:
     name: Sentry/HybridSDK
+    # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_cocoapods_Specs_for_prs == 'true'
     needs: files-changed
     runs-on: macos-14
@@ -88,10 +84,6 @@ jobs:
       - name: Run CI Diagnostics
         if: failure()
         run: ./scripts/ci-diagnostics.sh
-
-  # This check validates that either all linting jobs passed or were skipped, which allows us
-  # to make linting a required check with only running the linting when required.
-  # So, we don't have to run linting, for example, for Changelog or ReadMe changes.
 
   lint_cocoapods_Specs-required-check:
     needs:

--- a/.github/workflows/lint-cocoapods-specs.yml
+++ b/.github/workflows/lint-cocoapods-specs.yml
@@ -17,20 +17,6 @@ on:
       - ".swiftlint.yml"
 
   pull_request:
-    paths:
-      - "Sources/**"
-      - "Tests/**"
-      - "test-server/**"
-      - "Samples/**"
-      - ".github/workflows/lint-cocoapods-specs.yml"
-      - "scripts/ci-select-xcode.sh"
-      - "scripts/ci-diagnostics.sh"
-      - "Sentry.xcodeproj/**"
-      - "*.podspec"
-      - "Gemfile.lock"
-      - "Makefile" # Make commands used for linting setup
-      - "Brewfile*" # Tools installation affects linting environment
-      - ".swiftlint.yml"
 
 # Concurrency configuration:
 # - We use workflow-specific concurrency groups to prevent multiple lint runs on the same code,
@@ -44,8 +30,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # This job detects if the PR contains changes that require running CocoaPods specs linting.
+  # If yes, the job will output a flag that will be used by the next jobs to run the linting.
+  # If no, the job will output a flag that will be used by the next jobs to skip running the linting.
+  # At the end of this workflow, we run a check that validates that either all linting jobs passed or were
+  # skipped, called lint_cocoapods_Specs-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_lint_cocoapods_Specs_for_prs: ${{ steps.changes.outputs.run_lint_cocoapods_Specs_for_prs }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   lint-podspec:
     name: ${{ matrix.podspec}} ${{ matrix.library_type }} ${{ matrix.platform}}
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_cocoapods_Specs_for_prs == 'true'
+    needs: files-changed
     runs-on: macos-14
     strategy:
       fail-fast: false
@@ -67,6 +75,8 @@ jobs:
 
   lint-hybrid-sdk-podspec:
     name: Sentry/HybridSDK
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_lint_cocoapods_Specs_for_prs == 'true'
+    needs: files-changed
     runs-on: macos-14
 
     steps:
@@ -78,3 +88,26 @@ jobs:
       - name: Run CI Diagnostics
         if: failure()
         run: ./scripts/ci-diagnostics.sh
+
+  # This check validates that either all linting jobs passed or were skipped, which allows us
+  # to make linting a required check with only running the linting when required.
+  # So, we don't have to run linting, for example, for Changelog or ReadMe changes.
+
+  lint_cocoapods_Specs-required-check:
+    needs:
+      [
+        files-changed,
+        lint-podspec,
+        lint-hybrid-sdk-podspec,
+      ]
+    name: Lint CocoaPods Specs
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the CocoaPods specs linting jobs has failed." && exit 1


### PR DESCRIPTION
## :scroll: Description

Implemented the migration of the `Lint CocoaPods Specs` workflow (`lint-cocoapods-specs.yml`) from `on.pull_request.paths` filtering to a `files-changed` job using `dorny/paths-filter`. This includes:
- Adding a new file filter `run_lint_cocoapods_Specs_for_prs` in `.github/file-filters.yml`.
- Removing the `paths` filter from the workflow's `on.pull_request`.
- Modifying the workflow to include a `files-changed` job, making the main `lint_cocoapods_specs` job conditional, and adding a `lint_cocoapods_Specs-required-check` job for required checks.
This ensures the workflow runs conditionally for PRs based on file changes, but always for schedule/workflow_dispatch events, and provides a reliable required check.

## :bulb: Motivation and Context

This change is part of a larger effort to migrate all workflows using `on.[event].paths` filtering to use a `files-changed` job with `dorny/paths-filter`. This approach allows for more robust required checks by introducing a dedicated job that always runs and serves as the main indicator for branch protection rules.

Fixes #5959.

See #5951 for full context on the migration strategy and #5893 for an example implementation.

## :green_heart: How did you test it?

The CI changes will be validated by observing the workflow runs on this pull request.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-10c3075a-7157-44ee-bba9-181f3ea4c3c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-10c3075a-7157-44ee-bba9-181f3ea4c3c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

#skip-changelog
