### PR TITLE
ref: Remove deprecated app start option

### DIFF
--- a/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
+++ b/Samples/SentrySampleShared/SentrySampleShared/SentrySDKWrapper.swift
@@ -481,7 +481,6 @@ extension SentrySDKWrapper {
                 return NSNumber(value: samplerValue)
             }
         }
-        options.enableAppLaunchProfiling = !SentrySDKOverrides.Profiling.disableAppStartProfiling.boolValue
       #endif // !SDK_V9
 
         if !SentrySDKOverrides.Profiling.disableUIProfiling.boolValue {

--- a/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
+++ b/Samples/iOS-ObjectiveC/iOS-ObjectiveC/AppDelegate.m
@@ -70,13 +70,6 @@
             };
 #    pragma clang diagnostic pop
         }
-
-        if (![args containsObject:@"--io.sentry.profiling.disable-app-start-profiling"]) {
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            options.enableAppLaunchProfiling = YES;
-#    pragma clang diagnostic pop
-        }
 #endif // !SDK_V9
 
         SentryHttpStatusCodeRange *httpStatusCodeRange =

--- a/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
+++ b/Samples/iOS-Swift/iOS-Swift/Profiling/ProfilingViewController.swift
@@ -197,11 +197,7 @@ private extension ProfilingViewController {
             profileAppStartsSwitch.isOn = v2Options.profileAppStarts
         } else {
             traceLifecycleSwitch.isOn = false
-          #if SDK_V9
             profileAppStartsSwitch.isOn = false
-          #else
-            profileAppStartsSwitch.isOn = options.enableAppLaunchProfiling
-          #endif // !SDK_V9
         }
     }
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -538,22 +538,6 @@ typedef void (^SentryProfilingConfigurationBlock)(SentryProfileOptions *_Nonnull
 @property (nullable, nonatomic, copy) SentryProfilingConfigurationBlock configureProfiling;
 
 #    if !SDK_V9
-/**
- * @warning This is an experimental feature and may still have bugs.
- * Set to @c YES to run the profiler as early as possible in an app launch, before you would
- * normally have the opportunity to call @c SentrySDK.start . If @c profilesSampleRate is nonnull,
- * the @c tracesSampleRate and @c profilesSampleRate are persisted to disk and read on the next app
- * launch to decide whether to profile that launch.
- * @warning If @c profilesSampleRate is @c nil then a continuous profile will be started on every
- * launch; if you desire sampling profiled launches, you must compute your own sample rate to decide
- * whether to set this property to @c YES or @c NO .
- * @warning This property is deprecated and will be removed in a future version of the SDK. See
- * @c SentryProfileOptions.startOnAppStart and @c SentryProfileOptions.lifecycle .
- * @note Profiling is automatically disabled if a thread sanitizer is attached.
- */
-@property (nonatomic, assign) BOOL enableAppLaunchProfiling DEPRECATED_MSG_ATTRIBUTE(
-    "This property is deprecated and will be removed in a future version of the SDK. See "
-    "SentryProfileOptions.startOnAppStart and SentryProfileOptions.lifecycle");
 
 /**
  * @note Profiling is not supported on watchOS or tvOS.

--- a/Sources/Sentry/SentyOptionsInternal.m
+++ b/Sources/Sentry/SentyOptionsInternal.m
@@ -373,9 +373,6 @@
 #        pragma clang diagnostic ignored "-Wdeprecated-declarations"
     [self setBool:options[@"enableProfiling"]
             block:^(BOOL value) { sentryOptions.enableProfiling = value; }];
-
-    [self setBool:options[NSStringFromSelector(@selector(enableAppLaunchProfiling))]
-            block:^(BOOL value) { sentryOptions.enableAppLaunchProfiling = value; }];
 #        pragma clang diagnostic pop
 #    endif // !SDK_V9
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -19,14 +19,6 @@ import Foundation
             features.append("timeToFullDisplayTracing")
         }
 
-#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-        #if !SDK_V9
-        if options.enableAppLaunchProfiling {
-            features.append("appLaunchProfiling")
-        }
-        #endif // !SDK_V9
-#endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-
 #if os(iOS) || os(tvOS)
 #if canImport(UIKit) && !SENTRY_NO_UIKIT
         if options.enablePreWarmedAppStartTracing {

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
@@ -65,7 +65,6 @@ private extension SentryAppStartProfilingConfigurationTests {
     @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     private func performTest(expectedOptions: LaunchProfileOptions, shouldProfileLaunch: Bool) {
         let actualOptions = Options()
-        actualOptions.enableAppLaunchProfiling = expectedOptions.enableAppLaunchProfiling
 
         if let tracesSampleRate = expectedOptions.tracesSampleRate {
             actualOptions.tracesSampleRate = NSNumber(value: tracesSampleRate)
@@ -104,155 +103,107 @@ private extension SentryAppStartProfilingConfigurationTests {
 // MARK: -
 private extension SentryAppStartProfilingConfigurationTests {
     static let invalidTransactionProfilingConfigurations = [
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: 0),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: 1),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: 0)
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1)
     ]
 
     static let invalidContinuousProfilingV1Configurations = [
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil)
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil)
     ]
 
     static let invalidTransactionProfilingWithV2OptionsConfigurations = [
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
-
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
-
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
-
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: 0, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true))
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: 1, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true))
     ]
 
     static let invalidContinuousProfilingV2Configurations = [
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
-
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true))
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 0, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: false)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true))
     ]
 
     static let validConfigurations = [
@@ -261,16 +212,12 @@ private extension SentryAppStartProfilingConfigurationTests {
         //
 
         // continuous profiling v2 trace lifecycle configurations
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .trace, sessionSampleRate: 1, profileAppStarts: true)),
 
         // continuous profiling v2 manual lifecycle configurations
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: false, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
-        LaunchProfileOptions(enableAppLaunchProfiling: true, tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true))
+        LaunchProfileOptions(tracesSampleRate: 0, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: 1, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true)),
+        LaunchProfileOptions(tracesSampleRate: nil, profilesSampleRate: nil, continuousProfileV2Options: .init(lifecycle: .manual, sessionSampleRate: 1, profileAppStarts: true))
     ]
 }
 
@@ -278,8 +225,6 @@ private extension SentryAppStartProfilingConfigurationTests {
 // MARK: Data structures
 // MARK: -
 struct LaunchProfileOptions: Equatable {
-    /// transaction profiling and continuous profiling v1
-    let enableAppLaunchProfiling: Bool
 
     /// to test transaction based profiling and continuous v2 trace lifecycle
     let tracesSampleRate: Float?
@@ -302,7 +247,6 @@ struct LaunchProfileOptions: Equatable {
 extension LaunchProfileOptions: CustomStringConvertible {
     var description: String {
         return "LaunchProfileOptions(\n"
-        + "\tenableAppLaunchProfiling: \(enableAppLaunchProfiling),\n"
         + "\ttracesSampleRate: \(String(describing: tracesSampleRate)),\n"
         + "\tprofilesSampleRate: \(String(describing: profilesSampleRate)),\n"
         + "\tcontinuousProfileV2Options: \(String(describing: continuousProfileV2Options))\n"

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -25,10 +25,6 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         options.enableTimeToFullDisplayTracing = true
         options.swiftAsyncStacktraces = true
 
-#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-        options.enableAppLaunchProfiling = true
-#endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-
 #if os(iOS) || os(tvOS)
 #if canImport(UIKit) && !SENTRY_NO_UIKIT
         options.enablePreWarmedAppStartTracing = true
@@ -46,10 +42,6 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         XCTAssert(features.contains("captureFailedRequests"))
         XCTAssert(features.contains("timeToFullDisplayTracing"))
         XCTAssert(features.contains("swiftAsyncStacktraces"))
-
-#if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-        XCTAssert(features.contains("appLaunchProfiling"))
-#endif // os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
 
 #if os(iOS) || os(tvOS)
 #if canImport(UIKit) && !SENTRY_NO_UIKIT

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -1397,17 +1397,6 @@
     XCTAssertIdentical(initialScope, options.initialScope);
 }
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
-- (void)testEnableAppLaunchProfilingDefaultValue
-{
-    SentryOptions *options = [self getValidOptions:@{}];
-    XCTAssertFalse(options.enableAppLaunchProfiling);
-}
-#    pragma clang diagnostic pop
-#endif // SENTRY_TARGET_PROFILING_SUPPORTED
-
 - (SentryOptions *)getValidOptions:(NSDictionary<NSString *, id> *)dict
 {
     NSError *error = nil;


### PR DESCRIPTION
Fully removes "enableAppLaunchProfiling" which is removed in V9

#skip-changelog

Closes #6461