### PR TITLE
fix(ci): Resolve symlink path before removing architectures

### DIFF
--- a/scripts/remove-architectures.sh
+++ b/scripts/remove-architectures.sh
@@ -34,6 +34,10 @@ echo "Excluded architectures: $EXCLUDED_ARCH"
 # Find all framework directories and process their binaries
 find "$XCARCHIVE_PATH" -name "*.framework" -type d | while read -r framework_path; do
     binary_path="$framework_path/$(basename "$framework_path" .framework)"
+    if [ -L "$binary_path" ]; then
+        echo "Resolving symlink at path: $binary_path"
+        binary_path=$(readlink -f "$binary_path")
+    fi
     if [ -f "$binary_path" ]; then
         echo "Processing binary: $binary_path"
         


### PR DESCRIPTION
## :scroll: Description

Resolve the symlink path before removing architectures slices. 

## :bulb: Motivation and Context

When removing architectures, we were not checking if the file was a symlink.
Fixes: #6046

## :green_heart: How did you test it?

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
