### PR TITLE
fix: Set default trace context status to ok

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Remove `uuid` and `name` of `SentryDebugMeta` (#6512) Use `debugID` instead of `uuid` and `codeFile` instead of `name`.
 - Enable enablePreWarmedAppStartTracing by default (#6508). With this option enabled, the SDK collects [prewarmed app starts](https://docs.sentry.io/platforms/apple/tracing/instrumentation/automatic-instrumentation/#prewarmed-app-start-tracing).
 - Change `value` and `type` of `SentryException` to be nullable (#6563)
+- Change the default trace context status to "ok" instead of "undefined" (#6611)
 
 ### Features
 

--- a/Sources/Sentry/SentrySpan.m
+++ b/Sources/Sentry/SentrySpan.m
@@ -351,7 +351,8 @@ NS_ASSUME_NONNULL_BEGIN
     }
 
     if (self.status != kSentrySpanStatusUndefined) {
-        [mutableDictionary setValue:nameForSentrySpanStatus(self.status) forKey:@"status"];
+        [mutableDictionary setValue:nameForSentrySpanStatus(self.status)
+                             forKey:kSentrySpanStatusSerializationKey];
     }
 
     [mutableDictionary setValue:@(self.timestamp.timeIntervalSince1970) forKey:@"timestamp"];

--- a/Sources/Sentry/include/SentrySpan+Private.h
+++ b/Sources/Sentry/include/SentrySpan+Private.h
@@ -2,6 +2,8 @@
 
 #import "SentryProfilingConditionals.h"
 
+static NSString *_Nonnull const kSentrySpanStatusSerializationKey = @"status";
+
 @interface SentrySpan ()
 
 #if SENTRY_TARGET_PROFILING_SUPPORTED

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -218,17 +218,18 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(event.dist, actual?.dist)
     }
     
-    func testApplyToEvent_ScopeWithSpan() {
+    func testApplyToEvent_ScopeWithSpan() throws {
         let scope = fixture.scope
         scope.span = fixture.transaction
         
         let actual = scope.applyTo(event: fixture.event, maxBreadcrumbs: 10)
-        let trace = fixture.event.context?["trace"]
-              
+        let trace = try XCTUnwrap(fixture.event.context?["trace"])
+
         XCTAssertEqual(actual?.transaction, fixture.transactionName)
-        XCTAssertEqual(trace?["op"] as? String, fixture.transactionOperation)
-        XCTAssertEqual(trace?["trace_id"] as? String, fixture.transaction.traceId.sentryIdString)
-        XCTAssertEqual(trace?["span_id"] as? String, fixture.transaction.spanId.sentrySpanIdString)
+        XCTAssertEqual(trace["op"] as? String, fixture.transactionOperation)
+        XCTAssertEqual(trace["trace_id"] as? String, fixture.transaction.traceId.sentryIdString)
+        XCTAssertEqual(trace["span_id"] as? String, fixture.transaction.spanId.sentrySpanIdString)
+        XCTAssertEqual(trace["status"] as? String, "ok")
     }
     
     func testApplyToEvent_EventWithDist() {
@@ -603,8 +604,12 @@ class SentryScopeSwiftTests: XCTestCase {
         let traceContext = try XCTUnwrap(observer.traceContext)
         let serializedTransaction = transaction.serialize()
 
-        XCTAssertEqual(Set(serializedTransaction.keys), Set(traceContext.keys))
-        
+        var expectedKeys = Set(serializedTransaction.keys)
+        // The transaction doesn't serialize the status when it's undefined, but the trace context sets it to OK.
+        expectedKeys.insert("status")
+
+        XCTAssertEqual(Set(traceContext.keys), expectedKeys)
+
         XCTAssertEqual(serializedTransaction["trace_id"] as? String, traceContext["trace_id"] as? String)
         XCTAssertEqual(serializedTransaction["span_id"] as? String, traceContext["span_id"] as? String)
         XCTAssertEqual(serializedTransaction["op"] as? String, traceContext["op"] as? String)
@@ -612,6 +617,7 @@ class SentryScopeSwiftTests: XCTestCase {
         XCTAssertEqual(serializedTransaction["type"] as? String, traceContext["type"] as? String)
         XCTAssertEqual(serializedTransaction["start_timestamp"] as? Double, traceContext["start_timestamp"] as? Double)
         XCTAssertEqual(serializedTransaction["timestamp"] as? Double, traceContext["timestamp"] as? Double)
+        XCTAssertEqual(traceContext["status"] as? String, "ok")
     }
 
     func testScopeObserver_setSpanToNil_SetsTraceContextToPropagationContext() throws {


### PR DESCRIPTION



## :scroll: Description

Set the default context status to ok instead of not sending it at all to avoid user confusion.

## :bulb: Motivation and Context

Fixes GH-6230

## :green_heart: How did you test it?

Unit tests and sample app

| Previously | Now |
|--------|--------|
| <img width="848" height="584" alt="image" src="https://github.com/user-attachments/assets/e183941a-ac03-4225-827e-fc15618a687d" /> |  <img width="1042" height="588" alt="Screenshot 2025-10-30 at 16 23 09" src="https://github.com/user-attachments/assets/86e123e7-86f9-488c-8ea0-00726fce56b3" /> | 


## :pencil: Checklist

You have to check all boxes before merging:

- [x] I added tests to verify the changes.
- [x] No new PII added or SDK only sends newly added PII if `sendDefaultPII` is enabled.
- [x] I updated the docs if needed.
- [x] I updated the wizard if needed.
- [x] Review from the native team if needed.
- [x] No breaking change or entry added to the changelog.
- [x] No breaking change for hybrid SDKs or communicated to hybrid SDKs.
