### PR TITLE
ref: Move trace propagation to its own class

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -143,6 +143,8 @@
 		62E2119A2DAE99FC007D7262 /* SentryAsyncSafeLog.m in Sources */ = {isa = PBXBuildFile; fileRef = 62E211992DAE99FC007D7262 /* SentryAsyncSafeLog.m */; };
 		62E300942D5202890037AA3F /* SentryExceptionCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E300932D5202830037AA3F /* SentryExceptionCodable.swift */; };
 		62E5325B2DEEC862000B2DD5 /* TestCurrentDateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624729172DE5980500DFEE00 /* TestCurrentDateProviderTests.swift */; };
+		62E59A532E8FB70000DB7A7B /* SentryTracePropagation.h in Headers */ = {isa = PBXBuildFile; fileRef = 62E59A522E8FB70000DB7A7B /* SentryTracePropagation.h */; };
+		62E59A5A2E8FB85300DB7A7B /* SentryTracePropagation.m in Sources */ = {isa = PBXBuildFile; fileRef = 62E59A592E8FB85300DB7A7B /* SentryTracePropagation.m */; };
 		62E75EB92E152953002EC91B /* InvocationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E75EB82E152953002EC91B /* InvocationsTests.swift */; };
 		62EF86A12C626D39004E058B /* SentryANRTrackerV2Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 621AE74E2C626CF70012E730 /* SentryANRTrackerV2Tests.swift */; };
 		62F05D2B2C0DB1F100916E3F /* SentryLogTestHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */; };
@@ -1377,6 +1379,8 @@
 		62E081AA29ED4322000F69FC /* SentryBreadcrumbTestDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryBreadcrumbTestDelegate.swift; sourceTree = "<group>"; };
 		62E211992DAE99FC007D7262 /* SentryAsyncSafeLog.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryAsyncSafeLog.m; sourceTree = "<group>"; };
 		62E300932D5202830037AA3F /* SentryExceptionCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryExceptionCodable.swift; sourceTree = "<group>"; };
+		62E59A522E8FB70000DB7A7B /* SentryTracePropagation.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryTracePropagation.h; path = include/SentryTracePropagation.h; sourceTree = "<group>"; };
+		62E59A592E8FB85300DB7A7B /* SentryTracePropagation.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryTracePropagation.m; sourceTree = "<group>"; };
 		62E75EB82E152953002EC91B /* InvocationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvocationsTests.swift; sourceTree = "<group>"; };
 		62F05D292C0DB1C800916E3F /* SentryLogTestHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SentryLogTestHelper.h; sourceTree = "<group>"; };
 		62F05D2A2C0DB1F100916E3F /* SentryLogTestHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryLogTestHelper.m; sourceTree = "<group>"; };
@@ -3714,6 +3718,8 @@
 				8E564AE5267AF22600FE117D /* SentryNetworkTrackingIntegration.m */,
 				8E564AEC267AF24400FE117D /* SentryNetworkTracker.h */,
 				8E564AE7267AF22600FE117D /* SentryNetworkTracker.m */,
+				62E59A522E8FB70000DB7A7B /* SentryTracePropagation.h */,
+				62E59A592E8FB85300DB7A7B /* SentryTracePropagation.m */,
 				D8370B6B273DF20F00F66E2D /* SentryNSURLSessionTaskSearch.h */,
 				D8370B68273DF1E900F66E2D /* SentryNSURLSessionTaskSearch.m */,
 				A8F17B332902870300990B25 /* SentryHttpStatusCodeRange.m */,
@@ -5071,6 +5077,7 @@
 				84A305572BC9EF8C00D84283 /* SentryTraceProfiler.h in Headers */,
 				FA034AC82DD3DB4900FE3107 /* SentryIntegrationProtocol.h in Headers */,
 				63FE715720DA4C1100CDBAE8 /* SentryCrashThread.h in Headers */,
