### PR TITLE
ref: SentryFileManager to Swift

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -178,8 +178,8 @@
 		635B3F391EBC6E2500A6176D /* SentryAsynchronousOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 635B3F371EBC6E2500A6176D /* SentryAsynchronousOperation.m */; };
 		6360850D1ED2AFE100E8599E /* SentryBreadcrumb.h in Headers */ = {isa = PBXBuildFile; fileRef = 6360850B1ED2AFE100E8599E /* SentryBreadcrumb.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6360850E1ED2AFE100E8599E /* SentryBreadcrumb.m in Sources */ = {isa = PBXBuildFile; fileRef = 6360850C1ED2AFE100E8599E /* SentryBreadcrumb.m */; };
-		636085131ED47BE600E8599E /* SentryFileManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 636085111ED47BE600E8599E /* SentryFileManager.h */; };
-		636085141ED47BE600E8599E /* SentryFileManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 636085121ED47BE600E8599E /* SentryFileManager.m */; };
+		636085131ED47BE600E8599E /* SentryFileManagerHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 636085111ED47BE600E8599E /* SentryFileManagerHelper.h */; };
+		636085141ED47BE600E8599E /* SentryFileManagerHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 636085121ED47BE600E8599E /* SentryFileManagerHelper.m */; };
 		6383953623ABA42C000C1594 /* SentryHttpTransport.h in Headers */ = {isa = PBXBuildFile; fileRef = 6383953523ABA42C000C1594 /* SentryHttpTransport.h */; };
 		638DC9A01EBC6B6400A66E41 /* SentryRequestOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 638DC99E1EBC6B6400A66E41 /* SentryRequestOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		638DC9A11EBC6B6400A66E41 /* SentryRequestOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 638DC99F1EBC6B6400A66E41 /* SentryRequestOperation.m */; };
@@ -1118,6 +1118,7 @@
 		FAEC270E2DF3526000878871 /* SentryUserFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */; };
 		FAEC273D2DF3933A00878871 /* NSData+Unzip.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEC273C2DF3933200878871 /* NSData+Unzip.m */; };
 		FAEEBFE22E736D4B00E79CA9 /* SentryViewHierarchyProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEEBFDC2E736D4100E79CA9 /* SentryViewHierarchyProvider.swift */; };
+		FAEEBFEA2E74517B00E79CA9 /* SentryFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEEBFE92E74517800E79CA9 /* SentryFileManager.swift */; };
 		FAEEC0522E75E55F00E79CA9 /* SentrySerializationSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEEC04C2E75E55A00E79CA9 /* SentrySerializationSwift.swift */; };
 		FAEFA12F2E4FAE1900C431D9 /* SentrySDKSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEFA1292E4FAE1700C431D9 /* SentrySDKSettings.swift */; };
 		FAF120182E70C08F006E1DA3 /* SentryEnvelopeHeaderHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FAF120122E70C088006E1DA3 /* SentryEnvelopeHeaderHelper.h */; };
@@ -1417,8 +1418,8 @@
 		635B3F371EBC6E2500A6176D /* SentryAsynchronousOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryAsynchronousOperation.m; sourceTree = "<group>"; };
 		6360850B1ED2AFE100E8599E /* SentryBreadcrumb.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryBreadcrumb.h; path = Public/SentryBreadcrumb.h; sourceTree = "<group>"; };
 		6360850C1ED2AFE100E8599E /* SentryBreadcrumb.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryBreadcrumb.m; sourceTree = "<group>"; };
-		636085111ED47BE600E8599E /* SentryFileManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryFileManager.h; path = include/SentryFileManager.h; sourceTree = "<group>"; };
-		636085121ED47BE600E8599E /* SentryFileManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryFileManager.m; sourceTree = "<group>"; };
+		636085111ED47BE600E8599E /* SentryFileManagerHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryFileManagerHelper.h; path = include/SentryFileManagerHelper.h; sourceTree = "<group>"; };
+		636085121ED47BE600E8599E /* SentryFileManagerHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SentryFileManagerHelper.m; sourceTree = "<group>"; };
 		6383953523ABA42C000C1594 /* SentryHttpTransport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryHttpTransport.h; path = include/SentryHttpTransport.h; sourceTree = "<group>"; };
 		6387B82F1ED851970045A84C /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		638DC99E1EBC6B6400A66E41 /* SentryRequestOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SentryRequestOperation.h; path = include/SentryRequestOperation.h; sourceTree = "<group>"; };
@@ -2463,6 +2464,7 @@
 		FAEC273C2DF3933200878871 /* NSData+Unzip.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+Unzip.m"; sourceTree = "<group>"; };
 		FAEC273E2DF393E000878871 /* NSData+Unzip.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSData+Unzip.h"; sourceTree = "<group>"; };
 		FAEEBFDC2E736D4100E79CA9 /* SentryViewHierarchyProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryViewHierarchyProvider.swift; sourceTree = "<group>"; };
+		FAEEBFE92E74517800E79CA9 /* SentryFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryFileManager.swift; sourceTree = "<group>"; };
 		FAEEC04C2E75E55A00E79CA9 /* SentrySerializationSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySerializationSwift.swift; sourceTree = "<group>"; };
 		FAEFA1292E4FAE1700C431D9 /* SentrySDKSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySDKSettings.swift; sourceTree = "<group>"; };
 		FAF120122E70C088006E1DA3 /* SentryEnvelopeHeaderHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryEnvelopeHeaderHelper.h; path = include/SentryEnvelopeHeaderHelper.h; sourceTree = "<group>"; };
@@ -2603,6 +2605,7 @@
 				FAE5797E2E7CF21300B710F9 /* SentryMigrateSessionInit.swift */,
 				62CB19242E77F8FD00AF5DA2 /* SentryDispatchSourceWrapper.swift */,
 				FAEEC04C2E75E55A00E79CA9 /* SentrySerializationSwift.swift */,
