### PR TITLE
ref: Begin moving dependencies to Swift

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -149,12 +149,12 @@ static BOOL isInitialializingDependencyContainer = NO;
         isInitialializingDependencyContainer = YES;
 
         _dispatchQueueWrapper = SentryDependencies.dispatchQueueWrapper;
-        _random = [[SentryRandom alloc] init];
-        _threadWrapper = [[SentryThreadWrapper alloc] init];
+        _random = SentryDependencies.random;
+        _threadWrapper = SentryDependencies.threadWrapper;
         _binaryImageCache = [[SentryBinaryImageCache alloc] init];
         _dateProvider = SentryDependencies.dateProvider;
 
-        _notificationCenterWrapper = NSNotificationCenter.defaultCenter;
+        _notificationCenterWrapper = SentryDependencies.notificationCenterWrapper;
 
         _processInfoWrapper = SentryDependencies.processInfoWrapper;
         _crashWrapper = [[SentryCrashWrapper alloc] initWithProcessInfoWrapper:_processInfoWrapper];
@@ -173,7 +173,7 @@ static BOOL isInitialializingDependencyContainer = NO;
 #endif // TARGET_OS_IOS && SENTRY_HAS_UIKIT
         ];
 
-        _sysctlWrapper = [[SentrySysctl alloc] init];
+        _sysctlWrapper = SentryDependencies.sysctlWrapper;
 
         SentryRetryAfterHeaderParser *retryAfterHeaderParser = [[SentryRetryAfterHeaderParser alloc]
             initWithHttpDateParser:[[SentryHttpDateParser alloc] init]
@@ -185,9 +185,6 @@ static BOOL isInitialializingDependencyContainer = NO;
             [[SentryDefaultRateLimits alloc] initWithRetryAfterHeaderParser:retryAfterHeaderParser
                                                          andRateLimitParser:rateLimitParser
                                                         currentDateProvider:_dateProvider];
-        _infoPlistWrapper = [[SentryInfoPlistWrapper alloc] init];
-        _sessionReplayEnvironmentChecker = [[SentrySessionReplayEnvironmentChecker alloc]
-            initWithInfoPlistWrapper:_infoPlistWrapper];
 
         _reachability = [[SentryReachability alloc] init];
 

--- a/Sources/Sentry/SentrySessionReplayIntegration.m
+++ b/Sources/Sentry/SentrySessionReplayIntegration.m
@@ -134,7 +134,7 @@ static SentryTouchTracker *_touchTracker;
 
     _notificationCenter = SentryDependencyContainer.sharedInstance.notificationCenterWrapper;
     _dateProvider = SentryDependencyContainer.sharedInstance.dateProvider;
-    _environmentChecker = SentryDependencyContainer.sharedInstance.sessionReplayEnvironmentChecker;
+    _environmentChecker = SentryDependencies.sessionReplayEnvironmentChecker;
 
     // We use the dispatch queue provider as a factory to create the queues, but store the queues
     // directly in this instance, so they get deallocated when the integration is deallocated.

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -34,8 +34,6 @@
 @protocol SentryProcessInfoSource;
 @protocol SentryNSNotificationCenterWrapper;
 @protocol SentryObjCRuntimeWrapper;
-@protocol SentryInfoPlistWrapperProvider;
-@protocol SentrySessionReplayEnvironmentCheckerProvider;
 
 #if SENTRY_HAS_METRIC_KIT
 @class SentryMXManager;
@@ -91,9 +89,6 @@ SENTRY_NO_INIT
 @property (nonatomic, strong) SentrySysctl *sysctlWrapper;
 @property (nonatomic, strong) id<SentryRateLimits> rateLimits;
 @property (nonatomic, strong) SentryThreadsafeApplication *threadsafeApplication;
-@property (nonatomic, strong) id<SentryInfoPlistWrapperProvider> infoPlistWrapper;
-@property (nonatomic, strong) id<SentrySessionReplayEnvironmentCheckerProvider>
-    sessionReplayEnvironmentChecker;
 
 @property (nonatomic, strong) SentryReachability *reachability;
 

--- a/Sources/Sentry/include/SentryHub+Private.h
+++ b/Sources/Sentry/include/SentryHub+Private.h
@@ -6,7 +6,6 @@
 @class SentryTransaction;
 @class SentryDispatchQueueWrapper;
 @class SentryEnvelope;
-@class SentryNSTimerFactory;
 @class SentrySession;
 @class SentryTracer;
 @class SentryTracerConfiguration;

--- a/Sources/Sentry/include/SentryTracer.h
+++ b/Sources/Sentry/include/SentryTracer.h
@@ -7,7 +7,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryDispatchQueueWrapper;
 @class SentryHub;
 @class SentryMeasurementValue;
-@class SentryNSTimerFactory;
 @class SentryTraceContext;
 @class SentryTraceHeader;
 @class SentryTracer;

--- a/Sources/Swift/Helper/Dependencies.swift
+++ b/Sources/Swift/Helper/Dependencies.swift
@@ -1,8 +1,16 @@
 @_implementationOnly import _SentryPrivate
 
 @objc(SentryDependencies) @_spi(Private) public final class Dependencies: NSObject {
+    @objc public static let random: SentryRandomProtocol = SentryRandom()
+    @objc public static let threadWrapper = SentryThreadWrapper()
     @objc public static let processInfoWrapper: SentryProcessInfoSource = ProcessInfo.processInfo
+    static let infoPlistWrapper: SentryInfoPlistWrapperProvider = SentryInfoPlistWrapper()
+    @objc public static let sessionReplayEnvironmentChecker: SentrySessionReplayEnvironmentChecker = {
+        SentrySessionReplayEnvironmentChecker(infoPlistWrapper: Dependencies.infoPlistWrapper)
+    }()
     @objc public static let dispatchQueueWrapper = SentryDispatchQueueWrapper()
+    @objc public static let notificationCenterWrapper: SentryNSNotificationCenterWrapper = NotificationCenter.default
+    @objc public static let sysctlWrapper = SentrySysctl()
     @objc public static let dateProvider = SentryDefaultCurrentDateProvider()
     public static let objcRuntimeWrapper = SentryDefaultObjCRuntimeWrapper()
 #if !os(watchOS) && !os(macOS) && !SENTRY_NO_UIKIT

--- a/Sources/Swift/Helper/InfoPlist/SentryInfoPlistWrapper.swift
+++ b/Sources/Swift/Helper/InfoPlist/SentryInfoPlistWrapper.swift
@@ -1,16 +1,10 @@
-@objc @_spi(Private) public class SentryInfoPlistWrapper: NSObject, SentryInfoPlistWrapperProvider {
+final class SentryInfoPlistWrapper: SentryInfoPlistWrapperProvider {
 
     private let bundle: Bundle
 
-    public override init() {
+    public init(bundle: Bundle = Bundle.main) {
         // We can not use defaults in the initializer because this class is used from Objective-C
-        self.bundle = Bundle.main
-        super.init()
-    }
-
-    public init(bundle: Bundle) {
         self.bundle = bundle
-        super.init()
     }
 
     // MARK: - Bridge to ObjC

--- a/Sources/Swift/Helper/InfoPlist/SentryInfoPlistWrapperProvider.swift
+++ b/Sources/Swift/Helper/InfoPlist/SentryInfoPlistWrapperProvider.swift
@@ -1,4 +1,4 @@
-@_spi(Private) @objc public protocol SentryInfoPlistWrapperProvider {
+protocol SentryInfoPlistWrapperProvider {
     /**
      * Retrieves a value from the app's `Info.plist` file for the given key and trys to cast it to a ``String``.
      *

--- a/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayEnvironmentChecker.swift
+++ b/Sources/Swift/Integrations/SessionReplay/SentrySessionReplayEnvironmentChecker.swift
@@ -12,7 +12,7 @@
 
     private let infoPlistWrapper: SentryInfoPlistWrapperProvider
 
-    @objc public init(infoPlistWrapper: SentryInfoPlistWrapperProvider) {
+    init(infoPlistWrapper: SentryInfoPlistWrapperProvider) {
         self.infoPlistWrapper = infoPlistWrapper
         super.init()
     }


### PR DESCRIPTION
Now that we just have one type left to migrate before moving all of the dependency container to Swift, I started moving some of the easier ones into Swift here

#skip-changelog

Closes #6443