### PR TITLE
chore: Remove various deprecated flags

### DIFF
--- a/SentryTestUtils/TestConstants.swift
+++ b/SentryTestUtils/TestConstants.swift
@@ -31,7 +31,6 @@ public struct TestConstants {
         return event
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @_spi(Private) public static var envelope: SentryEnvelope {
         let event = Event()
         let envelopeItem = SentryEnvelopeItem(event: event)

--- a/Sources/Sentry/SentryClient.m
+++ b/Sources/Sentry/SentryClient.m
@@ -519,11 +519,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
     }
 
     SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithSession:session];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:[SentryEnvelopeHeader empty]
                                                            singleItem:item];
-#pragma clang diagnostic pop
     [self captureEnvelope:envelope];
 }
 
@@ -568,11 +565,8 @@ NSString *const DropSessionLogMessage = @"Session has no release name. Won't sen
 
     // Hybrid SDKs may override the sdk info for a replay Event,
     // the same SDK should be used for the envelope header.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentrySdkInfo *sdkInfo = replayEvent.sdk ? [[SentrySdkInfo alloc] initWithDict:replayEvent.sdk]
                                              : [SentrySdkInfo global];
-#pragma clang diagnotsic pop
     SentryEnvelopeHeader *envelopeHeader =
         [[SentryEnvelopeHeader alloc] initWithId:replayEvent.eventId
                                          sdkInfo:sdkInfo

--- a/Sources/Sentry/SentryTransportAdapter.m
+++ b/Sources/Sentry/SentryTransportAdapter.m
@@ -51,11 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                                attachments:attachments];
     [items addObjectsFromArray:additionalEnvelopeItems];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentryEnvelopeHeader *envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:event.eventId
                                                                        traceContext:traceContext];
-#pragma clang diagnostic pop
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader items:items];
 
     [self sendEnvelope:envelope];
@@ -70,11 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
                                                                attachments:attachments];
     [items addObject:[[SentryEnvelopeItem alloc] initWithSession:session]];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentryEnvelopeHeader *envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:event.eventId
                                                                        traceContext:traceContext];
-#pragma clang diagnostic pop
 
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader items:items];
 
