### PR TITLE
Implement version bump util required check

### DIFF
--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -287,3 +287,17 @@ run_build_for_prs: &run_build_for_prs # Build-related code
   - "Gemfile.lock"
   - "Makefile" # Make commands used for CI build setup
   - "Brewfile*" # Dependency installation affects build environment
+
+run_version_bump_util_for_prs: &run_version_bump_util_for_prs # Version bump utility
+  - "Utils/VersionBump/**"
+  - ".github/workflows/version-bump-util.yml"
+  - "Sentry.podspec"
+  - "Package*.swift"
+  - "SentryPrivate.podspec"
+  - "SentrySwiftUI.podspec"
+  - "Sources/Sentry/SentryMeta.m"
+  - "Tests/HybridSDKTest/HybridPod.podspec"
+  - "Sources/Configuration/SDK.xcconfig"
+  - "Sources/Configuration/Versioning.xcconfig"
+  - "Sources/Configuration/SentrySwiftUI.xcconfig"
+  - "scripts/bump.sh"

--- a/.github/file-filters.yml
+++ b/.github/file-filters.yml
@@ -289,15 +289,24 @@ run_build_for_prs: &run_build_for_prs # Build-related code
   - "Brewfile*" # Dependency installation affects build environment
 
 run_version_bump_util_for_prs: &run_version_bump_util_for_prs # Version bump utility
+  # Version bump utilities
   - "Utils/VersionBump/**"
+
+  # GH Actions
   - ".github/workflows/version-bump-util.yml"
+
+  # Scripts
+  - "scripts/bump.sh"
+
+  # Sources
+  - "Sources/Sentry/SentryMeta.m"
+
+  # Project files
   - "Sentry.podspec"
-  - "Package*.swift"
   - "SentryPrivate.podspec"
   - "SentrySwiftUI.podspec"
-  - "Sources/Sentry/SentryMeta.m"
+  - "Package*.swift"
   - "Tests/HybridSDKTest/HybridPod.podspec"
   - "Sources/Configuration/SDK.xcconfig"
   - "Sources/Configuration/Versioning.xcconfig"
   - "Sources/Configuration/SentrySwiftUI.xcconfig"
-  - "scripts/bump.sh"

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -19,15 +19,9 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # This job detects if the PR contains changes that require running version-bump-util.
-  # If yes, the job will output a flag that will be used by the next job to run the version-bump-util.
-  # If no, the job will output a flag that will be used by the next job to skip running the version-bump-util.
-  # At the end of this workflow, we run a check that validates that either version_bump_util-required-check passed or were
-  # skipped, which is called version_bump_util-required-check.
   files-changed:
     name: Detect File Changes
     runs-on: ubuntu-latest
-    # Map a step output to a job output
     outputs:
       run_version_bump_util_for_prs: ${{ steps.changes.outputs.run_version_bump_util_for_prs }}
     steps:

--- a/.github/workflows/version-bump-util.yml
+++ b/.github/workflows/version-bump-util.yml
@@ -6,19 +6,6 @@ on:
       - main
 
   pull_request:
-    paths:
-      - "Utils/VersionBump/**"
-      - ".github/workflows/version-bump-util.yml"
-      - "./Sentry.podspec"
-      - "./Package*.swift"
-      - "./SentryPrivate.podspec"
-      - "./SentrySwiftUI.podspec"
-      - "./Sources/Sentry/SentryMeta.m"
-      - "./Tests/HybridSDKTest/HybridPod.podspec"
-      - "./Sources/Configuration/SDK.xcconfig"
-      - "./Sources/Configuration/Versioning.xcconfig"
-      - "./Sources/Configuration/SentrySwiftUI.xcconfig"
-      - "./scripts/bump.sh"
 
 # Concurrency configuration:
 # - We use workflow-specific concurrency groups to prevent multiple version bump utility tests,
