### PR TITLE
ref: Create redact options wrapper for Swift

### DIFF
--- a/Sources/Sentry/SentryDependencyContainer.m
+++ b/Sources/Sentry/SentryDependencyContainer.m
@@ -2,6 +2,7 @@
 
 #import "SentryDefaultThreadInspector.h"
 #import "SentryDelayedFramesTracker.h"
+#import "SentryDependencyContainerSwiftHelper.h"
 #import "SentryInternalCDefines.h"
 #import "SentryInternalDefines.h"
 #import "SentryLogC.h"
@@ -59,6 +60,9 @@ SentryApplicationProviderBlock defaultApplicationProvider = ^id<SentryApplicatio
 @end
 
 #if SENTRY_HAS_UIKIT
+@interface SentryDefaultRedactOptions () <SentryRedactOptions>
+@end
+
 @interface SentryWatchdogTerminationScopeObserver () <SentryScopeObserver>
 @end
 
@@ -279,21 +283,23 @@ static BOOL isInitialializingDependencyContainer = NO;
         if (_screenshotSource == nil) {
             // The options could be null here, but this is a general issue in the dependency
             // container and will be fixed in a future refactoring.
-            SentryViewScreenshotOptions *_Nonnull options = SENTRY_UNWRAP_NULLABLE(
-                SentryViewScreenshotOptions, SentrySDKInternal.options.screenshot);
+            SentryOptions *_Nonnull options
+                = SENTRY_UNWRAP_NULLABLE(SentryOptions, SentrySDKInternal.options);
 
             id<SentryViewRenderer> viewRenderer;
-            if (options.enableViewRendererV2) {
+            if ([SentryDependencyContainerSwiftHelper viewRendererV2Enabled:options]) {
                 viewRenderer = [[SentryViewRendererV2 alloc]
-                    initWithEnableFastViewRendering:options.enableFastViewRendering];
+                    initWithEnableFastViewRendering:[SentryDependencyContainerSwiftHelper
+                                                        fastViewRenderingEnabled:options]];
             } else {
                 viewRenderer = [[SentryDefaultViewRenderer alloc] init];
             }
 
-            SentryViewPhotographer *photographer =
-                [[SentryViewPhotographer alloc] initWithRenderer:viewRenderer
-                                                   redactOptions:options
-                                            enableMaskRendererV2:options.enableViewRendererV2];
+            SentryViewPhotographer *photographer = [[SentryViewPhotographer alloc]
+                    initWithRenderer:viewRenderer
+                       redactOptions:[SentryDependencyContainerSwiftHelper redactOptions:options]
+                enableMaskRendererV2:[SentryDependencyContainerSwiftHelper
+                                         viewRendererV2Enabled:options]];
             _screenshotSource = [[SentryScreenshotSource alloc] initWithPhotographer:photographer];
         }
 

--- a/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
+++ b/Sources/Sentry/SentryDependencyContainerSwiftHelper.m
@@ -6,6 +6,24 @@
 #import "SentrySDK+Private.h"
 #import "SentrySwift.h"
 
+@implementation SentryDefaultRedactOptions
+- (instancetype)initWithMaskAllText:(BOOL)maskAllText
+                      maskAllImages:(BOOL)maskAllImages
+                  maskedViewClasses:(NSArray<Class> *)maskedViewClasses
+                unmaskedViewClasses:(NSArray<Class> *)unmaskedViewClasses
+{
+    if (self = [super init]) {
+        _maskAllText = maskAllText;
+        _maskAllImages = maskAllImages;
+        _maskedViewClasses = maskedViewClasses;
+        _unmaskedViewClasses = unmaskedViewClasses;
+        return self;
+    }
+    return nil;
+}
+
+@end
+
 @implementation SentryDependencyContainerSwiftHelper
 
 #if SENTRY_HAS_UIKIT
@@ -13,6 +31,25 @@
 + (NSArray<UIWindow *> *)windows
 {
     return [SentryDependencyContainer.sharedInstance.application getWindows];
+}
+
++ (BOOL)fastViewRenderingEnabled:(SentryOptions *)options
+{
+    return options.screenshot.enableFastViewRendering;
+}
+
++ (BOOL)viewRendererV2Enabled:(SentryOptions *)options
+{
+    return options.screenshot.enableViewRendererV2;
+}
+
++ (SentryDefaultRedactOptions *)redactOptions:(SentryOptions *)options
+{
+    return [[SentryDefaultRedactOptions alloc]
+        initWithMaskAllText:options.screenshot.maskAllText
+              maskAllImages:options.screenshot.maskAllImages
+          maskedViewClasses:options.screenshot.maskedViewClasses
+        unmaskedViewClasses:options.screenshot.unmaskedViewClasses];
 }
 
 #endif // SENTRY_HAS_UIKIT

--- a/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
+++ b/Sources/Sentry/include/SentryDependencyContainerSwiftHelper.h
@@ -12,8 +12,18 @@
 @class SentryCrash;
 @class SentryNSProcessInfoWrapper;
 @class SentryDispatchQueueWrapper;
+@class SentryOptions;
 
 NS_ASSUME_NONNULL_BEGIN
+
+@interface SentryDefaultRedactOptions : NSObject
+
+@property (nonatomic) BOOL maskAllText;
+@property (nonatomic) BOOL maskAllImages;
+@property (nonatomic) NSArray<Class> *maskedViewClasses;
+@property (nonatomic) NSArray<Class> *unmaskedViewClasses;
+
+@end
 
 // Some Swift code needs to access Sentry types that we don’t want to completely
 // expose to Swift. This class is exposed to Swift
@@ -24,6 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_HAS_UIKIT
 
 + (nullable NSArray<UIWindow *> *)windows;
+
+// Since SentryOptions is in ObjC, Swift code can't see the SentryViewScreenshotOptions property
++ (BOOL)fastViewRenderingEnabled:(SentryOptions *)options;
++ (BOOL)viewRendererV2Enabled:(SentryOptions *)options;
++ (SentryDefaultRedactOptions *)redactOptions:(SentryOptions *)options;
 
 #endif // SENTRY_HAS_UIKIT
 


### PR DESCRIPTION
We cannot access the "screenshot" property from Swift, (since SentryOptions is in ObjC) so this helper lets us get these properties from the Swift dependency container

#skip-changelog

Closes #6476