### PR TITLE
chore: Refine sed command for binaryTarget removal

### DIFF
--- a/.github/actions/prepare-package.swift/action.yml
+++ b/.github/actions/prepare-package.swift/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         sed -i '' '/Sentry-Dynamic-WithARM64e/d' $PACKAGE_FILE
         sed -i '' '/Sentry-WithoutUIKitOrAppKit-WithARM64e/d' $PACKAGE_FILE
-        sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;/\n[[:space:]]*)[,]?$/d;}' $PACKAGE_FILE
+        sed -i '' '/^[[:space:]]*\.binaryTarget($/{N;/\n[[:space:]]*),\{0,1\}$/d;}' $PACKAGE_FILE
     - name: Change path of the framework
       shell: bash
       env:


### PR DESCRIPTION
Also removed step to delete newer package files from action, we don't need it any more since there is only one Package.swift

#skip-changelog


Closes #6188