### PR TITLE
chore: Cleanup interface for SentryScreenFrames without UIKit

### DIFF
--- a/Sources/Sentry/SentryScreenFrames.m
+++ b/Sources/Sentry/SentryScreenFrames.m
@@ -1,21 +1,20 @@
 #import <SentryScreenFrames.h>
 
-#if SENTRY_UIKIT_AVAILABLE
+#if SENTRY_HAS_UIKIT
 #    import "SentryInternalDefines.h"
 
 @implementation SentryScreenFrames
 
 - (instancetype)initWithTotal:(NSUInteger)total frozen:(NSUInteger)frozen slow:(NSUInteger)slow
 {
-#    if SENTRY_HAS_UIKIT
-#        if SENTRY_TARGET_PROFILING_SUPPORTED
+#    if SENTRY_TARGET_PROFILING_SUPPORTED
     return [self initWithTotal:total
                         frozen:frozen
                           slow:slow
            slowFrameTimestamps:@[]
          frozenFrameTimestamps:@[]
            frameRateTimestamps:@[]];
-#        else
+#    else
     if (self = [super init]) {
         _total = total;
         _slow = slow;
@@ -23,13 +22,7 @@
     }
 
     return self;
-#        endif // SENTRY_TARGET_PROFILING_SUPPORTED
-#    else
-    SENTRY_GRACEFUL_FATAL(
-        @"SentryScreenFrames only works with UIKit enabled. Ensure you're using the "
-        @"right configuration of Sentry that links UIKit.");
-    return nil;
-#    endif // SENTRY_HAS_UIKIT
+#    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -40,7 +33,6 @@
         frozenFrameTimestamps:(SentryFrameInfoTimeSeries *)frozenFrameTimestamps
           frameRateTimestamps:(SentryFrameInfoTimeSeries *)frameRateTimestamps
 {
-#        if SENTRY_HAS_UIKIT
     if (self = [super init]) {
         _total = total;
         _slow = slow;
@@ -51,29 +43,16 @@
     }
 
     return self;
-#        else
-    SENTRY_GRACEFUL_FATAL(
-        @"SentryScreenFrames only works with UIKit enabled. Ensure you're using the "
-        @"right configuration of Sentry that links UIKit.");
-    return nil;
-#        endif // SENTRY_HAS_UIKIT
 }
 
 - (nonnull id)copyWithZone:(nullable NSZone *)zone
 {
-#        if SENTRY_HAS_UIKIT
     return [[SentryScreenFrames allocWithZone:zone] initWithTotal:_total
                                                            frozen:_frozen
                                                              slow:_slow
                                               slowFrameTimestamps:[_slowFrameTimestamps copy]
                                             frozenFrameTimestamps:[_frozenFrameTimestamps copy]
                                               frameRateTimestamps:[_frameRateTimestamps copy]];
-#        else
-    SENTRY_GRACEFUL_FATAL(
-        @"SentryScreenFrames only works with UIKit enabled. Ensure you're using the "
-        @"right configuration of Sentry that links UIKit.");
-    return nil;
-#        endif // SENTRY_HAS_UIKIT
 }
 
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
@@ -93,4 +72,4 @@
 
 @end
 
-#endif // SENTRY_UIKIT_AVAILABLE
+#endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/HybridPublic/SentryScreenFrames.h
+++ b/Sources/Sentry/include/HybridPublic/SentryScreenFrames.h
@@ -4,7 +4,7 @@
 #    import "PrivatesHeader.h"
 #endif
 
-#if SENTRY_UIKIT_AVAILABLE
+#if SENTRY_HAS_UIKIT
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,10 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NSArray<NSDictionary<NSString *, NSNumber *> *> SentryFrameInfoTimeSeries;
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-/**
- * @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit
- * configurations even when targeting iOS or tvOS platforms.
- */
 @interface SentryScreenFrames : NSObject
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
                                 <NSCopying>
@@ -63,4 +59,4 @@ SENTRY_NO_INIT
 
 NS_ASSUME_NONNULL_END
 
-#endif // SENTRY_UIKIT_AVAILABLE
+#endif // SENTRY_HAS_UIKIT


### PR DESCRIPTION
I just noticed that this class had a strange pattern of logging errors when used without UIKit instead of using the macros we had defined. Updated it so it wouldn't accidentally get used, luckily it looks like there isn't a call site using it when it shouldn't

#skip-changelog

Closes #6313