### PR TITLE
fix: Replace string literal with NSData for newline in breadcrumb processor

### DIFF
--- a/Sources/Sentry/Processors/SentryWatchdogTerminationBreadcrumbProcessor.m
+++ b/Sources/Sentry/Processors/SentryWatchdogTerminationBreadcrumbProcessor.m
@@ -104,7 +104,8 @@
         fileSize = [self.fileHandle seekToEndOfFile];
 
         [self.fileHandle writeData:data];
-        [self.fileHandle writeData:[@"\n" dataUsingEncoding:NSASCIIStringEncoding]];
+        NSData *_Nonnull const newLineData = [NSData dataWithBytes:"\n" length:1];
+        [self.fileHandle writeData:newLineData];
 
         self.breadcrumbCounter += 1;
     } @catch (NSException *exception) {


### PR DESCRIPTION
See #5577 

#skip-changelog