### PR TITLE
ref: Convert SentrySysctl to Swift

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -542,8 +542,8 @@
 		7BD729962463E83300EA3610 /* SentryDateUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD729952463E83300EA3610 /* SentryDateUtil.h */; };
 		7BD729982463E93500EA3610 /* SentryDateUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BD729972463E93500EA3610 /* SentryDateUtil.m */; };
 		7BD7299A2463EA4A00EA3610 /* SentryDateUtilTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */; };
-		7BD86EC5264A63F6005439DB /* SentrySysctl.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD86EC4264A63F6005439DB /* SentrySysctl.h */; };
-		7BD86EC7264A641D005439DB /* SentrySysctl.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BD86EC6264A641D005439DB /* SentrySysctl.m */; };
+		7BD86EC5264A63F6005439DB /* SentrySysctlObjC.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD86EC4264A63F6005439DB /* SentrySysctlObjC.h */; };
+		7BD86EC7264A641D005439DB /* SentrySysctlObjC.m in Sources */ = {isa = PBXBuildFile; fileRef = 7BD86EC6264A641D005439DB /* SentrySysctlObjC.m */; };
 		7BD86ECB264A6DB5005439DB /* TestSysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD86ECA264A6DB5005439DB /* TestSysctl.swift */; };
 		7BD86ECD264A78A6005439DB /* SentryAppStartTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BD86ECC264A78A6005439DB /* SentryAppStartTrackerTests.swift */; };
 		7BD86ECF264A7C77005439DB /* SentryAppStartMeasurement.h in Headers */ = {isa = PBXBuildFile; fileRef = 7BD86ECE264A7C77005439DB /* SentryAppStartMeasurement.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1119,6 +1119,7 @@
 		FACEED132E3179A10007B4AC /* SentyOptionsInternal.m in Sources */ = {isa = PBXBuildFile; fileRef = FACEED122E3179A10007B4AC /* SentyOptionsInternal.m */; };
 		FAE2DAB82E1F317900262307 /* SentryProfilingSwiftHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = FAE2DAB72E1F317900262307 /* SentryProfilingSwiftHelpers.m */; };
 		FAE2DABA2E1F318900262307 /* SentryProfilingSwiftHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = FAE2DAB92E1F318900262307 /* SentryProfilingSwiftHelpers.h */; };
+		FAE5798D2E7D9D4C00B710F9 /* SentrySysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE579872E7D9D4900B710F9 /* SentrySysctl.swift */; };
 		FAE80C242E4695B40010A595 /* SentryEvent+Serialize.h in Headers */ = {isa = PBXBuildFile; fileRef = FAE80C232E4695AE0010A595 /* SentryEvent+Serialize.h */; };
 		FAEC270E2DF3526000878871 /* SentryUserFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */; };
 		FAEC273D2DF3933A00878871 /* NSData+Unzip.m in Sources */ = {isa = PBXBuildFile; fileRef = FAEC273C2DF3933200878871 /* NSData+Unzip.m */; };
