### PR TITLE
chore: Use Xcode 26.1 and iOS 26.1 on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -261,8 +261,8 @@ jobs:
           - name: iOS 26 Sentry
             runs-on: macos-26
             platform: "iOS"
-            xcode: "26.0.1"
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            test-destination-os: "26.1"
             device: "iPhone 17 Pro"
             scheme: "Sentry"
 
@@ -290,8 +290,8 @@ jobs:
           - name: macOS 26 Sentry
             runs-on: macos-26
             platform: "macOS"
-            xcode: "26.0.1"
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            test-destination-os: "26.1"
             scheme: "Sentry"
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
@@ -346,8 +346,8 @@ jobs:
           - name: tvOS 26 Sentry
             runs-on: macos-26
             platform: "tvOS"
-            xcode: "26.0.1"
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            test-destination-os: "26.1"
             device: "Apple TV"
             scheme: "Sentry"
 
@@ -360,7 +360,7 @@ jobs:
 
       # Based on a comment in CircleCI forum, we need to boot the simulator for Xcode 26: https://discuss.circleci.com/t/xcode-26-rc/54066/18
       - name: Boot simulator
-        if: ${{matrix.platform == 'iOS' && matrix.test-destination-os == '26.0'}}
+        if: ${{matrix.platform == 'iOS' && matrix.test-destination-os == '26.1'}}
         run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
 
       # We split building and running tests in two steps so we know how long running the tests takes.

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -80,13 +80,13 @@ jobs:
         env:
           XCODE_VERSION: ${{ inputs.xcode_version }}
       - name: Install required platforms for Xcode 26
-        if: ${{ inputs.xcode_version == '26.0.1' }}
+        if: ${{ inputs.xcode_version == '26.1' }}
         env:
           PLATFORM: ${{ inputs.platform }}
         run: ./scripts/ci-install-xOS-26-platforms.sh --platforms "$PLATFORM"
 
       - name: Create simulator device for Xcode 26
-        if: ${{ inputs.xcode_version == '26.0.1' }}
+        if: ${{ inputs.xcode_version == '26.1' }}
         env:
           PLATFORM: ${{ inputs.platform }}
           OS_VERSION: ${{ inputs.test-destination-os }}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -75,10 +75,10 @@ jobs:
           - name: iOS 26
             platform:
               runs-on: macos-15
-              xcode: "26.0.1"
+              xcode: "26.1"
               platform: "iOS"
               device: "iPhone 17 Pro"
-              test-destination-os: "26.0"
+              test-destination-os: "26.1"
 
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -97,9 +97,9 @@ jobs:
           - name: iOS 26
             runs-on: macos-15
             platform: "iOS"
-            xcode: "26.0.1"
-            device: iPhone 16 Pro
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            device: iPhone 17 Pro
+            test-destination-os: "26.1"
     with:
       fastlane_command: ui_tests_ios_swift
       files_suffix: _xcode_${{matrix.xcode}}-${{matrix.device}}

--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -55,9 +55,9 @@ case "$XCODE_VERSION" in
         IOS_VERSION="18.4"
         log_notice "Selected: $SIMULATOR with iOS $IOS_VERSION for Xcode $XCODE_VERSION"
         ;;
-    "26.0.1")
+    "26.1")
         SIMULATOR="iPhone 17 Pro"
-        IOS_VERSION="26.0"
+        IOS_VERSION="26.1"
         log_notice "Selected: $SIMULATOR with iOS $IOS_VERSION for Xcode $XCODE_VERSION"
         ;;
     *)


### PR DESCRIPTION
Test Xcode 26.1 and iOS 26.1 beta for CI

Given how unstable iOS 26.0 has been recently, let's try using iOS 26.1 beta

#skip-changelog

Closes #6468