### PR TITLE
Fix swiftlint warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,7 +53,7 @@ only_rules:
   - private_unit_test
   - prohibited_super_call
   - redundant_nil_coalescing
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   - redundant_string_enum_value
   - redundant_void_return
   - return_arrow_whitespace

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,6 +1,6 @@
 parent_config: ../.swiftlint.yml
 
-enabled_rules:
+opt_in_rules:
   - test_case_accessibility
 
 custom_rules:


### PR DESCRIPTION
## :scroll: Description

Updated SwiftLint configuration files (`.swiftlint.yml` and `Tests/.swiftlint.yml`) to use current rule names and configuration keys.

## :bulb: Motivation and Context

This change addresses deprecation warnings reported by SwiftLint regarding outdated rule names and configuration keys. Specifically:
- `redundant_optional_initialization` was renamed to `implicit_optional_initialization`.
- `enabled_rules` was renamed to `opt_in_rules`.
Updating these ensures compatibility with newer SwiftLint versions and removes the warnings.

## :green_heart: How did you test it?

The changes directly address the reported deprecation warnings by updating the configuration files with the correct, non-deprecated names.

## :pencil: Checklist

You have to check all boxes before merging:

- [ ] I added tests to verify the changes.
- [ ] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [ ] I updated the docs if needed.
- [ ] I updated the wizard if needed.
- [ ] Review from the native team if needed.
- [ ] No breaking change or entry added to the changelog.
- [ ] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c2e1e61-145c-4aac-bf9f-ae217b21a3ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c2e1e61-145c-4aac-bf9f-ae217b21a3ed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