@@ -1819,8 +1820,8 @@
 		7BD729952463E83300EA3610 /* SentryDateUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryDateUtil.h; path = include/SentryDateUtil.h; sourceTree = "<group>"; };
 		7BD729972463E93500EA3610 /* SentryDateUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryDateUtil.m; sourceTree = "<group>"; };
 		7BD729992463EA4A00EA3610 /* SentryDateUtilTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryDateUtilTests.swift; sourceTree = "<group>"; };
-		7BD86EC4264A63F6005439DB /* SentrySysctl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySysctl.h; path = include/SentrySysctl.h; sourceTree = "<group>"; };
-		7BD86EC6264A641D005439DB /* SentrySysctl.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySysctl.m; sourceTree = "<group>"; };
+		7BD86EC4264A63F6005439DB /* SentrySysctlObjC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySysctlObjC.h; path = include/SentrySysctlObjC.h; sourceTree = "<group>"; };
+		7BD86EC6264A641D005439DB /* SentrySysctlObjC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySysctlObjC.m; sourceTree = "<group>"; };
 		7BD86ECA264A6DB5005439DB /* TestSysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestSysctl.swift; sourceTree = "<group>"; };
 		7BD86ECC264A78A6005439DB /* SentryAppStartTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryAppStartTrackerTests.swift; sourceTree = "<group>"; };
 		7BD86ECE264A7C77005439DB /* SentryAppStartMeasurement.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryAppStartMeasurement.h; path = include/HybridPublic/SentryAppStartMeasurement.h; sourceTree = "<group>"; };
@@ -2466,6 +2467,7 @@
 		FACEED122E3179A10007B4AC /* SentyOptionsInternal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentyOptionsInternal.m; sourceTree = "<group>"; };
 		FAE2DAB72E1F317900262307 /* SentryProfilingSwiftHelpers.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryProfilingSwiftHelpers.m; sourceTree = "<group>"; };
 		FAE2DAB92E1F318900262307 /* SentryProfilingSwiftHelpers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryProfilingSwiftHelpers.h; path = Sources/Sentry/include/SentryProfilingSwiftHelpers.h; sourceTree = SOURCE_ROOT; };
+		FAE579872E7D9D4900B710F9 /* SentrySysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentrySysctl.swift; sourceTree = "<group>"; };
 		FAE80C232E4695AE0010A595 /* SentryEvent+Serialize.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "SentryEvent+Serialize.h"; path = "include/SentryEvent+Serialize.h"; sourceTree = "<group>"; };
 		FAEC270D2DF3526000878871 /* SentryUserFeedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryUserFeedback.swift; sourceTree = "<group>"; };
 		FAEC273C2DF3933200878871 /* NSData+Unzip.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSData+Unzip.m"; sourceTree = "<group>"; };
@@ -2605,6 +2607,7 @@
 		621D9F2D2B9B030E003D94DE /* Helper */ = {
 			isa = PBXGroup;
 			children = (
+				FAE579872E7D9D4900B710F9 /* SentrySysctl.swift */,
 				62CB19242E77F8FD00AF5DA2 /* SentryDispatchSourceWrapper.swift */,
 				FAEEC04C2E75E55A00E79CA9 /* SentrySerializationSwift.swift */,
 				FA94E71B2E6F26BF00576666 /* SentrySerialization+ReplayRecording.swift */,
@@ -2933,8 +2936,8 @@
 				FAB7BBA82E2577A2007301E1 /* SentryModels+Serializable.h */,
 				7B8ECBF926498906005FE2EF /* SentryAppStateManager.h */,
 				7B8ECBFB26498958005FE2EF /* SentryAppStateManager.m */,
-				7BD86EC4264A63F6005439DB /* SentrySysctl.h */,
-				7BD86EC6264A641D005439DB /* SentrySysctl.m */,
+				7BD86EC4264A63F6005439DB /* SentrySysctlObjC.h */,
+				7BD86EC6264A641D005439DB /* SentrySysctlObjC.m */,
 				D8479327278873A100BE8E99 /* SentryByteCountFormatter.h */,
 				D84793242788737D00BE8E99 /* SentryByteCountFormatter.m */,
 				7B2A70DA27D607CF008B0D15 /* SentryThreadWrapper.h */,
@@ -5130,7 +5133,7 @@
 				7B0DC72F288698F70039995F /* NSMutableDictionary+Sentry.h in Headers */,
 				63FE713920DA4C1100CDBAE8 /* SentryCrashMach.h in Headers */,
 				63EED6BE2237923600E02400 /* SentryOptions.h in Headers */,
-				7BD86EC5264A63F6005439DB /* SentrySysctl.h in Headers */,
+				7BD86EC5264A63F6005439DB /* SentrySysctlObjC.h in Headers */,
 				63BE85701ECEC6DE00DC44F5 /* SentryDateUtils.h in Headers */,
 				63FE709520DA4C1000CDBAE8 /* SentryCrashReportFilterBasic.h in Headers */,
 				D8B088B629C9E3FF00213258 /* SentryTracerConfiguration.h in Headers */,
@@ -5871,6 +5874,7 @@
 				D4CD2A812DE9F91900DA9F59 /* SentryRedactRegionType.swift in Sources */,
 				6344DDB11EC308E400D9160D /* SentryCrashInstallationReporter.m in Sources */,
 				84BA62272CAE2EEF0049F636 /* SentryUserFeedbackWidgetButtonView.swift in Sources */,
+				FAE5798D2E7D9D4C00B710F9 /* SentrySysctl.swift in Sources */,
 				D85596F3280580F10041FF8B /* SentryScreenshotIntegration.m in Sources */,
 				92ECD73E2E05AD320063EC10 /* SentryLogLevel.swift in Sources */,
 				92ECD7402E05AD580063EC10 /* SentryLogAttribute.swift in Sources */,
@@ -5937,7 +5941,7 @@
 				8EBF870926140D37001A6853 /* SentryPerformanceTracker.m in Sources */,
 				D865893029D6ECA7000BE151 /* SentryCrashBinaryImageCache.c in Sources */,
 				D859696B27BECD8F0036A46E /* SentryCoreDataTrackingIntegration.m in Sources */,
-				7BD86EC7264A641D005439DB /* SentrySysctl.m in Sources */,
+				7BD86EC7264A641D005439DB /* SentrySysctlObjC.m in Sources */,
 				84281C432A578E5600EE88F2 /* SentryProfilerState.mm in Sources */,
 				D859697327BECDD20036A46E /* SentryCoreDataSwizzling.m in Sources */,
 				FABB48B32E59310D0071397E /* SentryMeasurementValue.swift in Sources */,

--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -7,7 +7,6 @@
 #    import "SentryDefines.h"
 #    import "SentryFramesTracker.h"
 #    import "SentryLogC.h"
-#    import "SentrySysctl.h"
 #    import <PrivateSentrySDKOnly.h>
 #    import <SentryDependencyContainer.h>
 #    import <SentryInternalDefines.h>

--- a/Sources/Sentry/SentryAppStateManager.m
+++ b/Sources/Sentry/SentryAppStateManager.m
@@ -1,7 +1,6 @@
 #import "SentryCrashSysCtl.h"
 #import "SentryDependencyContainer.h"
 #import "SentryNotificationNames.h"
-#import "SentrySysctl.h"
 #import <SentryAppStateManager.h>
 #import <SentryFileManager.h>
 #import <SentryOptions.h>

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -27,7 +27,6 @@
 #import <SentrySDK+Private.h>
 #import <SentrySwift.h>
 #import <SentrySwizzleWrapper.h>
-#import <SentrySysctl.h>
 #import <SentryThreadWrapper.h>
 #import <SentryTracer.h>
 #import <SentryUIViewControllerPerformanceTracker.h>

--- a/Sources/Sentry/SentrySysctlObjC.m
+++ b/Sources/Sentry/SentrySysctlObjC.m
@@ -1,4 +1,4 @@
-#import "SentrySysctl.h"
+#import "SentrySysctlObjC.h"
 #import "SentryCrashSysCtl.h"
 #import "SentrySwift.h"
 #import "SentryTime.h"
@@ -26,7 +26,7 @@ sentryModuleInitializationHook(void)
     moduleInitializationTimestamp = [NSDate date];
 }
 
-@implementation SentrySysctl
+@implementation SentrySysctlObjC
 
 + (void)load
 {

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -46,6 +46,7 @@
 #import "SentrySessionInternal.h"
 #import "SentrySpanDataKey.h"
 #import "SentrySpanOperation.h"
+#import "SentrySysctlObjC.h"
 #import "SentryTraceHeader.h"
 #import "SentryTraceOrigin.h"
 #import "SentryUser+Serialize.h"

--- a/Sources/Sentry/include/SentrySysctlObjC.h
+++ b/Sources/Sentry/include/SentrySysctlObjC.h
@@ -3,9 +3,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- * A wrapper around sysctl for testability.
+ * This needs to be in ObjC because it overrides the +load method
  */
-@interface SentrySysctl : NSObject
+@interface SentrySysctlObjC : NSObject
 
 /**
  * Returns the time the system was booted with a precision of microseconds.

--- a/Sources/Swift/Helper/SentrySysctl.swift
+++ b/Sources/Swift/Helper/SentrySysctl.swift
@@ -1,0 +1,37 @@
+@_implementationOnly import _SentryPrivate
+
+/// A wrapper around sysctl for testability.
+@_spi(Private) @objc public class SentrySysctl: NSObject {
+    
+    private let objcHelper = SentrySysctlObjC()
+    
+    /// Returns the time the system was booted with a precision of microseconds.
+    ///
+    /// @warning We must not send this information off device because Apple forbids that.
+    /// We are allowed send the amount of time that has elapsed between events that occurred within the
+    /// app though. For more information see
+    /// https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api#4278394.
+    @objc public var systemBootTimestamp: Date {
+        objcHelper.systemBootTimestamp
+    }
+    
+    @objc public var processStartTimestamp: Date {
+        objcHelper.processStartTimestamp
+    }
+    
+    /// The system time that the process started, as measured in @c SentrySysctl.load, essentially the
+    /// earliest time we can record a system timestamp, which is the number of nanoseconds since the
+    /// device booted, which is why we can't simply convert @c processStartTimestamp to the nanosecond
+    /// representation of its @c timeIntervalSinceReferenceDate .
+    @objc public var runtimeInitSystemTimestamp: UInt64 {
+        objcHelper.runtimeInitSystemTimestamp
+    }
+    
+    @objc public var runtimeInitTimestamp: Date {
+        objcHelper.runtimeInitTimestamp
+    }
+    
+    @objc public var moduleInitializationTimestamp: Date {
+        objcHelper.moduleInitializationTimestamp
+    }
+}

--- a/Tests/SentryTests/Helper/SentrySysctlTests.swift
+++ b/Tests/SentryTests/Helper/SentrySysctlTests.swift
@@ -1,3 +1,4 @@
+@_spi(Private) import Sentry
 import XCTest
 
 class SentrySysctlTests: XCTestCase {

--- a/Tests/SentryTests/Helper/TestSysctl.swift
+++ b/Tests/SentryTests/Helper/TestSysctl.swift
@@ -1,4 +1,5 @@
 import Foundation
+@_spi(Private) @testable import Sentry
 
 class TestSysctl: SentrySysctl {
     

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -187,7 +187,6 @@
 #import "SentrySwift.h"
 #import "SentrySwiftAsyncIntegration.h"
 #import "SentrySwizzleWrapper.h"
-#import "SentrySysctl.h"
 #import "SentrySystemEventBreadcrumbs.h"
 #import "SentrySystemWrapper.h"
 #import "SentryTestIntegration.h"


### PR DESCRIPTION
Convert this to swift by wrapping the ObjC implementation

#skip-changelog

Closes #6210