### PR TITLE
ref: Move ThreadInspector initialization to Swift

### DIFF
--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -31,7 +31,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
-@property (nonatomic, strong) id<SentryThreadInspector> threadInspector;
+@property (nonatomic, strong) SentryThreadInspector *threadInspector;
 @property (atomic, assign) BOOL reportAppHangs;
 @property (atomic, assign) BOOL enableReportNonFullyBlockingAppHangs;
 

--- a/Sources/Sentry/SentryDefaultThreadInspector.m
+++ b/Sources/Sentry/SentryDefaultThreadInspector.m
@@ -66,7 +66,7 @@ getStackEntriesFromThread(SentryCrashThread thread, struct SentryCrashMachineCon
     return self;
 }
 
-- (instancetype)initWithOptions:(SentryOptions *)options
+- (instancetype)initWithOptions:(SentryOptions *_Nullable)options
 {
     SentryInAppLogic *inAppLogic =
         [[SentryInAppLogic alloc] initWithInAppIncludes:options.inAppIncludes

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -63,9 +63,6 @@ SentryApplicationProviderBlock defaultApplicationProvider = ^id<SentryApplicatio
 @interface SentryFileManager () <SentryFileManagerProtocol>
 @end
 
-@interface SentryDefaultThreadInspector () <SentryThreadInspector>
-@end
-
 @interface SentryDefaultAppStateManager () <SentryAppStateManager>
 @end
 
@@ -153,7 +150,7 @@ static BOOL isInitialializingDependencyContainer = NO;
 
         _notificationCenterWrapper = NSNotificationCenter.defaultCenter;
 
-        _processInfoWrapper = NSProcessInfo.processInfo;
+        _processInfoWrapper = SentryDependencies.processInfoWrapper;
         _crashWrapper = [[SentryCrashWrapper alloc] initWithProcessInfoWrapper:_processInfoWrapper];
 #if SENTRY_HAS_UIKIT
         _uiDeviceWrapper = SentryDependencies.uiDeviceWrapper;
@@ -227,10 +224,9 @@ static BOOL isInitialializingDependencyContainer = NO;
                                     notificationCenterWrapper:self.notificationCenterWrapper]);
 }
 
-- (id<SentryThreadInspector>)threadInspector SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+- (SentryThreadInspector *)threadInspector SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
-    SENTRY_LAZY_INIT(_threadInspector,
-        [[SentryDefaultThreadInspector alloc] initWithOptions:SentrySDKInternal.options]);
+    return SentryDependencies.threadInspector;
 }
 
 - (SentryFileIOTracker *)fileIOTracker SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK

--- a/Sources/Sentry/SentryFileIOTracker.m
+++ b/Sources/Sentry/SentryFileIOTracker.m
@@ -22,7 +22,7 @@
 
 @property (nonatomic, assign) BOOL isEnabled;
 @property (nonatomic, strong) NSMutableSet<NSData *> *processingData;
-@property (nonatomic, strong) id<SentryThreadInspector> threadInspector;
+@property (nonatomic, strong) SentryThreadInspector *threadInspector;
 @property (nonatomic, strong) id<SentryProcessInfoSource> processInfoWrapper;
 
 @end
@@ -42,7 +42,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
     return SentryDependencyContainer.sharedInstance.fileIOTracker;
 }
 
