### PR TITLE
ref: Convert SentryANRTracker to class

### DIFF
--- a/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryContinuousProfiler.mm
@@ -2,7 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryDependencyContainer.h"
+#    import "SentryDependencyContainerSwiftHelper.h"
 #    import "SentryInternalDefines.h"
 #    import "SentryLogC.h"
 #    import "SentryMetricProfiler.h"
@@ -83,7 +83,7 @@ _sentry_threadUnsafe_transmitChunkEnvelope(void)
 
     // Move the serialization work to a background queue to avoid potentially
     // blocking the main thread. The serialization can take several milliseconds.
-    sentry_dispatchAsync(SentryDependencyContainer.sharedInstance.dispatchQueueWrapper, ^{
+    sentry_dispatchAsync(SentryDependencyContainerSwiftHelper.dispatchQueueWrapper, ^{
         NSDictionary *_Nonnull serializedMetrics
             = serializeContinuousProfileMetrics(metricProfilerState);
         SentryEnvelope *_Nullable envelope
@@ -199,7 +199,7 @@ _sentry_unsafe_stopTimerAndCleanup()
 + (void)scheduleTimer
 {
     sentry_dispatchAsyncOnMainIfNotMainThread(
-        SentryDependencyContainer.sharedInstance.dispatchQueueWrapper, ^{
+        SentryDependencyContainerSwiftHelper.dispatchQueueWrapper, ^{
             std::lock_guard<std::mutex> l(_threadUnsafe_gContinuousProfilerLock);
             if (_chunkTimer != nil) {
                 SENTRY_LOG_WARN(

--- a/Sources/Sentry/Profiling/SentryProfilerState.mm
+++ b/Sources/Sentry/Profiling/SentryProfilerState.mm
@@ -2,7 +2,7 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryAsyncSafeLog.h"
 #    import "SentryBacktrace.hpp"
-#    import "SentryDependencyContainer.h"
+#    import "SentryDependencyContainerSwiftHelper.h"
 #    import "SentryFormatter.h"
 #    import "SentryInternalDefines.h"
 #    import "SentryProfileTimeseries.h"
@@ -73,7 +73,7 @@ parseBacktraceSymbolsFunctionName(const char *symbol)
         _mutableState = [[SentryProfilerMutableState alloc] init];
         _mainThreadID = 0;
         sentry_dispatchAsyncOnMainIfNotMainThread(
-            SentryDependencyContainer.sharedInstance.dispatchQueueWrapper,
+            SentryDependencyContainerSwiftHelper.dispatchQueueWrapper,
             ^{ [self cacheMainThreadID]; });
     }
     return self;

--- a/Sources/Sentry/Profiling/SentryTraceProfiler.mm
+++ b/Sources/Sentry/Profiling/SentryTraceProfiler.mm
@@ -2,8 +2,7 @@
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 
-#    import "SentryDependencyContainer.h"
-
+#    import "SentryDependencyContainerSwiftHelper.h"
 #    import "SentryInternalDefines.h"
 #    import "SentryLogC.h"
 #    import "SentryMetricProfiler.h"
@@ -85,7 +84,7 @@ SentryProfiler *_Nullable _threadUnsafe_gTraceProfiler;
 + (void)scheduleTimeoutTimer
 {
     sentry_dispatchAsyncOnMainIfNotMainThread(
-        SentryDependencyContainer.sharedInstance.dispatchQueueWrapper, ^{
+        SentryDependencyContainerSwiftHelper.dispatchQueueWrapper, ^{
             std::lock_guard<std::mutex> l(_threadUnsafe_gTraceProfilerLock);
             if (_sentry_threadUnsafe_traceProfileTimeoutTimer != nil) {
                 return;

--- a/Sources/Sentry/SentryANRTrackerV1.m
+++ b/Sources/Sentry/SentryANRTrackerV1.m
@@ -13,7 +13,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     kSentryANRTrackerStopping
 };
 
-@interface SentryANRTrackerV1 () <SentryANRTracker>
+@interface SentryANRTrackerV1 ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
@@ -26,6 +26,15 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
 @implementation SentryANRTrackerV1 {
     NSObject *threadLock;
     SentryANRTrackerState state;
+}
+
+- (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
+{
+    return
+        [self initWithTimeoutInterval:timeoutInterval
+                         crashWrapper:SentryDependencyContainer.sharedInstance.crashWrapper
+                 dispatchQueueWrapper:SentryDependencyContainer.sharedInstance.dispatchQueueWrapper
+                        threadWrapper:SentryDependencyContainer.sharedInstance.threadWrapper];
 }
 
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
@@ -42,11 +51,6 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         threadLock = [[NSObject alloc] init];
         state = kSentryANRTrackerNotRunning;
     }
-    return self;
-}
-
-- (id<SentryANRTracker>)asProtocol
-{
     return self;
 }
 

--- a/Sources/Sentry/SentryANRTrackerV2.m
+++ b/Sources/Sentry/SentryANRTrackerV2.m
@@ -17,7 +17,7 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
     kSentryANRTrackerStopping
 };
 
-@interface SentryANRTrackerV2 () <SentryANRTracker>
+@interface SentryANRTrackerV2 ()
 
 @property (nonatomic, strong) SentryCrashWrapper *crashWrapper;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;
@@ -31,6 +31,16 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
 @implementation SentryANRTrackerV2 {
     NSObject *threadLock;
     SentryANRTrackerState state;
+}
+
+- (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
+{
+    return
+        [self initWithTimeoutInterval:timeoutInterval
+                         crashWrapper:SentryDependencyContainer.sharedInstance.crashWrapper
+                 dispatchQueueWrapper:SentryDependencyContainer.sharedInstance.dispatchQueueWrapper
+                        threadWrapper:SentryDependencyContainer.sharedInstance.threadWrapper
+                        framesTracker:SentryDependencyContainer.sharedInstance.framesTracker];
 }
 
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
@@ -49,11 +59,6 @@ typedef NS_ENUM(NSInteger, SentryANRTrackerState) {
         threadLock = [[NSObject alloc] init];
         state = kSentryANRTrackerNotRunning;
     }
-    return self;
-}
-
-- (id<SentryANRTracker>)asProtocol
-{
     return self;
 }
 

--- a/Sources/Sentry/SentryANRTrackingIntegration.m
+++ b/Sources/Sentry/SentryANRTrackingIntegration.m
@@ -24,7 +24,7 @@ static NSString *const SentryANRMechanismDataAppHangDuration = @"app_hang_durati
 
 @interface SentryANRTrackingIntegration () <SentryANRTrackerDelegate>
 
-@property (nonatomic, strong) id<SentryANRTracker> tracker;
+@property (nonatomic, strong) SentryANRTracker *tracker;
 @property (nonatomic, strong) SentryOptions *options;
 @property (nonatomic, strong) SentryFileManager *fileManager;
 @property (nonatomic, strong) SentryDispatchQueueWrapper *dispatchQueueWrapper;

--- a/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
+++ b/Sources/Sentry/SentryAutoBreadcrumbTrackingIntegration.m
@@ -4,6 +4,7 @@
 #import "SentryLogC.h"
 #import "SentryOptions.h"
 #import "SentrySDKInternal.h"
+#import "SentrySwift.h"
 #import "SentrySystemEventBreadcrumbs.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/Sources/Sentry/SentryCoreDataTrackingIntegration.m
+++ b/Sources/Sentry/SentryCoreDataTrackingIntegration.m
@@ -6,6 +6,7 @@
 #import "SentryLogC.h"
 #import "SentryNSDataSwizzling.h"
 #import "SentryOptions.h"
+#import "SentrySwift.h"
 
 @interface SentryCoreDataTrackingIntegration ()
 

--- a/Sources/Sentry/SentryDelayedFramesTracker.m
+++ b/Sources/Sentry/SentryDelayedFramesTracker.m
@@ -3,6 +3,7 @@
 #if SENTRY_HAS_UIKIT
 
 #    import "SentryDelayedFrame.h"
+#    import "SentryDependencyContainer.h"
 #    import "SentryInternalCDefines.h"
 #    import "SentryLogC.h"
 #    import "SentrySwift.h"
@@ -21,6 +22,13 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @implementation SentryDelayedFramesTracker
+
+- (instancetype)initWithKeepDelayedFramesDuration:(CFTimeInterval)keepDelayedFramesDuration
+{
+    return [self
+        initWithKeepDelayedFramesDuration:keepDelayedFramesDuration
+                             dateProvider:SentryDependencyContainer.sharedInstance.dateProvider];
+}
 
 - (instancetype)initWithKeepDelayedFramesDuration:(CFTimeInterval)keepDelayedFramesDuration
                                      dateProvider:(id<SentryCurrentDateProvider>)dateProvider

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -17,6 +17,11 @@
 
 #endif // SENTRY_HAS_UIKIT
 
++ (SentryDispatchQueueWrapper *)dispatchQueueWrapper
+{
+    return SentryDependencyContainer.sharedInstance.dispatchQueueWrapper;
+}
+
 + (void)dispatchSyncOnMainQueue:(void (^)(void))block
 {
     [SentryDependencyContainer.sharedInstance.dispatchQueueWrapper dispatchSyncOnMainQueue:block];

--- a/Sources/Sentry/SentryProfiler.mm
+++ b/Sources/Sentry/SentryProfiler.mm
@@ -3,7 +3,7 @@
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    import "SentryClient+Private.h"
 #    import "SentryContinuousProfiler.h"
-#    import "SentryDependencyContainer.h"
+#    import "SentryDependencyContainerSwiftHelper.h"
 #    import "SentryFileManagerHelper.h"
 #    import "SentryHub+Private.h"
 #    import "SentryInternalDefines.h"
@@ -121,7 +121,7 @@ sentry_sdkInitProfilerTasks(SentryOptions *options, SentryHub *hub)
 
     sentry_configureContinuousProfiling(options);
 
-    sentry_dispatchAsync(SentryDependencyContainer.sharedInstance.dispatchQueueWrapper, ^{
+    sentry_dispatchAsync(SentryDependencyContainerSwiftHelper.dispatchQueueWrapper, ^{
         if (configurationFromLaunch.isProfilingThisLaunch) {
             BOOL shouldStopAndTransmitLaunchProfile = YES;
 

--- a/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
+++ b/Sources/Sentry/SentryWatchdogTerminationTrackingIntegration.m
@@ -13,14 +13,13 @@
 #    import <SentrySwift.h>
 #    import <SentryWatchdogTerminationBreadcrumbProcessor.h>
 #    import <SentryWatchdogTerminationLogic.h>
-#    import <SentryWatchdogTerminationScopeObserver.h>
 #    import <SentryWatchdogTerminationTracker.h>
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryWatchdogTerminationTrackingIntegration () <SentryANRTrackerDelegate>
 
 @property (nonatomic, strong) SentryWatchdogTerminationTracker *tracker;
-@property (nonatomic, strong) id<SentryANRTracker> anrTracker;
+@property (nonatomic, strong) SentryANRTracker *anrTracker;
 @property (nullable, nonatomic, copy) NSString *testConfigurationFilePath;
 @property (nonatomic, strong) SentryAppStateManager *appStateManager;
 

--- a/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
+++ b/Sources/Sentry/include/HybridPublic/SentryDependencyContainer.h
@@ -24,9 +24,9 @@
 @class SentrySessionTracker;
 @class SentryGlobalEventProcessor;
 @class SentryThreadInspector;
+@class SentryANRTracker;
 @class SentryReachability;
 
-@protocol SentryANRTracker;
 @protocol SentryRandomProtocol;
 @protocol SentryCurrentDateProvider;
 @protocol SentryRateLimits;
@@ -106,9 +106,9 @@ SENTRY_NO_INIT
 @property (nonatomic, strong, nullable) SentryScopePersistentStore *scopePersistentStore;
 @property (nonatomic, strong) SentryDebugImageProvider *debugImageProvider;
 
-- (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout;
+- (SentryANRTracker *)getANRTracker:(NSTimeInterval)timeout;
 #if SENTRY_HAS_UIKIT
-- (id<SentryANRTracker>)getANRTracker:(NSTimeInterval)timeout isV2Enabled:(BOOL)isV2Enabled;
+- (SentryANRTracker *)getANRTracker:(NSTimeInterval)timeout isV2Enabled:(BOOL)isV2Enabled;
 #endif // SENTRY_HAS_UIKIT
 
 - (nullable id<SentryApplication>)application;

--- a/Sources/Sentry/include/SentryANRTrackerV1.h
+++ b/Sources/Sentry/include/SentryANRTrackerV1.h
@@ -4,7 +4,7 @@
 @class SentryCrashWrapper;
 @class SentryDispatchQueueWrapper;
 @class SentryThreadWrapper;
-@protocol SentryANRTracker;
+@protocol SentryANRTrackerDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -24,12 +24,16 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryANRTrackerV1 : NSObject
 SENTRY_NO_INIT
 
+- (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
                            crashWrapper:(SentryCrashWrapper *)crashWrapper
                    dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                           threadWrapper:(SentryThreadWrapper *)threadWrapper;
 
-- (id<SentryANRTracker>)asProtocol;
+- (void)addListener:(id<SentryANRTrackerDelegate>)listener;
+- (void)removeListener:(id<SentryANRTrackerDelegate>)listener;
+- (void)clear;
 
 @end
 

--- a/Sources/Sentry/include/SentryANRTrackerV2.h
+++ b/Sources/Sentry/include/SentryANRTrackerV2.h
@@ -6,7 +6,7 @@
 @class SentryDispatchQueueWrapper;
 @class SentryThreadWrapper;
 @class SentryFramesTracker;
-@protocol SentryANRTracker;
+@protocol SentryANRTrackerDelegate;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,13 +23,17 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryANRTrackerV2 : NSObject
 SENTRY_NO_INIT
 
+- (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval;
+
 - (instancetype)initWithTimeoutInterval:(NSTimeInterval)timeoutInterval
                            crashWrapper:(SentryCrashWrapper *)crashWrapper
                    dispatchQueueWrapper:(SentryDispatchQueueWrapper *)dispatchQueueWrapper
                           threadWrapper:(SentryThreadWrapper *)threadWrapper
                           framesTracker:(SentryFramesTracker *)framesTracker;
 
-- (id<SentryANRTracker>)asProtocol;
+- (void)addListener:(id<SentryANRTrackerDelegate>)listener;
+- (void)removeListener:(id<SentryANRTrackerDelegate>)listener;
+- (void)clear;
 
 @end
 

--- a/Sources/Sentry/include/SentryDelayedFramesTracker.h
+++ b/Sources/Sentry/include/SentryDelayedFramesTracker.h
@@ -16,6 +16,15 @@ SENTRY_NO_INIT
  * the current time minus the @c keepDelayedFramesDuration.
  *
  * @param keepDelayedFramesDuration The maximum duration to keep delayed frames records in memory.
+ */
+- (instancetype)initWithKeepDelayedFramesDuration:(CFTimeInterval)keepDelayedFramesDuration;
+
+/**
+ * Initializes a @c SentryDelayedFramesTracker. This class keeps track of information on delayed
+ * frames. Whenever a new delayed frame is recorded, it removes recorded delayed frames older than
+ * the current time minus the @c keepDelayedFramesDuration.
+ *
+ * @param keepDelayedFramesDuration The maximum duration to keep delayed frames records in memory.
  * @param dateProvider The instance of a date provider.
  */
 - (instancetype)initWithKeepDelayedFramesDuration:(CFTimeInterval)keepDelayedFramesDuration

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -11,6 +11,7 @@
 @class SentryHub;
 @class SentryCrash;
 @class SentryNSProcessInfoWrapper;
+@class SentryDispatchQueueWrapper;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -26,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 #endif // SENTRY_HAS_UIKIT
 
++ (SentryDispatchQueueWrapper *)dispatchQueueWrapper;
 + (void)dispatchSyncOnMainQueue:(void (^)(void))block;
 + (id<SentryObjCRuntimeWrapper>)objcRuntimeWrapper;
 + (SentryHub *)currentHub;

--- a/Sources/Swift/Core/Integrations/ANR/SentryANRTracker.swift
+++ b/Sources/Swift/Core/Integrations/ANR/SentryANRTracker.swift
@@ -1,11 +1,29 @@
 import Foundation
 
-@objc
-@_spi(Private) public protocol SentryANRTracker {
-    @objc(addListener:)
-    func add(listener: SentryANRTrackerDelegate)
-    @objc(removeListener:)
-    func remove(listener: SentryANRTrackerDelegate)
+@_spi(Private) @objc public final class SentryANRTracker: NSObject {
+    
+    let helper: SentryANRTrackerProtocol
+    
+    @objc public init(helper: SentryANRTrackerProtocol) {
+        self.helper = helper
+    }
+    
+    @objc(addListener:) public func add(listener: SentryANRTrackerDelegate) {
+        helper.addListener(listener)
+    }
+    
+    @objc(removeListener:) public func remove(listener: SentryANRTrackerDelegate) {
+        helper.removeListener(listener)
+    }
+    
+    @objc public func clear() {
+        helper.clear()
+    }
+}
+
+@_spi(Private) @objc public protocol SentryANRTrackerProtocol {
+    @objc func addListener(_ listender: SentryANRTrackerDelegate)
+    @objc func removeListener(_ listener: SentryANRTrackerDelegate)
     
     /// Only used for tests.
     func clear()

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationTests.swift
@@ -1,3 +1,4 @@
+@_spi(Private) import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
+++ b/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
@@ -1,6 +1,6 @@
 import _SentryPrivate
 @_spi(Private) @testable import Sentry
-@_spi(Private) import SentryTestUtils
+@_spi(Private) @testable import SentryTestUtils
 import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)

--- a/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
+++ b/Tests/SentryTests/Helper/SentryDependencyContainerTests.swift
@@ -21,7 +21,7 @@ final class SentryDependencyContainerTests: XCTestCase {
 
     func testGetANRTrackerV2() {
         let instance = SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: true)
-        XCTAssertTrue(instance is SentryANRTrackerV2)
+        XCTAssertTrue(instance.helper is SentryANRTrackerV2)
 
         SentryDependencyContainer.reset()
 
@@ -29,27 +29,27 @@ final class SentryDependencyContainerTests: XCTestCase {
 
     func testGetANRTrackerV1() {
         let instance = SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: false)
-        XCTAssertTrue(instance is SentryANRTrackerV1)
+        XCTAssertTrue(instance.helper is SentryANRTrackerV1)
 
         SentryDependencyContainer.reset()
     }
 
     func testGetANRTrackerV2AndThenV1_FirstCalledVersionStaysTheSame() {
         let instance1 = SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: true)
-        XCTAssertTrue(instance1 is SentryANRTrackerV2)
+        XCTAssertTrue(instance1.helper is SentryANRTrackerV2)
 
         let instance2 = SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: false)
-        XCTAssertTrue(instance2 is SentryANRTrackerV2)
+        XCTAssertTrue(instance2.helper is SentryANRTrackerV2)
 
         SentryDependencyContainer.reset()
     }
 
     func testGetANRTrackerV1AndThenV2_FirstCalledVersionStaysTheSame() {
         let instance1 = SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: false)
-        XCTAssertTrue(instance1 is SentryANRTrackerV1)
+        XCTAssertTrue(instance1.helper is SentryANRTrackerV1)
 
         let instance2 = SentryDependencyContainer.sharedInstance().getANRTracker(2.0, isV2Enabled: true)
-        XCTAssertTrue(instance2 is SentryANRTrackerV1)
+        XCTAssertTrue(instance2.helper is SentryANRTrackerV1)
 
         SentryDependencyContainer.reset()
     }
@@ -59,7 +59,7 @@ final class SentryDependencyContainerTests: XCTestCase {
     func testGetANRTracker_ReturnsV1() {
 
         let instance = SentryDependencyContainer.sharedInstance().getANRTracker(2.0)
-        XCTAssertTrue(instance is SentryANRTrackerV1)
+        XCTAssertTrue(instance.helper is SentryANRTrackerV1)
 
         SentryDependencyContainer.reset()
     }

--- a/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
+++ b/Tests/SentryTests/Helper/SentryExtraContextProviderTests.swift
@@ -1,4 +1,4 @@
-@_spi(Private) import Sentry
+@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1IntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1IntegrationTests.swift
@@ -12,11 +12,11 @@ final class SentryANRTrackerV1IntegrationTests: XCTestCase {
 
         let listener = SentryANRTrackerTestDelegate()
 
-        let anrTracker: SentryANRTracker = SentryANRTrackerV1(
+        let anrTracker = SentryANRTracker(helper: SentryANRTrackerV1(
             timeoutInterval: 0.01,
             crashWrapper: TestSentryCrashWrapper(processInfoWrapper: ProcessInfo.processInfo),
             dispatchQueueWrapper: SentryDispatchQueueWrapper(),
-            threadWrapper: SentryThreadWrapper()) as! SentryANRTracker
+            threadWrapper: SentryThreadWrapper()))
 
         anrTracker.add(listener: listener)
 

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV1Tests.swift
@@ -2,6 +2,8 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
+@_spi(Private) extension SentryANRTrackerV1: SentryANRTrackerProtocol { }
+
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
 class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
 
@@ -40,11 +42,11 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         
         fixture = Fixture()
         
-        sut = SentryANRTrackerV1(
+        sut = SentryANRTracker(helper: SentryANRTrackerV1(
             timeoutInterval: fixture.timeoutInterval,
             crashWrapper: fixture.crashWrapper,
             dispatchQueueWrapper: fixture.dispatchQueue,
-            threadWrapper: fixture.threadWrapper) as? SentryANRTracker
+            threadWrapper: fixture.threadWrapper))
     }
     
     override func tearDown() {
@@ -198,7 +200,7 @@ class SentryANRTrackerV1Tests: XCTestCase, SentryANRTrackerDelegate {
         sut.add(listener: self)
         sut.remove(listener: self)
         
-        let listeners = Dynamic(sut).listeners.asObject as? NSHashTable<NSObject>
+        let listeners = Dynamic(sut.helper).listeners.asObject as? NSHashTable<NSObject>
         
         XCTAssertGreaterThan(addListenersCount, listeners?.count ?? addListenersCount)
         

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackerV2Tests.swift
@@ -3,6 +3,9 @@
 import XCTest
 
 #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+
+@_spi(Private) extension SentryANRTrackerV2: SentryANRTrackerProtocol { }
+
 class SentryANRTrackerV2Tests: XCTestCase {
     
     private let waitTimeout: TimeInterval = 10.0
@@ -30,12 +33,12 @@ class SentryANRTrackerV2Tests: XCTestCase {
             displayLinkWrapper.normalFrame()
         }
         
-        return (SentryANRTrackerV2(
+        return (SentryANRTracker(helper: SentryANRTrackerV2(
             timeoutInterval: timeoutInterval,
             crashWrapper: crashWrapper,
             dispatchQueueWrapper: dispatchQueue,
             threadWrapper: threadWrapper,
-            framesTracker: framesTracker) as! SentryANRTracker, currentDate, displayLinkWrapper, crashWrapper, threadWrapper, framesTracker)
+            framesTracker: framesTracker)), currentDate, displayLinkWrapper, crashWrapper, threadWrapper, framesTracker)
     }
     
     /// When no frame gets rendered its a fully blocking app hang.
@@ -447,7 +450,7 @@ class SentryANRTrackerV2Tests: XCTestCase {
         
         triggerFullyBlockingAppHang(currentDate)
         
-        let listeners = Dynamic(sut).listeners.asObject as? NSHashTable<NSObject>
+        let listeners = Dynamic(sut.helper).listeners.asObject as? NSHashTable<NSObject>
         
         XCTAssertGreaterThan(addListenersCount, listeners?.count ?? addListenersCount)
         

--- a/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/ANR/SentryANRTrackingIntegrationTests.swift
@@ -52,8 +52,8 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         givenInitializedTracker()
         
         let tracker = Dynamic(sut).tracker.asAnyObject
-        XCTAssertNotNil(tracker)
-        XCTAssertTrue(tracker is SentryANRTrackerV1)
+        XCTAssertNotNil(tracker as? SentryANRTracker)
+        XCTAssertTrue((tracker as? SentryANRTracker)?.helper is SentryANRTrackerV1)
     }
     
     func test_enableAppHangsTracking_Disabled() {
@@ -88,8 +88,8 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         XCTAssertTrue(result)
 
         let tracker = Dynamic(sut).tracker.asAnyObject
-        XCTAssertNotNil(tracker)
-        XCTAssertTrue(tracker is SentryANRTrackerV2)
+        XCTAssertNotNil(tracker as? SentryANRTracker)
+        XCTAssertTrue((tracker as? SentryANRTracker)?.helper is SentryANRTrackerV2)
     }
 #endif
     
@@ -350,7 +350,7 @@ class SentryANRTrackingIntegrationTests: SentrySDKIntegrationTestsBase {
         
         let tracker = SentryDependencyContainer.sharedInstance().getANRTracker(self.options.appHangTimeoutInterval)
         
-        let listeners = try XCTUnwrap(Dynamic(tracker).listeners.asObject as? NSHashTable<NSObject>)
+        let listeners = try XCTUnwrap(Dynamic(tracker.helper).listeners.asObject as? NSHashTable<NSObject>)
         
         XCTAssertEqual(1, listeners.count)
     }

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackerTest.swift
@@ -1,5 +1,5 @@
 import CoreData
-@testable import Sentry
+@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/UIEvents/SentryUIEventTrackerTests.swift
@@ -1,4 +1,4 @@
-import Sentry
+@_spi(Private) import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
+++ b/Tests/SentryTests/Networking/SentryTransportFactoryTests.swift
@@ -1,4 +1,4 @@
-@_spi(Private) import Sentry
+@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/SentryClient+TestInit.h
+++ b/Tests/SentryTests/SentryClient+TestInit.h
@@ -1,5 +1,6 @@
 #import "SentryTransport.h"
 
+@protocol SentryCurrentDateProvider;
 @protocol SentryRandomProtocol;
 
 @class SentryCrashWrapper;

--- a/Tests/SentryTests/SentryScreenshotSourceTests.swift
+++ b/Tests/SentryTests/SentryScreenshotSourceTests.swift
@@ -1,4 +1,4 @@
-@_spi(Private) import Sentry
+@_spi(Private) @testable import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 

--- a/Tests/SentryTests/State/SentryInstallationTests.swift
+++ b/Tests/SentryTests/State/SentryInstallationTests.swift
@@ -1,3 +1,4 @@
+@_spi(Private) import Sentry
 @_spi(Private) import SentryTestUtils
 import XCTest
 


### PR DESCRIPTION
I pulled this change out of the overall dependency container Swift refactor to make that PR easier to review

#skip-changelog

Closes #6466