### PR TITLE
chore(ci): Migrate danger workflow to v3

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -16,4 +16,6 @@ concurrency:
 jobs:
   danger:
     name: Danger
-    uses: getsentry/github-workflows/.github/workflows/danger.yml@v2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/danger@v3


### PR DESCRIPTION
## Summary

Migrates the Danger workflow from v2 (reusable workflow) to v3 (composite action).

This supersedes the incorrect Dependabot PR #6303, which only updated the version number but did not perform the required structural changes for the v2 to v3 migration.

## Changes

- Converted from reusable workflow pattern (`uses: getsentry/github-workflows/.github/workflows/danger.yml@v2`)
- To composite action pattern (`uses: getsentry/github-workflows/danger@v3`)
- Added `runs-on: ubuntu-latest` as required for composite actions
- Restructured job from job-level `uses` to steps-based approach

## Benefits

- Latest Danger JS version (v13.0.4)
- Better conventional commit scope handling
- Enhanced support for non-conventional PR titles

#skip-changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)