### PR TITLE
docs: Add note to README with reference to v8 branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 _Bad software is everywhere, and we're tired of it. Sentry is on a mission to help developers write better software faster, so we can get back to enjoying technology. If you want to join us [<kbd>**Check out our open positions**</kbd>](https://sentry.io/careers/)_
 
+> [!NOTE]
+> You are currently viewing the **`main`** branch which contains the upcoming **v9** release with breaking changes.
+>
+> For the stable **v8** release, please switch to the [`v8.x` branch](https://github.com/getsentry/sentry-cocoa/tree/v8.x) and refer to the [v8 CHANGELOG](https://github.com/getsentry/sentry-cocoa/blob/v8.x/CHANGELOG.md).
+
 # Official Sentry SDK for iOS / tvOS / macOS / watchOS <sup>(1)</sup>
 
 [![Build](https://img.shields.io/github/actions/workflow/status/getsentry/sentry-cocoa/build.yml?branch=main)](https://github.com/getsentry/sentry-cocoa/actions/workflows/build.yml?query=branch%3Amain)


### PR DESCRIPTION
We should inform repository visitors that they see the upcoming v9 version and a reference to the v8 branch.

See https://github.com/getsentry/sentry-cocoa/pull/6389#issuecomment-3389046299 for more information

Counterpart to #6402

#skip-changelog