### PR TITLE
ref: Use forward declarations in header

### DIFF
--- a/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
+++ b/Sources/Sentry/Profiling/SentryProfiledTracerConcurrency.mm
@@ -24,6 +24,7 @@
 #    import "SentrySamplerDecision.h"
 #    import "SentryTraceProfiler.h"
 #    import "SentryTracer+Private.h"
+#    import "SentryTracerConfiguration.h"
 #    import "SentryTransaction.h"
 
 #    if SENTRY_HAS_UIKIT

--- a/Sources/Sentry/SentryHub.m
+++ b/Sources/Sentry/SentryHub.m
@@ -20,6 +20,7 @@
 #import "SentrySwift.h"
 #import "SentryTraceOrigin.h"
 #import "SentryTracer.h"
+#import "SentryTracerConfiguration.h"
 #import "SentryTransaction.h"
 #import "SentryTransactionContext+Private.h"
 

--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -7,6 +7,7 @@
 #import "SentrySpanId.h"
 #import "SentrySpanProtocol.h"
 #import "SentryTracer.h"
+#import "SentryTracerConfiguration.h"
 #import "SentryTransactionContext+Private.h"
 
 #import "SentryProfilingConditionals.h"

--- a/Sources/Sentry/SentryTracer.m
+++ b/Sources/Sentry/SentryTracer.m
@@ -23,6 +23,7 @@
 #import "SentryTime.h"
 #import "SentryTraceContext.h"
 #import "SentryTracer+Private.h"
+#import "SentryTracerConfiguration.h"
 #import "SentryTransaction.h"
 #import "SentryTransactionContext.h"
 #import <NSMutableDictionary+Sentry.h>

--- a/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
+++ b/Sources/Sentry/SentryUIEventTrackerTransactionMode.m
@@ -13,6 +13,7 @@
 #    import <SentrySpanOperation.h>
 #    import <SentryTraceOrigin.h>
 #    import <SentryTracer.h>
+#    import <SentryTracerConfiguration.h>
 #    import <SentryTransactionContext+Private.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -1,8 +1,6 @@
 #import "SentryDefines.h"
 #import "SentryProfilingConditionals.h"
 #import "SentrySpan.h"
-#import "SentrySpanProtocol.h"
-#import "SentryTracerConfiguration.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,7 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryTraceContext;
 @class SentryTraceHeader;
 @class SentryTracer;
+@class SentryTracerConfiguration;
 @class SentryTransactionContext;
+
+@protocol SentrySpan;
 
 static NSTimeInterval const SentryTracerDefaultTimeout = 3.0;
 

--- a/Sources/Sentry/include/SentryUIViewControllerPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryUIViewControllerPerformanceTracker.h
@@ -2,7 +2,6 @@
 
 #if SENTRY_HAS_UIKIT
 
-@class SentrySpan;
 @class SentryInAppLogic;
 @class SentryTimeToDisplayTracker;
 @class UIViewController;


### PR DESCRIPTION
Cleans up a few imports which will make the swift migration a bit easier and improve the output of the migration script

#skip-changelog