### PR TITLE
chore: Remove V9 checks for segment

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -4,7 +4,6 @@
 
 Removes deprecated SentryDebugImageProvider class (#5598)
 Makes app hang tracking V2 the default and removes the option to enable/disable it (#5615)
-Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)
 Removes public SentrySerializable conformance from many public models (#5636, #5840, #5982)
 Removes deprecated `setExtraValue` from SentrySpan (#5864)
 Removes `integrations` property from `SentryOptions` (#5749)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Removes unused SentryLogLevel (#5591)
 - Removes deprecated getStoreEndpoint (#5591)
 - Removes deprecated useSpan function (#5591)
+- Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)
+- Removes deprecated TraceContext initializers (#6348)
 - Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)
 - Removes `enablePerformanceV2` option and makes this the default. The app start duration will now finish when the first frame is drawn instead of when the OS posts the UIWindowDidBecomeVisibleNotification. (#6008)
 - Removes enableTracing property from SentryOptions (#5694)

--- a/Sources/Sentry/Public/SentryBaggage.h
+++ b/Sources/Sentry/Public/SentryBaggage.h
@@ -41,13 +41,6 @@ NS_SWIFT_NAME(Baggage)
 @property (nullable, nonatomic, readonly) NSString *userId;
 
 /**
- * The value of a segment attribute in the user's data bag, if it exists.
- */
-#if !SDK_V9
-@property (nullable, nonatomic, readonly) NSString *userSegment;
-#endif
-
-/**
  * The random value used to determine if the trace is sampled.
  *
  * A float (`0.1234` notation) in the range of `[0, 1)` (including 0.0, excluding 1.0).
@@ -71,9 +64,6 @@ NS_SWIFT_NAME(Baggage)
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                         sampled:(nullable NSString *)sampled
                        replayId:(nullable NSString *)replayId;
@@ -83,9 +73,6 @@ NS_SWIFT_NAME(Baggage)
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                      sampleRand:(nullable NSString *)sampleRand
                         sampled:(nullable NSString *)sampled

--- a/Sources/Sentry/Public/SentryTraceContext.h
+++ b/Sources/Sentry/Public/SentryTraceContext.h
@@ -51,13 +51,6 @@ NS_SWIFT_NAME(TraceContext)
 @property (nullable, nonatomic, readonly) NSString *transaction;
 
 /**
- * A subset of the scope's user context.
- */
-#if !SDK_V9
-@property (nullable, nonatomic, readonly) NSString *userSegment;
-#endif
-
-/**
  * Serialized sample rate used for this trace.
  */
 @property (nullable, nonatomic, readonly) NSString *sampleRate;
@@ -85,9 +78,6 @@ NS_SWIFT_NAME(TraceContext)
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                         sampled:(nullable NSString *)sampled
                        replayId:(nullable NSString *)replayId;
@@ -100,9 +90,6 @@ NS_SWIFT_NAME(TraceContext)
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                      sampleRand:(nullable NSString *)sampleRand
                         sampled:(nullable NSString *)sampled
@@ -125,7 +112,6 @@ NS_SWIFT_NAME(TraceContext)
                                   scope:(nullable SentryScope *)scope
                                 options:(SentryOptions *)options;
 
-#if SDK_V9
 /**
  * Initializes a SentryTraceContext with data from a traceId, options and replayId.
  *
@@ -133,21 +119,8 @@ NS_SWIFT_NAME(TraceContext)
  *  @param options The current active options.
  *  @param replayId The current session replay.
  */
-#else
-/**
- * Initializes a SentryTraceContext with data from a traceId, options, userSegment and replayId.
- *
- *  @param traceId The current tracer.
- *  @param options The current active options.
- *  @param userSegment You can retrieve this usually from the `scope.userObject.segment`.
- *  @param replayId The current session replay.
- */
-#endif
 - (instancetype)initWithTraceId:(SentryId *)traceId
                         options:(SentryOptions *)options
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                        replayId:(nullable NSString *)replayId;
 
 /**

--- a/Sources/Sentry/Public/SentryTransactionContext.h
+++ b/Sources/Sentry/Public/SentryTransactionContext.h
@@ -72,36 +72,8 @@ SENTRY_NO_INIT
 - (instancetype)initWithName:(NSString *)name
                    operation:(NSString *)operation
                      sampled:(SentrySampleDecision)sampled
-    DEPRECATED_MSG_ATTRIBUTE("Use initWithName:operation:sampled:sampleRate:sampleRand instead");
-
-/**
- * @param name Transaction name
- * @param operation The operation this span is measuring.
- * @param sampled Determines whether the trace should be sampled.
- */
-- (instancetype)initWithName:(NSString *)name
-                   operation:(NSString *)operation
-                     sampled:(SentrySampleDecision)sampled
                   sampleRate:(nullable NSNumber *)sampleRate
                   sampleRand:(nullable NSNumber *)sampleRand;
-
-/**
- * @param name Transaction name
- * @param operation The operation this span is measuring.
- * @param traceId Trace Id
- * @param spanId Span Id
- * @param parentSpanId Parent span id
- * @param parentSampled Whether the parent is sampled
- */
-- (instancetype)initWithName:(NSString *)name
-                   operation:(NSString *)operation
-                     traceId:(SentryId *)traceId
-                      spanId:(SentrySpanId *)spanId
-                parentSpanId:(nullable SentrySpanId *)parentSpanId
-               parentSampled:(SentrySampleDecision)parentSampled
-    DEPRECATED_MSG_ATTRIBUTE("Use "
-                             "initWithName:operation:traceId:spanId:parentSpanId:parentSampled:"
-                             "parentSampleRate:parentSampleRand instead");
 
 /**
  * @param name Transaction name

--- a/Sources/Sentry/Public/SentryUser.h
+++ b/Sources/Sentry/Public/SentryUser.h
@@ -41,15 +41,6 @@ NS_SWIFT_NAME(User)
  */
 @property (atomic, copy) NSString *_Nullable ipAddress;
 
-#if !SDK_V9
-/**
- * The user segment, for apps that divide users in user segments.
- * @deprecated This field will be removed in the next major version.
- */
-@property (atomic, copy) NSString *_Nullable segment DEPRECATED_MSG_ATTRIBUTE(
-    "This field is deprecated and will be removed in the next major update.");
-#endif // !SDK_V9
-
 /**
  * Optional: Human readable name
  */

--- a/Sources/Sentry/SentryBaggage.m
+++ b/Sources/Sentry/SentryBaggage.m
@@ -15,9 +15,6 @@
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                         sampled:(nullable NSString *)sampled
                        replayId:(nullable NSString *)replayId
@@ -27,9 +24,6 @@
                      releaseName:releaseName
                      environment:environment
                      transaction:transaction
-#if !SDK_V9
-                     userSegment:userSegment
-#endif
                       sampleRate:sampleRate
                       sampleRand:nil
                          sampled:sampled
@@ -41,9 +35,6 @@
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                      sampleRand:(nullable NSString *)sampleRand
                         sampled:(nullable NSString *)sampled
@@ -56,9 +47,6 @@
         _releaseName = releaseName;
         _environment = environment;
         _transaction = transaction;
-#if !SDK_V9
-        _userSegment = userSegment;
-#endif
         _sampleRate = sampleRate;
         _sampleRand = sampleRand;
         _sampled = sampled;
@@ -87,12 +75,6 @@
     if (_transaction != nil) {
         [information setValue:_transaction forKey:@"sentry-transaction"];
     }
-
-#if !SDK_V9
-    if (_userSegment != nil) {
-        [information setValue:_userSegment forKey:@"sentry-user_segment"];
-    }
-#endif
 
     if (_sampleRand != nil) {
         [information setValue:_sampleRand forKey:@"sentry-sample_rand"];

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -420,18 +420,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     if (event.error || event.exceptions.count > 0) {
-#if !SDK_V9
-        NSString *segment = nil;
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        segment = scope.userObject.segment;
-#    pragma clang diagnostic pop
-#endif
         return [[SentryTraceContext alloc] initWithTraceId:scope.propagationContext.traceId
                                                    options:self.options
-#if !SDK_V9
-                                               userSegment:segment
-#endif
                                                   replayId:scope.replayId];
     }
 

--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -210,20 +210,9 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
     SentryPropagationContext *propagationContext
         = SentrySDKInternal.currentHub.scope.propagationContext;
 
-#if !SDK_V9
-    NSString *segment = nil;
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    segment = SentrySDKInternal.currentHub.scope.userObject.segment;
-#    pragma clang diagnostic pop
-#endif
-
     SentryTraceContext *traceContext =
         [[SentryTraceContext alloc] initWithTraceId:propagationContext.traceId
                                             options:SentrySDKInternal.currentHub.client.options
-#if !SDK_V9
-                                        userSegment:segment
-#endif
                                            replayId:SentrySDKInternal.currentHub.scope.replayId];
 
     [SentryTracePropagation addBaggageHeader:[traceContext toBaggage]

--- a/Sources/Sentry/SentryTraceContext.m
+++ b/Sources/Sentry/SentryTraceContext.m
@@ -23,9 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                         sampled:(nullable NSString *)sampled
                        replayId:(nullable NSString *)replayId
@@ -35,9 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
                      releaseName:releaseName
                      environment:environment
                      transaction:transaction
-#if !SDK_V9
-                     userSegment:userSegment
-#endif
                       sampleRate:sampleRate
                       sampleRand:nil
                          sampled:sampled
@@ -49,9 +43,6 @@ NS_ASSUME_NONNULL_BEGIN
                     releaseName:(nullable NSString *)releaseName
                     environment:(nullable NSString *)environment
                     transaction:(nullable NSString *)transaction
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                      sampleRate:(nullable NSString *)sampleRate
                      sampleRand:(nullable NSString *)sampleRand
                         sampled:(nullable NSString *)sampled
@@ -63,9 +54,6 @@ NS_ASSUME_NONNULL_BEGIN
         _environment = environment;
         _releaseName = releaseName;
         _transaction = transaction;
-#if !SDK_V9
-        _userSegment = userSegment;
-#endif
         _sampleRand = sampleRand;
         _sampleRate = sampleRate;
         _sampled = sampled;
@@ -91,16 +79,6 @@ NS_ASSUME_NONNULL_BEGIN
         return nil;
     }
 
-#if !SDK_V9
-    NSString *userSegment = nil;
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    if (scope.userObject.segment) {
-        userSegment = scope.userObject.segment;
-    }
-#    pragma clang diagnostic pop
-#endif // !SDK_V9
-
     NSString *serializedSampleRand = nil;
     NSNumber *sampleRand = [tracer.transactionContext sampleRand];
     if (sampleRand != nil) {
@@ -123,9 +101,6 @@ NS_ASSUME_NONNULL_BEGIN
                      releaseName:options.releaseName
                      environment:options.environment
                      transaction:tracer.transactionContext.name
-#if !SDK_V9
-                     userSegment:userSegment
-#endif
                       sampleRate:serializedSampleRate
                       sampleRand:serializedSampleRand
                          sampled:sampled
@@ -134,9 +109,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)initWithTraceId:(SentryId *)traceId
                         options:(SentryOptions *)options
-#if !SDK_V9
-                    userSegment:(nullable NSString *)userSegment
-#endif
                        replayId:(nullable NSString *)replayId;
 {
     return [[SentryTraceContext alloc] initWithTraceId:traceId
@@ -144,9 +116,6 @@ NS_ASSUME_NONNULL_BEGIN
                                            releaseName:options.releaseName
                                            environment:options.environment
                                            transaction:nil
-#if !SDK_V9
-                                           userSegment:userSegment
-#endif
                                             sampleRate:nil
                                             sampleRand:nil
                                                sampled:nil
@@ -167,25 +136,11 @@ NS_ASSUME_NONNULL_BEGIN
     if (traceId == nil || publicKey == nil)
         return nil;
 
-#if !SDK_V9
-    NSString *userSegment;
-    if (dictionary[@"user"] != nil) {
-        NSDictionary *userInfo = dictionary[@"user"];
-        if ([userInfo[@"segment"] isKindOfClass:[NSString class]])
-            userSegment = userInfo[@"segment"];
-    } else {
-        userSegment = dictionary[@"user_segment"];
-    }
-#endif
-
     return [self initWithTraceId:traceId
                        publicKey:publicKey
                      releaseName:dictionary[@"release"]
                      environment:dictionary[@"environment"]
                      transaction:dictionary[@"transaction"]
-#if !SDK_V9
-                     userSegment:userSegment
-#endif
                       sampleRate:dictionary[@"sample_rate"]
                       sampleRand:dictionary[@"sample_rand"]
                          sampled:dictionary[@"sampled"]
@@ -199,9 +154,6 @@ NS_ASSUME_NONNULL_BEGIN
                                                        releaseName:_releaseName
                                                        environment:_environment
                                                        transaction:_transaction
-#if !SDK_V9
-                                                       userSegment:_userSegment
-#endif
                                                         sampleRate:_sampleRate
                                                         sampleRand:_sampleRand
                                                            sampled:_sampled
@@ -225,12 +177,6 @@ NS_ASSUME_NONNULL_BEGIN
     if (_transaction != nil) {
         [result setValue:_transaction forKey:@"transaction"];
     }
-
-#if !SDK_V9
-    if (_userSegment != nil) {
-        [result setValue:_userSegment forKey:@"user_segment"];
-    }
-#endif
 
     if (_sampleRand != nil) {
         [result setValue:_sampleRand forKey:@"sample_rand"];

--- a/Sources/Sentry/SentryUser.m
+++ b/Sources/Sentry/SentryUser.m
@@ -32,13 +32,6 @@ NS_ASSUME_NONNULL_BEGIN
                 self.username = value;
             } else if ([key isEqualToString:@"ip_address"] && isString) {
                 self.ipAddress = value;
-            } else if ([key isEqualToString:@"segment"] && isString) {
-#if !SDK_V9
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                self.segment = value;
-#    pragma clang diagnostic pop
-#endif // !SDK_V9
             } else if ([key isEqualToString:@"data"] && isDictionary) {
                 self.data = value;
             } else {
@@ -75,12 +68,6 @@ NS_ASSUME_NONNULL_BEGIN
         copy.email = self.email;
         copy.username = self.username;
         copy.ipAddress = self.ipAddress;
-#if !SDK_V9
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        copy.segment = self.segment;
-#    pragma clang diagnostic pop
-#endif // !SDK_V9
         copy.name = self.name;
         copy.geo = self.geo.copy;
         copy.data = self.data.copy;
@@ -98,12 +85,6 @@ NS_ASSUME_NONNULL_BEGIN
     [serializedData setValue:self.email forKey:@"email"];
     [serializedData setValue:self.username forKey:@"username"];
     [serializedData setValue:self.ipAddress forKey:@"ip_address"];
-#if !SDK_V9
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [serializedData setValue:self.segment forKey:@"segment"];
-#    pragma clang diagnostic pop
-#endif // !SDK_V9
     [serializedData setValue:self.name forKey:@"name"];
     [serializedData setValue:[self.geo serialize] forKey:@"geo"];
     [serializedData setValue:sentry_sanitize(self.data) forKey:@"data"];
@@ -158,16 +139,6 @@ NS_ASSUME_NONNULL_BEGIN
         return NO;
     }
 
-#if !SDK_V9
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSString *otherSegment = user.segment;
-    if (self.segment != otherSegment && ![self.segment isEqualToString:otherSegment]) {
-        return NO;
-    }
-#    pragma clang diagnostic pop
-#endif // !SDK_V9
-
     NSString *otherName = user.name;
     if (self.name != otherName && ![self.name isEqualToString:otherName]) {
         return NO;
@@ -199,12 +170,6 @@ NS_ASSUME_NONNULL_BEGIN
     hash = hash * 23 + [self.email hash];
     hash = hash * 23 + [self.username hash];
     hash = hash * 23 + [self.ipAddress hash];
-#if !SDK_V9
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    hash = hash * 23 + [self.segment hash];
-#    pragma clang diagnostic pop
-#endif // !SDK_V9
     hash = hash * 23 + [self.name hash];
     hash = hash * 23 + [self.geo hash];
     hash = hash * 23 + [self.data hash];

--- a/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryDebugMetaCodable.swift
@@ -10,6 +10,7 @@ final class DebugMetaDecodable: DebugMeta {
 #else
 typealias DebugMetaDecodable = DebugMeta
 #endif
+
 extension DebugMetaDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -22,12 +23,12 @@ extension DebugMetaDecodable: Decodable {
         case imageVmAddress = "image_vmaddr"
         case codeFile = "code_file"
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
+
+      #if !SDK_V9
+      required convenience public init(from decoder: any Decoder) throws {
+          try self.init(decodedFrom: decoder)
+      }
+      #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryUserCodable.swift
@@ -20,16 +20,7 @@ extension UserDecodable: Decodable {
         case geo
         case data
     }
-    
-     @available(*, deprecated, message: """
-     This method is only deprecated to silence the deprecation warning of the property \
-     segment. Our Xcode project has deprecations as warnings and warnings as errors \
-     configured. Therefore, compilation fails without marking this init method as \
-     deprecated. It is safe to use this deprecated init method. Instead of turning off \
-     deprecation warnings for the whole project, we accept the tradeoff of marking this \
-     init method as deprecated because we don't expect many users to use it. Sadly, \
-     Swift doesn't offer a better way of silencing a deprecation warning.
-     """)
+
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.init()
@@ -37,9 +28,6 @@ extension UserDecodable: Decodable {
         self.email = try container.decodeIfPresent(String.self, forKey: .email)
         self.username = try container.decodeIfPresent(String.self, forKey: .username)
         self.ipAddress = try container.decodeIfPresent(String.self, forKey: .ipAddress)
-        #if !SDK_V9
-        self.segment = try container.decodeIfPresent(String.self, forKey: .segment)
-        #endif // !SDK_V9
         self.name = try container.decodeIfPresent(String.self, forKey: .name)
         self.geo = try container.decodeIfPresent(GeoDecodable.self, forKey: .geo)
         

--- a/Tests/SentryTests/Helper/SentrySerializationTests.swift
+++ b/Tests/SentryTests/Helper/SentrySerializationTests.swift
@@ -12,7 +12,6 @@ class SentrySerializationTests: XCTestCase {
             releaseName: "RELEASE_NAME",
             environment: "TEST",
             transaction: "transaction",
-            userSegment: "some segment",
             sampleRate: "0.25",
             sampleRand: "0.6543",
             sampled: "true",
@@ -173,7 +172,7 @@ class SentrySerializationTests: XCTestCase {
     
     @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testEnvelopeWithData_TraceContextWithoutUser_ReturnsTraceContext() throws {
-        let trace = TraceContext(trace: SentryId(), publicKey: "PUBLIC_KEY", releaseName: "RELEASE_NAME", environment: "TEST", transaction: "transaction", userSegment: nil, sampleRate: nil, sampled: nil, replayId: nil)
+        let trace = TraceContext(trace: SentryId(), publicKey: "PUBLIC_KEY", releaseName: "RELEASE_NAME", environment: "TEST", transaction: "transaction", sampleRate: nil, sampled: nil, replayId: nil)
         
         let envelopeHeader = SentryEnvelopeHeader(id: nil, traceContext: trace)
         let envelope = SentryEnvelope(header: envelopeHeader, singleItem: createItemWithEmptyAttachment())
@@ -194,7 +193,6 @@ class SentrySerializationTests: XCTestCase {
             releaseName: "RELEASE_NAME",
             environment: "TEST",
             transaction: "transaction",
-            userSegment: nil,
             sampleRate: nil,
             sampleRand: nil,
             sampled: nil,
@@ -704,7 +702,6 @@ class SentrySerializationTests: XCTestCase {
         XCTAssertEqual(firstTrace.publicKey, secondTrace.publicKey, "Public key is not equal", file: file, line: line)
         XCTAssertEqual(firstTrace.releaseName, secondTrace.releaseName, "Release name is not equal", file: file, line: line)
         XCTAssertEqual(firstTrace.environment, secondTrace.environment, "Environment is not equal", file: file, line: line)
-        XCTAssertEqual(firstTrace.userSegment, secondTrace.userSegment, "User segment is not equal", file: file, line: line)
         XCTAssertEqual(firstTrace.sampleRand, secondTrace.sampleRand, "Sample rand is not equal", file: file, line: line)
         XCTAssertEqual(firstTrace.sampleRate, secondTrace.sampleRate, "Sample rate is not equal", file: file, line: line)
     }

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -970,7 +970,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         sut.urlSessionTaskResume(task)
 
         let expectedTraceHeader = SentrySDKInternal.currentHub().scope.propagationContext.traceHeader.value()
-        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, userSegment: self.fixture.scope.userObject?.segment, replayId: nil)
+        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, replayId: nil)
         let expectedBaggageHeader = traceContext.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["baggage"] ?? "", expectedBaggageHeader)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)
@@ -983,7 +983,7 @@ class SentryNetworkTrackerTests: XCTestCase {
         sut.urlSessionTaskResume(task)
 
         let expectedTraceHeader = SentrySDKInternal.currentHub().scope.propagationContext.traceHeader.value()
-        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, userSegment: self.fixture.scope.userObject?.segment, replayId: nil)
+        let traceContext = TraceContext(trace: SentrySDKInternal.currentHub().scope.propagationContext.traceId, options: self.fixture.options, replayId: nil)
         let expectedBaggageHeader = traceContext.toBaggage().toHTTPHeader(withOriginalBaggage: nil)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["baggage"] ?? "", expectedBaggageHeader)
         XCTAssertEqual(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"] ?? "", expectedTraceHeader)

--- a/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
+++ b/Tests/SentryTests/Protocol/SentryEnvelopeTests.swift
@@ -162,7 +162,7 @@ class SentryEnvelopeTests: XCTestCase {
     @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testInitSentryEnvelopeHeader_SetIdAndTraceState() {
         let eventId = SentryId()
-        let traceContext = TraceContext(trace: SentryId(), publicKey: "publicKey", releaseName: "releaseName", environment: "environment", transaction: "transaction", userSegment: nil, sampleRate: nil, sampled: nil, replayId: nil)
+        let traceContext = TraceContext(trace: SentryId(), publicKey: "publicKey", releaseName: "releaseName", environment: "environment", transaction: "transaction", sampleRate: nil, sampled: nil, replayId: nil)
         
         let envelopeHeader = SentryEnvelopeHeader(id: eventId, traceContext: traceContext)
         XCTAssertEqual(eventId, envelopeHeader.eventId)

--- a/Tests/SentryTests/Protocol/SentryUserTests.swift
+++ b/Tests/SentryTests/Protocol/SentryUserTests.swift
@@ -10,7 +10,6 @@ class SentryUserTests: XCTestCase {
             "email": "fixture-email",
             "username": "fixture-username",
             "ip_address": "fixture-ip_address",
-            "segment": "fixture-segment",
             "data": [
                 "fixture-key": "fixture-value"
             ],
@@ -22,7 +21,6 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(user.email, "fixture-email")
         XCTAssertEqual(user.username, "fixture-username")
         XCTAssertEqual(user.ipAddress, "fixture-ip_address")
-        XCTAssertEqual(user.segment, "fixture-segment")
         XCTAssertEqual(user.data?["fixture-key"] as? String, "fixture-value")
         XCTAssertEqual(user.value(forKey: "unknown") as? NSDictionary, ["foo": "bar"])
     }
@@ -38,7 +36,6 @@ class SentryUserTests: XCTestCase {
         user.email = ""
         user.username = ""
         user.ipAddress = ""
-        user.segment = ""
         user.name = ""
         user.geo = Geo()
         user.data?.removeAll()
@@ -48,7 +45,6 @@ class SentryUserTests: XCTestCase {
         XCTAssertEqual(TestData.user.email, actual["email"] as? String)
         XCTAssertEqual(TestData.user.username, actual["username"] as? String)
         XCTAssertEqual(TestData.user.ipAddress, actual["ip_address"] as? String)
-        XCTAssertEqual(TestData.user.segment, actual["segment"] as? String)
         XCTAssertEqual(TestData.user.name, actual["name"] as? String)
         XCTAssertEqual(["some": ["data": "data", "date": TestData.timestampAs8601String]], actual["data"] as? Dictionary)
         XCTAssertEqual("data", actual["some"] as? String)
@@ -126,7 +122,6 @@ class SentryUserTests: XCTestCase {
         try testIsNotEqual { user in user.email = "" }
         try testIsNotEqual { user in user.username = "" }
         try testIsNotEqual { user in user.ipAddress = "" }
-        try testIsNotEqual { user in user.segment = "" }
         try testIsNotEqual { user in user.name = "" }
         try testIsNotEqual { user in user.geo = Geo() }
         try testIsNotEqual { user in user.data?.removeAll() }
@@ -147,7 +142,6 @@ class SentryUserTests: XCTestCase {
         user.email = ""
         user.username = ""
         user.ipAddress = ""
-        user.segment = ""
         user.name = ""
         user.geo = Geo()
         user.data = [:]
@@ -185,7 +179,6 @@ class SentryUserTests: XCTestCase {
                     user.email = "john@example.com"
                     user.username = "\(i)"
                     user.ipAddress = "\(i)"
-                    user.segment = "\(i)"
                     user.name = "\(i)"
                     
                     user.geo?.city = "\(i)"

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -798,7 +798,7 @@ class SentryClientTests: XCTestCase {
             try assertValidErrorEvent(eventWithSessionArguments.event, error)
             XCTAssertEqual(fixture.session, eventWithSessionArguments.session)
             
-            let expectedTraceContext = TraceContext(trace: scope.propagationContext.traceId, options: Options(), userSegment: "segment", replayId: nil) 
+            let expectedTraceContext = TraceContext(trace: scope.propagationContext.traceId, options: Options(), replayId: nil)
             XCTAssertEqual(eventWithSessionArguments.traceContext?.traceId,
                            expectedTraceContext.traceId)
         }

--- a/Tests/SentryTests/SentryHubTests.swift
+++ b/Tests/SentryTests/SentryHubTests.swift
@@ -429,9 +429,8 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(span.sampled, .no)
     }
     
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testCaptureTransaction_CapturesEventAsync() throws {
-        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .yes))
+        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .yes, sampleRate: nil, sampleRand: nil))
 
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.capture(try XCTUnwrap(trans as? Transaction), with: Scope())
@@ -458,9 +457,8 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(self.fixture.dispatchQueueWrapper.dispatchAsyncInvocations.count, 1)
     }
 
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testCaptureSampledTransaction_DoesNotCaptureEvent() throws {
-        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no))
+        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no, sampleRate: nil, sampleRand: nil))
 
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.capture(try XCTUnwrap(trans as? Transaction), with: Scope())
@@ -487,9 +485,8 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(self.fixture.client.captureEventWithScopeInvocations.count, 0)
     }
     
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testCaptureSampledTransaction_RecordsLostEvent() throws {
-        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no))
+        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no, sampleRate: nil, sampleRand: nil))
 
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.capture(try XCTUnwrap(trans as? Transaction), with: Scope())
@@ -522,9 +519,8 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(lostEvent?.reason, .sampleRate)
     }
     
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testCaptureSampledTransaction_RecordsLostSpans() throws {
-        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no))
+        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no, sampleRate: nil, sampleRand: nil))
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         
         if let tracer = transaction as? SentryTracer {
@@ -576,12 +572,11 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(lostEvent?.quantity, 4)
     }
     
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testSaveCrashTransaction_SavesTransaction() throws {
         let scope = fixture.scope
         let sut = SentryHub(client: fixture.client, andScope: scope)
         
-        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .yes))
+        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .yes, sampleRate: nil, sampleRand: nil))
 
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.saveCrash(try XCTUnwrap(trans as? Transaction))
@@ -618,12 +613,11 @@ class SentryHubTests: XCTestCase {
         XCTAssertEqual(0, client.recordLostEvents.count)
     }
     
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testSaveCrashTransaction_NotSampled_DoesNotSaveTransaction() throws {
         let scope = fixture.scope
         let sut = SentryHub(client: fixture.client, andScope: scope)
         
-        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no))
+        let transaction = sut.startTransaction(transactionContext: TransactionContext(name: fixture.transactionName, operation: fixture.transactionOperation, sampled: .no, sampleRate: nil, sampleRand: nil))
 
         let trans = Dynamic(transaction).toTransaction().asAnyObject
         sut.saveCrash(try XCTUnwrap(trans as? Transaction))

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -32,7 +32,6 @@ class SentryScopeSwiftTests: XCTestCase {
             user.email = "user@sentry.io"
             user.username = "user123"
             user.ipAddress = "127.0.0.1"
-            user.segment = "segmentA"
             user.name = "User"
             user.ipAddress = ipAddress
             

--- a/Tests/SentryTests/Transaction/SentryBaggageTests.swift
+++ b/Tests/SentryTests/Transaction/SentryBaggageTests.swift
@@ -7,13 +7,13 @@ class SentryBaggageTests: XCTestCase {
     // MARK: - Tests without sampleRand
 
     func test_baggageToHeader_AppendToOriginal() {
-        let header = Baggage(trace: SentryId.empty, publicKey: "publicKey", releaseName: "release name", environment: "teste", transaction: "transaction", userSegment: "test user", sampleRate: "0.49", sampled: "true", replayId: "some_replay_id").toHTTPHeader(withOriginalBaggage: ["a": "a", "sentry-trace_id": "to-be-overwritten"])
+        let header = Baggage(trace: SentryId.empty, publicKey: "publicKey", releaseName: "release name", environment: "teste", transaction: "transaction", sampleRate: "0.49", sampled: "true", replayId: "some_replay_id").toHTTPHeader(withOriginalBaggage: ["a": "a", "sentry-trace_id": "to-be-overwritten"])
 
-        XCTAssertEqual(header, "a=a,sentry-environment=teste,sentry-public_key=publicKey,sentry-release=release%20name,sentry-replay_id=some_replay_id,sentry-sample_rate=0.49,sentry-sampled=true,sentry-trace_id=00000000000000000000000000000000,sentry-transaction=transaction,sentry-user_segment=test%20user")
+        XCTAssertEqual(header, "a=a,sentry-environment=teste,sentry-public_key=publicKey,sentry-release=release%20name,sentry-replay_id=some_replay_id,sentry-sample_rate=0.49,sentry-sampled=true,sentry-trace_id=00000000000000000000000000000000,sentry-transaction=transaction")
     }
     
     func test_baggageToHeader_onlyTrace_ignoreNils() {
-        let header = Baggage(trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil, transaction: nil, userSegment: nil, sampleRate: nil, sampled: nil, replayId: nil).toHTTPHeader(withOriginalBaggage: nil)
+        let header = Baggage(trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil, transaction: nil, sampleRate: nil, sampled: nil, replayId: nil).toHTTPHeader(withOriginalBaggage: nil)
         
         XCTAssertEqual(header, "sentry-public_key=publicKey,sentry-trace_id=00000000000000000000000000000000")
     }
@@ -24,7 +24,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: "release name", environment: "teste",
-            transaction: "transaction", userSegment: "test user",
+            transaction: "transaction",
             sampleRate: "0.49", sampleRand: "0.6543", sampled: "true",
             replayId: "some_replay_id"
         )
@@ -33,14 +33,14 @@ class SentryBaggageTests: XCTestCase {
         let header = baggage.toHTTPHeader(withOriginalBaggage: ["a": "a", "sentry-trace_id": "to-be-overwritten"])
 
         // -- Assert --
-        XCTAssertEqual(header, "a=a,sentry-environment=teste,sentry-public_key=publicKey,sentry-release=release%20name,sentry-replay_id=some_replay_id,sentry-sample_rand=0.6543,sentry-sample_rate=0.49,sentry-sampled=true,sentry-trace_id=00000000000000000000000000000000,sentry-transaction=transaction,sentry-user_segment=test%20user")
+        XCTAssertEqual(header, "a=a,sentry-environment=teste,sentry-public_key=publicKey,sentry-release=release%20name,sentry-replay_id=some_replay_id,sentry-sample_rand=0.6543,sentry-sample_rate=0.49,sentry-sampled=true,sentry-trace_id=00000000000000000000000000000000,sentry-transaction=transaction")
     }
 
     func testWithSampleRand_baggageToHeader_onlyTrace_ignoreNils() {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: nil, sampleRand: nil, sampled: nil, replayId: nil
         )
 
@@ -55,7 +55,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: "release name", environment: nil,
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: nil, sampleRand: nil, sampled: nil, replayId: nil
         )
 
@@ -70,7 +70,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: "environment",
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: nil, sampleRand: nil, sampled: nil, replayId: nil
         )
 
@@ -85,7 +85,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: "transaction", userSegment: nil,
+            transaction: "transaction",
             sampleRate: nil, sampleRand: nil, sampled: nil, replayId: nil
         )
 