+				62E59A532E8FB70000DB7A7B /* SentryTracePropagation.h in Headers */,
 				7BF9EF862722D10600B5BBEF /* SentryTestObjCRuntimeWrapper.h in Headers */,
 				15360CD2243277A000112302 /* SentrySessionTracker.h in Headers */,
 				63FE718B20DA4C1100CDBAE8 /* SentryCrashReport.h in Headers */,
@@ -5954,6 +5961,7 @@
 				629194A92D51F976000F7C6B /* SentryDebugMetaCodable.swift in Sources */,
 				63FE714520DA4C1100CDBAE8 /* SentryCrashObjC.c in Sources */,
 				63FE710520DA4C1000CDBAE8 /* SentryAsyncSafeLog.c in Sources */,
+				62E59A5A2E8FB85300DB7A7B /* SentryTracePropagation.m in Sources */,
 				62E300942D5202890037AA3F /* SentryExceptionCodable.swift in Sources */,
 				0A2D8D5B289815C0008720F6 /* SentryBaseIntegration.m in Sources */,
 				639FCF991EBC7B9700778193 /* SentryEvent.m in Sources */,

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -27,6 +27,7 @@
 #import "SentryTraceContext.h"
 #import "SentryTraceHeader.h"
 #import "SentryTraceOrigin.h"
+#import "SentryTracePropagation.h"
 #import "SentryTracer.h"
 #import "SentryUser.h"
 #import <objc/runtime.h>
@@ -105,35 +106,6 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     _isNetworkTrackingEnabled = NO;
     _isCaptureFailedRequestsEnabled = NO;
     _isGraphQLOperationTrackingEnabled = NO;
-}
-
-- (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets
-{
-    for (id targetCheck in targets) {
-        if ([targetCheck isKindOfClass:[NSRegularExpression class]]) {
-            NSString *string = URL.absoluteString;
-            NSUInteger numberOfMatches =
-                [targetCheck numberOfMatchesInString:string
-                                             options:0
-                                               range:NSMakeRange(0, [string length])];
-            if (numberOfMatches > 0) {
-                return YES;
-            }
-        } else if ([targetCheck isKindOfClass:[NSString class]]) {
-            if ([URL.absoluteString containsString:targetCheck]) {
-                return YES;
-            }
-        }
-    }
-
-    return NO;
-}
-
-- (BOOL)sessionTaskRequiresPropagation:(NSURLSessionTask *)sessionTask
-{
-    return sessionTask.currentRequest != nil &&
-        [self isTargetMatch:sessionTask.currentRequest.URL
-                withTargets:SentrySDKInternal.options.tracePropagationTargets];
 }
 
 - (void)urlSessionTaskResume:(NSURLSessionTask *)sessionTask
@@ -217,7 +189,9 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         }
 
         SentryBaggage *baggage = [[[SentryTracer getTracer:span] traceContext] toBaggage];
-        [self addBaggageHeader:baggage traceHeader:[netSpan toTraceHeader] toRequest:sessionTask];
+        [SentryTracePropagation addBaggageHeader:baggage
+                                     traceHeader:[netSpan toTraceHeader]
+                                       toRequest:sessionTask];
 
         SENTRY_LOG_DEBUG(
             @"SentryNetworkTracker automatically started HTTP span for sessionTask: %@",
@@ -249,66 +223,9 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 #endif
                                            replayId:SentrySDKInternal.currentHub.scope.replayId];
 
