### PR TITLE
chore(ci): Change analyze target in Makefile to log path to result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ current_package_diff.patch
 
 uikit-check-build
 *.xcarchive
+
+# Output of `make analyze`
+analyzer

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,18 @@ test-ui-critical:
 
 analyze:
 	rm -rf analyzer
-	set -o pipefail && NSUnbufferedIO=YES xcodebuild analyze -workspace Sentry.xcworkspace -scheme Sentry -configuration Release CLANG_ANALYZER_OUTPUT=html CLANG_ANALYZER_OUTPUT_DIR=analyzer CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify && [[ -z `find analyzer -name "*.html"` ]]
+	set -o pipefail && NSUnbufferedIO=YES xcodebuild analyze \
+		-workspace Sentry.xcworkspace \
+		-scheme Sentry \
+		-configuration Release \
+		CLANG_ANALYZER_OUTPUT=html \
+		CLANG_ANALYZER_OUTPUT_DIR=analyzer \
+		CODE_SIGNING_ALLOWED="NO" 2>&1 | xcbeautify --preserve-unbeautified
+	@if [[ -n `find analyzer -name "*.html"` ]]; then \
+		echo "Analyzer found issues:"; \
+		find analyzer -name "*.html"; \
+		exit 1; \
+	fi
 
 # Since Carthage 0.38.0 we need to create separate .framework.zip and .xcframework.zip archives.
 # After creating the zips we create a JSON to be able to test Carthage locally.


### PR DESCRIPTION
When running `make analyze` with actual errors, it didn't present any details like in [this run](https://github.com/getsentry/sentry-cocoa/actions/runs/18039189634/job/51333330428?pr=6208). It looks like this:

```
...
Analyze Succeeded
Error: Process completed with exit code 2.
```

The analyze flow checks if there are any analyzer output files by finding them using `find analyzer -name "*.html"`. This PR checks for them and if any are found it logs them.

#skip-changelog

Closes #6305

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improve `make analyze` to preserve logs, surface analyzer report paths, and fail when issues are found; ignore `analyzer/` output.
> 
> - **CI/Tooling**:
>   - Update `Makefile` `analyze` target:
>     - Run `xcodebuild analyze` with multiline args and `xcbeautify --preserve-unbeautified`.
>     - After build, detect analyzer HTML reports in `analyzer/`; if present, print their paths and fail.
> - **Repo hygiene**:
>   - Add `analyzer` (output of `make analyze`) to `.gitignore`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffe9021518713993fd58ec5980d00af0550722a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->