### PR TITLE
ci: Remove unit tests on iOS 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -228,17 +228,6 @@ jobs:
         include:
           # We are running tests on iOS 17 and later, as there were OS-internal changes introduced in succeeding versions.
 
-          # iOS 16 - Use macOS-26 with Xcode 26.1 to download iOS 16.4 runtime (latest toolkit)
-          - name: iOS 16 Sentry
-            runs-on: macos-26
-            xcode: "26.1"
-            test-destination-os: "16.4"
-            install_platforms: true
-            platform: "iOS"
-            create_device: true
-            device: "iPhone 14 Pro"
-            scheme: "Sentry"
-
           # iOS 17 - Use pre-installed iOS 17.5 runtime on macOS-14 with Xcode 15.4
           - name: iOS 17 Sentry
             runs-on: macos-14


### PR DESCRIPTION
The iOS 16 unit tests often time out in Continuous Integration (CI). Downloading the simulator and booting the device typically takes about 5 minutes each. Additionally, the xcodebuild process can take a couple of minutes before Xcode actually starts running the tests in CI.

From past experience, manually downloading a simulator runtime and creating one tends to result in a higher flake rate for the tests. Even when they are stable, the iOS 16 job still takes a considerable amount of time to complete. Therefore, rather than retaining these tests, which only provide a small benefit in terms of bug detection on iOS 16, we should consider removing them.

#skip-changelog

Closes #6531