### PR TITLE
chore: Remove more deprecated APIs in V9

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -2,9 +2,6 @@
 
 ### Breaking Changes
 
-Removes unused SentryLogLevel (#5591)
-Removes deprecated getStoreEndpoint (#5591)
-Removes deprecated useSpan function (#5591)
 Removes deprecated SentryDebugImageProvider class (#5598)
 Makes app hang tracking V2 the default and removes the option to enable/disable it (#5615)
 Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Breaking Changes
 
-Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)
-Removes `enablePerformanceV2` option and makes this the default. The app start duration will now finish when the first frame is drawn instead of when the OS posts the UIWindowDidBecomeVisibleNotification. (#6008)
+- Removes unused SentryLogLevel (#5591)
+- Removes deprecated getStoreEndpoint (#5591)
+- Removes deprecated useSpan function (#5591)
+- Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)
+- Removes `enablePerformanceV2` option and makes this the default. The app start duration will now finish when the first frame is drawn instead of when the OS posts the UIWindowDidBecomeVisibleNotification. (#6008)
 
 ### Features
 

--- a/Sources/Sentry/Public/SentryDefines.h
+++ b/Sources/Sentry/Public/SentryDefines.h
@@ -152,25 +152,6 @@ typedef BOOL (^SentryShouldQueueEvent)(
 typedef NSNumber *_Nullable (^SentryTracesSamplerCallback)(
     SentrySamplingContext *_Nonnull samplingContext);
 
-#if !SDK_V9
-/**
- * Function pointer for span manipulation.
- * @param span The span to be used.
- */
-typedef void (^SentrySpanCallback)(id<SentrySpan> _Nullable span DEPRECATED_MSG_ATTRIBUTE(
-    "See `SentryScope.useSpan` for reasoning of deprecation."));
-
-/**
- * Log level.
- */
-typedef NS_ENUM(NSInteger, SentryLogLevel) {
-    kSentryLogLevelNone = 1,
-    kSentryLogLevelError,
-    kSentryLogLevelDebug,
-    kSentryLogLevelVerbose
-};
-#endif // !SDK_V9
-
 /**
  * Sentry level.
  */

--- a/Sources/Sentry/Public/SentryDsn.h
+++ b/Sources/Sentry/Public/SentryDsn.h
@@ -11,9 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)getHash;
 
-#if !SDK_V9
-- (NSURL *)getStoreEndpoint DEPRECATED_MSG_ATTRIBUTE("This endpoint is no longer used");
-#endif // !SDK_V9
 - (NSURL *)getEnvelopeEndpoint;
 
 @end

--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -165,18 +165,6 @@ NS_SWIFT_NAME(Scope)
  */
 - (void)clear;
 
-#if !SDK_V9
-/**
- * Mutates the current transaction atomically.
- * @param callback the SentrySpanCallback.
- */
-- (void)useSpan:(SentrySpanCallback)callback
-    DEPRECATED_MSG_ATTRIBUTE(
-        "This method was used to create an atomic block that could be used to mutate the current "
-        "span. It is not atomic anymore and due to issues with memory safety in `NSBlock` it is "
-        "now considered unsafe and deprecated. Use `span` instead.");
-#endif // !SDK_V9
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/SentryDsn.m
+++ b/Sources/Sentry/SentryDsn.m
@@ -11,7 +11,6 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation SentryDsn {
-    NSURL *_storeEndpoint;
     NSURL *_envelopeEndpoint;
 }
 
@@ -40,20 +39,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return output;
 }
-
-#if !SDK_V9
-- (NSURL *)getStoreEndpoint
-{
-    if (nil == _storeEndpoint) {
-        @synchronized(self) {
-            if (nil == _storeEndpoint) {
-                _storeEndpoint = [[self getBaseEndpoint] URLByAppendingPathComponent:@"store/"];
-            }
-        }
-    }
-    return _storeEndpoint;
-}
-#endif // !SDK_V9
 
 - (NSURL *)getEnvelopeEndpoint
 {

--- a/Sources/Sentry/SentryScope.m
+++ b/Sources/Sentry/SentryScope.m
@@ -153,14 +153,6 @@ NS_ASSUME_NONNULL_BEGIN
     }
 }
 
-#if !SDK_V9
-- (void)useSpan:(SentrySpanCallback)callback
-{
-    id<SentrySpan> localSpan = [self span];
-    callback(localSpan);
-}
-#endif // !SDK_V9
-
 - (void)clear
 {
     // As we need to synchronize the accesses of the arrays and dictionaries and we use the

--- a/Tests/SentryTests/Networking/SentryDsnTests.m
+++ b/Tests/SentryTests/Networking/SentryDsnTests.m
@@ -47,28 +47,6 @@
     XCTAssertNil(options);
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)testDsnUrl
-{
-    NSError *error = nil;
-    SentryDsn *dsn = [[SentryDsn alloc] initWithString:@"https://username:password@getsentry.net/1"
-                                      didFailWithError:&error];
-
-    XCTAssertEqualObjects(
-        [[dsn getStoreEndpoint] absoluteString], @"https://getsentry.net/api/1/store/");
-    XCTAssertNil(error);
-
-    SentryDsn *dsn2 =
-        [[SentryDsn alloc] initWithString:@"https://username:password@sentry.io/foo/bar/baz/1"
-                         didFailWithError:&error];
-
-    XCTAssertEqualObjects(
-        [[dsn2 getStoreEndpoint] absoluteString], @"https://sentry.io/foo/bar/baz/api/1/store/");
-    XCTAssertNil(error);
-}
-#pragma clang diagnostic pop
-
 - (void)testGetEnvelopeUrl
 {
     NSError *error = nil;
@@ -87,19 +65,6 @@
         @"https://sentry.io/foo/bar/baz/api/1/envelope/");
     XCTAssertNil(error);
 }
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)testGetStoreDsnCachesResult
-{
-    SentryDsn *dsn = [[SentryDsn alloc] initWithString:@"https://username:password@getsentry.net/1"
-                                      didFailWithError:nil];
-
-    XCTAssertNotNil([dsn getStoreEndpoint]);
-    // Assert same reference
-    XCTAssertTrue([dsn getStoreEndpoint] == [dsn getStoreEndpoint]);
-}
-#pragma clang diagnostic pop
 
 - (void)testInitWithInvalidString
 {


### PR DESCRIPTION
Removes more code that is not included in V9

#skip-changelog