### PR TITLE
fix: Fix watchdog tracking on V9

### DIFF
--- a/Sources/Sentry/SentryBaseIntegration.m
+++ b/Sources/Sentry/SentryBaseIntegration.m
@@ -186,8 +186,14 @@ NS_ASSUME_NONNULL_BEGIN
         BOOL performanceDisabled
             = !options.enableAutoPerformanceTracing || !options.isTracingEnabled;
         BOOL appHangsV2Disabled = options.isAppHangTrackingV2Disabled;
+#    if SDK_V9
+        BOOL watchdogDisabled = !options.enableWatchdogTerminationTracking;
+#    else
+        // Before V9 this should have no effect so set it to YES
+        BOOL watchdogDisabled = YES;
+#    endif // SDK_V9
 
-        if (performanceDisabled && appHangsV2Disabled) {
+        if (performanceDisabled && appHangsV2Disabled && watchdogDisabled) {
             if (appHangsV2Disabled) {
                 SENTRY_LOG_DEBUG(@"Not going to enable %@ because enableAppHangTrackingV2 is "
                                  @"disabled or the appHangTimeoutInterval is 0.",
@@ -199,6 +205,15 @@ NS_ASSUME_NONNULL_BEGIN
                                  @"isTracingEnabled are disabled.",
                     self.integrationName);
             }
+
+#    if SDK_V9
+            if (watchdogDisabled) {
+                SENTRY_LOG_DEBUG(
+                    @"Not going to enable %@ because enableWatchdogTerminationTracking "
+                    @"is disabled.",
+                    self.integrationName);
+            }
+#    endif // SKD_V9
 
             return NO;
         }


### PR DESCRIPTION
Watchdog tracking requires the hang tracker, and on V9 the hang tracker requires frame tracking. If you disable hang tracking on V9 but have watchdog tracking enabled, we need to make sure the frame tracker still runs

#skip-changelog

Closes #6227
Closes #6228
Closes #6229