### PR TITLE
ref: Remove watchdog breadcrumb processor from dependency container

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -421,20 +421,10 @@ static BOOL isInitialializingDependencyContainer = NO;
     // This method is only a factory, therefore do not keep a reference.
     // The scope observer will be created each time it is needed.
     return [[SentryWatchdogTerminationScopeObserver alloc]
-        initWithBreadcrumbProcessor:
-            [self
-                getWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs:options.maxBreadcrumbs]
+        initWithBreadcrumbProcessor:[[SentryWatchdogTerminationBreadcrumbProcessor alloc]
+                                        initWithMaxBreadcrumbs:options.maxBreadcrumbs
+                                                   fileManager:self.fileManager]
                 attributesProcessor:self.watchdogTerminationAttributesProcessor];
-}
-
-- (SentryWatchdogTerminationBreadcrumbProcessor *)
-    getWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs:(NSInteger)maxBreadcrumbs
-{
-    // This method is only a factory, therefore do not keep a reference.
-    // The processor will be created each time it is needed.
-    return [[SentryWatchdogTerminationBreadcrumbProcessor alloc]
-        initWithMaxBreadcrumbs:maxBreadcrumbs
-                   fileManager:self.fileManager];
 }
 
 - (SentryWatchdogTerminationAttributesProcessor *)

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -47,7 +47,6 @@
 @class SentryUIViewControllerPerformanceTracker;
 @class SentryWatchdogTerminationScopeObserver;
 @class SentryWatchdogTerminationAttributesProcessor;
-@class SentryWatchdogTerminationBreadcrumbProcessor;
 #endif // SENTRY_UIKIT_AVAILABLE
 
 #if SENTRY_HAS_UIKIT
@@ -140,8 +139,6 @@ SENTRY_NO_INIT
 #if SENTRY_HAS_UIKIT
 - (SentryWatchdogTerminationScopeObserver *)getWatchdogTerminationScopeObserverWithOptions:
     (SentryOptions *)options;
-- (SentryWatchdogTerminationBreadcrumbProcessor *)
-    getWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs:(NSInteger)maxBreadcrumbs;
 @property (nonatomic, strong)
     SentryWatchdogTerminationAttributesProcessor *watchdogTerminationAttributesProcessor;
 #endif

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -146,7 +146,6 @@ final class SentryDependencyContainerTests: XCTestCase {
 #endif // os(iOS) || os(macOS)
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().getWatchdogTerminationBreadcrumbProcessor(withMaxBreadcrumbs: 10))
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().watchdogTerminationAttributesProcessor)
 #endif
 
@@ -176,50 +175,6 @@ final class SentryDependencyContainerTests: XCTestCase {
 
         // -- Assert --
         XCTAssertIdentical(scopePersistentStore1, scopePersistentStore2)
-    }
-
-    func testGetWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs_shouldReturnNewInstancePerCall() throws {
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-        // -- Arrange --
-        let options = Options()
-        options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
-
-        let container = SentryDependencyContainer.sharedInstance()
-
-        // -- Act --
-        let processor1 = container.getWatchdogTerminationBreadcrumbProcessor(withMaxBreadcrumbs: 10)
-        let processor2 = container.getWatchdogTerminationBreadcrumbProcessor(withMaxBreadcrumbs: 5)
-
-        // -- Assert --
-        XCTAssertNotIdentical(processor1, processor2)
-#else
-        throw XCTSkip("This test is only applicable for iOS, tvOS, and macOS platforms.")
-#endif
-    }
-
-    func testGetWatchdogTerminationBreadcrumbProcessorWithMaxBreadcrumbs_shouldUseParameters() throws {
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-        // -- Arrange --
-        let options = Options()
-        options.dsn = SentryDependencyContainerTests.dsn
-        SentrySDKInternal.setStart(with: options)
-
-        let container = SentryDependencyContainer.sharedInstance()
-
-        // -- Act --
-        let processor1 = container.getWatchdogTerminationBreadcrumbProcessor(withMaxBreadcrumbs: 10)
-        let processor2 = container.getWatchdogTerminationBreadcrumbProcessor(withMaxBreadcrumbs: 5)
-
-        // -- Assert --
-        // This assertion relys on internal implementation details of the processor.
-        // It is best practice not to rely on internal implementation details.
-        // There is no other way to test this, because the max breadcrumbs property is private.
-        XCTAssertEqual(Dynamic(processor1).maxBreadcrumbs, 10)
-        XCTAssertEqual(Dynamic(processor2).maxBreadcrumbs, 5)
-#else
-        throw XCTSkip("This test is only applicable for iOS, tvOS, and macOS platforms.")
-#endif
     }
 
     func testSentryWatchdogTerminationAttributesProcessor_shouldReturnSameInstance() throws {


### PR DESCRIPTION
Rather than converting this to Swift, I realized it's not actually used as part of the interface of the dependency container and can just be removed. So this will close https://linear.app/getsentry/issue/COCOA-715/convert-sentrywatchdogterminationbreadcrumbprocessor

#skip-changelog