### PR TITLE
chore(deps): bump rexml from 3.4.1 to 3.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,7 +265,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retriable (3.1.2)
-    rexml (3.4.1)
+    rexml (3.4.2)
     rouge (3.28.0)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
Original PR https://github.com/getsentry/sentry-cocoa/pull/6189. Reopend it myself so we have the permissions to run the required checks.

Bumps [rexml](https://github.com/ruby/rexml) from 3.4.1 to 3.4.2.
- [Release notes](https://github.com/ruby/rexml/releases)
- [Changelog](https://github.com/ruby/rexml/blob/master/NEWS.md)
- [Commits](https://github.com/ruby/rexml/compare/v3.4.1...v3.4.2)

---
updated-dependencies:
- dependency-name: rexml dependency-version: 3.4.2 dependency-type: indirect ...

#skip-changelog

Closes #6195