### PR TITLE
ref: Use scope observer protocol in dependency container

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -407,8 +407,7 @@ static BOOL isInitialializingDependencyContainer = NO;
 }
 
 #if SENTRY_HAS_UIKIT
-- (SentryWatchdogTerminationScopeObserver *)getWatchdogTerminationScopeObserverWithOptions:
-    (SentryOptions *)options
+- (id<SentryScopeObserver>)getWatchdogTerminationScopeObserverWithOptions:(SentryOptions *)options
 {
     // This method is only a factory, therefore do not keep a reference.
     // The scope observer will be created each time it is needed.

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -88,9 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
 
     self.appStateManager = appStateManager;
 
-    SentryWatchdogTerminationScopeObserver *scopeObserver =
-        [SentryDependencyContainer.sharedInstance
-            getWatchdogTerminationScopeObserverWithOptions:options];
+    id<SentryScopeObserver> scopeObserver = [SentryDependencyContainer.sharedInstance
+        getWatchdogTerminationScopeObserverWithOptions:options];
 
     [SentrySDKInternal.currentHub configureScope:^(SentryScope *_Nonnull outerScope) {
         // Add the observer to the scope so that it can be notified when the scope changes.

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -45,8 +45,8 @@
 @class SentryScreenshotSource;
 @class SentryViewHierarchyProvider;
 @class SentryUIViewControllerPerformanceTracker;
-@class SentryWatchdogTerminationScopeObserver;
 @class SentryWatchdogTerminationAttributesProcessor;
+@protocol SentryScopeObserver;
 #endif // SENTRY_UIKIT_AVAILABLE
 
 #if SENTRY_HAS_UIKIT
@@ -136,8 +136,7 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) id<SentryObjCRuntimeWrapper> objcRuntimeWrapper;
 
 #if SENTRY_HAS_UIKIT
-- (SentryWatchdogTerminationScopeObserver *)getWatchdogTerminationScopeObserverWithOptions:
-    (SentryOptions *)options;
+- (id<SentryScopeObserver>)getWatchdogTerminationScopeObserverWithOptions:(SentryOptions *)options;
 @property (nonatomic, strong)
     SentryWatchdogTerminationAttributesProcessor *watchdogTerminationAttributesProcessor;
 #endif

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -1,11 +1,12 @@
 #import <Foundation/Foundation.h>
 
 #import "SentryScope.h"
-#import "SentryScopeObserver.h"
 
 @class SentryAttachment;
 @class SentryPropagationContext;
 @class SentrySession;
+
+@protocol SentryScopeObserver;
 
 NS_ASSUME_NONNULL_BEGIN
 


### PR DESCRIPTION
I realized the dependency container header declared this function to return `SentryWatchdogTerminationScopeObserver` but really all that it needed was to be a type conforming to `SentryScopeObserver `. So updated it to this protocol, it will make the Swift conversion easier

#skip-changelog

Closes #6424