### PR TITLE
chore: Remove deprecation flags that are not needed

### DIFF
--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -2,7 +2,6 @@
 import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
-@available(*, deprecated, message: "App launch profiling is deprecated in favor of continuous profiling.")
 final class SentryAppLaunchProfilingTests: XCTestCase {
     private var fixture: SentryProfileTestFixture!
 
@@ -18,7 +17,6 @@ final class SentryAppLaunchProfilingTests: XCTestCase {
 }
 
 // MARK: continuous profiling v2
-@available(*, deprecated, message: "This is only deprecated because SentryAppLaunchProfilingTests is deprecated. Once trace based and continuous profiling v1 is removed this deprecation can be removed.")
 extension SentryAppLaunchProfilingTests {
     func testContinuousLaunchProfileV2TraceLifecycleConfiguration() throws {
         // Arrange
@@ -88,7 +86,6 @@ extension SentryAppLaunchProfilingTests {
 
 // MARK: continuous profiling v2 (iOS-only)
 #if !os(macOS)
-@available(*, deprecated, message: "This is only deprecated because SentryAppLaunchProfilingTests is deprecated. Once trace based and continuous profiling v1 is removed this deprecation can be removed.")
 extension SentryAppLaunchProfilingTests {
     func testLaunchContinuousProfileV2TraceLifecycleNotStoppedOnFullyDisplayed() throws {
         // Arrange

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
@@ -5,7 +5,6 @@ import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
 /// Validate stopping behavior of launch profiles that run with one set of configured options, where the SDK is started on that launch with a different set of options, to validate that the configured options persisted to disk from the previous launch are the ones used to determine how/when to stop the profiler, and not the new options currently in memory
-@available(*, deprecated, message: "This is only marked as deprecated because it must still test some deprecated profiling APIs, but the deprecation warnings are converted to errors in our test targets. Once the deprecated API are removed, this can also be removed.")
 final class SentryAppStartProfilingConfigurationChangeTests: XCTestCase {
     private var fixture: SentryProfileTestFixture!
 
@@ -22,7 +21,6 @@ final class SentryAppStartProfilingConfigurationChangeTests: XCTestCase {
 
 #if !os(macOS)
 // MARK: configuring launch profiling with TTFD disabled, then launching with it enabled (iOS-only)
-@available(*, deprecated, message: "This is only marked as deprecated because it must still test some deprecated profiling APIs, but the deprecation warnings are converted to errors in our test targets. Once the deprecated API are removed, this can also be removed.")
 extension SentryAppStartProfilingConfigurationChangeTests {
     func test_lastLaunch_continuousV2_manualLifecycle_noTTFD_currentLaunch_continuousV2_traceLifecycle_withTTFD() throws {
         // Arrange
@@ -195,7 +193,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
 }
 
 // MARK: configuring launch profiling with TTFD enabled, then launching with it disabled (iOS-only)
-@available(*, deprecated, message: "This is only marked as deprecated because it must still test some deprecated profiling APIs, but the deprecation warnings are converted to errors in our test targets. Once the deprecated API are removed, this can also be removed.")
 extension SentryAppStartProfilingConfigurationChangeTests {
     // MARK: starting with continuous v2 manual lifecycle with TTFD
     func test_lastLaunch_continuousV2_manualLifecycle_withTTFD_currentLaunch_continuousV2_traceLifecycle_noTTFD() throws {

--- a/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
+++ b/Tests/SentryProfilerTests/SentryContinuousProfilerTests.swift
@@ -5,7 +5,6 @@ import XCTest
 
 #if os(iOS) || os(macOS) || targetEnvironment(macCatalyst)
 
-@available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
 final class SentryContinuousProfilerTests: XCTestCase {
     private var fixture: SentryProfileTestFixture!
     
@@ -243,7 +242,6 @@ final class SentryContinuousProfilerTests: XCTestCase {
     }
 }
 
-@available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
 private extension SentryContinuousProfilerTests {
     func addMockSamples(mockAddresses: [NSNumber]) throws {
         let mockThreadMetadata = SentryProfileTestFixture.ThreadMetadata(id: 1, priority: 2, name: "main")

--- a/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
+++ b/Tests/SentryProfilerTests/SentryProfileTestFixture.swift
@@ -43,7 +43,6 @@ class SentryProfileTestFixture {
     lazy var framesTracker = TestFramesTracker(displayLinkWrapper: displayLinkWrapper, dateProvider: currentDateProvider, dispatchQueueWrapper: dispatchQueueWrapper, notificationCenter: notificationCenter, delayedFramesTracker: TestDelayedWrapper(keepDelayedFramesDuration: 0, dateProvider: currentDateProvider))
 #endif // !os(macOS)
     
-    @available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
     init() {
         SentryDependencyContainer.sharedInstance().dispatchQueueWrapper = dispatchQueueWrapper
         SentryDependencyContainer.sharedInstance().dateProvider = currentDateProvider

--- a/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
+++ b/Tests/SentryTests/Integrations/Performance/CoreData/SentryCoreDataTrackingIntegrationTest.swift
@@ -9,7 +9,6 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
         let options: Options
         let coreDataStack: TestCoreDataStack
 
-        @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
         init(testName: String) {
             coreDataStack = TestCoreDataStack(databaseFilename: "db-\(testName.hashValue).sqlite")
             options = Options()
@@ -27,7 +26,6 @@ class SentryCoreDataTrackingIntegrationTests: XCTestCase {
     
     private var fixture: Fixture!
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUp() {
         super.setUp()
         fixture = Fixture(testName: self.name)

--- a/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/DataSentryTracingIntegrationTests.swift
@@ -20,7 +20,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
 
         init() {}
 
-        @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
         func getSut(testName: String, isSDKEnabled: Bool = true, isEnabled: Bool = true) throws -> Data {
             let fileManager = FileManager.default
             let tempDirUrl = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -132,7 +131,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
 
     // MARK: - Data.init(contentsOfWithSentryTracing:)
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_shouldTraceManually() throws {
         // -- Arrange --
         let expectedData = try fixture.getSut(testName: self.name)
@@ -162,7 +160,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertGreaterThan(endTimestamp.timeIntervalSince1970, startTimestamp.timeIntervalSince1970)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracingWithOptions_shouldPassOptionsToSystemImplementation() throws {
         // -- Arrange --
         let expectedData = try fixture.getSut(testName: self.name)
@@ -190,7 +187,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(mappedSentryData, expectedData)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_throwsError_shouldTraceManuallyWithErrorRethrow() throws {
         // -- Arrange --
         let _ = try fixture.getSut(testName: self.name)
@@ -217,7 +213,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertGreaterThan(endTimestamp.timeIntervalSince1970, startTimestamp.timeIntervalSince1970)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_nonFileUrl_shouldNotTraceManually() throws {
         // -- Arrange --
         let _ = try fixture.getSut(testName: self.name)
@@ -231,7 +226,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(parentTransaction.children.count, 0)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_trackerIsNotEnabled_shouldNotTraceManually() throws {
         // -- Arrange --
         let _ = try fixture.getSut(testName: self.name, isEnabled: false)
@@ -245,7 +239,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(parentTransaction.children.count, 0)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_fileIsIgnored_shouldNotTraceManually() throws {
         // -- Arrange --
         let _ = try fixture.getSut(testName: self.name)
@@ -259,7 +252,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(parentTransaction.children.count, 0)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_SDKIsNotStarted_shouldReadData() throws {
         // -- Arrange --
         let _ = try fixture.getSut(testName: self.name, isSDKEnabled: false)
@@ -272,7 +264,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(data, fixture.data)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testInitContentsOfWithSentryTracing_SDKIsClosed_shouldReadData() throws {
         // -- Arrange --
         let _ = try fixture.getSut(testName: self.name)
@@ -288,7 +279,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
 
     // MARK: - Data.writeWithSentryTracing(to:)
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_shouldTraceManuallyWithErrorRethrow() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name)
@@ -324,7 +314,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertGreaterThan(endTimestamp.timeIntervalSince1970, startTimestamp.timeIntervalSince1970)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracingWithOptions_shouldPassOptionsToSystemImplementation() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name)
@@ -356,7 +345,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(writtenData, sut)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_throwsError_shouldTraceManuallyWithErrorRethrow() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name)
@@ -383,7 +371,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertGreaterThan(endTimestamp.timeIntervalSince1970, startTimestamp.timeIntervalSince1970)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_nonFileUrl_shouldNotTraceManually() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name)
@@ -396,7 +383,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(parentTransaction.children.count, 0)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_trackerIsNotEnabled_shouldNotTraceManually() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name, isEnabled: false)
@@ -409,7 +395,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(parentTransaction.children.count, 0)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_fileIsIgnored_shouldNotTraceManually() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name)
@@ -429,7 +414,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(parentTransaction.children.count, 0)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_SDKIsNotStarted_shouldWriteFile() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name, isSDKEnabled: false)
@@ -448,7 +432,6 @@ class DataSentryTracingIntegrationTests: XCTestCase {
         XCTAssertEqual(writtenData, fixture.data)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testWriteWithSentryTracing_SDKIsClosed_shouldWriteFile() throws {
         // -- Arrange --
         let sut: Data = try fixture.getSut(testName: self.name)

--- a/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/FileManagerTracingIntegrationTests.swift
@@ -3,7 +3,6 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
-@available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
 class FileManagerSentryTracingIntegrationTests: XCTestCase {
     private class Fixture {
         let mockDateProvider: TestCurrentDateProvider = {

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerSwiftHelpersTests.swift
@@ -20,7 +20,6 @@ class SentryFileIOTrackerSwiftHelpersTests: XCTestCase {
     private let destPath = "/path/to/dest"
     private let testError = NSError(domain: "Test", code: 1, userInfo: nil)
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUp() {
         mockedDateProvider = TestCurrentDateProvider()
         SentryDependencyContainer.sharedInstance().dateProvider = mockedDateProvider

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackerTests.swift
@@ -47,7 +47,6 @@ class SentryFileIOTrackerTests: XCTestCase {
 
     private var fixture: Fixture!
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUpWithError() throws {
         try super.setUpWithError()
         fixture = try Fixture()

--- a/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/IO/SentryFileIOTrackingIntegrationTests.swift
@@ -11,7 +11,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         let fileURL: URL!
         let fileDirectory: URL!
         
-        @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
         func getOptions(enableAutoPerformanceTracing: Bool = true, enableFileIOTracing: Bool = true, enableSwizzling: Bool = true, enableDataSwizzling: Bool = true, enableFileManagerSwizzling: Bool = true, tracesSampleRate: NSNumber = 1) -> Options {
             let result = Options()
             result.removeAllIntegrations()
@@ -69,7 +68,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         SentrySDK.close()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_WritingTrackingDisabled_forIOOption() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(enableFileIOTracing: false))
@@ -78,7 +76,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_WritingTrackingDisabled_forSwizzlingOption() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(enableSwizzling: false))
@@ -87,7 +84,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_WritingTrackingDisabled_forAutoPerformanceTrackingOption() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(enableAutoPerformanceTracing: false))
@@ -96,7 +92,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_WritingTrackingDisabled_TracingDisabled() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(tracesSampleRate: 0))
@@ -105,7 +100,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testData_Writing_Tracking() {
         // -- Arrange --
         let expectedSpanCount: Int
@@ -127,7 +121,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         }
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testData_WritingWithOption_Tracking() {
         // -- Arrange --
         let expectedSpanCount: Int
@@ -149,7 +142,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         }
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingTrackingDisabled_forIOOption() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(enableFileIOTracing: false))
@@ -158,7 +150,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingTrackingDisabled_forSwizzlingOption() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(enableSwizzling: false))
@@ -167,7 +158,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingTrackingDisabled_forAutoPerformanceTrackingOption() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(enableAutoPerformanceTracing: false))
@@ -176,7 +166,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingTrackingDisabled_TracingDisabled() {
         // -- Act --
         SentrySDK.start(options: fixture.getOptions(tracesSampleRate: 0))
@@ -185,7 +174,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testData_ReadingURL_Tracking() {
         // -- Arrange --
         let expectedSpanCount: Int
@@ -205,7 +193,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         }
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testData_ReadingURLWithOption_Tracking() throws {
         // -- Arrange --
         let expectedSpanCount: Int
@@ -226,7 +213,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(data?.count, fixture.data.count)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingFile_Tracking() {
         // -- Arrange --
         SentrySDK.start(options: fixture.getOptions())
@@ -238,7 +224,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(data?.count, fixture.data.count)
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingFileWithOptions_Tracking() {
         // -- Arrange --
         SentrySDK.start(options: fixture.getOptions())
@@ -250,7 +235,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(data?.count, fixture.data.count)
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_ReadingBigFile() {
         // -- Arrange --
         SentrySDK.start(options: fixture.getOptions())
@@ -265,7 +249,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(data?.count, 295_760)
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_WritingBigFile() {
         // -- Arrange --
         guard let jsonFile = getBigFilePath() else {
@@ -295,7 +278,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         ?? bundle.path(forResource: "fatal-error-binary-images-message2", ofType: "json")
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_DataConsistency_readUrl() {
         SentrySDK.start(options: fixture.getOptions())
         
@@ -310,7 +292,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(randomValue, readValue)
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_DataConsistency_readPath() {
         SentrySDK.start(options: fixture.getOptions())
         
@@ -324,7 +305,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         XCTAssertEqual(randomValue, readValue)
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testEnableDataSwizzling_isNotEnabled_shouldNotSwizzleNSDataMethods() {
         // -- Arrange --
         let options = fixture.getOptions(enableDataSwizzling: false)
@@ -334,7 +314,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         assertWriteWithNoSpans()
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testDisableFileManagerSwizzling_isNotEnabledAndDataSwizzlingIsEnabled_shouldTrackWithSpan() throws {
         // -- Arrange --
         if #available(iOS 18, macOS 15, tvOS 18, *) {
@@ -350,7 +329,6 @@ class SentryFileIOTrackingIntegrationTests: XCTestCase {
         }
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testDisableFileManagerSwizzling_isNotEnabled_shouldNotTrackWithSpan() throws {
         // -- Arrange --
         if #available(iOS 18, macOS 15, tvOS 18, *) {

--- a/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/Network/SentryNetworkTrackerIntegrationTests.swift
@@ -15,7 +15,6 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
         let dateProvider = TestCurrentDateProvider()
         let options: Options
         
-        @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
         init() {
             options = Options()
             options.dsn = SentryNetworkTrackerIntegrationTests.dsnAsString
@@ -29,7 +28,6 @@ class SentryNetworkTrackerIntegrationTests: XCTestCase {
     
     private var fixture: Fixture!
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUp() {
         super.setUp()
         fixture = Fixture()

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerPerformanceTrackerTests.swift
@@ -41,7 +41,6 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
             return SentryInAppLogic(inAppIncludes: options.inAppIncludes, inAppExcludes: [])
         }
         
-        @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
         init() {
             options = Options.noIntegrations()
             let imageName = String(
@@ -68,7 +67,6 @@ class SentryUIViewControllerPerformanceTrackerTests: XCTestCase {
     
     private var fixture: Fixture!
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUp() {
         super.setUp()
         fixture = Fixture()

--- a/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
+++ b/Tests/SentryTests/Integrations/Performance/UIViewController/SentryUIViewControllerSwizzlingTests.swift
@@ -15,7 +15,6 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
         let binaryImageCache: SentryBinaryImageCache
         var options: Options
         
-        @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
         init() {
             subClassFinder = TestSubClassFinder(dispatchQueue: dispatchQueue, objcRuntimeWrapper: objcRuntimeWrapper, swizzleClassNameExcludes: [])
             binaryImageCache = SentryDependencyContainer.sharedInstance().binaryImageCache
@@ -49,7 +48,6 @@ class SentryUIViewControllerSwizzlingTests: XCTestCase {
     
     private var fixture: Fixture!
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUp() {
         super.setUp()
         fixture = Fixture()

--- a/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/Screenshot/SentryScreenshotIntegrationTests.swift
@@ -41,7 +41,6 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         clearTestState()
     }
 
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_attachScreenshot_disabled() {
         SentrySDK.start {
             $0.removeAllIntegrations()
@@ -51,7 +50,6 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         XCTAssertFalse(sentrycrash_hasSaveScreenshotCallback())
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_attachScreenshot_enabled() {
         SentrySDK.start {
             $0.removeAllIntegrations()
@@ -61,7 +59,6 @@ class SentryScreenshotIntegrationTests: XCTestCase {
         XCTAssertTrue(sentrycrash_hasSaveScreenshotCallback())
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func test_uninstall() {
         SentrySDK.start {
             $0.removeAllIntegrations()

--- a/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
+++ b/Tests/SentryTests/Integrations/SentryCrash/SentryCrashIntegrationTests.swift
@@ -91,7 +91,6 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
     }
     
     // Test for GH-581
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testReleaseNamePassedToSentryCrash() throws {
         let releaseName = "1.0.0"
         let dist = "14G60"
@@ -111,7 +110,6 @@ class SentryCrashIntegrationTests: NotificationCenterTestCase {
         assertUserInfoField(userInfo: userInfo, key: "dist", expected: dist)
     }
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     func testContext_IsPassedToSentryCrash() throws {
         SentrySDK.start { options in
             options.dsn = SentryCrashIntegrationTests.dsnAsString

--- a/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
+++ b/Tests/SentryTests/Integrations/Session/SentrySessionGeneratorTests.swift
@@ -22,7 +22,6 @@ class SentrySessionGeneratorTests: NotificationCenterTestCase {
     private var options: Options!
     private var fileManager: SentryFileManager!
     
-    @available(*, deprecated, message: "This is deprecated because SentryOptions integrations is deprecated")
     override func setUp() {
         super.setUp()
         

--- a/Tests/SentryTests/SentrySDKInternalTests.swift
+++ b/Tests/SentryTests/SentrySDKInternalTests.swift
@@ -46,7 +46,6 @@ class SentrySDKInternalTests: XCTestCase {
         let operation = "ui.load"
         let transactionName = "Load Main Screen"
 
-        @available(*, deprecated, message: "This is marked deprecated as a workaround until we can remove SentryUserFeedback in favor of SentryFeedback. When SentryUserFeedback is removed, this deprecation annotation can be removed.")
         init() {
             SentryDependencyContainer.sharedInstance().dateProvider = currentDate
 
@@ -82,7 +81,6 @@ class SentrySDKInternalTests: XCTestCase {
 
     private var fixture: Fixture!
 
-    @available(*, deprecated, message: "This is marked deprecated as a workaround (for the workaround deprecating the Fixture.init method) until we can remove SentryUserFeedback in favor of SentryFeedback. When SentryUserFeedback is removed, this deprecation annotation can be removed.")
     override func setUp() {
         super.setUp()
         fixture = Fixture()

--- a/Tests/SentryTests/SentrySDKTests.swift
+++ b/Tests/SentryTests/SentrySDKTests.swift
@@ -45,7 +45,6 @@ class SentrySDKTests: XCTestCase {
         let operation = "ui.load"
         let transactionName = "Load Main Screen"
 
-        @available(*, deprecated, message: "This is marked deprecated as a workaround until we can remove SentryUserFeedback in favor of SentryFeedback. When SentryUserFeedback is removed, this deprecation annotation can be removed.")
         init() {
             SentryDependencyContainer.sharedInstance().dateProvider = currentDate
 
@@ -81,7 +80,6 @@ class SentrySDKTests: XCTestCase {
 
     private var fixture: Fixture!
 
-    @available(*, deprecated, message: "This is marked deprecated as a workaround (for the workaround deprecating the Fixture.init method) until we can remove SentryUserFeedback in favor of SentryFeedback. When SentryUserFeedback is removed, this deprecation annotation can be removed.")
     override func setUp() {
         super.setUp()
         fixture = Fixture()

--- a/Tests/SentryTests/Transaction/SentrySpanTests.swift
+++ b/Tests/SentryTests/Transaction/SentrySpanTests.swift
@@ -2,7 +2,6 @@
 @_spi(Private) import SentryTestUtils
 import XCTest
 
-@available(*, deprecated, message: "This is only marked as deprecated because profilesSampleRate is marked as deprecated. Once that is removed this can be removed.")
 class SentrySpanTests: XCTestCase {
     private var logOutput: TestLogOutput!
     private var fixture: Fixture!

--- a/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
+++ b/Tests/SentryTests/Transaction/SentryTransactionContextTests.swift
@@ -278,7 +278,6 @@ class SentryTransactionContextTests: XCTestCase {
         )
     }
 
-    @available(*, deprecated, message: "The test is marked as deprecated to silence the deprecation warning of the initializer")
     func testPublicInit_WithNameTraceIdSpanIdParentSpanIdParentSampled_withNilValues() {
         // Act
         let context = TransactionContext(


### PR DESCRIPTION
The deprecated APIs were removed so we don't need this anymore

#skip-changelog

Closes #6598