### PR TITLE
fix: Wrong Frame Delay when becoming active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - Fixes warnings about minimum OS version being lower than Xcode supported version (#5591)
 - Fix rendering method for fast view rendering (#6360)
+- Fix wrong Frame Delay when becoming active, which lead to false reported app hangs when the app moves to the foreground after being in the background (#6381)
 
 ## 8.56.2
 

--- a/Sources/Sentry/SentryDelayedFramesTracker.m
+++ b/Sources/Sentry/SentryDelayedFramesTracker.m
@@ -28,9 +28,20 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
         _keepDelayedFramesDuration = keepDelayedFramesDuration;
         _dateProvider = dateProvider;
-        [self resetDelayedFramesTimeStamps];
+        [self reset];
     }
     return self;
+}
+
+- (void)reset
+{
+    _delayedFrames = [NSMutableArray array];
+    _previousFrameSystemTimestamp = 0;
+    SentryDelayedFrame *initialFrame =
+        [[SentryDelayedFrame alloc] initWithStartTimestamp:[self.dateProvider systemTime]
+                                          expectedDuration:0
+                                            actualDuration:0];
+    [_delayedFrames addObject:initialFrame];
 }
 
 - (void)setPreviousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp
@@ -45,16 +56,6 @@ NS_ASSUME_NONNULL_BEGIN
     "thread.")
 {
     return _previousFrameSystemTimestamp;
-}
-
-- (void)resetDelayedFramesTimeStamps
-{
-    _delayedFrames = [NSMutableArray array];
-    SentryDelayedFrame *initialFrame =
-        [[SentryDelayedFrame alloc] initWithStartTimestamp:[self.dateProvider systemTime]
-                                          expectedDuration:0
-                                            actualDuration:0];
-    [_delayedFrames addObject:initialFrame];
 }
 
 - (void)recordDelayedFrame:(uint64_t)startSystemTimestamp

--- a/Sources/Sentry/SentryFramesTracker.m
+++ b/Sources/Sentry/SentryFramesTracker.m
@@ -104,7 +104,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     [self resetProfilingTimestampsInternal];
 #    endif // SENTRY_TARGET_PROFILING_SUPPORTED
 
-    [self.delayedFramesTracker resetDelayedFramesTimeStamps];
+    [self.delayedFramesTracker reset];
 }
 
 #    if SENTRY_TARGET_PROFILING_SUPPORTED
@@ -164,6 +164,7 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     }
 
     _isRunning = YES;
+
     // Reset the previous frame timestamp to avoid wrong metrics being collected
     self.previousFrameTimestamp = SentryPreviousFrameInitialValue;
     [_displayLinkWrapper linkWithTarget:self selector:@selector(displayLinkCallback)];
@@ -320,6 +321,11 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
 - (void)pause
 {
     _isRunning = NO;
+
+    // When the frames tracker is paused, we must reset the delayed frames tracker since accurate
+    // frame delay statistics cannot be provided, as we can't account for events during the pause.
+    [self.delayedFramesTracker reset];
+
     [self.displayLinkWrapper invalidate];
 }
 
@@ -332,7 +338,6 @@ slowFrameThreshold(uint64_t actualFramesPerSecond)
     _isStarted = NO;
 
     [self pause];
-    [self.delayedFramesTracker resetDelayedFramesTimeStamps];
 
     // Remove the observers with the most specific detail possible, see
     // https://developer.apple.com/documentation/foundation/nsnotificationcenter/1413994-removeobserver

--- a/Sources/Sentry/include/SentryDelayedFramesTracker.h
+++ b/Sources/Sentry/include/SentryDelayedFramesTracker.h
@@ -21,14 +21,14 @@ SENTRY_NO_INIT
 - (instancetype)initWithKeepDelayedFramesDuration:(CFTimeInterval)keepDelayedFramesDuration
                                      dateProvider:(id<SentryCurrentDateProvider>)dateProvider;
 
-- (void)resetDelayedFramesTimeStamps;
-
 - (void)recordDelayedFrame:(uint64_t)startSystemTimestamp
     thisFrameSystemTimestamp:(uint64_t)thisFrameSystemTimestamp
             expectedDuration:(CFTimeInterval)expectedDuration
               actualDuration:(CFTimeInterval)actualDuration;
 
 - (void)setPreviousFrameSystemTimestamp:(uint64_t)previousFrameSystemTimestamp;
+
+- (void)reset;
 
 /**
  * This method returns the duration of all delayed frames between startSystemTimestamp and


### PR DESCRIPTION
## :scroll: Description

The SDK reported false frame delay statistics when it moved from the background to the foreground, which also led to falsely reported app hangs.

After merging this PR, I'm going to open up the same PR to v8 and release a hotfix.

## :bulb: Motivation and Context

Fixes GH-6345

## :green_heart: How did you test it?

I failed to reproduce the exact problem the user described in GH-6345, and so did the user. I noticed that the SDK calculated wrong frame delay numbers when moving from the background to the foreground, so I added unit tests for these scenarios.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