@@ -96,26 +96,11 @@ class SentryBaggageTests: XCTestCase {
         XCTAssertEqual(header, "sentry-public_key=publicKey,sentry-trace_id=00000000000000000000000000000000,sentry-transaction=transaction")
     }
 
-    func testToHTTPHeader_userSegmentInOriginalBaggage_shouldBeOverwritten() {
-        // -- Arrange --
-        let baggage = Baggage(
-            trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: nil, userSegment: "segment", 
-            sampleRate: nil, sampleRand: nil, sampled: nil, replayId: nil
-        )
-
-        // -- Act --
-        let header = baggage.toHTTPHeader(withOriginalBaggage: ["sentry-user_segment": "original segment"])
-
-        // -- Assert --
-        XCTAssertEqual(header, "sentry-public_key=publicKey,sentry-trace_id=00000000000000000000000000000000,sentry-user_segment=segment")
-    }
-
     func testToHTTPHeader_sampleRateInOriginalBaggage_shouldBeOverwritten() {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: "1.0", sampleRand: nil, sampled: nil, replayId: nil
         )
 
@@ -130,7 +115,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: nil, sampleRand: "0.5", sampled: nil, replayId: nil
         )
 
@@ -145,7 +130,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: nil, sampleRand: nil, sampled: "true", replayId: nil
         )
 
