### PR TITLE
test: Extract isTargetTests to own test class

### DIFF
--- a/Sentry.xcodeproj/project.pbxproj
+++ b/Sentry.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		62A456E32B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */; };
 		62A456E52B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m in Sources */ = {isa = PBXBuildFile; fileRef = 62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */; };
 		62AB8C9E2BF3925700BFC2AC /* WeakReference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62AB8C9D2BF3925700BFC2AC /* WeakReference.swift */; };
+		62B220BB2E93A9EC004620FF /* SentryTracePropagationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62B220BA2E93A9EC004620FF /* SentryTracePropagationTests.swift */; };
 		62BDDD122D51FD540024CCD1 /* SentryThreadCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62BDDD112D51FD540024CCD1 /* SentryThreadCodable.swift */; };
 		62C1AFAB2B7E10EA0038C5F7 /* SentrySpotlightTransport.m in Sources */ = {isa = PBXBuildFile; fileRef = 62C1AFAA2B7E10EA0038C5F7 /* SentrySpotlightTransport.m */; };
 		62C25C862B075F4900C68CBD /* TestOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62C25C852B075F4900C68CBD /* TestOptions.swift */; };
@@ -1360,6 +1361,7 @@
 		62A456E22B0370AA003F19A1 /* SentryUIEventTrackerTransactionMode.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentryUIEventTrackerTransactionMode.h; path = include/SentryUIEventTrackerTransactionMode.h; sourceTree = "<group>"; };
 		62A456E42B0370E0003F19A1 /* SentryUIEventTrackerTransactionMode.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentryUIEventTrackerTransactionMode.m; sourceTree = "<group>"; };
 		62AB8C9D2BF3925700BFC2AC /* WeakReference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakReference.swift; sourceTree = "<group>"; };
+		62B220BA2E93A9EC004620FF /* SentryTracePropagationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryTracePropagationTests.swift; sourceTree = "<group>"; };
 		62BDDD112D51FD540024CCD1 /* SentryThreadCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryThreadCodable.swift; sourceTree = "<group>"; };
 		62C1AFA92B7E10D30038C5F7 /* SentrySpotlightTransport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = SentrySpotlightTransport.h; path = include/SentrySpotlightTransport.h; sourceTree = "<group>"; };
 		62C1AFAA2B7E10EA0038C5F7 /* SentrySpotlightTransport.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SentrySpotlightTransport.m; sourceTree = "<group>"; };
@@ -3825,6 +3827,7 @@
 				8EAE8E5C2681768000D6958B /* URLSessionTaskMock.h */,
 				8EAE8E5D2681768000D6958B /* URLSessionTaskMock.m */,
 				8EA05EEC267C2AB200C82B30 /* SentryNetworkTrackerTests.swift */,
+				62B220BA2E93A9EC004620FF /* SentryTracePropagationTests.swift */,
 				7B8CA85626DD4E6200DD872C /* SentryNetworkTrackerIntegrationTests.swift */,
 				6276E68A2E7A779B002A4A8F /* SentryNetworkTrackerIntegrationTestServerTests.swift */,
 				D8751FA4274743710032F4DE /* SentryNSURLSessionTaskSearchTests.swift */,
@@ -6046,6 +6049,7 @@
 				7BFAA6E7297AA16A00E7E02E /* SentryCrashMonitor_CppException_Tests.mm in Sources */,
 				9286059929A50BAB00F96038 /* SentryGeoTests.swift in Sources */,
 				621655662DB12A8900810504 /* SentryCrashMach-OTests.m in Sources */,
+				62B220BB2E93A9EC004620FF /* SentryTracePropagationTests.swift in Sources */,
 				D8B76B0828081461000A58C4 /* TestSentryScreenshotProvider.swift in Sources */,
 				A8AFFCD22907DA7600967CD7 /* SentryHttpStatusCodeRangeTests.swift in Sources */,
 				7BE2C7F8257000A4003B66C7 /* SentryTestIntegration.m in Sources */,

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerTests.swift
@@ -956,37 +956,6 @@ class SentryNetworkTrackerTests: XCTestCase {
         XCTAssertNil(task.currentRequest?.allHTTPHeaderFields?["sentry-trace"])
     }
 
-    func testIsTargetMatch() throws {
-        // Default: all urls
-        let defaultRegex = try XCTUnwrap(NSRegularExpression(pattern: ".*"))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: [ defaultRegex ]))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: [ defaultRegex ]))
-
-        // Strings: hostname
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost"]))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost-but-not-really")), withTargets: ["localhost"])) // works because of `contains`
-        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["localhost"]))
-
-        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["www.example.com"]))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["www.example.com"]))
-        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://api.example.com/api/projects")), withTargets: ["www.example.com"]))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com.evil.com/api/projects")), withTargets: ["www.example.com"])) // works because of `contains`
-
-        // Test regex
-        let regex = try XCTUnwrap(NSRegularExpression(pattern: "http://www.example.com/api/.*"))
-        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: [regex]))
-        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/url")), withTargets: [regex]))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: [regex]))
-
-        // Regex and string
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost", regex]))
-        XCTAssertFalse(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/url")), withTargets: ["localhost", regex]))
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://www.example.com/api/projects")), withTargets: ["localhost", regex]))
-
-        // String and integer (which isn't valid, make sure it doesn't crash)
-        XCTAssertTrue(SentryTracePropagation.isTargetMatch(try XCTUnwrap(URL(string: "http://localhost")), withTargets: ["localhost", 123]))
-    }
-
     func testCaptureHTTPClientErrorRequest() throws {
         let sut = fixture.getSut()
 

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryTracePropagationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryTracePropagationTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+
+final class SentryTracePropagationTests: XCTestCase {
+
+    func testIsTargetMatchWithDefaultRegex_MatchesAllURLs() throws {
+        // Arrange
+        let defaultRegex = try XCTUnwrap(NSRegularExpression(pattern: ".*"))
+        let localhostURL = try XCTUnwrap(URL(string: "http://localhost"))
+        let exampleURL = try XCTUnwrap(URL(string: "http://www.example.com/api/projects"))
+        
+        // Act & Assert
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(localhostURL, withTargets: [defaultRegex]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(exampleURL, withTargets: [defaultRegex]))
+    }
+    
+    func testIsTargetMatchWithStringHostname_MatchesExactHostname() throws {
+        // Arrange
+        let localhostURL = try XCTUnwrap(URL(string: "http://localhost"))
+        let exampleURL = try XCTUnwrap(URL(string: "http://www.example.com/api/projects"))
+        let apiExampleURL = try XCTUnwrap(URL(string: "http://api.example.com/api/projects"))
+        let localhostTargets = ["localhost"]
+        let exampleTargets = ["www.example.com"]
+        
+        // Act & Assert
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(localhostURL, withTargets: localhostTargets))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(exampleURL, withTargets: localhostTargets))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(localhostURL, withTargets: exampleTargets))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(exampleURL, withTargets: exampleTargets))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(apiExampleURL, withTargets: exampleTargets))
+    }
+    
+    func testIsTargetMatchWithStringHostname_MatchesSubstrings() throws {
+        // Arrange
+        let localhostExtendedURL = try XCTUnwrap(URL(string: "http://localhost-but-not-really"))
+        let evilURL = try XCTUnwrap(URL(string: "http://www.example.com.evil.com/api/projects"))
+        let localhostTargets = ["localhost"]
+        let exampleTargets = ["www.example.com"]
+        
+        // Act & Assert
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(localhostExtendedURL, withTargets: localhostTargets))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(evilURL, withTargets: exampleTargets))
+    }
+    
+    func testIsTargetMatchWithRegexPattern_MatchesSpecificPatterns() throws {
+        // Arrange
+        let regex = try XCTUnwrap(NSRegularExpression(pattern: "http://www.example.com/api/.*"))
+        let localhostURL = try XCTUnwrap(URL(string: "http://localhost"))
+        let nonAPIURL = try XCTUnwrap(URL(string: "http://www.example.com/url"))
+        let apiURL = try XCTUnwrap(URL(string: "http://www.example.com/api/projects"))
+        
+        // Act & Assert
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(localhostURL, withTargets: [regex]))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(nonAPIURL, withTargets: [regex]))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(apiURL, withTargets: [regex]))
+    }
+    
+    func testIsTargetMatchWithMixedRegexAndString_MatchesEitherTarget() throws {
+        // Arrange
+        let regex = try XCTUnwrap(NSRegularExpression(pattern: "http://www.example.com/api/.*"))
+        let localhostURL = try XCTUnwrap(URL(string: "http://localhost"))
+        let nonAPIURL = try XCTUnwrap(URL(string: "http://www.example.com/url"))
+        let apiURL = try XCTUnwrap(URL(string: "http://www.example.com/api/projects"))
+        let mixedTargets = ["localhost", regex] as [Any]
+        
+        // Act & Assert
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(localhostURL, withTargets: mixedTargets))
+        XCTAssertFalse(SentryTracePropagation.isTargetMatch(nonAPIURL, withTargets: mixedTargets))
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(apiURL, withTargets: mixedTargets))
+    }
+    
+    func testIsTargetMatchWithInvalidInput_DoesNotCrash() throws {
+        // Arrange
+        let localhostURL = try XCTUnwrap(URL(string: "http://localhost"))
+        let targetsWithInvalidType = ["localhost", 123] as [Any]
+        
+        // Act & Assert
+        XCTAssertTrue(SentryTracePropagation.isTargetMatch(localhostURL, withTargets: targetsWithInvalidType))
+    }
+
+}


### PR DESCRIPTION
## :scroll: Description

Refactored trace propagation tests by moving them from `SentryNetworkTrackerTests` to a dedicated `SentryTracePropagationTests` file. The tests were also improved with better organization, more descriptive test names, and clearer arrange-act-assert patterns.

## :bulb: Motivation and Context

This change improves test organization by separating trace propagation tests into their own file, making the codebase more maintainable. The refactored tests are now more readable with better naming conventions and structure.

## :green_heart: How did you test it?

Ran the existing tests to ensure they still pass after being moved and refactored.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.

#skip-changelog 

Closes #6353