### PR TITLE
chore(ci): Add timeout to UI tests

### DIFF
--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -58,6 +58,7 @@ jobs:
   common-ui-tests:
     name: UI Tests Common
     runs-on: ${{ inputs.macos_version }}
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Some tests have run for more than 2 hours: https://github.com/getsentry/sentry-cocoa/actions/runs/18385712036/job/52383740960

This will avoid the issue with a loose timeout

#skip-changelog

Closes #6392