### PR TITLE
ref: Enhance nullability handling in profiling

### DIFF
--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -252,6 +252,12 @@ _sentry_unsafe_stopTimerAndCleanup()
     std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
     return _threadUnsafe_gContinuousCurrentProfiler;
 }
+
++ (void)transmitChunkEnvelope
+{
+    std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
+    _sentry_threadUnsafe_transmitChunkEnvelope();
+}
 #    endif // defined(SENTRY_TEST) || defined(SENTRY_TEST_CI) || defined(DEBUG)
 
 @end

--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -362,8 +362,13 @@ SentryId *_Nullable sentry_startProfilerForTrace(SentryTracerConfiguration *conf
             SENTRY_LOG_DEBUG(@"Not a root span, will not start automatically for trace lifecycle.");
             return nil;
         }
-        return _sentry_startContinuousProfilerV2ForTrace(
-            sentry_getProfiling(SENTRY_UNWRAP_NULLABLE(SentryClient, client)), transactionContext);
+        SentryProfileOptions *_Nullable profilingOptions
+            = sentry_getProfiling(SENTRY_UNWRAP_NULLABLE(SentryClient, client));
+        if (profilingOptions == nil) {
+            SENTRY_LOG_DEBUG(@"No profiling options found, will not start profiler.");
+            return nil;
+        }
+        return _sentry_startContinuousProfilerV2ForTrace(profilingOptions, transactionContext);
     }
     BOOL profileShouldBeSampled
         = configuration.profilesSamplerDecision.decision == kSentrySampleDecisionYes;

--- a/Sources/Sentry/Profiling/SentryProfilerSerialization.m
+++ b/Sources/Sentry/Profiling/SentryProfilerSerialization.m
@@ -163,13 +163,18 @@ sentry_serializedTraceProfileData(
     };
 
     bool isEmulated = sentry_isSimulatorBuild();
-    payload[SENTRY_CONTEXT_DEVICE_KEY] = @{
+    NSMutableDictionary *deviceDict = [[NSMutableDictionary alloc] initWithDictionary:@{
         @"architecture" : sentry_getCPUArchitecture(),
         @"is_emulator" : @(isEmulated),
         @"locale" : NSLocale.currentLocale.localeIdentifier,
         @"manufacturer" : @"Apple",
-        @"model" : isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel()
-    };
+    }];
+    NSString *_Nullable deviceModel
+        = isEmulated ? sentry_getSimulatorDeviceModel() : sentry_getDeviceModel();
+    if (deviceModel != nil) {
+        deviceDict[@"model"] = SENTRY_UNWRAP_NULLABLE(NSString, deviceModel);
+    }
+    payload[SENTRY_CONTEXT_DEVICE_KEY] = deviceDict;
 
     payload[@"profile_id"] = [[[SentryId alloc] init] sentryIdString];
     payload[@"truncation_reason"] = truncationReason;
@@ -380,12 +385,15 @@ SentryEnvelopeItem *_Nullable sentry_traceProfileEnvelopeItem(SentryHub *hub,
     }
 
     payload[@"platform"] = SentryPlatformName;
-    payload[@"transaction"] = @ {
+    NSMutableDictionary *transactionDict = [[NSMutableDictionary alloc] initWithDictionary:@ {
         @"id" : transaction.eventId.sentryIdString,
         @"trace_id" : transaction.trace.traceId.sentryIdString,
-        @"name" : transaction.transaction,
         @"active_thread_id" : [transaction.trace.transactionContext sentry_threadInfo].threadId
-    };
+    }];
+    if (transaction.transaction) {
+        transactionDict[@"name"] = transaction.transaction;
+    }
+    payload[@"transaction"] = transactionDict;
     payload[@"timestamp"] = sentry_toIso8601String(startTimestamp);
 
     NSData *JSONData = [SentrySerialization dataWithJSONObject:payload];

--- a/Sources/Sentry/Profiling/SentryProfilerState.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerState.mm
@@ -4,6 +4,7 @@
 #    import "SentryBacktrace.hpp"
 #    import "SentryDependencyContainer.h"
 #    import "SentryFormatter.h"
+#    import "SentryInternalDefines.h"
 #    import "SentryProfileTimeseries.h"
 #    import "SentryProfilingSwiftHelpers.h"
 #    import "SentrySample.h"
@@ -28,10 +29,15 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
                                  options:0
                                    error:nil];
     });
