### PR TITLE
chore: Cleanup some unreachable code after v9

### DIFF
--- a/Sources/Sentry/Profiling/SentryLaunchProfiling.m
+++ b/Sources/Sentry/Profiling/SentryLaunchProfiling.m
@@ -28,8 +28,6 @@ NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate = @"traces";
 NSString *const kSentryLaunchProfileConfigKeyTracesSampleRand = @"traces.sample_rand";
 NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate = @"profiles";
 NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRand = @"profiles.sample_rand";
-NSString *const kSentryLaunchProfileConfigKeyContinuousProfilingV2
-    = @"continuous-profiling-v2-enabled";
 NSString *const kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle
     = @"continuous-profiling-v2-lifecycle";
 NSString *const kSentryLaunchProfileConfigKeyWaitForFullDisplay
@@ -254,10 +252,6 @@ _sentry_nondeduplicated_startLaunchProfile(void)
     NSDictionary<NSString *, NSNumber *> *persistedLaunchConfigOptionsDict
         = sentry_persistedLaunchProfileConfigurationOptions();
 
-    BOOL isContinuousV2 =
-        [persistedLaunchConfigOptionsDict[kSentryLaunchProfileConfigKeyContinuousProfilingV2]
-            boolValue];
-
     SentrySamplerDecision *decision
         = _sentry_profileSampleDecision(persistedLaunchConfigOptionsDict);
     if (nil == decision) {
@@ -279,34 +273,28 @@ _sentry_nondeduplicated_startLaunchProfile(void)
     BOOL shouldWaitForFullDisplay = shouldWaitForFullDisplayValue.boolValue;
 
     SentryProfileOptions *profileOptions = nil;
-    if (isContinuousV2) {
-        SENTRY_LOG_DEBUG(@"Starting continuous launch profile v2.");
-        NSNumber *lifecycleValue = persistedLaunchConfigOptionsDict
-            [kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle];
-        if (lifecycleValue == nil) {
-            SENTRY_LOG_ERROR(
-                @"Missing expected launch profile config parameter for lifecycle. Will "
-                @"not proceed with launch profile.");
-            _sentry_cleanUpConfigFile();
-            return;
-        }
-
-        profileOptions = [[SentryProfileOptions alloc] init];
-
-        SentryProfileLifecycle lifecycle = lifecycleValue.intValue;
-        if (lifecycle == SentryProfileLifecycleManual) {
-            _sentry_continuousProfilingV2_startManualLaunchProfile(persistedLaunchConfigOptionsDict,
-                profileOptions, decision, shouldWaitForFullDisplay);
-            _sentry_cleanUpConfigFile();
-            return;
-        }
-
-        _sentry_hydrateV2Options(persistedLaunchConfigOptionsDict, profileOptions, decision,
-            SentryProfileLifecycleTrace, shouldWaitForFullDisplay);
-    } else {
-        sentry_profileConfiguration =
-            [[SentryProfileConfiguration alloc] initWaitingForFullDisplay:shouldWaitForFullDisplay];
+    SENTRY_LOG_DEBUG(@"Starting continuous launch profile v2.");
+    NSNumber *lifecycleValue = persistedLaunchConfigOptionsDict
+        [kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle];
+    if (lifecycleValue == nil) {
+        SENTRY_LOG_ERROR(@"Missing expected launch profile config parameter for lifecycle. Will "
+                         @"not proceed with launch profile.");
+        _sentry_cleanUpConfigFile();
+        return;
     }
+
+    profileOptions = [[SentryProfileOptions alloc] init];
+
+    SentryProfileLifecycle lifecycle = lifecycleValue.intValue;
+    if (lifecycle == SentryProfileLifecycleManual) {
+        _sentry_continuousProfilingV2_startManualLaunchProfile(
+            persistedLaunchConfigOptionsDict, profileOptions, decision, shouldWaitForFullDisplay);
+        _sentry_cleanUpConfigFile();
+        return;
+    }
+
+    _sentry_hydrateV2Options(persistedLaunchConfigOptionsDict, profileOptions, decision,
+        SentryProfileLifecycleTrace, shouldWaitForFullDisplay);
 
     // trace lifecycle UI profiling (continuous profiling v2) and trace-based profiling both join
     // paths here
@@ -333,22 +321,19 @@ sentry_configureLaunchProfilingForNextLaunch(SentryOptions *options)
             [NSMutableDictionary<NSString *, NSNumber *> dictionary];
         configDict[kSentryLaunchProfileConfigKeyWaitForFullDisplay] =
             @(options.enableTimeToFullDisplayTracing);
-        if ([options isContinuousProfilingEnabled]) {
-            SENTRY_LOG_DEBUG(@"Configuring continuous launch profile v2.");
-            configDict[kSentryLaunchProfileConfigKeyContinuousProfilingV2] = @YES;
-            configDict[kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle] =
-                @(options.profiling.lifecycle);
-            if (options.profiling.lifecycle == SentryProfileLifecycleTrace) {
-                configDict[kSentryLaunchProfileConfigKeyTracesSampleRate]
-                    = config.tracesDecision.sampleRate;
-                configDict[kSentryLaunchProfileConfigKeyTracesSampleRand]
-                    = config.tracesDecision.sampleRand;
-            }
-            configDict[kSentryLaunchProfileConfigKeyProfilesSampleRate]
-                = config.profilesDecision.sampleRate;
-            configDict[kSentryLaunchProfileConfigKeyProfilesSampleRand]
-                = config.profilesDecision.sampleRand;
+        SENTRY_LOG_DEBUG(@"Configuring continuous launch profile v2.");
+        configDict[kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle] =
+            @(options.profiling.lifecycle);
+        if (options.profiling.lifecycle == SentryProfileLifecycleTrace) {
+            configDict[kSentryLaunchProfileConfigKeyTracesSampleRate]
+                = config.tracesDecision.sampleRate;
+            configDict[kSentryLaunchProfileConfigKeyTracesSampleRand]
+                = config.tracesDecision.sampleRand;
         }
+        configDict[kSentryLaunchProfileConfigKeyProfilesSampleRate]
+            = config.profilesDecision.sampleRate;
+        configDict[kSentryLaunchProfileConfigKeyProfilesSampleRand]
+            = config.profilesDecision.sampleRand;
         writeAppLaunchProfilingConfigFile(configDict);
     }];
 }

