### PR TITLE
ci: Explain why no unit tests on macCatalyst 26

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,6 +186,8 @@ jobs:
             test-destination-os: "latest"
             scheme: "Sentry"
 
+          ## We don't run unit tests on macCatalyst 26 yet because of https://github.com/getsentry/sentry-cocoa/issues/6165.
+
           # We don't run the unit tests on tvOS 16 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, tvOS 15 or tvOS 16 is minimal.
           # We are running tests on tvOS 17 and latest, as there were OS-internal changes introduced in succeeding versions.


### PR DESCRIPTION
Follow up on https://github.com/getsentry/sentry-cocoa/issues/6061

#skip-changelog

Closes #6176