-    const auto symbolNSStr = [NSString stringWithUTF8String:symbol];
-    const auto match = [regex firstMatchInString:symbolNSStr
-                                         options:0
-                                           range:NSMakeRange(0, [symbolNSStr length])];
+    NSString *_Nullable const symbolNSStr = [NSString stringWithUTF8String:symbol];
+    if (symbolNSStr == nil) {
+        SENTRY_LOG_ERROR(@"Failed to convert backtrace symbol to NSString.");
+        return @"<unknown>";
+    }
+    NSTextCheckingResult *_Nullable match =
+        [regex firstMatchInString:SENTRY_UNWRAP_NULLABLE(NSString, symbolNSStr)
+                          options:0
+                            range:NSMakeRange(0, [symbolNSStr length])];
     if (match == nil) {
         return symbolNSStr;
     }
@@ -144,7 +150,7 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
                 state.frameIndexLookup[instructionAddress] = newFrameIndex;
                 [state.frames addObject:frame];
             } else {
-                [stack addObject:frameIndex];
+                [stack addObject:SENTRY_UNWRAP_NULLABLE(NSNumber, frameIndex)];
             }
         }
 #    if defined(DEBUG)
@@ -157,9 +163,9 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         sample.threadID = backtrace.threadMetadata.threadID;
 
         const auto stackKey = [stack componentsJoinedByString:@"|"];
-        const auto stackIndex = state.stackIndexLookup[stackKey];
+        NSNumber *_Nullable stackIndex = state.stackIndexLookup[stackKey];
         if (stackIndex) {
-            sample.stackIndex = stackIndex;
+            sample.stackIndex = SENTRY_UNWRAP_NULLABLE(NSNumber, stackIndex);
         } else {
             const auto nextStackIndex = @(state.stacks.count);
             sample.stackIndex = nextStackIndex;

--- a/Sources/Sentry/Profiling/SentryProfilingSwiftHelpers.m
+++ b/Sources/Sentry/Profiling/SentryProfilingSwiftHelpers.m
@@ -28,8 +28,7 @@ sentry_isProfilingCorrelatedToTraces(SentryClient *client)
     return [client.options isProfilingCorrelatedToTraces];
 }
 
-SentryProfileOptions *
-sentry_getProfiling(SentryClient *client)
+SentryProfileOptions *_Nullable sentry_getProfiling(SentryClient *client)
 {
     return client.options.profiling;
 }
@@ -82,8 +81,7 @@ sentry_profileAppStarts(SentryProfileOptions *options)
     return options.profileAppStarts;
 }
 
-SentrySpanId *
-sentry_getParentSpanID(SentryTransactionContext *context)
+SentrySpanId *_Nullable sentry_getParentSpanID(SentryTransactionContext *context)
 {
     return context.parentSpanId;
 }

--- a/Sources/Sentry/Profiling/SentryTraceProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryTraceProfiler.mm
@@ -4,6 +4,7 @@
 
 #    import "SentryDependencyContainer.h"
 
+#    import "SentryInternalDefines.h"
 #    import "SentryLogC.h"
 #    import "SentryMetricProfiler.h"
 #    import "SentryProfiledTracerConcurrency.h"
@@ -35,7 +36,8 @@ SentryProfiler *_Nullable _threadUnsafe_gTraceProfiler;
 
         if ([_threadUnsafe_gTraceProfiler isRunning]) {
             SENTRY_LOG_DEBUG(@"A trace profiler is already running.");
-            sentry_trackTransactionProfilerForTrace(_threadUnsafe_gTraceProfiler, traceId);
+            sentry_trackTransactionProfilerForTrace(
+                SENTRY_UNWRAP_NULLABLE(SentryProfiler, _threadUnsafe_gTraceProfiler), traceId);
             // record a new metric sample for every concurrent span start
             [_threadUnsafe_gTraceProfiler.metricProfiler recordMetrics];
             return YES;
@@ -49,7 +51,8 @@ SentryProfiler *_Nullable _threadUnsafe_gTraceProfiler;
         }
 
         _threadUnsafe_gTraceProfiler.profilerId = sentry_getSentryId();
-        sentry_trackTransactionProfilerForTrace(_threadUnsafe_gTraceProfiler, traceId);
+        sentry_trackTransactionProfilerForTrace(
+            SENTRY_UNWRAP_NULLABLE(SentryProfiler, _threadUnsafe_gTraceProfiler), traceId);
     }
 
     [self scheduleTimeoutTimer];

--- a/Sources/Sentry/SentryDevice.m
+++ b/Sources/Sentry/SentryDevice.m
@@ -193,12 +193,11 @@ sentry_getOSVersion(void)
 #endif // SENTRY_HAS_UIKIT
 }
 