@@ -160,7 +145,7 @@ class SentryBaggageTests: XCTestCase {
         // -- Arrange --
         let baggage = Baggage(
             trace: SentryId.empty, publicKey: "publicKey", releaseName: nil, environment: nil,
-            transaction: nil, userSegment: nil,
+            transaction: nil,
             sampleRate: nil, sampleRand: nil, sampled: nil, replayId: "replay-id"
         )
 

--- a/Tests/SentryTests/Transaction/SentryTraceContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTraceContextTests.swift
@@ -12,7 +12,6 @@ class SentryTraceContextTests: XCTestCase {
         let scope: Scope
         let tracer: SentryTracer
         let userId = "SomeUserID"
-        let userSegment = "Test Segment"
         let sampleRand = "0.6543"
         let sampleRate = "0.45"
         let traceId: SentryId
@@ -22,7 +21,6 @@ class SentryTraceContextTests: XCTestCase {
         let sampled = "true"
         let replayId = "some_replay_id"
         
-        @available(*, deprecated)
         init() {
             options = Options()
             options.dsn = SentryTraceContextTests.dsnAsString
@@ -30,11 +28,10 @@ class SentryTraceContextTests: XCTestCase {
             options.environment = environment
             options.sendDefaultPii = true
             
-            tracer = SentryTracer(transactionContext: TransactionContext(name: transactionName, operation: transactionOperation, sampled: .yes), hub: nil)
+            tracer = SentryTracer(transactionContext: TransactionContext(name: transactionName, operation: transactionOperation, sampled: .yes, sampleRate: nil, sampleRand: nil), hub: nil)
 
             scope = Scope()
             scope.setUser(User(userId: userId))
-            scope.userObject?.segment = userSegment
             scope.span = tracer
             scope.replayId = replayId
             
@@ -44,7 +41,6 @@ class SentryTraceContextTests: XCTestCase {
     
     private var fixture: Fixture!
     
-    @available(*, deprecated)
     override func setUp() {
         super.setUp()
         fixture = Fixture()
@@ -63,7 +59,6 @@ class SentryTraceContextTests: XCTestCase {
             releaseName: fixture.releaseName,
             environment: fixture.environment,
             transaction: fixture.transactionName,
-            userSegment: fixture.userSegment,
             sampleRate: fixture.sampleRate,
             sampled: fixture.sampled,
             replayId: fixture.replayId
@@ -81,7 +76,6 @@ class SentryTraceContextTests: XCTestCase {
             releaseName: fixture.releaseName,
             environment: fixture.environment,
             transaction: fixture.transactionName,
-            userSegment: fixture.userSegment,
             sampleRate: fixture.sampleRate,
             sampleRand: fixture.sampleRand,
             sampled: fixture.sampled,
@@ -96,7 +90,6 @@ class SentryTraceContextTests: XCTestCase {
             expectedReleaseName: fixture.releaseName,
             expectedEnvironment: fixture.environment,
             expectedTransaction: fixture.transactionName,
-            expectedUserSegment: fixture.userSegment,
             expectedSampled: fixture.sampled,
             expectedSampleRate: fixture.sampleRate,
             expectedSampleRand: fixture.sampleRand,
@@ -151,7 +144,7 @@ class SentryTraceContextTests: XCTestCase {
         let traceId = SentryId()
         
         // Act
-        let traceContext = TraceContext(trace: traceId, options: options, userSegment: "segment", replayId: "replayId")
+        let traceContext = TraceContext(trace: traceId, options: options, replayId: "replayId")
         
         // Assert
         XCTAssertEqual(options.parsedDsn?.url.user, traceContext.publicKey)
@@ -159,7 +152,6 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertEqual(options.releaseName, traceContext.releaseName)
         XCTAssertEqual(options.environment, traceContext.environment)
         XCTAssertNil(traceContext.transaction)
-        XCTAssertEqual("segment", traceContext.userSegment)
         XCTAssertEqual(traceContext.replayId, "replayId")
         XCTAssertNil(traceContext.sampleRate)
         XCTAssertNil(traceContext.sampleRand)
@@ -174,7 +166,7 @@ class SentryTraceContextTests: XCTestCase {
         let traceId = SentryId()
 
         // Act
-        let traceContext = TraceContext(trace: traceId, options: options, userSegment: nil, replayId: nil)
+        let traceContext = TraceContext(trace: traceId, options: options, replayId: nil)
         
         // Assert
         XCTAssertEqual(options.parsedDsn?.url.user, traceContext.publicKey)
@@ -182,7 +174,6 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertEqual(options.releaseName, traceContext.releaseName)
         XCTAssertEqual(options.environment, traceContext.environment)
         XCTAssertNil(traceContext.transaction)
-        XCTAssertNil(traceContext.userSegment)
         XCTAssertNil(traceContext.sampleRate)
         XCTAssertNil(traceContext.sampleRand)
         XCTAssertNil(traceContext.sampled)
@@ -196,7 +187,6 @@ class SentryTraceContextTests: XCTestCase {
             releaseName: fixture.releaseName,
             environment: fixture.environment,
             transaction: fixture.transactionName,
-            userSegment: fixture.userSegment,
             sampleRate: fixture.sampleRate,
             sampleRand: fixture.sampleRand,
             sampled: fixture.sampled,
@@ -210,7 +200,6 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertEqual(baggage.publicKey, fixture.publicKey)
         XCTAssertEqual(baggage.releaseName, fixture.releaseName)
         XCTAssertEqual(baggage.environment, fixture.environment)
-        XCTAssertEqual(baggage.userSegment, fixture.userSegment)
         XCTAssertEqual(baggage.sampleRate, fixture.sampleRate)
         XCTAssertEqual(baggage.sampled, fixture.sampled)
         XCTAssertEqual(baggage.sampleRand, fixture.sampleRand)
@@ -223,7 +212,6 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertEqual(traceContext.releaseName, fixture.releaseName)
         XCTAssertEqual(traceContext.environment, fixture.environment)
         XCTAssertEqual(traceContext.transaction, fixture.transactionName)
-        XCTAssertEqual(traceContext.userSegment, fixture.userSegment)
         XCTAssertEqual(traceContext.sampled, fixture.sampled)
         XCTAssertEqual(traceContext.replayId, fixture.replayId)
     }
@@ -235,7 +223,6 @@ class SentryTraceContextTests: XCTestCase {
         expectedReleaseName: String,
         expectedEnvironment: String,
         expectedTransaction: String,
-        expectedUserSegment: String,
         expectedSampled: String,
         expectedSampleRate: String,
         expectedSampleRand: String,
@@ -246,7 +233,6 @@ class SentryTraceContextTests: XCTestCase {
         XCTAssertEqual(traceContext.releaseName, expectedReleaseName, "Release Name does not match", file: file, line: line)
         XCTAssertEqual(traceContext.environment, expectedEnvironment, "Environment does not match", file: file, line: line)
         XCTAssertEqual(traceContext.transaction, expectedTransaction, "Transaction does not match", file: file, line: line)
-        XCTAssertEqual(traceContext.userSegment, expectedUserSegment, "User Segment does not match", file: file, line: line)
         XCTAssertEqual(traceContext.sampled, expectedSampled, "Sampled does not match", file: file, line: line)
         XCTAssertEqual(traceContext.sampleRate, expectedSampleRate, "Sample Rate does not match", file: file, line: line)
         XCTAssertEqual(traceContext.sampleRand, expectedSampleRand, "Sample Rand does not match", file: file, line: line)

--- a/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
@@ -40,16 +40,14 @@ class SentryTransactionContextTests: XCTestCase {
         assertContext(context: context, transactionName: "", sampled: .yes)
     }
 
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testPublicInit_WithNameOperationSampled() {
-        let context = TransactionContext(name: transactionName, operation: operation, sampled: .yes)
+        let context = TransactionContext(name: transactionName, operation: operation, sampled: .yes, sampleRate: nil, sampleRand: nil)
         
         assertContext(context: context, sampled: .yes)
     }
 
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testPublicInit_WithAllParams() {
-        let context = TransactionContext(name: transactionName, operation: operation, trace: traceID, spanId: spanID, parentSpanId: parentSpanID, parentSampled: .no)
+        let context = TransactionContext(name: transactionName, operation: operation, trace: traceID, spanId: spanID, parentSpanId: parentSpanID, parentSampled: .no, parentSampleRate: nil, parentSampleRand: nil)
         
         assertContext(context: context, isParentSpanIdNil: false)
         XCTAssertEqual(traceID, context.traceId)
@@ -199,10 +197,9 @@ class SentryTransactionContextTests: XCTestCase {
         )
     }
 
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testPublicInit_WithNameOperationSampled_shouldMatchExpectedValues() {
         // Act
-        let context = TransactionContext(name: transactionName, operation: operation, sampled: sampled)
+        let context = TransactionContext(name: transactionName, operation: operation, sampled: sampled, sampleRate: nil, sampleRand: nil)
 
         // Assert
         assertFullContext(
@@ -250,7 +247,6 @@ class SentryTransactionContextTests: XCTestCase {
         )
     }
 
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testPublicInit_WithNameTraceIdSpanIdParentSpanIdParentSampled() {
         // Act
         let context = TransactionContext(
@@ -259,7 +255,9 @@ class SentryTransactionContextTests: XCTestCase {
             trace: traceID,
             spanId: spanID,
             parentSpanId: parentSpanID,
-            parentSampled: parentSampled
+            parentSampled: parentSampled,
+            parentSampleRate: nil,
+            parentSampleRand: nil
         )
 
         // Assert
@@ -289,7 +287,9 @@ class SentryTransactionContextTests: XCTestCase {
             trace: traceID,
             spanId: spanID,
             parentSpanId: nil,
-            parentSampled: parentSampled
+            parentSampled: parentSampled,
+            parentSampleRate: nil,
+            parentSampleRand: nil
         )
 
         // Assert

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -38070,48 +38070,6 @@
           {
             "kind": "Constructor",
             "name": "init",
-            "printedName": "init(name:operation:sampled:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "TransactionContext",
-                "printedName": "Sentry.TransactionContext",
-                "usr": "c:objc(cs)SentryTransactionContext"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentrySampleDecision",
-                "printedName": "Sentry.SentrySampleDecision",
-                "usr": "c:@E@SentrySampleDecision"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:objc(cs)SentryTransactionContext(im)initWithName:operation:sampled:",
-            "moduleName": "Sentry",
-            "deprecated": true,
-            "objc_name": "initWithName:operation:sampled:",
-            "declAttributes": [
-              "Available",
-              "ObjC",
-              "Dynamic"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
             "printedName": "init(name:operation:sampled:sampleRate:sampleRand:)",
             "children": [
               {
@@ -38172,74 +38130,6 @@
             "moduleName": "Sentry",
             "objc_name": "initWithName:operation:sampled:sampleRate:sampleRand:",
             "declAttributes": [
-              "ObjC",
-              "Dynamic"
-            ],
-            "init_kind": "Designated"
-          },
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init(name:operation:trace:spanId:parentSpanId:parentSampled:)",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "TransactionContext",
-                "printedName": "Sentry.TransactionContext",
-                "usr": "c:objc(cs)SentryTransactionContext"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "String",
-                "printedName": "Swift.String",
-                "usr": "s:SS"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentryId",
-                "printedName": "Sentry.SentryId",
-                "usr": "c:@M@Sentry@objc(cs)SentryId"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SpanId",
-                "printedName": "Sentry.SpanId",
-                "usr": "c:objc(cs)SentrySpanId"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "Optional",
-                "printedName": "Sentry.SpanId?",
-                "children": [
-                  {
-                    "kind": "TypeNominal",
-                    "name": "SpanId",
-                    "printedName": "Sentry.SpanId",
-                    "usr": "c:objc(cs)SentrySpanId"
-                  }
-                ],
-                "usr": "s:Sq"
-              },
-              {
-                "kind": "TypeNominal",
-                "name": "SentrySampleDecision",
-                "printedName": "Sentry.SentrySampleDecision",
-                "usr": "c:@E@SentrySampleDecision"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:objc(cs)SentryTransactionContext(im)initWithName:operation:traceId:spanId:parentSpanId:parentSampled:",
-            "moduleName": "Sentry",
-            "deprecated": true,
-            "objc_name": "initWithName:operation:traceId:spanId:parentSpanId:parentSampled:",
-            "declAttributes": [
-              "Available",
               "ObjC",
               "Dynamic"
             ],


### PR DESCRIPTION
Removes V9 checks for deprecated segment property and deprecated TraceContext initializers

#skip-changelog

Closes #6349, #4093