### PR TITLE
chore(ci): Enable logs for ANR tests

### DIFF
--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -11,6 +11,8 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
     private var anrStoppedExpectation: XCTestExpectation!
     private let waitTimeout: TimeInterval = 5.0
     private var lastANRStoppedResult: SentryANRStoppedResult?
+    private var previousIsDebug: Bool = false
+    private var previousDiagnosticLevel: SentryLevel = .info
     
     private class Fixture {
         let timeoutInterval: TimeInterval = 5
@@ -27,6 +29,10 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
 
     override func setUp() {
         super.setUp()
+        
+        self.previousIsDebug = SentrySDKLog.isDebug
+        self.previousDiagnosticLevel = SentrySDKLog.diagnosticLevel
+        SentrySDKLog._configure(true, diagnosticLevel: .debug)
         
         anrDetectedExpectation = expectation(description: "ANR Detection")
         anrStoppedExpectation = expectation(description: "ANR Stopped")
@@ -47,6 +53,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         
         wait(for: [fixture.threadWrapper.threadFinishedExpectation], timeout: 5)
         XCTAssertEqual(0, fixture.threadWrapper.threads.count)
+        SentrySDKLog._configure(self.previousIsDebug, diagnosticLevel: self.previousDiagnosticLevel)
         clearTestState()
     }
     


### PR DESCRIPTION
ANRv1 Tests are flaky, this enables logs for these tests to help us debug the issue.

Either the test are wrong or there is a bug in the logic.

Example failed test: https://github.com/getsentry/sentry-cocoa/actions/runs/18412639357/job/52468729315?pr=6377

#skip-changelog

Closes #6409