### PR TITLE
feat: Add SentryDistribution

### DIFF
--- a/.github/actions/prepare-package.swift/action.yml
+++ b/.github/actions/prepare-package.swift/action.yml
@@ -5,6 +5,12 @@ inputs:
     description: "Whether the build is a PR"
     required: true
     default: "false"
+  remove-duplicate:
+    description: "Whether to remove targets that produce duplicate files. These targets cause SPM validation errors."
+    default: "false"
+  change-path:
+    description: "Whether to change the path of the framework"
+    default: "true"
   package-file:
     description: "The package file to prepare"
     required: true
@@ -22,7 +28,17 @@ runs:
         sed -i '' '/Sentry-Dynamic-WithARM64e/d' $PACKAGE_FILE
         sed -i '' '/Sentry-WithoutUIKitOrAppKit-WithARM64e/d' $PACKAGE_FILE
         sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;/\n[[:space:]]*),\{0,1\}$/d;}' $PACKAGE_FILE
+    - name: Remove duplicate target
+      if: ${{ inputs.remove-duplicate == 'true' }}
+      shell: bash
+      env:
+        PACKAGE_FILE: ${{ inputs.package-file }}
+      run: |
+        sed -i '' '/Sentry-Dynamic/d' $PACKAGE_FILE
+        sed -i '' '/Sentry-WithoutUIKitOrAppKit/d' $PACKAGE_FILE
+        sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;/\n[[:space:]]*),\{0,1\}$/d;}' $PACKAGE_FILE
     - name: Change path of the framework