-    [self addBaggageHeader:[traceContext toBaggage]
-               traceHeader:[propagationContext traceHeader]
-                 toRequest:sessionTask];
-}
-
-- (void)addBaggageHeader:(SentryBaggage *)baggage
-             traceHeader:(SentryTraceHeader *)traceHeader
-               toRequest:(NSURLSessionTask *)sessionTask
-{
-    if (![self sessionTaskRequiresPropagation:sessionTask]) {
-        SENTRY_LOG_DEBUG(@"Not adding trace_id and baggage headers for %@",
-            sessionTask.currentRequest.URL.absoluteString);
-        return;
-    }
-    NSString *baggageHeader = @"";
-
-    if (baggage != nil) {
-        NSDictionary *originalBaggage = [SentryBaggageSerialization
-            decode:sessionTask.currentRequest.allHTTPHeaderFields[SENTRY_BAGGAGE_HEADER]];
-
-        if (originalBaggage[@"sentry-trace_id"] == nil) {
-            baggageHeader = [baggage toHTTPHeaderWithOriginalBaggage:originalBaggage];
-        }
-    }
-
-    // First we check if the current request is mutable, so we could easily add a new
-    // header. Otherwise we try to change the current request for a new one with the extra
-    // header.
-    if ([sessionTask.currentRequest isKindOfClass:[NSMutableURLRequest class]]) {
-        NSMutableURLRequest *currentRequest = (NSMutableURLRequest *)sessionTask.currentRequest;
-
-        if ([currentRequest valueForHTTPHeaderField:SENTRY_TRACE_HEADER] == nil) {
-            [currentRequest setValue:traceHeader.value forHTTPHeaderField:SENTRY_TRACE_HEADER];
-        }
-
-        if (baggageHeader.length > 0) {
-            [currentRequest setValue:baggageHeader forHTTPHeaderField:SENTRY_BAGGAGE_HEADER];
-        }
-    } else {
-        // Even though NSURLSessionTask doesn't have 'setCurrentRequest', some subclasses
-        // do. For those subclasses we replace the currentRequest with a mutable one with
-        // the additional trace header. Since NSURLSessionTask is a public class and can be
-        // override, we believe this is not considered a private api.
-        SEL setCurrentRequestSelector = NSSelectorFromString(@"setCurrentRequest:");
-        if ([sessionTask respondsToSelector:setCurrentRequestSelector]) {
-            NSMutableURLRequest *newRequest = [sessionTask.currentRequest mutableCopy];
-
-            if ([newRequest valueForHTTPHeaderField:SENTRY_TRACE_HEADER] == nil) {
-                [newRequest setValue:traceHeader.value forHTTPHeaderField:SENTRY_TRACE_HEADER];
-            }
-
-            if (baggageHeader.length > 0) {
-                [newRequest setValue:baggageHeader forHTTPHeaderField:SENTRY_BAGGAGE_HEADER];
-            }
-
-            void (*func)(id, SEL, id param)
-                = (void *)[sessionTask methodForSelector:setCurrentRequestSelector];
-            func(sessionTask, setCurrentRequestSelector, newRequest);
-        }
-    }
+    [SentryTracePropagation addBaggageHeader:[traceContext toBaggage]
+                                 traceHeader:[propagationContext traceHeader]
+                                   toRequest:sessionTask];
 }
 
 - (void)urlSessionTask:(NSURLSessionTask *)sessionTask setState:(NSURLSessionTaskState)newState
@@ -401,8 +318,8 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         return;
     }
 
