### PR TITLE
chore: Bump simulators to 26.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,8 +243,8 @@ jobs:
           - name: iOS 26 Sentry
             runs-on: macos-26
             platform: "iOS"
-            xcode: "26.0.1"
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            test-destination-os: "26.1"
             device: "iPhone 17 Pro"
             scheme: "Sentry"
 
@@ -272,8 +272,8 @@ jobs:
           - name: macOS 26 Sentry
             runs-on: macos-26
             platform: "macOS"
-            xcode: "26.0.1"
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            test-destination-os: "26.1"
             scheme: "Sentry"
 
           # Catalyst. We test the latest version, as the risk something breaking on Catalyst and not
@@ -328,8 +328,8 @@ jobs:
           - name: tvOS 26 Sentry
             runs-on: macos-26
             platform: "tvOS"
-            xcode: "26.0.1"
-            test-destination-os: "26.0"
+            xcode: "26.1"
+            test-destination-os: "26.1"
             device: "Apple TV"
             scheme: "Sentry"
 

--- a/.github/workflows/ui-tests-common.yml
+++ b/.github/workflows/ui-tests-common.yml
@@ -79,11 +79,11 @@ jobs:
         env:
           XCODE_VERSION: ${{ inputs.xcode_version }}
       - name: Install required platforms for Xcode 26
-        if: ${{ inputs.xcode_version == '26.0.1' }}
+        if: ${{ inputs.xcode_version == '26.1' }}
         run: ./scripts/ci-install-xOS-26-platforms.sh --platforms "${{inputs.platform}}"
 
       - name: Create simulator device for Xcode 26
-        if: ${{ inputs.xcode_version == '26.0.1' }}
+        if: ${{ inputs.xcode_version == '26.1' }}
         run: ./scripts/ci-create-simulator.sh --platform "${{inputs.platform}}" --os-version "${{inputs.test-destination-os}}" --device-name "${{inputs.device}}"
       - run: make init-ci-build
         if: ${{ inputs.build_with_make }}

--- a/.github/workflows/ui-tests-critical.yml
+++ b/.github/workflows/ui-tests-critical.yml
@@ -76,10 +76,10 @@ jobs:
           - name: iOS 26
             platform:
               runs-on: macos-15
-              xcode: "26.0.1"
+              xcode: "26.1"
               platform: "iOS"
               device: "iPhone 16 Pro"
-              test-destination-os: "26.0"
+              test-destination-os: "26.1"
 
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -98,9 +98,9 @@ jobs:
           - name: iOS 26
             runs-on: macos-15
             platform: "iOS"
-            xcode: "26.0.1"
+            xcode: "26.1"
             device: iPhone 16 Pro
-            test-destination-os: "26.0"
+            test-destination-os: "26.1"
     with:
       fastlane_command: ui_tests_ios_swift
       files_suffix: _xcode_${{matrix.xcode}}-${{matrix.device}}

--- a/scripts/ci-create-simulator.sh
+++ b/scripts/ci-create-simulator.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/ci-utils.sh"
 
 # Usage: ./scripts/ci-create-simulator.sh --platform <platform> --os-version <os_version> --device-name <device_name>
-# Example: ./scripts/ci-create-simulator.sh --platform iOS --os-version 26.0 --device-name "iPhone 16e"
+# Example: ./scripts/ci-create-simulator.sh --platform iOS --os-version 26.1 --device-name "iPhone 16e"
 
 PLATFORM=""
 OS_VERSION=""
@@ -19,7 +19,7 @@ DEVICE_NAME=""
 
 usage() {
   log_error "Usage: $0 --platform <platform> --os-version <os_version> --device-name <device_name>"
-  log_error "  Example: $0 --platform iOS --os-version 26.0 --device-name \"iPhone 16e\""
+  log_error "  Example: $0 --platform iOS --os-version 26.1 --device-name \"iPhone 16e\""
   exit 1
 }
 

--- a/scripts/ci-install-xOS-26-platforms.sh
+++ b/scripts/ci-install-xOS-26-platforms.sh
@@ -48,28 +48,28 @@ IFS=',' read -ra PLATFORM_ARRAY <<< "$PLATFORMS"
 for platform in "${PLATFORM_ARRAY[@]}"; do
     case "$platform" in
         "iOS")
-            begin_group "Installing iOS 26.0 simulator"
+            begin_group "Installing iOS 26.1 simulator"
             xcodebuild -downloadPlatform iOS -quiet || {
                 log_warning "Failed to download iOS platform, continuing..."
             }
             end_group
             ;;
         "tvOS")
-            begin_group "Installing tvOS 26.0 simulator"
+            begin_group "Installing tvOS 26.1 simulator"
             xcodebuild -downloadPlatform tvOS -quiet || {
                 log_warning "Failed to download tvOS platform, continuing..."
             }
             end_group
             ;;
         "visionOS")
-            begin_group "Installing visionOS 26.0 simulator"
+            begin_group "Installing visionOS 26.1 simulator"
             xcodebuild -downloadPlatform visionOS -quiet || {
                 log_warning "Failed to download visionOS platform, continuing..."
             }
             end_group
             ;;
         "watchOS")
-            begin_group "Installing watchOS 26.0 simulator"
+            begin_group "Installing watchOS 26.1 simulator"
             xcodebuild -downloadPlatform watchOS -quiet || {
                 log_warning "Failed to download watchOS platform, continuing..."
             }


### PR DESCRIPTION
iOS 26 is not available on CI anymore.
Use 26.1

#skip-changelog