### PR TITLE
fix: Prevent duplicate issue creation in PR automation workflow

### DIFF
--- a/.github/workflows/create-issue-for-unreferenced-pr.yml
+++ b/.github/workflows/create-issue-for-unreferenced-pr.yml
@@ -71,7 +71,7 @@ jobs:
             // Check if there's already an issue created by this automation for this PR
             // Search for issues that mention this PR and were created by github-actions bot
             const existingIssuesResponse = await github.rest.search.issuesAndPullRequests({
-              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open "${prUrl}" in:title in:body`,
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open author:app/github-actions "${prUrl}" in:title in:body`,
             });
 
             if (existingIssuesResponse.data.total_count > 0) {


### PR DESCRIPTION
The workflow was creating duplicate issues when multiple trigger events (opened, edited, synchronize, etc.) fired in quick succession. Both workflow runs would check the PR simultaneously, find no issue reference, and each create a new issue.

Added a check to search for existing issues created by this automation before creating a new one. The workflow now searches for open issues that contain the PR URL and were created by github-actions bot, preventing duplicate issue creation.

Fixes the issue where PR #6386 had two issues created (#6499 and #6500).

#skip-changelog