### PR TITLE
ci: Increase timeout for iOS 26 unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -217,7 +217,7 @@ jobs:
   unit-tests:
     name: Unit ${{matrix.name}}
     runs-on: ${{matrix.runs-on}}
-    timeout-minutes: 20
+    timeout-minutes: ${{ matrix.timeout || 20 }}
     needs: files-changed
     if: needs.files-changed.outputs.run_unit_tests_for_prs == 'true'
 
@@ -257,6 +257,8 @@ jobs:
             create_device: true
             device: "iPhone 17 Pro"
             scheme: "Sentry"
+            # This runner seems to be slower than the others, so we give it more time because otherwise it frequently times out. The build step often alone takes 10 minutes and also booting the simulator takes a while.
+            timeout: 30
 
           # We don't run the unit tests on macOS 13 cause we run them on all on GH actions available iOS versions.
           # The chance of missing a bug solely on tvOS 16 that doesn't occur on iOS, macOS 12 or macOS 14 is minimal.


### PR DESCRIPTION
It seems like the macOS 26 runner requires more time to build the tests and to boot the simulator. Therefore, we give it more time before timing out.

#skip-changelog

Closes #6559