+      if: ${{ inputs.change-path == 'true' }}
       shell: bash
       env:
         PACKAGE_FILE: ${{ inputs.package-file }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,6 +98,8 @@ jobs:
             config: DebugV9
           - scheme: iOS-ObjectiveC
             config: DebugV9
+          - scheme: DistributionSample
+            config: Debug
 
     steps:
       - uses: actions/checkout@v5
@@ -128,6 +130,26 @@ jobs:
       - name: Debug Xcode environment
         if: ${{ failure() || cancelled() }}
         run: ./scripts/ci-diagnostics.sh
+
+  build-distribution:
+    name: Build the distribution framework
+    runs-on: macos-15
+    needs: files-changed
+    steps:
+      - uses: actions/checkout@v5
+
+      - run: ./scripts/ci-select-xcode.sh 16.4
+        shell: sh
+      - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace
+      - run: set -o pipefail && NSUnbufferedIO=YES xcodebuild build -scheme SentryDistribution -sdk iphoneos -destination 'generic/platform=iphoneos' | tee raw-build-output-spm.log | xcbeautify
+        shell: sh
+      - name: Upload SPM Build Logs
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: raw-build-output-spm
+          path: |
+            raw-build-output-spm.log
 
   build-spm:
     name: Build with SPM
@@ -340,6 +362,7 @@ jobs:
         files-changed,
         ios-swift-release,
         build-sample,
+        build-distribution,
         build-spm,
         build-v9,
         check-debug-without-UIKit,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,29 @@ jobs:
         if: failure()
         run: ./scripts/ci-diagnostics.sh
 
+  distribution-tests:
+    name: Distribution Tests
+    runs-on: macos-15
+    needs: files-changed
+    steps:
+      - uses: actions/checkout@v5
+      - name: Prepare Package.swift
+        uses: ./.github/actions/prepare-package.swift
+        with:
+          is-pr: ${{ github.event_name == 'pull_request' }}
+          change-path: false
+          remove-duplicate: true
+      - run: rm -r Sentry.xcodeproj && rm -r Sentry.xcworkspace
+      - run: set -o pipefail && NSUnbufferedIO=YES SKIP_BINARIES=1 xcodebuild test -scheme Sentry-Package -sdk iphonesimulator -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 16 Pro' | tee raw-test-output-distribution.log | xcbeautify --preserve-unbeautified
+        shell: sh
+      - name: Upload Distribution Test Logs
+        uses: actions/upload-artifact@v4
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: raw-test-output-distribution
+          path: |
+            raw-test-output-distribution.log
+
   # This matrix runs only the unit tests requiring the test server.
   # We do this to speed up the other unit test jobs and to avoid running the
   # test server with potential side effects in GH actions for all unit tests.
@@ -453,6 +476,7 @@ jobs:
       [
         files-changed,
         build-test-server,
+        distribution-tests,
         unit-tests,
         unit-tests-with-test-server,
       ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add SentryDistribution as Swift Package Manager target (#6149)
+
 ## 8.56.2
 
 ### Fixes

--- a/Makefile
+++ b/Makefile
@@ -189,3 +189,4 @@ xcode-ci:
 	xcodegen --spec Samples/watchOS-Swift/watchOS-Swift.yml
 	xcodegen --spec TestSamples/SwiftUITestSample/SwiftUITestSample.yml
 	xcodegen --spec TestSamples/SwiftUICrashTest/SwiftUICrashTest.yml
+	xcodegen --spec Samples/DistributionSample/DistributionSample.yml

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ var products: [Product] = [
     .library(name: "Sentry-Dynamic-WithARM64e", targets: ["Sentry-Dynamic-WithARM64e"]),
     .library(name: "Sentry-WithoutUIKitOrAppKit", targets: ["Sentry-WithoutUIKitOrAppKit", "SentryCppHelper"]),
     .library(name: "Sentry-WithoutUIKitOrAppKit-WithARM64e", targets: ["Sentry-WithoutUIKitOrAppKit-WithARM64e", "SentryCppHelper"]),
-    .library(name: "SentrySwiftUI", targets: ["Sentry", "SentrySwiftUI", "SentryCppHelper"])
+    .library(name: "SentrySwiftUI", targets: ["Sentry", "SentrySwiftUI", "SentryCppHelper"]),
+    .library(name: "SentryDistribution", targets: ["SentryDistribution"])
 ]
 
 var targets: [Target] = [
@@ -66,7 +67,9 @@ var targets: [Target] = [
         linkerSettings: [
          .linkedLibrary("c++")
         ]
-    )
+    ),
+    .target(name: "SentryDistribution", path: "Sources/SentryDistribution"),
+    .testTarget(name: "SentryDistributionTests", dependencies: ["SentryDistribution"], path: "Sources/SentryDistributionTests")
 ]
 
 let env = getenv("EXPERIMENTAL_SPM_BUILDS")
@@ -101,7 +104,7 @@ if let env = env, String(cString: env, encoding: .utf8) == "1" {
             name: "SentryObjc",
             dependencies: ["SentrySwift"],
             path: "Sources",
-            exclude: ["Sentry/SentryDummyPublicEmptyClass.m", "Sentry/SentryDummyPrivateEmptyClass.m", "Swift", "SentrySwiftUI", "Resources", "Configuration", "SentryCppHelper"],
+            exclude: ["Sentry/SentryDummyPublicEmptyClass.m", "Sentry/SentryDummyPrivateEmptyClass.m", "Swift", "SentrySwiftUI", "Resources", "Configuration", "SentryCppHelper", "SentryDistribution", "SentryDistributionTests"],
             cSettings: [
                 .headerSearchPath("Sentry/include/HybridPublic"),
                 .headerSearchPath("Sentry"),

--- a/Samples/DistributionSample/DistributionSample.xcconfig
+++ b/Samples/DistributionSample/DistributionSample.xcconfig
@@ -1,0 +1,4 @@
+PRODUCT_BUNDLE_IDENTIFIER = io.sentry.sample.DistributionSample
+INFOPLIST_FILE = DistributionSample/Info.plist
+SUPPORTED_PLATFORMS = iphoneos iphonesimulator
+IPHONEOS_DEPLOYMENT_TARGET = 15.0

--- a/Samples/DistributionSample/DistributionSample.yml
+++ b/Samples/DistributionSample/DistributionSample.yml
@@ -1,0 +1,31 @@
+name: DistributionSample
+createIntermediateGroups: true
+generateEmptyDirectories: true
+configs:
+  Debug: debug
+  Release: release
+options:
+  bundleIdPrefix: io.sentry.sample.
+packages:
+  Sentry:
+    path: ../../
+targets:
+  DistributionSample:
+    type: application
+    platform: auto
+    sources:
+      - DistributionSample
+    dependencies:
+      - package: Sentry
+        products:
+          - SentryDistribution
+    configFiles:
+      Debug: DistributionSample.xcconfig
+      Release: DistributionSample.xcconfig
+schemes:
+  DistributionSample:
+    templates:
+      - SampleAppScheme
+    build:
+      targets:
+        DistributionSample: all

--- a/Samples/DistributionSample/DistributionSample/App.swift
+++ b/Samples/DistributionSample/DistributionSample/App.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct DemoAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Samples/DistributionSample/DistributionSample/Constants.swift
+++ b/Samples/DistributionSample/DistributionSample/Constants.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum Constants {
+  static let accessToken = ""
+  static let organization = ""
+  static let project = ""
+}

--- a/Samples/DistributionSample/DistributionSample/ContentView.swift
+++ b/Samples/DistributionSample/DistributionSample/ContentView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct ContentView: View {
+  var body: some View {
+    VStack(spacing: 20.0) {
+      Button("Check For Update Swift") {
+        UpdateUtil.checkForUpdates()
+      }
+      .padding()
+      .background(.blue)
+      .foregroundColor(.white)
+      .cornerRadius(10)
+    }
+    .padding()
+  }
+}
+
+#Preview {
+  ContentView()
+}

--- a/Samples/DistributionSample/DistributionSample/Info.plist
+++ b/Samples/DistributionSample/DistributionSample/Info.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>GIT_BRANCH</key>
+	<string>&lt;branch&gt;</string>
+	<key>GIT_COMMIT_HASH</key>
+	<string>&lt;sha&gt;</string>
+	<key>GIT_STATUS_CLEAN</key>
+	<string>&lt;status&gt;</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Samples/DistributionSample/DistributionSample/UpdateUtil.swift
+++ b/Samples/DistributionSample/DistributionSample/UpdateUtil.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SentryDistribution
+import UIKit
+
+enum UpdateUtil {
+  @MainActor
+  static func checkForUpdates() {
+    let params = CheckForUpdateParams(accessToken: Constants.accessToken, organization: Constants.organization, project: Constants.project)
+    Updater.checkForUpdate(params: params) { result in
+      handleUpdateResult(result: result)
+    }
+  }
+  
+  static func handleUpdateResult(result: Result<UpdateCheckResponse, Error>) {
+    guard case let .success(releaseInfo) = result else {
+      if case let .failure(error) = result {
+        print("Error checking for update: \(error)")
+      }
+      return
+    }
+    
+    guard let releaseInfo = releaseInfo.update else {
+      print("Already up to date")
+      return
+    }
+    
+    UpdateUtil.installRelease(releaseInfo: releaseInfo)
+  }
+
+  private static func installRelease(releaseInfo: ReleaseInfo) {
+    guard let url = Updater.buildUrlForInstall(releaseInfo.downloadUrl) else {
+      return
+    }
+    DispatchQueue.main.async {
+      Updater.install(url: url)
+    }
+  }
+}

--- a/Sentry.xcworkspace/contents.xcworkspacedata
+++ b/Sentry.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,9 @@
          location = "group:Samples/README.md">
       </FileRef>
       <FileRef
+         location = "group:Samples/DistributionSample/DistributionSample.xcodeproj">
+      </FileRef>
+      <FileRef
          location = "group:Samples/SentrySampleShared/SentrySampleShared.xcodeproj">
       </FileRef>
       <FileRef

--- a/Sources/SentryDistribution/Mach-O/BinaryParser.swift
+++ b/Sources/SentryDistribution/Mach-O/BinaryParser.swift
@@ -1,0 +1,32 @@
+import Darwin
+import Foundation
+import MachO
+
+typealias GetUUIDFuncType = (@convention(c) (UnsafePointer<mach_header>, UnsafeRawPointer) -> Bool)
+fileprivate let _dyld_get_image_uuid = unsafeBitCast(dlsym(dlopen(nil, RTLD_LAZY), "_dyld_get_image_uuid"), to: GetUUIDFuncType.self)
+
+enum BinaryParser {
+  
+  static func getMainBinaryUUID(getUUID: GetUUIDFuncType = _dyld_get_image_uuid) -> String? {
+    guard let executableName = Bundle.main.infoDictionary?["CFBundleExecutable"] as? String else {
+      return nil
+    }
+    let executablePath = "\(Bundle.main.bundlePath)/\(executableName)"
+    
+    for i in 0..<_dyld_image_count() {
+      guard let header = _dyld_get_image_header(i) else { continue }
+      let imagePath = String(cString: _dyld_get_image_name(i))
+      
+      guard imagePath == executablePath else {
+        continue
+      }
+
+      var _uuid: uuid_t = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+      let _ = withUnsafeMutablePointer(to: &_uuid) {
+        getUUID(header, $0)
+      }
+      return UUID(uuid: _uuid).uuidString
+    }
+    return nil
+  }
+}

--- a/Sources/SentryDistribution/Models/CheckForUpdateParams.swift
+++ b/Sources/SentryDistribution/Models/CheckForUpdateParams.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A model for configuring parameters needed to check for app updates.
+public struct CheckForUpdateParams {
+  /// Creates a new instance with the required parameters for update checking.
+  /// - Parameters:
+  ///   - accessToken: Bearer token for authentication with Sentry API
+  ///   - organization: Sentry organization slug
+  ///   - project: Sentry project slug
+  ///   - hostname: Sentry hostname (defaults to "us.sentry.io")
+  ///   - binaryIdentifierOverride: Optional UUID override for the main binary
+  ///   - appIdOverride: Optional bundle identifier override
+  public init(accessToken: String, organization: String, project: String, hostname: String = "us.sentry.io", binaryIdentifierOverride: String? = nil, appIdOverride: String? = nil) {
+    self.accessToken = accessToken
+    self.organization = organization
+    self.project = project
+    self.hostname = hostname
+    self.binaryIdentifierOverride = binaryIdentifierOverride
+    self.appIdOverride = appIdOverride
+  }
+
+  let accessToken: String
+  let organization: String
+  let project: String
+  let hostname: String
+  let binaryIdentifierOverride: String?
+  let appIdOverride: String?
+}

--- a/Sources/SentryDistribution/Models/ReleaseInfo.swift
+++ b/Sources/SentryDistribution/Models/ReleaseInfo.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Information about a release version returned from the update check API.
+public struct ReleaseInfo: Decodable, Sendable {
+  /// Unique identifier for the release
+  public let id: String
+  /// Build version string (e.g., "1.2.3")
+  public let buildVersion: String
+  /// Build number (e.g., 123)
+  public let buildNumber: Int
+  /// Optional release notes describing changes
+  public let releaseNotes: String?
+  /// URL to download the IPA file
+  public let downloadUrl: String
+  /// Optional URL to the app icon
+  public let iconUrl: String?
+  /// Display name of the app
+  public let appName: String
+  private let createdDate: String
+
+  /// Parsed creation date from the server response
+  public var created: Date? {
+    Date.fromString(createdDate)
+  }
+}

--- a/Sources/SentryDistribution/Models/UpdateCheckResponse.swift
+++ b/Sources/SentryDistribution/Models/UpdateCheckResponse.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Response from the update check API containing current and available release information.
+public struct UpdateCheckResponse: Decodable, Sendable {
+  /// Information about the currently installed release
+  public let current: ReleaseInfo?
+  /// Information about the available update (nil if no update available)
+  public let update: ReleaseInfo?
+}

--- a/Sources/SentryDistribution/Network/URLSession+Distribute.swift
+++ b/Sources/SentryDistribution/Network/URLSession+Distribute.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension URLSession {
+  
+  func perform<T: Sendable & Decodable>(
+    _ request: URLRequest,
+    decode decodable: T.Type,
+    completion: @escaping @Sendable (Result<T, Error>) -> Void) {
+    dataTask(with: request) { (data, response, error) in
+      var result: Result<T, Error> = .failure(.unknownError)
+      defer {
+        completion(result)
+      }
+      if let error = error {
+        result = .failure(.requestError(error))
+        return
+      }
+      guard let httpResponse = response as? HTTPURLResponse,
+            let data = data else {
+        result = .failure(.invalidData)
+        return
+      }
+      guard (200...299).contains(httpResponse.statusCode) else {
+        result = .failure(.unknownError)
+        return
+      }
+      
+      do {
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.keyDecodingStrategy = .convertFromSnakeCase
+        result = .success(try jsonDecoder.decode(decodable, from: data))
+      } catch {
+        result = .failure(.decodeError(error))
+      }
+    }.resume()
+  }
+
+}

--- a/Sources/SentryDistribution/Updater.swift
+++ b/Sources/SentryDistribution/Updater.swift
@@ -1,0 +1,117 @@
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// A class for checking and installing app updates from Sentry's distribution service.
+public final class Updater: Sendable {
+  
+  // MARK: - Public
+
+  /// Checks if there is an update available for the app, based on the provided `params`.
+  ///
+  ///
+  /// - Parameters:
+  ///   - params: A `CheckForUpdateParams` object.
+  ///   - completion: A closure that is called with the result of the update check.
+  ///
+  /// - Example:
+  /// ```
+  /// let params = CheckForUpdateParams(accessToken: "your_access_token")
+  /// Updater.checkForUpdate(params: params) { result in
+  ///     switch result {
+  ///     case .success(let releaseInfo):
+  ///       if let releaseInfo = releaseInfo.update {
+  ///         print("Update found: \(releaseInfo)")
+  ///       } else {
+  ///         print("Already up to date")
+  ///       }
+  ///     case .failure(let error):
+  ///         print("Error checking for update: \(error)")
+  ///     }
+  /// }
+  /// ```
+  public static func checkForUpdate(params: CheckForUpdateParams,
+                                    completion: @escaping @Sendable (Result<UpdateCheckResponse, Swift.Error>) -> Void) {
+    shared.getUpdatesFromBackend(params: params) { result in
+      completion(result.mapError { $0 })
+    }
+  }
+
+  #if canImport(UIKit)
+  /// Install an update from the provided URL
+  /// - Parameter url: The itms-services URL
+  @MainActor public static func install(url: URL) {
+    UIApplication.shared.open(url) { _ in
+      // Post notification event before closing the app
+      NotificationCenter.default.post(name: UIApplication.willTerminateNotification, object: nil)
+
+      // Close the app after a slight delay so it has time to execute code for the notification
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        // We need to exit since iOS doesn't start the install until the app exits
+        exit(0)
+      }
+    }
+  }
+  #endif
+
+  /// Obtain a URL to install an IPA
+  /// - Parameter plistUrl: The URL to the plist containing the IPA information
+  /// - Returns: a URL ready to install the IPA using itms-services
+  public static func buildUrlForInstall(_ plistUrl: String) -> URL? {
+    var components = URLComponents()
+    components.scheme = "itms-services"
+    components.queryItems = [
+      URLQueryItem(name: "action", value: "download-manifest"),
+      URLQueryItem(name: "url", value: plistUrl)
+    ]
+    return components.url
+  }
+  
+  // MARK: - Internal
+  init(session: URLSession = URLSession(configuration: URLSessionConfiguration.ephemeral)) {
+    self.session = session
+  }
+  
+  func getUpdatesFromBackend(
+    params: CheckForUpdateParams,
+    completion: @escaping @Sendable (Result<UpdateCheckResponse, Error>) -> Void) {
+    guard var components = URLComponents(string: "https://\(params.hostname)/api/0/projects/\(params.organization)/\(params.project)/preprodartifacts/check-for-updates/") else {
+      completion(.failure(.invalidUrl))
+      return
+    }
+    guard let bundleId = params.appIdOverride ?? Bundle.main.bundleIdentifier else {
+      completion(.failure(.noBundleId))
+      return
+    }
+    
+    components.queryItems = [
+      URLQueryItem(name: "main_binary_identifier", value: params.binaryIdentifierOverride ?? uuid),
+      URLQueryItem(name: "app_id", value: bundleId),
+      URLQueryItem(name: "platform", value: "ios")
+    ]
+    if let shortVersionString = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+      components.queryItems?.append(URLQueryItem(name: "build_version", value: shortVersionString))
+    }
+    if let bundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String {
+      components.queryItems?.append(URLQueryItem(name: "build_number", value: bundleVersion))
+    }
+    
+    guard let url = components.url else {
+      completion(.failure(.invalidUrl))
+      return
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("Bearer \(params.accessToken)", forHTTPHeaderField: "Authorization")
+
+    session.perform(request, decode: UpdateCheckResponse.self) { result in
+      completion(result)
+    }
+  }
+
+  // MARK: - Private
+  static let shared = Updater()
+  private let session: URLSession
+  private let uuid = BinaryParser.getMainBinaryUUID()
+}

--- a/Sources/SentryDistribution/Utils/Date+Parse.swift
+++ b/Sources/SentryDistribution/Utils/Date+Parse.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension Date {
+  static let formatter = {
+    let formatter = DateFormatter()
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+    return formatter
+  }()
+
+  static func fromString(_ input: String) -> Date? {
+    return formatter.date(from: input)
+  }
+}

--- a/Sources/SentryDistribution/Utils/Error.swift
+++ b/Sources/SentryDistribution/Utils/Error.swift
@@ -1,0 +1,8 @@
+enum Error: Swift.Error {
+  case invalidUrl
+  case noBundleId
+  case invalidData
+  case requestError(Swift.Error)
+  case decodeError(Swift.Error)
+  case unknownError
+}

--- a/Sources/SentryDistributionTests/BinaryParserTests.swift
+++ b/Sources/SentryDistributionTests/BinaryParserTests.swift
@@ -1,0 +1,15 @@
+@testable import SentryDistribution
+import Testing
+
+@Test func testBinaryParserGetsCorrectUUID() throws {
+  let uuid = BinaryParser.getMainBinaryUUID { _, ptr in
+    let mutable = UnsafeMutableRawPointer(mutating: ptr)
+    for i in 0..<16 {
+      // Use a fixed value of 10 so we can expect to see repeated 0x0A
+      // in the resulting UUID.
+      mutable.storeBytes(of: 10, toByteOffset: i, as: CChar.self)
+    }
+    return true
+  }
+  #expect(uuid == "0A0A0A0A-0A0A-0A0A-0A0A-0A0A0A0A0A0A")
+}

--- a/Sources/SentryDistributionTests/CheckForUpdateParamsTests.swift
+++ b/Sources/SentryDistributionTests/CheckForUpdateParamsTests.swift
@@ -1,0 +1,15 @@
+@testable import SentryDistribution
+import Testing
+
+@Test func testCheckForUpdatesParamsDefaults() throws {
+  let token = "token"
+  let org = "org"
+  let project = "project"
+  let checkForUpdatesParams = CheckForUpdateParams(accessToken: token, organization: org, project: project)
+  #expect(checkForUpdatesParams.accessToken == token)
+  #expect(checkForUpdatesParams.organization == org)
+  #expect(checkForUpdatesParams.project == project)
+  #expect(checkForUpdatesParams.hostname == "us.sentry.io")
+  #expect(checkForUpdatesParams.appIdOverride == nil)
+  #expect(checkForUpdatesParams.binaryIdentifierOverride == nil)
+}

--- a/Sources/SentryDistributionTests/DistributionReleaseInfoTests.swift
+++ b/Sources/SentryDistributionTests/DistributionReleaseInfoTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+@testable import SentryDistribution
+import Testing
+
+@Test func testParseDateWithFractionalSecondsWorks() async throws {
+  let dateString = "2025-01-31T12:34:56.000Z"
+  let expectedDate = Date(timeIntervalSince1970: 1_738_326_896) // Friday, 31 January 2025 12:34:56 GMT
+  let date = Date.fromString(dateString)
+  
+  #expect(date == expectedDate, "Invalid parser")
+}
+
+@Test func testParserUpToMiliseconds() async throws {
+  let dateString = "2025-02-24T01:07:51.101Z"
+  let date = Date.fromString(dateString)
+  
+  guard let date else {
+    Issue.record("Failed to parse date")
+    return
+  }
+  
+  var calendar = Calendar.current
+  calendar.timeZone = try #require(TimeZone(secondsFromGMT: 0))
+  let dateComponents = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second, .nanosecond], from: date)
+  
+  #expect(dateComponents.year == 2_025, "Different year")
+  #expect(dateComponents.month == 2, "Different month")
+  #expect(dateComponents.day == 24, "Different day")
+  #expect(dateComponents.hour == 1, "Different hour")
+  #expect(dateComponents.minute == 7, "Different minute")
+  #expect(dateComponents.second == 51, "Different second")
+  
+  // Nanoseconds is the closest floating point number
+  let miliseconds = try #require(dateComponents.nanosecond) / 1_000_000
+  #expect(miliseconds == 101, "Different nanosecond")
+}

