### PR TITLE
ref: Use final when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking Changes
 
+- Moves `SentryEventDecoder` to SPI (#6365)
+- Makes `PreviewRedactOptions`, `SentryProfileOptions`, `SentryRedactViewHelper`, `SentryViewScreenshotOptions`, `SentryReplayOptions`, `SentryUserFeedbackConfiguration`, `SentryUserFeedbackFormConfiguration`, `SentryUserFeedbackThemeConfiguration`, `SentryUserFeedbackWidgetConfiguration`, `SentryFeedback`, and `SentryExperimentalOptions` `final` (#6365)
 - Removes Decodable conformances from the public API of model classes (#5691)
 - Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)
 - Removes `enablePerformanceV2` option and makes this the default. The app start duration will now finish when the first frame is drawn instead of when the OS posts the UIWindowDidBecomeVisibleNotification. (#6008)

--- a/Sources/SentrySwiftUI/Preview/PreviewRedactOptions.swift
+++ b/Sources/SentrySwiftUI/Preview/PreviewRedactOptions.swift
@@ -6,7 +6,7 @@ import Sentry
  *
  * - Note: See ``SentryReplayOptions.DefaultValues`` for the default values of each parameter.
  */
-public class PreviewRedactOptions: SentryRedactOptions {
+public final class PreviewRedactOptions: SentryRedactOptions {
     /**
      * Flag to redact all text in the app by drawing a rectangle over it.
      *

--- a/Sources/Swift/Core/Integrations/Performance/SentryProfileOptions.swift
+++ b/Sources/Swift/Core/Integrations/Performance/SentryProfileOptions.swift
@@ -9,7 +9,7 @@ import Foundation
 /// will have no effect, nor will `SentrySDK.startProfiler()` or `SentrySDK.stopProfiler()`.
 /// - note: Profiling is automatically disabled if a thread sanitizer is attached.
 @objcMembers
-public class SentryProfileOptions: NSObject {
+public final class SentryProfileOptions: NSObject {
     /// Different modes for starting and stopping the profiler.
     @objc public enum SentryProfileLifecycle: Int {
         /// Profiling is controlled manually, and is independent of transactions & spans. Developers

--- a/Sources/Swift/Core/Tools/ViewCapture/SentryRedactViewHelper.swift
+++ b/Sources/Swift/Core/Tools/ViewCapture/SentryRedactViewHelper.swift
@@ -8,7 +8,7 @@ import WebKit
 #endif
 
 @objcMembers
-public class SentryRedactViewHelper: NSObject {
+public final class SentryRedactViewHelper: NSObject {
     private static var associatedRedactObjectHandle: UInt8 = 0
     private static var associatedIgnoreObjectHandle: UInt8 = 0
     private static var associatedClipOutObjectHandle: UInt8 = 0

--- a/Sources/Swift/Integrations/Screenshot/SentryScreenshotOptions.swift
+++ b/Sources/Swift/Integrations/Screenshot/SentryScreenshotOptions.swift
@@ -1,13 +1,13 @@
 import Foundation
 
 @objcMembers
-public class SentryViewScreenshotOptions: NSObject, SentryRedactOptions {
+public final class SentryViewScreenshotOptions: NSObject, SentryRedactOptions {
     /**
      * Default values for the screenshot options.
      *
      * - Note: These values are used to ensure the different initializers use the same default values.
      */
-    public class DefaultValues {
+    public final class DefaultValues {
         public static let enableViewRendererV2: Bool = true
         public static let enableFastViewRendering: Bool = false
         

--- a/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentryReplayOptions.swift
@@ -2,13 +2,13 @@
 import Foundation
 
 @objcMembers
-public class SentryReplayOptions: NSObject, SentryRedactOptions {
+public final class SentryReplayOptions: NSObject, SentryRedactOptions {
     /**
      * Default values for the session replay options.
      *
      * - Note: These values are used to ensure the different initializers use the same default values.
      */
-    public class DefaultValues {
+    public final class DefaultValues {
         public static let sessionSampleRate: Float = 0
         public static let onErrorSampleRate: Float = 0
         public static let maskAllText: Bool = true

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackConfiguration.swift
@@ -8,7 +8,7 @@ import UIKit
  */
 @available(iOS 13.0, *)
 @objcMembers
-public class SentryUserFeedbackConfiguration: NSObject {
+public final class SentryUserFeedbackConfiguration: NSObject {
     /**
      * Whether or not to show animations, like for presenting and dismissing the form.
      * - note: Default: `true`.

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackFormConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackFormConfiguration.swift
@@ -7,7 +7,7 @@ import UIKit
  */
 @available(iOS 13.0, *)
 @objcMembers
-public class SentryUserFeedbackFormConfiguration: NSObject {
+public final class SentryUserFeedbackFormConfiguration: NSObject {
     // MARK: General settings
     
     /**

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackThemeConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackThemeConfiguration.swift
@@ -7,7 +7,7 @@ import UIKit
  */
 @available(iOS 13.0, *)
 @objcMembers
-public class SentryUserFeedbackThemeConfiguration: NSObject {
+public final class SentryUserFeedbackThemeConfiguration: NSObject {
     /**
      * The font family to use for form text elements.
      * - note: Defaults to the system default, if this property is `nil`.
@@ -93,7 +93,7 @@ public class SentryUserFeedbackThemeConfiguration: NSObject {
      */
     public var errorColor = UIScreen.main.traitCollection.userInterfaceStyle == .dark ? UIColor(red: 245 / 255, green: 84 / 255, blue: 89 / 255, alpha: 1) : UIColor(red: 223 / 255, green: 51 / 255, blue: 56 / 255, alpha: 1)
     
-    @objc public class SentryFormElementOutlineStyle: NSObject {
+    @objc public final class SentryFormElementOutlineStyle: NSObject {
         /**
          * Outline color for form inputs.
          * - note: Default: The system default of a UITextField outline with borderStyle of .roundedRect.

--- a/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
+++ b/Sources/Swift/Integrations/UserFeedback/Configuration/SentryUserFeedbackWidgetConfiguration.swift
@@ -7,7 +7,7 @@ import UIKit
  */
 @available(iOS 13.0, *)
 @objcMembers
-public class SentryUserFeedbackWidgetConfiguration: NSObject {
+public final class SentryUserFeedbackWidgetConfiguration: NSObject {
     /**
      * Automatically inject the widget button into the application UI.
      * - note: Default: `true`

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 @objcMembers
-public class SentryFeedback: NSObject {
+public final class SentryFeedback: NSObject {
     @objc public enum SentryFeedbackSource: Int {
         public var serialize: String {
             switch self {

--- a/Sources/Swift/Protocol/Codable/SentryEventDecoder.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventDecoder.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 @objcMembers
-public class SentryEventDecoder: NSObject {
-    @_spi(Private) public static func decodeEvent(jsonData: Data) -> Event? {
+@_spi(Private) public class SentryEventDecoder: NSObject {
+    public static func decodeEvent(jsonData: Data) -> Event? {
         return decodeFromJSONData(jsonData: jsonData) as SentryEventDecodable?
     }
 }

--- a/Sources/Swift/SentryExperimentalOptions.swift
+++ b/Sources/Swift/SentryExperimentalOptions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 @objcMembers
-public class SentryExperimentalOptions: NSObject {
+public final class SentryExperimentalOptions: NSObject {
     /**
      * Enables swizzling of`NSData` to automatically track file operations.
      *

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -40911,6 +40911,9 @@
             "usr": "s:6Sentry0A21ViewScreenshotOptionsC13DefaultValuesC",
             "mangledName": "$s6Sentry0A21ViewScreenshotOptionsC13DefaultValuesC",
             "moduleName": "Sentry",
+            "declAttributes": [
+              "Final"
+            ],
             "hasMissingDesignatedInitializers": true,
             "conformances": [
               {
@@ -40946,6 +40949,7 @@
             "mangledName": "$s6Sentry0A21ViewScreenshotOptionsC06enableB10RendererV2Sbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -40969,6 +40973,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -40996,6 +41001,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -41019,6 +41025,7 @@
             "mangledName": "$s6Sentry0A21ViewScreenshotOptionsC010enableFastB9RenderingSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -41042,6 +41049,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -41069,6 +41077,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -41094,6 +41103,7 @@
             "objc_name": "maskAllImages",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -41117,6 +41127,7 @@
                 "implicit": true,
                 "objc_name": "maskAllImages",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -41144,6 +41155,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -41169,6 +41181,7 @@
             "objc_name": "maskAllText",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -41192,6 +41205,7 @@
                 "implicit": true,
                 "objc_name": "maskAllText",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -41219,6 +41233,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -41279,6 +41294,7 @@
             "objc_name": "maskedViewClasses",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -41337,6 +41353,7 @@
                 "implicit": true,
                 "objc_name": "maskedViewClasses",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -41399,6 +41416,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -41459,6 +41477,7 @@
             "objc_name": "unmaskedViewClasses",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -41517,6 +41536,7 @@
                 "implicit": true,
                 "objc_name": "unmaskedViewClasses",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -41579,6 +41599,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -41764,7 +41785,7 @@
             "objc_name": "description",
             "declAttributes": [
               "ObjC",
-              "Dynamic",
+              "Final",
               "Override"
             ],
             "accessors": [
@@ -41787,7 +41808,7 @@
                 "overriding": true,
                 "objc_name": "description",
                 "declAttributes": [
-                  "Dynamic",
+                  "Final",
                   "ObjC",
                   "Override"
                 ],
@@ -41801,6 +41822,7 @@
         "mangledName": "$s6Sentry0A21ViewScreenshotOptionsC",
         "moduleName": "Sentry",
         "declAttributes": [
+          "Final",
           "ObjCMembers",
           "ObjC"
         ],
@@ -42263,6 +42285,7 @@
         "mangledName": "$s6Sentry0A8FeedbackC",
         "moduleName": "Sentry",
         "declAttributes": [
+          "Final",
           "ObjCMembers",
           "ObjC"
         ],
@@ -45697,6 +45720,9 @@
             "usr": "s:6Sentry0A13ReplayOptionsC13DefaultValuesC",
             "mangledName": "$s6Sentry0A13ReplayOptionsC13DefaultValuesC",
             "moduleName": "Sentry",
+            "declAttributes": [
+              "Final"
+            ],
             "hasMissingDesignatedInitializers": true,
             "conformances": [
               {
@@ -46056,6 +46082,7 @@
             "mangledName": "$s6Sentry0A13ReplayOptionsC17sessionSampleRateSfvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -46079,6 +46106,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46106,6 +46134,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46129,6 +46158,7 @@
             "mangledName": "$s6Sentry0A13ReplayOptionsC17onErrorSampleRateSfvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -46152,6 +46182,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46179,6 +46210,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46204,6 +46236,7 @@
             "objc_name": "maskAllText",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -46227,6 +46260,7 @@
                 "implicit": true,
                 "objc_name": "maskAllText",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46254,6 +46288,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46279,6 +46314,7 @@
             "objc_name": "maskAllImages",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -46302,6 +46338,7 @@
                 "implicit": true,
                 "objc_name": "maskAllImages",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46329,6 +46366,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46352,6 +46390,7 @@
             "mangledName": "$s6Sentry0A13ReplayOptionsC7qualityAC0aB7QualityOvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -46375,6 +46414,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46402,6 +46442,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46462,6 +46503,7 @@
             "objc_name": "maskedViewClasses",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -46520,6 +46562,7 @@
                 "implicit": true,
                 "objc_name": "maskedViewClasses",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46582,6 +46625,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46642,6 +46686,7 @@
             "objc_name": "unmaskedViewClasses",
             "declAttributes": [
               "ObjC",
+              "Final",
               "HasStorage"
             ],
             "hasStorage": true,
@@ -46700,6 +46745,7 @@
                 "implicit": true,
                 "objc_name": "unmaskedViewClasses",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46762,6 +46808,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46786,6 +46833,7 @@
             "moduleName": "Sentry",
             "deprecated": true,
             "declAttributes": [
+              "Final",
               "Available",
               "ObjC"
             ],
@@ -46807,6 +46855,7 @@
                 "mangledName": "$s6Sentry0A13ReplayOptionsC30enableExperimentalViewRendererSbvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46834,6 +46883,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setEnableExperimentalViewRenderer:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46857,6 +46907,7 @@
             "mangledName": "$s6Sentry0A13ReplayOptionsC20enableViewRendererV2Sbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -46880,6 +46931,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46907,6 +46959,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -46930,6 +46983,7 @@
             "mangledName": "$s6Sentry0A13ReplayOptionsC23enableFastViewRenderingSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -46953,6 +47007,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -46980,6 +47035,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47081,6 +47137,7 @@
         "mangledName": "$s6Sentry0A13ReplayOptionsC",
         "moduleName": "Sentry",
         "declAttributes": [
+          "Final",
           "ObjCMembers",
           "ObjC"
         ],
@@ -47098,108 +47155,6 @@
             "usr": "c:@M@Sentry@objc(pl)SentryRedactOptions",
             "mangledName": "$s6Sentry0A13RedactOptionsP"
           },
-          {
-            "kind": "Conformance",
-            "name": "Copyable",
-            "printedName": "Copyable",
-            "usr": "s:s8CopyableP",
-            "mangledName": "$ss8CopyableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Escapable",
-            "printedName": "Escapable",
-            "usr": "s:s9EscapableP",
-            "mangledName": "$ss9EscapableP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "NSObjectProtocol",
-            "printedName": "NSObjectProtocol",
-            "usr": "c:objc(pl)NSObject"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Equatable",
-            "printedName": "Equatable",
-            "usr": "s:SQ",
-            "mangledName": "$sSQ"
-          },
-          {
-            "kind": "Conformance",
-            "name": "Hashable",
-            "printedName": "Hashable",
-            "usr": "s:SH",
-            "mangledName": "$sSH"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CVarArg",
-            "printedName": "CVarArg",
-            "usr": "s:s7CVarArgP",
-            "mangledName": "$ss7CVarArgP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomStringConvertible",
-            "printedName": "CustomStringConvertible",
-            "usr": "s:s23CustomStringConvertibleP",
-            "mangledName": "$ss23CustomStringConvertibleP"
-          },
-          {
-            "kind": "Conformance",
-            "name": "CustomDebugStringConvertible",
-            "printedName": "CustomDebugStringConvertible",
-            "usr": "s:s28CustomDebugStringConvertibleP",
-            "mangledName": "$ss28CustomDebugStringConvertibleP"
-          }
-        ]
-      },
-      {
-        "kind": "TypeDecl",
-        "name": "SentryEventDecoder",
-        "printedName": "SentryEventDecoder",
-        "children": [
-          {
-            "kind": "Constructor",
-            "name": "init",
-            "printedName": "init()",
-            "children": [
-              {
-                "kind": "TypeNominal",
-                "name": "SentryEventDecoder",
-                "printedName": "Sentry.SentryEventDecoder",
-                "usr": "c:@M@Sentry@objc(cs)SentryEventDecoder"
-              }
-            ],
-            "declKind": "Constructor",
-            "usr": "c:@M@Sentry@objc(cs)SentryEventDecoder(im)init",
-            "mangledName": "$s6Sentry0A12EventDecoderCACycfc",
-            "moduleName": "Sentry",
-            "overriding": true,
-            "objc_name": "init",
-            "declAttributes": [
-              "ObjC",
-              "Dynamic",
-              "Override"
-            ],
-            "init_kind": "Designated"
-          }
-        ],
-        "declKind": "Class",
-        "usr": "c:@M@Sentry@objc(cs)SentryEventDecoder",
-        "mangledName": "$s6Sentry0A12EventDecoderC",
-        "moduleName": "Sentry",
-        "declAttributes": [
-          "ObjCMembers",
-          "ObjC"
-        ],
-        "superclassUsr": "c:objc(cs)NSObject",
-        "inheritsConvenienceInitializers": true,
-        "superclassNames": [
-          "ObjectiveC.NSObject"
-        ],
-        "conformances": [
           {
             "kind": "Conformance",
             "name": "Copyable",
@@ -47279,6 +47234,7 @@
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC10animationsSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47302,6 +47258,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -47329,6 +47286,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47380,6 +47338,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47430,6 +47389,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -47484,6 +47444,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47507,6 +47468,7 @@
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC15useShakeGestureSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47530,6 +47492,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -47557,6 +47520,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47580,6 +47544,7 @@
             "mangledName": "$s6Sentry0A25UserFeedbackConfigurationC22showFormForScreenshotsSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47603,6 +47568,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -47630,6 +47596,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47662,6 +47629,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47693,6 +47661,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -47728,6 +47697,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47779,6 +47749,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47829,6 +47800,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -47883,6 +47855,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -47928,6 +47901,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -47972,6 +47946,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48020,6 +47995,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -48070,6 +48046,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -48119,6 +48096,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48172,6 +48150,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -48222,6 +48201,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -48271,6 +48251,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48324,6 +48305,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -48388,6 +48370,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -48451,6 +48434,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48518,6 +48502,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -48569,6 +48554,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -48619,6 +48605,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48673,6 +48660,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -48724,6 +48712,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -48774,6 +48763,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48828,6 +48818,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -48879,6 +48870,7 @@
             "moduleName": "Sentry",
             "declAttributes": [
               "HasInitialValue",
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -48929,6 +48921,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -48983,6 +48976,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -49022,6 +49016,7 @@
         "intro_iOS": "13.0",
         "declAttributes": [
           "Available",
+          "Final",
           "ObjCMembers",
           "Available",
           "ObjC"
@@ -49351,6 +49346,7 @@
             "mangledName": "$s6Sentry0A14ProfileOptionsC9lifecycleAC0aB9LifecycleOvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -49374,6 +49370,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -49401,6 +49398,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -49424,6 +49422,7 @@
             "mangledName": "$s6Sentry0A14ProfileOptionsC17sessionSampleRateSfvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -49447,6 +49446,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -49474,6 +49474,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -49497,6 +49498,7 @@
             "mangledName": "$s6Sentry0A14ProfileOptionsC16profileAppStartsSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -49520,6 +49522,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -49547,6 +49550,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -49584,6 +49588,7 @@
         "mangledName": "$s6Sentry0A14ProfileOptionsC",
         "moduleName": "Sentry",
         "declAttributes": [
+          "Final",
           "ObjCMembers",
           "ObjC"
         ],
@@ -51775,6 +51780,7 @@
         "mangledName": "$s6Sentry0A16RedactViewHelperC",
         "moduleName": "Sentry",
         "declAttributes": [
+          "Final",
           "ObjCMembers",
           "ObjC"
         ],
@@ -53165,6 +53171,7 @@
             "mangledName": "$s6Sentry0A19ExperimentalOptionsC19enableDataSwizzlingSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53188,6 +53195,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53215,6 +53223,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53238,6 +53247,7 @@
             "mangledName": "$s6Sentry0A19ExperimentalOptionsC26enableFileManagerSwizzlingSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53261,6 +53271,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53288,6 +53299,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53311,6 +53323,7 @@
             "mangledName": "$s6Sentry0A19ExperimentalOptionsC30enableUnhandledCPPExceptionsV2Sbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53334,6 +53347,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53361,6 +53375,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53384,6 +53399,7 @@
             "mangledName": "$s6Sentry0A19ExperimentalOptionsC10enableLogsSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53407,6 +53423,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53434,6 +53451,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53471,6 +53489,7 @@
         "mangledName": "$s6Sentry0A19ExperimentalOptionsC",
         "moduleName": "Sentry",
         "declAttributes": [
+          "Final",
           "ObjCMembers",
           "ObjC"
         ],
@@ -53567,6 +53586,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC10fontFamilySSSgvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -53595,6 +53615,7 @@
                 "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC10fontFamilySSSgvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53630,6 +53651,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setFontFamily:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53653,6 +53675,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC10foregroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53676,6 +53699,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53703,6 +53727,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53726,6 +53751,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC10backgroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53749,6 +53775,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53776,6 +53803,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53799,6 +53827,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC16submitForegroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53822,6 +53851,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53849,6 +53879,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53872,6 +53903,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC16submitBackgroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -53895,6 +53927,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53922,6 +53955,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -53945,6 +53979,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC16buttonForegroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -53965,6 +54000,7 @@
                 "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC16buttonForegroundSo7UIColorCvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -53992,6 +54028,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setButtonForeground:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54015,6 +54052,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC16buttonBackgroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -54038,6 +54076,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54065,6 +54104,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54088,6 +54128,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC10errorColorSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -54111,6 +54152,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54138,6 +54180,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54166,6 +54209,7 @@
                 "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC5colorSo7UIColorCvp",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "HasStorage"
                 ],
                 "hasStorage": true,
@@ -54187,6 +54231,9 @@
                     "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC5colorSo7UIColorCvg",
                     "moduleName": "Sentry",
                     "implicit": true,
+                    "declAttributes": [
+                      "Final"
+                    ],
                     "accessorKind": "get"
                   },
                   {
@@ -54211,6 +54258,9 @@
                     "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC5colorSo7UIColorCvs",
                     "moduleName": "Sentry",
                     "implicit": true,
+                    "declAttributes": [
+                      "Final"
+                    ],
                     "accessorKind": "set"
                   }
                 ]
@@ -54232,6 +54282,7 @@
                 "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC12cornerRadius12CoreGraphics7CGFloatVvp",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "HasStorage"
                 ],
                 "hasStorage": true,
@@ -54253,6 +54304,9 @@
                     "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC12cornerRadius12CoreGraphics7CGFloatVvg",
                     "moduleName": "Sentry",
                     "implicit": true,
+                    "declAttributes": [
+                      "Final"
+                    ],
                     "accessorKind": "get"
                   },
                   {
@@ -54277,6 +54331,9 @@
                     "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC12cornerRadius12CoreGraphics7CGFloatVvs",
                     "moduleName": "Sentry",
                     "implicit": true,
+                    "declAttributes": [
+                      "Final"
+                    ],
                     "accessorKind": "set"
                   }
                 ]
@@ -54298,6 +54355,7 @@
                 "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC12outlineWidth12CoreGraphics7CGFloatVvp",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "HasStorage"
                 ],
                 "hasStorage": true,
@@ -54319,6 +54377,9 @@
                     "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC12outlineWidth12CoreGraphics7CGFloatVvg",
                     "moduleName": "Sentry",
                     "implicit": true,
+                    "declAttributes": [
+                      "Final"
+                    ],
                     "accessorKind": "get"
                   },
                   {
@@ -54343,6 +54404,9 @@
                     "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC12outlineWidth12CoreGraphics7CGFloatVvs",
                     "moduleName": "Sentry",
                     "implicit": true,
+                    "declAttributes": [
+                      "Final"
+                    ],
                     "accessorKind": "set"
                   }
                 ]
@@ -54396,6 +54460,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC0A23FormElementOutlineStyleC",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "superclassUsr": "c:objc(cs)NSObject",
@@ -54477,6 +54542,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC12outlineStyleAC0a18FormElementOutlineG0Cvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -54497,6 +54563,7 @@
                 "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC12outlineStyleAC0a18FormElementOutlineG0Cvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54524,6 +54591,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setOutlineStyle:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54547,6 +54615,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC15inputBackgroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -54570,6 +54639,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54597,6 +54667,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54620,6 +54691,7 @@
             "mangledName": "$s6Sentry0A30UserFeedbackThemeConfigurationC15inputForegroundSo7UIColorCvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -54643,6 +54715,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54670,6 +54743,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54709,6 +54783,7 @@
         "intro_iOS": "13.0",
         "declAttributes": [
           "Available",
+          "Final",
           "ObjCMembers",
           "Available",
           "ObjC"
@@ -54798,6 +54873,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC10autoInjectSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -54821,6 +54897,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54848,6 +54925,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54879,6 +54957,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC9labelTextSSSgvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -54907,6 +54986,7 @@
                 "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC9labelTextSSSgvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -54942,6 +55022,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setLabelText:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -54965,6 +55046,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC8showIconSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -54988,6 +55070,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55015,6 +55098,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55046,6 +55130,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC24widgetAccessibilityLabelSSSgvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -55074,6 +55159,7 @@
                 "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC24widgetAccessibilityLabelSSSgvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55109,6 +55195,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setWidgetAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55132,6 +55219,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC11windowLevelSo08UIWindowG0avp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -55155,6 +55243,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55182,6 +55271,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55205,6 +55295,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC8locationSo21NSDirectionalRectEdgeVvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -55228,6 +55319,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55255,6 +55347,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55278,6 +55371,7 @@
             "mangledName": "$s6Sentry0A31UserFeedbackWidgetConfigurationC14layoutUIOffsetSo0G0Vvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -55301,6 +55395,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55328,6 +55423,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55367,6 +55463,7 @@
         "intro_iOS": "13.0",
         "declAttributes": [
           "Available",
+          "Final",
           "ObjCMembers",
           "Available",
           "ObjC"
@@ -55812,6 +55909,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC03useaB0Sbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -55835,6 +55933,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55862,6 +55961,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55885,6 +55985,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC12showBrandingSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -55908,6 +56009,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -55935,6 +56037,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -55958,6 +56061,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC9formTitleSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -55981,6 +56085,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56008,6 +56113,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56031,6 +56137,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC12messageLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56054,6 +56161,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56081,6 +56189,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56104,6 +56213,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC18messagePlaceholderSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56127,6 +56237,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56154,6 +56265,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56177,6 +56289,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC33messageTextViewAccessibilityLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -56197,6 +56310,7 @@
                 "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC33messageTextViewAccessibilityLabelSSvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56224,6 +56338,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setMessageTextViewAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56247,6 +56362,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC15isRequiredLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56270,6 +56386,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56297,6 +56414,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56320,6 +56438,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC27removeScreenshotButtonLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56343,6 +56462,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56370,6 +56490,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56393,6 +56514,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC40removeScreenshotButtonAccessibilityLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -56413,6 +56535,7 @@
                 "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC40removeScreenshotButtonAccessibilityLabelSSvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56440,6 +56563,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setRemoveScreenshotButtonAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56463,6 +56587,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC14isNameRequiredSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56486,6 +56611,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56513,6 +56639,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56536,6 +56663,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC8showNameSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56559,6 +56687,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56586,6 +56715,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56609,6 +56739,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC9nameLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56632,6 +56763,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56659,6 +56791,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56682,6 +56815,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC15namePlaceholderSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56705,6 +56839,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56732,6 +56867,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56755,6 +56891,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC31nameTextFieldAccessibilityLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -56775,6 +56912,7 @@
                 "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC31nameTextFieldAccessibilityLabelSSvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56802,6 +56940,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setNameTextFieldAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56825,6 +56964,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC15isEmailRequiredSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56848,6 +56988,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56875,6 +57016,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56898,6 +57040,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC9showEmailSbvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56921,6 +57064,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -56948,6 +57092,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -56971,6 +57116,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC10emailLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -56994,6 +57140,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57021,6 +57168,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57044,6 +57192,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC16emailPlaceholderSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -57067,6 +57216,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57094,6 +57244,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57117,6 +57268,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC32emailTextFieldAccessibilityLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -57137,6 +57289,7 @@
                 "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC32emailTextFieldAccessibilityLabelSSvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57164,6 +57317,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setEmailTextFieldAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57187,6 +57341,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC17submitButtonLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -57210,6 +57365,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57237,6 +57393,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57260,6 +57417,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC30submitButtonAccessibilityLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -57280,6 +57438,7 @@
                 "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC30submitButtonAccessibilityLabelSSvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57307,6 +57466,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setSubmitButtonAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57330,6 +57490,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC17cancelButtonLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC",
               "HasStorage"
             ],
@@ -57353,6 +57514,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57380,6 +57542,7 @@
                 "moduleName": "Sentry",
                 "implicit": true,
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57403,6 +57566,7 @@
             "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC30cancelButtonAccessibilityLabelSSvp",
             "moduleName": "Sentry",
             "declAttributes": [
+              "Final",
               "ObjC"
             ],
             "accessors": [
@@ -57423,6 +57587,7 @@
                 "mangledName": "$s6Sentry0A29UserFeedbackFormConfigurationC30cancelButtonAccessibilityLabelSSvg",
                 "moduleName": "Sentry",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "get"
@@ -57450,6 +57615,7 @@
                 "moduleName": "Sentry",
                 "objc_name": "setCancelButtonAccessibilityLabel:",
                 "declAttributes": [
+                  "Final",
                   "ObjC"
                 ],
                 "accessorKind": "set"
@@ -57489,6 +57655,7 @@
         "intro_iOS": "13.0",
         "declAttributes": [
           "Available",
+          "Final",
           "ObjCMembers",
           "Available",
           "ObjC"


### PR DESCRIPTION
Some v9 changes to add `final` and one case where `spi` was missing.

#skip-changelog

Closes #6366