### PR TITLE
chore: Remove UI tests for iOS 16

### DIFF
--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -52,18 +52,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # iOS 16 - Use macOS-26 with Xcode 26.1 to download iOS 16.4 runtime (latest toolkit)
-          # macOS 13 was sunset in November 2025, so we moved to macOS-26 with latest Xcode for iOS 16 testing
-          - name: iOS 16
-            platform:
-              runs-on: macos-26
-              xcode: "26.1"
-              test-destination-os: "16.4"
-              install_platforms: true
-              platform: "iOS"
-              create_device: true
-              device: "iPhone 14 Pro"
-
           # macos-14 iOS 17 not included due to the XCUIServerNotFound errors causing flaky tests
 
           # iOS 18 - Use pre-installed iOS 18.4 runtime on macOS-15

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -79,16 +79,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # iOS 16 - Use macOS-26 with Xcode 26.1 to download iOS 16.4 runtime (latest toolkit)
-          - name: iOS 16
-            runs-on: macos-26
-            xcode: "26.1"
-            test-destination-os: "16.4"
-            install_platforms: true
-            platform: "iOS"
-            create_device: true
-            device: iPhone 14 Pro
-
           # iOS 17 - Use pre-installed iOS 17.5 runtime on macOS-14 with Xcode 15.4
           - name: iOS 17
             runs-on: macos-14

--- a/develop-docs/DECISIONS.md
+++ b/develop-docs/DECISIONS.md
@@ -433,3 +433,10 @@ Future types conforming to Decodable can be written in Swift from the start and 
 ## v9
 
 Work on the v9 SDK is being done behind the compiler flag `SDK_V9`. CI builds the SDK with this flag enabled to ensure it does not break during the course of non-v9 development. This SDK version will focus on quality and be a part of Sentry’s quality quarter initiative. Notably, the minimum supported OS version will be bumped in this release. The changelog for this release is being tracked in [CHANGELOG-v9.md](../CHANGELOG-v9.md).
+
+## Remove iOS 16 support
+
+Date: October 28, 2025
+Contributors: @philprime, @philipphofmann, @itaybre
+
+While we keep supporting iOS 16 in the v9 SDK, we will remove testing in iOS 16 due to flakiness when running on GitHub Actions simulators as the test runners keep timing out.


### PR DESCRIPTION
Due to flakiness of test runners for iOS 16 I want to propose we remove it.
It is still the oldest version we are going to keep supporting, but right now it is more blocking than helpful.

Eventually it might make sense to add it back when we have a different runner infrastructure.

#skip-changelog

Closes #6566