-    if (![self isTargetMatch:myRequest.URL
-                 withTargets:SentrySDKInternal.options.failedRequestTargets]) {
+    if (![SentryTracePropagation isTargetMatch:myRequest.URL
+                                   withTargets:SentrySDKInternal.options.failedRequestTargets]) {
         SENTRY_LOG_DEBUG(
             @"Request url isn't within the request targets, not capturing HTTP Client errors.");
         return;

--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -1,0 +1,96 @@
+#import <SentryBaggage.h>
+#import <SentryLogC.h>
+#import <SentrySDK+Private.h>
+#import <SentrySwift.h>
+#import <SentryTraceHeader.h>
+#import <SentryTracePropagation.h>
+
+@implementation SentryTracePropagation
+
++ (void)addBaggageHeader:(SentryBaggage *)baggage
+             traceHeader:(SentryTraceHeader *)traceHeader
+               toRequest:(NSURLSessionTask *)sessionTask
+{
+    if (![SentryTracePropagation sessionTaskRequiresPropagation:sessionTask]) {
+        SENTRY_LOG_DEBUG(@"Not adding trace_id and baggage headers for %@",
+            sessionTask.currentRequest.URL.absoluteString);
+        return;
+    }
+    NSString *baggageHeader = @"";
+
+    if (baggage != nil) {
+        NSDictionary *originalBaggage = [SentryBaggageSerialization
+            decode:sessionTask.currentRequest.allHTTPHeaderFields[SENTRY_BAGGAGE_HEADER]];
+
+        if (originalBaggage[@"sentry-trace_id"] == nil) {
+            baggageHeader = [baggage toHTTPHeaderWithOriginalBaggage:originalBaggage];
+        }
+    }
+
+    // First we check if the current request is mutable, so we could easily add a new
+    // header. Otherwise we try to change the current request for a new one with the extra
+    // header.
+    if ([sessionTask.currentRequest isKindOfClass:[NSMutableURLRequest class]]) {
+        NSMutableURLRequest *currentRequest = (NSMutableURLRequest *)sessionTask.currentRequest;
+
+        if ([currentRequest valueForHTTPHeaderField:SENTRY_TRACE_HEADER] == nil) {
+            [currentRequest setValue:traceHeader.value forHTTPHeaderField:SENTRY_TRACE_HEADER];
+        }
+
+        if (baggageHeader.length > 0) {
+            [currentRequest setValue:baggageHeader forHTTPHeaderField:SENTRY_BAGGAGE_HEADER];
+        }
+    } else {
+        // Even though NSURLSessionTask doesn't have 'setCurrentRequest', some subclasses
+        // do. For those subclasses we replace the currentRequest with a mutable one with
+        // the additional trace header. Since NSURLSessionTask is a public class and can be
+        // override, we believe this is not considered a private api.
+        SEL setCurrentRequestSelector = NSSelectorFromString(@"setCurrentRequest:");
+        if ([sessionTask respondsToSelector:setCurrentRequestSelector]) {
+            NSMutableURLRequest *newRequest = [sessionTask.currentRequest mutableCopy];
+
+            if ([newRequest valueForHTTPHeaderField:SENTRY_TRACE_HEADER] == nil) {
+                [newRequest setValue:traceHeader.value forHTTPHeaderField:SENTRY_TRACE_HEADER];
+            }
+
+            if (baggageHeader.length > 0) {
+                [newRequest setValue:baggageHeader forHTTPHeaderField:SENTRY_BAGGAGE_HEADER];
+            }
+
+            void (*func)(id, SEL, id param)
+                = (void *)[sessionTask methodForSelector:setCurrentRequestSelector];
+            func(sessionTask, setCurrentRequestSelector, newRequest);
+        }
+    }
+}
+
++ (BOOL)sessionTaskRequiresPropagation:(NSURLSessionTask *)sessionTask
+{
+    return sessionTask.currentRequest != nil &&
+        [SentryTracePropagation isTargetMatch:sessionTask.currentRequest.URL
+                                  withTargets:SentrySDKInternal.options.tracePropagationTargets];
+}
+
++ (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets
+{
+    for (id targetCheck in targets) {
+        if ([targetCheck isKindOfClass:[NSRegularExpression class]]) {
+            NSString *string = URL.absoluteString;
+            NSUInteger numberOfMatches =
+                [targetCheck numberOfMatchesInString:string
+                                             options:0
+                                               range:NSMakeRange(0, [string length])];
+            if (numberOfMatches > 0) {
+                return YES;
+            }
+        } else if ([targetCheck isKindOfClass:[NSString class]]) {
+            if ([URL.absoluteString containsString:targetCheck]) {
+                return YES;
+            }
+        }
+    }
+
+    return NO;
+}
+
+@end

--- a/Sources/Sentry/include/SentryNetworkTracker.h
+++ b/Sources/Sentry/include/SentryNetworkTracker.h
@@ -19,7 +19,6 @@ static NSString *const SENTRY_NETWORK_REQUEST_TRACKER_BREADCRUMB
 - (void)enableNetworkBreadcrumbs;
 - (void)enableCaptureFailedRequests;
 - (void)enableGraphQLOperationTracking;
-- (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets;
 - (void)disable;
 
 @property (nonatomic, readonly) BOOL isNetworkTrackingEnabled;

--- a/Sources/Sentry/include/SentryTracePropagation.h
+++ b/Sources/Sentry/include/SentryTracePropagation.h
@@ -1,0 +1,18 @@
+#import "SentryDefines.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class SentryBaggage;
+@class SentryTraceHeader;
+
+@interface SentryTracePropagation : NSObject
+
++ (void)addBaggageHeader:(SentryBaggage *)baggage
+             traceHeader:(SentryTraceHeader *)traceHeader
+               toRequest:(NSURLSessionTask *)sessionTask;
+
++ (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -959,33 +959,32 @@ class SentryNetworkTrackerTests: XCTestCase {
     func testIsTargetMatch() throws {
         // Default: all urls
         let defaultRegex = try XCTUnwrap(NSRegularExpression(pattern: ".*"))
-        let sut = fixture.getSut()
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: [ defaultRegex ]))
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: [ defaultRegex ]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: [ defaultRegex ]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: [ defaultRegex ]))
 
         // Strings: hostname
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost"]))
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost-but-not-really")), withTargets: ["localhost"])) // works because of `contains`
-        XCTAssertFalse(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["localhost"]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost"]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost-but-not-really")), withTargets: ["localhost"])) // works because of `contains`
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["localhost"]))
 