--- a/Sources/Sentry/include/SentryLaunchProfiling.h
+++ b/Sources/Sentry/include/SentryLaunchProfiling.h
@@ -18,7 +18,6 @@ SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRate;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyTracesSampleRand;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRate;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyProfilesSampleRand;
-SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyContinuousProfilingV2;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle;
 SENTRY_EXTERN NSString *const kSentryLaunchProfileConfigKeyWaitForFullDisplay;
 

--- a/Sources/Sentry/include/SentryProfileConfiguration.h
+++ b/Sources/Sentry/include/SentryProfileConfiguration.h
@@ -38,11 +38,6 @@ SENTRY_NO_INIT
 /** Initializer for SDK start if a configuration hasn't already been loaded for a launch profile. */
 - (instancetype)initWithProfileOptions:(SentryProfileOptions *)options;
 
-/**
- * Initializer for both trace-based and continuous V1 (aka continuous beta) launch profiles.
- */
-- (instancetype)initWaitingForFullDisplay:(BOOL)shouldWaitForFullDisplay;
-
 /** Initializer for launch UI profiles (aka continuous V2). */
 - (instancetype)initContinuousProfilingV2WaitingForFullDisplay:(BOOL)shouldWaitForFullDisplay
                                                samplerDecision:(SentrySamplerDecision *)decision

--- a/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppLaunchProfilingTests.swift
@@ -39,7 +39,6 @@ extension SentryAppLaunchProfilingTests {
         // Assert
         XCTAssert(appLaunchProfileConfigFileExists())
         let dict = try XCTUnwrap(sentry_persistedLaunchProfileConfigurationOptions())
-        XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyContinuousProfilingV2]), true)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRate]), 1)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRand]), 0.5)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyTracesSampleRate]), 1)
@@ -71,7 +70,6 @@ extension SentryAppLaunchProfilingTests {
         // Assert
         XCTAssert(appLaunchProfileConfigFileExists())
         let dict = try XCTUnwrap(sentry_persistedLaunchProfileConfigurationOptions())
-        XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyContinuousProfilingV2]), true)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRate]), 1)
         XCTAssertEqual(try XCTUnwrap(dict[kSentryLaunchProfileConfigKeyProfilesSampleRand]), 0.5)
         XCTAssertNil(dict[kSentryLaunchProfileConfigKeyTracesSampleRate])

--- a/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
+++ b/Tests/SentryProfilerTests/SentryAppStartProfilingConfigurationChangeTests.swift
@@ -28,7 +28,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.manual.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -70,7 +69,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.manual.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -112,7 +110,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.trace.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -155,7 +152,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.trace.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -202,7 +198,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.manual.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -244,7 +239,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.manual.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -286,7 +280,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.trace.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,
@@ -335,7 +328,6 @@ extension SentryAppStartProfilingConfigurationChangeTests {
         // Arrange
         // persisted configuration simulating previous launch
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.trace.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 0.5,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,

--- a/Tests/SentryProfilerTests/SentryApplaunchProfilingMalformedConfigFileTests.swift
+++ b/Tests/SentryProfilerTests/SentryApplaunchProfilingMalformedConfigFileTests.swift
@@ -35,7 +35,6 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
     func testMalformedConfigFile_ContinuousV2MissingLifecycle_DoesNotStartProfilingAndRemovesFile() throws {
         // Create a config file with continuous profiling v2 enabled but missing lifecycle
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 1.0,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5
             // Missing: kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle
@@ -59,7 +58,6 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
     func testMalformedConfigFile_ContinuousV2ManualMissingSampleRate_DoesNotStartProfilingAndRemovesFile() throws {
         // Create a config file with continuous profiling v2 manual lifecycle but missing sample rate
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.manual.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5
             // Missing: kSentryLaunchProfileConfigKeyProfilesSampleRate
@@ -83,7 +81,6 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
     func testMalformedConfigFile_ContinuousV2ManualMissingSampleRand_DoesNotStartProfilingAndRemovesFile() throws {
         // Create a config file with continuous profiling v2 manual lifecycle but missing sample rand
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.manual.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 1.0
             // Missing: kSentryLaunchProfileConfigKeyProfilesSampleRand
@@ -222,7 +219,6 @@ class SentryAppLaunchProfilingMalformedConfigFileTests: XCTestCase {
     func testMalformedConfigFile_ContinuousV2TraceLifecycleMissingTracesRate_DoesNotStartProfilingAndRemovesFile() throws {
         // Create a config file with continuous profiling v2 trace lifecycle but missing traces sample rate
         let configDict: [String: Any] = [
-            kSentryLaunchProfileConfigKeyContinuousProfilingV2: true,
             kSentryLaunchProfileConfigKeyContinuousProfilingV2Lifecycle: SentryProfileLifecycle.trace.rawValue,
             kSentryLaunchProfileConfigKeyProfilesSampleRate: 1.0,
             kSentryLaunchProfileConfigKeyProfilesSampleRand: 0.5,


### PR DESCRIPTION
The `kSentryLaunchProfileConfigKeyContinuousProfilingV2 ` key isn't needed anymore because continuousV2 is now the only profiling mode in V9

#skip-changelog

Closes #6600