### PR TITLE
chore: Remove more codable v9 checks

### DIFF
--- a/Sources/Sentry/Public/SentryThread.h
+++ b/Sources/Sentry/Public/SentryThread.h
@@ -20,19 +20,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 SENTRY_NO_INIT
 
-#if SDK_V9
 /**
  * Number of the thread.
  *
  * Can be nil for threads in recrash reports where the thread index information is not available.
  */
 @property (nullable, nonatomic, copy) NSNumber *threadId;
-#else
-/**
- * Number of the thread
- */
-@property (nonatomic, copy) NSNumber *threadId;
-#endif // SDK_V9
 
 /**
  * Name (if available) of the thread
@@ -59,21 +52,12 @@ SENTRY_NO_INIT
  */
 @property (nullable, nonatomic, copy) NSNumber *isMain;
 
-#if SDK_V9
 /**
  * Initializes a SentryThread with its id
  * @param threadId NSNumber or nil if thread index is not available (e.g., recrash reports)
  * @return SentryThread
  */
 - (instancetype)initWithThreadId:(nullable NSNumber *)threadId;
-#else
-/**
- * Initializes a SentryThread with its id
- * @param threadId NSNumber
- * @return SentryThread
- */
-- (instancetype)initWithThreadId:(NSNumber *)threadId;
-#endif // SDK_V9
 
 @end
 