-NSString *
-sentry_getDeviceModel(void)
+NSString *_Nullable sentry_getDeviceModel(void)
 {
 #if TARGET_OS_SIMULATOR
     // iPhone/iPad, Watch and TV simulators
-    NSString *simulatedDeviceModelName = sentry_getSimulatorDeviceModel();
+    NSString *_Nullable simulatedDeviceModelName = sentry_getSimulatorDeviceModel();
     SENTRY_LOG_DEBUG(@"Got simulated device model name %@ (running on %@)",
         simulatedDeviceModelName, getHardwareDescription(HW_MODEL));
     return simulatedDeviceModelName;
@@ -225,8 +224,7 @@ sentry_getDeviceModel(void)
 #endif // TARGET_OS_SIMULATOR
 }
 
-NSString *
-sentry_getSimulatorDeviceModel(void)
+NSString *_Nullable sentry_getSimulatorDeviceModel(void)
 {
     return NSProcessInfo.processInfo.environment[@"SIMULATOR_MODEL_IDENTIFIER"];
 }

--- a/Sources/Sentry/include/SentryDevice.h
+++ b/Sources/Sentry/include/SentryDevice.h
@@ -26,7 +26,7 @@ NSString *sentry_getOSVersion(void);
  * @return The Apple hardware descriptor, such as @c iPhone14,4 or @c MacBookPro10,8 .
  * @note If running on a simulator, this will be the model of the simulated device.
  */
