### PR TITLE
Implement testflight required checks job

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -287,3 +287,18 @@ run_build_for_prs: &run_build_for_prs # Build-related code
   - "Gemfile.lock"
   - "Makefile" # Make commands used for CI build setup
   - "Brewfile*" # Dependency installation affects build environment
+
+run_testflight_for_prs: &run_testflight_for_prs # Testflight-related code
+  - "Sources/**"
+  - "Samples/iOS-Swift/**"
+
+  # GH Actions
+  - ".github/workflows/testflight.yml"
+  - ".github/file-filters.yml"
+
+  # Scripts
+  - "scripts/ci-select-xcode.sh"
+  - "scripts/ci-diagnostics.sh"
+
+  # Other
+  - "fastlane/**"

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -14,9 +14,6 @@ on:
       - "scripts/ci-diagnostics.sh"
 
   pull_request:
-    paths:
-      - ".github/workflows/testflight.yml"
-      - "scripts/ci-diagnostics.sh"
   workflow_dispatch:
 
 # Concurrency configuration:
@@ -31,7 +28,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # This job detects if the PR contains changes that require running testflight.
+  # If yes, the job will output a flag that will be used by the next job to run the testflight.
+  # If no, the job will output a flag that will be used by the next job to skip running the testflight.
+  # At the end of this workflow, we run a check that validates that either upload_to_testflight passed or was
+  # skipped, which is called testflight-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_testflight_for_prs: ${{ steps.changes.outputs.run_testflight_for_prs }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   upload_to_testflight:
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_testflight_for_prs == 'true'
+    needs: files-changed
     name: Build and Upload iOS-Swift to Testflight
     runs-on: macos-15
     steps:
@@ -81,3 +100,24 @@ jobs:
       - name: Run CI Diagnostics
         if: failure()
         run: ./scripts/ci-diagnostics.sh
+
+  # This check validates that either upload_to_testflight passed or was skipped, which allows us
+  # to make testflight a required check with only running the upload_to_testflight when required.
+  # So, we don't have to run upload_to_testflight, for example, for unrelated changes.
+  testflight-required-check:
+    needs:
+      [
+        files-changed,
+        upload_to_testflight,
+      ]
+    name: Testflight
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the testflight jobs has failed." && exit 1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -5,14 +5,6 @@ on:
       - main
       - release/**
 
-    paths:
-      - "Sources/**"
-      - "Samples/iOS-Swift/**"
-      - ".github/workflows/testflight.yml"
-      - "fastlane/**"
-      - "scripts/ci-select-xcode.sh"
-      - "scripts/ci-diagnostics.sh"
-
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## :scroll: Description

This PR migrates the `testflight.yml` workflow to use `dorny/paths-filter` for conditional execution on pull requests. It removes path filtering from both `push` and `pull_request` events, introduces a `files-changed` job to detect relevant file changes for PRs, and makes the main `upload_to_testflight` job conditional. A `testflight-required-check` job is added to serve as a reliable required check for branch protection.

## :bulb: Motivation and Context

This change is required to enforce required checks for the Testflight workflow, as detailed in #5951. It allows the workflow to:
- Always run for `push` events to `main` and `release/**` branches, and for `workflow_dispatch` events.
- Run conditionally for `pull_request` events only when relevant files (defined in the new `run_testflight_for_prs` filter) are changed, improving CI efficiency.
- Provide a consistent `testflight-required-check` status for branch protection rules, regardless of whether the main job was run or skipped.
This implementation follows the pattern established in #5893.

Fixes #5951

## :green_heart: How did you test it?

Tested by observing CI runs on a draft pull request with various file changes to ensure conditional execution and required check behavior.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-cdf14e3a-d5d1-40d7-bf1e-870a1e524b90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cdf14e3a-d5d1-40d7-bf1e-870a1e524b90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