--- a/Sources/SentryDistributionTests/MockURLProtocol.swift
+++ b/Sources/SentryDistributionTests/MockURLProtocol.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class MockURLProtocol: URLProtocol {
+  override class func canInit(with request: URLRequest) -> Bool {
+    true
+  }
+  
+  override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+    request
+  }
+  
+  static var startLoading: ((URLRequest) throws -> (URLResponse, Data))?
+  
+  override func startLoading() {
+    guard let handler = Self.startLoading else {
+      return
+    }
+
+    if let (response, data) = try? handler(request) {
+      client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+      client?.urlProtocol(self, didLoad: data)
+      client?.urlProtocolDidFinishLoading(self)
+    }
+  }
+  
+  override func stopLoading() { }
+}

--- a/Sources/SentryDistributionTests/UpdaterTests.swift
+++ b/Sources/SentryDistributionTests/UpdaterTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+@testable import SentryDistribution
+import Testing
+
+@Test func testUpdaterReturnsErrorForInvalidHostname() async throws {
+  let parmas = CheckForUpdateParams(accessToken: "", organization: "", project: "", hostname: "%")
+  await confirmation("Receives error") { confirm in
+    Updater.checkForUpdate(params: parmas) { result in
+      switch result {
+      case .success:
+        #expect(Bool(false), "Should not be a successful response")
+      case .failure(let error):
+        switch error as? Error {
+        case .invalidUrl:
+          confirm()
+        default:
+          #expect(Bool(false), "Unexpected error case \(error)")
+        }
+      }
+    }
+  }
+}
+
+@Test func testSuccessfullUpdateRequest() async throws {
+  let params = CheckForUpdateParams(accessToken: "token", organization: "org", project: "project")
+  let configuration = URLSessionConfiguration.default
+  configuration.protocolClasses = [MockURLProtocol.self]
+  let session = URLSession(configuration: configuration)
+
+  await confirmation("Called network") { confirm in
+    MockURLProtocol.startLoading = { request in
+      let url = try #require(request.url)
+      let response = try #require(HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil))
+      let jsonString = "{\"update\":{\"id\":\"\", \"build_version\":\"\", \"build_number\":0,\"download_url\":\"\",\"app_name\":\"\",\"created_date\":\"\"}}"
+      confirm()
+      return (response, Data(jsonString.utf8))
+    }
+    
+    await withCheckedContinuation { continuation in
+      Updater(session: session).getUpdatesFromBackend(params: params) { result in
+        switch result {
+        case .success(let response):
+          #expect(response.current == nil)
+          #expect(response.update != nil)
+          continuation.resume()
+        case .failure(let error):
+          #expect(Bool(false), "Should be a successful response but got \(error)")
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds the ETDistribution model to the package.swift

Intentionally not supporting cocoapods or usage from ObjC for now, that can come in a future version.

There are a few ways we could expose this API:

1. Using the `SentrySDK` naming so you would do something like `SentrySDK.checkForUpdates()`
  - a: As an extension from the existing `SentrySDK`. This is not preferred because it means users would have to depend on both the Sentry target, and the distribution target.
  - b: As a new target containing a new object with the same name. So there would be `Sentry.SentrySDK` and `SentryDistribution.SentrySDK` but most of the time you wouldn't need the module prefixes if they are being used in different files.
2. With a new type name like `Distribution`. This is what this PR does. The API is:
```
import SentryDistribution

Updater.checkForUpdates()
```

Closes #6173

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new `SentryDistribution` SwiftPM target with update-checking API, includes sample app and CI build/test coverage.
> 
> - **SDK / SPM**:
>   - Add `SentryDistribution` target and `SentryDistributionTests` in `Package.swift`.
>   - Implement update-checking API (`Updater`, models, networking, Mach-O UUID parsing, utils) under `Sources/SentryDistribution`.
> - **Samples**:
>   - Add `Samples/DistributionSample` app (XcodeGen spec, SwiftUI app, update flow) and include it in workspace and Makefile.
> - **CI**:
>   - Extend `.github/actions/prepare-package.swift` with `remove-duplicate` and `change-path` inputs and conditional steps.
>   - Add `build-distribution` job to build `SentryDistribution` framework.
>   - Add `distribution-tests` job to run SPM package tests (with duplicate target removal), and wire into required checks.
>   - Build matrix: include `DistributionSample` scheme.
> - **Changelog**:
>   - Unreleased: feature entry for `SentryDistribution` as a SwiftPM target.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e87db3c1fc82f1bf8d081f6a81054c7ec39bb4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->