### PR TITLE
feat: enablePreWarmedAppStartTracing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Removes `enablePerformanceV2` option and makes this the default. The app start duration will now finish when the first frame is drawn instead of when the OS posts the UIWindowDidBecomeVisibleNotification. (#6008)
 - Removes enableTracing property from SentryOptions (#5694)
 - Structured Logs: Move options out of experimental (#6359)
+- Enable enablePreWarmedAppStartTracing by default (#6508). With this option enabled, the SDK collects [prewarmed app starts](https://docs.sentry.io/platforms/apple/tracing/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing).
 
 ### Features
 

--- a/Sources/Sentry/Public/SentryOptions.h
+++ b/Sources/Sentry/Public/SentryOptions.h
@@ -381,9 +381,11 @@ NS_SWIFT_NAME(Options)
  * @note You can filter for different app start types in Discover with
  * @c app_start_type:cold.prewarmed ,
  * @c app_start_type:warm.prewarmed , @c app_start_type:cold , and @c app_start_type:warm .
+ *
  * @warning This feature is not available in @c DebugWithoutUIKit and @c ReleaseWithoutUIKit
  * configurations even when targeting iOS or tvOS platforms.
- * @note Default value is @c NO .
+ *
+ * @note Default value is @c YES .
  */
 @property (nonatomic, assign) BOOL enablePreWarmedAppStartTracing;
 

--- a/Sources/Sentry/SentryOptions.m
+++ b/Sources/Sentry/SentryOptions.m
@@ -100,7 +100,7 @@ NSString *const kSentryDefaultEnvironment = @"production";
         self.reportAccessibilityIdentifier = YES;
         self.enableUserInteractionTracing = YES;
         self.idleTimeout = SentryTracerDefaultTimeout;
-        self.enablePreWarmedAppStartTracing = NO;
+        self.enablePreWarmedAppStartTracing = YES;
         self.enableReportNonFullyBlockingAppHangs = YES;
 #endif // SENTRY_HAS_UIKIT
 

--- a/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
+++ b/Sources/Swift/Helper/SentryEnabledFeaturesBuilder.swift
@@ -17,14 +17,6 @@ import Foundation
         if options.enableTimeToFullDisplayTracing {
             features.append("timeToFullDisplayTracing")
         }
-
-#if os(iOS) || os(tvOS)
-#if canImport(UIKit) && !SENTRY_NO_UIKIT
-        if options.enablePreWarmedAppStartTracing {
-            features.append("preWarmedAppStartTracing")
-        }
-#endif // canImport(UIKit)
-#endif // os(iOS) || os(tvOS)
         
         if options.swiftAsyncStacktraces {
             features.append("swiftAsyncStacktraces")

--- a/Sources/Swift/Helper/SentrySdkInfo.swift
+++ b/Sources/Swift/Helper/SentrySdkInfo.swift
@@ -54,12 +54,7 @@ import Foundation
     
     @objc public convenience init(withOptions options: Options?) {
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
-        var integrations = SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames()
-        #if (os(iOS) || os(tvOS) || (swift(>=5.9) && os(visionOS))) && !SENTRY_NO_UIKIT
-            if options?.enablePreWarmedAppStartTracing ?? false {
-                integrations.append("PreWarmedAppStartTracing")
-            }
-        #endif
+        let integrations = SentrySDKInternal.currentHub().trimmedInstalledIntegrationNames()
         var packages = SentryExtraPackages.getPackages()
         let sdkPackage = SentrySdkPackage.global()
         if let sdkPackage {

--- a/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
+++ b/Tests/SentryTests/Helper/SentryEnabledFeaturesBuilderTests.swift
@@ -25,12 +25,6 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         options.enableTimeToFullDisplayTracing = true
         options.swiftAsyncStacktraces = true
 
-#if os(iOS) || os(tvOS)
-#if canImport(UIKit) && !SENTRY_NO_UIKIT
-        options.enablePreWarmedAppStartTracing = true
-#endif // canImport(UIKit)
-#endif // os(iOS) || os(tvOS)
-
         // -- Act --
         let features = SentryEnabledFeaturesBuilder.getEnabledFeatures(options: options)
 
@@ -38,12 +32,6 @@ final class SentryEnabledFeaturesBuilderTests: XCTestCase {
         XCTAssert(features.contains("captureFailedRequests"))
         XCTAssert(features.contains("timeToFullDisplayTracing"))
         XCTAssert(features.contains("swiftAsyncStacktraces"))
-
-#if os(iOS) || os(tvOS)
-#if canImport(UIKit) && !SENTRY_NO_UIKIT
-        XCTAssert(features.contains("preWarmedAppStartTracing"))
-#endif // canImport(UIKit)
-#endif // os(iOS) || os(tvOS)
     }
 
     func testEnablePersistingTracesWhenCrashing() {

--- a/Tests/SentryTests/SentryClientTests.swift
+++ b/Tests/SentryTests/SentryClientTests.swift
@@ -1736,37 +1736,6 @@ class SentryClientTests: XCTestCase {
         let features = try XCTUnwrap(actual.sdk?["features"] as? [String])
         XCTAssert(features.contains("captureFailedRequests"))
     }
-
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-    func testTrackPreWarmedAppStartTracking() throws {
-        try testFeatureTrackingAsIntegration(integrationName: "PreWarmedAppStartTracing") {
-            $0.enablePreWarmedAppStartTracing = true
-        }
-    }
-#endif
-    
-    private func testFeatureTrackingAsIntegration(integrationName: String, configureOptions: (Options) -> Void) throws {
-        SentrySDK.start(options: Options())
-
-        let eventId = fixture.getSut(configureOptions: { options in
-            configureOptions(options)
-        }).capture(message: fixture.messageAsString)
-
-        eventId.assertIsNotEmpty()
-        let actual = try lastSentEvent()
-        var expectedIntegrations = ["AutoBreadcrumbTracking", "AutoSessionTracking", "Crash", "NetworkTracking", integrationName]
-        if !SentryDependencyContainer.sharedInstance().crashWrapper.isBeingTraced {
-            expectedIntegrations = ["ANRTracking"] + expectedIntegrations
-        }
-#if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-        expectedIntegrations.append("FramesTracking")
-#endif // os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
-
-        assertArrayEquals(
-            expected: expectedIntegrations,
-            actual: actual.sdk?["integrations"] as? [String]
-        )
-    }
     
     func testSetSDKIntegrations_NoIntegrations() throws {
         let expected: [String] = []

--- a/Tests/SentryTests/SentryOptionsTest.m
+++ b/Tests/SentryTests/SentryOptionsTest.m
@@ -732,7 +732,7 @@
     XCTAssertFalse(options.attachScreenshot);
     XCTAssertEqual(3.0, options.idleTimeout);
     XCTAssertEqual(options.enableUserInteractionTracing, YES);
-    XCTAssertEqual(options.enablePreWarmedAppStartTracing, NO);
+    XCTAssertEqual(options.enablePreWarmedAppStartTracing, YES);
     XCTAssertEqual(options.attachViewHierarchy, NO);
     XCTAssertEqual(options.reportAccessibilityIdentifier, YES);
     XCTAssertEqual(options.sessionReplay.onErrorSampleRate, 0);
@@ -917,7 +917,7 @@
 
 - (void)testEnablePreWarmedAppStartTracking
 {
-    [self testBooleanField:@"enablePreWarmedAppStartTracing" defaultValue:NO];
+    [self testBooleanField:@"enablePreWarmedAppStartTracing" defaultValue:YES];
 }
 
 - (void)testSessionReplaySettingsInit


### PR DESCRIPTION
## :scroll: Description

Set the default value of enablePreWarmedAppStartTracing to true.

Docs PR https://github.com/getsentry/sentry-docs/pull/15295.

## :bulb: Motivation and Context

Fixes GH-3535

## :green_heart: How did you test it?
Unit tests.

## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
