### PR TITLE
fix: Make scope span readonly in V9

### DIFF
--- a/CHANGELOG-v9.md
+++ b/CHANGELOG-v9.md
@@ -7,4 +7,3 @@ Makes app hang tracking V2 the default and removes the option to enable/disable 
 Removes public SentrySerializable conformance from many public models (#5636, #5840, #5982)
 Removes `integrations` property from `SentryOptions` (#5749)
 Makes `SentryEventDecodable` internal (#5808)
-The `span` property on `SentryScope` is now readonly (#5866)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Removes deprecated `setExtraValue` from SentrySpan (#5864)
 - Removes deprecated getStoreEndpoint (#5591)
 - Removes deprecated useSpan function (#5591)
+- The `span` property on `SentryScope` is now readonly (#5866)
 - Removes segment property on SentryUser, SentryBaggage, and SentryTraceContext (#5638)
 - Removes deprecated TraceContext initializers (#6348)
 - Removes deprecated user feedback API, this is replaced with the new feedback API (#5591)

--- a/Sources/Sentry/Public/SentryScope.h
+++ b/Sources/Sentry/Public/SentryScope.h
@@ -33,11 +33,7 @@ NS_SWIFT_NAME(Scope)
  * Returns current Span or Transaction.
  * @return current Span or Transaction or null if transaction has not been set.
  */
-#if SDK_V9
 @property (nullable, nonatomic, readonly, strong) id<SentrySpan> span;
-#else
-@property (nullable, nonatomic, strong) id<SentrySpan> span;
-#endif // SDK_V9
 
 /**
  * The id of current session replay.

--- a/Sources/Sentry/include/SentryScope+Private.h
+++ b/Sources/Sentry/include/SentryScope+Private.h
@@ -13,6 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface SentryScope ()
 
 @property (atomic, copy, nullable) NSString *environmentString;
+@property (nullable, nonatomic, strong) id<SentrySpan> span;
 
 @property (atomic, strong, readonly) NSArray<SentryAttachment *> *attachments;
 


### PR DESCRIPTION
As title, just removes the V9 checks. The extra line was needed for it to pass unit tests which set the span property.

#skip-changelog

Closes #6527