### PR TITLE
chore: Backport test fixes for v8 branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,13 +108,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: iOS 18
-            runs-on: macos-15
-            platform: "iOS"
-            xcode: "16.4"
-            device: "iPhone 16 Pro"
-            test-destination-os: "18.5"
-
+          # Running the tests with simulators is incredibly flaky. Our assumption is that simulators might have difficulties
+          # with communicating with the test server in CI.
+          # We are going to add these back in https://github.com/getsentry/sentry-cocoa/issues/6361
           - name: macOS 15
             runs-on: macos-15
             platform: "macOS"
@@ -339,6 +335,11 @@ jobs:
 
       - name: Install Slather
         run: gem install slather
+
+      # Based on a comment in CircleCI forum, we need to boot the simulator for Xcode 26: https://discuss.circleci.com/t/xcode-26-rc/54066/18
+      - name: Boot simulator
+        if: ${{matrix.platform == 'iOS' && matrix.test-destination-os == '26.1'}}
+        run: ./scripts/ci-boot-simulator.sh --xcode ${{matrix.xcode}}
 
       # We split building and running tests in two steps so we know how long running the tests takes.
       - name: Build tests

--- a/scripts/ci-boot-simulator.sh
+++ b/scripts/ci-boot-simulator.sh
@@ -55,6 +55,11 @@ case "$XCODE_VERSION" in
         IOS_VERSION="18.4"
         log_notice "Selected: $SIMULATOR with iOS $IOS_VERSION for Xcode $XCODE_VERSION"
         ;;
+    "26.1")
+        SIMULATOR="iPhone 16 Pro"
+        IOS_VERSION="26.1"
+        log_notice "Selected: $SIMULATOR with iOS $IOS_VERSION for Xcode $XCODE_VERSION"
+        ;;
     *)
         SIMULATOR="iPhone 16 Pro" # Default fallback
         IOS_VERSION="18.4"


### PR DESCRIPTION
Backports fixes from: 
- https://github.com/getsentry/sentry-cocoa/pull/6350
- https://github.com/getsentry/sentry-cocoa/pull/6435

Into v8 branch to help the release process

#skip-changelog