### PR TITLE
test: Skip flaky user feedback UITests

### DIFF
--- a/Plans/iOS-Swift_Base.xctestplan
+++ b/Plans/iOS-Swift_Base.xctestplan
@@ -19,6 +19,13 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "UserFeedbackUITests\/testAddingAndRemovingScreenshots()",
+        "UserFeedbackUITests\/testAddingScreenshots()",
+        "UserFeedbackUITests\/testSubmitCustomButton()",
+        "UserFeedbackUITests\/testSubmitFullyFilledCustomForm()",
+        "UserFeedbackUITests\/testSubmitFullyFilledForm()"
+      ],
       "target" : {
         "containerPath" : "container:iOS-Swift.xcodeproj",
         "identifier" : "0217293F044A3AEED8E37A25",


### PR DESCRIPTION
Disable the user feedback tests that assert the latest envelope content, as this approach is unreliable. The assertion relies on retrieving the latest envelope, which the transport often sends, causing it to be missing and resulting in a test failure.

#skip-changelog