--- a/Sources/Sentry/SentryBreadcrumb.m
+++ b/Sources/Sentry/SentryBreadcrumb.m
@@ -77,7 +77,7 @@
 {
     if (other == self)
         return YES;
-    if (!other || ![[other class] isEqual:[self class]])
+    if (!other || ![other isKindOfClass:[SentryBreadcrumb class]])
         return NO;
 
     return [self isEqualToBreadcrumb:SENTRY_UNWRAP_NULLABLE(SentryBreadcrumb, other)];

--- a/Sources/Sentry/SentryGeo.m
+++ b/Sources/Sentry/SentryGeo.m
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
     if (other == self) {
         return YES;
     }
-    if (!other || ![[other class] isEqual:[self class]]) {
+    if (!other || ![other isKindOfClass:[SentryGeo class]]) {
         return NO;
     }
 

--- a/Sources/Sentry/SentryThread.mm
+++ b/Sources/Sentry/SentryThread.mm
@@ -12,11 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation SentryThread
 
-#if SDK_V9
 - (instancetype)initWithThreadId:(nullable NSNumber *)threadId
-#else
-- (instancetype)initWithThreadId:(NSNumber *)threadId
-#endif // SDK_V9
 {
     self = [super init];
     if (self) {

--- a/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryBreadcrumbCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class BreadcrumbDecodable: Breadcrumb {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias BreadcrumbDecodable = Breadcrumb
-#endif
+
 extension BreadcrumbDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -21,12 +18,6 @@ extension BreadcrumbDecodable: Decodable {
         case data
         case origin
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventCodable.swift
@@ -16,16 +16,6 @@ import Foundation
  * overridden. Therefore, we add the Decodable implementation not on the Event, but to a subclass of
  * the event.
  */
-#if !SDK_V9
-@objc(SentryEventDecodable)
-open class SentryEventDecodable: Event, Decodable {
-    required convenience public init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.init()
-        try writePropertiesFrom(container: container)
-    }
-}
-#else
 final class SentryEventDecodable: Event, Decodable {
     required convenience public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
@@ -33,7 +23,6 @@ final class SentryEventDecodable: Event, Decodable {
         try writePropertiesFrom(container: container)
     }
 }
-#endif
 
 extension SentryEventDecodable {
     private enum CodingKeys: String, CodingKey {

--- a/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryExceptionCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class ExceptionDecodable: Exception {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias ExceptionDecodable = Exception
-#endif
+
 extension ExceptionDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -20,12 +17,6 @@ extension ExceptionDecodable: Decodable {
         case threadId = "thread_id"
         case stacktrace   
     }
-
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryFrameCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class FrameDecodable: Frame {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias FrameDecodable = Frame
-#endif
+
 extension FrameDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
@@ -34,12 +31,6 @@ extension FrameDecodable: Decodable {
         case inApp = "in_app"
         case stackStart = "stack_start"
     }
-
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         self.init()

--- a/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryGeoCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class GeoDecodable: Geo {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias GeoDecodable = Geo
-#endif
+
 extension GeoDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -17,12 +14,6 @@ extension GeoDecodable: Decodable {
         case countryCode = "country_code"
         case region
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class MechanismDecodable: Mechanism {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias MechanismDecodable = Mechanism
-#endif
+
 extension MechanismDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
@@ -21,12 +18,6 @@ extension MechanismDecodable: Decodable {
         case helpLink = "help_link"
         case meta
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMechanismMetaCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class MechanismMetaDecodable: MechanismMeta {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias MechanismMetaDecodable = MechanismMeta
-#endif
+
 extension MechanismMetaDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
@@ -17,12 +14,6 @@ extension MechanismMetaDecodable: Decodable {
         case machException = "mach_exception"
         case error = "ns_error"
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         self.init()

--- a/Sources/Swift/Protocol/Codable/SentryMessage.swift
+++ b/Sources/Swift/Protocol/Codable/SentryMessage.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class SentryMessageDecodable: SentryMessage {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias SentryMessageDecodable = SentryMessage
-#endif
+
 extension SentryMessageDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -17,12 +14,6 @@ extension SentryMessageDecodable: Decodable {
         case message
         case params
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryNSErrorCodable.swift
@@ -1,27 +1,18 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class SentryNSErrorDecodable: SentryNSError {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias SentryNSErrorDecodable = SentryNSError
-#endif
+
 extension SentryNSErrorDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
         case domain
         case code
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryRequestCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class SentryRequestDecodable: SentryRequest {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias SentryRequestDecodable = SentryRequest
-#endif
+
 extension SentryRequestDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -21,12 +18,6 @@ extension SentryRequestDecodable: Decodable {
         case queryString = "query_string"
         case url
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryStacktraceCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class SentryStacktraceDecodable: SentryStacktrace {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias SentryStacktraceDecodable = SentryStacktrace
-#endif
+
 extension SentryStacktraceDecodable: Decodable {
 
     enum CodingKeys: String, CodingKey {
@@ -17,12 +14,6 @@ extension SentryStacktraceDecodable: Decodable {
         case registers
         case snapshot
     }
-    
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
+++ b/Sources/Swift/Protocol/Codable/SentryThreadCodable.swift
@@ -1,15 +1,12 @@
 @_implementationOnly import _SentryPrivate
 import Foundation
 
-#if SDK_V9
 final class SentryThreadDecodable: SentryThread {
     convenience public init(from decoder: any Decoder) throws {
         try self.init(decodedFrom: decoder)
     }
 }
-#else
-typealias SentryThreadDecodable = SentryThread
-#endif
+
 extension SentryThreadDecodable: Decodable {
     
     private enum CodingKeys: String, CodingKey {
@@ -20,12 +17,6 @@ extension SentryThreadDecodable: Decodable {
         case current
         case isMain = "main"
     }
-
-    #if !SDK_V9
-    required convenience public init(from decoder: any Decoder) throws {
-        try self.init(decodedFrom: decoder)
-    }
-    #endif
 
     private convenience init(decodedFrom decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)

--- a/Tests/SentryTests/Protocol/Codable/SentryCodableTests.swift
+++ b/Tests/SentryTests/Protocol/Codable/SentryCodableTests.swift
@@ -31,17 +31,17 @@ class SentryCodableTests: XCTestCase {
     }
     
     func testDecodeWithEmptyData_ReturnsNil() {
-        XCTAssertNil(decodeFromJSONData(jsonData: Data()) as Geo?)
+        XCTAssertNil(decodeFromJSONData(jsonData: Data()) as GeoDecodable?)
     }
     
     func testDecodeWithGarbageData_ReturnsNil() {
         let data = Data("garbage".utf8)
-        XCTAssertNil(decodeFromJSONData(jsonData: data) as Geo?)
+        XCTAssertNil(decodeFromJSONData(jsonData: data) as GeoDecodable?)
     }
     
     func testDecodeWithWrongJSON_ReturnsEmptyObject() {
         let wrongJSON = Data("{\"wrong\": \"json\"}".utf8)
-        let actual = decodeFromJSONData(jsonData: wrongJSON) as Geo?
+        let actual = decodeFromJSONData(jsonData: wrongJSON) as GeoDecodable?
         let expected = Geo()
         
         XCTAssertEqual(expected, actual)
@@ -49,7 +49,7 @@ class SentryCodableTests: XCTestCase {
     
     func testDecodeWithBrokenJSON_ReturnsNil() {
         let brokenJSON = Data("{\"broken\": \"json\"".utf8)
-        XCTAssertNil(decodeFromJSONData(jsonData: brokenJSON) as Geo?)
+        XCTAssertNil(decodeFromJSONData(jsonData: brokenJSON) as GeoDecodable?)
     }
 
 }

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -140,7 +140,7 @@ class SentryBreadcrumbTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Breadcrumb?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as BreadcrumbDecodable?)
         
         // Assert
         XCTAssertEqual(crumb.level, decoded.level)
@@ -164,7 +164,7 @@ class SentryBreadcrumbTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Breadcrumb?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as BreadcrumbDecodable?)
         
         // Assert
         XCTAssertEqual(crumb, decoded)

--- a/Tests/SentryTests/Protocol/SentryDebugMetaTests.swift
+++ b/Tests/SentryTests/Protocol/SentryDebugMetaTests.swift
@@ -28,7 +28,7 @@ class SentryDebugMetaTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as DebugMeta?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as DebugMetaDecodable?)
 
         // Assert
         XCTAssertEqual(debugMeta.uuid, decoded.uuid)
@@ -48,7 +48,7 @@ class SentryDebugMetaTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as DebugMeta?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as DebugMetaDecodable?)
 
         // Assert
         XCTAssertNil(decoded.uuid)
@@ -69,7 +69,7 @@ class SentryDebugMetaTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as DebugMeta?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as DebugMetaDecodable?)
 
         // Assert
         XCTAssertEqual(debugMeta.uuid, decoded.uuid)

--- a/Tests/SentryTests/Protocol/SentryExceptionTests.swift
+++ b/Tests/SentryTests/Protocol/SentryExceptionTests.swift
@@ -33,7 +33,7 @@ class SentryExceptionTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
 
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Exception?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as ExceptionDecodable?)
 
         // Assert
         XCTAssertEqual(exception.type, decoded.type)
@@ -60,7 +60,7 @@ class SentryExceptionTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
 
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Exception?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as ExceptionDecodable?)
 
         // Assert
         XCTAssertEqual(exception.type, decoded.type)

--- a/Tests/SentryTests/Protocol/SentryFrameTests.swift
+++ b/Tests/SentryTests/Protocol/SentryFrameTests.swift
@@ -61,7 +61,7 @@ class SentryFrameTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: frame.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Frame?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as FrameDecodable?)
         
         // Assert
         XCTAssertEqual(frame.symbolAddress, decoded.symbolAddress)
@@ -88,7 +88,7 @@ class SentryFrameTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: frame.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Frame?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as FrameDecodable?)
         
         // Assert
         XCTAssertEqual(frame.symbolAddress, decoded.symbolAddress)
@@ -115,7 +115,7 @@ class SentryFrameTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: frame.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Frame?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as FrameDecodable?)
         
         // Assert
         XCTAssertNil(decoded.symbolAddress)

--- a/Tests/SentryTests/Protocol/SentryGeoTests.swift
+++ b/Tests/SentryTests/Protocol/SentryGeoTests.swift
@@ -43,7 +43,7 @@ class SentryGeoTests: XCTestCase {
         let actual = geo.serialize()
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
-        let decoded = decodeFromJSONData(jsonData: data) as Geo?
+        let decoded = decodeFromJSONData(jsonData: data) as GeoDecodable?
         
         XCTAssertEqual(geo, decoded)
     }
@@ -53,7 +53,7 @@ class SentryGeoTests: XCTestCase {
         let actual = geo.serialize()
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
-        let decoded = decodeFromJSONData(jsonData: data) as Geo?
+        let decoded = decodeFromJSONData(jsonData: data) as GeoDecodable?
         
         XCTAssertEqual(geo, decoded)
     }

--- a/Tests/SentryTests/Protocol/SentryMechanismMetaTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismMetaTests.swift
@@ -49,7 +49,7 @@ class SentryMechanismMetaTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: sut.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as MechanismMeta?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as MechanismMetaDecodable?)
         
         // Assert
         try assertSignal(actual: decoded.signal, expected: sut.signal)
@@ -67,7 +67,7 @@ class SentryMechanismMetaTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: sut.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as MechanismMeta?)   
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as MechanismMetaDecodable?)
 
         // Assert
         XCTAssertNil(decoded.signal)

--- a/Tests/SentryTests/Protocol/SentryMechanismTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMechanismTests.swift
@@ -51,7 +51,7 @@ class SentryMechanismTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: expected.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Mechanism?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as MechanismDecodable?)
         
         // Assert
         XCTAssertEqual(expected.type, decoded.type)
@@ -70,7 +70,7 @@ class SentryMechanismTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: expected.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as Mechanism?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as MechanismDecodable?)
         
         // Assert
         XCTAssertEqual(expected.type, decoded.type)

--- a/Tests/SentryTests/Protocol/SentryMessageTests.swift
+++ b/Tests/SentryTests/Protocol/SentryMessageTests.swift
@@ -84,7 +84,7 @@ class SentryMessageTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryMessage?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryMessageDecodable?)
         
         // Assert
         XCTAssertEqual(message.formatted, decoded.formatted)
@@ -101,7 +101,7 @@ class SentryMessageTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
 
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryMessage?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryMessageDecodable?)
 
         // Assert
         XCTAssertEqual(message.formatted, decoded.formatted)

--- a/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
+++ b/Tests/SentryTests/Protocol/SentryNSErrorTests.swift
@@ -18,7 +18,7 @@ class SentryNSErrorTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: error.serialize()))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryNSError?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryNSErrorDecodable?)
         
         // Assert
         XCTAssertEqual(error.code, decoded.code)
@@ -33,7 +33,7 @@ class SentryNSErrorTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: serialized))
         
         // Act & Assert
-        XCTAssertNil(decodeFromJSONData(jsonData: data) as SentryNSError?)
+        XCTAssertNil(decodeFromJSONData(jsonData: data) as SentryNSErrorDecodable?)
     }
 
     func testSerializeWithUnderlyingNSError() {

--- a/Tests/SentryTests/Protocol/SentryRequestTests.swift
+++ b/Tests/SentryTests/Protocol/SentryRequestTests.swift
@@ -42,7 +42,7 @@ class SentryRequestTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryRequest?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryRequestDecodable?)
         
         // Assert
         XCTAssertEqual(request.bodySize, decoded.bodySize)
@@ -61,7 +61,7 @@ class SentryRequestTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryRequest?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryRequestDecodable?)
         
         // Assert
         XCTAssertNil(decoded.bodySize)
@@ -81,7 +81,7 @@ class SentryRequestTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
 
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryRequest?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryRequestDecodable?)
 
         // Assert
         XCTAssertEqual(request.bodySize, decoded.bodySize)

--- a/Tests/SentryTests/Protocol/SentryStacktraceTests.swift
+++ b/Tests/SentryTests/Protocol/SentryStacktraceTests.swift
@@ -45,7 +45,7 @@ class SentryStacktraceTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: serialized))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktrace?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktraceDecodable?)
         
         // Assert
         XCTAssertEqual(stacktrace.frames.count, decoded.frames.count)
