### PR TITLE
test: Disable flaky test SentrySDKInternalTests.testResumeAndPauseAppHangTracking()

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -41,6 +41,7 @@
         "SentryProfilerSwiftTests\/testConcurrentSpansWithTimeout()",
         "SentryReachabilityTest\/testMultipleReachabilityObservers",
         "SentrySDKIntegrationTestsBase",
+        "SentrySDKInternalTests\/testResumeAndPauseAppHangTracking()",
         "SentrySDKTests\/testStartOnTheMainThread()",
         "SentrySessionGeneratorTests\/testSendSessions()",
         "SentrySubClassFinderTests\/testActOnSubclassesOfViewController()",


### PR DESCRIPTION
This test has been flaking on many pull requests

#skip-changelog