### PR TITLE
chore: Remove extra V9 check

### DIFF
--- a/Sources/Sentry/Public/SentryBreadcrumb.h
+++ b/Sources/Sentry/Public/SentryBreadcrumb.h
@@ -59,9 +59,7 @@ NS_SWIFT_NAME(Breadcrumb)
 - (instancetype)init;
 + (instancetype)new NS_UNAVAILABLE;
 
-#if !SDK_V9
 - (NSDictionary<NSString *, id> *)serialize;
-#endif // !SDK_V9
 
 - (BOOL)isEqual:(id _Nullable)other;
 

--- a/sdk_api.json
+++ b/sdk_api.json
@@ -2838,6 +2838,43 @@
           },
           {
             "kind": "Function",
+            "name": "serialize",
+            "printedName": "serialize()",
+            "children": [
+              {
+                "kind": "TypeNominal",
+                "name": "Dictionary",
+                "printedName": "[Swift.String : Any]",
+                "children": [
+                  {
+                    "kind": "TypeNominal",
+                    "name": "String",
+                    "printedName": "Swift.String",
+                    "usr": "s:SS"
+                  },
+                  {
+                    "kind": "TypeNominal",
+                    "name": "ProtocolComposition",
+                    "printedName": "Any"
+                  }
+                ],
+                "usr": "s:SD"
+              }
+            ],
+            "declKind": "Func",
+            "usr": "c:objc(cs)SentryBreadcrumb(im)serialize",
+            "moduleName": "Sentry",
+            "isOpen": true,
+            "objc_name": "serialize",
+            "declAttributes": [
+              "DiscardableResult",
+              "ObjC",
+              "Dynamic"
+            ],
+            "funcSelfKind": "NonMutating"
+          },
+          {
+            "kind": "Function",
             "name": "isEqual",
             "printedName": "isEqual(_:)",
             "children": [


### PR DESCRIPTION
Decided not to do this in V9, I missed this one spot in https://github.com/getsentry/sentry-cocoa/pull/6574

#skip-changelog

Closes #6595