### PR TITLE
test: Remove not required deprecation warnings

### DIFF
--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1312,40 +1312,35 @@ class SentryClientTests: XCTestCase {
         let serializedSpans = try XCTUnwrap(serialized["spans"] as? [[String: Any]])
         XCTAssertEqual(1, serializedSpans.count)
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_MessageNotSent() {
         let sut = fixture.getSutWithNoDsn()
         let eventId = sut.capture(message: fixture.messageAsString)
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testDisabled_MessageNotSent() {
         let sut = fixture.getSutDisabledSdk()
         let eventId = sut.capture(message: fixture.messageAsString)
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_ExceptionNotSent() {
         let sut = fixture.getSutWithNoDsn()
         let eventId = sut.capture(exception: exception)
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_ErrorNotSent() {
         let sut = fixture.getSutWithNoDsn()
         let eventId = sut.capture(error: error)
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_SessionsNotSent() {
         _ = SentryEnvelope(event: Event())
         fixture.getSut(configureOptions: { options in
@@ -1354,8 +1349,7 @@ class SentryClientTests: XCTestCase {
 
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_EventWithSessionsNotSent() {
         _ = SentryEnvelope(event: Event())
         let eventId = fixture.getSut(configureOptions: { options in
@@ -1365,8 +1359,7 @@ class SentryClientTests: XCTestCase {
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_ExceptionWithSessionsNotSent() {
         _ = SentryEnvelope(event: Event())
         let eventId = fixture.getSut(configureOptions: { options in
@@ -1378,8 +1371,7 @@ class SentryClientTests: XCTestCase {
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testNoDsn_ErrorWithSessionsNotSent() {
         _ = SentryEnvelope(event: Event())
         let eventId = fixture.getSut(configureOptions: { options in
@@ -1391,23 +1383,19 @@ class SentryClientTests: XCTestCase {
         eventId.assertIsEmpty()
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertSampleRate is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testSampleRateNil_EventNotSampled() throws {
         try assertSampleRate(sampleRate: nil, randomValue: 0, isSampled: false)
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertSampleRate is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testSampleRateBiggerRandom_EventNotSampled() throws {
         try assertSampleRate(sampleRate: 0.5, randomValue: 0.49, isSampled: false)
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertSampleRate is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testSampleRateEqualsRandom_EventNotSampled() throws {
         try assertSampleRate(sampleRate: 0.5, randomValue: 0.5, isSampled: false)
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertSampleRate is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, these deprecation annotations can go away.")
+
     func testSampleRateSmallerRandom_EventSampled() throws {
         try assertSampleRate(sampleRate: 0.50, randomValue: 0.51, isSampled: true)
     }
@@ -1621,35 +1609,31 @@ class SentryClientTests: XCTestCase {
         XCTAssertEqual(fixture.transport.recordLostEventsWithCount.get(2)?.reason, SentryDiscardReason.eventProcessor)
         XCTAssertEqual(fixture.transport.recordLostEventsWithCount.get(2)?.quantity, 1)
     }
-    @available(*, deprecated, message: "-[SentryClient captureUserFeedback:] is deprecated. -[SentryClient captureFeedback:withScope:] is the new way. This test case can be removed in favor of testNoDsn_FeedbackNotSent when -[SentryClient captureUserFeedback:] is removed.")
+
     func testNoDsn_UserFeedbackNotSent() {
         let sut = fixture.getSutWithNoDsn()
         sut.capture(userFeedback: UserFeedback(eventId: SentryId()))
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "-[SentryClient captureUserFeedback:] is deprecated. -[SentryClient captureFeedback:withScope:] is the new way. This test case can be removed in favor of testDisabled_FeedbackNotSent when -[SentryClient captureUserFeedback:] is removed.")
+
     func testDisabled_UserFeedbackNotSent() {
         let sut = fixture.getSutDisabledSdk()
         sut.capture(userFeedback: UserFeedback(eventId: SentryId()))
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "-[SentryClient captureUserFeedback:] is deprecated. -[SentryClient captureFeedback:withScope:] is the new way. This test case can be removed in favor of testCaptureFeedback_WithEmptyEventId when -[SentryClient captureUserFeedback:] is removed.")
+
     func testCaptureUserFeedback_WithEmptyEventId() {
         let sut = fixture.getSut()
         sut.capture(userFeedback: UserFeedback(eventId: SentryId.empty))
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, this deprecation annotation can go away.")
+
     func testNoDsn_FeedbackNotSent() {
         let sut = fixture.getSutWithNoDsn()
         sut.capture(feedback: fixture.feedback, scope: fixture.scope)
         assertNothingSent()
     }
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, this deprecation annotation can go away.")
+
     func testDisabled_FeedbackNotSent() {
         let sut = fixture.getSutDisabledSdk()
         sut.capture(feedback: fixture.feedback, scope: fixture.scope)
@@ -2395,8 +2379,7 @@ private extension SentryClientTests {
     private func shortenIntegrations(_ integrations: [String]?) -> [String]? {
         return integrations?.map { $0.replacingOccurrences(of: "Sentry", with: "").replacingOccurrences(of: "Integration", with: "") }
     }
-    
-    @available(*, deprecated, message: "Remove check on transportAdapter.userFeedbackInvocations when SentryUserFeedback is removed in favor of SentryFeedback. Then this deprecation annotation can be removed.")
+
     private func assertNothingSent() {
         XCTAssertTrue(fixture.transport.sentEnvelopes.isEmpty)
         XCTAssertEqual(0, fixture.transportAdapter.sentEventsWithSessionTraceState.count)
@@ -2459,8 +2442,7 @@ private extension SentryClientTests {
         
     }
 #endif
-    
-    @available(*, deprecated, message: "This is only marked as deprecated because assertNothingSent is marked as deprecated, due to it using a deprecated property inside it. When that property usage is removed, this deprecation annotations can be removed.")
+
     func assertSampleRate( sampleRate: NSNumber?, randomValue: Double, isSampled: Bool) throws {
         fixture.random.value = randomValue
         


### PR DESCRIPTION
The code still compiles when removing all of these deprecation warnings.

#skip-changelog