-NSString *sentry_getDeviceModel(void);
+NSString *_Nullable sentry_getDeviceModel(void);
 
 /**
  * @return The Apple hardware descriptor of the simulated device, such as @c iPhone14,4 or

--- a/Sources/Sentry/include/SentryProfilingSwiftHelpers.h
+++ b/Sources/Sentry/include/SentryProfilingSwiftHelpers.h
@@ -23,7 +23,7 @@ BOOL sentry_isContinuousProfilingEnabled(SentryClient *client);
 #endif // !SDK_V9
 BOOL sentry_isContinuousProfilingV2Enabled(SentryClient *client);
 BOOL sentry_isProfilingCorrelatedToTraces(SentryClient *client);
-SentryProfileOptions *sentry_getProfiling(SentryClient *client);
+SentryProfileOptions *_Nullable sentry_getProfiling(SentryClient *client);
 NSString *sentry_stringFromSentryID(SentryId *sentryID);
 NSDate *sentry_getDate(void);
 uint64_t sentry_getSystemTime(void);
@@ -32,7 +32,7 @@ SentryProfileOptions *sentry_getSentryProfileOptions(void);
 BOOL sentry_isTraceLifecycle(SentryProfileOptions *options);
 float sentry_sessionSampleRate(SentryProfileOptions *options);
 BOOL sentry_profileAppStarts(SentryProfileOptions *options);
-SentrySpanId *sentry_getParentSpanID(SentryTransactionContext *context);
+SentrySpanId *_Nullable sentry_getParentSpanID(SentryTransactionContext *context);
 SentryId *sentry_getTraceID(SentryTransactionContext *context);
 BOOL sentry_isNotSampled(SentryTransactionContext *context);
 void sentry_dispatchAsync(SentryDispatchQueueWrapper *wrapper, dispatch_block_t block);

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -222,6 +222,44 @@ final class SentryContinuousProfilerTests: XCTestCase {
         try fixture.timeoutTimerFactory.check()
         XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
     }
+    
+    func testTransmitChunkEnvelopeWithNilProfiler() throws {
+        // Arrange
+        // Ensure no profiler is currently running
+        XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
+        
+        // Act
+        SentryContinuousProfiler.transmitChunkEnvelope()
+        
+        // Assert
+        // The function should handle nil profiler gracefully:
+        // 1. Should not crash when no profiler is running
+        // 2. Should return early and log a debug message
+        // 3. Should not attempt to capture any envelopes
+        XCTAssertFalse(SentryContinuousProfiler.isCurrentlyProfiling())
+        XCTAssertTrue(fixture.client?.captureEnvelopeInvocations.isEmpty ?? true)
+    }
+    
+    func testEnvelopeCreationFailure() throws {
+        // Arrange
+        // Start continuous profiler and add mock samples
+        SentryContinuousProfiler.start()
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
+        try addMockSamples(mockAddresses: [0x1, 0x2])
+        
+        // Act
+        // Advance time to trigger chunk creation and test envelope creation null handling
+        fixture.currentDateProvider.advanceBy(interval: 60)
+        
+        // Assert
+        // This tests that the profiler continues running even if envelope creation fails
+        // The code includes: if (envelope == nil) { SENTRY_LOG_ERROR(...); return; }
+        XCTAssertTrue(SentryContinuousProfiler.isCurrentlyProfiling())
+        
+        // Clean up
+        SentryContinuousProfiler.stop()
+        try assertContinuousProfileStoppage()
+    }
 }
 
 @available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")

--- a/Tests/SentryProfilerTests/SentryProfilerTests.mm
+++ b/Tests/SentryProfilerTests/SentryProfilerTests.mm
@@ -2,6 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
+#    import "SentryContinuousProfiler+Test.h"
 #    import "SentryEvent+Private.h"
 #    import "SentryHub+Test.h"
 #    import "SentryProfileTimeseries.h"
@@ -45,6 +46,21 @@ using namespace sentry::profiling;
     const auto symbols = backtrace_symbols(buffer, nptrs);
     XCTAssertEqualObjects(parseBacktraceSymbolsFunctionName(symbols[0]),
         @"-[SentryProfilerTests testParseFunctionNameWithBacktraceSymbolsInput]");
+}
+
+- (void)testParseFunctionNameWithInvalidUTF8Input
+{
+    // Arrange
+    // Create an invalid UTF-8 sequence: 0xFF is not a valid start byte in UTF-8
+    const char invalidUTF8[] = { (char)0xFF, (char)0xFE, (char)0xFD, 0x00 };
+
+    // Act
+    // Parse the invalid UTF-8 symbol - should handle failure gracefully
+    NSString *result = parseBacktraceSymbolsFunctionName(invalidUTF8);
+
+    // Assert
+    // Should return "<unknown>" when stringWithUTF8String fails
+    XCTAssertEqualObjects(result, @"<unknown>");
 }
 
 - (void)testTraceProfilerCanBeInitializedOnMainThread

--- a/Tests/SentryProfilerTests/SentryProfilingSwiftHelpersTests.m
+++ b/Tests/SentryProfilerTests/SentryProfilingSwiftHelpersTests.m
@@ -50,6 +50,15 @@
     XCTAssertEqual(client.options.profiling, sentry_getProfiling(client));
 }
 
+- (void)testGetProfiling_whenProfilingOptionsIsNil_shouldReturnNil
+{
+    SentryOptions *options = [[SentryOptions alloc] init];
+    options.dsn = @"https://username:password@app.getsentry.com/12345";
+    options.profiling = nil;
+    SentryClient *client = [[SentryClient alloc] initWithOptions:options];
+    XCTAssertNil(sentry_getProfiling(client));
+}
+
 - (void)testStringFromSentryID
 {
     SentryId *sentryId = [[SentryId alloc] init];
@@ -112,6 +121,17 @@
                                                 operation:@""
                                                   sampled:kSentrySampleDecisionNo];
     XCTAssertEqual(context.parentSpanId, sentry_getParentSpanID(context));
+}
+
+- (void)testGetParentSpanID_whenParentIdIsNil_shouldReturnNil
+{
+    SentryTransactionContext *context =
+        [[SentryTransactionContext alloc] initWithTraceId:[[SentryId alloc] init]
+                                                   spanId:[[SentrySpanId alloc] init]
+                                                 parentId:nil
+                                                operation:@""
+                                                  sampled:kSentrySampleDecisionNo];
+    XCTAssertNil(sentry_getParentSpanID(context));
 }
 
 - (void)testGetTraceID

--- a/Tests/SentryTests/SentryContinuousProfiler+Test.h
+++ b/Tests/SentryTests/SentryContinuousProfiler+Test.h
@@ -10,6 +10,7 @@
 
 + (void)stopTimerAndCleanup;
 + (nullable SentryProfiler *)profiler;
++ (void)transmitChunkEnvelope;
 
 @end
 


### PR DESCRIPTION
## :scroll: Description

- Updated device model functions to return nullable types for better safety.
- Improved error handling in continuous profiler to log when no profiler is running.
- Added nullability checks in various profiling-related functions to prevent potential crashes.
- Enhanced tests to cover scenarios where profiling options or parent span IDs are nil.

## :bulb: Motivation and Context

Closes #6201
Closes #6202 
Closes #6203 
Closes #6204 
Closes #6205 

## :green_heart: How did you test it?

- Unit tests

#skip-changelog