### PR TITLE
fix: Handle nil options when starting profiling

### DIFF
--- a/Sources/Sentry/SentrySDKInternal.m
+++ b/Sources/Sentry/SentrySDKInternal.m
@@ -704,9 +704,12 @@ static NSDate *_Nullable startTimestamp = nil;
             @"properties, so you can also just remove those lines from your configuration "
             @"altogether) before attempting to start a continuous profiling session. This behavior "
             @"relies on deprecated options and will change in a future version.");
+#    else
+    if (options == nil) {
+        SENTRY_LOG_WARN(@"Cannot start profiling when options are nil.");
+#    endif
         return;
     }
-#    endif // !SDK_V9
 
     if (options.profiling != nil) {
         if (options.profiling.lifecycle == SentryProfileLifecycleTrace) {
@@ -772,9 +775,12 @@ static NSDate *_Nullable startTimestamp = nil;
             @"properties, so you can also just remove those lines from your configuration "
             @"altogether) before attempting to stop a continuous profiling session. This behavior "
             @"relies on deprecated options and will change in a future version.");
+#    else
+    if (options == nil) {
+        SENTRY_LOG_WARN(@"Cannot stop profiling when options are nil.");
+#    endif
         return;
     }
-#    endif // !SDK_V9
 
     if (options.profiling != nil && options.profiling.lifecycle == SentryProfileLifecycleTrace) {
         SENTRY_LOG_WARN(

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -42,9 +42,9 @@ NS_ASSUME_NONNULL_BEGIN
     SentryFramesTracker *_framesTracker;
 #endif // SENTRY_HAS_UIKIT
 
-#if SENTRY_TARGET_PROFILING_SUPPORTED && !SDK_V9
+#if SENTRY_TARGET_PROFILING_SUPPORTED
     BOOL _isContinuousProfiling;
-#endif //  SENTRY_TARGET_PROFILING_SUPPORTED && !SDK_V9
+#endif //  SENTRY_TARGET_PROFILING_SUPPORTED
 }
 
 - (instancetype)initWithContext:(SentrySpanContext *)context
@@ -93,8 +93,10 @@ NS_ASSUME_NONNULL_BEGIN
 #if SENTRY_TARGET_PROFILING_SUPPORTED
 #    if !SDK_V9
         _isContinuousProfiling = [SentrySDKInternal.options isContinuousProfilingEnabled];
+#    else
+        _isContinuousProfiling = SentrySDKInternal.options != nil;
+#    endif
         if (_isContinuousProfiling) {
-#    endif // !SDK_V9
             _profileSessionID = SentryContinuousProfiler.currentProfilerID.sentryIdString;
             if (_profileSessionID == nil) {
                 [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
@@ -103,9 +105,7 @@ NS_ASSUME_NONNULL_BEGIN
                            name:kSentryNotificationContinuousProfileStarted
                          object:nil];
             }
-#    if !SDK_V9
         }
-#    endif // !SDK_V9
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
     }
 
@@ -132,16 +132,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)stopObservingContinuousProfiling
 {
-#    if !SDK_V9
     if (_isContinuousProfiling) {
-#    endif // !SDK_V9
         [SentryDependencyContainer.sharedInstance.notificationCenterWrapper
             removeObserver:self
                       name:kSentryNotificationContinuousProfileStarted
                     object:nil];
-#    if !SDK_V9
     }
-#    endif // !SDK_V9
 }
 #endif // SENTRY_TARGET_PROFILING_SUPPORTED
 


### PR DESCRIPTION
The v9 codepath assumed `isContinuousProfilingEnabled` would return true, but we also need to handle the case where options is nil

#skip-changelog

Closes #6498