### PR TITLE
ci: Remove extra sample app builds from v8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,15 +74,11 @@ jobs:
       matrix:
         # other sample projects are built in ui-tests
         include:
-          - scheme: macOS-Swift
-            config: Debug
           - scheme: watchOS-Swift WatchKit App
             config: Debug
           - scheme: macOS-SwiftUI
             config: Debug
           - scheme: SessionReplay-CameraTest
-            config: Debug
-          - scheme: visionOS-Swift
             config: Debug
           - scheme: iOS-Swift
             config: DebugV9


### PR DESCRIPTION
This was building both v8 and v9, we don't need to build the v8 one anymore

#skip-changelog

Closes #6457