-        XCTAssertFalse(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["www.example.com"]))
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["www.example.com"]))
-        XCTAssertFalse(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://api.example.com/api/projects")), withTargets: ["www.example.com"]))
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com.evil.com/api/projects")), withTargets: ["www.example.com"])) // works because of `contains`
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["www.example.com"]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["www.example.com"]))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://api.example.com/api/projects")), withTargets: ["www.example.com"]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com.evil.com/api/projects")), withTargets: ["www.example.com"])) // works because of `contains`
 
         // Test regex
         let regex = try XCTUnwrap(NSRegularExpression(pattern: "http://www.example.com/api/.*"))
-        XCTAssertFalse(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: [regex]))
-        XCTAssertFalse(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/url")), withTargets: [regex]))
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: [regex]))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: [regex]))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/url")), withTargets: [regex]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: [regex]))
 
         // Regex and string
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost", regex]))
-        XCTAssertFalse(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/url")), withTargets: ["localhost", regex]))
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["localhost", regex]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost", regex]))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/url")), withTargets: ["localhost", regex]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["localhost", regex]))
 
         // String and integer (which isn't valid, make sure it doesn't crash)
-        XCTAssertTrue(sut.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost", 123]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost", 123]))
     }
 
     func testCaptureHTTPClientErrorRequest() throws {

--- a/Tests/SentryTests/SentryTests-Bridging-Header.h
+++ b/Tests/SentryTests/SentryTests-Bridging-Header.h
@@ -184,6 +184,7 @@
 #import "SentryTime.h"
 #import "SentryTimeToDisplayTracker.h"
 #import "SentryTraceOrigin.h"
+#import "SentryTracePropagation.h"
 #import "SentryTracer+Private.h"
 #import "SentryTracer+Test.h"
 #import "SentryTracerConfiguration.h"


### PR DESCRIPTION
Extract the trace propagation logic into its own class, so it's easier to test and maintain.

Prep for https://github.com/getsentry/sentry-cocoa/issues/6017.

#skip-changelog 

Closes #6339