### PR TITLE
ci: Only run test server on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,9 +130,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Running the tests with simulators is incredibly flaky. As we don't touch that code often, the risk is small
-          # that the unit tests break on iOS but not on macOS, and it's better to have rock-solid unit tests, we only run
-          #these on macOS.
+          # Running the tests with simulators is incredibly flaky. Our assumption is that simulators might have difficulties
+          # with communicating with the test server in CI.
+          # As we don't touch that code often, the risk is small that the unit tests break on iOS but not on macOS, and it's
+          # better to have rock-solid unit tests, we only run these on macOS.
           - name: macOS 15
             runs-on: macos-15
             platform: "macOS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,8 +132,7 @@ jobs:
         include:
           # Running the tests with simulators is incredibly flaky. Our assumption is that simulators might have difficulties
           # with communicating with the test server in CI.
-          # As we don't touch that code often, the risk is small that the unit tests break on iOS but not on macOS, and it's
-          # better to have rock-solid unit tests, we only run these on macOS.
+          # We are going to add these back in https://github.com/getsentry/sentry-cocoa/issues/6361
           - name: macOS 15
             runs-on: macos-15
             platform: "macOS"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,13 +130,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: iOS 18
-            runs-on: macos-15
-            platform: "iOS"
-            xcode: "16.4"
-            device: "iPhone 16 Pro"
-            test-destination-os: "18.5"
-
+          # Running the tests with simulators is incredibly flaky. As we don't touch that code often, the risk is small
+          # that the unit tests break on iOS but not on macOS, and it's better to have rock-solid unit tests, we only run
+          #these on macOS.
           - name: macOS 15
             runs-on: macos-15
             platform: "macOS"


### PR DESCRIPTION
The test server tests on iOS are very flaky. Let's only run these on macOS, as they didn't fail there in the last two weeks.
Perhaps that's because the simulator has difficulty communicating with a running test server in CI.

<img width="2984" height="2086" alt="Screenshot 2025-10-06 at 07 10 25" src="https://github.com/user-attachments/assets/35f140c4-05ef-4367-976d-d6f4e061bcf1" />


#skip-changelog

Closes #6351