@@ -32,7 +19,29 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # This job detects if the PR contains changes that require running version-bump-util.
+  # If yes, the job will output a flag that will be used by the next job to run the version-bump-util.
+  # If no, the job will output a flag that will be used by the next job to skip running the version-bump-util.
+  # At the end of this workflow, we run a check that validates that either version_bump_util-required-check passed or were
+  # skipped, which is called version_bump_util-required-check.
+  files-changed:
+    name: Detect File Changes
+    runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      run_version_bump_util_for_prs: ${{ steps.changes.outputs.run_version_bump_util_for_prs }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Get changed files
+        id: changes
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          token: ${{ github.token }}
+          filters: .github/file-filters.yml
+
   run-version-bump:
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_version_bump_util_for_prs == 'true'
+    needs: files-changed
     # The release workflow uses the Makefile to bump the version so it needs to be tested.
     name: Run Version Bump (Makefile)
     # We intentionally run this on ubuntu because the release workflow also runs on ubuntu, which uses the version bump util.
@@ -49,6 +58,8 @@ jobs:
       - run: make verify-version TO=${{ steps.generate-version-number.outputs.VERSION }}
 
   run-version-bump-script:
+    if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_version_bump_util_for_prs == 'true'
+    needs: files-changed
     # Craft uses the shell script to bump the version so it needs to be tested.
     name: Run Version Bump (Shell Script)
     runs-on: ubuntu-latest
@@ -91,3 +102,25 @@ jobs:
             --dynamic-checksum "f6325cd8f05523d60222451fa61b3cd3d58148e5a21236f82abfd3f92750c87c" \
             --dynamic-with-arm64e-checksum "bbb84b054e5792aa705b95541aa4585f793e566a6b95638f8fef8e308d9782c3" \
             --last-release-runid "${{ github.run_id }}"
+
+  # This check validates that either version-bump-util passed or was skipped, which allows us
+  # to make version-bump-util a required check with only running the version-bump-util when required.
+  # So, we don't have to run version-bump-util, for example, for unrelated changes.
+  version_bump_util-required-check:
+    needs:
+      [
+        files-changed,
+        run-version-bump,
+        run-version-bump-script,
+      ]
+    name: Test Version Bump Util
+    # This is necessary since a failed/skipped dependent job would cause this job to be skipped
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      # If any jobs we depend on fails gets cancelled or times out, this job will fail.
+      # Skipped jobs are not considered failures.
+      - name: Check for failures
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "One of the version-bump-util jobs has failed." && exit 1


### PR DESCRIPTION
## :scroll: Description

This PR migrates the `version-bump-util.yml` workflow to use `dorny/paths-filter` for conditional execution on pull requests.

Specifically, it:
- Adds a new file filter `run_version_bump_util_for_prs` in `.github/file-filters.yml`.
- Removes the `on.pull_request.paths` filter from `version-bump-util.yml`.
- Introduces a `files-changed` job to detect relevant file modifications.
- Makes the main `run-version-bump` and `run-version-bump-script` jobs conditional based on the `files-changed` output.
- Adds a `version_bump_util-required-check` job that always runs to act as a reliable required check for branch protection.

## :bulb: Motivation and Context

This change is part of a broader initiative to migrate all workflows using `on.[event].paths` filtering to a `files-changed` job with `dorny/paths-filter`. The primary motivation is to enable robust required checks for branch protection rules, even when the main workflow jobs are conditionally skipped based on file changes. This ensures that the workflow always provides a clear status for PRs, regardless of whether the core logic runs.

Fixes #COCOA-593
See #5951 for full context on the migration. Reference implementation in #5893.

## :green_heart: How did you test it?

The changes were verified by observing the behavior of the `version-bump-util.yml` workflow on pull requests with and without relevant file changes, as well as on `workflow_dispatch` events. The `version_bump_util-required-check` job correctly reflects the status of the conditional jobs.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog

---
<a href="https://cursor.com/background-agent?bcId=bc-2d708542-0789-4fa1-9b56-fcfd5da911d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2d708542-0789-4fa1-9b56-fcfd5da911d6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

