### PR TITLE
chore(ci): Fallback to macos-14 for React Native check

### DIFF
--- a/.github/workflows/test-cross-platform.yml
+++ b/.github/workflows/test-cross-platform.yml
@@ -37,7 +37,7 @@ jobs:
     # Run the job only for PRs with related changes or non-PR events.
     if: github.event_name != 'pull_request' || needs.files-changed.outputs.run_test_cross_platform_for_prs == 'true'
     needs: files-changed
-    runs-on: macos-15
+    runs-on: macos-14
     # This job can take a while to run, so we set a timeout.
     timeout-minutes: 30
     steps:
@@ -65,7 +65,7 @@ jobs:
           node-version: 18
           cache: "yarn"
           cache-dependency-path: sentry-react-native/yarn.lock
-      - run: ./sentry-cocoa/scripts/ci-select-xcode.sh 16.4
+      - run: ./sentry-cocoa/scripts/ci-select-xcode.sh 16.2
 
       - name: Install SDK JS Dependencies
         working-directory: sentry-react-native


### PR DESCRIPTION
## :scroll: Description

Similar to https://github.com/getsentry/sentry-react-native/pull/5079 fallsback to macos-14 for RN jobs. An issue has been opened to revisit this https://github.com/getsentry/sentry-react-native/issues/5082

<!--- Describe your changes in detail -->

## :bulb: Motivation and Context

Failed CI check https://github.com/getsentry/sentry-cocoa/actions/runs/17321918286/job/49322882904?pr=6018

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## :green_heart: How did you test it?

CI

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog