### PR TITLE
ref: Remove SentrySDK from trace propagation class

### DIFF
--- a/Sources/Sentry/SentryNetworkTracker.m
+++ b/Sources/Sentry/SentryNetworkTracker.m
@@ -191,6 +191,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
         SentryBaggage *baggage = [[[SentryTracer getTracer:span] traceContext] toBaggage];
         [SentryTracePropagation addBaggageHeader:baggage
                                      traceHeader:[netSpan toTraceHeader]
+                         tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
                                        toRequest:sessionTask];
 
         SENTRY_LOG_DEBUG(
@@ -225,6 +226,7 @@ static NSString *const SentryNetworkTrackerThreadSanitizerMessage
 
     [SentryTracePropagation addBaggageHeader:[traceContext toBaggage]
                                  traceHeader:[propagationContext traceHeader]
+                     tracePropagationTargets:SentrySDKInternal.options.tracePropagationTargets
                                    toRequest:sessionTask];
 }
 

--- a/Sources/Sentry/SentryTracePropagation.m
+++ b/Sources/Sentry/SentryTracePropagation.m
@@ -1,6 +1,5 @@
 #import <SentryBaggage.h>
 #import <SentryLogC.h>
-#import <SentrySDK+Private.h>
 #import <SentrySwift.h>
 #import <SentryTraceHeader.h>
 #import <SentryTracePropagation.h>
@@ -8,10 +7,12 @@
 @implementation SentryTracePropagation
 
 + (void)addBaggageHeader:(SentryBaggage *)baggage
-             traceHeader:(SentryTraceHeader *)traceHeader
-               toRequest:(NSURLSessionTask *)sessionTask
+                traceHeader:(SentryTraceHeader *)traceHeader
+    tracePropagationTargets:(NSArray *)tracePropagationTargets
+                  toRequest:(NSURLSessionTask *)sessionTask
 {
-    if (![SentryTracePropagation sessionTaskRequiresPropagation:sessionTask]) {
+    if (![SentryTracePropagation sessionTaskRequiresPropagation:sessionTask
+                                        tracePropagationTargets:tracePropagationTargets]) {
         SENTRY_LOG_DEBUG(@"Not adding trace_id and baggage headers for %@",
             sessionTask.currentRequest.URL.absoluteString);
         return;
@@ -65,10 +66,11 @@
 }
 
 + (BOOL)sessionTaskRequiresPropagation:(NSURLSessionTask *)sessionTask
+               tracePropagationTargets:(NSArray *)tracePropagationTargets
 {
     return sessionTask.currentRequest != nil &&
         [SentryTracePropagation isTargetMatch:sessionTask.currentRequest.URL
-                                  withTargets:SentrySDKInternal.options.tracePropagationTargets];
+                                  withTargets:tracePropagationTargets];
 }
 
 + (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets

--- a/Sources/Sentry/include/SentryTracePropagation.h
+++ b/Sources/Sentry/include/SentryTracePropagation.h
@@ -8,8 +8,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryTracePropagation : NSObject
 
 + (void)addBaggageHeader:(SentryBaggage *)baggage
-             traceHeader:(SentryTraceHeader *)traceHeader
-               toRequest:(NSURLSessionTask *)sessionTask;
+                traceHeader:(SentryTraceHeader *)traceHeader
+    tracePropagationTargets:(NSArray *)tracePropagationTargets
+                  toRequest:(NSURLSessionTask *)sessionTask;
 
 + (BOOL)isTargetMatch:(NSURL *)URL withTargets:(NSArray *)targets;
 


### PR DESCRIPTION
## :scroll: Description

Refactored `SentryTracePropagation` to accept `tracePropagationTargets` as a parameter instead of directly accessing it from `SentrySDKInternal.options`. This removes the dependency on `SentrySDK+Private.h` in the trace propagation module.

## :bulb: Motivation and Context

This change improves the architecture by reducing direct dependencies on the SDK internals. By passing the `tracePropagationTargets` as a parameter, the trace propagation functionality becomes more modular and easier to test.

#skip-changelog


Closes #6355