+				FAEEBFE92E74517800E79CA9 /* SentryFileManager.swift */,
 				FA94E7232E6F32FA00576666 /* SentryEnvelopeItemType.swift */,
 				FA458CBD2E691A6E0061B13D /* SentryProcessInfo.swift */,
 				F4A930222E65FDAF006DA6EF /* SentryMobileProvisionParser.swift */,
@@ -2897,10 +2900,10 @@
 				63AA769C1EB9C57A00D153DE /* SentryError.mm */,
 				7B42C47F27E08F33009B58C2 /* SentryDependencyContainer.h */,
 				7B42C48127E08F4B009B58C2 /* SentryDependencyContainer.m */,
-				636085111ED47BE600E8599E /* SentryFileManager.h */,
+				636085111ED47BE600E8599E /* SentryFileManagerHelper.h */,
 				FA3734832E0F07A20091EF24 /* SentryDependencyContainerSwiftHelper.h */,
 				FA3734852E0F092F0091EF24 /* SentryDependencyContainerSwiftHelper.m */,
-				636085121ED47BE600E8599E /* SentryFileManager.m */,
+				636085121ED47BE600E8599E /* SentryFileManagerHelper.m */,
 				7BC3936725B1AB3E004F03D3 /* SentryLevelMapper.h */,
 				7BC3936D25B1AB72004F03D3 /* SentryLevelMapper.m */,
 				D8AE48B12C5786AA0092A2A6 /* SentryLogC.h */,
@@ -5203,7 +5206,7 @@
 				63AA76A51EB9CBC200D153DE /* SentryDsn.h in Headers */,
 				844EDD6C2949387000C86F34 /* SentryMetricProfiler.h in Headers */,
 				F452438A2DE65968003E8F50 /* ExceptionCatcher.h in Headers */,
-				636085131ED47BE600E8599E /* SentryFileManager.h in Headers */,
+				636085131ED47BE600E8599E /* SentryFileManagerHelper.h in Headers */,
 				7BD729962463E83300EA3610 /* SentryDateUtil.h in Headers */,
 				63FE707B20DA4C1000CDBAE8 /* SentryDictionaryDeepSearch.h in Headers */,
 				6344DDB91EC3115C00D9160D /* SentryCrashReportConverter.h in Headers */,
@@ -5859,6 +5862,7 @@
 				FAE57BF72E83049E00B710F9 /* SentryDisplayLinkWrapper.swift in Sources */,
 				D4CD2A802DE9F91900DA9F59 /* SentryRedactRegion.swift in Sources */,
 				D4CD2A812DE9F91900DA9F59 /* SentryRedactRegionType.swift in Sources */,
+				FAEEBFEA2E74517B00E79CA9 /* SentryFileManager.swift in Sources */,
 				6344DDB11EC308E400D9160D /* SentryCrashInstallationReporter.m in Sources */,
 				84BA62272CAE2EEF0049F636 /* SentryUserFeedbackWidgetButtonView.swift in Sources */,
 				FAE5798D2E7D9D4C00B710F9 /* SentrySysctl.swift in Sources */,
@@ -5945,7 +5949,7 @@
 				FAB3599A2E05D8080083D5E3 /* SentryEventSwiftHelper.m in Sources */,
 				F41362112E1C55AF00B84443 /* SentryScopePersistentStore+Tags.swift in Sources */,
 				7B4E375F258231FC00059C93 /* SentryAttachment.m in Sources */,
