### PR TITLE
Fix Changelog: Move PR 5800 to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix missing view hierachy when enabling `attachScreenshot` too (#5989)
 - Fix macOS's frameworks not following the versioned framework structure (#6049)
 - Add warning to addBreadcrumb when used before SDK init (#6083)
+- Add null-handling for parsed DSN in SentryHTTPTransport (#5800)
 
 ### Improvements
 
@@ -51,10 +52,6 @@
 >
 > If your app does not need arm64e, you don't need to make any changes.
 > But if your app _needs arm64e_ please use `Sentry-Dynamic-WithARM64e` or `Sentry-WithoutUIKitOrAppKit-WithARM64e` from 8.55.0 so you don't have issues uploading to the App Store.
-
-### Fixes
-
-- Add null-handling for parsed DSN in SentryHTTPTransport (#5800)
 
 ### Features
 


### PR DESCRIPTION
We merged #5800 after releasing 8.55.0. We need to move it up to the unreleased section.

<img width="2608" height="842" alt="Screenshot 2025-09-08 at 08 56 34" src="https://github.com/user-attachments/assets/89723e79-a2d0-49ce-9adc-1a3bd3c5c40a" />


#skip-changelog 