### PR TITLE
chore: Enforce Xcode 16 for update-api script

### DIFF
--- a/scripts/update-api.sh
+++ b/scripts/update-api.sh
@@ -11,8 +11,6 @@ if [[ "$XCODE_MAJOR_VERSION" != "16" ]]; then
     exit 1
 fi
 
-echo "✓ Xcode $XCODE_VERSION is selected (required: Xcode 16.x)"
-
 ./scripts/build-xcframework-slice.sh "iphoneos" "Sentry" "-Dynamic" "mh_dylib" "V9"
 
 ./scripts/assemble-xcframework.sh "Sentry" "-Dynamic" "" "iphoneos" "$(pwd)/Carthage/archive/Sentry-Dynamic/SDK_NAME.xcarchive"


### PR DESCRIPTION
We must run the update-api script with Xcode 16 as Xcode 26 produces a different result because it doesn't include the ObjC public API.

Related PR https://github.com/getsentry/sentry-cocoa/pull/6213.

#skip-changelog

Closes #6399