### PR TITLE
ref: Refactor app state manager to not use protocol

### DIFF
--- a/Sources/Sentry/SentryAppStartTracker.m
+++ b/Sources/Sentry/SentryAppStartTracker.m
@@ -28,7 +28,7 @@ static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 180.0;
 
 @property (nonatomic, strong, nullable) SentryAppState *previousAppState;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
-@property (nonatomic, strong) id<SentryAppStateManager> appStateManager;
+@property (nonatomic, strong) SentryAppStateManager *appStateManager;
 @property (nonatomic, strong) SentryFramesTracker *framesTracker;
 @property (nonatomic, assign) BOOL wasInBackground;
 @property (nonatomic, strong) NSDate *didFinishLaunchingTimestamp;
@@ -51,7 +51,7 @@ static const NSTimeInterval SENTRY_APP_START_MAX_DURATION = 180.0;
 }
 
 - (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-                             appStateManager:(id<SentryAppStateManager>)appStateManager
+                             appStateManager:(SentryAppStateManager *)appStateManager
                                framesTracker:(SentryFramesTracker *)framesTracker
               enablePreWarmedAppStartTracing:(BOOL)enablePreWarmedAppStartTracing
 {

--- a/Sources/Sentry/SentryAppStartTrackingIntegration.m
+++ b/Sources/Sentry/SentryAppStartTrackingIntegration.m
@@ -24,7 +24,7 @@
         return NO;
     }
 
-    id<SentryAppStateManager> appStateManager =
+    SentryAppStateManager *appStateManager =
         [SentryDependencyContainer sharedInstance].appStateManager;
 
     self.tracker = [[SentryAppStartTracker alloc]

--- a/Sources/Sentry/SentryCrashIntegration.m
+++ b/Sources/Sentry/SentryCrashIntegration.m
@@ -90,7 +90,7 @@ sentry_finishAndSaveTransaction(void)
     self.options = options;
 
 #if SENTRY_HAS_UIKIT
-    id<SentryAppStateManager> appStateManager =
+    SentryAppStateManager *appStateManager =
         [SentryDependencyContainer sharedInstance].appStateManager;
     SentryWatchdogTerminationLogic *logic =
         [[SentryWatchdogTerminationLogic alloc] initWithOptions:options

--- a/Sources/Sentry/SentryDefaultAppStateManager.m
+++ b/Sources/Sentry/SentryDefaultAppStateManager.m
@@ -12,29 +12,31 @@
 
 @interface SentryDefaultAppStateManager ()
 
-@property (nonatomic, strong) SentryOptions *options;
-@property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
-@property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
 @property (nonatomic, strong) id<SentryNSNotificationCenterWrapper> notificationCenterWrapper;
+@property (nonatomic, copy) void (^storeCurrent)(void);
+@property (nonatomic, copy) void (^updateTerminated)(void);
+@property (nonatomic, copy) void (^updateSDKNotRunning)(void);
+@property (nonatomic, copy) void (^updateActive)(BOOL);
 @property (nonatomic) NSInteger startCount;
 
 @end
 
 @implementation SentryDefaultAppStateManager
 
-- (instancetype)initWithOptions:(SentryOptions *_Nullable)options
-                   crashWrapper:(SentryCrashWrapper *)crashWrapper
-                    fileManager:(SentryFileManager *_Nullable)fileManager
-           dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-      notificationCenterWrapper:(id<SentryNSNotificationCenterWrapper>)notificationCenterWrapper
+- (instancetype)initWithStoreCurrent:(void (^)(void))storeCurrent
+                    updateTerminated:(void (^)(void))updateTerminated
+                 updateSDKNotRunning:(void (^)(void))updateSDKNotRunning
+                        updateActive:(void (^)(BOOL))updateActive
 {
     if (self = [super init]) {
-        self.options = options;
-        self.crashWrapper = crashWrapper;
-        self.fileManager = fileManager;
-        self.dispatchQueue = dispatchQueueWrapper;
-        self.notificationCenterWrapper = notificationCenterWrapper;
+        self.dispatchQueue = SentryDependencyContainer.sharedInstance.dispatchQueueWrapper;
+        self.notificationCenterWrapper
+            = SentryDependencyContainer.sharedInstance.notificationCenterWrapper;
+        self.storeCurrent = storeCurrent;
+        self.updateTerminated = updateTerminated;
+        self.updateSDKNotRunning = updateSDKNotRunning;
+        self.updateActive = updateActive;
         self.startCount = 0;
     }
     return self;
@@ -65,7 +67,7 @@
                                                name:SentryWillTerminateNotification
                                              object:nil];
 
-        [self storeCurrentAppState];
+        self.storeCurrent();
     }
 
     self.startCount += 1;
@@ -84,8 +86,7 @@
     }
 
     if (forceStop) {
-        [self
-            updateAppStateInBackground:^(SentryAppState *appState) { appState.isSDKRunning = NO; }];
+        [self.dispatchQueue dispatchAsyncWithBlock:^{ self.updateSDKNotRunning(); }];
 
         self.startCount = 0;
     } else {
@@ -130,7 +131,7 @@
  */
 - (void)didBecomeActive
 {
-    [self updateAppStateInBackground:^(SentryAppState *appState) { appState.isActive = YES; }];
+    [self.dispatchQueue dispatchAsyncWithBlock:^{ self.updateActive(YES); }];
 }
 
 /**
@@ -139,7 +140,7 @@
  */
 - (void)willResignActive
 {
-    [self updateAppStateInBackground:^(SentryAppState *appState) { appState.isActive = NO; }];
+    [self.dispatchQueue dispatchAsyncWithBlock:^{ self.updateActive(NO); }];
 }
 
 - (void)willTerminate
@@ -147,51 +148,7 @@
     // The app is terminating so it is fine to do this on the main thread.
     // Furthermore, so users can manually post UIApplicationWillTerminateNotification and then call
     // exit(0), to avoid getting false watchdog terminations when using exit(0), see GH-1252.
-    [self updateAppState:^(SentryAppState *appState) { appState.wasTerminated = YES; }];
-}
-
-- (void)updateAppStateInBackground:(void (^)(SentryAppState *))block
-{
-    // We accept the tradeoff that the app state might not be 100% up to date over blocking the main
-    // thread.
-    [self.dispatchQueue dispatchAsyncWithBlock:^{ [self updateAppState:block]; }];
-}
-
-- (void)updateAppState:(void (^)(SentryAppState *))block
-{
-    @synchronized(self) {
-        SentryAppState *appState = [self.fileManager readAppState];
-        if (appState != nil) {
-            block(appState);
-            [self.fileManager storeAppState:appState];
-        }
-    }
-}
-
-- (SentryAppState *)buildCurrentAppState
-{
-    // Is the current process being traced or not? If it is a debugger is attached.
-    bool isDebugging = self.crashWrapper.isBeingTraced;
-
-    UIDevice *device = [UIDevice currentDevice];
-    NSString *vendorId = [device.identifierForVendor UUIDString];
-
-    return [[SentryAppState alloc] initWithReleaseName:self.options.releaseName
-                                             osVersion:device.systemVersion
-                                              vendorId:vendorId
-                                           isDebugging:isDebugging
-                                   systemBootTimestamp:SentryDependencyContainer.sharedInstance
-                                                           .sysctlWrapper.systemBootTimestamp];
-}
-
-- (nullable SentryAppState *)loadPreviousAppState
-{
-    return [self.fileManager readPreviousAppState];
-}
-
-- (void)storeCurrentAppState
-{
-    [self.fileManager storeAppState:[self buildCurrentAppState]];
+    self.updateTerminated();
 }
 
 #endif

--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -9,7 +9,6 @@
 #import "SentrySwift.h"
 #import "SentrySystemWrapper.h"
 #import <SentryDebugImageProvider+HybridSDKs.h>
-#import <SentryDefaultAppStateManager.h>
 #import <SentryDefaultUIViewControllerPerformanceTracker.h>
 #import <SentryDependencyContainer.h>
 #import <SentryPerformanceTracker.h>
@@ -56,9 +55,6 @@ SentryApplicationProviderBlock defaultApplicationProvider = ^id<SentryApplicatio
 };
 
 @interface SentryFileManager () <SentryFileManagerProtocol>
