### PR TITLE
ref: Use SentrySpan protocol instead of class

### DIFF
--- a/Sources/Sentry/SentryTimeToDisplayTracker.m
+++ b/Sources/Sentry/SentryTimeToDisplayTracker.m
@@ -25,8 +25,8 @@
 
 @interface SentryTimeToDisplayTracker () <SentryFramesTrackerListener>
 
-@property (nonatomic, weak) SentrySpan *initialDisplaySpan;
-@property (nonatomic, weak) SentrySpan *fullDisplaySpan;
+@property (nonatomic, weak) id<SentrySpan> initialDisplaySpan;
+@property (nonatomic, weak) id<SentrySpan> fullDisplaySpan;
 @property (nonatomic, strong, readonly) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 
 @end
@@ -198,7 +198,7 @@
     }
 }
 
-- (void)addTimeToDisplayMeasurement:(SentrySpan *)span name:(NSString *)name
+- (void)addTimeToDisplayMeasurement:(id<SentrySpan>)span name:(NSString *)name
 {
     NSTimeInterval duration = [span.timestamp timeIntervalSinceDate:span.startTimestamp] * 1000;
     [span setMeasurement:name value:@(duration) unit:SentryMeasurementUnitDuration.millisecond];

--- a/Sources/Sentry/include/SentryTimeToDisplayTracker.h
+++ b/Sources/Sentry/include/SentryTimeToDisplayTracker.h
@@ -2,10 +2,11 @@
 
 #if SENTRY_HAS_UIKIT
 
-@class SentrySpan;
 @class SentryTracer;
 @class SentryDispatchQueueWrapper;
 @class UIViewController;
+
+@protocol SentrySpan;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -19,9 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryTimeToDisplayTracker : NSObject
 SENTRY_NO_INIT
 
-@property (nullable, nonatomic, weak, readonly) SentrySpan *initialDisplaySpan;
+@property (nullable, nonatomic, weak, readonly) id<SentrySpan> initialDisplaySpan;
 
-@property (nullable, nonatomic, weak, readonly) SentrySpan *fullDisplaySpan;
+@property (nullable, nonatomic, weak, readonly) id<SentrySpan> fullDisplaySpan;
 
 @property (nonatomic, readonly) BOOL waitForFullDisplay;
 


### PR DESCRIPTION
The SentrySpan protocol is already part of the public interface and can therefore be used from Swift. The SentrySpan class is still internal to objc. To make this Swift migration easier I changed it to use the protocol, which seems to compile fine

#skip-changelog

Closes #6299

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch `SentryTimeToDisplayTracker` to the `SentrySpan` protocol (`id<SentrySpan>`) for span properties and method parameters.
> 
> - **Core (time-to-display tracking)**
>   - Update `SentryTimeToDisplayTracker` to use `id<SentrySpan>` instead of `SentrySpan` for `initialDisplaySpan` and `fullDisplaySpan` in `Sources/Sentry/SentryTimeToDisplayTracker.m` and `Sources/Sentry/include/SentryTimeToDisplayTracker.h`.
>   - Change method signature `addTimeToDisplayMeasurement:` to accept `id<SentrySpan>`.
>   - Header: replace `@class SentrySpan;` with `@protocol SentrySpan;` and adjust property declarations accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 485088e9866913c7f2756b3615bbd43be8c00b49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->