-- (instancetype)initWithThreadInspector:(id<SentryThreadInspector>)threadInspector
+- (instancetype)initWithThreadInspector:(SentryThreadInspector *)threadInspector
                      processInfoWrapper:(id<SentryProcessInfoSource>)processInfoWrapper
 {
     if (self = [super init]) {
@@ -245,7 +245,7 @@ NSString *const SENTRY_TRACKING_COUNTER_KEY = @"SENTRY_TRACKING_COUNTER_KEY";
         return;
     }
 
-    id<SentryThreadInspector> threadInspector = self.threadInspector;
+    SentryThreadInspector *threadInspector = self.threadInspector;
     SentryStacktrace *stackTrace = [threadInspector stacktraceForCurrentThreadAsyncUnsafe];
 
     NSArray *frames = [stackTrace.frames

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -23,6 +23,7 @@
 @class SentryOptions;
 @class SentrySessionTracker;
 @class SentryGlobalEventProcessor;
+@class SentryThreadInspector;
 @class SentryReachability;
 
 @protocol SentryAppStateManager;
@@ -33,7 +34,6 @@
 @protocol SentryApplication;
 @protocol SentryProcessInfoSource;
 @protocol SentryNSNotificationCenterWrapper;
-@protocol SentryThreadInspector;
 @protocol SentryObjCRuntimeWrapper;
 
 #if SENTRY_HAS_METRIC_KIT
@@ -100,7 +100,7 @@ SENTRY_NO_INIT
 
 @property (nonatomic, strong, nullable) SentryFileManager *fileManager;
 @property (nonatomic, strong) id<SentryAppStateManager> appStateManager;
-@property (nonatomic, strong) id<SentryThreadInspector> threadInspector;
+@property (nonatomic, strong, readonly) SentryThreadInspector *threadInspector;
 @property (nonatomic, strong) SentryFileIOTracker *fileIOTracker;
 @property (nonatomic, strong) SentryCrash *crashReporter;
 @property (nonatomic, strong) SentryScopePersistentStore *scopePersistentStore;

--- a/Sources/Sentry/include/SentryDefaultThreadInspector.h
+++ b/Sources/Sentry/include/SentryDefaultThreadInspector.h
@@ -1,4 +1,4 @@
-#import "SentryCrashMachineContextWrapper.h"
+#import "SentryCrashThread.h"
 #import "SentryDefines.h"
 #import <Foundation/Foundation.h>
 
@@ -6,6 +6,8 @@
 @class SentryStacktrace;
 @class SentryStacktraceBuilder;
 @class SentryThread;
+
+@protocol SentryCrashMachineContextWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,7 +18,7 @@ SENTRY_NO_INIT
        andMachineContextWrapper:(id<SentryCrashMachineContextWrapper>)machineContextWrapper
                     symbolicate:(BOOL)symbolicate;
 
-- (instancetype)initWithOptions:(SentryOptions *)options;
+- (instancetype)initWithOptions:(SentryOptions *_Nullable)options;
 
 - (nullable SentryStacktrace *)stacktraceForCurrentThreadAsyncUnsafe;
 

--- a/Sources/Sentry/include/SentryFileIOTracker.h
+++ b/Sources/Sentry/include/SentryFileIOTracker.h
@@ -3,7 +3,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol SentryProcessInfoSource;
-@protocol SentryThreadInspector;
+@class SentryThreadInspector;
 
 @interface SentryFileIOTracker : NSObject
 SENTRY_NO_INIT
@@ -18,7 +18,7 @@ SENTRY_NO_INIT
  */
 + (instancetype _Nullable)sharedInstance;
 
-- (instancetype)initWithThreadInspector:(id<SentryThreadInspector>)threadInspector
+- (instancetype)initWithThreadInspector:(SentryThreadInspector *)threadInspector
                      processInfoWrapper:(id<SentryProcessInfoSource>)processInfoWrapper;
 
 - (void)enable;

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -29,6 +29,7 @@
 #import "SentryCrashMonitor_AppState.h"
 #import "SentryCrashMonitor_System.h"
 #import "SentryDateUtils.h"
+#import "SentryDefaultThreadInspector.h"
 #import "SentryDependencyContainerSwiftHelper.h"
 #import "SentryEvent+Serialize.h"
 #import "SentryFileIOTracker.h"

--- a/Sources/Swift/Helper/Dependencies.swift
+++ b/Sources/Swift/Helper/Dependencies.swift
@@ -1,8 +1,14 @@
+@_implementationOnly import _SentryPrivate
+
 @objc(SentryDependencies) @_spi(Private) public final class Dependencies: NSObject {
+    @objc public static let processInfoWrapper: SentryProcessInfoSource = ProcessInfo.processInfo
     @objc public static let dispatchQueueWrapper = SentryDispatchQueueWrapper()
     @objc public static let dateProvider = SentryDefaultCurrentDateProvider()
     public static let objcRuntimeWrapper = SentryDefaultObjCRuntimeWrapper()
 #if !os(watchOS) && !os(macOS) && !SENTRY_NO_UIKIT
     @objc public static let uiDeviceWrapper = SentryDefaultUIDeviceWrapper(queueWrapper: Dependencies.dispatchQueueWrapper)
 #endif // !os(watchOS) && !os(macOS) && !SENTRY_NO_UIKIT
+
+    @objc public static var threadInspector: SentryThreadInspector = SentryThreadInspector()
+
 }

--- a/Sources/Swift/SentryCrash/SentryThreadInspector.swift
+++ b/Sources/Swift/SentryCrash/SentryThreadInspector.swift
@@ -1,5 +1,25 @@
-@_spi(Private) @objc public protocol SentryThreadInspector {
-    func stacktraceForCurrentThreadAsyncUnsafe() -> SentryStacktrace?
-    func getCurrentThreadsWithStackTrace() -> [SentryThread]
-    func getThreadName(_ thread: UInt) -> String?
+@_implementationOnly import _SentryPrivate
+
+@_spi(Private) @objc public class SentryThreadInspector: NSObject {
+    private let internalHelper: SentryDefaultThreadInspector
+    
+    override init() {
+        internalHelper = SentryDefaultThreadInspector(options: SentrySDKInternal.options)
+    }
+
+    @objc public init(options: Options) {
+        internalHelper = SentryDefaultThreadInspector(options: options)
+    }
+
+    @objc public func stacktraceForCurrentThreadAsyncUnsafe() -> SentryStacktrace? {
+        internalHelper.stacktraceForCurrentThreadAsyncUnsafe()
+    }
+    
+    @objc public func getCurrentThreadsWithStackTrace() -> [SentryThread] {
+        internalHelper.getCurrentThreadsWithStackTrace()
+    }
+    
+    @objc public func getThreadName(_ thread: UInt) -> String? {
+        internalHelper.getThreadName(thread)
+    }
 }

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -783,6 +783,6 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
             threadInspector.allThreads = []
         }
 
-        Dynamic(SentryDependencyContainer.sharedInstance()).threadInspector = threadInspector
+        Dependencies.threadInspector = threadInspector
     }
 }

