### PR TITLE
ref: Cleanup SentryUIViewControllerPerformanceTracker interface

### DIFF
--- a/Sources/Sentry/SentryPerformanceTracker.m
+++ b/Sources/Sentry/SentryPerformanceTracker.m
@@ -1,4 +1,5 @@
 #import "SentryPerformanceTracker.h"
+#import "SentryDependencyContainer.h"
 #import "SentryHub+Private.h"
 #import "SentryLogC.h"
 #import "SentrySDK+Private.h"
@@ -233,6 +234,11 @@ NS_ASSUME_NONNULL_BEGIN
     @synchronized(self.spans) {
         return self.spans[spanId];
     }
+}
+
+- (BOOL)hasSpan:(SentrySpanId *)spanId
+{
+    return [self getSpan:spanId] != nil;
 }
 
 - (nullable id<SentrySpan>)getActiveSpan

--- a/Sources/Sentry/include/SentryPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryPerformanceTracker.h
@@ -102,6 +102,8 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable id<SentrySpan>)getSpan:(SentrySpanId *)spanId;
 
+- (BOOL)hasSpan:(SentrySpanId *)spanId;
+
 - (BOOL)pushActiveSpan:(SentrySpanId *)spanId;
 
 - (void)popActiveSpan;

--- a/Sources/Sentry/include/SentryUIViewControllerPerformanceTracker.h
+++ b/Sources/Sentry/include/SentryUIViewControllerPerformanceTracker.h
@@ -5,11 +5,26 @@
 @class SentryInAppLogic;
 @class SentryTimeToDisplayTracker;
 @class UIViewController;
-@class SentryTracer;
+@class SentrySpanId;
 @class SentryPerformanceTracker;
 @class SentryDispatchQueueWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