@@ -85,11 +79,8 @@ NS_ASSUME_NONNULL_BEGIN
 {
     SentryEnvelopeItem *item = [[SentryEnvelopeItem alloc] initWithEvent:event];
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     SentryEnvelopeHeader *envelopeHeader = [[SentryEnvelopeHeader alloc] initWithId:event.eventId
                                                                        traceContext:traceContext];
-#pragma clang diagnostic pop
 
     SentryEnvelope *envelope = [[SentryEnvelope alloc] initWithHeader:envelopeHeader
                                                                 items:@[ item ]];

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -4,7 +4,6 @@ import Foundation
 @objcMembers @_spi(Private) public class SentryEnabledFeaturesBuilder: NSObject {
 
     // swiftlint:disable cyclomatic_complexity function_body_length
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     public static func getEnabledFeatures(options: Options?) -> [String] {
         guard let options = options else {
             return []

--- a/Sources/Swift/Helper/SentrySdkInfo.swift
+++ b/Sources/Swift/Helper/SentrySdkInfo.swift
@@ -8,7 +8,6 @@ import Foundation
  */
 @_spi(Private) @objc public final class SentrySdkInfo: NSObject, SentrySerializable {
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc public static func global() -> Self {
         Self(withOptions: SentrySDKInternal.currentHub().getClient()?.options)
     }
@@ -53,7 +52,6 @@ import Foundation
      */
     @objc public let settings: SentrySDKSettings
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc public convenience init(withOptions options: Options?) {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
         var integrations = SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames()

--- a/Sources/Swift/Tools/SentryEnvelope.swift
+++ b/Sources/Swift/Tools/SentryEnvelope.swift
@@ -2,7 +2,6 @@
 
 @_spi(Private) @objc public final class SentryEnvelope: NSObject {
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc(initWithId:singleItem:) public convenience init(id: SentryId?, singleItem item: SentryEnvelopeItem) {
         self.init(header: SentryEnvelopeHeader(id: id), singleItem: item)
     }
@@ -11,18 +10,15 @@
         self.init(header: header, items: [item])
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc(initWithId:items:) public convenience init(id: SentryId?, items: [SentryEnvelopeItem]) {
         self.init(header: SentryEnvelopeHeader(id: id), items: items)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     convenience init(session: SentrySession) {
         let item = SentryEnvelopeItem(session: session)
         self.init(header: SentryEnvelopeHeader(id: nil), singleItem: item)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     convenience init(sessions: [SentrySession]) {
         let items = sessions.map { SentryEnvelopeItem(session: $0) }
         self.init(header: SentryEnvelopeHeader(id: nil), items: items)
@@ -33,7 +29,6 @@
         self.items = items
     }
 
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     convenience init(event: Event) {
         let item = SentryEnvelopeItem(event: event)
         let headerId = SentryEnvelopeHeaderHelper.headerId(from: event)

--- a/Sources/Swift/Tools/SentryEnvelopeHeader.swift
+++ b/Sources/Swift/Tools/SentryEnvelopeHeader.swift
@@ -7,7 +7,6 @@
      * @param eventId The identifier of the event. Can be nil if no event in the envelope or attachment
      * related to event.
      */
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc public convenience init(id eventId: SentryId?) {
         self.init(id: eventId, traceContext: nil)
     }
@@ -18,7 +17,6 @@
      * attachment related to event.
      * @param traceContext Current trace state.
      */
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc public convenience init(id eventId: SentryId?, traceContext: TraceContext?) {
         self.init(id: eventId, sdkInfo: SentrySdkInfo.global(), traceContext: traceContext)
     }
@@ -40,7 +38,6 @@
         self.traceContext = traceContext
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     @objc public static func empty() -> Self {
         Self(id: nil, traceContext: nil)
     }

--- a/Tests/SentryTests/Helper/SentryFileManagerTests.swift
+++ b/Tests/SentryTests/Helper/SentryFileManagerTests.swift
@@ -26,7 +26,6 @@ class SentryFileManagerTests: XCTestCase {
         
         let expectedSessionUpdate: SentrySession
         
-        @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
         init() throws {
             currentDateProvider = TestCurrentDateProvider()
             dispatchQueueWrapper = TestSentryDispatchQueueWrapper()
@@ -104,7 +103,6 @@ class SentryFileManagerTests: XCTestCase {
     private var fixture: Fixture!
     private var sut: SentryFileManager!
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     override func setUpWithError() throws {
         try super.setUpWithError()
         fixture = try Fixture()
@@ -127,7 +125,6 @@ class SentryFileManagerTests: XCTestCase {
         sut.deleteAbnormalSession()
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testInitDoesNotOverrideDirectories() {
         sut.store(TestConstants.envelope)
         sut.storeCurrentSession(SentrySession(releaseName: "1.0.0", distinctId: "some-id"))
@@ -165,7 +162,6 @@ class SentryFileManagerTests: XCTestCase {
         assertEventFolderDoesntExist()
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testStoreEnvelope() throws {
         let envelope = TestConstants.envelope
         sut.store(envelope)
@@ -188,7 +184,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertNil(sut.store(envelope))
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDeleteOldEnvelopes() throws {
         try givenOldEnvelopes()
         
@@ -261,7 +256,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(logMessages.count, 1)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDeleteOldEnvelopes_WithEmptyDSN() throws {
         fixture.options.dsn = nil
         sut = fixture.getSut()
@@ -274,7 +268,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(sut.getAllEnvelopes().count, 0)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDontDeleteYoungEnvelopes() throws {
         let envelope = TestConstants.envelope
         let path = try XCTUnwrap(sut.store(envelope))
@@ -290,7 +283,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(sut.getAllEnvelopes().count, 1)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDontDeleteYoungEnvelopesFromOldEnvelopesFolder() throws {
         let envelope = TestConstants.envelope
         sut.store(envelope)
@@ -306,7 +298,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(sut.getAllEnvelopes().count, 1)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testFileManagerDeallocated_OldEnvelopesNotDeleted() throws {
         try givenOldEnvelopes()
         
@@ -334,7 +325,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertFalse(logOutput.loggedMessages.contains(where: { $0.contains("[error]") }))
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDefaultMaxEnvelopes() {
         for _ in 0...(fixture.maxCacheItems + 1) {
             sut.store(TestConstants.envelope)
@@ -344,7 +334,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(fixture.maxCacheItems, events.count)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDefaultMaxEnvelopes_CallsEnvelopeItemDeleted() {
         let event = Event()
         let envelope = SentryEnvelope(id: event.eventId, items: [
@@ -362,7 +351,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(expected, fixture.envelopeItemsDeleted.invocations)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDefaultMaxEnvelopesConcurrent() {
         let maxCacheItems = 1
         let sut = fixture.getSut(maxCacheItems: UInt(maxCacheItems))
@@ -388,7 +376,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(maxCacheItems, events.count)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMaxEnvelopesSet() {
         let maxCacheItems: UInt = 15
         sut = fixture.getSut(maxCacheItems: maxCacheItems)
@@ -399,7 +386,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(maxCacheItems, UInt(events.count))
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_SessionUpdateIsLast() throws {
         sut.store(fixture.sessionEnvelope)
         // just some other session
@@ -413,7 +399,6 @@ class SentryFileManagerTests: XCTestCase {
         assertSessionEnvelopesStored(count: 2)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_SessionUpdateIsSecond() throws {
         sut.store(fixture.sessionEnvelope)
         sut.store(fixture.sessionUpdateEnvelope)
@@ -425,7 +410,6 @@ class SentryFileManagerTests: XCTestCase {
         assertSessionEnvelopesStored(count: 1)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_IsInMiddle() throws {
         sut.store(fixture.sessionEnvelope)
         for _ in 0...10 {
@@ -440,7 +424,6 @@ class SentryFileManagerTests: XCTestCase {
         assertSessionEnvelopesStored(count: 1)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_MovesInitFlagOnlyToFirstSessionUpdate() throws {
         sut.store(fixture.sessionEnvelope)
         for _ in 0...10 {
@@ -459,7 +442,6 @@ class SentryFileManagerTests: XCTestCase {
         assertSessionEnvelopesStored(count: 3)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_NoOtherSessionUpdate() {
         sut.store(fixture.sessionEnvelope)
         sut.store(fixture.sessionUpdateEnvelope)
@@ -470,7 +452,6 @@ class SentryFileManagerTests: XCTestCase {
         assertSessionEnvelopesStored(count: 0)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_FailToLoadEnvelope() throws {
         sut.store(fixture.sessionEnvelope)
         
@@ -489,7 +470,6 @@ class SentryFileManagerTests: XCTestCase {
         try assertSessionInitMoved(sut.getAllEnvelopes().last!)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testMigrateSessionInit_DoesNotCallEnvelopeItemDeleted() {
         sut.store(fixture.sessionEnvelope)
         sut.store(fixture.sessionUpdateEnvelope)
@@ -500,7 +480,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(0, fixture.envelopeItemsDeleted.count)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testGetAllEnvelopesAreSortedByDateAscending() {
         givenMaximumEnvelopes()
         
@@ -517,7 +496,6 @@ class SentryFileManagerTests: XCTestCase {
         }
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testGetOldestEnvelope() {
         givenMaximumEnvelopes()
         
@@ -653,7 +631,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertNil(actualTimestamp)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testGetAllStoredEventsAndEnvelopes() {
         sut.store(TestConstants.envelope)
         sut.store(TestConstants.envelope)
@@ -661,7 +638,6 @@ class SentryFileManagerTests: XCTestCase {
         XCTAssertEqual(2, sut.getAllEnvelopes().count)
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDeleteAllFolders() {
         storeEvent()
         sut.store(TestConstants.envelope)
@@ -674,7 +650,6 @@ class SentryFileManagerTests: XCTestCase {
         assertEventFolderDoesntExist()
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func testDeleteAllStoredEnvelopes() {
         sut.store(TestConstants.envelope)
         
@@ -1450,7 +1425,6 @@ private extension SentryFileManagerTests {
 
 // MARK: Private
 private extension SentryFileManagerTests {
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func givenMaximumEnvelopes() {
         fixture.eventIds.forEach { id in
             let envelope = SentryEnvelope(id: id, singleItem: SentryEnvelopeItem(event: Event()))
@@ -1468,7 +1442,6 @@ private extension SentryFileManagerTests {
         }
     }
     
-    @available(*, deprecated, message: "This is only marked as deprecated because enableAppLaunchProfiling is marked as deprecated. Once that is removed this can be removed.")
     func givenOldEnvelopes() throws {
         let envelope = TestConstants.envelope
         let path = try XCTUnwrap(sut.store(envelope))


### PR DESCRIPTION
All these were marked deprecated because of APIs that were removed in V9

#skip-changelog

Closes #6488