-				636085141ED47BE600E8599E /* SentryFileManager.m in Sources */,
+				636085141ED47BE600E8599E /* SentryFileManagerHelper.m in Sources */,
 				63FE710B20DA4C1000CDBAE8 /* SentryCrashMach.c in Sources */,
 				63FE707720DA4C1000CDBAE8 /* SentryDictionaryDeepSearch.m in Sources */,
 				FACEED132E3179A10007B4AC /* SentyOptionsInternal.m in Sources */,

--- a/SentryTestUtils/SentryFileManager+Test.h
+++ b/SentryTestUtils/SentryFileManager+Test.h
@@ -1,4 +1,4 @@
-#import "SentryFileManager.h"
+#import "SentryFileManagerHelper.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,11 +11,7 @@ NSString *_Nullable sentryBuildScopedCachesDirectoryPath(NSString *cachesDirecto
 SENTRY_EXTERN NSURL *_Nullable launchProfileConfigFileURL(void);
 SENTRY_EXTERN NSURL *_Nullable sentryLaunchConfigFileURL;
 
-@interface SentryFileManager ()
-
-@property (nonatomic, copy) NSString *eventsPath;
-@property (nonatomic, copy) NSString *envelopesPath;
-@property (nonatomic, copy) NSString *timezoneOffsetFilePath;
+@interface SentryFileManagerHelper ()
 
 - (void)clearDiskState;
 

--- a/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
+++ b/SentryTestUtils/SentryTestUtils-ObjC-BridgingHeader.h
@@ -34,6 +34,7 @@
 #import "SentryDependencyContainer.h"
 #import "SentryDispatchFactory.h"
 #import "SentryFileManager+Test.h"
+#import "SentryFileManagerHelper.h"
 #import "SentryHub+Private.h"
 #import "SentryHub+Test.h"
 #import "SentryLogC.h"

--- a/SentryTestUtils/TestClient.swift
+++ b/SentryTestUtils/TestClient.swift
@@ -16,11 +16,11 @@ public class TestClient: SentryClient {
         )
     }
 
-    public override init?(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool) {
+    @_spi(Private) public override init?(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool) {
         super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: TestTransportAdapter(transports: [TestTransport()], options: options))
     }
     