@@ -61,7 +61,7 @@ class SentryStacktraceTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: serialized))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktrace?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktraceDecodable?)
         
         // Assert
         XCTAssertEqual(stacktrace.frames.count, decoded.frames.count)
@@ -77,7 +77,7 @@ class SentryStacktraceTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: serialized))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktrace?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktraceDecodable?)
         
         // Assert
         XCTAssertEqual(stacktrace.frames.count, decoded.frames.count)
@@ -93,7 +93,7 @@ class SentryStacktraceTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: serialized))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktrace?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryStacktraceDecodable?)
         
         // Assert
         XCTAssertEqual(stacktrace.frames.count, decoded.frames.count)

--- a/Tests/SentryTests/Protocol/SentryThreadTests.swift
+++ b/Tests/SentryTests/Protocol/SentryThreadTests.swift
@@ -43,7 +43,7 @@ class SentryThreadTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryThread?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryThreadDecodable?)
         
         // Assert
         XCTAssertEqual(thread.threadId, decoded.threadId)
@@ -66,7 +66,7 @@ class SentryThreadTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act
-        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryThread?)
+        let decoded = try XCTUnwrap(decodeFromJSONData(jsonData: data) as SentryThreadDecodable?)
         
         // Assert
         XCTAssertEqual(thread.threadId, decoded.threadId)
@@ -85,7 +85,7 @@ class SentryThreadTests: XCTestCase {
         let data = try XCTUnwrap(SentrySerializationSwift.data(withJSONObject: actual))
         
         // Act & Assert
-        XCTAssertNil(decodeFromJSONData(jsonData: data) as SentryThread?)
+        XCTAssertNil(decodeFromJSONData(jsonData: data) as SentryThreadDecodable?)
     }
     
 }


### PR DESCRIPTION
Removing the SDK_V9 checks here. This is already in the changelog from my previous PR

#skip-changelog

Closes #6364