### PR TITLE
chore: Increase maximum stacktrace length to 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 ### Improvements
 
 - Replace deprecated SCNetworkReachability with NWPathMonitor (#6019)
+- Increase number of frames per stacktrace to 500
 
 ## 8.57.0
 

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.h
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashStackCursor_MachineContext.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-#define MAX_STACKTRACE_LENGTH 100
+#define MAX_STACKTRACE_LENGTH 500
 
 /** Initialize a stack cursor for a machine context.
  *


### PR DESCRIPTION
This PR increases the stacktrace limit to 500 frames in sync to the limits defined in https://develop.sentry.dev/sdk/data-model/event-payloads/stacktrace/#attributes

Part of #5913