### PR TITLE
ci(v8): Bump Xcode from 26.0 to 26.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,7 +266,7 @@ jobs:
           - name: iOS 26 Sentry
             runs-on: macos-26
             platform: "iOS"
-            xcode: "26.0"
+            xcode: "26.0.1"
             test-destination-os: "26.0"
             device: "iPhone 17 Pro"
             scheme: "Sentry"
@@ -295,7 +295,7 @@ jobs:
           - name: macOS 26 Sentry
             runs-on: macos-26
             platform: "macOS"
-            xcode: "26.0"
+            xcode: "26.0.1"
             test-destination-os: "26.0"
             scheme: "Sentry"
 
@@ -351,7 +351,7 @@ jobs:
           - name: tvOS 26 Sentry
             runs-on: macos-26
             platform: "tvOS"
-            xcode: "26.0"
+            xcode: "26.0.1"
             test-destination-os: "26.0"
             device: "Apple TV"
             scheme: "Sentry"

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -79,11 +79,11 @@ jobs:
         env:
           XCODE_VERSION: ${{ inputs.xcode_version }}
       - name: Install required platforms for Xcode 26
-        if: ${{ inputs.xcode_version == '26.0' }}
+        if: ${{ inputs.xcode_version == '26.0.1' }}
         run: ./scripts/ci-install-xOS-26-platforms.sh --platforms "${{inputs.platform}}"
 
       - name: Create simulator device for Xcode 26
-        if: ${{ inputs.xcode_version == '26.0' }}
+        if: ${{ inputs.xcode_version == '26.0.1' }}
         run: ./scripts/ci-create-simulator.sh --platform "${{inputs.platform}}" --os-version "${{inputs.test-destination-os}}" --device-name "${{inputs.device}}"
       - run: make init-ci-build
         if: ${{ inputs.build_with_make }}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -76,7 +76,7 @@ jobs:
           - name: iOS 26
             platform:
               runs-on: macos-15
-              xcode: "26.0"
+              xcode: "26.0.1"
               platform: "iOS"
               device: "iPhone 16 Pro"
               test-destination-os: "26.0"

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -98,7 +98,7 @@ jobs:
           - name: iOS 26
             runs-on: macos-15
             platform: "iOS"
-            xcode: "26.0"
+            xcode: "26.0.1"
             device: iPhone 16 Pro
             test-destination-os: "26.0"
     with:


### PR DESCRIPTION
CI on v8 fails with 
```
Run ./scripts/ci-select-xcode.sh 26.0
Available Xcode versions:
1) 16.4 (16F6)
2) 26.0.1 (17A400) (Selected)
3) 26.1 Beta (17B5025f)
Enter the number of the Xcode to select: Not a valid number. Expecting a whole number between 1-3, but given nothing.
Error: Process completed with exit code 1.
```

This fixes that problem by using Xcode 26.0.1.

#skip-changelog

Closes #6395