### PR TITLE
chore(ci): Update concurrency configuration in auto-update-tools workflow

### DIFF
--- a/.github/workflows/auto-update-tools.yml
+++ b/.github/workflows/auto-update-tools.yml
@@ -23,16 +23,16 @@ permissions:
   pull-requests: write
 
 # Concurrency configuration:
-# - We use a named concurrency group to prevent multiple instances of this workflow from running
-#   simultaneously, which could lead to race conditions when creating branches and pull requests.
-#   Since this workflow modifies version files and creates PRs, concurrent runs could interfere
-#   with each other, resulting in conflicting branches or duplicate PRs.
+# - For pull requests, we use a workflow-and-ref–scoped group to keep runs isolated per PR while
+#   still cancelling outdated runs on the same PR.
+# - For non-PR events (schedule, workflow_dispatch, pushes), we use a fixed global group so only
+#   one repository-wide run can execute at a time, preventing race conditions when creating
+#   branches and pull requests.
 # - We enable cancellation of in-progress runs because only the most recent run matters for
-#   version updates. There's no value in completing outdated runs, especially for scheduled
-#   workflows that might queue up overnight. This approach conserves GitHub Actions minutes
-#   and ensures we're always working with the latest repository state.
+#   version updates. This conserves GitHub Actions minutes and ensures we always work with the
+#   latest repository state.
 concurrency:
-  group: "auto-update-tools"
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || 'auto-update-tools' }}
   cancel-in-progress: true
 
 jobs:
@@ -113,11 +113,7 @@ jobs:
   # to make auto-update-tools a required check with only running the auto-update-tools when required.
   # So, we don't have to run auto-update-tools, for example, for unrelated changes.
   auto_update_tools-required-check:
-    needs:
-      [
-        files-changed,
-        auto-update-tools,
-      ]
+    needs: [files-changed, auto-update-tools]
     name: Auto Update Tools
     # This is necessary since a failed/skipped dependent job would cause this job to be skipped
     if: always()


### PR DESCRIPTION
I started noticing that workflow runs of `auto-update-tools.yml` were getting cancelled in pull requests. The reason was that the concurrency group was the same for all pull requests, so they were cancelling each other.

Refined concurrency settings to isolate runs per pull request while maintaining a global group for non-PR events, preventing race conditions.

#skip-changelog

Closes #6583