### PR TITLE
fix: Use of SentrySpan as class

### DIFF
--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -21,7 +21,8 @@
 #    import "SentrySpan.h"
 #    import "SentryTracer.h"
 #else
-@class SentrySpan;
+@protocol SentrySpan;
+
 @interface SentryTracer : NSObject <SentrySpan>
 @end
 #endif
@@ -81,9 +82,9 @@ typedef NS_ENUM(NSUInteger, SentrySpanStatus);
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-@property (nullable, nonatomic, weak, readonly) SentrySpan *initialDisplaySpan;
+@property (nullable, nonatomic, weak, readonly) id<SentrySpan> initialDisplaySpan;
 
-@property (nullable, nonatomic, weak, readonly) SentrySpan *fullDisplaySpan;
+@property (nullable, nonatomic, weak, readonly) id<SentrySpan> fullDisplaySpan;
 
 @property (nonatomic, readonly) BOOL waitForFullDisplay;
 

--- a/Sources/Swift/Integrations/Performance/IO/SentryFileIOTracker.swift
+++ b/Sources/Swift/Integrations/Performance/IO/SentryFileIOTracker.swift
@@ -1,11 +1,5 @@
 @_implementationOnly import _SentryPrivate
 
-@_spi(Private) @objc public protocol SpanProtocol {
-    @objc(setDataValue:forKey:) func setData(value: Any, key: String)
-    func finish()
-    @objc(finishWithStatus:) func finish(status: SentrySpanStatus)
-}
-
 @_spi(Private) @objc public class SentryFileIOTracker: NSObject {
 
     private let helper: SentryFileIOTrackerHelper


### PR DESCRIPTION
This deletes an unused "SpanProtocol" that I had accidentally left in from a previous PR (https://github.com/getsentry/sentry-cocoa/pull/6274)

It also corrects the usage of SentrySpan in a forward declaration that I happened to notice while working on another Swift conversion

#skip-changelog

Closes #6416