+
+@protocol SentryInitialDisplayReporting
+
+- (void)reportInitialDisplay;
+
+@end
+
+@interface SentrySwiftUISpanHelper : NSObject
+
+@property (nonatomic, readonly) BOOL hasSpan;
+
+@property (nonatomic, strong, readonly, nullable) id<SentryInitialDisplayReporting>
+    initialDisplayReporting;
+
+@end
 
 /**
  * Class responsible to track UI performance.
@@ -95,9 +110,9 @@ SENTRY_NO_INIT
 
 - (void)reportFullyDisplayed;
 
-- (nullable SentryTimeToDisplayTracker *)startTimeToDisplayTrackerForScreen:(NSString *)screenName
-                                                         waitForFullDisplay:(BOOL)waitForFullDisplay
-                                                                     tracer:(SentryTracer *)tracer;
+- (SentrySwiftUISpanHelper *)startTimeToDisplayTrackerForScreen:(NSString *)screenName
+                                             waitForFullDisplay:(BOOL)waitforFullDisplay
+                                                  transactionId:(SentrySpanId *)transactionId;
 
 @end
 

--- a/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
+++ b/Sources/SentrySwiftUI/SentryInternal/SentryInternal.h
@@ -71,10 +71,16 @@ typedef NS_ENUM(NSUInteger, SentrySpanStatus);
 
 - (nullable id<SentrySpan>)getSpan:(SentrySpanId *)spanId;
 
+- (BOOL)hasSpan:(SentrySpanId *)spanId;
+
 - (BOOL)pushActiveSpan:(SentrySpanId *)spanId;
 
 - (void)popActiveSpan;
 
+@end
+
+@protocol SentryInitialDisplayReporting
+- (void)reportInitialDisplay;
 @end
 
 @interface SentryTimeToDisplayTracker : NSObject
@@ -103,13 +109,22 @@ typedef NS_ENUM(NSUInteger, SentrySpanStatus);
 
 @end
 
+@interface SentrySwiftUISpanHelper : NSObject
+
+@property (nonatomic, readonly) BOOL hasSpan;
+
+@property (nonatomic, strong, readonly, nullable) id<SentryInitialDisplayReporting>
+    initialDisplayReporting;
+
+@end
+
 @interface SentryUIViewControllerPerformanceTracker : NSObject
 
 - (void)reportFullyDisplayed;
 
-- (nullable SentryTimeToDisplayTracker *)startTimeToDisplayTrackerForScreen:(NSString *)screenName
-                                                         waitForFullDisplay:(BOOL)waitForFullDisplay
-                                                                     tracer:(SentryTracer *)tracer;
+- (SentrySwiftUISpanHelper *)startTimeToDisplayTrackerForScreen:(NSString *)screenName
+                                             waitForFullDisplay:(BOOL)waitforFullDisplay
+                                                  transactionId:(SentrySpanId *)transactionId;
 
 @end
 

--- a/Sources/SentrySwiftUI/SentryTracedView.swift
+++ b/Sources/SentrySwiftUI/SentryTracedView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 class SentryTraceViewModel {
     private var transactionId: SpanId?
     private var viewAppeared: Bool = false
-    private var tracker: SentryTimeToDisplayTracker?
+    private var tracker: SentryInitialDisplayReporting?
     
     let name: String
     let nameSource: SentryTransactionNameSource
@@ -27,13 +27,13 @@ class SentryTraceViewModel {
     func startSpan() -> SpanId? {
         guard !viewAppeared else { return nil }
         
-        let trace = startRootTransaction()
-        let name = trace != nil ? "\(name) - body" : name
+        let hasTrace = startRootTransaction()
+        let name = hasTrace ? "\(name) - body" : name
         return createBodySpan(name: name)
     }
     
-    private func startRootTransaction() -> SentryTracer? {
-        guard SentryPerformanceTracker.shared.activeSpanId() == nil else { return nil }
+    private func startRootTransaction() -> Bool {
+        guard SentryPerformanceTracker.shared.activeSpanId() == nil else { return false }
         
         let transactionId = SentryPerformanceTracker.shared.startSpan(
             withName: name,
@@ -43,14 +43,15 @@ class SentryTraceViewModel {
         )
         SentryPerformanceTracker.shared.pushActiveSpan(transactionId)
         self.transactionId = transactionId
-        let tracer = SentryPerformanceTracker.shared.getSpan(transactionId) as? SentryTracer
 #if canImport(SwiftUI) && canImport(UIKit) && os(iOS) || os(tvOS)
-        if let tracer = tracer {
-            let uiViewControllerPerformanceTracker = SentryDependencyContainer.sharedInstance().uiViewControllerPerformanceTracker
-            tracker = uiViewControllerPerformanceTracker.startTimeToDisplay(forScreen: name, waitForFullDisplay: waitForFullDisplay, tracer: tracer)
-        }
+        let uiViewControllerPerformanceTracker = SentryDependencyContainer.sharedInstance().uiViewControllerPerformanceTracker
+        let swiftUITraceHelper = uiViewControllerPerformanceTracker.startTimeToDisplay(forScreen: name, waitForFullDisplay: waitForFullDisplay, transactionId: transactionId)
+        self.tracker = swiftUITraceHelper.initialDisplayReporting
+        return swiftUITraceHelper.hasSpan
+#else
+        return SentryPerformanceTracker.shared.hasSpan(transactionId)
 #endif
-        return tracer
+        
     }
     
     private func createBodySpan(name: String) -> SpanId {


### PR DESCRIPTION
I'm preparing to migrate SentryUIViewControllerPerformanceTracker to Swift, but realized it does not need the dependency on "SentryTracer" or "SentryTimeToDisplayTracker" because it can be refactored to have that be an implementation detail not part of the API. This will make the Swift migration much more straightforward and save the migration of many additional classes that are right now blocking the migration.

This will also unblock: https://linear.app/getsentry/issue/COCOA-554/convert-sentryperformancetracker-to-swift

#skip-changelog