### PR TITLE
Remove V9 checks for SentrySerializable

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -4,7 +4,6 @@
 
 Removes deprecated SentryDebugImageProvider class (#5598)
 Makes app hang tracking V2 the default and removes the option to enable/disable it (#5615)
-Removes public SentrySerializable conformance from many public models (#5636, #5840, #5982)
 Removes `integrations` property from `SentryOptions` (#5749)
 Makes `SentryEventDecodable` internal (#5808)
 The `span` property on `SentryScope` is now readonly (#5866)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removes deprecated `setExtraValue` from SentrySpan (#5864)
 - Removes deprecated getStoreEndpoint (#5591)
 - Removes deprecated useSpan function (#5591)
+- Removes public SentrySerializable conformance from many public models (#5636, #5840, #5982)
 - Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)
 - Removes deprecated TraceContext initializers (#6348)
 - Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)

--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -6,17 +6,11 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(Breadcrumb)
 @interface SentryBreadcrumb : NSObject
-#if !SDK_V9
-                              <SentrySerializable>
-#endif
 
 /**
  * Level of breadcrumb
@@ -63,10 +57,6 @@ NS_SWIFT_NAME(Breadcrumb)
 - (instancetype)initWithLevel:(SentryLevel)level category:(NSString *)category;
 - (instancetype)init;
 + (instancetype)new NS_UNAVAILABLE;
-
-#if !SDK_V9
-- (NSDictionary<NSString *, id> *)serialize;
-#endif // !SDK_V9
 
 - (BOOL)isEqual:(id _Nullable)other;
 

--- a/Sources/Sentry/Public/SentryDebugMeta.h
+++ b/Sources/Sentry/Public/SentryDebugMeta.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,9 +20,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 NS_SWIFT_NAME(DebugMeta)
 @interface SentryDebugMeta : NSObject
-#if !SDK_V9
-                             <SentrySerializable>
-#endif
 
 /**
  * Identifier of the dynamic library or executable. It is the value of the @c LC_UUID load command

--- a/Sources/Sentry/Public/SentryEnvelopeItemHeader.h
+++ b/Sources/Sentry/Public/SentryEnvelopeItemHeader.h
@@ -5,16 +5,10 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryEnvelopeItemHeader : NSObject
-#if !SDK_V9
-                                      <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryEvent.h
+++ b/Sources/Sentry/Public/SentryEvent.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif // !SDK_V9
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,9 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(Event)
 @interface SentryEvent : NSObject
-#if !SDK_V9
-                         <SentrySerializable>
-#endif // !SDK_V9
 
 /**
  * This will be set by the initializer.

--- a/Sources/Sentry/Public/SentryException.h
+++ b/Sources/Sentry/Public/SentryException.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,9 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(Exception)
 @interface SentryException : NSObject
-#if !SDK_V9
-                             <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryFrame.h
+++ b/Sources/Sentry/Public/SentryFrame.h
@@ -6,18 +6,11 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(Frame)
 @interface SentryFrame : NSObject
-#if !SDK_V9
-                         <SentrySerializable>
-#endif
-
 /**
  * SymbolAddress of the frame
  */

--- a/Sources/Sentry/Public/SentryGeo.h
+++ b/Sources/Sentry/Public/SentryGeo.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -23,12 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///   }
 /// }
 NS_SWIFT_NAME(Geo)
-@interface SentryGeo : NSObject
-#if !SDK_V9
-                       <SentrySerializable, NSCopying>
-#else
-                       <NSCopying>
-#endif
+@interface SentryGeo : NSObject <NSCopying>
 
 /**
  * Optional: Human readable city name.

--- a/Sources/Sentry/Public/SentryMechanism.h
+++ b/Sources/Sentry/Public/SentryMechanism.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,9 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(Mechanism)
 @interface SentryMechanism : NSObject
-#if !SDK_V9
-                             <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryMechanismMeta.h
+++ b/Sources/Sentry/Public/SentryMechanismMeta.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 @class SentryNSError;
 
@@ -21,9 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 NS_SWIFT_NAME(MechanismMeta)
 @interface SentryMechanismMeta : NSObject
-#if !SDK_V9
-                                 <SentrySerializable>
-#endif
 
 - (instancetype)init;
 

--- a/Sources/Sentry/Public/SentryMessage.h
+++ b/Sources/Sentry/Public/SentryMessage.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -18,9 +15,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @see https://develop.sentry.dev/sdk/event-payloads/message/
  */
 @interface SentryMessage : NSObject
-#if !SDK_V9
-                           <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryNSError.h
+++ b/Sources/Sentry/Public/SentryNSError.h
@@ -6,9 +6,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,9 +13,6 @@ NS_ASSUME_NONNULL_BEGIN
  * Sentry representation of an @c NSError to send to Sentry.
  */
 @interface SentryNSError : NSObject
-#if !SDK_V9
-                           <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryRequest.h
+++ b/Sources/Sentry/Public/SentryRequest.h
@@ -5,16 +5,10 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryRequest : NSObject
-#if !SDK_V9
-                           <SentrySerializable>
-#endif
 
 /**
  * Optional: HTTP response body size.

--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -5,9 +5,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif // SDK_V9
 #import SENTRY_HEADER(SentrySpanProtocol)
 
 @class SentryAttachment;
@@ -25,9 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 NS_SWIFT_NAME(Scope)
 @interface SentryScope : NSObject
-#if !SDK_V9
-                         <SentrySerializable>
-#endif // !SDK_V9
 
 /**
  * Returns current Span or Transaction.
@@ -123,13 +117,6 @@ NS_SWIFT_NAME(Scope)
  * Clears all breadcrumbs in the scope
  */
 - (void)clearBreadcrumbs;
-
-#if !SDK_V9
-/**
- * Serializes the Scope to JSON
- */
-- (NSDictionary<NSString *, id> *)serialize;
-#endif // !SDK_V9
 
 /**
  * Sets context values which will overwrite SentryEvent.context when event is

--- a/Sources/Sentry/Public/SentrySpanContext.h
+++ b/Sources/Sentry/Public/SentrySpanContext.h
@@ -6,9 +6,6 @@
 #    import <SentryDefines.h>
 #endif
 #import SENTRY_HEADER(SentrySampleDecision)
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 #import SENTRY_HEADER(SentrySpanStatus)
 
 NS_ASSUME_NONNULL_BEGIN
@@ -20,9 +17,6 @@ static NSString const *SENTRY_TRACE_TYPE = @"trace";
 
 NS_SWIFT_NAME(SpanContext)
 @interface SentrySpanContext : NSObject
-#if !SDK_V9
-                               <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentrySpanProtocol.h
+++ b/Sources/Sentry/Public/SentrySpanProtocol.h
@@ -5,9 +5,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif // SDK_V9
 #import SENTRY_HEADER(SentrySpanContext)
 
 NS_ASSUME_NONNULL_BEGIN
@@ -19,11 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class SentryTraceHeader;
 
 NS_SWIFT_NAME(Span)
-#if SDK_V9
 @protocol SentrySpan <NSObject>
-#else
-@protocol SentrySpan <SentrySerializable>
-#endif
 
 /**
  * Determines which trace the Span belongs to.

--- a/Sources/Sentry/Public/SentryStacktrace.h
+++ b/Sources/Sentry/Public/SentryStacktrace.h
@@ -6,18 +6,12 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryFrame;
 
 @interface SentryStacktrace : NSObject
-#if !SDK_V9
-                              <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryThread.h
+++ b/Sources/Sentry/Public/SentryThread.h
@@ -5,18 +5,12 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryStacktrace;
 
 @interface SentryThread : NSObject
-#if !SDK_V9
-                          <SentrySerializable>
-#endif
 
 SENTRY_NO_INIT
 

--- a/Sources/Sentry/Public/SentryTraceContext.h
+++ b/Sources/Sentry/Public/SentryTraceContext.h
@@ -5,9 +5,6 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -20,9 +17,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 NS_SWIFT_NAME(TraceContext)
 @interface SentryTraceContext : NSObject
-#if !SDK_V9
-                                <SentrySerializable>
-#endif
 
 /**
  * UUID V4 encoded as a hexadecimal sequence with no dashes (e.g. 771a43a4192642f0b136d5159a501700)

--- a/Sources/Sentry/Public/SentryUser.h
+++ b/Sources/Sentry/Public/SentryUser.h
@@ -5,21 +5,13 @@
 #else
 #    import <SentryDefines.h>
 #endif
-#if !SDK_V9
-#    import SENTRY_HEADER(SentrySerializable)
-#endif // !SDK_V9
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class SentryGeo;
 
 NS_SWIFT_NAME(User)
-@interface SentryUser : NSObject
-#if SDK_V9
-                        <NSCopying>
-#else
-                        <SentrySerializable, NSCopying>
-#endif // SDK_V9
+@interface SentryUser : NSObject <NSCopying>
 
 /**
  * Optional: Id of the user

--- a/Sources/Sentry/include/SentryEvent+Serialize.h
+++ b/Sources/Sentry/include/SentryEvent+Serialize.h
@@ -1,8 +1,10 @@
-#if SDK_V9
-#    import "SentryEvent.h"
-#    import "SentrySerializable.h"
+#import "SentryEvent.h"
+#import "SentrySerializable.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryEvent () <SentrySerializable>
 
 @end
-#endif // SDK_V9
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Sentry/include/SentryModels+Serializable.h
+++ b/Sources/Sentry/include/SentryModels+Serializable.h
@@ -1,22 +1,21 @@
-#if SDK_V9
-#    import "SentryBreadcrumb.h"
-#    import "SentryDebugMeta.h"
-#    import "SentryEnvelopeItemHeader.h"
-#    import "SentryEvent.h"
-#    import "SentryException.h"
-#    import "SentryFrame.h"
-#    import "SentryGeo.h"
-#    import "SentryInternalSerializable.h"
-#    import "SentryMechanism.h"
-#    import "SentryMechanismMeta.h"
-#    import "SentryMessage.h"
-#    import "SentryNSError.h"
-#    import "SentryRequest.h"
-#    import "SentryScope.h"
-#    import "SentryStacktrace.h"
-#    import "SentryThread.h"
-#    import "SentryTraceContext.h"
-#    import "SentryUser.h"
+#import "SentryBreadcrumb.h"
+#import "SentryDebugMeta.h"
+#import "SentryEnvelopeItemHeader.h"
+#import "SentryEvent.h"
+#import "SentryException.h"
+#import "SentryFrame.h"
+#import "SentryGeo.h"
+#import "SentryInternalSerializable.h"
+#import "SentryMechanism.h"
+#import "SentryMechanismMeta.h"
+#import "SentryMessage.h"
+#import "SentryNSError.h"
+#import "SentryRequest.h"
+#import "SentryScope.h"
+#import "SentryStacktrace.h"
+#import "SentryThread.h"
+#import "SentryTraceContext.h"
+#import "SentryUser.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -97,5 +96,3 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 NS_ASSUME_NONNULL_END
-
-#endif // SDK_V9

--- a/Sources/Sentry/include/SentryUser+Serialize.h
+++ b/Sources/Sentry/include/SentryUser+Serialize.h
@@ -1,8 +1,10 @@
-#if SDK_V9
-#    import "SentrySerializable.h"
-#    import "SentryUser.h"
+#import "SentrySerializable.h"
+#import "SentryUser.h"
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface SentryUser () <SentrySerializable>
 
 @end
-#endif // SDK_V9
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Swift/Integrations/SentryGlobalEventProcessor.swift
+++ b/Sources/Swift/Integrations/SentryGlobalEventProcessor.swift
@@ -1,3 +1,5 @@
+@_implementationOnly import _SentryPrivate
+
 @_spi(Private) public typealias SentryEventProcessor = (Event) -> Event?
 
 @_spi(Private) @objc public final class SentryGlobalEventProcessor: NSObject {

--- a/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
+++ b/Sources/Swift/Integrations/UserFeedback/SentryFeedback.swift
@@ -42,20 +42,11 @@ public final class SentryFeedback: NSObject {
     }
 }
 
-#if !SDK_V9
-extension SentryFeedback: SentrySerializable { }
-#endif
-
 extension SentryFeedback {
-    #if SDK_V9
+
     @_spi(Private) public func serialize() -> [String: Any] {
         return internalSerialize()
     }
-    #else
-    public func serialize() -> [String: Any] {
-        return internalSerialize()
-    }
-    #endif
 
     private func internalSerialize() -> [String: Any] {
         let numberOfOptionalItems = (name == nil ? 0 : 1) + (email == nil ? 0 : 1) + (associatedEventId == nil ? 0 : 1)

--- a/Sources/Swift/Protocol/Codable/SentryEventDecoder.swift
+++ b/Sources/Swift/Protocol/Codable/SentryEventDecoder.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers

--- a/Sources/Swift/SentryCrash/SentryThreadInspecting.swift
+++ b/Sources/Swift/SentryCrash/SentryThreadInspecting.swift
@@ -1,3 +1,5 @@
+@_implementationOnly import _SentryPrivate
+
 @_spi(Private) @objc public protocol SentryThreadInspecting {
     func getCurrentThreadsWithStackTrace() -> [SentryThread]
     func getThreadName(_ thread: UInt) -> String?

--- a/Sources/Swift/State/SentryScopeObserver.swift
+++ b/Sources/Swift/State/SentryScopeObserver.swift
@@ -1,3 +1,5 @@
+@_implementationOnly import _SentryPrivate
+
 @_spi(Private) @objc public protocol SentryScopeObserver: NSObjectProtocol {
     func setUser(_ user: User?)
     func setTags(_ tags: [String: String]?)

--- a/Sources/Swift/Tools/SentryClientReport.swift
+++ b/Sources/Swift/Tools/SentryClientReport.swift
@@ -1,3 +1,5 @@
+@_implementationOnly import _SentryPrivate
+
 @objc
 @_spi(Private) public final class SentryClientReport: NSObject, SentrySerializable {
     

--- a/Sources/Swift/Tools/SentryDiscardedEvent.swift
+++ b/Sources/Swift/Tools/SentryDiscardedEvent.swift
@@ -1,3 +1,4 @@
+@_implementationOnly import _SentryPrivate
 import Foundation
 
 @objcMembers


### PR DESCRIPTION
In V9 these protocol conformances are made internal

#skip-changelog

Closes #6523