-    public override init(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, transportAdapter: SentryTransportAdapter) {
+    @_spi(Private) public override init(options: Options, fileManager: SentryFileManager, deleteOldEnvelopeItems: Bool, transportAdapter: SentryTransportAdapter) {
         super.init(options: options, fileManager: fileManager, deleteOldEnvelopeItems: deleteOldEnvelopeItems, transportAdapter: transportAdapter)
     }
     

--- a/SentryTestUtils/TestFileManager.swift
+++ b/SentryTestUtils/TestFileManager.swift
@@ -1,8 +1,8 @@
 import _SentryPrivate
 import Foundation
-@_spi(Private) import Sentry
+@_spi(Private) @testable import Sentry
 
-public class TestFileManager: SentryFileManager {
+@_spi(Private) public class TestFileManager: SentryFileManager {
     var timestampLastInForeground: Date?
     var readTimestampLastInForegroundInvocations: Int = 0
     var storeTimestampLastInForegroundInvocations: Int = 0

--- a/Sources/Sentry/Processors/SentryWatchdogTerminationBreadcrumbProcessor.m
+++ b/Sources/Sentry/Processors/SentryWatchdogTerminationBreadcrumbProcessor.m
@@ -1,5 +1,4 @@
 #import "SentryWatchdogTerminationBreadcrumbProcessor.h"
-#import "SentryFileManager.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"
 #import "SentrySerialization.h"

--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -4,7 +4,7 @@
 
 #    import "SentryContinuousProfiler.h"
 #    import "SentryDependencyContainer.h"
-#    import "SentryFileManager.h"
+#    import "SentryFileManagerHelper.h"
 #    import "SentryInternalDefines.h"
 #    import "SentryLaunchProfiling.h"
 #    import "SentryLogC.h"

--- a/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilerTestHelpers.m
@@ -2,10 +2,11 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryFileManager.h"
+#    import "SentryFileManagerHelper.h"
 #    import "SentryInternalDefines.h"
 #    import "SentryLaunchProfiling.h"
 #    import "SentrySerialization.h"
+#    import "SentrySwift.h"
 
 BOOL
 sentry_threadSanitizerIsPresent(void)

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -4,7 +4,6 @@
 #import "SentryDependencyContainer.h"
 #import "SentryEvent.h"
 #import "SentryException.h"
-#import "SentryFileManager.h"
 #import "SentryHub+Private.h"
 #import "SentryLogC.h"
 #import "SentryMechanism.h"

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -2,7 +2,6 @@
 #import "SentryDependencyContainer.h"
 #import "SentryNotificationNames.h"
 #import <SentryAppStateManager.h>
-#import <SentryFileManager.h>
 #import <SentryOptions.h>
 #import <SentrySwift.h>
 

--- a/Sources/Sentry/SentryAsyncLog.m
+++ b/Sources/Sentry/SentryAsyncLog.m
@@ -1,6 +1,6 @@
 #import "SentryAsyncLog.h"
 #import "SentryAsyncSafeLog.h"
-#import "SentryFileManager.h"
+#import "SentryFileManagerHelper.h"
 #import "SentryInternalCDefines.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -1,7 +1,6 @@
 #import "SentryAutoBreadcrumbTrackingIntegration.h"
 #import "SentryBreadcrumbTracker.h"
 #import "SentryDependencyContainer.h"
-#import "SentryFileManager.h"
 #import "SentryLogC.h"
 #import "SentryOptions.h"
 #import "SentrySDKInternal.h"

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -11,7 +11,6 @@
 #import "SentryEvent+Private.h"
 #import "SentryException.h"
 #import "SentryExtraContextProvider.h"
-#import "SentryFileManager.h"
 #import "SentryHub+Private.h"
 #import "SentryHub.h"
 #import "SentryInstallation.h"

--- a/Sources/Sentry/SentryCrashIntegrationSessionHandler.m
+++ b/Sources/Sentry/SentryCrashIntegrationSessionHandler.m
@@ -1,7 +1,6 @@
 #import "SentryCrashIntegrationSessionHandler.h"
 #import "SentryClient+Private.h"
 #import "SentryDependencyContainer.h"
-#import "SentryFileManager.h"
 #import "SentryHub.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -3,7 +3,6 @@
 #import "SentryDispatchFactory.h"
 #import "SentryExtraContextProvider.h"
 #import "SentryFileIOTracker.h"
-#import "SentryFileManager.h"
 #import "SentryInternalCDefines.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -2,7 +2,6 @@
 #import "SentryByteCountFormatter.h"
 #import "SentryClient+Private.h"
 #import "SentryDependencyContainer.h"
-#import "SentryFileManager.h"
 #import "SentryFrame.h"
 #import "SentryHub+Private.h"
 #import "SentryInternalDefines.h"

--- a/Sources/Sentry/SentryHttpTransport.m
+++ b/Sources/Sentry/SentryHttpTransport.m
@@ -7,7 +7,6 @@
 #import "SentryEnvelopeItemHeader.h"
 #import "SentryEnvelopeRateLimit.h"
 #import "SentryEvent.h"
-#import "SentryFileManager.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"
 #import "SentryNSURLRequestBuilder.h"
@@ -93,8 +92,9 @@
         [self.envelopeRateLimit setDelegate:self];
         typeof(self) __weak weakSelf = self;
         [self.fileManager
-            setEnvelopeDeletedCallback:^(SentryEnvelopeItem *item, SentryDataCategory category) {
-                [weakSelf envelopeItemDeleted:item withCategory:category];
+            setEnvelopeDeletedCallback:^(SentryEnvelopeItem *item, NSUInteger category) {
+                [weakSelf envelopeItemDeleted:item
+                                 withCategory:sentryDataCategoryForNSUInteger(category)];
             }];
 
         [self sendAllCachedEnvelopes];

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -2,7 +2,6 @@
 #import "SentryDependencyContainer.h"
 #import "SentryEnvelopeItemHeader.h"
 #import "SentryEvent+Private.h"
-#import "SentryFileManager.h"
 #import "SentryHub+Private.h"
 #import "SentryInstallation.h"
 #import "SentryIntegrationProtocol.h"

--- a/Sources/Sentry/SentryLogC.m
+++ b/Sources/Sentry/SentryLogC.m
@@ -1,6 +1,5 @@
 #import "SentryLogC.h"
 #import "SentryAsyncSafeLog.h"
-#import "SentryFileManager.h"
 #import "SentryInternalCDefines.h"
 #import "SentryLevelMapper.h"
 #import "SentrySwift.h"

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -4,7 +4,7 @@
 #    import "SentryClient+Private.h"
 #    import "SentryContinuousProfiler.h"
 #    import "SentryDependencyContainer.h"
-#    import "SentryFileManager.h"
+#    import "SentryFileManagerHelper.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryHub+Private.h"
 #    import "SentryInternalDefines.h"

--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -7,7 +7,6 @@
 #import "SentryClient+Private.h"
 #import "SentryCrash.h"
 #import "SentryDependencyContainer.h"
-#import "SentryFileManager.h"
 #import "SentryHub+Private.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -7,7 +7,6 @@
 #    import "SentryDispatchFactory.h"
 #    import "SentryDispatchQueueProviderProtocol.h"
 #    import "SentryEvent+Private.h"
-#    import "SentryFileManager.h"
 #    import "SentryHub+Private.h"
 #    import "SentryLogC.h"
 #    import "SentryOptions.h"

--- a/Sources/Sentry/SentrySessionTracker.m
+++ b/Sources/Sentry/SentrySessionTracker.m
@@ -1,7 +1,6 @@
 #import "SentrySessionTracker.h"
 #import "SentryClient+Private.h"
 #import "SentryClient.h"
-#import "SentryFileManager.h"
 #import "SentryHub+Private.h"
 #import "SentryInternalNotificationNames.h"
 #import "SentryLogC.h"

--- a/Sources/Sentry/SentrySystemEventBreadcrumbs.m
+++ b/Sources/Sentry/SentrySystemEventBreadcrumbs.m
@@ -3,7 +3,6 @@
 #import "SentryBreadcrumbDelegate.h"
 #import "SentryDefines.h"
 #import "SentryDependencyContainer.h"
-#import "SentryFileManager.h"
 #import "SentryLogC.h"
 #import "SentrySwift.h"
 

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -3,7 +3,6 @@
 #import "SentryDebugImageProvider+HybridSDKs.h"
 #import "SentryDependencyContainer.h"
 #import "SentryEvent+Private.h"
-#import "SentryFileManager.h"
 #import "SentryHub+Private.h"
 #import "SentryInternalCDefines.h"
 #import "SentryInternalDefines.h"

--- a/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
+++ b/Sources/Sentry/SentryWatchdogTerminationScopeObserver.m
@@ -3,7 +3,6 @@
 #if SENTRY_HAS_UIKIT
 
 #    import <SentryBreadcrumb.h>
-#    import <SentryFileManager.h>
 #    import <SentryLogC.h>
 #    import <SentrySwift.h>
 #    import <SentryWatchdogTerminationBreadcrumbProcessor.h>

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -1,6 +1,5 @@
 #import "SentryDateUtils.h"
 #import "SentryEvent+Private.h"
-#import "SentryFileManager.h"
 #import "SentrySwift.h"
 #import <SentryAppStateManager.h>
 #import <SentryClient+Private.h>

--- a/Sources/Sentry/include/SentryHttpTransport.h
+++ b/Sources/Sentry/include/SentryHttpTransport.h
@@ -8,6 +8,7 @@
 @class SentryDispatchQueueWrapper;
 @class SentryNSURLRequestBuilder;
 @class SentryDsn;
+@class SentryFileManager;
 @protocol SentryCurrentDateProvider;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -32,7 +32,7 @@
 #import "SentryDependencyContainerSwiftHelper.h"
 #import "SentryEvent+Serialize.h"
 #import "SentryFileIOTracker.h"
-#import "SentryFileManager.h"
+#import "SentryFileManagerHelper.h"
 #import "SentryLevelHelper.h"
 #import "SentryMeta.h"
 #import "SentryModels+Serializable.h"

--- a/Sources/Swift/Helper/SentryFileManager.swift
+++ b/Sources/Swift/Helper/SentryFileManager.swift
@@ -1,0 +1,308 @@
+@_implementationOnly import _SentryPrivate
+
+@_spi(Private) @objc public class SentryFileManager: NSObject {
+
+    // The UInt is a SentryDataCategory. This type cannot be in the Swift public interface since it's `implementationOnly`
+    // We can use the enum type directly once users of this callback are written in Swift and we can drop the @objc annotation
+    @objc public var envelopeDeletedCallback: ((SentryEnvelopeItem, UInt) -> Void)?
+
+    @objc public var basePath: String {
+        helper.basePath
+    }
+    @objc public var sentryPath: String {
+        helper.sentryPath
+    }
+
+    @objc public var breadcrumbsFilePathOne: String {
+        helper.breadcrumbsFilePathOne
+    }
+    @objc public var breadcrumbsFilePathTwo: String {
+        helper.breadcrumbsFilePathTwo
+    }
+    @objc public var previousBreadcrumbsFilePathOne: String {
+        helper.previousBreadcrumbsFilePathOne
+    }
+    @objc public var previousBreadcrumbsFilePathTwo: String {
+        helper.previousBreadcrumbsFilePathTwo
+    }
+
+    @objc public init(options: Options, dateProvider: SentryCurrentDateProvider, dispatchQueueWrapper: SentryDispatchQueueWrapper) throws {
+        dispatchQueue = dispatchQueueWrapper
+        self.dateProvider = dateProvider
+        helper = try SentryFileManagerHelper(options: options)
+        super.init()
+
+        helper.handleEnvelopesLimit = { [weak self] in
+            self?.handleEnvelopesLimit()
+        }
+    }
+
+    @discardableResult @objc(storeEnvelope:) public func store(_ envelope: SentryEnvelope) -> String? {
+        let envelopeData = SentrySerializationSwift.data(with: envelope)
+        guard let envelopeData else {
+            SentrySDKLog.error("Serialization of envelope failed. Can't store envelope.")
+            return nil
+        }
+        return helper.storeEnvelopeData(envelopeData, currentTime: self.dateProvider.date().timeIntervalSince1970)
+    }
+    
+    @objc public func getEnvelopesPath(_ filePath: String) -> String? {
+        helper.getEnvelopesPath(filePath)
+    }
+
+    @objc public func getAllEnvelopes() -> [SentryFileContents] {
+        allFilesContentInFolder(path: envelopesPath)
+    }
+
+    @objc public func getOldestEnvelope() -> SentryFileContents? {
+        let pathsOfAllEnvelopes = helper.pathsOfAllEnvelopes()
+        
+        if let pathsOfAllEnvelopes, pathsOfAllEnvelopes.count > 0 {
+            let filePath = pathsOfAllEnvelopes[0]
+            return getFileContents(folderPath: envelopesPath, filePath: filePath)
+        }
+
+        return nil
+    }
+
+    @objc public func deleteOldEnvelopeItems() {
+        let dateProvider = self.dateProvider
+        dispatchQueue.dispatchAsync { [weak self] in
+            let now = dateProvider.date().timeIntervalSince1970
+            self?.helper.deleteOldEnvelopes(fromAllSentryPaths: now)
+        }
+    }
+    
+    @objc public func deleteAllEnvelopes() {
+        helper.deleteAllEnvelopes()
+    }
+    
+    @objc public func getSentryPathAsURL() -> URL {
+        helper.getSentryPathAsURL()
+    }
+
+    @objc public func moveState(_ stateFilePath: String, toPreviousState previousStateFilePath: String) {
+        helper.moveState(stateFilePath, toPreviousState: previousStateFilePath)
+    }
+    
+    @objc public func storeCurrentSession(_ session: SentrySession) {
+        helper.storeCurrentSessionData(SentrySerializationSwift.data(withJSONObject: session.serialize()))
+    }
+    
+    @objc public func readCurrentSession() -> SentrySession? {
+        helper.readCurrentSession().flatMap { SentrySerializationSwift.session(with: $0) }
+    }
+    
+    @objc public func deleteCurrentSession() {
+        helper.deleteCurrentSession()
+    }
+    
+    @objc public func storeCrashedSession(_ session: SentrySession) {
+        helper.storeCrashedSessionData(SentrySerializationSwift.data(withJSONObject: session.serialize()))
+    }
+
+    @objc public func readCrashedSession() -> SentrySession? {
+        helper.readCrashedSession().flatMap { SentrySerializationSwift.session(with: $0) }
+    }
+    
+    @objc public func deleteCrashedSession() {
+        helper.deleteCrashedSession()
+    }
+
+    @objc public func storeAbnormalSession(_ session: SentrySession) {
+        helper.storeAbnormalSessionData(SentrySerializationSwift.data(withJSONObject: session.serialize()))
+    }
+    
+    @objc public func readAbnormalSession() -> SentrySession? {
+        helper.readAbnormalSession().flatMap { SentrySerializationSwift.session(with: $0) }
+    }
+    
+    @objc public func deleteAbnormalSession() {
+        helper.deleteAbnormalSession()
+    }
+    
+    @objc public func storeTimestampLast(inForeground timestamp: Date) {
+        helper.storeTimestampLast(inForeground: timestamp)
+    }
+    
+    @objc public func readTimestampLastInForeground() -> Date? {
+        helper.readTimestampLastInForeground()
+    }
+    
+    @objc public func deleteTimestampLastInForeground() {
+        helper.deleteTimestampLastInForeground()
+    }
+
+    @objc(storeAppState:) public func store(_ appState: SentryAppState) {
+        guard let data = SentrySerializationSwift.data(withJSONObject: appState.serialize()) else {
+            SentrySDKLog.error("Failed to store app state, because of an error in serialization")
+            return
+        }
+
+        helper.storeAppStateData(data)
+    }
+    
+    @objc public func moveAppStateToPreviousAppState() {
+        helper.moveAppStateToPreviousAppState()
+    }
+    
+    @objc public func readAppState() -> SentryAppState? {
+        helper.readAppStateData().flatMap { SentrySerializationSwift.appState(with: $0) }
+    }
+    
+    @objc public func readPreviousAppState() -> SentryAppState? {
+        helper.readPreviousAppState().flatMap { SentrySerializationSwift.appState(with: $0) }
+    }
+    
+    @objc public func deleteAppState() {
+        helper.deleteAppState()
+    }
+
+    @objc public func moveBreadcrumbsToPreviousBreadcrumbs() {
+        helper.moveBreadcrumbsToPreviousBreadcrumbs()
+    }
+    
+    @objc public func readPreviousBreadcrumbs() -> [Any] {
+        helper.readPreviousBreadcrumbs()
+    }
+    
+    @objc public func readTimezoneOffset() -> NSNumber? {
+        helper.readTimezoneOffset()
+    }
+    
+    @objc public func storeTimezoneOffset(_ offset: Int) {
+        helper.storeTimezoneOffset(offset)
+    }
+    
+    @objc public func deleteTimezoneOffset() {
+        helper.deleteTimezoneOffset()
+    }
+
+    @objc(storeAppHangEvent:) public func storeAppHang(_ event: Event) {
+        helper.storeAppHang(event)
+    }
+    
+    @objc public func readAppHangEvent() -> Event? {
+        helper.readAppHangEvent()
+    }
+    
+    @objc public func appHangEventExists() -> Bool {
+        helper.appHangEventExists()
+    }
+    
+    @objc public func deleteAppHangEvent() {
+        helper.deleteAppHangEvent()
+    }
+
+    @objc public static func createDirectory(atPath path: String) throws {
+        try SentryFileManagerHelper.createDirectory(atPath: path)
+    }
+    
+    @objc public func deleteAllFolders() {
+        helper.deleteAllFolders()
+    }
+    
+    @objc public func removeFile(atPath path: String) {
+        helper.removeFile(atPath: path)
+    }
+    
+    @objc public func allFilesInFolder(_ path: String) -> [String] {
+        helper.allFiles(inFolder: path)
+    }
+    
+    @objc public func isDirectory(_ path: String) -> Bool {
+        helper.isDirectory(path)
+    }
+    
+    @objc public func readData(fromPath path: String) throws -> Data {
+        try helper.readData(fromPath: path)
+    }
+    
+    @discardableResult @objc(writeData:toPath:) public func write(_ data: Data, toPath: String) -> Bool {
+        helper.write(data, toPath: toPath)
+    }
+    
+    // MARK: Internal
+    
+    var appHangEventFilePath: String {
+        helper.appHangEventFilePath
+    }
+
+    var appStateFilePath: String {
+        helper.appStateFilePath
+    }
+
+    func clearDiskState() {
+        helper.clearDiskState()
+    }
+    
+    var envelopesPath: String {
+        helper.envelopesPath
+    }
+    
+    var timezoneOffsetFilePath: String {
+        helper.timezoneOffsetFilePath
+    }
+    
+    var eventsPath: String {
+        helper.eventsPath
+    }
+    
+    // MARK: Private
+
+    private let helper: SentryFileManagerHelper
+    private let dispatchQueue: SentryDispatchQueueWrapper
+    private let dateProvider: SentryCurrentDateProvider
+    
+    private func allFilesContentInFolder(path: String) -> [SentryFileContents] {
+        allFilesInFolder(path).compactMap { filePath in
+            getFileContents(folderPath: path, filePath: filePath)
+        }
+    }
+    
+    private func getFileContents(folderPath: String, filePath: String) -> SentryFileContents? {
+        let finalPath = (folderPath as NSString).appendingPathComponent(filePath)
+        guard let content = FileManager.default.contents(atPath: finalPath) else {
+            return nil
+        }
+        return SentryFileContents(path: finalPath, contents: content)
+    }
+    
+    private func handleEnvelopesLimit() {
+        let envelopeFilePaths = allFilesInFolder(envelopesPath)
+        let numberOfEnvelopesToRemove = envelopeFilePaths.count - Int(helper.maxEnvelopes)
+        if numberOfEnvelopesToRemove <= 0 {
+            return
+        }
+        
+        for i in 0..<numberOfEnvelopesToRemove {
+            let envelopeFilePath = (envelopesPath as NSString).appendingPathComponent(envelopeFilePaths[i])
+            var envelopePathsCopy = Array(envelopeFilePaths)
+            envelopePathsCopy.remove(at: i)
+            
+            let envelopeData = FileManager.default.contents(atPath: envelopeFilePath)
+            let envelope = SentrySerializationSwift.envelope(with: envelopeData ?? Data())
+            let didMigrateSessionInit: Bool
+            if let envelope {
+                didMigrateSessionInit = SentryMigrateSessionInit.migrateSessionInit(envelope: envelope, envelopesDirPath: envelopesPath, envelopeFilePaths: envelopePathsCopy)
+            } else {
+                didMigrateSessionInit = false
+            }
+            
+            for item in envelope?.items ?? [] {
+                let rateLimitCategory = sentryDataCategoryForEnvelopItemType(item.header.type)
+                // When migrating the session init, the envelope to delete still contains the session
+                // migrated to another envelope. Therefore, the envelope item is not deleted but
+                // migrated.
+                
+                if didMigrateSessionInit && rateLimitCategory == SentryDataCategory.session {
+                    continue
+                }
+                
+                envelopeDeletedCallback?(item, rateLimitCategory.rawValue)
+            }
+            removeFile(atPath: envelopeFilePath)
+        }
+        SentrySDKLog.debug("Removed \(numberOfEnvelopesToRemove) file(s) from <\((envelopesPath as NSString).lastPathComponent)>")
+    }
+}

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -60,8 +60,8 @@ class SentryFileManagerTests: XCTestCase {
                 dateProvider: currentDateProvider,
                 dispatchQueueWrapper: dispatchQueueWrapper
             )
-            sut.setEnvelopeDeletedCallback { [weak self] _, category in
-                self?.envelopeItemsDeleted.record(category)
+            sut.envelopeDeletedCallback = { [weak self] _, category in
+                self?.envelopeItemsDeleted.record(sentryDataCategoryForNSUInteger(category))
             }
             return sut
         }
@@ -73,8 +73,8 @@ class SentryFileManagerTests: XCTestCase {
                 dateProvider: currentDateProvider,
                 dispatchQueueWrapper: dispatchQueueWrapper
             )
-            sut.setEnvelopeDeletedCallback { [weak self] _, category in
-                self?.envelopeItemsDeleted.record(category)
+            sut.envelopeDeletedCallback = { [weak self] _, category in
+                self?.envelopeItemsDeleted.record(sentryDataCategoryForNSUInteger(category))
             }
             return sut
         }
@@ -625,7 +625,7 @@ class SentryFileManagerTests: XCTestCase {
             }
             
             dispatchQueue.async {
-                self.sut.readAbnormalSession()
+                _ = self.sut.readAbnormalSession()
                 expectation.fulfill()
             }
             
@@ -689,7 +689,7 @@ class SentryFileManagerTests: XCTestCase {
         SentrySDKLog.configureLog(true, diagnosticLevel: .debug)
         
         sut.deleteAllFolders()
-        sut.getAllEnvelopes()
+        _ = sut.getAllEnvelopes()
         
         let debugLogMessages = logOutput.loggedMessages.filter { $0.contains("[Sentry] [info]") && $0.contains("Returning empty files list, as folder doesn't exist at path:") }
         XCTAssertEqual(debugLogMessages.count, 1)
@@ -863,7 +863,7 @@ class SentryFileManagerTests: XCTestCase {
     func testAppHangEventExists_WithGarbage_ReturnsTrue() throws {
         // Arrange
         let fileManager = FileManager.default
-        let appHangEventFilePath = try XCTUnwrap(Dynamic(sut).appHangEventFilePath.asString)
+        let appHangEventFilePath = sut.appHangEventFilePath
         
         fileManager.createFile(atPath: appHangEventFilePath, contents: Data("garbage".utf8), attributes: nil)
 
@@ -1491,7 +1491,7 @@ private extension SentryFileManagerTests {
     }
     
     func setImmutableForAppState(immutable: Bool) {
-        let appStateFilePath = Dynamic(sut).appStateFilePath.asString ?? ""
+        let appStateFilePath = sut.appStateFilePath
         let fileManager = FileManager.default
         
         if !fileManager.fileExists(atPath: appStateFilePath) {
@@ -1506,7 +1506,7 @@ private extension SentryFileManagerTests {
     }
 
     func setImmutableForTimezoneOffset(immutable: Bool) {
-        let timezoneOffsetFilePath = Dynamic(sut).timezoneOffsetFilePath.asString ?? ""
+        let timezoneOffsetFilePath = sut.timezoneOffsetFilePath
         let fileManager = FileManager.default
 
         if !fileManager.fileExists(atPath: timezoneOffsetFilePath) {

--- a/Tests/SentryTests/SentryInterfacesTests.m
+++ b/Tests/SentryTests/SentryInterfacesTests.m
@@ -5,7 +5,6 @@
 #import "SentryDateUtils.h"
 #import "SentryEvent.h"
 #import "SentryException.h"
-#import "SentryFileManager.h"
 #import "SentryFrame.h"
 #import "SentryMechanism.h"
 #import "SentryMeta.h"

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -119,7 +119,7 @@
 #import "SentryFileIOTracker.h"
 #import "SentryFileIOTrackingIntegration.h"
 #import "SentryFileManager+Test.h"
-#import "SentryFileManager.h"
+#import "SentryFileManagerHelper.h"
 #import "SentryFormatter.h"
 #import "SentryFrame.h"
 #import "SentryFramesTrackingIntegration.h"


### PR DESCRIPTION
To make this safe most of the conversion is just wrapping the old SentryFileManager which I renamed to SentryFileManagerHelper. There were two changes actually made:

1 - Many functions in SentryFileManagerHelper that previously used an SDK internal type like AppState or Session, now use NSData. The serializing/deserializing is done in the Swift version but is just one function call so very little code change.

2 - The callback for pruning the maximum number of envelopes has been moved to Swift, it's just one function and had existing tests.

#skip-changelog

Closes #6238