--- a/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
+++ b/Tests/SentryTests/Integrations/Feedback/SentryFeedbackTests.swift
@@ -208,7 +208,7 @@ class SentryFeedbackTests: XCTestCase {
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )),
             deleteOldEnvelopeItems: false,
-            threadInspector: TestThreadInspector.instance,
+            threadInspector: TestDefaultThreadInspector.instance,
             debugImageProvider: TestDebugImageProvider(),
             random: TestRandom(value: 1.0),
             locale: Locale(identifier: "en_US"),
@@ -251,7 +251,7 @@ class SentryFeedbackTests: XCTestCase {
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )),
             deleteOldEnvelopeItems: false,
-            threadInspector: TestThreadInspector.instance,
+            threadInspector: TestDefaultThreadInspector.instance,
             debugImageProvider: TestDebugImageProvider(),
             random: TestRandom(value: 1.0),
             locale: Locale(identifier: "en_US"),
@@ -294,7 +294,7 @@ class SentryFeedbackTests: XCTestCase {
                 dispatchQueueWrapper: TestSentryDispatchQueueWrapper()
             )),
             deleteOldEnvelopeItems: false,
-            threadInspector: TestThreadInspector.instance,
+            threadInspector: TestDefaultThreadInspector.instance,
             debugImageProvider: TestDebugImageProvider(),
             random: TestRandom(value: 1.0),
             locale: Locale(identifier: "en_US"),

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -10,7 +10,7 @@ class SentryCoreDataTrackerTests: XCTestCase {
         lazy var context: TestNSManagedObjectContext = {
             coreDataStack.managedObjectContext
         }()
-        let threadInspector = TestThreadInspector.instance
+        let threadInspector = TestDefaultThreadInspector.instance
         let imageProvider = TestDebugImageProvider()
 
         init(testName: String) {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
@@ -1,5 +1,5 @@
 // swiftlint:disable file_length
-@testable import Sentry
+@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 
@@ -29,7 +29,7 @@ class SentryFileIOTrackerSwiftHelpersTests: XCTestCase {
         SentrySDKInternal.setCurrentHub(hub)
 
         tracker = SentryFileIOTracker(
-            threadInspector: TestThreadInspector(options: .noIntegrations()),
+            threadInspector: SentryThreadInspector(),
             processInfoWrapper: MockSentryProcessInfo()
         )
     }

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryNSFileManagerSwizzlingTests.m
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryNSFileManagerSwizzlingTests.m
@@ -56,8 +56,8 @@
     SentryOptions *options = [[SentryOptions alloc] init];
     options.experimental.enableFileManagerSwizzling = enableFileManagerSwizzling;
 
-    SentryDefaultThreadInspector *threadInspector =
-        [[SentryDefaultThreadInspector alloc] initWithOptions:options];
+    SentryThreadInspector *threadInspector =
+        [[SentryThreadInspector alloc] initWithOptions:options];
     id<SentryProcessInfoSource> processInfoWrapper =
         [SentryDependencyContainer.sharedInstance processInfoWrapper];
     self->tracker = [[SentryFileIOTracker alloc] initWithThreadInspector:threadInspector

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -16,7 +16,7 @@ class SentryClientTests: XCTestCase {
 
         let dateProvider = TestCurrentDateProvider()
         let debugImageProvider = TestDebugImageProvider()
-        let threadInspector = TestThreadInspector.instance
+        let threadInspector = TestDefaultThreadInspector.instance
         
         let session: SentrySession
         let event: Event

--- a/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
+++ b/Tests/SentryTests/SentryCrash/TestThreadInspector.swift
@@ -1,18 +1,16 @@
 import Foundation
-@_spi(Private) import Sentry
+@_spi(Private) @testable import Sentry
 
-@_spi(Private) extension SentryDefaultThreadInspector: SentryThreadInspector { }
-
-class TestThreadInspector: SentryDefaultThreadInspector {
+class TestDefaultThreadInspector: SentryDefaultThreadInspector {
     
     var allThreads: [SentryThread]?
     
-    static var instance: TestThreadInspector {
+    static var instance: TestDefaultThreadInspector {
         // We need something to pass to the super initializer, because the empty initializer has been marked unavailable.
         let inAppLogic = SentryInAppLogic(inAppIncludes: [], inAppExcludes: [])
         let crashStackEntryMapper = SentryCrashStackEntryMapper(inAppLogic: inAppLogic)
         let stacktraceBuilder = SentryStacktraceBuilder(crashStackEntryMapper: crashStackEntryMapper)
-        return TestThreadInspector(stacktraceBuilder: stacktraceBuilder, andMachineContextWrapper: SentryCrashDefaultMachineContextWrapper(), symbolicate: false)
+        return TestDefaultThreadInspector(stacktraceBuilder: stacktraceBuilder, andMachineContextWrapper: SentryCrashDefaultMachineContextWrapper(), symbolicate: false)
     }
 
     override func stacktraceForCurrentThreadAsyncUnsafe() -> SentryStacktrace? {
@@ -21,6 +19,24 @@ class TestThreadInspector: SentryDefaultThreadInspector {
     
     override func getCurrentThreads() -> [SentryThread] {
         return allThreads ?? [TestData.thread]
+    }
+
+    override func getCurrentThreadsWithStackTrace() -> [SentryThread] {
+        return allThreads ?? [TestData.thread]
+    }
+
+}
+
+class TestThreadInspector: SentryThreadInspector {
+    
+    var allThreads: [SentryThread]?
+    
+    static var instance: TestThreadInspector {
+        return TestThreadInspector()
+    }
+
+    override func stacktraceForCurrentThreadAsyncUnsafe() -> SentryStacktrace? {
+        return allThreads?.first?.stacktrace ?? TestData.thread.stacktrace
     }
 
     override func getCurrentThreadsWithStackTrace() -> [SentryThread] {


### PR DESCRIPTION
This moves SentryThreadInspector to a class so that it an be initialized from a Swift file. This is a prerequisite for https://github.com/getsentry/sentry-cocoa/pull/6274 because the FileIOTracker will also need to be initialized in Swift (and is dependent on SentryThreadInspector)

These need to be moved to the Swift file instead of SentryDependencies.m because in SPM you cannot have Swift code access a Swift type that is forward declared in an objc header. The FileIOTracker has this kind of usage - so it needs to be made accessible from somewhere other than the SentryDependencies.h header.

#skip-changelog

Closes #6406