-@end
-
-@interface SentryDefaultAppStateManager () <SentryAppStateManager>
 @end
 
 #if SENTRY_HAS_UIKIT
@@ -218,14 +214,13 @@ static BOOL isInitialializingDependencyContainer = NO;
     }));
 }
 
-- (id<SentryAppStateManager>)appStateManager SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
+- (SentryAppStateManager *)appStateManager SENTRY_THREAD_SANITIZER_DOUBLE_CHECKED_LOCK
 {
     SENTRY_LAZY_INIT(_appStateManager,
-        [[SentryDefaultAppStateManager alloc] initWithOptions:SentrySDKInternal.options
-                                                 crashWrapper:self.crashWrapper
-                                                  fileManager:self.fileManager
-                                         dispatchQueueWrapper:self.dispatchQueueWrapper
-                                    notificationCenterWrapper:self.notificationCenterWrapper]);
+        [[SentryAppStateManager alloc] initWithOptions:SentrySDKInternal.options
+                                          crashWrapper:self.crashWrapper
+                                           fileManager:self.fileManager
+                                         sysctlWrapper:self.sysctlWrapper]);
 }
 - (SentryThreadInspector *)threadInspector
 {

--- a/Sources/Sentry/SentryWatchdogTerminationLogic.m
+++ b/Sources/Sentry/SentryWatchdogTerminationLogic.m
@@ -11,7 +11,7 @@
 
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryCrashWrapper *crashAdapter;
-@property (nonatomic, strong) id<SentryAppStateManager> appStateManager;
+@property (nonatomic, strong) SentryAppStateManager *appStateManager;
 
 @end
 
@@ -19,7 +19,7 @@
 
 - (instancetype)initWithOptions:(SentryOptions *)options
                    crashAdapter:(SentryCrashWrapper *)crashAdapter
-                appStateManager:(id<SentryAppStateManager>)appStateManager
+                appStateManager:(SentryAppStateManager *)appStateManager
 {
     if (self = [super init]) {
         self.options = options;

--- a/Sources/Sentry/SentryWatchdogTerminationTracker.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTracker.m
@@ -17,7 +17,7 @@
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryWatchdogTerminationLogic *watchdogTerminationLogic;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueue;
-@property (nonatomic, strong) id<SentryAppStateManager> appStateManager;
+@property (nonatomic, strong) SentryAppStateManager *appStateManager;
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryScopePersistentStore *scopePersistentStore;
 
@@ -27,7 +27,7 @@
 
 - (instancetype)initWithOptions:(SentryOptions *)options
        watchdogTerminationLogic:(SentryWatchdogTerminationLogic *)watchdogTerminationLogic
-                appStateManager:(id<SentryAppStateManager>)appStateManager
+                appStateManager:(SentryAppStateManager *)appStateManager
            dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                     fileManager:(SentryFileManager *)fileManager
            scopePersistentStore:(SentryScopePersistentStore *)scopePersistentStore

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) SentryWatchdogTerminationTracker *tracker;
 @property (nonatomic, strong) id<SentryANRTracker> anrTracker;
 @property (nullable, nonatomic, copy) NSString *testConfigurationFilePath;
-@property (nonatomic, strong) id<SentryAppStateManager> appStateManager;
+@property (nonatomic, strong) SentryAppStateManager *appStateManager;
 
 @end
 
@@ -56,7 +56,7 @@ NS_ASSUME_NONNULL_BEGIN
                                               attributes:attributes];
 
     SentryFileManager *fileManager = [[[SentrySDKInternal currentHub] getClient] fileManager];
-    id<SentryAppStateManager> appStateManager =
+    SentryAppStateManager *appStateManager =
         [SentryDependencyContainer sharedInstance].appStateManager;
     SentryCrashWrapper *crashWrapper = [SentryDependencyContainer sharedInstance].crashWrapper;
     SentryWatchdogTerminationLogic *logic =

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -20,12 +20,12 @@
 @class SentryFileIOTracker;
 @class SentryScopePersistentStore;
 @class SentryOptions;
+@class SentryAppStateManager;
 @class SentrySessionTracker;
 @class SentryGlobalEventProcessor;
 @class SentryThreadInspector;
 @class SentryReachability;
 
-@protocol SentryAppStateManager;
 @protocol SentryANRTracker;
 @protocol SentryRandomProtocol;
 @protocol SentryCurrentDateProvider;
@@ -99,7 +99,7 @@ SENTRY_NO_INIT
 #pragma mark - Lazy Dependencies
 
 @property (nonatomic, strong, nullable) SentryFileManager *fileManager;
-@property (nonatomic, strong) id<SentryAppStateManager> appStateManager;
+@property (nonatomic, strong) SentryAppStateManager *appStateManager;
 @property (nonatomic, strong, readonly) SentryThreadInspector *threadInspector;
 @property (nonatomic, strong, readonly) SentryFileIOTracker *fileIOTracker;
 @property (nonatomic, strong) SentryCrashSwift *crashReporter;

--- a/Sources/Sentry/include/SentryAppStartTracker.h
+++ b/Sources/Sentry/include/SentryAppStartTracker.h
@@ -3,7 +3,7 @@
 #if SENTRY_HAS_UIKIT
 
 @class SentryDispatchQueueWrapper;
-@protocol SentryAppStateManager;
+@class SentryAppStateManager;
 @class SentryFramesTracker;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -20,7 +20,7 @@ SENTRY_NO_INIT
 @property (nonatomic) BOOL isRunning;
 
 - (instancetype)initWithDispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-                             appStateManager:(id<SentryAppStateManager>)appStateManager
+                             appStateManager:(SentryAppStateManager *)appStateManager
                                framesTracker:(SentryFramesTracker *)framesTracker
               enablePreWarmedAppStartTracing:(BOOL)enablePreWarmedAppStartTracing;
 

--- a/Sources/Sentry/include/SentryDefaultAppStateManager.h
+++ b/Sources/Sentry/include/SentryDefaultAppStateManager.h
@@ -15,32 +15,16 @@ SENTRY_NO_INIT
 
 @property (nonatomic, readonly) NSInteger startCount;
 
-- (instancetype)initWithOptions:(SentryOptions *_Nullable)options
-                   crashWrapper:(SentryCrashWrapper *)crashWrapper
-                    fileManager:(SentryFileManager *_Nullable)fileManager
-           dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
-      notificationCenterWrapper:(id<SentryNSNotificationCenterWrapper>)notificationCenterWrapper;
+- (instancetype)initWithStoreCurrent:(void (^)(void))storeCurrent
+                    updateTerminated:(void (^)(void))updateTerminated
+                 updateSDKNotRunning:(void (^)(void))updateSDKNotRunning
+                        updateActive:(void (^)(BOOL))updateActive;
 
 #if SENTRY_HAS_UIKIT
 
 - (void)start;
 - (void)stop;
 - (void)stopWithForce:(BOOL)forceStop;
-
-/**
- * Builds the current app state.
- * @discussion The systemBootTimestamp is calculated by taking the current time and subtracting
- * @c NSProcesInfo.systemUptime . @c NSProcesInfo.systemUptime returns the amount of time the system
- * has been awake since the last time it was restarted. This means This is a good enough
- * approximation about the timestamp the system booted.
- */
-- (SentryAppState *)buildCurrentAppState;
-
-- (nullable SentryAppState *)loadPreviousAppState;
-
-- (void)storeCurrentAppState;
-
-- (void)updateAppState:(void (^)(SentryAppState *))block;
 
 #endif
 

--- a/Sources/Sentry/include/SentryPrivate.h
+++ b/Sources/Sentry/include/SentryPrivate.h
@@ -29,6 +29,7 @@
 #import "SentryCrashMonitor_AppState.h"
 #import "SentryCrashMonitor_System.h"
 #import "SentryDateUtils.h"
+#import "SentryDefaultAppStateManager.h"
 #import "SentryDefaultThreadInspector.h"
 #import "SentryDependencyContainerSwiftHelper.h"
 #import "SentryDeviceContextKeys.h"

--- a/Sources/Sentry/include/SentryWatchdogTerminationLogic.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationLogic.h
@@ -3,7 +3,7 @@
 #if SENTRY_HAS_UIKIT
 
 @class SentryAppState;
-@protocol SentryAppStateManager;
+@class SentryAppStateManager;
 @class SentryCrashWrapper;
 @class SentryFileManager;
 @class SentryOptions;
@@ -15,7 +15,7 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithOptions:(SentryOptions *)options
                    crashAdapter:(SentryCrashWrapper *)crashAdapter
-                appStateManager:(id<SentryAppStateManager>)appStateManager;
+                appStateManager:(SentryAppStateManager *)appStateManager;
 
 - (BOOL)isWatchdogTermination;
 

--- a/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
+++ b/Sources/Sentry/include/SentryWatchdogTerminationTracker.h
@@ -1,6 +1,6 @@
 #import "SentryDefines.h"
 
-@protocol SentryAppStateManager;
+@class SentryAppStateManager;
 @class SentryDispatchQueueWrapper;
 @class SentryFileManager;
 @class SentryOptions;
@@ -25,7 +25,7 @@ SENTRY_NO_INIT
 
 - (instancetype)initWithOptions:(SentryOptions *)options
        watchdogTerminationLogic:(SentryWatchdogTerminationLogic *)watchdogTerminationLogic
-                appStateManager:(id<SentryAppStateManager>)appStateManager
+                appStateManager:(SentryAppStateManager *)appStateManager
            dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                     fileManager:(SentryFileManager *)fileManager
            scopePersistentStore:(SentryScopePersistentStore *)scopeStore;

--- a/Sources/Swift/SentryAppState.swift
+++ b/Sources/Swift/SentryAppState.swift
@@ -5,7 +5,7 @@ import Foundation
     
     public private(set) var releaseName: String?
     public private(set) var osVersion: String
-    public private(set) var vendorId: String
+    public private(set) var vendorId: String?
     public private(set) var isDebugging: Bool
     
     /// The boot time of the system rounded down to seconds. As the precision of the serialization is
@@ -22,7 +22,7 @@ import Foundation
     public var isANROngoing: Bool
     public var isSDKRunning: Bool
     
-    public init(releaseName: String?, osVersion: String, vendorId: String, isDebugging: Bool, systemBootTimestamp: Date) {
+    public init(releaseName: String?, osVersion: String, vendorId: String?, isDebugging: Bool, systemBootTimestamp: Date) {
         self.releaseName = releaseName
         self.osVersion = osVersion
         self.vendorId = vendorId
@@ -119,7 +119,9 @@ import Foundation
             data["release_name"] = releaseName
         }
         data["os_version"] = self.osVersion
-        data["vendor_id"] = self.vendorId
+        if let vendorId = self.vendorId {
+            data["vendor_id"] = vendorId
+        }
         data["is_debugging"] = NSNumber(value: self.isDebugging)
         data["system_boot_timestamp"] = sentry_toIso8601String(self.systemBootTimestamp)
         data["is_active"] = NSNumber(value: self.isActive)

--- a/Sources/Swift/SentryAppStateManager.swift
+++ b/Sources/Swift/SentryAppStateManager.swift
@@ -1,9 +1,72 @@
-@_spi(Private) @objc public protocol SentryAppStateManager {
-    var startCount: Int { get }
+@_implementationOnly import _SentryPrivate
+
+#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+import UIKit
+#endif
+
+@_spi(Private) @objc public final class SentryAppStateManager: NSObject {
     
-    func start()
-    func stop()
-    func stop(withForce force: Bool)
+    private let options: Options?
+    private let crashWrapper: SentryCrashWrapper
+    private let fileManager: SentryFileManager?
+#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+    private let _updateAppState: (@escaping (SentryAppState) -> Void) -> Void
+    private let _buildCurrentAppState: () -> SentryAppState
+    private let helper: SentryDefaultAppStateManager
+#endif
+    
+    @objc public init(options: Options?, crashWrapper: SentryCrashWrapper, fileManager: SentryFileManager?, sysctlWrapper: SentrySysctl) {
+        self.options = options
+        self.crashWrapper = crashWrapper
+        self.fileManager = fileManager
+#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+        let lock = NSRecursiveLock()
+        let buildCurrentAppState = {
+            // Is the current process being traced or not? If it is a debugger is attached.
+            let isDebugging = crashWrapper.isBeingTraced
+
+            let device = UIDevice.current
+            let vendorId = device.identifierForVendor?.uuidString
+
+            return SentryAppState(releaseName: options?.releaseName, osVersion: device.systemVersion, vendorId: vendorId, isDebugging: isDebugging, systemBootTimestamp: sysctlWrapper.systemBootTimestamp)
+        }
+        _buildCurrentAppState = buildCurrentAppState
+        let updateAppState: (@escaping (SentryAppState) -> Void) -> Void = { block in
+            lock.synchronized {
+                let appState = fileManager?.readAppState()
+                if let appState {
+                    block(appState)
+                    fileManager?.store(appState)
+                }
+            }
+        }
+        _updateAppState = updateAppState
+        helper = SentryDefaultAppStateManager(storeCurrent: {
+            fileManager?.store(buildCurrentAppState())
+        }, updateTerminated: {
+            updateAppState { $0.wasTerminated = true }
+        }, updateSDKNotRunning: {
+            updateAppState { $0.isSDKRunning = false }
+        }, updateActive: { active in
+            updateAppState { $0.isActive = active }
+        })
+#endif
+    }
+    
+#if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
+    var startCount: Int {
+        helper.startCount
+    }
+    
+    @objc public func start() {
+        helper.start()
+    }
+    @objc public func stop() {
+        helper.stop()
+    }
+    @objc public func stop(withForce force: Bool) {
+        helper.stop(withForce: force)
+    }
     
     /**
      * Builds the current app state.
@@ -12,11 +75,20 @@
      * has been awake since the last time it was restarted. This means This is a good enough
      * approximation about the timestamp the system booted.
      */
-    func buildCurrentAppState() -> SentryAppState
+    @objc public func buildCurrentAppState() -> SentryAppState {
+        _buildCurrentAppState()
+    }
     
-    func loadPreviousAppState() -> SentryAppState?
+    @objc public func loadPreviousAppState() -> SentryAppState? {
+        fileManager?.readPreviousAppState()
+    }
     
-    func storeCurrentAppState()
+    func storeCurrentAppState() {
+        fileManager?.store(buildCurrentAppState())
+    }
     
-    func updateAppState(_ block: @escaping (SentryAppState) -> Void)
+    @objc public func updateAppState(_ block: @escaping (SentryAppState) -> Void) {
+        _updateAppState(block)
+    }
+#endif
 }

--- a/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateManagerTests.swift
@@ -1,4 +1,4 @@
-@_spi(Private) import Sentry
+@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 
@@ -28,12 +28,13 @@ class SentryAppStateManagerTests: XCTestCase {
 
         func getSut() -> SentryAppStateManager {
             SentryDependencyContainer.sharedInstance().sysctlWrapper = TestSysctl()
-            return SentryDefaultAppStateManager(
+            SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
+            SentryDependencyContainer.sharedInstance().notificationCenterWrapper = notificationCenterWrapper
+            return SentryAppStateManager(
                 options: options,
                 crashWrapper: TestSentryCrashWrapper(processInfoWrapper: ProcessInfo.processInfo),
                 fileManager: fileManager,
-                dispatchQueueWrapper: TestSentryDispatchQueueWrapper(),
-                notificationCenterWrapper: notificationCenterWrapper
+                sysctlWrapper: SentryDependencyContainer.sharedInstance().sysctlWrapper
             )
         }
     }

--- a/Tests/SentryTests/Helper/SentryAppStateTests.swift
+++ b/Tests/SentryTests/Helper/SentryAppStateTests.swift
@@ -41,7 +41,7 @@ class SentryAppStateTests: XCTestCase {
         let dict = [
             "release_name": releaseName,
             "os_version": appState.osVersion,
-            "vendor_id": appState.vendorId,
+            "vendor_id": appState.vendorId ?? "",
             "is_debugging": appState.isDebugging,
             "system_boot_timestamp": sentry_toIso8601String(appState.systemBootTimestamp),
             "is_active": appState.isActive,

--- a/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/AppStartTracking/SentryAppStartTrackerTests.swift
@@ -40,13 +40,12 @@ class SentryAppStartTrackerTests: NotificationCenterTestCase {
             )
 
             SentryDependencyContainer.sharedInstance().sysctlWrapper = sysctl
-            
-            appStateManager = SentryDefaultAppStateManager(
+            SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueue
+            appStateManager = SentryAppStateManager(
                 options: options,
                 crashWrapper: crashWrapper,
                 fileManager: fileManager,
-                dispatchQueueWrapper: dispatchQueue,
-                notificationCenterWrapper: NotificationCenter.default
+                sysctlWrapper: sysctl
             )
             
             framesTracker = SentryFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: currentDate, dispatchQueueWrapper: TestSentryDispatchQueueWrapper(),

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackerTests.swift
@@ -57,12 +57,12 @@ class SentryWatchdogTerminationTrackerTests: NotificationCenterTestCase {
         }
         
         func getSut(fileManager: SentryFileManager) throws -> SentryWatchdogTerminationTracker {
-            let appStateManager = SentryDefaultAppStateManager(
+            SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueue
+            let appStateManager = SentryAppStateManager(
                 options: options,
                 crashWrapper: crashWrapper,
                 fileManager: fileManager,
-                dispatchQueueWrapper: self.dispatchQueue,
-                notificationCenterWrapper: NotificationCenter.default
+                sysctlWrapper: sysctl
             )
             let logic = SentryWatchdogTerminationLogic(
                 options: options,

--- a/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/WatchdogTerminations/SentryWatchdogTerminationTrackingIntegrationTests.swift
@@ -4,8 +4,6 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
-@_spi(Private) extension SentryDefaultAppStateManager: SentryAppStateManager { }
-
 class SentryWatchdogTerminationIntegrationTests: XCTestCase {
     private static let dsn = TestConstants.dsnForTestCase(type: SentryWatchdogTerminationIntegrationTests.self)
 
@@ -18,7 +16,7 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
         let watchdogTerminationAttributesProcessor: TestSentryWatchdogTerminationAttributesProcessor
         let hub: SentryHub
         let scope: Scope
-        let appStateManager: SentryDefaultAppStateManager
+        let appStateManager: SentryAppStateManager
 
         convenience init() throws {
             let options = Options()
@@ -51,12 +49,13 @@ class SentryWatchdogTerminationIntegrationTests: XCTestCase {
             container.fileManager = fileManager
 
             let notificationCenterWrapper = TestNSNotificationCenterWrapper()
-            appStateManager = SentryDefaultAppStateManager(
+            SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueueWrapper
+            SentryDependencyContainer.sharedInstance().notificationCenterWrapper = notificationCenterWrapper
+            appStateManager = SentryAppStateManager(
                 options: options,
                 crashWrapper: crashWrapper,
                 fileManager: fileManager,
-                dispatchQueueWrapper: dispatchQueueWrapper,
-                notificationCenterWrapper: notificationCenterWrapper
+                sysctlWrapper: SentryDependencyContainer.sharedInstance().sysctlWrapper
             )
             container.appStateManager = appStateManager
             appStateManager.start()


### PR DESCRIPTION
This also needs to use a class instead of a protocol to finish the swift conversion

#skip-changelog

Closes #6453