### PR TITLE
feat(V9): Make performance V2 the default in V9

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -16,6 +16,7 @@ Removes deprecated `setExtraValue` from SentrySpan (#5864)
 Removes `integrations` property from `SentryOptions` (#5749)
 Makes `SentryEventDecodable` internal (#5808)
 The `span` property on `SentryScope` is now readonly (#5866)
+Removes `enablePerformanceV2` option and makes this the default (#6008)
 
 ### Fixes
 

--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -135,7 +135,9 @@ public struct SentrySDKWrapper {
         options.enableCrashHandler = !SentrySDKOverrides.Other.disableCrashHandling.boolValue
         options.enablePersistingTracesWhenCrashing = true
         options.enableTimeToFullDisplayTracing = !SentrySDKOverrides.Performance.disableTimeToFullDisplayTracing.boolValue
+      #if !SDK_V9
         options.enablePerformanceV2 = !SentrySDKOverrides.Performance.disablePerformanceV2.boolValue
+      #endif
         options.failedRequestStatusCodes = [ HttpStatusCodeRange(min: 400, max: 599) ]
 
     #if targetEnvironment(simulator)

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -288,6 +288,7 @@ NS_SWIFT_NAME(Options)
  */
 @property (nonatomic, assign) BOOL enableAutoPerformanceTracing;
 
+#if !SDK_V9
 /**
  * We're working to update our Performance product offering in order to be able to provide better
  * insights and highlight specific actions you can take to improve your mobile app's overall
@@ -296,6 +297,7 @@ NS_SWIFT_NAME(Options)
  * UIWindowDidBecomeVisibleNotification. This change will be the default in the next major version.
  */
 @property (nonatomic, assign) BOOL enablePerformanceV2;
+#endif // !SDK_V9
 
 /**
  * @warning This is an experimental feature and may still have bugs.

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -28,12 +28,17 @@
     SentryAppStateManager *appStateManager =
         [SentryDependencyContainer sharedInstance].appStateManager;
 
+#    if SDK_V9
+    BOOL usePerformanceV2 = YES;
+#    else
+    BOOL usePerformanceV2 = options.enablePerformanceV2;
+#    endif // SDK_V9
     self.tracker = [[SentryAppStartTracker alloc]
           initWithDispatchQueueWrapper:[[SentryDispatchQueueWrapper alloc] init]
                        appStateManager:appStateManager
                          framesTracker:SentryDependencyContainer.sharedInstance.framesTracker
         enablePreWarmedAppStartTracing:options.enablePreWarmedAppStartTracing
-                   enablePerformanceV2:options.enablePerformanceV2];
+                   enablePerformanceV2:usePerformanceV2];
     [self.tracker start];
 
     return YES;

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -88,7 +88,9 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.maxAttachmentSize = 20 * 1024 * 1024;
         self.sendDefaultPii = NO;
         self.enableAutoPerformanceTracing = YES;
+#if !SDK_V9
         self.enablePerformanceV2 = NO;
+#endif // !SDK_V9
         self.enablePersistingTracesWhenCrashing = NO;
         self.enableCaptureFailedRequests = YES;
         self.environment = kSentryDefaultEnvironment;

--- a/Sources/Sentry/SentyOptionsInternal.m
+++ b/Sources/Sentry/SentyOptionsInternal.m
@@ -240,8 +240,10 @@
     [self setBool:options[@"enableAutoPerformanceTracing"]
             block:^(BOOL value) { sentryOptions.enableAutoPerformanceTracing = value; }];
 
+#if !SDK_V9
     [self setBool:options[@"enablePerformanceV2"]
             block:^(BOOL value) { sentryOptions.enablePerformanceV2 = value; }];
+#endif // !SDK_V9
 
     [self setBool:options[@"enablePersistingTracesWhenCrashing"]
             block:^(BOOL value) { sentryOptions.enablePersistingTracesWhenCrashing = value; }];

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -15,9 +15,11 @@ import Foundation
             features.append("captureFailedRequests")
         }
         
+        #if !SDK_V9
         if options.enablePerformanceV2 {
             features.append("performanceV2")
         }
+        #endif // !SDK_V9
         
         if options.enableTimeToFullDisplayTracing {
             features.append("timeToFullDisplayTracing")


### PR DESCRIPTION
As the comment on this property already stated, it should be the default in V9

#skip-changelog