### PR TITLE
test: Move testRemoveImageFromBeginning to flaky plan

### DIFF
--- a/Plans/Sentry_Base.xctestplan
+++ b/Plans/Sentry_Base.xctestplan
@@ -31,6 +31,7 @@
         "SentryANRTrackerTests\/testMultipleListeners()",
         "SentryCoreDataTrackerTests\/testFetchRequestBackgroundThread()",
         "SentryCoreDataTrackerTests\/testSaveBackgroundThread()",
+        "SentryCrashBinaryImageCacheTests\/testRemoveImageFromBeginning",
         "SentryCrashIntegrationTests\/testStartUpCrash_CallsFlush()",
         "SentryCrashReportStore_Tests\/testCrashReportCount1",
         "SentryCrashReportStore_Tests\/testDeleteAllReports",

--- a/Plans/Sentry_Flaky.xctestplan
+++ b/Plans/Sentry_Flaky.xctestplan
@@ -16,6 +16,7 @@
   "testTargets" : [
     {
       "selectedTests" : [
+        "SentryCrashBinaryImageCacheTests\/testRemoveImageFromBeginning",
         "SentryHttpTransportFlushIntegrationTests"
       ],
       "target" : {


### PR DESCRIPTION
Failed here https://github.com/getsentry/sentry-cocoa/actions/runs/18787642237/job/53609842526

#skip-changelog 

Closes #6556