### PR TITLE
ref: Remove SentrySystemWrapper from the dependency container

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -363,15 +363,6 @@ static BOOL isInitialializingDependencyContainer = NO;
 }
 #endif // SENTRY_UIKIT_AVAILABLE
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-- (SentrySystemWrapper *)systemWrapper SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
-{
-    SENTRY_LAZY_INIT(_systemWrapper,
-        [[SentrySystemWrapper alloc]
-            initWithProcessorCount:self.processInfoWrapper.processorCount]);
-}
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
-
 - (SentryDispatchFactory *)dispatchFactory SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_dispatchFactory, [[SentryDispatchFactory alloc] init]);

--- a/Sources/Sentry/SentryMetricProfiler.m
+++ b/Sources/Sentry/SentryMetricProfiler.m
@@ -123,6 +123,16 @@ serializeContinuousProfileMetrics(NSDictionary *state)
     return dict;
 }
 
+@interface SentryMetricProfiler ()
+
+@property SentrySystemWrapper *systemWrapper;
+
+@end
+
+#    if SENTRY_TEST || SENTRY_TEST_CI
+static SentrySystemWrapper *_systemWrapperOverride = nil;
+#    endif
+
 @implementation SentryMetricProfiler {
     SentryDispatchSourceWrapper *_dispatchSource;
 
@@ -140,10 +150,28 @@ serializeContinuousProfileMetrics(NSDictionary *state)
     if (self = [super init]) {
         // It doesn't make sense to acquire a lock in the init.
         [self clearNotThreadSafe];
+#    if SENTRY_TEST || SENTRY_TEST_CI
+        self.systemWrapper = _systemWrapperOverride
+            ? _systemWrapperOverride
+            : [[SentrySystemWrapper alloc]
+                  initWithProcessorCount:SentryDependencyContainer.sharedInstance.processInfoWrapper
+                                             .processorCount];
+#    else
+        self.systemWrapper = [[SentrySystemWrapper alloc]
+            initWithProcessorCount:SentryDependencyContainer.sharedInstance.processInfoWrapper
+                                       .processorCount];
+#    endif
         _mode = mode;
     }
     return self;
 }
+
+#    if SENTRY_TEST || SENTRY_TEST_CI
++ (void)setSystemWrapperOverride:(SentrySystemWrapper *)value
+{
+    _systemWrapperOverride = value;
+}
+#    endif
 
 - (void)dealloc
 {
@@ -249,8 +277,7 @@ serializeContinuousProfileMetrics(NSDictionary *state)
 - (void)recordMemoryFootprint
 {
     NSError *error;
-    SentryRAMBytes footprintBytes =
-        [SentryDependencyContainer.sharedInstance.systemWrapper memoryFootprintBytes:&error];
+    SentryRAMBytes footprintBytes = [self.systemWrapper memoryFootprintBytes:&error];
 
     if (error) {
         SENTRY_LOG_ERROR(@"Failed to read memory footprint: %@", error);
@@ -265,8 +292,7 @@ serializeContinuousProfileMetrics(NSDictionary *state)
 - (void)recordCPUsage
 {
     NSError *error;
-    NSNumber *result =
-        [SentryDependencyContainer.sharedInstance.systemWrapper cpuUsageWithError:&error];
+    NSNumber *result = [self.systemWrapper cpuUsageWithError:&error];
 
     if (error) {
         SENTRY_LOG_ERROR(@"Failed to read CPU usages: %@", error);
@@ -287,8 +313,7 @@ serializeContinuousProfileMetrics(NSDictionary *state)
 - (void)recordEnergyUsageEstimate
 {
     NSError *error;
-    NSNumber *reading =
-        [SentryDependencyContainer.sharedInstance.systemWrapper cpuEnergyUsageWithError:&error];
+    NSNumber *reading = [self.systemWrapper cpuEnergyUsageWithError:&error];
     if (error) {
         SENTRY_LOG_ERROR(@"Failed to read CPU energy usage: %@", error);
         return;

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -16,7 +16,6 @@
 @class SentrySwizzleWrapper;
 @class SentrySysctl;
 @class SentryThreadsafeApplication;
-@class SentrySystemWrapper;
 @class SentryThreadWrapper;
 @class SentryFileIOTracker;
 @class SentryScopePersistentStore;
@@ -118,9 +117,6 @@ SENTRY_NO_INIT
 
 - (nullable id<SentryApplication>)application;
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-@property (nonatomic, strong) SentrySystemWrapper *systemWrapper;
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
 @property (nonatomic, strong) SentryDispatchFactory *dispatchFactory;
 @property (nonatomic, strong) SentryNSTimerFactory *timerFactory;
 

--- a/Sources/Sentry/include/SentryMetricProfiler.h
+++ b/Sources/Sentry/include/SentryMetricProfiler.h
@@ -6,6 +6,7 @@
 #    import "SentryProfilerDefines.h"
 
 @class SentryTransaction;
+@class SentrySystemWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -67,6 +68,10 @@ SENTRY_NO_INIT
  * payload for transmission.
  */
 - (NSDictionary *)copyMetricProfilerData;
+
+#    if SENTRY_TEST || SENTRY_TEST_CI
++ (void)setSystemWrapperOverride:(SentrySystemWrapper *)value;
+#    endif
 
 @end
 

--- a/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
+++ b/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
@@ -44,10 +44,10 @@ class SentryProfileTestFixture {
         SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueueWrapper
         SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider
         SentryDependencyContainer.sharedInstance().random = TestRandom(value: fixedRandomValue)
-        SentryDependencyContainer.sharedInstance().systemWrapper = systemWrapper
         SentryDependencyContainer.sharedInstance().processInfoWrapper = processInfoWrapper
         SentryDependencyContainer.sharedInstance().dispatchFactory = dispatchFactory
         SentryDependencyContainer.sharedInstance().notificationCenterWrapper = notificationCenter
+        SentryMetricProfiler.setSystemWrapperOverride(systemWrapper)
 
         timeoutTimerFactory = TestSentryNSTimerFactory(currentDateProvider: self.currentDateProvider)
         SentryDependencyContainer.sharedInstance().timerFactory = timeoutTimerFactory

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -124,9 +124,6 @@ final class SentryDependencyContainerTests: XCTestCase {
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: true))
 #endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 
-#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-                    XCTAssertNotNil(SentryDependencyContainer.sharedInstance().systemWrapper)
-#endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().dispatchFactory)
                     XCTAssertNotNil(SentryDependencyContainer.sharedInstance().timerFactory)
 


### PR DESCRIPTION
As @philipphofmann noticed, we don't need to have this be a property in the dependency container, which removes the need to convert it to Swift and closes https://linear.app/getsentry/issue/COCOA-537/convert-sentrysystemwrapper-to-swift

#skip-changelog